### PR TITLE
ci: update GitHub Actions for Node 24 runners

### DIFF
--- a/.github/actions/devenv/action.yml
+++ b/.github/actions/devenv/action.yml
@@ -18,7 +18,7 @@ runs:
         prefix-key: "${{ inputs.cache-version }}"
 
     - name: cache cargo binaries
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ./.bin
         key: ${{ runner.os }}-cargo-bin-${{ inputs.cache-version }}-${{ env.RUSTUP_TOOLCHAIN }}-${{ hashFiles('rust-toolchain.toml', 'Cargo.toml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -89,7 +89,7 @@ jobs:
       id-token: write
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: setup
         uses: ./.github/actions/devenv

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: setup rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- upgrade `actions/checkout` from `v4` to `v6` in CI and docs workflows
- upgrade the composite devenv cache step from `actions/cache@v4` to `actions/cache@v5`
- remove the Node 20 deprecation warning path from the repository workflows

## Testing
- rely on PR GitHub Actions checks