### PR TITLE
refactor: hide changeset paths from default context

### DIFF
--- a/.changeset/022-context-default-cleanup.md
+++ b/.changeset/022-context-default-cleanup.md
@@ -1,0 +1,5 @@
+---
+monochange: patch
+---
+
+Keep the source changeset path available as `$changeset_path`, but stop showing it by default in the rendered `$context` metadata block and document all fine-grained release-note metadata variables more thoroughly.

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -81,15 +81,32 @@ You can also customize release-note rendering with a workspace-wide `[release_no
 
 Supported template variables include:
 
-- core release-note values: `$summary`, `$details`, `$package`, `$version`, `$target_id`, `$bump`, and `$type`
-- pre-rendered metadata block: `$context` (preferred) or legacy alias `$provenance`
-- authored file path: `$changeset_path`
-- change owner / actor: `$change_owner`, `$change_owner_link`
-- linked review request: `$review_request`, `$review_request_link`
-- linked commits: `$introduced_commit`, `$introduced_commit_link`, `$last_updated_commit`, `$last_updated_commit_link`
-- linked issues: `$closed_issues`, `$closed_issue_links`, `$related_issues`, `$related_issue_links`
+| Variable                    | Meaning                                                               | Notes                                                                                                 |
+| --------------------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `$summary`                  | rendered release-note summary heading                                 | always available                                                                                      |
+| `$details`                  | optional long-form details body                                       | omitted when the changeset has no details                                                             |
+| `$package`                  | owning package id for the rendered entry                              | useful in shared templates                                                                            |
+| `$version`                  | release version for the current target                                | package or group version                                                                              |
+| `$target_id`                | release target id                                                     | package id or group id                                                                                |
+| `$bump`                     | resolved bump severity                                                | `patch`, `minor`, or `major`                                                                          |
+| `$type`                     | changeset note type                                                   | e.g. `feature`, `fix`, `security`; omitted when absent                                                |
+| `$context`                  | compact default metadata block                                        | preferred rendered block for human-readable notes                                                     |
+| `$provenance`               | legacy alias for `$context`                                           | kept for backward compatibility                                                                       |
+| `$changeset_path`           | source `.changeset/*.md` path                                         | tracked in manifests and still available for custom templates, but not shown by default in `$context` |
+| `$change_owner`             | plain-text hosted actor label                                         | usually something like `@ifiokjr`                                                                     |
+| `$change_owner_link`        | markdown link to the hosted actor                                     | falls back to plain text when no URL is available                                                     |
+| `$review_request`           | plain-text PR/MR label                                                | e.g. `PR #31` or `MR !42`                                                                             |
+| `$review_request_link`      | markdown link to the PR/MR                                            | falls back to plain text when no URL is available                                                     |
+| `$introduced_commit`        | short SHA for the commit that first introduced the changeset          | plain text only                                                                                       |
+| `$introduced_commit_link`   | markdown link to the introducing commit                               | preferred for changelog output                                                                        |
+| `$last_updated_commit`      | short SHA for the most recent commit that changed the changeset       | only populated when different from `$introduced_commit`                                               |
+| `$last_updated_commit_link` | markdown link to the most recent commit that changed the changeset    | only populated when different from `$introduced_commit`                                               |
+| `$closed_issues`            | plain-text list of issues closed by the linked review request         | typically `#12, #18`                                                                                  |
+| `$closed_issue_links`       | markdown links to issues closed by the linked review request          | preferred for changelog output                                                                        |
+| `$related_issues`           | plain-text list of related issues that were referenced but not closed | host support may vary                                                                                 |
+| `$related_issue_links`      | markdown links to related issues that were referenced but not closed  | host support may vary                                                                                 |
 
-The `*_link` variants render markdown links when the hosting provider exposes URLs. The `$context` block is the easiest default because it collapses available metadata into a compact, human-readable note without forcing every template to handle missing fields explicitly.
+The `*_link` variants render markdown links when the hosting provider exposes URLs. By default `$context` renders the highest-value metadata for readers — owner, review request, introduced commit, last updated commit when different, and linked issues — without exposing the transient `.changeset/*.md` path unless you explicitly reference `$changeset_path` in your template.
 
 <!-- {/configurationPackageOverridesSnippet} -->
 

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -2537,7 +2537,7 @@ fn build_rendered_changeset_context(
 		changeset_path: changeset_path.clone(),
 		..RenderedChangesetContext::default()
 	};
-	let mut lines = vec![format!("> _Changeset:_ `{changeset_path}`")];
+	let mut lines = Vec::new();
 	let Some(context) = changeset.context.as_ref() else {
 		rendered.context = lines.join("\n");
 		return rendered;

--- a/crates/monochange/tests/changeset_provenance.rs
+++ b/crates/monochange/tests/changeset_provenance.rs
@@ -103,7 +103,7 @@ Track the commit history in release notes.
 	let rendered = parsed["changelogs"][0]["rendered"]
 		.as_str()
 		.unwrap_or_else(|| panic!("expected rendered changelog"));
-	assert!(rendered.contains("> _Changeset:_ `.changeset/feature.md`"));
+	assert!(!rendered.contains("> _Changeset:_ `.changeset/feature.md`"));
 	assert!(rendered.contains(&introduced_sha[..7]));
 	assert!(rendered.contains(&updated_sha[..7]));
 }

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -398,15 +398,32 @@ You can also customize release-note rendering with a workspace-wide `[release_no
 
 Supported template variables include:
 
-- core release-note values: `$summary`, `$details`, `$package`, `$version`, `$target_id`, `$bump`, and `$type`
-- pre-rendered metadata block: `$context` (preferred) or legacy alias `$provenance`
-- authored file path: `$changeset_path`
-- change owner / actor: `$change_owner`, `$change_owner_link`
-- linked review request: `$review_request`, `$review_request_link`
-- linked commits: `$introduced_commit`, `$introduced_commit_link`, `$last_updated_commit`, `$last_updated_commit_link`
-- linked issues: `$closed_issues`, `$closed_issue_links`, `$related_issues`, `$related_issue_links`
+| Variable                    | Meaning                                                               | Notes                                                                                                 |
+| --------------------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `$summary`                  | rendered release-note summary heading                                 | always available                                                                                      |
+| `$details`                  | optional long-form details body                                       | omitted when the changeset has no details                                                             |
+| `$package`                  | owning package id for the rendered entry                              | useful in shared templates                                                                            |
+| `$version`                  | release version for the current target                                | package or group version                                                                              |
+| `$target_id`                | release target id                                                     | package id or group id                                                                                |
+| `$bump`                     | resolved bump severity                                                | `patch`, `minor`, or `major`                                                                          |
+| `$type`                     | changeset note type                                                   | e.g. `feature`, `fix`, `security`; omitted when absent                                                |
+| `$context`                  | compact default metadata block                                        | preferred rendered block for human-readable notes                                                     |
+| `$provenance`               | legacy alias for `$context`                                           | kept for backward compatibility                                                                       |
+| `$changeset_path`           | source `.changeset/*.md` path                                         | tracked in manifests and still available for custom templates, but not shown by default in `$context` |
+| `$change_owner`             | plain-text hosted actor label                                         | usually something like `@ifiokjr`                                                                     |
+| `$change_owner_link`        | markdown link to the hosted actor                                     | falls back to plain text when no URL is available                                                     |
+| `$review_request`           | plain-text PR/MR label                                                | e.g. `PR #31` or `MR !42`                                                                             |
+| `$review_request_link`      | markdown link to the PR/MR                                            | falls back to plain text when no URL is available                                                     |
+| `$introduced_commit`        | short SHA for the commit that first introduced the changeset          | plain text only                                                                                       |
+| `$introduced_commit_link`   | markdown link to the introducing commit                               | preferred for changelog output                                                                        |
+| `$last_updated_commit`      | short SHA for the most recent commit that changed the changeset       | only populated when different from `$introduced_commit`                                               |
+| `$last_updated_commit_link` | markdown link to the most recent commit that changed the changeset    | only populated when different from `$introduced_commit`                                               |
+| `$closed_issues`            | plain-text list of issues closed by the linked review request         | typically `#12, #18`                                                                                  |
+| `$closed_issue_links`       | markdown links to issues closed by the linked review request          | preferred for changelog output                                                                        |
+| `$related_issues`           | plain-text list of related issues that were referenced but not closed | host support may vary                                                                                 |
+| `$related_issue_links`      | markdown links to related issues that were referenced but not closed  | host support may vary                                                                                 |
 
-The `*_link` variants render markdown links when the hosting provider exposes URLs. The `$context` block is the easiest default because it collapses available metadata into a compact, human-readable note without forcing every template to handle missing fields explicitly.
+The `*_link` variants render markdown links when the hosting provider exposes URLs. By default `$context` renders the highest-value metadata for readers — owner, review request, introduced commit, last updated commit when different, and linked issues — without exposing the transient `.changeset/*.md` path unless you explicitly reference `$changeset_path` in your template.
 
 <!-- {/configurationPackageOverridesSnippet} -->
 

--- a/docs/src/guide/08-github-automation.md
+++ b/docs/src/guide/08-github-automation.md
@@ -113,7 +113,7 @@ type = "OpenReleaseRequest"
 
 <!-- {/githubAutomationReleaseConfigExample} -->
 
-When you want fine-grained changelog formatting instead of the default `$context` block, GitHub-backed release notes can reference individual metadata fields such as `$change_owner_link`, `$review_request_link`, `$introduced_commit_link`, `$closed_issue_links`, and `$related_issue_links`. Those variables render markdown links when host URLs are available, so generated changelogs can point directly at the responsible actor, the PR, and linked issues.
+When you want fine-grained changelog formatting instead of the default `$context` block, GitHub-backed release notes can reference individual metadata fields such as `$change_owner_link`, `$review_request_link`, `$introduced_commit_link`, `$closed_issue_links`, and `$related_issue_links`. Those variables render markdown links when host URLs are available, so generated changelogs can point directly at the responsible actor, the PR, and linked issues. The source changeset path stays available through `$changeset_path`, but `$context` keeps that transient file path out of the default rendered note.
 
 ## Deployment intents and changeset policy
 


### PR DESCRIPTION
## Summary
- stop showing the transient `.changeset/*.md` path in the default `$context` metadata block
- keep `$changeset_path` available for custom templates and release manifests
- document every release-note template variable in more detail, including the fine-grained linked metadata fields
- clarify GitHub automation docs around `$context` vs explicit metadata variables

## Validation
- `cargo test --workspace`
- `devenv shell -- lint:all`
- `devenv shell -- mc verify --format json --changed-paths .changeset/022-context-default-cleanup.md --changed-paths .templates/guides.t.md --changed-paths crates/monochange/src/lib.rs --changed-paths crates/monochange/tests/changeset_provenance.rs --changed-paths docs/src/guide/04-configuration.md --changed-paths docs/src/guide/08-github-automation.md`

## Notes
- `$context` now defaults to owner / review / commit / issue metadata only
- `$changeset_path` is still supported for teams that explicitly want to show source changeset file paths
