### PR TITLE
ci: add coverage checks and codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,34 @@ jobs:
       - name: build book
         run: build:book
         shell: devenv shell -- bash -e {0}
+
+  coverage:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+
+      - name: setup
+        uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: run coverage
+        run: coverage:all
+        shell: devenv shell -- bash -e {0}
+
+      - name: upload coverage to codecov
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: ./target/coverage/lcov.info
+          disable_search: true
+          fail_ci_if_error: true
+          flags: rust
+          name: monochange-rust-workspace
+          verbose: true

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -73,6 +73,7 @@ docs:verify
 docs:doctor
 lint:all
 test:all
+coverage:all
 build:all
 build:book
 ```
@@ -91,6 +92,7 @@ docs:doctor
 mc changes add --root . --package crates/monochange --bump patch --reason "describe the change"
 lint:all
 test:all
+coverage:all
 build:all
 build:book
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,7 @@ docs:doctor
 mc changes add --root . --package crates/monochange --bump patch --reason "describe the change"
 lint:all
 test:all
+coverage:all
 build:all
 build:book
 ```

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "60...100"
+  status:
+    project:
+      default:
+        target: 70%
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%

--- a/devenv.nix
+++ b/devenv.nix
@@ -128,10 +128,14 @@ in
     };
     "coverage:all" = {
       exec = ''
-        set -e
-        cargo llvm-cov nextest --workspace --all-features --lcov --output-path lcov.info
+        set -euo pipefail
+        mkdir -p target/coverage
+        cargo llvm-cov clean --workspace
+        cargo llvm-cov nextest --workspace --all-features --all-targets --no-report
+        cargo llvm-cov report --summary-only --fail-under-lines 70
+        cargo llvm-cov report --lcov --output-path target/coverage/lcov.info
       '';
-      description = "Run coverage across the crates.";
+      description = "Run workspace coverage, enforce a 70% line-coverage floor, and write target/coverage/lcov.info.";
       binary = "bash";
     };
     "fix:all" = {

--- a/docs/src/guide/01-installation.md
+++ b/docs/src/guide/01-installation.md
@@ -26,6 +26,7 @@ docs:verify
 docs:doctor
 lint:all
 test:all
+coverage:all
 build:all
 build:book
 ```

--- a/readme.md
+++ b/readme.md
@@ -157,6 +157,7 @@ docs:verify
 docs:doctor
 lint:all
 test:all
+coverage:all
 build:all
 build:book
 ```


### PR DESCRIPTION
## Summary
- add workspace coverage checks to CI and local devenv tasks
- upload LCOV coverage reports with `codecov/codecov-action@v5`
- configure an initial 70% project coverage threshold for now, with room to raise it toward 90% later

## What changed
- add a dedicated `coverage` job to `.github/workflows/ci.yml`
- upload `target/coverage/lcov.info` to Codecov using OIDC auth
- add `codecov.yml` with project and patch coverage status settings
- update `coverage:all` to:
  - run workspace coverage across all targets
  - enforce a 70% line coverage floor locally/in CI
  - emit `target/coverage/lcov.info`
- add `coverage:all` to shared docs/command lists

## Notes
- doctests remain validated in `test:docs`
- coverage-instrumented doctests with `cargo-llvm-cov` are still a nightly-only path, so the stable coverage job focuses on the workspace's all-targets test surface
- the threshold is intentionally conservative at 70% for this pass and can be ratcheted up toward 90% in follow-up work

## Validation
- `devenv shell -- docs:update`
- `devenv shell -- docs:check`
- `devenv shell -- lint:format`
- `devenv shell -- test:docs`
- `devenv shell -- coverage:all`
