### PR TITLE
ci: auto-enable pages for docs release

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: configure pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: build book
         run: build:book


### PR DESCRIPTION
## Summary
- fix the failing `docs-release` workflow by letting `actions/configure-pages` enable GitHub Pages automatically

## Root cause
The workflow failed in `configure pages` with:

- `Get Pages site failed`
- `HttpError: Not Found`

The repository did not have a Pages site configured yet, so `actions/configure-pages@v5` failed before the book could build.

## Fix
- set `enablement: true` on `actions/configure-pages@v5`

## Validation
- confirmed the repository Pages API previously returned `404`
- enabled Pages for the repository
- reran the failing `docs-release` workflow
