### PR TITLE
feat: validate cargo workspace-versioned packages share the same group

### DIFF
--- a/.changeset/020-cargo-workspace-version-group-validation.md
+++ b/.changeset/020-cargo-workspace-version-group-validation.md
@@ -1,0 +1,9 @@
+---
+main: minor
+---
+
+#### validate that cargo workspace-versioned packages share the same group
+
+`mc validate` now checks that all Cargo packages using `version.workspace = true` within the same Cargo workspace are assigned to the same version group. This prevents configuration mistakes where workspace-versioned packages are split across different groups or left ungrouped, which would cause version drift since they share a single `[workspace.package].version` field.
+
+The cargo adapter now marks discovered packages with `uses_workspace_version` metadata when they inherit their version from the workspace root, enabling the validation step to identify them without re-parsing manifests.

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -1411,6 +1411,75 @@ type = "PrepareRelease"
 	);
 }
 
+#[test]
+fn validate_rejects_workspace_versioned_packages_in_different_groups() {
+	let fixture_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+		.join("../../fixtures/cargo/workspace-versioned-different-groups");
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_directory(&fixture_root, tempdir.path());
+
+	let error = run_cli(
+		tempdir.path(),
+		[OsString::from("mc"), OsString::from("validate")],
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected validation failure"));
+	let rendered = error.to_string();
+
+	assert!(rendered.contains("version.workspace = true"));
+	assert!(rendered.contains("same version group"));
+}
+
+#[test]
+fn validate_rejects_workspace_versioned_packages_not_in_any_group() {
+	let fixture_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+		.join("../../fixtures/cargo/workspace-versioned-ungrouped");
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_directory(&fixture_root, tempdir.path());
+
+	let error = run_cli(
+		tempdir.path(),
+		[OsString::from("mc"), OsString::from("validate")],
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected validation failure"));
+	let rendered = error.to_string();
+
+	assert!(rendered.contains("version.workspace = true"));
+	assert!(rendered.contains("same version group"));
+	assert!(rendered.contains("not in any group"));
+}
+
+#[test]
+fn validate_accepts_workspace_versioned_packages_in_same_group() {
+	let fixture_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+		.join("../../fixtures/cargo/workspace-versioned-same-group");
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_directory(&fixture_root, tempdir.path());
+
+	let output = run_cli(
+		tempdir.path(),
+		[OsString::from("mc"), OsString::from("validate")],
+	)
+	.unwrap_or_else(|error| panic!("validate output: {error}"));
+	assert!(output.contains("workspace validation passed"));
+}
+
+#[test]
+fn validate_accepts_single_workspace_versioned_package_without_group() {
+	let fixture_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+		.join("../../fixtures/cargo/workspace-versioned-single");
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_directory(&fixture_root, tempdir.path());
+
+	let output = run_cli(
+		tempdir.path(),
+		[OsString::from("mc"), OsString::from("validate")],
+	)
+	.unwrap_or_else(|error| panic!("validate output: {error}"));
+	assert!(output.contains("workspace validation passed"));
+}
+
 fn write_file(path: impl AsRef<Path>, content: &str) {
 	let path = path.as_ref();
 	if let Some(parent) = path.parent() {

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -778,6 +778,7 @@ fn execute_cli_command(
 		match step {
 			CliStepDefinition::Validate => {
 				validate_workspace(root)?;
+				validate_cargo_workspace_version_groups(root)?;
 				output = Some(format!(
 					"workspace validation passed for {}",
 					root_relative(root, root).display()
@@ -1790,6 +1791,67 @@ fn package_type_for_ecosystem(ecosystem: Ecosystem) -> PackageType {
 		Ecosystem::Dart => PackageType::Dart,
 		Ecosystem::Flutter => PackageType::Flutter,
 	}
+}
+
+fn validate_cargo_workspace_version_groups(root: &Path) -> MonochangeResult<()> {
+	let configuration = load_workspace_configuration(root)?;
+	if configuration.packages.is_empty() {
+		return Ok(());
+	}
+
+	let cargo_discovery = discover_cargo_packages(root)?;
+	let mut packages = cargo_discovery.packages;
+	if packages.is_empty() {
+		return Ok(());
+	}
+
+	apply_version_groups(&mut packages, &configuration)?;
+
+	let mut workspace_versioned = BTreeMap::<PathBuf, Vec<usize>>::new();
+	for (index, package) in packages.iter().enumerate() {
+		if package.ecosystem == Ecosystem::Cargo
+			&& package.metadata.contains_key("config_id")
+			&& package
+				.metadata
+				.get("uses_workspace_version")
+				.map(String::as_str)
+				== Some("true")
+		{
+			workspace_versioned
+				.entry(package.workspace_root.clone())
+				.or_default()
+				.push(index);
+		}
+	}
+
+	for indices in workspace_versioned.values() {
+		if indices.len() < 2 {
+			continue;
+		}
+
+		let group_ids = indices
+			.iter()
+			.filter_map(|index| packages.get(*index))
+			.map(|package| package.version_group_id.as_deref())
+			.collect::<BTreeSet<_>>();
+
+		if group_ids.len() > 1 || group_ids.contains(&None) {
+			let details = indices
+				.iter()
+				.filter_map(|index| packages.get(*index))
+				.map(|package| match &package.version_group_id {
+					Some(group_id) => format!("`{}` in group `{}`", package.name, group_id),
+					None => format!("`{}` not in any group", package.name),
+				})
+				.collect::<Vec<_>>();
+			return Err(MonochangeError::Config(format!(
+				"cargo packages using `version.workspace = true` must belong to the same version group, but found mismatched assignments: {}",
+				details.join(", ")
+			)));
+		}
+	}
+
+	Ok(())
 }
 
 pub fn discover_workspace(root: &Path) -> MonochangeResult<DiscoveryReport> {

--- a/crates/monochange/tests/cli_output.rs
+++ b/crates/monochange/tests/cli_output.rs
@@ -32,8 +32,10 @@ macro_rules! apply_common_filters {
 #[test]
 fn validate_cli_succeeds_for_valid_workspace() {
 	apply_common_filters!();
+	let fixture_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+		.join("../../fixtures/cargo/workspace-versioned-grouped-release");
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
-	seed_ungrouped_release_fixture(tempdir.path());
+	copy_directory(&fixture_root, tempdir.path());
 
 	assert_cmd_snapshot!(
 		cli().current_dir(tempdir.path()).arg("validate"),
@@ -787,6 +789,36 @@ packages = ["core"]
 	help: move the package into exactly one [group.<id>] declaration
 	"###
 	);
+}
+
+fn copy_directory(source: &Path, destination: &Path) {
+	fs::create_dir_all(destination)
+		.unwrap_or_else(|error| panic!("create destination {}: {error}", destination.display()));
+	for entry in fs::read_dir(source)
+		.unwrap_or_else(|error| panic!("read dir {}: {error}", source.display()))
+	{
+		let entry = entry.unwrap_or_else(|error| panic!("dir entry: {error}"));
+		let source_path = entry.path();
+		let destination_path = destination.join(entry.file_name());
+		let file_type = entry
+			.file_type()
+			.unwrap_or_else(|error| panic!("file type {}: {error}", source_path.display()));
+		if file_type.is_dir() {
+			copy_directory(&source_path, &destination_path);
+		} else if file_type.is_file() {
+			if let Some(parent) = destination_path.parent() {
+				fs::create_dir_all(parent)
+					.unwrap_or_else(|error| panic!("create parent {}: {error}", parent.display()));
+			}
+			fs::copy(&source_path, &destination_path).unwrap_or_else(|error| {
+				panic!(
+					"copy {} -> {}: {error}",
+					source_path.display(),
+					destination_path.display()
+				)
+			});
+		}
+	}
 }
 
 fn seed_ungrouped_release_fixture(root: &Path) {

--- a/crates/monochange_cargo/src/__tests.rs
+++ b/crates/monochange_cargo/src/__tests.rs
@@ -1,11 +1,9 @@
-use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 
 use monochange_core::materialize_dependency_edges;
 use monochange_core::ChangeSignal;
 use monochange_semver::CompatibilityProvider;
-use tempfile::tempdir;
 
 use crate::discover_cargo_packages;
 use crate::RustSemverProvider;
@@ -34,37 +32,15 @@ fn discovers_cargo_workspace_members() {
 
 #[test]
 fn cargo_workspace_members_inherit_workspace_package_versions() {
-	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
-	fs::create_dir_all(tempdir.path().join("crates/core"))
-		.unwrap_or_else(|error| panic!("create core dir: {error}"));
-	fs::write(
-		tempdir.path().join("Cargo.toml"),
-		r#"
-[workspace]
-members = ["crates/*"]
-
-[workspace.package]
-version = "2.3.4"
-"#,
-	)
-	.unwrap_or_else(|error| panic!("workspace manifest: {error}"));
-	fs::write(
-		tempdir.path().join("crates/core/Cargo.toml"),
-		r#"
-[package]
-name = "workspace-core"
-version = { workspace = true }
-edition = "2021"
-"#,
-	)
-	.unwrap_or_else(|error| panic!("package manifest: {error}"));
-
-	let discovery = discover_cargo_packages(tempdir.path())
+	let fixture_root =
+		Path::new(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/cargo/workspace-versioned");
+	let discovery = discover_cargo_packages(&fixture_root)
 		.unwrap_or_else(|error| panic!("cargo discovery: {error}"));
 	let package = discovery
 		.packages
-		.first()
-		.unwrap_or_else(|| panic!("expected one package"));
+		.iter()
+		.find(|package| package.name == "workspace-core")
+		.unwrap_or_else(|| panic!("expected workspace-core package"));
 
 	assert_eq!(
 		package
@@ -73,6 +49,40 @@ edition = "2021"
 			.map(ToString::to_string)
 			.as_deref(),
 		Some("2.3.4")
+	);
+}
+
+#[test]
+fn cargo_workspace_members_mark_uses_workspace_version_metadata() {
+	let fixture_root =
+		Path::new(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/cargo/workspace-versioned");
+	let discovery = discover_cargo_packages(&fixture_root)
+		.unwrap_or_else(|error| panic!("cargo discovery: {error}"));
+
+	let core_package = discovery
+		.packages
+		.iter()
+		.find(|package| package.name == "workspace-core")
+		.unwrap_or_else(|| panic!("expected workspace-core package"));
+	assert_eq!(
+		core_package
+			.metadata
+			.get("uses_workspace_version")
+			.map(String::as_str),
+		Some("true")
+	);
+
+	let app_package = discovery
+		.packages
+		.iter()
+		.find(|package| package.name == "workspace-app")
+		.unwrap_or_else(|| panic!("expected workspace-app package"));
+	assert_eq!(
+		app_package
+			.metadata
+			.get("uses_workspace_version")
+			.map(String::as_str),
+		None
 	);
 }
 

--- a/crates/monochange_cargo/src/lib.rs
+++ b/crates/monochange_cargo/src/lib.rs
@@ -305,6 +305,17 @@ fn parse_package_manifest(
 		version,
 		publish_state,
 	);
+	let uses_workspace_version = package
+		.get("version")
+		.and_then(Value::as_table)
+		.and_then(|table| table.get("workspace"))
+		.and_then(Value::as_bool)
+		.unwrap_or(false);
+	if uses_workspace_version {
+		package_record
+			.metadata
+			.insert("uses_workspace_version".to_string(), "true".to_string());
+	}
 	package_record.declared_dependencies = parse_dependencies(&parsed);
 	Ok(Some(package_record))
 }

--- a/docs/agents/workflow.md
+++ b/docs/agents/workflow.md
@@ -10,4 +10,5 @@
 - Implement the smallest change that makes the tests pass.
 - After making changes, run `fix:all` so formatting and clippy autofixes are applied before final validation.
 - Update docs, READMEs, fixtures, changeset examples, and templates when behavior changes.
+- Always include a `.changeset/*.md` file in feature and fix branches that change behavior in any published crate. Use `mc change` to generate the file, targeting the affected packages or groups with the appropriate bump level.
 - Run the full local validation suite before opening a PR.

--- a/fixtures/cargo/workspace-versioned-different-groups/Cargo.toml
+++ b/fixtures/cargo/workspace-versioned-different-groups/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+members = ["crates/*"]
+
+[workspace.package]
+version = "1.0.0"

--- a/fixtures/cargo/workspace-versioned-different-groups/crates/alpha/Cargo.toml
+++ b/fixtures/cargo/workspace-versioned-different-groups/crates/alpha/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "alpha"
+version = { workspace = true }

--- a/fixtures/cargo/workspace-versioned-different-groups/crates/beta/Cargo.toml
+++ b/fixtures/cargo/workspace-versioned-different-groups/crates/beta/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "beta"
+version = { workspace = true }

--- a/fixtures/cargo/workspace-versioned-different-groups/crates/gamma/Cargo.toml
+++ b/fixtures/cargo/workspace-versioned-different-groups/crates/gamma/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "gamma"
+version = { workspace = true }

--- a/fixtures/cargo/workspace-versioned-different-groups/monochange.toml
+++ b/fixtures/cargo/workspace-versioned-different-groups/monochange.toml
@@ -1,0 +1,17 @@
+[defaults]
+package_type = "cargo"
+
+[package.alpha]
+path = "crates/alpha"
+
+[package.beta]
+path = "crates/beta"
+
+[package.gamma]
+path = "crates/gamma"
+
+[group.group-a]
+packages = ["alpha", "beta"]
+
+[group.group-b]
+packages = ["gamma"]

--- a/fixtures/cargo/workspace-versioned-grouped-release/.changeset/feature.md
+++ b/fixtures/cargo/workspace-versioned-grouped-release/.changeset/feature.md
@@ -1,0 +1,5 @@
+---
+core: minor
+---
+
+#### add feature

--- a/fixtures/cargo/workspace-versioned-grouped-release/Cargo.toml
+++ b/fixtures/cargo/workspace-versioned-grouped-release/Cargo.toml
@@ -1,0 +1,10 @@
+[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[workspace.package]
+version = "1.0.0"
+
+[workspace.dependencies]
+workflow-core = { path = "./crates/core", version = "1.0.0" }
+workflow-app = { path = "./crates/app", version = "1.0.0" }

--- a/fixtures/cargo/workspace-versioned-grouped-release/crates/app/Cargo.toml
+++ b/fixtures/cargo/workspace-versioned-grouped-release/crates/app/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "workflow-app"
+version = { workspace = true }
+edition = "2021"
+
+[dependencies]
+workflow-core = { workspace = true }

--- a/fixtures/cargo/workspace-versioned-grouped-release/crates/core/Cargo.toml
+++ b/fixtures/cargo/workspace-versioned-grouped-release/crates/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "workflow-core"
+version = { workspace = true }
+edition = "2021"

--- a/fixtures/cargo/workspace-versioned-grouped-release/monochange.toml
+++ b/fixtures/cargo/workspace-versioned-grouped-release/monochange.toml
@@ -1,0 +1,15 @@
+[defaults]
+parent_bump = "patch"
+package_type = "cargo"
+
+[package.core]
+path = "crates/core"
+
+[package.app]
+path = "crates/app"
+
+[group.sdk]
+packages = ["core", "app"]
+
+[ecosystems.cargo]
+enabled = true

--- a/fixtures/cargo/workspace-versioned-same-group/Cargo.toml
+++ b/fixtures/cargo/workspace-versioned-same-group/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+members = ["crates/*"]
+
+[workspace.package]
+version = "1.0.0"

--- a/fixtures/cargo/workspace-versioned-same-group/crates/alpha/Cargo.toml
+++ b/fixtures/cargo/workspace-versioned-same-group/crates/alpha/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "alpha"
+version = { workspace = true }

--- a/fixtures/cargo/workspace-versioned-same-group/crates/beta/Cargo.toml
+++ b/fixtures/cargo/workspace-versioned-same-group/crates/beta/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "beta"
+version = { workspace = true }

--- a/fixtures/cargo/workspace-versioned-same-group/monochange.toml
+++ b/fixtures/cargo/workspace-versioned-same-group/monochange.toml
@@ -1,0 +1,11 @@
+[defaults]
+package_type = "cargo"
+
+[package.alpha]
+path = "crates/alpha"
+
+[package.beta]
+path = "crates/beta"
+
+[group.sdk]
+packages = ["alpha", "beta"]

--- a/fixtures/cargo/workspace-versioned-single/Cargo.toml
+++ b/fixtures/cargo/workspace-versioned-single/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+members = ["crates/*"]
+
+[workspace.package]
+version = "1.0.0"

--- a/fixtures/cargo/workspace-versioned-single/crates/alpha/Cargo.toml
+++ b/fixtures/cargo/workspace-versioned-single/crates/alpha/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "alpha"
+version = { workspace = true }

--- a/fixtures/cargo/workspace-versioned-single/monochange.toml
+++ b/fixtures/cargo/workspace-versioned-single/monochange.toml
@@ -1,0 +1,5 @@
+[defaults]
+package_type = "cargo"
+
+[package.alpha]
+path = "crates/alpha"

--- a/fixtures/cargo/workspace-versioned-ungrouped/Cargo.toml
+++ b/fixtures/cargo/workspace-versioned-ungrouped/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+members = ["crates/*"]
+
+[workspace.package]
+version = "1.0.0"

--- a/fixtures/cargo/workspace-versioned-ungrouped/crates/alpha/Cargo.toml
+++ b/fixtures/cargo/workspace-versioned-ungrouped/crates/alpha/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "alpha"
+version = { workspace = true }

--- a/fixtures/cargo/workspace-versioned-ungrouped/crates/beta/Cargo.toml
+++ b/fixtures/cargo/workspace-versioned-ungrouped/crates/beta/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "beta"
+version = { workspace = true }

--- a/fixtures/cargo/workspace-versioned-ungrouped/monochange.toml
+++ b/fixtures/cargo/workspace-versioned-ungrouped/monochange.toml
@@ -1,0 +1,8 @@
+[defaults]
+package_type = "cargo"
+
+[package.alpha]
+path = "crates/alpha"
+
+[package.beta]
+path = "crates/beta"

--- a/fixtures/cargo/workspace-versioned/Cargo.toml
+++ b/fixtures/cargo/workspace-versioned/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+members = ["crates/*"]
+
+[workspace.package]
+version = "2.3.4"

--- a/fixtures/cargo/workspace-versioned/crates/app/Cargo.toml
+++ b/fixtures/cargo/workspace-versioned/crates/app/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "workspace-app"
+version = "1.0.0"
+edition = "2021"

--- a/fixtures/cargo/workspace-versioned/crates/core/Cargo.toml
+++ b/fixtures/cargo/workspace-versioned/crates/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "workspace-core"
+version = { workspace = true }
+edition = "2021"


### PR DESCRIPTION
## Summary

This PR ensures the Cargo ecosystem correctly handles `version = { workspace = true }` packages during validation and version updates.

### Changes

**Cargo adapter metadata tracking** (`monochange_cargo`)
- When a Cargo package uses `version = { workspace = true }`, the `PackageRecord` is now marked with `uses_workspace_version = "true"` metadata
- Packages with explicit version strings do NOT get this metadata

**Workspace version group validation** (`monochange`)
- `mc validate` now checks that all Cargo packages using `version.workspace = true` within the same Cargo workspace belong to the same version group
- Error cases caught:
  - Workspace-versioned packages split across different groups
  - Multiple workspace-versioned packages not assigned to any group
- Single workspace-versioned packages without a group are allowed (no constraint needed)
- The existing cargo manifest update logic already correctly skips editing packages with workspace-inherited versions (it updates the workspace root manifest instead)

### Tests added
- `cargo_workspace_members_mark_uses_workspace_version_metadata` — verifies metadata tagging
- `validate_rejects_workspace_versioned_packages_in_different_groups` — split across groups → error
- `validate_rejects_workspace_versioned_packages_not_in_any_group` — ungrouped → error
- `validate_accepts_workspace_versioned_packages_in_same_group` — same group → success
- `validate_accepts_single_workspace_versioned_package_without_group` — single pkg → success
- Updated `validate_cli_succeeds_for_valid_workspace` snapshot test to use a grouped fixture