### PR TITLE
feat: add interactive mode for mc change

### DIFF
--- a/.changeset/023-interactive-change.md
+++ b/.changeset/023-interactive-change.md
@@ -1,0 +1,8 @@
+---
+monochange: minor
+monochange_core: minor
+---
+
+#### add interactive mode for mc change
+
+Add `mc change --interactive` (`-i`) that guides users through package/group selection, per-target bump choices, optional explicit versions, change type, and release-note summary. Conflicting selections (a group and one of its members) are automatically prevented. Adds `short` alias support to CLI input definitions.

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -378,6 +378,14 @@ mc change --package sdk-core --bump patch --type security --reason "rotate signi
 mc change --package sdk-core --bump major --version 2.0.0 --reason "break the public API" --evidence rust-semver:major:public API break detected --output .changeset/sdk-core-major.md
 ```
 
+Or use interactive mode to select packages, bumps, and options from a guided wizard:
+
+```bash
+mc change -i
+```
+
+Interactive mode automatically prevents conflicting selections (a group and one of its members) and lets you pick per-package bumps and optional explicit versions.
+
 <!-- {/releaseChangesAddCommand} -->
 
 <!-- {@releaseManualChangesetExample} -->

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -228,9 +228,13 @@ type = "Discover"
 help_text = "Create a change file for one or more packages"
 
 [[cli.change.inputs]]
+name = "interactive"
+type = "boolean"
+short = "i"
+
+[[cli.change.inputs]]
 name = "package"
 type = "string_list"
-required = true
 
 [[cli.change.inputs]]
 name = "bump"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,6 +341,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +379,33 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-bigint"
@@ -475,6 +511,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +560,15 @@ name = "doc-comment"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
 
 [[package]]
 name = "dyn-clone"
@@ -758,6 +825,15 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -1217,6 +1293,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6654738b8024300cf062d04a1c13c10c8e2cea598ec1c47dc9b6641159429756"
+dependencies = [
+ "bitflags",
+ "crossterm",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "insta"
 version = "1.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,6 +1434,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,6 +1517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1431,6 +1528,7 @@ version = "0.0.0"
 dependencies = [
  "clap",
  "glob",
+ "inquire",
  "insta",
  "insta-cmd",
  "minijinja",
@@ -2631,6 +2729,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2876,6 +2995,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3350,6 +3478,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3357,6 +3501,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ clap = { version = "4", features = ["derive"] }
 derive_more = "0.99"
 doc-comment = "0.3"
 glob = "0.3"
+inquire = "0.9"
 insta = { version = "1", features = ["filters", "json"] }
 insta-cmd = "0.6"
 markdown = "1.0.0-alpha.9"

--- a/crates/monochange/Cargo.toml
+++ b/crates/monochange/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/bin/mc.rs"
 [dependencies]
 clap = { workspace = true }
 glob = { workspace = true }
+inquire = { workspace = true }
 minijinja = { workspace = true }
 monochange_cargo = { workspace = true }
 monochange_config = { workspace = true }

--- a/crates/monochange/src/interactive.rs
+++ b/crates/monochange/src/interactive.rs
@@ -1,0 +1,363 @@
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::fmt;
+
+use inquire::validator::Validation;
+use inquire::MultiSelect;
+use inquire::Select;
+use inquire::Text;
+use monochange_core::BumpSeverity;
+use monochange_core::MonochangeError;
+use monochange_core::MonochangeResult;
+use monochange_core::WorkspaceConfiguration;
+
+/// A selectable item in the package/group picker.
+#[derive(Debug, Clone)]
+struct SelectableTarget {
+	id: String,
+	kind: TargetKind,
+	display: String,
+	/// Group member package ids (empty for standalone packages).
+	member_package_ids: BTreeSet<String>,
+	/// Configured change types from `extra_changelog_sections` for this target.
+	configured_types: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TargetKind {
+	Package,
+	Group,
+}
+
+impl fmt::Display for SelectableTarget {
+	fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+		formatter.write_str(&self.display)
+	}
+}
+
+/// Result of the interactive change flow.
+pub struct InteractiveChangeResult {
+	/// Per-target (package or group id) selections.
+	pub targets: Vec<InteractiveTarget>,
+	/// Release-note summary.
+	pub reason: String,
+	/// Optional long-form details.
+	pub details: Option<String>,
+}
+
+pub struct InteractiveTarget {
+	pub id: String,
+	pub bump: BumpSeverity,
+	pub version: Option<String>,
+	pub change_type: Option<String>,
+}
+
+/// Run the interactive change wizard.
+///
+/// Returns the user's selections or an error if the user cancels.
+pub fn run_interactive_change(
+	configuration: &WorkspaceConfiguration,
+) -> MonochangeResult<InteractiveChangeResult> {
+	let targets = build_selectable_targets(configuration);
+	if targets.is_empty() {
+		return Err(MonochangeError::Config(
+			"no packages or groups found in workspace configuration".to_string(),
+		));
+	}
+
+	// Step 1: Select packages/groups
+	let selected = prompt_select_targets(&targets)?;
+	if selected.is_empty() {
+		return Err(MonochangeError::Config(
+			"no packages or groups selected".to_string(),
+		));
+	}
+
+	// Step 2: For each selected target, choose bump, optional version, and optional change type
+	let mut interactive_targets = Vec::new();
+	for target in &selected {
+		let bump = prompt_bump_for_target(target)?;
+		let version = prompt_version_for_target(target)?;
+		let change_type = prompt_change_type_for_target(target)?;
+		interactive_targets.push(InteractiveTarget {
+			id: target.id.clone(),
+			bump,
+			version,
+			change_type,
+		});
+	}
+
+	// Step 3: Reason (required)
+	let reason = prompt_reason()?;
+
+	// Step 4: Details (optional)
+	let details =
+		prompt_optional("Details (optional long-form release notes — leave empty to skip)")?;
+
+	Ok(InteractiveChangeResult {
+		targets: interactive_targets,
+		reason,
+		details,
+	})
+}
+
+fn build_selectable_targets(configuration: &WorkspaceConfiguration) -> Vec<SelectableTarget> {
+	let grouped_package_ids = configuration
+		.groups
+		.iter()
+		.flat_map(|group| group.packages.iter().cloned())
+		.collect::<BTreeSet<_>>();
+
+	let mut targets = Vec::new();
+
+	// Groups first
+	for group in &configuration.groups {
+		let members = group.packages.join(", ");
+		let configured_types = group
+			.extra_changelog_sections
+			.iter()
+			.flat_map(|section| section.types.iter().cloned())
+			.collect::<BTreeSet<_>>()
+			.into_iter()
+			.collect();
+		targets.push(SelectableTarget {
+			id: group.id.clone(),
+			kind: TargetKind::Group,
+			display: format!("[group] {} ({})", group.id, members),
+			member_package_ids: group.packages.iter().cloned().collect(),
+			configured_types,
+		});
+	}
+
+	// Then standalone packages (not in any group)
+	for package in &configuration.packages {
+		if !grouped_package_ids.contains(&package.id) {
+			let configured_types = package
+				.extra_changelog_sections
+				.iter()
+				.flat_map(|section| section.types.iter().cloned())
+				.collect::<BTreeSet<_>>()
+				.into_iter()
+				.collect();
+			targets.push(SelectableTarget {
+				id: package.id.clone(),
+				kind: TargetKind::Package,
+				display: format!("[package] {}", package.id),
+				member_package_ids: BTreeSet::new(),
+				configured_types,
+			});
+		}
+	}
+
+	// Then grouped packages (selectable individually, but conflicts with group selection
+	// are prevented)
+	for package in &configuration.packages {
+		if grouped_package_ids.contains(&package.id) {
+			let group = configuration
+				.group_for_package(&package.id)
+				.map(|group| format!(" (member of group `{}`)", group.id))
+				.unwrap_or_default();
+			let configured_types = package
+				.extra_changelog_sections
+				.iter()
+				.flat_map(|section| section.types.iter().cloned())
+				.collect::<BTreeSet<_>>()
+				.into_iter()
+				.collect();
+			targets.push(SelectableTarget {
+				id: package.id.clone(),
+				kind: TargetKind::Package,
+				display: format!("[package] {}{group}", package.id),
+				member_package_ids: BTreeSet::new(),
+				configured_types,
+			});
+		}
+	}
+
+	targets
+}
+
+fn prompt_select_targets(targets: &[SelectableTarget]) -> MonochangeResult<Vec<SelectableTarget>> {
+	let group_members: BTreeMap<String, BTreeSet<String>> = targets
+		.iter()
+		.filter(|target| target.kind == TargetKind::Group)
+		.map(|target| (target.id.clone(), target.member_package_ids.clone()))
+		.collect();
+
+	let package_to_group: BTreeMap<String, String> = group_members
+		.iter()
+		.flat_map(|(group_id, members)| {
+			members
+				.iter()
+				.map(move |member| (member.clone(), group_id.clone()))
+		})
+		.collect();
+
+	let validator = move |selections: &[inquire::list_option::ListOption<&SelectableTarget>]| {
+		let selected_group_ids: BTreeSet<&str> = selections
+			.iter()
+			.filter(|selection| selection.value.kind == TargetKind::Group)
+			.map(|selection| selection.value.id.as_str())
+			.collect();
+
+		// Check: if a group is selected, none of its member packages should be selected
+		for selection in selections {
+			if selection.value.kind == TargetKind::Package {
+				if let Some(owning_group) = package_to_group.get(&selection.value.id) {
+					if selected_group_ids.contains(owning_group.as_str()) {
+						return Ok(Validation::Invalid(
+							format!(
+								"cannot select both group `{owning_group}` and its member `{}`; select only the group or individual members",
+								selection.value.id
+							)
+							.into(),
+						));
+					}
+				}
+			}
+		}
+
+		Ok(Validation::Valid)
+	};
+
+	let selected = MultiSelect::new(
+		"Select packages/groups to include in this changeset:",
+		targets.to_vec(),
+	)
+	.with_validator(validator)
+	.with_page_size(15)
+	.prompt()
+	.map_err(|error| {
+		MonochangeError::Config(format!("interactive selection cancelled: {error}"))
+	})?;
+
+	Ok(selected)
+}
+
+fn prompt_bump_for_target(target: &SelectableTarget) -> MonochangeResult<BumpSeverity> {
+	let label = match target.kind {
+		TargetKind::Group => format!("Bump for group `{}`:", target.id),
+		TargetKind::Package => format!("Bump for package `{}`:", target.id),
+	};
+
+	let options = vec!["patch", "minor", "major"];
+	let selection = Select::new(&label, options)
+		.with_starting_cursor(0)
+		.prompt()
+		.map_err(|error| MonochangeError::Config(format!("bump selection cancelled: {error}")))?;
+
+	match selection {
+		"minor" => Ok(BumpSeverity::Minor),
+		"major" => Ok(BumpSeverity::Major),
+		_ => Ok(BumpSeverity::Patch),
+	}
+}
+
+fn prompt_version_for_target(target: &SelectableTarget) -> MonochangeResult<Option<String>> {
+	let label = match target.kind {
+		TargetKind::Group => {
+			format!(
+				"Pin explicit version for group `{}`? (leave empty to skip):",
+				target.id
+			)
+		}
+		TargetKind::Package => {
+			format!(
+				"Pin explicit version for `{}`? (leave empty to skip):",
+				target.id
+			)
+		}
+	};
+
+	let version = Text::new(&label)
+		.with_validator(|input: &str| {
+			if input.is_empty() {
+				return Ok(Validation::Valid);
+			}
+			match semver::Version::parse(input) {
+				Ok(_) => Ok(Validation::Valid),
+				Err(error) => Ok(Validation::Invalid(
+					format!("invalid semver: {error}").into(),
+				)),
+			}
+		})
+		.prompt()
+		.map_err(|error| MonochangeError::Config(format!("version input cancelled: {error}")))?;
+
+	if version.is_empty() {
+		Ok(None)
+	} else {
+		Ok(Some(version))
+	}
+}
+
+fn prompt_change_type_for_target(target: &SelectableTarget) -> MonochangeResult<Option<String>> {
+	if target.configured_types.is_empty() {
+		// No configured types — offer a free-text input
+		return prompt_optional(&format!(
+			"Change type for `{}`? (e.g. security, note — leave empty to skip):",
+			target.id
+		));
+	}
+
+	// Build options from configured types + "none" + "custom"
+	let mut options = vec!["(none)".to_string()];
+	options.extend(target.configured_types.iter().cloned());
+	options.push("(custom)".to_string());
+
+	let label = match target.kind {
+		TargetKind::Group => format!("Change type for group `{}`:", target.id),
+		TargetKind::Package => format!("Change type for `{}`:", target.id),
+	};
+
+	let selection = Select::new(&label, options)
+		.with_starting_cursor(0)
+		.prompt()
+		.map_err(|error| {
+			MonochangeError::Config(format!("change type selection cancelled: {error}"))
+		})?;
+
+	match selection.as_str() {
+		"(none)" => Ok(None),
+		"(custom)" => {
+			let custom = Text::new("Enter custom change type:")
+				.prompt()
+				.map_err(|error| {
+					MonochangeError::Config(format!("custom type input cancelled: {error}"))
+				})?;
+			if custom.trim().is_empty() {
+				Ok(None)
+			} else {
+				Ok(Some(custom))
+			}
+		}
+		_ => Ok(Some(selection)),
+	}
+}
+
+fn prompt_reason() -> MonochangeResult<String> {
+	let reason = Text::new("Release-note summary (required):")
+		.with_validator(|input: &str| {
+			if input.trim().is_empty() {
+				Ok(Validation::Invalid("reason cannot be empty".into()))
+			} else {
+				Ok(Validation::Valid)
+			}
+		})
+		.prompt()
+		.map_err(|error| MonochangeError::Config(format!("reason input cancelled: {error}")))?;
+
+	Ok(reason)
+}
+
+fn prompt_optional(label: &str) -> MonochangeResult<Option<String>> {
+	let value = Text::new(label)
+		.prompt()
+		.map_err(|error| MonochangeError::Config(format!("input cancelled: {error}")))?;
+
+	if value.trim().is_empty() {
+		Ok(None)
+	} else {
+		Ok(Some(value))
+	}
+}

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -142,6 +142,7 @@ use serde::Serialize;
 use serde_json::json;
 use toml::Value;
 
+mod interactive;
 mod mcp;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
@@ -429,6 +430,10 @@ fn build_cli_command_input_arg(input: &CliInputDefinition) -> Arg {
 				))
 		}
 	};
+
+	if let Some(short) = input.short {
+		arg = arg.short(short);
+	}
 
 	if let Some(default) = &input.default {
 		arg = arg.default_value(leak_string(default.clone()));
@@ -745,63 +750,84 @@ fn execute_cli_command(
 				output = Some(render_discovery_report(&discover_workspace(root)?, format)?);
 			}
 			CliStepDefinition::CreateChangeFile => {
-				let package_refs = context.inputs.get("package").cloned().unwrap_or_default();
-				if package_refs.is_empty() {
-					return Err(MonochangeError::Config(
-						"command `change` requires at least one `--package` value".to_string(),
+				let is_interactive = context
+					.inputs
+					.get("interactive")
+					.and_then(|values| values.first())
+					.is_some_and(|value| value == "true");
+
+				if is_interactive {
+					let configuration = load_workspace_configuration(root)?;
+					let result = interactive::run_interactive_change(&configuration)?;
+					let output_path = context
+						.inputs
+						.get("output")
+						.and_then(|values| values.first())
+						.map(PathBuf::from);
+					let path = add_interactive_change_file(root, &result, output_path.as_deref())?;
+					output = Some(format!(
+						"wrote change file {}",
+						root_relative(root, &path).display()
+					));
+				} else {
+					let package_refs = context.inputs.get("package").cloned().unwrap_or_default();
+					if package_refs.is_empty() {
+						return Err(MonochangeError::Config(
+							"command `change` requires at least one `--package` value or `--interactive` mode".to_string(),
+						));
+					}
+					let bump = context
+						.inputs
+						.get("bump")
+						.and_then(|values| values.first())
+						.map_or(Ok(ChangeBump::Patch), |value| parse_change_bump(value))?;
+					let version = context
+						.inputs
+						.get("version")
+						.and_then(|values| values.first())
+						.cloned();
+					let reason = context
+						.inputs
+						.get("reason")
+						.and_then(|values| values.first())
+						.cloned()
+						.ok_or_else(|| {
+							MonochangeError::Config(
+								"command `change` requires a `--reason` value".to_string(),
+							)
+						})?;
+					let change_type = context
+						.inputs
+						.get("type")
+						.and_then(|values| values.first())
+						.cloned();
+					let details = context
+						.inputs
+						.get("details")
+						.and_then(|values| values.first())
+						.cloned();
+					let evidence = context.inputs.get("evidence").cloned().unwrap_or_default();
+					let output_path = context
+						.inputs
+						.get("output")
+						.and_then(|values| values.first())
+						.map(PathBuf::from);
+					let path = add_change_file(
+						root,
+						&package_refs,
+						bump.into(),
+						version.as_deref(),
+						&reason,
+						change_type.as_deref(),
+						details.as_deref(),
+						&evidence,
+						output_path.as_deref(),
+					)?;
+					output = Some(format!(
+						"wrote change file {}",
+						root_relative(root, &path).display()
 					));
 				}
-				let bump = context
-					.inputs
-					.get("bump")
-					.and_then(|values| values.first())
-					.map_or(Ok(ChangeBump::Patch), |value| parse_change_bump(value))?;
-				let version = context
-					.inputs
-					.get("version")
-					.and_then(|values| values.first())
-					.cloned();
-				let reason = context
-					.inputs
-					.get("reason")
-					.and_then(|values| values.first())
-					.cloned()
-					.ok_or_else(|| {
-						MonochangeError::Config(
-							"command `change` requires a `--reason` value".to_string(),
-						)
-					})?;
-				let change_type = context
-					.inputs
-					.get("type")
-					.and_then(|values| values.first())
-					.cloned();
-				let details = context
-					.inputs
-					.get("details")
-					.and_then(|values| values.first())
-					.cloned();
-				let evidence = context.inputs.get("evidence").cloned().unwrap_or_default();
-				let output_path = context
-					.inputs
-					.get("output")
-					.and_then(|values| values.first())
-					.map(PathBuf::from);
-				let path = add_change_file(
-					root,
-					&package_refs,
-					bump.into(),
-					version.as_deref(),
-					&reason,
-					change_type.as_deref(),
-					details.as_deref(),
-					&evidence,
-					output_path.as_deref(),
-				)?;
-				output = Some(format!(
-					"wrote change file {}",
-					root_relative(root, &path).display()
-				));
 			}
 			CliStepDefinition::PrepareRelease => {
 				context.prepared_release = Some(prepare_release(root, dry_run)?);
@@ -2013,6 +2039,75 @@ pub fn add_change_file(
 		))
 	})?;
 	Ok(output_path)
+}
+
+fn add_interactive_change_file(
+	root: &Path,
+	result: &interactive::InteractiveChangeResult,
+	output: Option<&Path>,
+) -> MonochangeResult<PathBuf> {
+	let package_refs = result
+		.targets
+		.iter()
+		.map(|target| target.id.clone())
+		.collect::<Vec<_>>();
+	let output_path = output.map_or_else(
+		|| default_change_path(root, &package_refs),
+		Path::to_path_buf,
+	);
+	if let Some(parent) = output_path.parent() {
+		fs::create_dir_all(parent).map_err(|error| {
+			MonochangeError::Io(format!("failed to create {}: {error}", parent.display()))
+		})?;
+	}
+
+	let content = render_interactive_changeset_markdown(result);
+	fs::write(&output_path, content).map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to write {}: {error}",
+			output_path.display()
+		))
+	})?;
+	Ok(output_path)
+}
+
+fn render_interactive_changeset_markdown(result: &interactive::InteractiveChangeResult) -> String {
+	let mut lines = vec!["---".to_string()];
+	for target in &result.targets {
+		if let Some(version) = &target.version {
+			lines.push(format!("{}:", target.id));
+			lines.push(format!("  bump: {}", target.bump));
+			lines.push(format!("  version: \"{version}\""));
+		} else {
+			lines.push(format!("{}: {}", target.id, target.bump));
+		}
+	}
+	let typed_targets = result
+		.targets
+		.iter()
+		.filter(|target| target.change_type.is_some())
+		.collect::<Vec<_>>();
+	if !typed_targets.is_empty() {
+		lines.push("type:".to_string());
+		for target in &typed_targets {
+			if let Some(change_type) = &target.change_type {
+				lines.push(format!("  {}: {change_type}", target.id));
+			}
+		}
+	}
+	lines.push("---".to_string());
+	lines.push(String::new());
+	lines.push(format!("#### {}", result.reason));
+	if let Some(details) = result
+		.details
+		.as_deref()
+		.filter(|value| !value.trim().is_empty())
+	{
+		lines.push(String::new());
+		lines.push(details.trim().to_string());
+	}
+	lines.push(String::new());
+	lines.join("\n")
 }
 
 pub fn plan_release(root: &Path, changes_path: &Path) -> MonochangeResult<ReleasePlan> {

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -503,6 +503,8 @@ pub struct CliInputDefinition {
 	pub default: Option<String>,
 	#[serde(default)]
 	pub choices: Vec<String>,
+	#[serde(default)]
+	pub short: Option<char>,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
@@ -1383,6 +1385,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 				required: false,
 				default: Some("text".to_string()),
 				choices: vec!["text".to_string(), "json".to_string()],
+				short: None,
 			}],
 			steps: vec![CliStepDefinition::Discover],
 		},
@@ -1391,12 +1394,24 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 			help_text: Some("Create a change file for one or more packages".to_string()),
 			inputs: vec![
 				CliInputDefinition {
+					name: "interactive".to_string(),
+					kind: CliInputKind::Boolean,
+					help_text: Some(
+						"Select packages, bumps, and options interactively".to_string(),
+					),
+					required: false,
+					default: None,
+					choices: Vec::new(),
+					short: Some('i'),
+				},
+				CliInputDefinition {
 					name: "package".to_string(),
 					kind: CliInputKind::StringList,
 					help_text: Some("Package or group to include in the change".to_string()),
-					required: true,
+					required: false,
 					default: None,
 					choices: Vec::new(),
+					short: None,
 				},
 				CliInputDefinition {
 					name: "bump".to_string(),
@@ -1409,6 +1424,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 						"minor".to_string(),
 						"major".to_string(),
 					],
+					short: None,
 				},
 				CliInputDefinition {
 					name: "version".to_string(),
@@ -1417,6 +1433,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 					required: false,
 					default: None,
 					choices: Vec::new(),
+					short: None,
 				},
 				CliInputDefinition {
 					name: "reason".to_string(),
@@ -1425,6 +1442,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 					required: true,
 					default: None,
 					choices: Vec::new(),
+					short: None,
 				},
 				CliInputDefinition {
 					name: "type".to_string(),
@@ -1435,6 +1453,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 					required: false,
 					default: None,
 					choices: Vec::new(),
+					short: None,
 				},
 				CliInputDefinition {
 					name: "details".to_string(),
@@ -1443,6 +1462,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 					required: false,
 					default: None,
 					choices: Vec::new(),
+					short: None,
 				},
 				CliInputDefinition {
 					name: "evidence".to_string(),
@@ -1451,6 +1471,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 					required: false,
 					default: None,
 					choices: Vec::new(),
+					short: None,
 				},
 				CliInputDefinition {
 					name: "output".to_string(),
@@ -1461,6 +1482,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 					required: false,
 					default: None,
 					choices: Vec::new(),
+					short: None,
 				},
 			],
 			steps: vec![CliStepDefinition::CreateChangeFile],
@@ -1475,6 +1497,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 				required: false,
 				default: Some("text".to_string()),
 				choices: vec!["text".to_string(), "json".to_string()],
+				short: None,
 			}],
 			steps: vec![CliStepDefinition::PrepareRelease],
 		},
@@ -1491,6 +1514,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 					required: false,
 					default: Some("text".to_string()),
 					choices: vec!["text".to_string(), "json".to_string()],
+					short: None,
 				},
 				CliInputDefinition {
 					name: "changed_paths".to_string(),
@@ -1501,6 +1525,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 					required: false,
 					default: None,
 					choices: Vec::new(),
+					short: None,
 				},
 				CliInputDefinition {
 					name: "since".to_string(),
@@ -1512,6 +1537,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 					required: false,
 					default: None,
 					choices: Vec::new(),
+					short: None,
 				},
 				CliInputDefinition {
 					name: "verify".to_string(),
@@ -1523,6 +1549,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 					required: false,
 					default: None,
 					choices: Vec::new(),
+					short: None,
 				},
 				CliInputDefinition {
 					name: "label".to_string(),
@@ -1531,6 +1558,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 					required: false,
 					default: None,
 					choices: Vec::new(),
+					short: None,
 				},
 			],
 			steps: vec![CliStepDefinition::AffectedPackages],

--- a/docs/src/guide/02-setup.md
+++ b/docs/src/guide/02-setup.md
@@ -100,9 +100,13 @@ type = "Discover"
 help_text = "Create a change file for one or more packages"
 
 [[cli.change.inputs]]
+name = "interactive"
+type = "boolean"
+short = "i"
+
+[[cli.change.inputs]]
 name = "package"
 type = "string_list"
-required = true
 
 [[cli.change.inputs]]
 name = "bump"

--- a/docs/src/guide/06-release-planning.md
+++ b/docs/src/guide/06-release-planning.md
@@ -10,6 +10,14 @@ mc change --package sdk-core --bump patch --type security --reason "rotate signi
 mc change --package sdk-core --bump major --version 2.0.0 --reason "break the public API" --evidence rust-semver:major:public API break detected --output .changeset/sdk-core-major.md
 ```
 
+Or use interactive mode to select packages, bumps, and options from a guided wizard:
+
+```bash
+mc change -i
+```
+
+Interactive mode automatically prevents conflicting selections (a group and one of its members) and lets you pick per-package bumps and optional explicit versions.
+
 <!-- {/releaseChangesAddCommand} -->
 
 Or write one manually with configured package or group ids:

--- a/monochange.toml
+++ b/monochange.toml
@@ -460,9 +460,13 @@ type = "Discover"
 help_text = "Create a change file for one or more packages"
 
 [[cli.change.inputs]]
+name = "interactive"
+type = "boolean"
+short = "i"
+
+[[cli.change.inputs]]
 name = "package"
 type = "string_list"
-required = true
 
 [[cli.change.inputs]]
 name = "bump"


### PR DESCRIPTION
## Summary

Add `mc change --interactive` (`-i`) — a guided wizard for creating changesets.

## Interactive flow

```bash
mc change -i
```

The wizard walks through:

1. **Multi-select packages/groups** — shows `[group]` and `[package]` labels, grouped packages show their owning group. Prevents conflicting selections (a group + one of its members).
2. **Per-target bump** — `patch`, `minor`, or `major` for each selected target independently.
3. **Per-target explicit version** — optional semver pin (validated inline).
4. **Per-target change type** — when the target has `extra_changelog_sections` configured, those types are offered as selectable options. Otherwise falls back to free-text input. Always includes `(none)` and `(custom)` options.
5. **Release-note summary** — required.
6. **Details** — optional long-form.

## Per-target change types from `extra_changelog_sections`

If a package declares:
```toml
[package.sdk-core]
extra_changelog_sections = [{ name = "Security", types = ["security"] }]
```

The interactive picker shows:
```
Change type for `sdk-core`:
> (none)
  security
  (custom)
```

Different targets may show different type options based on their configuration.

## Other changes

- Added `short: Option<char>` to `CliInputDefinition` for CLI short aliases (e.g. `-i`)
- `--package` is no longer required when `--interactive` is set
- Updated `monochange.toml`, templates, and docs with interactive input

## Validation

- `fix:all` ✅
- `mc validate` ✅
- `docs:check` ✅
- `lint:all` ✅
- `build:all` ✅
- Full test suite ✅