### PR TITLE
chore: add pnpm workspace with root package.json

### DIFF
--- a/.changeset/021-pnpm-workspace-setup.md
+++ b/.changeset/021-pnpm-workspace-setup.md
@@ -1,0 +1,5 @@
+---
+monochange: patch
+---
+
+Add pnpm workspace configuration with a root `package.json`, register `npm/skill` as a workspace member, and add `node_modules/` to `.gitignore`.

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 devenv.local.nix
 
 **/dist/**
+node_modules/
 
 # insta snapshots
 *.pending-snap

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+	"private": true,
+	"name": "@monochange/root",
+	"description": "Monorepo root for monochange npm packages",
+	"license": "Unlicense",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/ifiokjr/monochange.git"
+	},
+	"engines": {
+		"node": ">=18",
+		"pnpm": ">=9"
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,10 @@
+lockfileVersion: "9.0"
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .: {}
+
+  npm/skill: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+useNodeVersion: 24.14.0
+nodeVersion: 24.14.0
+packages:
+  - "npm/skill"


### PR DESCRIPTION
## Summary

Add pnpm workspace configuration so the `npm/` packages are managed as a monorepo.

### Changes
- **`pnpm-workspace.yaml`** — add `packages: ["npm/skill"]` alongside the existing `useNodeVersion`/`nodeVersion` settings
- **`package.json`** — private root package for the workspace
- **`pnpm-lock.yaml`** — generated lockfile (no dependencies yet)
- **`.gitignore`** — add `node_modules/`
- **`.changeset/021-pnpm-workspace-setup.md`** — changeset for `monochange` (patch)

### Validation
- `cargo test --workspace` ✅
- `devenv shell -- lint:all` ✅
- `pnpm install` recognises both the root and `npm/skill` as workspace projects
