### PR TITLE
chore: align historical changesets with package-id-first guidance

### DIFF
--- a/.changeset/008-config-driven-cli-workflows.md
+++ b/.changeset/008-config-driven-cli-workflows.md
@@ -1,5 +1,5 @@
 ---
-main: major
+monochange: major
 ---
 
 #### replace built-in command structure with workflow-defined top-level commands

--- a/.changeset/012-source-providers.md
+++ b/.changeset/012-source-providers.md
@@ -1,5 +1,5 @@
 ---
-main: minor
+monochange: minor
 ---
 
 #### add configurable source providers for release automation

--- a/.changeset/013-assistant-mcp-and-npm.md
+++ b/.changeset/013-assistant-mcp-and-npm.md
@@ -1,5 +1,5 @@
 ---
-main: minor
+monochange: minor
 ---
 
 #### add assistant setup, MCP server, and npm distribution

--- a/.changeset/018-verify-command.md
+++ b/.changeset/018-verify-command.md
@@ -1,5 +1,5 @@
 ---
-main: patch
+monochange: patch
 ---
 
 #### add package-aware changeset verification primitive and default verify command

--- a/.changeset/020-cargo-workspace-version-group-validation.md
+++ b/.changeset/020-cargo-workspace-version-group-validation.md
@@ -1,5 +1,5 @@
 ---
-main: minor
+monochange: minor
 ---
 
 #### validate that cargo workspace-versioned packages share the same group

--- a/.changeset/020-minijinja-templates.md
+++ b/.changeset/020-minijinja-templates.md
@@ -1,5 +1,5 @@
 ---
-main: minor
+monochange: minor
 ---
 
 #### migrate all variable interpolation to minijinja templates

--- a/.changeset/021-remove-deployments.md
+++ b/.changeset/021-remove-deployments.md
@@ -1,5 +1,5 @@
 ---
-main: minor
+monochange: minor
 ---
 
 #### remove deployments feature

--- a/.changeset/grouped-changelog-readability.md
+++ b/.changeset/grouped-changelog-readability.md
@@ -1,5 +1,5 @@
 ---
-main: patch
+monochange: patch
 ---
 
 #### improve grouped changelog readability


### PR DESCRIPTION
## Summary
- Reviewed all repository changesets under `.changeset/`.
- Replaced legacy `main` changeset targets with package-id-first entries (`monochange`) in historical changesets where group targeting was used.
- This keeps changeset metadata aligned with the current recommended practice of targeting package ids while preserving grouped sync semantics in planning.

## Validation
- `cargo test -p monochange --tests`
