### PR TITLE
fix: make --reason optional at clap level for interactive mode

### DIFF
--- a/.changeset/025-fix-interactive-reason-required.md
+++ b/.changeset/025-fix-interactive-reason-required.md
@@ -1,0 +1,6 @@
+---
+monochange: patch
+monochange_core: patch
+---
+
+#### make --reason optional at clap level for interactive mode

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -249,7 +249,6 @@ type = "string"
 [[cli.change.inputs]]
 name = "reason"
 type = "string"
-required = true
 
 [[cli.change.inputs]]
 name = "type"

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -1439,7 +1439,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 					name: "reason".to_string(),
 					kind: CliInputKind::String,
 					help_text: Some("Short release-note summary for this change".to_string()),
-					required: true,
+					required: false,
 					default: None,
 					choices: Vec::new(),
 					short: None,

--- a/docs/src/guide/02-setup.md
+++ b/docs/src/guide/02-setup.md
@@ -121,7 +121,6 @@ type = "string"
 [[cli.change.inputs]]
 name = "reason"
 type = "string"
-required = true
 
 [[cli.change.inputs]]
 name = "type"

--- a/monochange.toml
+++ b/monochange.toml
@@ -481,7 +481,6 @@ type = "string"
 [[cli.change.inputs]]
 name = "reason"
 type = "string"
-required = true
 
 [[cli.change.inputs]]
 name = "type"


### PR DESCRIPTION
## Problem

`mc change --interactive` failed with:
```
error: the following required arguments were not provided:
  --reason <REASON>
```

Clap rejected the command before the interactive wizard could prompt for the reason.

## Fix

Change `--reason` from `required: true` to `required: false` in the `CliInputDefinition`. The non-interactive path already validates at runtime and returns a clear error if `--reason` is missing.

Updated in:
- `crates/monochange_core/src/lib.rs` — default CLI command definition
- `monochange.toml` — config file
- `.templates/project.t.md` — template (synced to `docs/src/guide/02-setup.md`)

## Validation

`fix:all` ✅ `mc validate` ✅ `docs:check` ✅ `lint:all` ✅ `build:all` ✅ tests ✅