### PR TITLE
docs: refresh shared CLI and automation guides

### DIFF
--- a/.templates/crates.t.md
+++ b/.templates/crates.t.md
@@ -128,7 +128,7 @@ Reach for this crate when you want one API and CLI surface that discovers packag
 ```bash
 mc init
 mc discover --format json
-mc change --package crates/monochange --bump patch --reason "describe the change"
+mc change --package monochange --bump patch --reason "describe the change"
 mc release --dry-run --format json
 ```
 

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -115,7 +115,13 @@ default = "text"
 [[cli.release.steps]]
 type = "PrepareRelease"
 
-[[cli.release.steps]]
+[cli.release-manifest]
+help_text = "Prepare a release and write a stable JSON manifest"
+
+[[cli.release-manifest.steps]]
+type = "PrepareRelease"
+
+[[cli.release-manifest.steps]]
 type = "RenderReleaseManifest"
 path = ".monochange/release-manifest.json"
 
@@ -277,7 +283,8 @@ Current implementation notes:
 
 - `defaults.include_private` is parsed, but discovery behavior is still centered on the supported fixture-driven CLI commands in this milestone
 - `version_groups.strategy` belongs to the legacy model and should be migrated to `[group.<id>]`
-- `[ecosystems.*].enabled/roots/exclude` are parsed and documented as the ecosystem control surface
+- legacy `[[workflows]]` configuration is no longer supported; use `[cli.<command>]` plus `[[cli.<command>.steps]]` instead
+- `[ecosystems.*].enabled/roots/exclude` are parsed, but discovery still scans all supported ecosystems regardless of those settings today
 - `package_overrides.changelog` is a legacy setting that should be migrated to package declarations
 - GitHub release publication currently expects `[github]` plus `[github.releases]` and uses `octocrab` with `GITHUB_TOKEN` / `GH_TOKEN` for live API calls outside dry-run mode
 - GitHub release pull requests currently expect `[github.pull_requests]` and use `git` for local branch/commit/push operations plus `octocrab` for live GitHub API calls
@@ -333,6 +340,7 @@ Legacy `version_groups.strategy` is no longer the primary authoring model. The c
 ```bash
 mc change --package sdk-core --bump minor --reason "public API addition"
 mc change --package sdk-core --bump patch --type security --reason "rotate signing keys" --details "Roll the signing key before the release window closes."
+mc change --package sdk-core --bump major --reason "break the public API" --evidence rust-semver:major:public API break detected --output .changeset/sdk-core-major.md
 ```
 
 <!-- {/releaseChangesAddCommand} -->
@@ -373,6 +381,7 @@ evidence:
 - `mc change` defaults `--bump` to `patch`
 - markdown change files require an explicit `patch`, `minor`, or `major` entry per package
 - optional change `type` values can route entries into custom changelog sections without changing semver impact
+- `mc change` can attach extra `--evidence ...` entries and write to a deterministic path with `--output ...`
 - change templates support detailed multi-line release-note entries through `$details`
 - dependents default to the configured `parent_bump`
 - Rust semver evidence can escalate both the changed crate and its dependents
@@ -413,6 +422,10 @@ Current `PrepareRelease` behavior:
 
 A GitHub Actions check can pass changed paths and labels directly into a policy workflow, for example:
 
+<!-- {/releaseWorkflowBehavior} -->
+
+<!-- {@changesetPolicyGitHubActionWorkflow} -->
+
 ```yaml
 name: changeset-policy
 
@@ -431,6 +444,7 @@ concurrency:
 
 jobs:
   check:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -455,25 +469,30 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
           mapfile -t labels < <(jq -r '.[]' <<<"$PR_LABELS_JSON")
           args=(changeset-check --format json)
+
           for path in $CHANGED_FILES; do
             args+=(--changed-path "$path")
           done
+
           for label in "${labels[@]}"; do
             args+=(--label "$label")
           done
-          devenv shell -- mc "${args[@]}" | tee policy.json
+
+          devenv shell -- mc "${args[@]}" | tee policy.raw
+          awk 'BEGIN { capture = 0 } /^\{/ { capture = 1 } capture { print }' policy.raw > policy.json
           jq -e '.status != "failed"' policy.json >/dev/null
 ```
 
-<!-- {/releaseWorkflowBehavior} -->
+<!-- {/changesetPolicyGitHubActionWorkflow} -->
 
 <!-- {@githubAutomationOverview} -->
 
 MonoChange keeps GitHub automation layered on top of the same `PrepareRelease` result used for normal release planning.
 
-That means one set of `.changeset/*.md` inputs can drive all of these workflows consistently:
+That means one set of `.changeset/*.md` inputs can drive all of these commands and automation flows consistently:
 
 - `mc release-manifest` writes a stable JSON artifact for downstream automation
 - `mc publish-release` previews or publishes GitHub releases from the structured release notes
@@ -526,47 +545,44 @@ title = "chore(release): prepare release"
 labels = ["release", "automated"]
 auto_merge = false
 
-[[workflows]]
-name = "release-manifest"
+[cli.release-manifest]
 help_text = "Prepare a release and write a stable JSON manifest"
 
-[[workflows.steps]]
+[[cli.release-manifest.steps]]
 type = "PrepareRelease"
 
-[[workflows.steps]]
+[[cli.release-manifest.steps]]
 type = "RenderReleaseManifest"
 path = ".monochange/release-manifest.json"
 
-[[workflows]]
-name = "publish-release"
+[cli.publish-release]
 help_text = "Prepare a release and publish GitHub releases"
 
-[[workflows.inputs]]
+[[cli.publish-release.inputs]]
 name = "format"
 type = "choice"
 choices = ["text", "json"]
 default = "text"
 
-[[workflows.steps]]
+[[cli.publish-release.steps]]
 type = "PrepareRelease"
 
-[[workflows.steps]]
+[[cli.publish-release.steps]]
 type = "PublishGitHubRelease"
 
-[[workflows]]
-name = "release-pr"
+[cli.release-pr]
 help_text = "Prepare a release and open or update a GitHub release pull request"
 
-[[workflows.inputs]]
+[[cli.release-pr.inputs]]
 name = "format"
 type = "choice"
 choices = ["text", "json"]
 default = "text"
 
-[[workflows.steps]]
+[[cli.release-pr.steps]]
 type = "PrepareRelease"
 
-[[workflows.steps]]
+[[cli.release-pr.steps]]
 type = "OpenReleasePullRequest"
 ```
 
@@ -609,42 +625,40 @@ release_targets = ["main"]
 requires = ["main"]
 metadata = { site = "github-pages" }
 
-[[workflows]]
-name = "release-deploy"
+[cli.release-deploy]
 help_text = "Prepare a release and emit deployment intents"
 
-[[workflows.inputs]]
+[[cli.release-deploy.inputs]]
 name = "format"
 type = "choice"
 choices = ["text", "json"]
 default = "text"
 
-[[workflows.steps]]
+[[cli.release-deploy.steps]]
 type = "PrepareRelease"
 
-[[workflows.steps]]
+[[cli.release-deploy.steps]]
 type = "Deploy"
 
-[[workflows]]
-name = "changeset-check"
+[cli.changeset-check]
 help_text = "Evaluate pull-request changeset policy"
 
-[[workflows.inputs]]
+[[cli.changeset-check.inputs]]
 name = "format"
 type = "choice"
 choices = ["text", "json"]
 default = "text"
 
-[[workflows.inputs]]
+[[cli.changeset-check.inputs]]
 name = "changed_path"
 type = "string_list"
 required = true
 
-[[workflows.inputs]]
+[[cli.changeset-check.inputs]]
 name = "label"
 type = "string_list"
 
-[[workflows.steps]]
+[[cli.changeset-check.steps]]
 type = "EnforceChangesetPolicy"
 ```
 
@@ -655,7 +669,7 @@ type = "EnforceChangesetPolicy"
 The MonoChange repository itself can dogfood this model by:
 
 - declaring `[github]`, `[github.releases]`, and `[github.pull_requests]` in `monochange.toml`
-- exposing `release-manifest`, `publish-release`, `release-pr`, `release-deploy`, and `changeset-check` as top-level workflows
+- exposing `release-manifest`, `publish-release`, `release-pr`, `release-deploy`, and `changeset-check` as top-level CLI commands
 - running a real `changeset-policy` GitHub Actions workflow that shells into `mc changeset-check`
 - keeping docs deployment represented as a deployment intent so downstream workflows can reason about it from the release manifest
 

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -82,6 +82,7 @@ mc validate
 mc discover --format json
 mc change --package monochange --bump minor --reason "add release planning"
 mc release --dry-run --format json
+mc release-manifest --dry-run
 mc publish-release --dry-run --format json
 mc release-pr --dry-run --format json
 mc release-deploy --dry-run --format json
@@ -241,6 +242,14 @@ type = "string"
 name = "details"
 type = "string"
 
+[[cli.change.inputs]]
+name = "evidence"
+type = "string_list"
+
+[[cli.change.inputs]]
+name = "output"
+type = "path"
+
 [[cli.change.steps]]
 type = "CreateChangeFile"
 
@@ -311,26 +320,25 @@ type = "PrepareRelease"
 [[cli.release-deploy.steps]]
 type = "Deploy"
 
-[[workflows]]
-name = "changeset-check"
+[cli.changeset-check]
 help_text = "Evaluate pull-request changeset policy"
 
-[[workflows.inputs]]
+[[cli.changeset-check.inputs]]
 name = "format"
 type = "choice"
 choices = ["text", "json"]
 default = "text"
 
-[[workflows.inputs]]
+[[cli.changeset-check.inputs]]
 name = "changed_path"
 type = "string_list"
 required = true
 
-[[workflows.inputs]]
+[[cli.changeset-check.inputs]]
 name = "label"
 type = "string_list"
 
-[[workflows.steps]]
+[[cli.changeset-check.steps]]
 type = "EnforceChangesetPolicy"
 ```
 
@@ -338,9 +346,9 @@ type = "EnforceChangesetPolicy"
 
 <!-- {@projectSetupConfigNote} -->
 
-This guide shows the preferred package/group configuration model together with the default top-level CLI commands emitted by `mc init`.
+This guide shows the preferred package/group configuration model together with an expanded CLI command surface.
 
-If you omit `[cli.<command>]` entries, MonoChange synthesizes the default `validate`, `discover`, `change`, and `release` commands automatically. Repositories can then customize those commands by declaring `[cli.<command>]` tables explicitly in `monochange.toml`.
+`mc init` emits the default `validate`, `discover`, `change`, and `release` commands using the same `[cli.<command>]` shape. Repositories can then customize those commands — or add commands such as `release-manifest`, `publish-release`, `release-pr`, `release-deploy`, and `changeset-check` — by declaring `[cli.<command>]` tables explicitly in `monochange.toml`.
 
 <!-- {/projectSetupConfigNote} -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ mc validate
 mc discover --format json
 mc change --package monochange --bump minor --reason "add release planning"
 mc release --dry-run --format json
+mc release-manifest --dry-run
 mc publish-release --dry-run --format json
 mc release-pr --dry-run --format json
 mc release-deploy --dry-run --format json

--- a/crates/monochange/readme.md
+++ b/crates/monochange/readme.md
@@ -33,7 +33,7 @@ Reach for this crate when you want one API and CLI surface that discovers packag
 ```bash
 mc init
 mc discover --format json
-mc change --package crates/monochange --bump patch --reason "describe the change"
+mc change --package monochange --bump patch --reason "describe the change"
 mc release --dry-run --format json
 ```
 

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -24,7 +24,7 @@
 //! ```bash
 //! mc init
 //! mc discover --format json
-//! mc change --package crates/monochange --bump patch --reason "describe the change"
+//! mc change --package monochange --bump patch --reason "describe the change"
 //! mc release --dry-run --format json
 //! ```
 //!

--- a/docs/src/guide/01-installation.md
+++ b/docs/src/guide/01-installation.md
@@ -13,6 +13,7 @@ mc validate
 mc discover --format json
 mc change --package monochange --bump minor --reason "add release planning"
 mc release --dry-run --format json
+mc release-manifest --dry-run
 mc publish-release --dry-run --format json
 mc release-pr --dry-run --format json
 mc release-deploy --dry-run --format json

--- a/docs/src/guide/02-setup.md
+++ b/docs/src/guide/02-setup.md
@@ -114,6 +114,14 @@ type = "string"
 name = "details"
 type = "string"
 
+[[cli.change.inputs]]
+name = "evidence"
+type = "string_list"
+
+[[cli.change.inputs]]
+name = "output"
+type = "path"
+
 [[cli.change.steps]]
 type = "CreateChangeFile"
 
@@ -184,26 +192,25 @@ type = "PrepareRelease"
 [[cli.release-deploy.steps]]
 type = "Deploy"
 
-[[workflows]]
-name = "changeset-check"
+[cli.changeset-check]
 help_text = "Evaluate pull-request changeset policy"
 
-[[workflows.inputs]]
+[[cli.changeset-check.inputs]]
 name = "format"
 type = "choice"
 choices = ["text", "json"]
 default = "text"
 
-[[workflows.inputs]]
+[[cli.changeset-check.inputs]]
 name = "changed_path"
 type = "string_list"
 required = true
 
-[[workflows.inputs]]
+[[cli.changeset-check.inputs]]
 name = "label"
 type = "string_list"
 
-[[workflows.steps]]
+[[cli.changeset-check.steps]]
 type = "EnforceChangesetPolicy"
 ```
 
@@ -211,9 +218,9 @@ type = "EnforceChangesetPolicy"
 
 <!-- {=projectSetupConfigNote} -->
 
-This guide shows the preferred package/group configuration model together with the default top-level CLI commands emitted by `mc init`.
+This guide shows the preferred package/group configuration model together with an expanded CLI command surface.
 
-If you omit `[cli.<command>]` entries, MonoChange synthesizes the default `validate`, `discover`, `change`, and `release` commands automatically. Repositories can then customize those commands by declaring `[cli.<command>]` tables explicitly in `monochange.toml`.
+`mc init` emits the default `validate`, `discover`, `change`, and `release` commands using the same `[cli.<command>]` shape. Repositories can then customize those commands — or add commands such as `release-manifest`, `publish-release`, `release-pr`, `release-deploy`, and `changeset-check` — by declaring `[cli.<command>]` tables explicitly in `monochange.toml`.
 
 <!-- {/projectSetupConfigNote} -->
 

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -154,9 +154,9 @@ versioned_files = [{ path = "group.toml", dependency = "sdk-core" }]
 
 Dependency targets in `versioned_files` must reference declared package ids.
 
-## Workflows
+## CLI commands
 
-Workflows are user-defined top-level commands. In this milestone, a workflow name such as `release` becomes invocable as `mc release`.
+CLI commands are user-defined top-level commands. Each `[cli.<command>]` entry becomes invocable as `mc <command>`, and legacy `[[workflows]]` tables are no longer supported.
 
 <!-- {=configurationWorkflowsSnippet} -->
 
@@ -192,7 +192,13 @@ default = "text"
 [[cli.release.steps]]
 type = "PrepareRelease"
 
-[[cli.release.steps]]
+[cli.release-manifest]
+help_text = "Prepare a release and write a stable JSON manifest"
+
+[[cli.release-manifest.steps]]
+type = "PrepareRelease"
+
+[[cli.release-manifest.steps]]
 type = "RenderReleaseManifest"
 path = ".monochange/release-manifest.json"
 
@@ -271,7 +277,7 @@ type = "EnforceChangesetPolicy"
 
 <!-- {/configurationWorkflowsSnippet} -->
 
-Workflow command interpolation variables:
+CLI command interpolation variables:
 
 <!-- {=configurationWorkflowVariables} -->
 
@@ -284,7 +290,7 @@ Workflow command interpolation variables:
 
 ## GitHub release settings
 
-Use `[github]` plus `[github.releases]` when you want workflow steps such as `PublishGitHubRelease` to derive repository release payloads from the prepared release.
+Use `[github]` plus `[github.releases]` when you want command steps such as `PublishGitHubRelease` to derive repository release payloads from the prepared release.
 
 <!-- {=configurationGitHubSnippet} -->
 
@@ -393,7 +399,8 @@ Current implementation notes:
 
 - `defaults.include_private` is parsed, but discovery behavior is still centered on the supported fixture-driven CLI commands in this milestone
 - `version_groups.strategy` belongs to the legacy model and should be migrated to `[group.<id>]`
-- `[ecosystems.*].enabled/roots/exclude` are parsed and documented as the ecosystem control surface
+- legacy `[[workflows]]` configuration is no longer supported; use `[cli.<command>]` plus `[[cli.<command>.steps]]` instead
+- `[ecosystems.*].enabled/roots/exclude` are parsed, but discovery still scans all supported ecosystems regardless of those settings today
 - `package_overrides.changelog` is a legacy setting that should be migrated to package declarations
 - GitHub release publication currently expects `[github]` plus `[github.releases]` and uses `octocrab` with `GITHUB_TOKEN` / `GH_TOKEN` for live API calls outside dry-run mode
 - GitHub release pull requests currently expect `[github.pull_requests]` and use `git` for local branch/commit/push operations plus `octocrab` for live GitHub API calls

--- a/docs/src/guide/06-release-planning.md
+++ b/docs/src/guide/06-release-planning.md
@@ -7,6 +7,7 @@ Create a changeset with the CLI:
 ```bash
 mc change --package sdk-core --bump minor --reason "public API addition"
 mc change --package sdk-core --bump patch --type security --reason "rotate signing keys" --details "Roll the signing key before the release window closes."
+mc change --package sdk-core --bump major --reason "break the public API" --evidence rust-semver:major:public API break detected --output .changeset/sdk-core-major.md
 ```
 
 <!-- {/releaseChangesAddCommand} -->
@@ -116,6 +117,10 @@ Current `PrepareRelease` behavior:
 
 A GitHub Actions check can pass changed paths and labels directly into a policy workflow, for example:
 
+<!-- {/releaseWorkflowBehavior} -->
+
+<!-- {=changesetPolicyGitHubActionWorkflow} -->
+
 ```yaml
 name: changeset-policy
 
@@ -134,6 +139,7 @@ concurrency:
 
 jobs:
   check:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -158,19 +164,24 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
           mapfile -t labels < <(jq -r '.[]' <<<"$PR_LABELS_JSON")
           args=(changeset-check --format json)
+
           for path in $CHANGED_FILES; do
             args+=(--changed-path "$path")
           done
+
           for label in "${labels[@]}"; do
             args+=(--label "$label")
           done
-          devenv shell -- mc "${args[@]}" | tee policy.json
+
+          devenv shell -- mc "${args[@]}" | tee policy.raw
+          awk 'BEGIN { capture = 0 } /^\{/ { capture = 1 } capture { print }' policy.raw > policy.json
           jq -e '.status != "failed"' policy.json >/dev/null
 ```
 
-<!-- {/releaseWorkflowBehavior} -->
+<!-- {/changesetPolicyGitHubActionWorkflow} -->
 
 Planning rules in this milestone:
 
@@ -179,6 +190,7 @@ Planning rules in this milestone:
 - `mc change` defaults `--bump` to `patch`
 - markdown change files require an explicit `patch`, `minor`, or `major` entry per package
 - optional change `type` values can route entries into custom changelog sections without changing semver impact
+- `mc change` can attach extra `--evidence ...` entries and write to a deterministic path with `--output ...`
 - change templates support detailed multi-line release-note entries through `$details`
 - dependents default to the configured `parent_bump`
 - Rust semver evidence can escalate both the changed crate and its dependents

--- a/docs/src/guide/08-github-automation.md
+++ b/docs/src/guide/08-github-automation.md
@@ -4,7 +4,7 @@
 
 MonoChange keeps GitHub automation layered on top of the same `PrepareRelease` result used for normal release planning.
 
-That means one set of `.changeset/*.md` inputs can drive all of these workflows consistently:
+That means one set of `.changeset/*.md` inputs can drive all of these commands and automation flows consistently:
 
 - `mc release-manifest` writes a stable JSON artifact for downstream automation
 - `mc publish-release` previews or publishes GitHub releases from the structured release notes
@@ -14,7 +14,7 @@ That means one set of `.changeset/*.md` inputs can drive all of these workflows 
 
 <!-- {/githubAutomationOverview} -->
 
-## Workflow commands
+## CLI commands
 
 <!-- {=githubAutomationWorkflowCommands} -->
 
@@ -61,47 +61,44 @@ title = "chore(release): prepare release"
 labels = ["release", "automated"]
 auto_merge = false
 
-[[workflows]]
-name = "release-manifest"
+[cli.release-manifest]
 help_text = "Prepare a release and write a stable JSON manifest"
 
-[[workflows.steps]]
+[[cli.release-manifest.steps]]
 type = "PrepareRelease"
 
-[[workflows.steps]]
+[[cli.release-manifest.steps]]
 type = "RenderReleaseManifest"
 path = ".monochange/release-manifest.json"
 
-[[workflows]]
-name = "publish-release"
+[cli.publish-release]
 help_text = "Prepare a release and publish GitHub releases"
 
-[[workflows.inputs]]
+[[cli.publish-release.inputs]]
 name = "format"
 type = "choice"
 choices = ["text", "json"]
 default = "text"
 
-[[workflows.steps]]
+[[cli.publish-release.steps]]
 type = "PrepareRelease"
 
-[[workflows.steps]]
+[[cli.publish-release.steps]]
 type = "PublishGitHubRelease"
 
-[[workflows]]
-name = "release-pr"
+[cli.release-pr]
 help_text = "Prepare a release and open or update a GitHub release pull request"
 
-[[workflows.inputs]]
+[[cli.release-pr.inputs]]
 name = "format"
 type = "choice"
 choices = ["text", "json"]
 default = "text"
 
-[[workflows.steps]]
+[[cli.release-pr.steps]]
 type = "PrepareRelease"
 
-[[workflows.steps]]
+[[cli.release-pr.steps]]
 type = "OpenReleasePullRequest"
 ```
 
@@ -146,48 +143,48 @@ release_targets = ["main"]
 requires = ["main"]
 metadata = { site = "github-pages" }
 
-[[workflows]]
-name = "release-deploy"
+[cli.release-deploy]
 help_text = "Prepare a release and emit deployment intents"
 
-[[workflows.inputs]]
+[[cli.release-deploy.inputs]]
 name = "format"
 type = "choice"
 choices = ["text", "json"]
 default = "text"
 
-[[workflows.steps]]
+[[cli.release-deploy.steps]]
 type = "PrepareRelease"
 
-[[workflows.steps]]
+[[cli.release-deploy.steps]]
 type = "Deploy"
 
-[[workflows]]
-name = "changeset-check"
+[cli.changeset-check]
 help_text = "Evaluate pull-request changeset policy"
 
-[[workflows.inputs]]
+[[cli.changeset-check.inputs]]
 name = "format"
 type = "choice"
 choices = ["text", "json"]
 default = "text"
 
-[[workflows.inputs]]
+[[cli.changeset-check.inputs]]
 name = "changed_path"
 type = "string_list"
 required = true
 
-[[workflows.inputs]]
+[[cli.changeset-check.inputs]]
 name = "label"
 type = "string_list"
 
-[[workflows.steps]]
+[[cli.changeset-check.steps]]
 type = "EnforceChangesetPolicy"
 ```
 
 <!-- {/githubAutomationPolicyAndDeployConfigExample} -->
 
 ## GitHub Actions policy workflow
+
+<!-- {=changesetPolicyGitHubActionWorkflow} -->
 
 ```yaml
 name: changeset-policy
@@ -207,6 +204,7 @@ concurrency:
 
 jobs:
   check:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -231,17 +229,24 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
           mapfile -t labels < <(jq -r '.[]' <<<"$PR_LABELS_JSON")
           args=(changeset-check --format json)
+
           for path in $CHANGED_FILES; do
             args+=(--changed-path "$path")
           done
+
           for label in "${labels[@]}"; do
             args+=(--label "$label")
           done
-          devenv shell -- mc "${args[@]}" | tee policy.json
+
+          devenv shell -- mc "${args[@]}" | tee policy.raw
+          awk 'BEGIN { capture = 0 } /^\{/ { capture = 1 } capture { print }' policy.raw > policy.json
           jq -e '.status != "failed"' policy.json >/dev/null
 ```
+
+<!-- {/changesetPolicyGitHubActionWorkflow} -->
 
 ## Dogfooding on the monochange repository
 
@@ -250,7 +255,7 @@ jobs:
 The MonoChange repository itself can dogfood this model by:
 
 - declaring `[github]`, `[github.releases]`, and `[github.pull_requests]` in `monochange.toml`
-- exposing `release-manifest`, `publish-release`, `release-pr`, `release-deploy`, and `changeset-check` as top-level workflows
+- exposing `release-manifest`, `publish-release`, `release-pr`, `release-deploy`, and `changeset-check` as top-level CLI commands
 - running a real `changeset-policy` GitHub Actions workflow that shells into `mc changeset-check`
 - keeping docs deployment represented as a deployment intent so downstream workflows can reason about it from the release manifest
 

--- a/readme.md
+++ b/readme.md
@@ -108,6 +108,7 @@ mc validate
 mc discover --format json
 mc change --package monochange --bump minor --reason "add release planning"
 mc release --dry-run --format json
+mc release-manifest --dry-run
 mc publish-release --dry-run --format json
 mc release-pr --dry-run --format json
 mc release-deploy --dry-run --format json


### PR DESCRIPTION
## Summary
- refresh shared docs so CLI/automation examples match the latest command model
- replace stale legacy `[[workflows]]` examples with `[cli.<command>]` examples
- deduplicate the changeset-policy GitHub Actions snippet with `mdt` and align it with the real workflow

## Validation
- devenv shell -- bash -lc 'docs:verify && lint:format'
