### PR TITLE
docs: polish workspace and crate readmes

### DIFF
--- a/.templates/crates.t.md
+++ b/.templates/crates.t.md
@@ -1,15 +1,126 @@
+<!-- {@crateReadmeBadgeRow} -->
+
+[![Crates.io][crate-image]][crate-link] [![Docs.rs][docs-image]][docs-link] [![CI][ci-status-image]][ci-status-link] [![Coverage][coverage-image]][coverage-link] [![License][license-image]][license-link]
+
+<!-- {/crateReadmeBadgeRow} -->
+
+<!-- {@repoStatusBadgeLinks} -->
+
+[ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
+[ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
+[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
+[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
+[license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
+[license-link]: https://opensource.org/license/unlicense
+
+<!-- {/repoStatusBadgeLinks} -->
+
+<!-- {@monochangeBadgeLinks} -->
+
+[crate-image]: https://img.shields.io/badge/crates.io-monochange-orange?logo=rust
+[crate-link]: https://crates.io/crates/monochange
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange/
+
+<!-- {/monochangeBadgeLinks} -->
+
+<!-- {@monochangeCoreBadgeLinks} -->
+
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__core-orange?logo=rust
+[crate-link]: https://crates.io/crates/monochange_core
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange__core-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange_core/
+
+<!-- {/monochangeCoreBadgeLinks} -->
+
+<!-- {@monochangeCargoBadgeLinks} -->
+
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__cargo-orange?logo=rust
+[crate-link]: https://crates.io/crates/monochange_cargo
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange__cargo-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange_cargo/
+
+<!-- {/monochangeCargoBadgeLinks} -->
+
+<!-- {@monochangeConfigBadgeLinks} -->
+
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__config-orange?logo=rust
+[crate-link]: https://crates.io/crates/monochange_config
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange__config-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange_config/
+
+<!-- {/monochangeConfigBadgeLinks} -->
+
+<!-- {@monochangeGraphBadgeLinks} -->
+
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__graph-orange?logo=rust
+[crate-link]: https://crates.io/crates/monochange_graph
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange__graph-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange_graph/
+
+<!-- {/monochangeGraphBadgeLinks} -->
+
+<!-- {@monochangeNpmBadgeLinks} -->
+
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__npm-orange?logo=rust
+[crate-link]: https://crates.io/crates/monochange_npm
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange__npm-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange_npm/
+
+<!-- {/monochangeNpmBadgeLinks} -->
+
+<!-- {@monochangeDenoBadgeLinks} -->
+
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__deno-orange?logo=rust
+[crate-link]: https://crates.io/crates/monochange_deno
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange__deno-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange_deno/
+
+<!-- {/monochangeDenoBadgeLinks} -->
+
+<!-- {@monochangeDartBadgeLinks} -->
+
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__dart-orange?logo=rust
+[crate-link]: https://crates.io/crates/monochange_dart
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange__dart-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange_dart/
+
+<!-- {/monochangeDartBadgeLinks} -->
+
+<!-- {@monochangeSemverBadgeLinks} -->
+
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__semver-orange?logo=rust
+[crate-link]: https://crates.io/crates/monochange_semver
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange__semver-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange_semver/
+
+<!-- {/monochangeSemverBadgeLinks} -->
+
 <!-- {@monochangeCrateDocs} -->
 
-# `monochange`
+`monochange` is the top-level entry point for the workspace.
 
-The `monochange` crate provides the end-user CLI.
+Reach for this crate when you want one API and CLI surface that can discover packages across Cargo, npm/pnpm/Bun, Deno, and Dart/Flutter workspaces, turn explicit change files into a release plan, and run configured release workflows from that plan.
 
-## Commands
+## Why use it?
+
+- coordinate one release workflow across several package ecosystems
+- expose discovery and release planning as either CLI commands or library calls
+- connect configuration loading, package discovery, graph propagation, and semver evidence in one place
+
+## Best for
+
+- shipping the `mc` CLI in CI or local release tooling
+- embedding the full end-to-end planner instead of wiring the lower-level crates together yourself
+- rendering discovery or release-plan output in text or JSON
+
+## Key commands
 
 ```bash
 mc workspace discover --root . --format json
 mc changes add --root . --package crates/monochange --bump patch --reason "describe the change"
 mc plan release --root . --changes .changeset/1234567890-crates-monochange.md --format json
+mc release --dry-run
 ```
 
 ## Responsibilities
@@ -18,16 +129,29 @@ mc plan release --root . --changes .changeset/1234567890-crates-monochange.md --
 - load `monochange.toml`
 - resolve change input files
 - render discovery and release-plan output in text or JSON
+- execute configured release workflows
 
 <!-- {/monochangeCrateDocs} -->
 
 <!-- {@monochangeCoreCrateDocs} -->
 
-# `monochange_core`
+`monochange_core` is the shared vocabulary for the `monochange` workspace.
 
-Shared domain types for `monochange`.
+Reach for this crate when you are building ecosystem adapters, release planners, or custom automation and need one set of types for packages, dependency edges, version groups, change signals, and release plans.
 
-This crate defines:
+## Why use it?
+
+- avoid redefining package and release domain models in each crate
+- share one error and result surface across discovery, planning, and workflow layers
+- pass normalized workspace data between adapters and planners without extra translation
+
+## Best for
+
+- implementing new ecosystem adapters against the shared `EcosystemAdapter` contract
+- moving normalized package or release data between crates without custom conversion code
+- depending on the workspace domain model without pulling in discovery or planning behavior
+
+## What it provides
 
 - normalized package and dependency records
 - version-group definitions and planned group outcomes
@@ -61,9 +185,21 @@ assert_eq!(package.current_version, Some(Version::new(1, 2, 3)));
 
 <!-- {@monochangeCargoCrateDocs} -->
 
-# `monochange_cargo`
+`monochange_cargo` discovers Cargo packages and surfaces Rust-specific release evidence.
 
-Cargo ecosystem support for `monochange`.
+Reach for this crate when you want to scan Cargo workspaces into normalized `monochange_core` records and optionally feed Rust semver evidence into release planning.
+
+## Why use it?
+
+- discover Cargo workspaces and standalone crates with one adapter
+- normalize crate manifests and dependency edges for the shared planner
+- attach Rust semver evidence through `RustSemverProvider`
+
+## Best for
+
+- building Cargo-aware discovery flows without the full CLI
+- feeding Rust semver evidence into release planning
+- converting Cargo workspace structure into shared `monochange_core` records
 
 ## Public entry points
 
@@ -82,9 +218,28 @@ Cargo ecosystem support for `monochange`.
 
 <!-- {@monochangeConfigCrateDocs} -->
 
-# `monochange_config`
+`monochange_config` parses and validates the inputs that drive planning and release workflows.
 
-Configuration and change-input parsing for `monochange`.
+Reach for this crate when you need to load `monochange.toml`, resolve package references, or turn `.changeset/*.md` files into validated change signals for the planner.
+
+## Why use it?
+
+- centralize config parsing and validation rules in one place
+- resolve package references against discovered workspace packages
+- keep workflow definitions, version groups, and change files aligned with the planner's expectations
+
+## Best for
+
+- validating configuration before handing it to planning code
+- parsing and resolving change files in custom automation
+- keeping package-reference rules consistent across tools
+
+## Public entry points
+
+- `load_workspace_configuration(root)` loads and validates `monochange.toml`
+- `load_change_signals(root, changes_dir, packages)` parses markdown change files into change signals
+- `resolve_package_reference(reference, workspace_root, packages)` maps package names, ids, and paths to discovered packages
+- `apply_version_groups(packages, configuration)` attaches configured version groups to discovered packages
 
 ## Responsibilities
 
@@ -97,9 +252,26 @@ Configuration and change-input parsing for `monochange`.
 
 <!-- {@monochangeGraphCrateDocs} -->
 
-# `monochange_graph`
+`monochange_graph` turns normalized workspace data into release decisions.
 
-Dependency-graph traversal and release propagation for `monochange`.
+Reach for this crate when you already have discovered packages, dependency edges, configuration, and change signals and need to calculate propagated bumps, synchronized version groups, and final release-plan output.
+
+## Why use it?
+
+- calculate release impact across direct and transitive dependents
+- keep version groups synchronized during planning
+- produce one deterministic release plan from normalized input data
+
+## Best for
+
+- embedding release-planning logic in custom automation or other tools
+- computing the exact set of packages that need to move after a change
+- separating planning logic from ecosystem-specific discovery code
+
+## Public entry points
+
+- `NormalizedGraph` builds adjacency and reverse-dependency views over package data
+- `build_release_plan(workspace_root, packages, dependency_edges, defaults, version_groups, change_signals, providers)` computes the release plan
 
 ## Responsibilities
 
@@ -112,9 +284,21 @@ Dependency-graph traversal and release propagation for `monochange`.
 
 <!-- {@monochangeNpmCrateDocs} -->
 
-# `monochange_npm`
+`monochange_npm` discovers npm-family packages and normalizes them for shared planning.
 
-npm-family ecosystem support for `monochange`.
+Reach for this crate when you want one adapter for npm, pnpm, and Bun workspaces that emits `monochange_core` package and dependency records.
+
+## Why use it?
+
+- discover several JavaScript package-manager layouts with one crate
+- normalize workspace metadata into the same graph used by the rest of `monochange`
+- capture dependency edges from `package.json` and `pnpm-workspace.yaml`
+
+## Best for
+
+- scanning JavaScript or TypeScript monorepos into normalized package records
+- supporting npm, pnpm, and Bun with one discovery surface
+- feeding JS workspace topology into shared planning code
 
 ## Public entry points
 
@@ -132,9 +316,21 @@ npm-family ecosystem support for `monochange`.
 
 <!-- {@monochangeDenoCrateDocs} -->
 
-# `monochange_deno`
+`monochange_deno` discovers Deno packages and workspace members for the shared planner.
 
-Deno ecosystem support for `monochange`.
+Reach for this crate when you need to scan `deno.json` or `deno.jsonc` files, expand Deno workspaces, and normalize Deno dependencies into `monochange_core` records.
+
+## Why use it?
+
+- discover Deno workspaces and standalone packages with one adapter
+- normalize manifest and dependency data for cross-ecosystem release planning
+- include Deno-specific import and dependency extraction in the shared graph
+
+## Best for
+
+- scanning Deno repos without adopting the full workspace CLI
+- turning `deno.json` metadata into shared package and dependency records
+- mixing Deno packages into a broader cross-ecosystem monorepo plan
 
 ## Public entry points
 
@@ -151,9 +347,21 @@ Deno ecosystem support for `monochange`.
 
 <!-- {@monochangeDartCrateDocs} -->
 
-# `monochange_dart`
+`monochange_dart` discovers Dart and Flutter packages for the shared planner.
 
-Dart and Flutter ecosystem support for `monochange`.
+Reach for this crate when you need to scan `pubspec.yaml` files, expand Dart or Flutter workspaces, and normalize package metadata into `monochange_core` records.
+
+## Why use it?
+
+- cover both pure Dart and Flutter package layouts with one adapter
+- normalize pubspec metadata and dependency edges for shared release planning
+- detect Flutter packages without maintaining a separate discovery path
+
+## Best for
+
+- scanning Dart or Flutter monorepos into normalized workspace records
+- reusing the same planning pipeline for mobile and non-mobile packages
+- discovering Flutter packages without a dedicated Flutter-only adapter layer
 
 ## Public entry points
 
@@ -171,9 +379,21 @@ Dart and Flutter ecosystem support for `monochange`.
 
 <!-- {@monochangeSemverCrateDocs} -->
 
-# `monochange_semver`
+`monochange_semver` merges requested bumps with compatibility evidence.
 
-Semver and compatibility helpers for `monochange`.
+Reach for this crate when you need deterministic severity calculations for direct changes, propagated dependent changes, or ecosystem-specific compatibility providers.
+
+## Why use it?
+
+- combine manual change requests with provider-generated compatibility assessments
+- share one bump-merging strategy across the workspace
+- implement custom `CompatibilityProvider` integrations for ecosystem-specific evidence
+
+## Best for
+
+- computing release severities outside the full planner
+- plugging ecosystem-specific compatibility logic into shared planning
+- reusing the workspace's bump-merging rules in custom tools
 
 ## Responsibilities
 

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -1,3 +1,46 @@
+<!-- {@projectReadmeOverview} -->
+
+`monochange` is a release-planning toolkit for monorepos that span more than one package ecosystem.
+
+It discovers packages, normalizes dependency data, applies version-group rules, turns explicit change files into release plans, and can run workflow-driven release preparation from those same inputs.
+
+Use it when your repository has outgrown one-ecosystem release tooling and you want one model for Cargo, npm/pnpm/Bun, Deno, and Dart/Flutter.
+
+<!-- {/projectReadmeOverview} -->
+
+<!-- {@projectWhyUse} -->
+
+- use one release-planning model across several language ecosystems
+- replace ad hoc scripts with explicit change files and deterministic release output
+- keep related packages synchronized with `[[version_groups]]`
+- propagate dependent bumps through one normalized dependency graph
+- embed the same discovery and planning logic in your own tooling through the workspace crates
+
+<!-- {/projectWhyUse} -->
+
+<!-- {@projectCrateCatalog} -->
+
+- `monochange` — end-user CLI and orchestration layer for discovery, planning, and workflow-driven releases.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange-orange?logo=rust)](https://crates.io/crates/monochange) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange-1f425f?logo=docs.rs)](https://docs.rs/monochange/)
+- `monochange_core` — shared domain model for packages, dependency edges, version groups, change signals, and release plans.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__core-orange?logo=rust)](https://crates.io/crates/monochange_core) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__core-1f425f?logo=docs.rs)](https://docs.rs/monochange_core/)
+- `monochange_config` — loads `monochange.toml`, parses `.changeset/*.md`, and validates planning inputs.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__config-orange?logo=rust)](https://crates.io/crates/monochange_config) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__config-1f425f?logo=docs.rs)](https://docs.rs/monochange_config/)
+- `monochange_graph` — propagates release impact through dependency edges and synchronized version groups.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__graph-orange?logo=rust)](https://crates.io/crates/monochange_graph) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__graph-1f425f?logo=docs.rs)](https://docs.rs/monochange_graph/)
+- `monochange_semver` — merges requested bumps with compatibility-provider evidence.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__semver-orange?logo=rust)](https://crates.io/crates/monochange_semver) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__semver-1f425f?logo=docs.rs)](https://docs.rs/monochange_semver/)
+- `monochange_cargo` — Cargo discovery plus Rust semver evidence integration.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__cargo-orange?logo=rust)](https://crates.io/crates/monochange_cargo) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__cargo-1f425f?logo=docs.rs)](https://docs.rs/monochange_cargo/)
+- `monochange_npm` — npm, pnpm, and Bun workspace discovery.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__npm-orange?logo=rust)](https://crates.io/crates/monochange_npm) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__npm-1f425f?logo=docs.rs)](https://docs.rs/monochange_npm/)
+- `monochange_deno` — Deno workspace and package discovery.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__deno-orange?logo=rust)](https://crates.io/crates/monochange_deno) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__deno-1f425f?logo=docs.rs)](https://docs.rs/monochange_deno/)
+- `monochange_dart` — Dart and Flutter workspace discovery.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__dart-orange?logo=rust)](https://crates.io/crates/monochange_dart) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__dart-1f425f?logo=docs.rs)](https://docs.rs/monochange_dart/)
+
+<!-- {/projectCrateCatalog} -->
+
 <!-- {@projectMilestoneCapabilities} -->
 
 - discover Cargo, npm/pnpm/Bun, Deno, Dart, and Flutter packages

--- a/crates/monochange/readme.md
+++ b/crates/monochange/readme.md
@@ -1,15 +1,40 @@
-<!-- {=monochangeCrateDocs} -->
-
 # `monochange`
 
-The `monochange` crate provides the end-user CLI.
+<br />
 
-## Commands
+<!-- {=crateReadmeBadgeRow} -->
+
+[![Crates.io][crate-image]][crate-link] [![Docs.rs][docs-image]][docs-link] [![CI][ci-status-image]][ci-status-link] [![Coverage][coverage-image]][coverage-link] [![License][license-image]][license-link]
+
+<!-- {/crateReadmeBadgeRow} -->
+
+<br />
+
+<!-- {=monochangeCrateDocs} -->
+
+`monochange` is the top-level entry point for the workspace.
+
+Reach for this crate when you want one API and CLI surface that can discover packages across Cargo, npm/pnpm/Bun, Deno, and Dart/Flutter workspaces, turn explicit change files into a release plan, and run configured release workflows from that plan.
+
+## Why use it?
+
+- coordinate one release workflow across several package ecosystems
+- expose discovery and release planning as either CLI commands or library calls
+- connect configuration loading, package discovery, graph propagation, and semver evidence in one place
+
+## Best for
+
+- shipping the `mc` CLI in CI or local release tooling
+- embedding the full end-to-end planner instead of wiring the lower-level crates together yourself
+- rendering discovery or release-plan output in text or JSON
+
+## Key commands
 
 ```bash
 mc workspace discover --root . --format json
 mc changes add --root . --package crates/monochange --bump patch --reason "describe the change"
 mc plan release --root . --changes .changeset/1234567890-crates-monochange.md --format json
+mc release --dry-run
 ```
 
 ## Responsibilities
@@ -18,5 +43,26 @@ mc plan release --root . --changes .changeset/1234567890-crates-monochange.md --
 - load `monochange.toml`
 - resolve change input files
 - render discovery and release-plan output in text or JSON
+- execute configured release workflows
 
 <!-- {/monochangeCrateDocs} -->
+
+<!-- {=monochangeBadgeLinks} -->
+
+[crate-image]: https://img.shields.io/badge/crates.io-monochange-orange?logo=rust
+[crate-link]: https://crates.io/crates/monochange
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange/
+
+<!-- {/monochangeBadgeLinks} -->
+
+<!-- {=repoStatusBadgeLinks} -->
+
+[ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
+[ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
+[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
+[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
+[license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
+[license-link]: https://opensource.org/license/unlicense
+
+<!-- {/repoStatusBadgeLinks} -->

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -1,16 +1,31 @@
 #![deny(clippy::all)]
 
-//! <!-- {=monochangeCrateDocs|trim|linePrefix:"//! ":true} -->
 //! # `monochange`
 //!
-//! The `monochange` crate provides the end-user CLI.
+//! <!-- {=monochangeCrateDocs|trim|linePrefix:"//! ":true} -->
+//! `monochange` is the top-level entry point for the workspace.
 //!
-//! ## Commands
+//! Reach for this crate when you want one API and CLI surface that can discover packages across Cargo, npm/pnpm/Bun, Deno, and Dart/Flutter workspaces, turn explicit change files into a release plan, and run configured release workflows from that plan.
+//!
+//! ## Why use it?
+//!
+//! - coordinate one release workflow across several package ecosystems
+//! - expose discovery and release planning as either CLI commands or library calls
+//! - connect configuration loading, package discovery, graph propagation, and semver evidence in one place
+//!
+//! ## Best for
+//!
+//! - shipping the `mc` CLI in CI or local release tooling
+//! - embedding the full end-to-end planner instead of wiring the lower-level crates together yourself
+//! - rendering discovery or release-plan output in text or JSON
+//!
+//! ## Key commands
 //!
 //! ```bash
 //! mc workspace discover --root . --format json
 //! mc changes add --root . --package crates/monochange --bump patch --reason "describe the change"
 //! mc plan release --root . --changes .changeset/1234567890-crates-monochange.md --format json
+//! mc release --dry-run
 //! ```
 //!
 //! ## Responsibilities
@@ -19,6 +34,7 @@
 //! - load `monochange.toml`
 //! - resolve change input files
 //! - render discovery and release-plan output in text or JSON
+//! - execute configured release workflows
 //! <!-- {/monochangeCrateDocs} -->
 
 use std::collections::BTreeMap;

--- a/crates/monochange_cargo/readme.md
+++ b/crates/monochange_cargo/readme.md
@@ -1,8 +1,32 @@
-<!-- {=monochangeCargoCrateDocs} -->
-
 # `monochange_cargo`
 
-Cargo ecosystem support for `monochange`.
+<br />
+
+<!-- {=crateReadmeBadgeRow} -->
+
+[![Crates.io][crate-image]][crate-link] [![Docs.rs][docs-image]][docs-link] [![CI][ci-status-image]][ci-status-link] [![Coverage][coverage-image]][coverage-link] [![License][license-image]][license-link]
+
+<!-- {/crateReadmeBadgeRow} -->
+
+<br />
+
+<!-- {=monochangeCargoCrateDocs} -->
+
+`monochange_cargo` discovers Cargo packages and surfaces Rust-specific release evidence.
+
+Reach for this crate when you want to scan Cargo workspaces into normalized `monochange_core` records and optionally feed Rust semver evidence into release planning.
+
+## Why use it?
+
+- discover Cargo workspaces and standalone crates with one adapter
+- normalize crate manifests and dependency edges for the shared planner
+- attach Rust semver evidence through `RustSemverProvider`
+
+## Best for
+
+- building Cargo-aware discovery flows without the full CLI
+- feeding Rust semver evidence into release planning
+- converting Cargo workspace structure into shared `monochange_core` records
 
 ## Public entry points
 
@@ -18,3 +42,23 @@ Cargo ecosystem support for `monochange`.
 - Rust semver provider integration for release planning
 
 <!-- {/monochangeCargoCrateDocs} -->
+
+<!-- {=monochangeCargoBadgeLinks} -->
+
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__cargo-orange?logo=rust
+[crate-link]: https://crates.io/crates/monochange_cargo
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange__cargo-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange_cargo/
+
+<!-- {/monochangeCargoBadgeLinks} -->
+
+<!-- {=repoStatusBadgeLinks} -->
+
+[ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
+[ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
+[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
+[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
+[license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
+[license-link]: https://opensource.org/license/unlicense
+
+<!-- {/repoStatusBadgeLinks} -->

--- a/crates/monochange_cargo/src/lib.rs
+++ b/crates/monochange_cargo/src/lib.rs
@@ -1,10 +1,24 @@
 #![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
-//! <!-- {=monochangeCargoCrateDocs|trim|linePrefix:"//! ":true} -->
 //! # `monochange_cargo`
 //!
-//! Cargo ecosystem support for `monochange`.
+//! <!-- {=monochangeCargoCrateDocs|trim|linePrefix:"//! ":true} -->
+//! `monochange_cargo` discovers Cargo packages and surfaces Rust-specific release evidence.
+//!
+//! Reach for this crate when you want to scan Cargo workspaces into normalized `monochange_core` records and optionally feed Rust semver evidence into release planning.
+//!
+//! ## Why use it?
+//!
+//! - discover Cargo workspaces and standalone crates with one adapter
+//! - normalize crate manifests and dependency edges for the shared planner
+//! - attach Rust semver evidence through `RustSemverProvider`
+//!
+//! ## Best for
+//!
+//! - building Cargo-aware discovery flows without the full CLI
+//! - feeding Rust semver evidence into release planning
+//! - converting Cargo workspace structure into shared `monochange_core` records
 //!
 //! ## Public entry points
 //!

--- a/crates/monochange_config/readme.md
+++ b/crates/monochange_config/readme.md
@@ -1,8 +1,39 @@
-<!-- {=monochangeConfigCrateDocs} -->
-
 # `monochange_config`
 
-Configuration and change-input parsing for `monochange`.
+<br />
+
+<!-- {=crateReadmeBadgeRow} -->
+
+[![Crates.io][crate-image]][crate-link] [![Docs.rs][docs-image]][docs-link] [![CI][ci-status-image]][ci-status-link] [![Coverage][coverage-image]][coverage-link] [![License][license-image]][license-link]
+
+<!-- {/crateReadmeBadgeRow} -->
+
+<br />
+
+<!-- {=monochangeConfigCrateDocs} -->
+
+`monochange_config` parses and validates the inputs that drive planning and release workflows.
+
+Reach for this crate when you need to load `monochange.toml`, resolve package references, or turn `.changeset/*.md` files into validated change signals for the planner.
+
+## Why use it?
+
+- centralize config parsing and validation rules in one place
+- resolve package references against discovered workspace packages
+- keep workflow definitions, version groups, and change files aligned with the planner's expectations
+
+## Best for
+
+- validating configuration before handing it to planning code
+- parsing and resolving change files in custom automation
+- keeping package-reference rules consistent across tools
+
+## Public entry points
+
+- `load_workspace_configuration(root)` loads and validates `monochange.toml`
+- `load_change_signals(root, changes_dir, packages)` parses markdown change files into change signals
+- `resolve_package_reference(reference, workspace_root, packages)` maps package names, ids, and paths to discovered packages
+- `apply_version_groups(packages, configuration)` attaches configured version groups to discovered packages
 
 ## Responsibilities
 
@@ -12,3 +43,23 @@ Configuration and change-input parsing for `monochange`.
 - parse change-input files, evidence, and changelog overrides
 
 <!-- {/monochangeConfigCrateDocs} -->
+
+<!-- {=monochangeConfigBadgeLinks} -->
+
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__config-orange?logo=rust
+[crate-link]: https://crates.io/crates/monochange_config
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange__config-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange_config/
+
+<!-- {/monochangeConfigBadgeLinks} -->
+
+<!-- {=repoStatusBadgeLinks} -->
+
+[ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
+[ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
+[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
+[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
+[license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
+[license-link]: https://opensource.org/license/unlicense
+
+<!-- {/repoStatusBadgeLinks} -->

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -1,10 +1,31 @@
 #![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
-//! <!-- {=monochangeConfigCrateDocs|trim|linePrefix:"//! ":true} -->
 //! # `monochange_config`
 //!
-//! Configuration and change-input parsing for `monochange`.
+//! <!-- {=monochangeConfigCrateDocs|trim|linePrefix:"//! ":true} -->
+//! `monochange_config` parses and validates the inputs that drive planning and release workflows.
+//!
+//! Reach for this crate when you need to load `monochange.toml`, resolve package references, or turn `.changeset/*.md` files into validated change signals for the planner.
+//!
+//! ## Why use it?
+//!
+//! - centralize config parsing and validation rules in one place
+//! - resolve package references against discovered workspace packages
+//! - keep workflow definitions, version groups, and change files aligned with the planner's expectations
+//!
+//! ## Best for
+//!
+//! - validating configuration before handing it to planning code
+//! - parsing and resolving change files in custom automation
+//! - keeping package-reference rules consistent across tools
+//!
+//! ## Public entry points
+//!
+//! - `load_workspace_configuration(root)` loads and validates `monochange.toml`
+//! - `load_change_signals(root, changes_dir, packages)` parses markdown change files into change signals
+//! - `resolve_package_reference(reference, workspace_root, packages)` maps package names, ids, and paths to discovered packages
+//! - `apply_version_groups(packages, configuration)` attaches configured version groups to discovered packages
 //!
 //! ## Responsibilities
 //!

--- a/crates/monochange_core/readme.md
+++ b/crates/monochange_core/readme.md
@@ -1,10 +1,34 @@
-<!-- {=monochangeCoreCrateDocs} -->
-
 # `monochange_core`
 
-Shared domain types for `monochange`.
+<br />
 
-This crate defines:
+<!-- {=crateReadmeBadgeRow} -->
+
+[![Crates.io][crate-image]][crate-link] [![Docs.rs][docs-image]][docs-link] [![CI][ci-status-image]][ci-status-link] [![Coverage][coverage-image]][coverage-link] [![License][license-image]][license-link]
+
+<!-- {/crateReadmeBadgeRow} -->
+
+<br />
+
+<!-- {=monochangeCoreCrateDocs} -->
+
+`monochange_core` is the shared vocabulary for the `monochange` workspace.
+
+Reach for this crate when you are building ecosystem adapters, release planners, or custom automation and need one set of types for packages, dependency edges, version groups, change signals, and release plans.
+
+## Why use it?
+
+- avoid redefining package and release domain models in each crate
+- share one error and result surface across discovery, planning, and workflow layers
+- pass normalized workspace data between adapters and planners without extra translation
+
+## Best for
+
+- implementing new ecosystem adapters against the shared `EcosystemAdapter` contract
+- moving normalized package or release data between crates without custom conversion code
+- depending on the workspace domain model without pulling in discovery or planning behavior
+
+## What it provides
 
 - normalized package and dependency records
 - version-group definitions and planned group outcomes
@@ -35,3 +59,23 @@ assert_eq!(package.current_version, Some(Version::new(1, 2, 3)));
 ```
 
 <!-- {/monochangeCoreCrateDocs} -->
+
+<!-- {=monochangeCoreBadgeLinks} -->
+
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__core-orange?logo=rust
+[crate-link]: https://crates.io/crates/monochange_core
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange__core-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange_core/
+
+<!-- {/monochangeCoreBadgeLinks} -->
+
+<!-- {=repoStatusBadgeLinks} -->
+
+[ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
+[ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
+[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
+[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
+[license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
+[license-link]: https://opensource.org/license/unlicense
+
+<!-- {/repoStatusBadgeLinks} -->

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -1,12 +1,26 @@
 #![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
-//! <!-- {=monochangeCoreCrateDocs|trim|linePrefix:"//! ":true} -->
 //! # `monochange_core`
 //!
-//! Shared domain types for `monochange`.
+//! <!-- {=monochangeCoreCrateDocs|trim|linePrefix:"//! ":true} -->
+//! `monochange_core` is the shared vocabulary for the `monochange` workspace.
 //!
-//! This crate defines:
+//! Reach for this crate when you are building ecosystem adapters, release planners, or custom automation and need one set of types for packages, dependency edges, version groups, change signals, and release plans.
+//!
+//! ## Why use it?
+//!
+//! - avoid redefining package and release domain models in each crate
+//! - share one error and result surface across discovery, planning, and workflow layers
+//! - pass normalized workspace data between adapters and planners without extra translation
+//!
+//! ## Best for
+//!
+//! - implementing new ecosystem adapters against the shared `EcosystemAdapter` contract
+//! - moving normalized package or release data between crates without custom conversion code
+//! - depending on the workspace domain model without pulling in discovery or planning behavior
+//!
+//! ## What it provides
 //!
 //! - normalized package and dependency records
 //! - version-group definitions and planned group outcomes

--- a/crates/monochange_dart/readme.md
+++ b/crates/monochange_dart/readme.md
@@ -1,8 +1,32 @@
-<!-- {=monochangeDartCrateDocs} -->
-
 # `monochange_dart`
 
-Dart and Flutter ecosystem support for `monochange`.
+<br />
+
+<!-- {=crateReadmeBadgeRow} -->
+
+[![Crates.io][crate-image]][crate-link] [![Docs.rs][docs-image]][docs-link] [![CI][ci-status-image]][ci-status-link] [![Coverage][coverage-image]][coverage-link] [![License][license-image]][license-link]
+
+<!-- {/crateReadmeBadgeRow} -->
+
+<br />
+
+<!-- {=monochangeDartCrateDocs} -->
+
+`monochange_dart` discovers Dart and Flutter packages for the shared planner.
+
+Reach for this crate when you need to scan `pubspec.yaml` files, expand Dart or Flutter workspaces, and normalize package metadata into `monochange_core` records.
+
+## Why use it?
+
+- cover both pure Dart and Flutter package layouts with one adapter
+- normalize pubspec metadata and dependency edges for shared release planning
+- detect Flutter packages without maintaining a separate discovery path
+
+## Best for
+
+- scanning Dart or Flutter monorepos into normalized workspace records
+- reusing the same planning pipeline for mobile and non-mobile packages
+- discovering Flutter packages without a dedicated Flutter-only adapter layer
 
 ## Public entry points
 
@@ -17,3 +41,23 @@ Dart and Flutter ecosystem support for `monochange`.
 - normalized dependency extraction
 
 <!-- {/monochangeDartCrateDocs} -->
+
+<!-- {=monochangeDartBadgeLinks} -->
+
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__dart-orange?logo=rust
+[crate-link]: https://crates.io/crates/monochange_dart
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange__dart-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange_dart/
+
+<!-- {/monochangeDartBadgeLinks} -->
+
+<!-- {=repoStatusBadgeLinks} -->
+
+[ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
+[ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
+[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
+[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
+[license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
+[license-link]: https://opensource.org/license/unlicense
+
+<!-- {/repoStatusBadgeLinks} -->

--- a/crates/monochange_dart/src/lib.rs
+++ b/crates/monochange_dart/src/lib.rs
@@ -1,10 +1,24 @@
 #![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
-//! <!-- {=monochangeDartCrateDocs|trim|linePrefix:"//! ":true} -->
 //! # `monochange_dart`
 //!
-//! Dart and Flutter ecosystem support for `monochange`.
+//! <!-- {=monochangeDartCrateDocs|trim|linePrefix:"//! ":true} -->
+//! `monochange_dart` discovers Dart and Flutter packages for the shared planner.
+//!
+//! Reach for this crate when you need to scan `pubspec.yaml` files, expand Dart or Flutter workspaces, and normalize package metadata into `monochange_core` records.
+//!
+//! ## Why use it?
+//!
+//! - cover both pure Dart and Flutter package layouts with one adapter
+//! - normalize pubspec metadata and dependency edges for shared release planning
+//! - detect Flutter packages without maintaining a separate discovery path
+//!
+//! ## Best for
+//!
+//! - scanning Dart or Flutter monorepos into normalized workspace records
+//! - reusing the same planning pipeline for mobile and non-mobile packages
+//! - discovering Flutter packages without a dedicated Flutter-only adapter layer
 //!
 //! ## Public entry points
 //!

--- a/crates/monochange_deno/readme.md
+++ b/crates/monochange_deno/readme.md
@@ -1,8 +1,32 @@
-<!-- {=monochangeDenoCrateDocs} -->
-
 # `monochange_deno`
 
-Deno ecosystem support for `monochange`.
+<br />
+
+<!-- {=crateReadmeBadgeRow} -->
+
+[![Crates.io][crate-image]][crate-link] [![Docs.rs][docs-image]][docs-link] [![CI][ci-status-image]][ci-status-link] [![Coverage][coverage-image]][coverage-link] [![License][license-image]][license-link]
+
+<!-- {/crateReadmeBadgeRow} -->
+
+<br />
+
+<!-- {=monochangeDenoCrateDocs} -->
+
+`monochange_deno` discovers Deno packages and workspace members for the shared planner.
+
+Reach for this crate when you need to scan `deno.json` or `deno.jsonc` files, expand Deno workspaces, and normalize Deno dependencies into `monochange_core` records.
+
+## Why use it?
+
+- discover Deno workspaces and standalone packages with one adapter
+- normalize manifest and dependency data for cross-ecosystem release planning
+- include Deno-specific import and dependency extraction in the shared graph
+
+## Best for
+
+- scanning Deno repos without adopting the full workspace CLI
+- turning `deno.json` metadata into shared package and dependency records
+- mixing Deno packages into a broader cross-ecosystem monorepo plan
 
 ## Public entry points
 
@@ -16,3 +40,23 @@ Deno ecosystem support for `monochange`.
 - normalized dependency and import extraction
 
 <!-- {/monochangeDenoCrateDocs} -->
+
+<!-- {=monochangeDenoBadgeLinks} -->
+
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__deno-orange?logo=rust
+[crate-link]: https://crates.io/crates/monochange_deno
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange__deno-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange_deno/
+
+<!-- {/monochangeDenoBadgeLinks} -->
+
+<!-- {=repoStatusBadgeLinks} -->
+
+[ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
+[ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
+[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
+[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
+[license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
+[license-link]: https://opensource.org/license/unlicense
+
+<!-- {/repoStatusBadgeLinks} -->

--- a/crates/monochange_deno/src/lib.rs
+++ b/crates/monochange_deno/src/lib.rs
@@ -1,10 +1,24 @@
 #![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
-//! <!-- {=monochangeDenoCrateDocs|trim|linePrefix:"//! ":true} -->
 //! # `monochange_deno`
 //!
-//! Deno ecosystem support for `monochange`.
+//! <!-- {=monochangeDenoCrateDocs|trim|linePrefix:"//! ":true} -->
+//! `monochange_deno` discovers Deno packages and workspace members for the shared planner.
+//!
+//! Reach for this crate when you need to scan `deno.json` or `deno.jsonc` files, expand Deno workspaces, and normalize Deno dependencies into `monochange_core` records.
+//!
+//! ## Why use it?
+//!
+//! - discover Deno workspaces and standalone packages with one adapter
+//! - normalize manifest and dependency data for cross-ecosystem release planning
+//! - include Deno-specific import and dependency extraction in the shared graph
+//!
+//! ## Best for
+//!
+//! - scanning Deno repos without adopting the full workspace CLI
+//! - turning `deno.json` metadata into shared package and dependency records
+//! - mixing Deno packages into a broader cross-ecosystem monorepo plan
 //!
 //! ## Public entry points
 //!

--- a/crates/monochange_graph/readme.md
+++ b/crates/monochange_graph/readme.md
@@ -1,8 +1,37 @@
-<!-- {=monochangeGraphCrateDocs} -->
-
 # `monochange_graph`
 
-Dependency-graph traversal and release propagation for `monochange`.
+<br />
+
+<!-- {=crateReadmeBadgeRow} -->
+
+[![Crates.io][crate-image]][crate-link] [![Docs.rs][docs-image]][docs-link] [![CI][ci-status-image]][ci-status-link] [![Coverage][coverage-image]][coverage-link] [![License][license-image]][license-link]
+
+<!-- {/crateReadmeBadgeRow} -->
+
+<br />
+
+<!-- {=monochangeGraphCrateDocs} -->
+
+`monochange_graph` turns normalized workspace data into release decisions.
+
+Reach for this crate when you already have discovered packages, dependency edges, configuration, and change signals and need to calculate propagated bumps, synchronized version groups, and final release-plan output.
+
+## Why use it?
+
+- calculate release impact across direct and transitive dependents
+- keep version groups synchronized during planning
+- produce one deterministic release plan from normalized input data
+
+## Best for
+
+- embedding release-planning logic in custom automation or other tools
+- computing the exact set of packages that need to move after a change
+- separating planning logic from ecosystem-specific discovery code
+
+## Public entry points
+
+- `NormalizedGraph` builds adjacency and reverse-dependency views over package data
+- `build_release_plan(workspace_root, packages, dependency_edges, defaults, version_groups, change_signals, providers)` computes the release plan
 
 ## Responsibilities
 
@@ -12,3 +41,23 @@ Dependency-graph traversal and release propagation for `monochange`.
 - calculate planned group versions
 
 <!-- {/monochangeGraphCrateDocs} -->
+
+<!-- {=monochangeGraphBadgeLinks} -->
+
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__graph-orange?logo=rust
+[crate-link]: https://crates.io/crates/monochange_graph
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange__graph-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange_graph/
+
+<!-- {/monochangeGraphBadgeLinks} -->
+
+<!-- {=repoStatusBadgeLinks} -->
+
+[ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
+[ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
+[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
+[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
+[license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
+[license-link]: https://opensource.org/license/unlicense
+
+<!-- {/repoStatusBadgeLinks} -->

--- a/crates/monochange_graph/src/lib.rs
+++ b/crates/monochange_graph/src/lib.rs
@@ -1,10 +1,29 @@
 #![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
-//! <!-- {=monochangeGraphCrateDocs|trim|linePrefix:"//! ":true} -->
 //! # `monochange_graph`
 //!
-//! Dependency-graph traversal and release propagation for `monochange`.
+//! <!-- {=monochangeGraphCrateDocs|trim|linePrefix:"//! ":true} -->
+//! `monochange_graph` turns normalized workspace data into release decisions.
+//!
+//! Reach for this crate when you already have discovered packages, dependency edges, configuration, and change signals and need to calculate propagated bumps, synchronized version groups, and final release-plan output.
+//!
+//! ## Why use it?
+//!
+//! - calculate release impact across direct and transitive dependents
+//! - keep version groups synchronized during planning
+//! - produce one deterministic release plan from normalized input data
+//!
+//! ## Best for
+//!
+//! - embedding release-planning logic in custom automation or other tools
+//! - computing the exact set of packages that need to move after a change
+//! - separating planning logic from ecosystem-specific discovery code
+//!
+//! ## Public entry points
+//!
+//! - `NormalizedGraph` builds adjacency and reverse-dependency views over package data
+//! - `build_release_plan(workspace_root, packages, dependency_edges, defaults, version_groups, change_signals, providers)` computes the release plan
 //!
 //! ## Responsibilities
 //!

--- a/crates/monochange_npm/readme.md
+++ b/crates/monochange_npm/readme.md
@@ -1,8 +1,32 @@
-<!-- {=monochangeNpmCrateDocs} -->
-
 # `monochange_npm`
 
-npm-family ecosystem support for `monochange`.
+<br />
+
+<!-- {=crateReadmeBadgeRow} -->
+
+[![Crates.io][crate-image]][crate-link] [![Docs.rs][docs-image]][docs-link] [![CI][ci-status-image]][ci-status-link] [![Coverage][coverage-image]][coverage-link] [![License][license-image]][license-link]
+
+<!-- {/crateReadmeBadgeRow} -->
+
+<br />
+
+<!-- {=monochangeNpmCrateDocs} -->
+
+`monochange_npm` discovers npm-family packages and normalizes them for shared planning.
+
+Reach for this crate when you want one adapter for npm, pnpm, and Bun workspaces that emits `monochange_core` package and dependency records.
+
+## Why use it?
+
+- discover several JavaScript package-manager layouts with one crate
+- normalize workspace metadata into the same graph used by the rest of `monochange`
+- capture dependency edges from `package.json` and `pnpm-workspace.yaml`
+
+## Best for
+
+- scanning JavaScript or TypeScript monorepos into normalized package records
+- supporting npm, pnpm, and Bun with one discovery surface
+- feeding JS workspace topology into shared planning code
 
 ## Public entry points
 
@@ -17,3 +41,23 @@ npm-family ecosystem support for `monochange`.
 - normalized dependency extraction
 
 <!-- {/monochangeNpmCrateDocs} -->
+
+<!-- {=monochangeNpmBadgeLinks} -->
+
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__npm-orange?logo=rust
+[crate-link]: https://crates.io/crates/monochange_npm
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange__npm-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange_npm/
+
+<!-- {/monochangeNpmBadgeLinks} -->
+
+<!-- {=repoStatusBadgeLinks} -->
+
+[ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
+[ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
+[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
+[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
+[license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
+[license-link]: https://opensource.org/license/unlicense
+
+<!-- {/repoStatusBadgeLinks} -->

--- a/crates/monochange_npm/src/lib.rs
+++ b/crates/monochange_npm/src/lib.rs
@@ -1,10 +1,24 @@
 #![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
-//! <!-- {=monochangeNpmCrateDocs|trim|linePrefix:"//! ":true} -->
 //! # `monochange_npm`
 //!
-//! npm-family ecosystem support for `monochange`.
+//! <!-- {=monochangeNpmCrateDocs|trim|linePrefix:"//! ":true} -->
+//! `monochange_npm` discovers npm-family packages and normalizes them for shared planning.
+//!
+//! Reach for this crate when you want one adapter for npm, pnpm, and Bun workspaces that emits `monochange_core` package and dependency records.
+//!
+//! ## Why use it?
+//!
+//! - discover several JavaScript package-manager layouts with one crate
+//! - normalize workspace metadata into the same graph used by the rest of `monochange`
+//! - capture dependency edges from `package.json` and `pnpm-workspace.yaml`
+//!
+//! ## Best for
+//!
+//! - scanning JavaScript or TypeScript monorepos into normalized package records
+//! - supporting npm, pnpm, and Bun with one discovery surface
+//! - feeding JS workspace topology into shared planning code
 //!
 //! ## Public entry points
 //!

--- a/crates/monochange_semver/readme.md
+++ b/crates/monochange_semver/readme.md
@@ -1,8 +1,32 @@
-<!-- {=monochangeSemverCrateDocs} -->
-
 # `monochange_semver`
 
-Semver and compatibility helpers for `monochange`.
+<br />
+
+<!-- {=crateReadmeBadgeRow} -->
+
+[![Crates.io][crate-image]][crate-link] [![Docs.rs][docs-image]][docs-link] [![CI][ci-status-image]][ci-status-link] [![Coverage][coverage-image]][coverage-link] [![License][license-image]][license-link]
+
+<!-- {/crateReadmeBadgeRow} -->
+
+<br />
+
+<!-- {=monochangeSemverCrateDocs} -->
+
+`monochange_semver` merges requested bumps with compatibility evidence.
+
+Reach for this crate when you need deterministic severity calculations for direct changes, propagated dependent changes, or ecosystem-specific compatibility providers.
+
+## Why use it?
+
+- combine manual change requests with provider-generated compatibility assessments
+- share one bump-merging strategy across the workspace
+- implement custom `CompatibilityProvider` integrations for ecosystem-specific evidence
+
+## Best for
+
+- computing release severities outside the full planner
+- plugging ecosystem-specific compatibility logic into shared planning
+- reusing the workspace's bump-merging rules in custom tools
 
 ## Responsibilities
 
@@ -26,3 +50,23 @@ assert_eq!(direct, BumpSeverity::Minor);
 ```
 
 <!-- {/monochangeSemverCrateDocs} -->
+
+<!-- {=monochangeSemverBadgeLinks} -->
+
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__semver-orange?logo=rust
+[crate-link]: https://crates.io/crates/monochange_semver
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange__semver-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange_semver/
+
+<!-- {/monochangeSemverBadgeLinks} -->
+
+<!-- {=repoStatusBadgeLinks} -->
+
+[ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
+[ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
+[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
+[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
+[license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
+[license-link]: https://opensource.org/license/unlicense
+
+<!-- {/repoStatusBadgeLinks} -->

--- a/crates/monochange_semver/src/lib.rs
+++ b/crates/monochange_semver/src/lib.rs
@@ -1,10 +1,24 @@
 #![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
-//! <!-- {=monochangeSemverCrateDocs|trim|linePrefix:"//! ":true} -->
 //! # `monochange_semver`
 //!
-//! Semver and compatibility helpers for `monochange`.
+//! <!-- {=monochangeSemverCrateDocs|trim|linePrefix:"//! ":true} -->
+//! `monochange_semver` merges requested bumps with compatibility evidence.
+//!
+//! Reach for this crate when you need deterministic severity calculations for direct changes, propagated dependent changes, or ecosystem-specific compatibility providers.
+//!
+//! ## Why use it?
+//!
+//! - combine manual change requests with provider-generated compatibility assessments
+//! - share one bump-merging strategy across the workspace
+//! - implement custom `CompatibilityProvider` integrations for ecosystem-specific evidence
+//!
+//! ## Best for
+//!
+//! - computing release severities outside the full planner
+//! - plugging ecosystem-specific compatibility logic into shared planning
+//! - reusing the workspace's bump-merging rules in custom tools
 //!
 //! ## Responsibilities
 //!

--- a/readme.md
+++ b/readme.md
@@ -2,9 +2,39 @@
 
 > manage versions and releases for your multiplatform, multilanguage monorepo
 
-`monochange` is a Rust workspace for cross-ecosystem package discovery and release planning.
+<br />
 
-Current milestone capabilities:
+<!-- {=crateReadmeBadgeRow} -->
+
+[![Crates.io][crate-image]][crate-link] [![Docs.rs][docs-image]][docs-link] [![CI][ci-status-image]][ci-status-link] [![Coverage][coverage-image]][coverage-link] [![License][license-image]][license-link]
+
+<!-- {/crateReadmeBadgeRow} -->
+
+<br />
+
+<!-- {=projectReadmeOverview} -->
+
+`monochange` is a release-planning toolkit for monorepos that span more than one package ecosystem.
+
+It discovers packages, normalizes dependency data, applies version-group rules, turns explicit change files into release plans, and can run workflow-driven release preparation from those same inputs.
+
+Use it when your repository has outgrown one-ecosystem release tooling and you want one model for Cargo, npm/pnpm/Bun, Deno, and Dart/Flutter.
+
+<!-- {/projectReadmeOverview} -->
+
+## Why use `monochange`?
+
+<!-- {=projectWhyUse} -->
+
+- use one release-planning model across several language ecosystems
+- replace ad hoc scripts with explicit change files and deterministic release output
+- keep related packages synchronized with `[[version_groups]]`
+- propagate dependent bumps through one normalized dependency graph
+- embed the same discovery and planning logic in your own tooling through the workspace crates
+
+<!-- {/projectWhyUse} -->
+
+## Current milestone capabilities
 
 <!-- {=projectMilestoneCapabilities} -->
 
@@ -17,6 +47,31 @@ Current milestone capabilities:
 - publish end-user documentation through the mdBook in `docs/`
 
 <!-- {/projectMilestoneCapabilities} -->
+
+## Workspace crates
+
+<!-- {=projectCrateCatalog} -->
+
+- `monochange` — end-user CLI and orchestration layer for discovery, planning, and workflow-driven releases.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange-orange?logo=rust)](https://crates.io/crates/monochange) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange-1f425f?logo=docs.rs)](https://docs.rs/monochange/)
+- `monochange_core` — shared domain model for packages, dependency edges, version groups, change signals, and release plans.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__core-orange?logo=rust)](https://crates.io/crates/monochange_core) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__core-1f425f?logo=docs.rs)](https://docs.rs/monochange_core/)
+- `monochange_config` — loads `monochange.toml`, parses `.changeset/*.md`, and validates planning inputs.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__config-orange?logo=rust)](https://crates.io/crates/monochange_config) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__config-1f425f?logo=docs.rs)](https://docs.rs/monochange_config/)
+- `monochange_graph` — propagates release impact through dependency edges and synchronized version groups.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__graph-orange?logo=rust)](https://crates.io/crates/monochange_graph) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__graph-1f425f?logo=docs.rs)](https://docs.rs/monochange_graph/)
+- `monochange_semver` — merges requested bumps with compatibility-provider evidence.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__semver-orange?logo=rust)](https://crates.io/crates/monochange_semver) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__semver-1f425f?logo=docs.rs)](https://docs.rs/monochange_semver/)
+- `monochange_cargo` — Cargo discovery plus Rust semver evidence integration.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__cargo-orange?logo=rust)](https://crates.io/crates/monochange_cargo) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__cargo-1f425f?logo=docs.rs)](https://docs.rs/monochange_cargo/)
+- `monochange_npm` — npm, pnpm, and Bun workspace discovery.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__npm-orange?logo=rust)](https://crates.io/crates/monochange_npm) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__npm-1f425f?logo=docs.rs)](https://docs.rs/monochange_npm/)
+- `monochange_deno` — Deno workspace and package discovery.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__deno-orange?logo=rust)](https://crates.io/crates/monochange_deno) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__deno-1f425f?logo=docs.rs)](https://docs.rs/monochange_deno/)
+- `monochange_dart` — Dart and Flutter workspace discovery.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__dart-orange?logo=rust)](https://crates.io/crates/monochange_dart) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__dart-1f425f?logo=docs.rs)](https://docs.rs/monochange_dart/)
+
+<!-- {/projectCrateCatalog} -->
 
 ## Quick start
 
@@ -109,3 +164,23 @@ build:book
 <!-- {/repoCommonDevelopmentCommands} -->
 
 See `docs/` for user-facing guides and `CONTRIBUTING.md` for workflow expectations.
+
+<!-- {=monochangeBadgeLinks} -->
+
+[crate-image]: https://img.shields.io/badge/crates.io-monochange-orange?logo=rust
+[crate-link]: https://crates.io/crates/monochange
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange/
+
+<!-- {/monochangeBadgeLinks} -->
+
+<!-- {=repoStatusBadgeLinks} -->
+
+[ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
+[ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
+[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
+[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
+[license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
+[license-link]: https://opensource.org/license/unlicense
+
+<!-- {/repoStatusBadgeLinks} -->


### PR DESCRIPTION
## Summary
- polish the root README so the repo purpose is clearer at a glance
- add badge rows for crates.io, docs.rs, CI, coverage, and license across the workspace readmes
- improve each crate README and crate-level docs with clearer purpose, why-use-it guidance, and better navigation via `mdt`

## Details
- keep README composition single-sourced with shared `mdt` providers
- refresh crate-level rust docs from the same shared README content
- expand per-crate copy with stronger "reach for this crate when" and "best for" guidance
- improve the root workspace crate catalog with badge links to crates.io and docs.rs

## Validation
- `devenv shell -- docs:update`
- `devenv shell -- docs:check`
- `devenv shell -- test:docs`
- `devenv shell -- lint:clippy`
- `devenv shell -- lint:format`
