### PR TITLE
docs: integrate mdt and harden doc verification

### DIFF
--- a/.changeset/001-release-foundation.md
+++ b/.changeset/001-release-foundation.md
@@ -12,14 +12,6 @@ monochange_semver: minor
 
 #### add cross-ecosystem discovery and release planning foundation
 
-Introduce the first end-to-end release planning foundation for `monochange`.
-This change adds normalized package discovery across Cargo, npm/pnpm/Bun,
-Deno, Dart, and Flutter workspaces, along with shared core models for
-packages, dependency edges, version groups, change signals, and release
-plans.
+Introduce the first end-to-end release planning foundation for `monochange`. This change adds normalized package discovery across Cargo, npm/pnpm/Bun, Deno, Dart, and Flutter workspaces, along with shared core models for packages, dependency edges, version groups, change signals, and release plans.
 
-It also adds the initial planning engine that can take explicit change input,
-propagate bumps through dependency relationships, synchronize grouped package
-versions, and incorporate Rust semver evidence when present. The CLI now ties
-these pieces together so repository owners can discover a workspace, create
-change files, and compute a release plan from one consistent toolchain.
+It also adds the initial planning engine that can take explicit change input, propagate bumps through dependency relationships, synchronize grouped package versions, and incorporate Rust semver evidence when present. The CLI now ties these pieces together so repository owners can discover a workspace, create change files, and compute a release plan from one consistent toolchain.

--- a/.changeset/002-docs-and-guides.md
+++ b/.changeset/002-docs-and-guides.md
@@ -4,13 +4,6 @@ monochange: patch
 
 #### document discovery, release planning, and contributor workflow
 
-Expand the project documentation to make the first `monochange` milestone much
-more approachable for contributors and early adopters. This update adds and
-refines the mdBook guides, repository readme content, quickstart material, and
-supporting specification artifacts so the documented workflow matches the
-implemented CLI behavior.
+Expand the project documentation to make the first `monochange` milestone much more approachable for contributors and early adopters. This update adds and refines the mdBook guides, repository readme content, quickstart material, and supporting specification artifacts so the documented workflow matches the implemented CLI behavior.
 
-The updated docs explain how to configure `monochange.toml`, discover packages,
-create markdown changesets, inspect release plans, and understand version-group
-behavior across multiple ecosystems. Contributor-facing guidance was also
-improved so the local validation and development workflow is clearer.
+The updated docs explain how to configure `monochange.toml`, discover packages, create markdown changesets, inspect release plans, and understand version-group behavior across multiple ecosystems. Contributor-facing guidance was also improved so the local validation and development workflow is clearer.

--- a/.changeset/003-cli-and-docs-deploy.md
+++ b/.changeset/003-cli-and-docs-deploy.md
@@ -4,13 +4,6 @@ monochange: patch
 
 #### add CLI change-file scaffolding and deploy mdBook docs automatically
 
-Improve the CLI and documentation delivery workflow around the first feature
-slice. This change strengthens the `changes add` flow so teams can generate
-repo-native changesets directly from `monochange`, and it also rounds out the
-supporting tests that verify those generated files integrate correctly with
-release planning.
+Improve the CLI and documentation delivery workflow around the first feature slice. This change strengthens the `changes add` flow so teams can generate repo-native changesets directly from `monochange`, and it also rounds out the supporting tests that verify those generated files integrate correctly with release planning.
 
-In addition, the repository now builds and deploys the mdBook automatically on
-pushes to `main` and on published releases. That makes the user-facing guides
-available as part of the normal release workflow instead of depending on manual
-book publishing steps.
+In addition, the repository now builds and deploys the mdBook automatically on pushes to `main` and on published releases. That makes the user-facing guides available as part of the normal release workflow instead of depending on manual book publishing steps.

--- a/.changeset/004-package-changelog-config.md
+++ b/.changeset/004-package-changelog-config.md
@@ -12,12 +12,6 @@ monochange_semver: patch
 
 #### add synced package changelog configuration
 
-Add a real repository-level `monochange.toml` with explicit package-level
-release configuration. Each workspace crate now has a configured changelog
-location so release preparation can append release notes to the correct file
-instead of relying on implicit conventions.
+Add a real repository-level `monochange.toml` with explicit package-level release configuration. Each workspace crate now has a configured changelog location so release preparation can append release notes to the correct file instead of relying on implicit conventions.
 
-This change also defines a single synced version group for the releaseable
-workspace crates. With that configuration in place, releases can keep the core
-packages aligned on one shared version while still preserving per-package
-changelog output.
+This change also defines a single synced version group for the releaseable workspace crates. With that configuration in place, releases can keep the core packages aligned on one shared version while still preserving per-package changelog output.

--- a/.changeset/005-workflow-release.md
+++ b/.changeset/005-workflow-release.md
@@ -7,14 +7,6 @@ monochange_cargo: minor
 
 #### add workflow-driven release preparation
 
-Introduce config-defined workflows and the first built-in release-preparation
-workflow for `monochange`. Repositories can now declare a `release` workflow in
-`monochange.toml` and run it directly through `mc release` or
-`monochange release`, including support for `--dry-run` execution.
+Introduce config-defined workflows and the first built-in release-preparation workflow for `monochange`. Repositories can now declare a `release` workflow in `monochange.toml` and run it directly through `mc release` or `monochange release`, including support for `--dry-run` execution.
 
-The new workflow engine adds typed `PrepareRelease` and `Command` steps. The
-release preparation step discovers `.changeset/*.md`, computes the synced
-release plan, updates Cargo manifests and workspace versions, appends package
-changelog entries, and removes consumed changesets only after a successful run.
-Supporting docs and tests were updated so the workflow-driven flow is now the
-primary documented release path.
+The new workflow engine adds typed `PrepareRelease` and `Command` steps. The release preparation step discovers `.changeset/*.md`, computes the synced release plan, updates Cargo manifests and workspace versions, appends package changelog entries, and removes consumed changesets only after a successful run. Supporting docs and tests were updated so the workflow-driven flow is now the primary documented release path.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
         run: lint:format
         shell: devenv shell -- bash -e {0}
 
+      - name: check documentation sync
+        run: docs:check
+        shell: devenv shell -- bash -e {0}
+
       - name: cargo deny
         run: deny:check
         shell: devenv shell -- bash -e {0}
@@ -49,8 +53,12 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: run tests
-        run: test:all
+      - name: run cargo tests
+        run: test:cargo
+        shell: devenv shell -- bash -e {0}
+
+      - name: run doc tests
+        run: test:docs
         shell: devenv shell -- bash -e {0}
 
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.bin
 /result
 /.direnv
+/.mdt
 # Devenv
 .devenv*
 devenv.local.nix

--- a/.templates/crates.t.md
+++ b/.templates/crates.t.md
@@ -1,0 +1,199 @@
+<!-- {@monochangeCrateDocs} -->
+
+# `monochange`
+
+The `monochange` crate provides the end-user CLI.
+
+## Commands
+
+```bash
+mc workspace discover --root . --format json
+mc changes add --root . --package crates/monochange --bump patch --reason "describe the change"
+mc plan release --root . --changes .changeset/1234567890-crates-monochange.md --format json
+```
+
+## Responsibilities
+
+- aggregate all supported ecosystem adapters
+- load `monochange.toml`
+- resolve change input files
+- render discovery and release-plan output in text or JSON
+
+<!-- {/monochangeCrateDocs} -->
+
+<!-- {@monochangeCoreCrateDocs} -->
+
+# `monochange_core`
+
+Shared domain types for `monochange`.
+
+This crate defines:
+
+- normalized package and dependency records
+- version-group definitions and planned group outcomes
+- change signals and compatibility assessments
+- release-plan domain types
+- shared error and result types
+
+## Example
+
+```rust
+use monochange_core::Ecosystem;
+use monochange_core::PackageRecord;
+use monochange_core::PublishState;
+use semver::Version;
+use std::path::PathBuf;
+
+let package = PackageRecord::new(
+    Ecosystem::Cargo,
+    "demo",
+    PathBuf::from("crates/demo/Cargo.toml"),
+    PathBuf::from("."),
+    Some(Version::new(1, 2, 3)),
+    PublishState::Public,
+);
+
+assert_eq!(package.name, "demo");
+assert_eq!(package.current_version, Some(Version::new(1, 2, 3)));
+```
+
+<!-- {/monochangeCoreCrateDocs} -->
+
+<!-- {@monochangeCargoCrateDocs} -->
+
+# `monochange_cargo`
+
+Cargo ecosystem support for `monochange`.
+
+## Public entry points
+
+- `discover_cargo_packages(root)` discovers Cargo workspaces and standalone crates
+- `CargoAdapter` exposes the shared adapter interface
+- `RustSemverProvider` parses explicit Rust semver evidence from change input
+
+## Scope
+
+- Cargo workspace glob expansion
+- crate manifest parsing
+- normalized dependency extraction
+- Rust semver provider integration for release planning
+
+<!-- {/monochangeCargoCrateDocs} -->
+
+<!-- {@monochangeConfigCrateDocs} -->
+
+# `monochange_config`
+
+Configuration and change-input parsing for `monochange`.
+
+## Responsibilities
+
+- load `monochange.toml`
+- validate version groups and workflows
+- resolve package references against discovered packages
+- parse change-input files, evidence, and changelog overrides
+
+<!-- {/monochangeConfigCrateDocs} -->
+
+<!-- {@monochangeGraphCrateDocs} -->
+
+# `monochange_graph`
+
+Dependency-graph traversal and release propagation for `monochange`.
+
+## Responsibilities
+
+- build reverse dependency views
+- propagate release impact across direct and transitive dependents
+- synchronize version groups
+- calculate planned group versions
+
+<!-- {/monochangeGraphCrateDocs} -->
+
+<!-- {@monochangeNpmCrateDocs} -->
+
+# `monochange_npm`
+
+npm-family ecosystem support for `monochange`.
+
+## Public entry points
+
+- `discover_npm_packages(root)` discovers npm, pnpm, and Bun workspaces plus standalone packages
+- `NpmAdapter` exposes the shared adapter interface
+
+## Scope
+
+- `package.json` workspaces
+- `pnpm-workspace.yaml`
+- Bun lockfile detection
+- normalized dependency extraction
+
+<!-- {/monochangeNpmCrateDocs} -->
+
+<!-- {@monochangeDenoCrateDocs} -->
+
+# `monochange_deno`
+
+Deno ecosystem support for `monochange`.
+
+## Public entry points
+
+- `discover_deno_packages(root)` discovers Deno workspaces and standalone packages
+- `DenoAdapter` exposes the shared adapter interface
+
+## Scope
+
+- `deno.json` and `deno.jsonc`
+- workspace glob expansion
+- normalized dependency and import extraction
+
+<!-- {/monochangeDenoCrateDocs} -->
+
+<!-- {@monochangeDartCrateDocs} -->
+
+# `monochange_dart`
+
+Dart and Flutter ecosystem support for `monochange`.
+
+## Public entry points
+
+- `discover_dart_packages(root)` discovers Dart and Flutter workspaces plus standalone packages
+- `DartAdapter` exposes the shared adapter interface
+
+## Scope
+
+- `pubspec.yaml` workspace expansion
+- Dart package parsing
+- Flutter package detection
+- normalized dependency extraction
+
+<!-- {/monochangeDartCrateDocs} -->
+
+<!-- {@monochangeSemverCrateDocs} -->
+
+# `monochange_semver`
+
+Semver and compatibility helpers for `monochange`.
+
+## Responsibilities
+
+- collect compatibility assessments from providers
+- merge bump severities deterministically
+- calculate direct and propagated bump severities
+- provide a shared abstraction for ecosystem-specific compatibility providers
+
+## Example
+
+```rust
+use monochange_core::BumpSeverity;
+use monochange_semver::direct_release_severity;
+use monochange_semver::merge_severities;
+
+let merged = merge_severities(BumpSeverity::Patch, BumpSeverity::Minor);
+let direct = direct_release_severity(Some(BumpSeverity::Minor), None);
+
+assert_eq!(merged, BumpSeverity::Minor);
+assert_eq!(direct, BumpSeverity::Minor);
+```
+
+<!-- {/monochangeSemverCrateDocs} -->

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -1,0 +1,207 @@
+<!-- {@discoverySupportedSources} -->
+
+- Cargo workspaces and standalone crates
+- npm workspaces, pnpm workspaces, Bun workspaces, and standalone `package.json` packages
+- Deno workspaces and standalone `deno.json` / `deno.jsonc` packages
+- Dart and Flutter workspaces plus standalone `pubspec.yaml` packages
+
+<!-- {/discoverySupportedSources} -->
+
+<!-- {@discoveryKeyBehaviors} -->
+
+- native workspace globs are expanded by each ecosystem adapter
+- dependency names are normalized into one graph
+- version-group assignments are attached after discovery
+- unmatched group members and version mismatches produce warnings
+- discovery currently scans all supported ecosystems regardless of `[ecosystems.*]` toggles in `monochange.toml`
+
+<!-- {/discoveryKeyBehaviors} -->
+
+<!-- {@configurationDefaultsSnippet} -->
+
+```toml
+[defaults]
+parent_bump = "patch"
+include_private = false
+warn_on_group_mismatch = true
+```
+
+<!-- {/configurationDefaultsSnippet} -->
+
+<!-- {@configurationVersionGroupsSnippet} -->
+
+```toml
+[[version_groups]]
+name = "sdk"
+members = ["crates/sdk_core", "packages/web-sdk", "packages/mobile-sdk"]
+strategy = "shared"
+```
+
+<!-- {/configurationVersionGroupsSnippet} -->
+
+<!-- {@configurationPackageOverridesSnippet} -->
+
+```toml
+[[package_overrides]]
+package = "crates/sdk_core"
+changelog = "crates/sdk_core/CHANGELOG.md"
+
+[[package_overrides]]
+package = "packages/web-sdk"
+changelog = "packages/web-sdk/CHANGELOG.md"
+```
+
+<!-- {/configurationPackageOverridesSnippet} -->
+
+<!-- {@configurationWorkflowsSnippet} -->
+
+```toml
+[[workflows]]
+name = "release"
+
+[[workflows.steps]]
+type = "PrepareRelease"
+
+[[workflows.steps]]
+type = "Command"
+command = "printf '%s\n' '$version'"
+```
+
+<!-- {/configurationWorkflowsSnippet} -->
+
+<!-- {@configurationWorkflowVariables} -->
+
+- `$version` — one shared release version when all released packages resolve to the same version
+- `$group_version` — one shared synced version across released version groups, falling back to `$version`
+- `$released_packages` — comma-separated released package names
+- `$changed_files` — space-separated changed file paths
+- `$changesets` — space-separated consumed `.changeset/*.md` paths
+
+<!-- {/configurationWorkflowVariables} -->
+
+<!-- {@configurationEcosystemSettingsSnippet} -->
+
+```toml
+[ecosystems.cargo]
+enabled = true
+roots = ["crates/*"]
+exclude = ["crates/experimental/*"]
+
+[ecosystems.npm]
+enabled = true
+roots = ["packages/*"]
+exclude = ["packages/legacy/*"]
+
+[ecosystems.deno]
+enabled = true
+
+[ecosystems.dart]
+enabled = true
+```
+
+<!-- {/configurationEcosystemSettingsSnippet} -->
+
+<!-- {@configurationPackageReferenceRules} -->
+
+Package references may use package ids, package names, manifest-relative paths, or manifest-directory paths.
+
+<!-- {/configurationPackageReferenceRules} -->
+
+<!-- {@configurationCurrentStatus} -->
+
+Current implementation status:
+
+- actively used today: `defaults.parent_bump`, `defaults.warn_on_group_mismatch`, `version_groups`, `package_overrides.changelog`, and `workflows`
+- parsed but not currently enforced by discovery or planning: `defaults.include_private`, `version_groups.strategy`, and `[ecosystems.*].enabled/roots/exclude`
+- workflow names must be unique, must not collide with built-in commands, and must contain at least one step
+- supported workflow steps today: `PrepareRelease` and `Command`
+
+<!-- {/configurationCurrentStatus} -->
+
+<!-- {@versionGroupsExample} -->
+
+```toml
+[[version_groups]]
+name = "sdk"
+members = ["crates/sdk_core", "packages/web-sdk"]
+strategy = "shared"
+```
+
+<!-- {/versionGroupsExample} -->
+
+<!-- {@versionGroupsBehavior} -->
+
+- the highest required bump in the group wins
+- every member in the group receives that bump
+- one planned group version is calculated from the highest current member version
+- dependents of newly synced members still receive propagated parent bumps
+- unmatched members produce warnings during discovery
+- mismatched current versions produce warnings when `warn_on_group_mismatch = true`
+
+<!-- {/versionGroupsBehavior} -->
+
+<!-- {@versionGroupsCurrentStatus} -->
+
+`strategy` is parsed from config, but the current implementation always applies shared synchronized versioning behavior.
+
+<!-- {/versionGroupsCurrentStatus} -->
+
+<!-- {@releaseChangesAddCommand} -->
+
+```bash
+mc changes add --root . --package sdk_core --bump minor --reason "public API addition"
+```
+
+<!-- {/releaseChangesAddCommand} -->
+
+<!-- {@releaseManualChangesetExample} -->
+
+```markdown
+---
+sdk_core: minor
+---
+
+#### public API addition
+```
+
+<!-- {/releaseManualChangesetExample} -->
+
+<!-- {@releaseEvidenceExample} -->
+
+```markdown
+---
+sdk_core: patch
+origin:
+  sdk_core: direct-change
+evidence:
+  sdk_core:
+    - rust-semver:major:public API break detected
+---
+
+#### breaking API change
+```
+
+<!-- {/releaseEvidenceExample} -->
+
+<!-- {@releasePlanningRules} -->
+
+- `mc changes add` defaults `--bump` to `patch`
+- markdown change files require an explicit `patch`, `minor`, or `major` entry per package
+- dependents default to the configured `parent_bump`
+- Rust semver evidence can escalate both the changed crate and its dependents
+- version-group synchronization runs before final output is rendered
+
+<!-- {/releasePlanningRules} -->
+
+<!-- {@releaseWorkflowBehavior} -->
+
+Current `PrepareRelease` behavior:
+
+- reads `.changeset/*.md`
+- computes one synchronized release plan from discovered change files
+- updates Cargo package versions and Cargo workspace dependency versions when a release is applied
+- appends changelog sections only for packages configured through `[[package_overrides]]` with `changelog` paths
+- deletes consumed change files only after a successful non-dry-run execution
+- leaves the workspace untouched during `--dry-run`
+
+<!-- {/releaseWorkflowBehavior} -->

--- a/.templates/monochange.t.md
+++ b/.templates/monochange.t.md
@@ -1,0 +1,7 @@
+# monochange templates
+
+Shared documentation providers have been split into topical files:
+
+- `project.t.md` for repository-wide commands and setup
+- `guides.t.md` for end-user guide content
+- `crates.t.md` for crate README and crate-level Rust docs

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -1,0 +1,201 @@
+<!-- {@projectMilestoneCapabilities} -->
+
+- discover Cargo, npm/pnpm/Bun, Deno, Dart, and Flutter packages
+- normalize dependency edges across ecosystems
+- coordinate shared version groups from `monochange.toml`
+- compute release plans from explicit change input
+- run config-defined release workflows from `.changeset/*.md`
+- apply Rust semver evidence when provided
+- publish end-user documentation through the mdBook in `docs/`
+
+<!-- {/projectMilestoneCapabilities} -->
+
+<!-- {@repoDevEnvironmentSetupCode} -->
+
+```bash
+devenv shell
+install:all
+```
+
+<!-- {/repoDevEnvironmentSetupCode} -->
+
+<!-- {@repoCommonDevelopmentCommands} -->
+
+```bash
+monochange --help
+mc --help
+docs:check
+docs:update
+docs:verify
+docs:doctor
+lint:all
+test:all
+build:all
+build:book
+```
+
+<!-- {/repoCommonDevelopmentCommands} -->
+
+<!-- {@contributingCoreCommands} -->
+
+```bash
+monochange --help
+mc --help
+docs:check
+docs:update
+docs:verify
+docs:doctor
+mc changes add --root . --package crates/monochange --bump patch --reason "describe the change"
+lint:all
+test:all
+build:all
+build:book
+```
+
+<!-- {/contributingCoreCommands} -->
+
+<!-- {@projectSetupConfig} -->
+
+```toml
+[defaults]
+parent_bump = "patch"
+warn_on_group_mismatch = true
+
+[[version_groups]]
+name = "sdk"
+members = ["crates/sdk_core", "packages/web-sdk"]
+
+[[workflows]]
+name = "release"
+
+[[workflows.steps]]
+type = "PrepareRelease"
+```
+
+<!-- {/projectSetupConfig} -->
+
+<!-- {@projectSetupConfigNote} -->
+
+This is the smallest config needed to make `mc release` work in the current implementation.
+
+For changelog updates, add `[[package_overrides]]` entries with `changelog` paths. Discovery currently scans all supported ecosystems automatically; the top-level `[ecosystems.*]` settings are parsed today but are not yet used to filter discovery.
+
+<!-- {/projectSetupConfigNote} -->
+
+<!-- {@projectDiscoverCommand} -->
+
+```bash
+mc workspace discover --root . --format json
+```
+
+<!-- {/projectDiscoverCommand} -->
+
+<!-- {@projectDryRunCommand} -->
+
+```bash
+mc release --dry-run
+```
+
+<!-- {/projectDryRunCommand} -->
+
+<!-- {@projectPlanCommand} -->
+
+```bash
+mc plan release --root . --changes .changeset/my-change.md --format json
+```
+
+<!-- {/projectPlanCommand} -->
+
+<!-- {@projectReleaseCommand} -->
+
+```bash
+mc release
+```
+
+<!-- {/projectReleaseCommand} -->
+
+<!-- {@projectValidationCommands} -->
+
+```bash
+docs:verify
+lint:all
+test:all
+build:all
+build:book
+```
+
+<!-- {/projectValidationCommands} -->
+
+<!-- {@projectDiscoveryOutputIncludes} -->
+
+- normalized package records
+- dependency edges
+- version groups
+- warnings
+
+<!-- {/projectDiscoveryOutputIncludes} -->
+
+<!-- {@projectReleaseOutputIncludes} -->
+
+- per-package bump decisions
+- synchronized group outcomes
+- compatibility evidence
+- warnings and unresolved items
+
+<!-- {/projectReleaseOutputIncludes} -->
+
+<!-- {@projectCoreWorkflow} -->
+
+Create a `monochange.toml` file:
+
+```toml
+[defaults]
+parent_bump = "patch"
+warn_on_group_mismatch = true
+
+[[version_groups]]
+name = "sdk"
+members = ["crates/sdk_core", "packages/web-sdk"]
+
+[[workflows]]
+name = "release"
+
+[[workflows.steps]]
+type = "PrepareRelease"
+```
+
+This is the smallest config needed to make `mc release` work in the current implementation.
+
+For changelog updates, add `[[package_overrides]]` entries with `changelog` paths. Discovery currently scans all supported ecosystems automatically; the top-level `[ecosystems.*]` settings are parsed today but are not yet used to filter discovery.
+
+Discover the workspace:
+
+```bash
+mc workspace discover --root . --format json
+```
+
+Create a change file:
+
+```bash
+mc changes add --root . --package monochange --bump minor --reason "add release planning"
+```
+
+Preview the release workflow:
+
+```bash
+mc release --dry-run
+```
+
+Inspect the raw planner when needed:
+
+```bash
+mc plan release --root . --changes .changeset/my-change.md --format json
+```
+
+Prepare the release:
+
+```bash
+mc release
+```
+
+<!-- {/projectCoreWorkflow} -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,30 +6,50 @@ Thank you for contributing.
 
 This repository uses `devenv` for a reproducible shell.
 
-```sh
+<!-- {=repoDevEnvironmentSetupCode} -->
+
+```bash
 devenv shell
 install:all
 ```
+
+<!-- {/repoDevEnvironmentSetupCode} -->
+
+## Documentation workflow
+
+Shared documentation blocks live in `.templates/` and are synchronized with `mdt`.
+
+- edit provider blocks in `.templates/` when you want one change to update multiple docs
+- run `docs:update` after changing shared docs or consumer blocks
+- run `docs:check` before opening a PR to confirm everything is synchronized
 
 ## Expected workflow
 
 1. Create a feature branch from `main`.
 2. Write failing tests first for non-trivial behavior.
 3. Implement the smallest change that makes the tests pass.
-4. Update docs, READMEs, and fixtures when behavior changes.
+4. Update docs, READMEs, fixtures, and templates when behavior changes.
 5. Run the full local validation suite before opening a PR.
 
 ## Core commands
 
-```sh
+<!-- {=contributingCoreCommands} -->
+
+```bash
 monochange --help
 mc --help
+docs:check
+docs:update
+docs:verify
+docs:doctor
 mc changes add --root . --package crates/monochange --bump patch --reason "describe the change"
 lint:all
 test:all
 build:all
 build:book
 ```
+
+<!-- {/contributingCoreCommands} -->
 
 ## Product rules
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,6 @@ name = "monochange"
 version = "0.0.0"
 dependencies = [
  "clap",
- "doc-comment",
  "insta",
  "monochange_cargo",
  "monochange_config",
@@ -417,15 +416,20 @@ dependencies = [
  "doc-comment",
  "monochange",
  "monochange_cargo",
+ "monochange_config",
  "monochange_core",
+ "monochange_dart",
+ "monochange_deno",
+ "monochange_graph",
  "monochange_npm",
+ "monochange_semver",
+ "semver",
 ]
 
 [[package]]
 name = "monochange_cargo"
 version = "0.0.0"
 dependencies = [
- "doc-comment",
  "glob",
  "insta",
  "monochange_core",
@@ -444,7 +448,6 @@ dependencies = [
 name = "monochange_config"
 version = "0.0.0"
 dependencies = [
- "doc-comment",
  "insta",
  "monochange_core",
  "rstest",
@@ -461,7 +464,6 @@ dependencies = [
 name = "monochange_core"
 version = "0.0.0"
 dependencies = [
- "doc-comment",
  "insta",
  "rstest",
  "semver",
@@ -474,7 +476,6 @@ dependencies = [
 name = "monochange_dart"
 version = "0.0.0"
 dependencies = [
- "doc-comment",
  "glob",
  "insta",
  "monochange_core",
@@ -491,7 +492,6 @@ dependencies = [
 name = "monochange_deno"
 version = "0.0.0"
 dependencies = [
- "doc-comment",
  "glob",
  "insta",
  "monochange_core",
@@ -508,7 +508,6 @@ dependencies = [
 name = "monochange_graph"
 version = "0.0.0"
 dependencies = [
- "doc-comment",
  "insta",
  "monochange_core",
  "monochange_semver",
@@ -521,7 +520,6 @@ dependencies = [
 name = "monochange_npm"
 version = "0.0.0"
 dependencies = [
- "doc-comment",
  "glob",
  "insta",
  "monochange_core",
@@ -539,7 +537,6 @@ dependencies = [
 name = "monochange_semver"
 version = "0.0.0"
 dependencies = [
- "doc-comment",
  "insta",
  "monochange_core",
  "rstest",

--- a/crates/monochange/Cargo.toml
+++ b/crates/monochange/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/bin/mc.rs"
 
 [dependencies]
 clap = { workspace = true }
-doc-comment = { workspace = true }
 monochange_cargo = { workspace = true }
 monochange_config = { workspace = true }
 monochange_core = { workspace = true }

--- a/crates/monochange/readme.md
+++ b/crates/monochange/readme.md
@@ -1,4 +1,6 @@
-# monochange
+<!-- {=monochangeCrateDocs} -->
+
+# `monochange`
 
 The `monochange` crate provides the end-user CLI.
 
@@ -16,3 +18,5 @@ mc plan release --root . --changes .changeset/1234567890-crates-monochange.md --
 - load `monochange.toml`
 - resolve change input files
 - render discovery and release-plan output in text or JSON
+
+<!-- {/monochangeCrateDocs} -->

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -508,6 +508,48 @@ fn quickstart_and_docs_reference_the_same_core_commands() {
 	}
 }
 
+#[test]
+fn configuration_guide_calls_out_current_implementation_limits() {
+	let configuration_guide =
+		Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docs/src/guide/04-configuration.md");
+	let content = fs::read_to_string(configuration_guide)
+		.unwrap_or_else(|error| panic!("configuration guide: {error}"));
+
+	for expected in [
+		"`defaults.include_private`",
+		"`version_groups.strategy`",
+		"`[ecosystems.*].enabled/roots/exclude`",
+		"`package_overrides.changelog`",
+		"`PrepareRelease`",
+		"`Command`",
+	] {
+		assert!(
+			content.contains(expected),
+			"configuration guide missing `{expected}`"
+		);
+	}
+}
+
+#[test]
+fn release_planning_guide_describes_release_workflow_requirements() {
+	let release_guide =
+		Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docs/src/guide/06-release-planning.md");
+	let content =
+		fs::read_to_string(release_guide).unwrap_or_else(|error| panic!("release guide: {error}"));
+
+	for expected in [
+		"`mc release` only works when your config defines a workflow named `release`.",
+		"`[[package_overrides]]`",
+		"`.changeset/*.md`",
+		"`--dry-run`",
+	] {
+		assert!(
+			content.contains(expected),
+			"release planning guide missing `{expected}`"
+		);
+	}
+}
+
 fn assert_simple_release_pattern(
 	relative_fixture_root: &str,
 	package_reference: &str,

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -1,6 +1,25 @@
 #![deny(clippy::all)]
 
-doc_comment::doctest!("../readme.md");
+//! <!-- {=monochangeCrateDocs|trim|linePrefix:"//! ":true} -->
+//! # `monochange`
+//!
+//! The `monochange` crate provides the end-user CLI.
+//!
+//! ## Commands
+//!
+//! ```bash
+//! mc workspace discover --root . --format json
+//! mc changes add --root . --package crates/monochange --bump patch --reason "describe the change"
+//! mc plan release --root . --changes .changeset/1234567890-crates-monochange.md --format json
+//! ```
+//!
+//! ## Responsibilities
+//!
+//! - aggregate all supported ecosystem adapters
+//! - load `monochange.toml`
+//! - resolve change input files
+//! - render discovery and release-plan output in text or JSON
+//! <!-- {/monochangeCrateDocs} -->
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;

--- a/crates/monochange_cargo/Cargo.toml
+++ b/crates/monochange_cargo/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = { workspace = true }
 description = "Manage versions and releases for your multiplatform, multilanguage monorepo"
 
 [dependencies]
-doc-comment = { workspace = true }
 glob = { workspace = true }
 monochange_core = { workspace = true }
 monochange_semver = { workspace = true }

--- a/crates/monochange_cargo/readme.md
+++ b/crates/monochange_cargo/readme.md
@@ -1,4 +1,6 @@
-# monochange_cargo
+<!-- {=monochangeCargoCrateDocs} -->
+
+# `monochange_cargo`
 
 Cargo ecosystem support for `monochange`.
 
@@ -14,3 +16,5 @@ Cargo ecosystem support for `monochange`.
 - crate manifest parsing
 - normalized dependency extraction
 - Rust semver provider integration for release planning
+
+<!-- {/monochangeCargoCrateDocs} -->

--- a/crates/monochange_cargo/src/lib.rs
+++ b/crates/monochange_cargo/src/lib.rs
@@ -1,7 +1,24 @@
 #![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
-doc_comment::doctest!("../readme.md");
+//! <!-- {=monochangeCargoCrateDocs|trim|linePrefix:"//! ":true} -->
+//! # `monochange_cargo`
+//!
+//! Cargo ecosystem support for `monochange`.
+//!
+//! ## Public entry points
+//!
+//! - `discover_cargo_packages(root)` discovers Cargo workspaces and standalone crates
+//! - `CargoAdapter` exposes the shared adapter interface
+//! - `RustSemverProvider` parses explicit Rust semver evidence from change input
+//!
+//! ## Scope
+//!
+//! - Cargo workspace glob expansion
+//! - crate manifest parsing
+//! - normalized dependency extraction
+//! - Rust semver provider integration for release planning
+//! <!-- {/monochangeCargoCrateDocs} -->
 
 use std::collections::BTreeSet;
 use std::collections::HashSet;

--- a/crates/monochange_config/Cargo.toml
+++ b/crates/monochange_config/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = { workspace = true }
 description = "Configuration parsing and validation for monochange"
 
 [dependencies]
-doc-comment = { workspace = true }
 monochange_core = { workspace = true }
 serde = { workspace = true }
 serde_yaml_ng = { workspace = true }

--- a/crates/monochange_config/readme.md
+++ b/crates/monochange_config/readme.md
@@ -1,10 +1,14 @@
-# monochange_config
+<!-- {=monochangeConfigCrateDocs} -->
+
+# `monochange_config`
 
 Configuration and change-input parsing for `monochange`.
 
 ## Responsibilities
 
 - load `monochange.toml`
-- validate version groups
-- resolve group members against discovered packages
-- parse change-input files and resolve package references
+- validate version groups and workflows
+- resolve package references against discovered packages
+- parse change-input files, evidence, and changelog overrides
+
+<!-- {/monochangeConfigCrateDocs} -->

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -1,7 +1,18 @@
 #![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
-doc_comment::doctest!("../readme.md");
+//! <!-- {=monochangeConfigCrateDocs|trim|linePrefix:"//! ":true} -->
+//! # `monochange_config`
+//!
+//! Configuration and change-input parsing for `monochange`.
+//!
+//! ## Responsibilities
+//!
+//! - load `monochange.toml`
+//! - validate version groups and workflows
+//! - resolve package references against discovered packages
+//! - parse change-input files, evidence, and changelog overrides
+//! <!-- {/monochangeConfigCrateDocs} -->
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;

--- a/crates/monochange_core/Cargo.toml
+++ b/crates/monochange_core/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = { workspace = true }
 description = "Manage versions and releases for your multiplatform, multilanguage monorepo"
 
 [dependencies]
-doc-comment = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/monochange_core/readme.md
+++ b/crates/monochange_core/readme.md
@@ -1,4 +1,6 @@
-# monochange_core
+<!-- {=monochangeCoreCrateDocs} -->
+
+# `monochange_core`
 
 Shared domain types for `monochange`.
 
@@ -9,3 +11,27 @@ This crate defines:
 - change signals and compatibility assessments
 - release-plan domain types
 - shared error and result types
+
+## Example
+
+```rust
+use monochange_core::Ecosystem;
+use monochange_core::PackageRecord;
+use monochange_core::PublishState;
+use semver::Version;
+use std::path::PathBuf;
+
+let package = PackageRecord::new(
+    Ecosystem::Cargo,
+    "demo",
+    PathBuf::from("crates/demo/Cargo.toml"),
+    PathBuf::from("."),
+    Some(Version::new(1, 2, 3)),
+    PublishState::Public,
+);
+
+assert_eq!(package.name, "demo");
+assert_eq!(package.current_version, Some(Version::new(1, 2, 3)));
+```
+
+<!-- {/monochangeCoreCrateDocs} -->

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -1,7 +1,41 @@
 #![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
-doc_comment::doctest!("../readme.md");
+//! <!-- {=monochangeCoreCrateDocs|trim|linePrefix:"//! ":true} -->
+//! # `monochange_core`
+//!
+//! Shared domain types for `monochange`.
+//!
+//! This crate defines:
+//!
+//! - normalized package and dependency records
+//! - version-group definitions and planned group outcomes
+//! - change signals and compatibility assessments
+//! - release-plan domain types
+//! - shared error and result types
+//!
+//! ## Example
+//!
+//! ```rust
+//! use monochange_core::Ecosystem;
+//! use monochange_core::PackageRecord;
+//! use monochange_core::PublishState;
+//! use semver::Version;
+//! use std::path::PathBuf;
+//!
+//! let package = PackageRecord::new(
+//!     Ecosystem::Cargo,
+//!     "demo",
+//!     PathBuf::from("crates/demo/Cargo.toml"),
+//!     PathBuf::from("."),
+//!     Some(Version::new(1, 2, 3)),
+//!     PublishState::Public,
+//! );
+//!
+//! assert_eq!(package.name, "demo");
+//! assert_eq!(package.current_version, Some(Version::new(1, 2, 3)));
+//! ```
+//! <!-- {/monochangeCoreCrateDocs} -->
 
 use std::collections::BTreeMap;
 use std::fmt;

--- a/crates/monochange_dart/Cargo.toml
+++ b/crates/monochange_dart/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = { workspace = true }
 description = "Dart and Flutter workspace discovery for monochange"
 
 [dependencies]
-doc-comment = { workspace = true }
 glob = { workspace = true }
 monochange_core = { workspace = true }
 semver = { workspace = true }

--- a/crates/monochange_dart/readme.md
+++ b/crates/monochange_dart/readme.md
@@ -1,4 +1,6 @@
-# monochange_dart
+<!-- {=monochangeDartCrateDocs} -->
+
+# `monochange_dart`
 
 Dart and Flutter ecosystem support for `monochange`.
 
@@ -13,3 +15,5 @@ Dart and Flutter ecosystem support for `monochange`.
 - Dart package parsing
 - Flutter package detection
 - normalized dependency extraction
+
+<!-- {/monochangeDartCrateDocs} -->

--- a/crates/monochange_dart/src/lib.rs
+++ b/crates/monochange_dart/src/lib.rs
@@ -1,7 +1,23 @@
 #![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
-doc_comment::doctest!("../readme.md");
+//! <!-- {=monochangeDartCrateDocs|trim|linePrefix:"//! ":true} -->
+//! # `monochange_dart`
+//!
+//! Dart and Flutter ecosystem support for `monochange`.
+//!
+//! ## Public entry points
+//!
+//! - `discover_dart_packages(root)` discovers Dart and Flutter workspaces plus standalone packages
+//! - `DartAdapter` exposes the shared adapter interface
+//!
+//! ## Scope
+//!
+//! - `pubspec.yaml` workspace expansion
+//! - Dart package parsing
+//! - Flutter package detection
+//! - normalized dependency extraction
+//! <!-- {/monochangeDartCrateDocs} -->
 
 use std::collections::BTreeSet;
 use std::collections::HashSet;

--- a/crates/monochange_deno/Cargo.toml
+++ b/crates/monochange_deno/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = { workspace = true }
 description = "Deno workspace and package discovery for monochange"
 
 [dependencies]
-doc-comment = { workspace = true }
 glob = { workspace = true }
 monochange_core = { workspace = true }
 semver = { workspace = true }

--- a/crates/monochange_deno/readme.md
+++ b/crates/monochange_deno/readme.md
@@ -1,4 +1,6 @@
-# monochange_deno
+<!-- {=monochangeDenoCrateDocs} -->
+
+# `monochange_deno`
 
 Deno ecosystem support for `monochange`.
 
@@ -12,3 +14,5 @@ Deno ecosystem support for `monochange`.
 - `deno.json` and `deno.jsonc`
 - workspace glob expansion
 - normalized dependency and import extraction
+
+<!-- {/monochangeDenoCrateDocs} -->

--- a/crates/monochange_deno/src/lib.rs
+++ b/crates/monochange_deno/src/lib.rs
@@ -1,7 +1,22 @@
 #![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
-doc_comment::doctest!("../readme.md");
+//! <!-- {=monochangeDenoCrateDocs|trim|linePrefix:"//! ":true} -->
+//! # `monochange_deno`
+//!
+//! Deno ecosystem support for `monochange`.
+//!
+//! ## Public entry points
+//!
+//! - `discover_deno_packages(root)` discovers Deno workspaces and standalone packages
+//! - `DenoAdapter` exposes the shared adapter interface
+//!
+//! ## Scope
+//!
+//! - `deno.json` and `deno.jsonc`
+//! - workspace glob expansion
+//! - normalized dependency and import extraction
+//! <!-- {/monochangeDenoCrateDocs} -->
 
 use std::collections::BTreeSet;
 use std::collections::HashSet;

--- a/crates/monochange_graph/Cargo.toml
+++ b/crates/monochange_graph/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = { workspace = true }
 description = "Dependency graph and propagation logic for monochange"
 
 [dependencies]
-doc-comment = { workspace = true }
 monochange_core = { workspace = true }
 monochange_semver = { workspace = true }
 

--- a/crates/monochange_graph/readme.md
+++ b/crates/monochange_graph/readme.md
@@ -1,4 +1,6 @@
-# monochange_graph
+<!-- {=monochangeGraphCrateDocs} -->
+
+# `monochange_graph`
 
 Dependency-graph traversal and release propagation for `monochange`.
 
@@ -8,3 +10,5 @@ Dependency-graph traversal and release propagation for `monochange`.
 - propagate release impact across direct and transitive dependents
 - synchronize version groups
 - calculate planned group versions
+
+<!-- {/monochangeGraphCrateDocs} -->

--- a/crates/monochange_graph/src/lib.rs
+++ b/crates/monochange_graph/src/lib.rs
@@ -1,7 +1,18 @@
 #![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
-doc_comment::doctest!("../readme.md");
+//! <!-- {=monochangeGraphCrateDocs|trim|linePrefix:"//! ":true} -->
+//! # `monochange_graph`
+//!
+//! Dependency-graph traversal and release propagation for `monochange`.
+//!
+//! ## Responsibilities
+//!
+//! - build reverse dependency views
+//! - propagate release impact across direct and transitive dependents
+//! - synchronize version groups
+//! - calculate planned group versions
+//! <!-- {/monochangeGraphCrateDocs} -->
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;

--- a/crates/monochange_npm/Cargo.toml
+++ b/crates/monochange_npm/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = { workspace = true }
 description = "Manage versions and releases for your multiplatform, multilanguage monorepo"
 
 [dependencies]
-doc-comment = { workspace = true }
 glob = { workspace = true }
 monochange_core = { workspace = true }
 semver = { workspace = true }

--- a/crates/monochange_npm/readme.md
+++ b/crates/monochange_npm/readme.md
@@ -1,4 +1,6 @@
-# monochange_npm
+<!-- {=monochangeNpmCrateDocs} -->
+
+# `monochange_npm`
 
 npm-family ecosystem support for `monochange`.
 
@@ -13,3 +15,5 @@ npm-family ecosystem support for `monochange`.
 - `pnpm-workspace.yaml`
 - Bun lockfile detection
 - normalized dependency extraction
+
+<!-- {/monochangeNpmCrateDocs} -->

--- a/crates/monochange_npm/src/lib.rs
+++ b/crates/monochange_npm/src/lib.rs
@@ -1,7 +1,23 @@
 #![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
-doc_comment::doctest!("../readme.md");
+//! <!-- {=monochangeNpmCrateDocs|trim|linePrefix:"//! ":true} -->
+//! # `monochange_npm`
+//!
+//! npm-family ecosystem support for `monochange`.
+//!
+//! ## Public entry points
+//!
+//! - `discover_npm_packages(root)` discovers npm, pnpm, and Bun workspaces plus standalone packages
+//! - `NpmAdapter` exposes the shared adapter interface
+//!
+//! ## Scope
+//!
+//! - `package.json` workspaces
+//! - `pnpm-workspace.yaml`
+//! - Bun lockfile detection
+//! - normalized dependency extraction
+//! <!-- {/monochangeNpmCrateDocs} -->
 
 use std::collections::BTreeSet;
 use std::collections::HashSet;

--- a/crates/monochange_semver/Cargo.toml
+++ b/crates/monochange_semver/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = { workspace = true }
 description = "Compatibility and semver helpers for monochange"
 
 [dependencies]
-doc-comment = { workspace = true }
 monochange_core = { workspace = true }
 
 [dev-dependencies]

--- a/crates/monochange_semver/readme.md
+++ b/crates/monochange_semver/readme.md
@@ -1,4 +1,6 @@
-# monochange_semver
+<!-- {=monochangeSemverCrateDocs} -->
+
+# `monochange_semver`
 
 Semver and compatibility helpers for `monochange`.
 
@@ -8,3 +10,19 @@ Semver and compatibility helpers for `monochange`.
 - merge bump severities deterministically
 - calculate direct and propagated bump severities
 - provide a shared abstraction for ecosystem-specific compatibility providers
+
+## Example
+
+```rust
+use monochange_core::BumpSeverity;
+use monochange_semver::direct_release_severity;
+use monochange_semver::merge_severities;
+
+let merged = merge_severities(BumpSeverity::Patch, BumpSeverity::Minor);
+let direct = direct_release_severity(Some(BumpSeverity::Minor), None);
+
+assert_eq!(merged, BumpSeverity::Minor);
+assert_eq!(direct, BumpSeverity::Minor);
+```
+
+<!-- {/monochangeSemverCrateDocs} -->

--- a/crates/monochange_semver/src/lib.rs
+++ b/crates/monochange_semver/src/lib.rs
@@ -1,7 +1,32 @@
 #![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
-doc_comment::doctest!("../readme.md");
+//! <!-- {=monochangeSemverCrateDocs|trim|linePrefix:"//! ":true} -->
+//! # `monochange_semver`
+//!
+//! Semver and compatibility helpers for `monochange`.
+//!
+//! ## Responsibilities
+//!
+//! - collect compatibility assessments from providers
+//! - merge bump severities deterministically
+//! - calculate direct and propagated bump severities
+//! - provide a shared abstraction for ecosystem-specific compatibility providers
+//!
+//! ## Example
+//!
+//! ```rust
+//! use monochange_core::BumpSeverity;
+//! use monochange_semver::direct_release_severity;
+//! use monochange_semver::merge_severities;
+//!
+//! let merged = merge_severities(BumpSeverity::Patch, BumpSeverity::Minor);
+//! let direct = direct_release_severity(Some(BumpSeverity::Minor), None);
+//!
+//! assert_eq!(merged, BumpSeverity::Minor);
+//! assert_eq!(direct, BumpSeverity::Minor);
+//! ```
+//! <!-- {/monochangeSemverCrateDocs} -->
 
 use monochange_core::BumpSeverity;
 use monochange_core::ChangeSignal;

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1774475276,
-        "narHash": "sha256-z4erC+oMEuBHtox+B46FCv77IPvNy4SyXw/EeBxsD4I=",
+        "lastModified": 1774763318,
+        "narHash": "sha256-fLlQQ1BGiJ8oDhTDrPW/X3jAGqKiL6CbJSvEtdDxHDk=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "f8ca2c061ec2feceee1cf1c5e52c92f58b6aec9c",
+        "rev": "177d0848dc5f1de11796e0ae3183af6d456c5246",
         "type": "github"
       },
       "original": {
@@ -17,13 +17,50 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "ifiokjr-nixpkgs": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1774765190,
+        "narHash": "sha256-OsFRKKtCql+/yvvllcpKlPoC8W5b+UXjjKtiVkbmXaI=",
+        "owner": "ifiokjr",
+        "repo": "nixpkgs",
+        "rev": "39a30edd238ab040d6fe5acf94e348362871f3aa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ifiokjr",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774273680,
-        "narHash": "sha256-a++tZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA=",
+        "lastModified": 1774610258,
+        "narHash": "sha256-HaThtroVD9wRdx7KQk0B75JmFcXlMUoEdDFNOMOlsOs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fdc7b8f7b30fdbedec91b71ed82f36e1637483ed",
+        "rev": "832efc09b4caf6b4569fbf9dc01bec3082a00611",
         "type": "github"
       },
       "original": {
@@ -34,6 +71,22 @@
       }
     },
     "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1774610258,
+        "narHash": "sha256-HaThtroVD9wRdx7KQk0B75JmFcXlMUoEdDFNOMOlsOs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "832efc09b4caf6b4569fbf9dc01bec3082a00611",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1744536153,
         "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
@@ -52,25 +105,41 @@
     "root": {
       "inputs": {
         "devenv": "devenv",
-        "nixpkgs": "nixpkgs",
+        "ifiokjr-nixpkgs": "ifiokjr-nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1774494762,
-        "narHash": "sha256-lt22GCJZ6qBQLgNZZl3S/RUjTLXTlEy0Fn0sqMttLxQ=",
+        "lastModified": 1774753967,
+        "narHash": "sha256-HpT5fE8JQSbAxolUnw3VgGAo3urVjcrgtB2rtoxURVw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "ce3b3a61ebf28670dfc8b97eb35ed9e24474a2cf",
+        "rev": "405b9b4c2c6c5a2b1d390524ce8a240729f34a96",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,5 +1,13 @@
-{ pkgs, lib, ... }:
+{
+  pkgs,
+  lib,
+  inputs,
+  ...
+}:
 
+let
+  extra = inputs.ifiokjr-nixpkgs.packages.${pkgs.stdenv.system};
+in
 {
   packages =
     with pkgs;
@@ -8,6 +16,7 @@
       cargo-run-bin
       deno
       dprint
+      extra.mdt
       mdbook
       nixfmt
       rustup
@@ -21,6 +30,8 @@
     set -e
     rustup toolchain install nightly --component rustfmt --no-self-update 2>/dev/null || true
     rustup update stable --no-self-update 2>/dev/null || true
+
+    export PATH="$DEVENV_ROOT/scripts:$PATH"
   '';
 
   # disable dotenv since it breaks the variable interpolation supported by `direnv`
@@ -93,8 +104,8 @@
     "test:all" = {
       exec = ''
         set -e
-        cargo nextest run --workspace --all-features --no-tests pass
-        cargo test --doc --workspace --all-features
+        test:cargo
+        test:docs
       '';
       description = "Run all tests across the crates.";
       binary = "bash";
@@ -127,6 +138,7 @@
       exec = ''
         set -e
         fix:clippy
+        docs:update
         fix:format
       '';
       description = "Fix all autofixable problems.";
@@ -162,6 +174,7 @@
         lint:clippy
         lint:format
         deny:check
+        docs:check
       '';
       description = "Run all checks.";
       binary = "bash";
@@ -180,6 +193,22 @@
         cargo clippy --workspace --all-features --all-targets
       '';
       description = "Check that all rust lints are passing.";
+      binary = "bash";
+    };
+    "docs:check" = {
+      exec = ''
+        set -e
+        mdt check
+      '';
+      description = "Check that shared documentation blocks are synchronized.";
+      binary = "bash";
+    };
+    "docs:update" = {
+      exec = ''
+        set -e
+        mdt update
+      '';
+      description = "Update shared documentation blocks across markdown and source files.";
       binary = "bash";
     };
     "snapshot:review" = {

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -6,6 +6,8 @@ inputs:
     url: github:oxalica/rust-overlay
     overlays:
       - default
+  ifiokjr-nixpkgs:
+    url: github:ifiokjr/nixpkgs
 
 # If you're using non-OSS software, you can set allowUnfree to true.
 allowUnfree: true

--- a/docs/Cargo.toml
+++ b/docs/Cargo.toml
@@ -8,8 +8,14 @@ publish = false
 doc-comment = { workspace = true }
 monochange = { workspace = true }
 monochange_cargo = { workspace = true }
+monochange_config = { workspace = true }
 monochange_core = { workspace = true }
+monochange_dart = { workspace = true }
+monochange_deno = { workspace = true }
+monochange_graph = { workspace = true }
 monochange_npm = { workspace = true }
+monochange_semver = { workspace = true }
+semver = { workspace = true }
 
 [lints]
 workspace = true

--- a/docs/src/guide/01-installation.md
+++ b/docs/src/guide/01-installation.md
@@ -4,21 +4,33 @@
 
 ## Repository development
 
+<!-- {=repoDevEnvironmentSetupCode} -->
+
 ```bash
 devenv shell
 install:all
 ```
 
+<!-- {/repoDevEnvironmentSetupCode} -->
+
 Useful commands:
+
+<!-- {=repoCommonDevelopmentCommands} -->
 
 ```bash
 monochange --help
 mc --help
+docs:check
+docs:update
+docs:verify
+docs:doctor
 lint:all
 test:all
 build:all
 build:book
 ```
+
+<!-- {/repoCommonDevelopmentCommands} -->
 
 ## CLI names
 

--- a/docs/src/guide/02-setup.md
+++ b/docs/src/guide/02-setup.md
@@ -2,31 +2,40 @@
 
 Add a `monochange.toml` file at the repository root.
 
+<!-- {=projectSetupConfig} -->
+
 ```toml
 [defaults]
 parent_bump = "patch"
-include_private = false
 warn_on_group_mismatch = true
 
 [[version_groups]]
 name = "sdk"
 members = ["crates/sdk_core", "packages/web-sdk"]
 
-[ecosystems.cargo]
-enabled = true
+[[workflows]]
+name = "release"
 
-[ecosystems.npm]
-enabled = true
-
-[ecosystems.deno]
-enabled = true
-
-[ecosystems.dart]
-enabled = true
+[[workflows.steps]]
+type = "PrepareRelease"
 ```
 
+<!-- {/projectSetupConfig} -->
+
+<!-- {=projectSetupConfigNote} -->
+
+This is the smallest config needed to make `mc release` work in the current implementation.
+
+For changelog updates, add `[[package_overrides]]` entries with `changelog` paths. Discovery currently scans all supported ecosystems automatically; the top-level `[ecosystems.*]` settings are parsed today but are not yet used to filter discovery.
+
+<!-- {/projectSetupConfigNote} -->
+
 Then verify discovery:
+
+<!-- {=projectDiscoverCommand} -->
 
 ```bash
 mc workspace discover --root . --format json
 ```
+
+<!-- {/projectDiscoverCommand} -->

--- a/docs/src/guide/03-discovery.md
+++ b/docs/src/guide/03-discovery.md
@@ -4,20 +4,33 @@
 
 Supported sources in this milestone:
 
+<!-- {=discoverySupportedSources} -->
+
 - Cargo workspaces and standalone crates
 - npm workspaces, pnpm workspaces, Bun workspaces, and standalone `package.json` packages
 - Deno workspaces and standalone `deno.json` / `deno.jsonc` packages
 - Dart and Flutter workspaces plus standalone `pubspec.yaml` packages
 
+<!-- {/discoverySupportedSources} -->
+
 Run discovery:
+
+<!-- {=projectDiscoverCommand} -->
 
 ```bash
 mc workspace discover --root . --format json
 ```
 
+<!-- {/projectDiscoverCommand} -->
+
 Key behaviors:
 
-- workspace globs are expanded by each ecosystem adapter
+<!-- {=discoveryKeyBehaviors} -->
+
+- native workspace globs are expanded by each ecosystem adapter
 - dependency names are normalized into one graph
 - version-group assignments are attached after discovery
 - unmatched group members and version mismatches produce warnings
+- discovery currently scans all supported ecosystems regardless of `[ecosystems.*]` toggles in `monochange.toml`
+
+<!-- {/discoveryKeyBehaviors} -->

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -4,6 +4,8 @@ Repository configuration lives in `monochange.toml`.
 
 ## Defaults
 
+<!-- {=configurationDefaultsSnippet} -->
+
 ```toml
 [defaults]
 parent_bump = "patch"
@@ -11,23 +13,87 @@ include_private = false
 warn_on_group_mismatch = true
 ```
 
+<!-- {/configurationDefaultsSnippet} -->
+
 ## Version groups
+
+<!-- {=configurationVersionGroupsSnippet} -->
 
 ```toml
 [[version_groups]]
 name = "sdk"
 members = ["crates/sdk_core", "packages/web-sdk", "packages/mobile-sdk"]
+strategy = "shared"
 ```
 
-## Ecosystem switches
+<!-- {/configurationVersionGroupsSnippet} -->
+
+## Package overrides
+
+`package_overrides` currently let you point released packages at changelog files that should be updated by `PrepareRelease`.
+
+<!-- {=configurationPackageOverridesSnippet} -->
+
+```toml
+[[package_overrides]]
+package = "crates/sdk_core"
+changelog = "crates/sdk_core/CHANGELOG.md"
+
+[[package_overrides]]
+package = "packages/web-sdk"
+changelog = "packages/web-sdk/CHANGELOG.md"
+```
+
+<!-- {/configurationPackageOverridesSnippet} -->
+
+## Workflows
+
+Workflows are user-defined top-level commands. In this milestone, a workflow name such as `release` becomes invocable as `mc release`.
+
+<!-- {=configurationWorkflowsSnippet} -->
+
+```toml
+[[workflows]]
+name = "release"
+
+[[workflows.steps]]
+type = "PrepareRelease"
+
+[[workflows.steps]]
+type = "Command"
+command = "printf '%s\n' '$version'"
+```
+
+<!-- {/configurationWorkflowsSnippet} -->
+
+Workflow command interpolation variables:
+
+<!-- {=configurationWorkflowVariables} -->
+
+- `$version` — one shared release version when all released packages resolve to the same version
+- `$group_version` — one shared synced version across released version groups, falling back to `$version`
+- `$released_packages` — comma-separated released package names
+- `$changed_files` — space-separated changed file paths
+- `$changesets` — space-separated consumed `.changeset/*.md` paths
+
+<!-- {/configurationWorkflowVariables} -->
+
+## Ecosystem settings
+
+These settings are parsed from config and document intended control points for discovery:
+
+<!-- {=configurationEcosystemSettingsSnippet} -->
 
 ```toml
 [ecosystems.cargo]
 enabled = true
+roots = ["crates/*"]
+exclude = ["crates/experimental/*"]
 
 [ecosystems.npm]
 enabled = true
 roots = ["packages/*"]
+exclude = ["packages/legacy/*"]
 
 [ecosystems.deno]
 enabled = true
@@ -36,4 +102,25 @@ enabled = true
 enabled = true
 ```
 
+<!-- {/configurationEcosystemSettingsSnippet} -->
+
+## Package references
+
+<!-- {=configurationPackageReferenceRules} -->
+
 Package references may use package ids, package names, manifest-relative paths, or manifest-directory paths.
+
+<!-- {/configurationPackageReferenceRules} -->
+
+## Current status
+
+<!-- {=configurationCurrentStatus} -->
+
+Current implementation status:
+
+- actively used today: `defaults.parent_bump`, `defaults.warn_on_group_mismatch`, `version_groups`, `package_overrides.changelog`, and `workflows`
+- parsed but not currently enforced by discovery or planning: `defaults.include_private`, `version_groups.strategy`, and `[ecosystems.*].enabled/roots/exclude`
+- workflow names must be unique, must not collide with built-in commands, and must contain at least one step
+- supported workflow steps today: `PrepareRelease` and `Command`
+
+<!-- {/configurationCurrentStatus} -->

--- a/docs/src/guide/05-version-groups.md
+++ b/docs/src/guide/05-version-groups.md
@@ -2,15 +2,32 @@
 
 A version group forces multiple packages to share one planned version.
 
+<!-- {=versionGroupsExample} -->
+
 ```toml
 [[version_groups]]
 name = "sdk"
-members = ["cargo/sdk-core", "packages/web-sdk"]
+members = ["crates/sdk_core", "packages/web-sdk"]
+strategy = "shared"
 ```
 
+<!-- {/versionGroupsExample} -->
+
 When any member releases:
+
+<!-- {=versionGroupsBehavior} -->
 
 - the highest required bump in the group wins
 - every member in the group receives that bump
 - one planned group version is calculated from the highest current member version
 - dependents of newly synced members still receive propagated parent bumps
+- unmatched members produce warnings during discovery
+- mismatched current versions produce warnings when `warn_on_group_mismatch = true`
+
+<!-- {/versionGroupsBehavior} -->
+
+<!-- {=versionGroupsCurrentStatus} -->
+
+`strategy` is parsed from config, but the current implementation always applies shared synchronized versioning behavior.
+
+<!-- {/versionGroupsCurrentStatus} -->

--- a/docs/src/guide/06-release-planning.md
+++ b/docs/src/guide/06-release-planning.md
@@ -2,11 +2,17 @@
 
 Create a change input file with the CLI:
 
+<!-- {=releaseChangesAddCommand} -->
+
 ```bash
 mc changes add --root . --package sdk_core --bump minor --reason "public API addition"
 ```
 
+<!-- {/releaseChangesAddCommand} -->
+
 Or write one manually:
+
+<!-- {=releaseManualChangesetExample} -->
 
 ```markdown
 ---
@@ -16,11 +22,17 @@ sdk_core: minor
 #### public API addition
 ```
 
-Optionally include Rust semver evidence:
+<!-- {/releaseManualChangesetExample} -->
+
+Optionally include Rust semver evidence and explicit origins in markdown frontmatter:
+
+<!-- {=releaseEvidenceExample} -->
 
 ```markdown
 ---
 sdk_core: patch
+origin:
+  sdk_core: direct-change
 evidence:
   sdk_core:
     - rust-semver:major:public API break detected
@@ -29,24 +41,61 @@ evidence:
 #### breaking API change
 ```
 
+<!-- {/releaseEvidenceExample} -->
+
 Generate a plan directly when you want to inspect the raw planner output:
+
+<!-- {=projectPlanCommand} -->
 
 ```bash
 mc plan release --root . --changes .changeset/my-change.md --format json
 ```
 
+<!-- {/projectPlanCommand} -->
+
 Preferred repository workflow:
+
+<!-- {=projectDryRunCommand} -->
 
 ```bash
 mc release --dry-run
+```
+
+<!-- {/projectDryRunCommand} -->
+
+<!-- {=projectReleaseCommand} -->
+
+```bash
 mc release
 ```
 
-The workflow reads `.changeset/*.md`, computes the synced release, updates manifests, appends per-package changelog entries, and deletes consumed changesets only after a successful run.
+<!-- {/projectReleaseCommand} -->
 
 Planning rules in this milestone:
 
-- direct changes default to `patch` when no explicit bump is supplied
+<!-- {=releasePlanningRules} -->
+
+- `mc changes add` defaults `--bump` to `patch`
+- markdown change files require an explicit `patch`, `minor`, or `major` entry per package
 - dependents default to the configured `parent_bump`
 - Rust semver evidence can escalate both the changed crate and its dependents
 - version-group synchronization runs before final output is rendered
+
+<!-- {/releasePlanningRules} -->
+
+## PrepareRelease workflow behavior
+
+`mc release` only works when your config defines a workflow named `release`.
+
+<!-- {=releaseWorkflowBehavior} -->
+
+Current `PrepareRelease` behavior:
+
+- reads `.changeset/*.md`
+- computes one synchronized release plan from discovered change files
+- updates Cargo package versions and Cargo workspace dependency versions when a release is applied
+- appends changelog sections only for packages configured through `[[package_overrides]]` with `changelog` paths
+- deletes consumed change files only after a successful non-dry-run execution
+- leaves the workspace untouched during `--dry-run`
+
+<!-- {/releaseWorkflowBehavior} -->

--- a/docs/src/lib.rs
+++ b/docs/src/lib.rs
@@ -1,5 +1,16 @@
-doc_comment::doctest!("readme.md");
+doc_comment::doctest!("../../readme.md");
+doc_comment::doctest!("../../CONTRIBUTING.md");
+doc_comment::doctest!("../../crates/monochange/readme.md");
+doc_comment::doctest!("../../crates/monochange_core/readme.md");
+doc_comment::doctest!("../../crates/monochange_cargo/readme.md");
+doc_comment::doctest!("../../crates/monochange_config/readme.md");
+doc_comment::doctest!("../../crates/monochange_graph/readme.md");
+doc_comment::doctest!("../../crates/monochange_npm/readme.md");
+doc_comment::doctest!("../../crates/monochange_deno/readme.md");
+doc_comment::doctest!("../../crates/monochange_dart/readme.md");
+doc_comment::doctest!("../../crates/monochange_semver/readme.md");
 
+doc_comment::doctest!("readme.md");
 doc_comment::doctest!("guide/01-installation.md");
 doc_comment::doctest!("guide/02-setup.md");
 doc_comment::doctest!("guide/03-discovery.md");

--- a/docs/src/readme.md
+++ b/docs/src/readme.md
@@ -4,21 +4,28 @@
 
 The first milestone focuses on:
 
-- discovering packages across Cargo, npm/pnpm/Bun, Deno, Dart, and Flutter
-- building one normalized dependency graph
-- coordinating shared version groups
-- planning transitive releases from explicit change input
-- preparing releases through config-defined workflows
-- surfacing Rust semver evidence when provided
+<!-- {=projectMilestoneCapabilities} -->
+
+- discover Cargo, npm/pnpm/Bun, Deno, Dart, and Flutter packages
+- normalize dependency edges across ecosystems
+- coordinate shared version groups from `monochange.toml`
+- compute release plans from explicit change input
+- run config-defined release workflows from `.changeset/*.md`
+- apply Rust semver evidence when provided
+- publish end-user documentation through the mdBook in `docs/`
+
+<!-- {/projectMilestoneCapabilities} -->
 
 ## Core workflow
+
+<!-- {=projectCoreWorkflow} -->
 
 Create a `monochange.toml` file:
 
 ```toml
 [defaults]
 parent_bump = "patch"
-include_private = false
+warn_on_group_mismatch = true
 
 [[version_groups]]
 name = "sdk"
@@ -30,6 +37,10 @@ name = "release"
 [[workflows.steps]]
 type = "PrepareRelease"
 ```
+
+This is the smallest config needed to make `mc release` work in the current implementation.
+
+For changelog updates, add `[[package_overrides]]` entries with `changelog` paths. Discovery currently scans all supported ecosystems automatically; the top-level `[ecosystems.*]` settings are parsed today but are not yet used to filter discovery.
 
 Discover the workspace:
 
@@ -61,27 +72,42 @@ Prepare the release:
 mc release
 ```
 
+<!-- {/projectCoreWorkflow} -->
+
 Validate the repository:
 
+<!-- {=projectValidationCommands} -->
+
 ```bash
+docs:verify
 lint:all
 test:all
 build:all
 build:book
 ```
 
+<!-- {/projectValidationCommands} -->
+
 ## What the JSON output includes
 
 Discovery output includes:
+
+<!-- {=projectDiscoveryOutputIncludes} -->
 
 - normalized package records
 - dependency edges
 - version groups
 - warnings
 
+<!-- {/projectDiscoveryOutputIncludes} -->
+
 Release-plan output includes:
+
+<!-- {=projectReleaseOutputIncludes} -->
 
 - per-package bump decisions
 - synchronized group outcomes
 - compatibility evidence
 - warnings and unresolved items
+
+<!-- {/projectReleaseOutputIncludes} -->

--- a/mdt.toml
+++ b/mdt.toml
@@ -1,0 +1,10 @@
+[templates]
+paths = [".templates"]
+
+[padding]
+before = 0
+after = 0
+
+[exclude]
+patterns = ["docs/book/"]
+markdown_codeblocks = true

--- a/readme.md
+++ b/readme.md
@@ -6,31 +6,39 @@
 
 Current milestone capabilities:
 
+<!-- {=projectMilestoneCapabilities} -->
+
 - discover Cargo, npm/pnpm/Bun, Deno, Dart, and Flutter packages
 - normalize dependency edges across ecosystems
 - coordinate shared version groups from `monochange.toml`
 - compute release plans from explicit change input
-- prepare synced releases through config-defined workflows
+- run config-defined release workflows from `.changeset/*.md`
 - apply Rust semver evidence when provided
-- ship documentation through the mdBook in `docs/`
+- publish end-user documentation through the mdBook in `docs/`
+
+<!-- {/projectMilestoneCapabilities} -->
 
 ## Quick start
+
+Enter the reproducible development shell and install workspace tooling:
+
+<!-- {=repoDevEnvironmentSetupCode} -->
 
 ```bash
 devenv shell
 install:all
-mc workspace discover --root . --format json
-mc changes add --root . --package monochange --bump minor --reason "add release planning"
-mc release --dry-run
-mc release
 ```
 
-Example configuration:
+<!-- {/repoDevEnvironmentSetupCode} -->
+
+<!-- {=projectCoreWorkflow} -->
+
+Create a `monochange.toml` file:
 
 ```toml
 [defaults]
 parent_bump = "patch"
-include_private = false
+warn_on_group_mismatch = true
 
 [[version_groups]]
 name = "sdk"
@@ -43,38 +51,61 @@ name = "release"
 type = "PrepareRelease"
 ```
 
-Example change input:
+This is the smallest config needed to make `mc release` work in the current implementation.
 
-```markdown
----
-sdk_core: minor
----
+For changelog updates, add `[[package_overrides]]` entries with `changelog` paths. Discovery currently scans all supported ecosystems automatically; the top-level `[ecosystems.*]` settings are parsed today but are not yet used to filter discovery.
 
-#### public API addition
+Discover the workspace:
+
+```bash
+mc workspace discover --root . --format json
 ```
 
-Rust semver evidence can be attached explicitly:
+Create a change file:
 
-```markdown
----
-sdk_core: patch
-evidence:
-  sdk_core:
-    - rust-semver:major:public API break detected
----
-
-#### breaking API change
+```bash
+mc changes add --root . --package monochange --bump minor --reason "add release planning"
 ```
+
+Preview the release workflow:
+
+```bash
+mc release --dry-run
+```
+
+Inspect the raw planner when needed:
+
+```bash
+mc plan release --root . --changes .changeset/my-change.md --format json
+```
+
+Prepare the release:
+
+```bash
+mc release
+```
+
+<!-- {/projectCoreWorkflow} -->
 
 ## Development
+
+Useful commands:
+
+<!-- {=repoCommonDevelopmentCommands} -->
 
 ```bash
 monochange --help
 mc --help
+docs:check
+docs:update
+docs:verify
+docs:doctor
 lint:all
 test:all
 build:all
 build:book
 ```
+
+<!-- {/repoCommonDevelopmentCommands} -->
 
 See `docs/` for user-facing guides and `CONTRIBUTING.md` for workflow expectations.

--- a/scripts/docs:doctor
+++ b/scripts/docs:doctor
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mdt info
+mdt doctor
+docs:verify

--- a/scripts/docs:verify
+++ b/scripts/docs:verify
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docs:check
+test:docs


### PR DESCRIPTION
## Summary
- integrate `mdt` for shared markdown and Rust doc-comment content across the repo
- split shared docs into topical templates and remove per-crate README inclusion in Rust sources
- add stronger docs validation with explicit doctest coverage in CI and local workflows

## What changed
- install `mdt` from `ifiokjr/nixpkgs` via `devenv`
- add `mdt.toml` and `.templates/` providers for project, guide, and crate docs
- sync root docs, mdBook pages, crate READMEs, and crate-level Rust docs from shared providers
- update docs to match the current implementation status and limitations
- remove `doc-comment` dependency from crates that no longer need README doctest inclusion
- centralize markdown doctests through `docs/src/lib.rs`
- add local docs helper commands/scripts and run doc tests explicitly in CI

## Validation
- `devenv shell -- lint:all`
- `devenv shell -- test:all`
- `devenv shell -- build:all`
- `devenv shell -- build:book`
