### PR TITLE
fix: skip broken pnpm-standalone install check in CI

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -7,6 +7,12 @@
 
 let
   extra = inputs.ifiokjr-nixpkgs.packages.${pkgs.stdenv.system};
+  pnpmStandalone = extra.pnpm-standalone.overrideAttrs (_old: {
+    # Keep using pnpm-standalone for Node management, but skip the upstream
+    # installCheck that currently fails on Linux CI when exercising the
+    # pnpm-activate-env helper under a synthetic `/usr/bin/env`-free path.
+    doInstallCheck = false;
+  });
 in
 {
   packages =
@@ -17,7 +23,7 @@ in
       deno
       dprint
       extra.mdt
-      extra.pnpm-standalone
+      pnpmStandalone
       mdbook
       nixfmt
       rustup


### PR DESCRIPTION
## Summary

Fix CI failure introduced by the `pnpm-standalone` switch (`b529b7f`).

### Root cause
The upstream `pnpm-standalone` nix package has an `installCheck` phase that exercises the `pnpm-activate-env` helper by creating a fake pnpm script with `#!/usr/bin/env bash`. On Linux CI runners (NixOS-style sandbox), `/usr/bin/env` does not exist, so the check fails with `bad interpreter: No such file or directory`.

### Fix
Override `pnpm-standalone` with `doInstallCheck = false` in `devenv.nix`. This keeps the package and `pnpm-activate-env` working while skipping the broken upstream check.

### What is preserved
- `pnpm-standalone` is still used (not reverted)
- `pnpm-activate-env` is still evaluated in `enterShell`
- Node version management via pnpm-standalone is unchanged

### Validation
- `devenv shell -- lint:all` ✅
- `pnpm --version` → `10.33.0` ✅
- `node --version` → `v24.14.0` ✅
- `mc verify --format json --changed-paths devenv.nix` → `not_required` ✅
