### PR TITLE
feat: pass --reason and --details through to interactive mode

### DIFF
--- a/.changeset/024-interactive-reason-passthrough.md
+++ b/.changeset/024-interactive-reason-passthrough.md
@@ -1,0 +1,5 @@
+---
+monochange: patch
+---
+
+#### pass CLI reason and details through to interactive mode

--- a/crates/monochange/src/interactive.rs
+++ b/crates/monochange/src/interactive.rs
@@ -52,11 +52,19 @@ pub struct InteractiveTarget {
 	pub change_type: Option<String>,
 }
 
+/// CLI-provided values that bypass their interactive prompts when present.
+#[derive(Debug, Default)]
+pub struct InteractiveOptions {
+	pub reason: Option<String>,
+	pub details: Option<String>,
+}
+
 /// Run the interactive change wizard.
 ///
 /// Returns the user's selections or an error if the user cancels.
 pub fn run_interactive_change(
 	configuration: &WorkspaceConfiguration,
+	options: &InteractiveOptions,
 ) -> MonochangeResult<InteractiveChangeResult> {
 	let targets = build_selectable_targets(configuration);
 	if targets.is_empty() {
@@ -87,12 +95,19 @@ pub fn run_interactive_change(
 		});
 	}
 
-	// Step 3: Reason (required)
-	let reason = prompt_reason()?;
+	// Step 3: Reason (required) — use CLI value if provided
+	let reason = if let Some(reason) = &options.reason {
+		reason.clone()
+	} else {
+		prompt_reason()?
+	};
 
-	// Step 4: Details (optional)
-	let details =
-		prompt_optional("Details (optional long-form release notes — leave empty to skip)")?;
+	// Step 4: Details (optional) — use CLI value if provided
+	let details = if let Some(details) = &options.details {
+		Some(details.clone())
+	} else {
+		prompt_optional("Details (optional long-form release notes — leave empty to skip)")?
+	};
 
 	Ok(InteractiveChangeResult {
 		targets: interactive_targets,

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -758,7 +758,19 @@ fn execute_cli_command(
 
 				if is_interactive {
 					let configuration = load_workspace_configuration(root)?;
-					let result = interactive::run_interactive_change(&configuration)?;
+					let options = interactive::InteractiveOptions {
+						reason: context
+							.inputs
+							.get("reason")
+							.and_then(|values| values.first())
+							.cloned(),
+						details: context
+							.inputs
+							.get("details")
+							.and_then(|values| values.first())
+							.cloned(),
+					};
+					let result = interactive::run_interactive_change(&configuration, &options)?;
 					let output_path = context
 						.inputs
 						.get("output")


### PR DESCRIPTION
## Summary

When `mc change -i --reason "..." --details "..."` is used, the interactive wizard skips the reason/details prompts and uses the CLI-provided values directly.

This lets users combine interactive package/bump/type selection with pre-specified release notes:

```bash
mc change -i --reason "fix memory leak in connection pool"
```

## Changes

- Added `InteractiveOptions` struct with optional `reason` and `details` fields
- `run_interactive_change` accepts `&InteractiveOptions` and skips prompts when values are present
- `CreateChangeFile` handler passes through CLI `reason` and `details` inputs

## Validation

- `fix:all` ✅ `mc validate` ✅ `docs:check` ✅ `lint:all` ✅ `build:all` ✅ tests ✅