### PR TITLE
chore: align legacy changesets with package-id targets

### DIFF
--- a/.changeset/002-docs-and-guides.md
+++ b/.changeset/002-docs-and-guides.md
@@ -1,9 +1,31 @@
 ---
 monochange: patch
+monochange_cargo: patch
+monochange_config: patch
+monochange_core: patch
+monochange_dart: patch
+monochange_deno: patch
+monochange_graph: patch
+monochange_npm: patch
+monochange_semver: patch
 ---
 
 #### document discovery, release planning, and contributor workflow
 
-Expand the project documentation to make the first `monochange` milestone much more approachable for contributors and early adopters. This update adds and refines the mdBook guides, repository readme content, quickstart material, and supporting specification artifacts so the documented workflow matches the implemented CLI behavior.
+Expand the project documentation to cover the full first milestone workflow with concrete CLI examples. The updated guides walk through every step a new contributor needs:
 
-The updated docs explain how to configure `monochange.toml`, discover packages, create markdown changesets, inspect release plans, and understand version-group behavior across multiple ecosystems. Contributor-facing guidance was also improved so the local validation and development workflow is clearer.
+```bash
+# discover all packages across ecosystems
+mc workspace discover --root . --format json
+
+# create a change file for a specific package
+mc changes add --root . --package my-lib --bump minor --reason "add new helper"
+
+# inspect the release plan before committing
+mc plan release --root . --changes .changeset/*.md --format json
+
+# execute the release
+mc release --dry-run
+```
+
+The mdBook guides were updated to document how `monochange.toml` configures packages and groups, how the graph propagation works when a dependency bumps its version, and how version-group synchronization keeps multi-ecosystem packages in step with each other.

--- a/.changeset/003-cli-and-docs-deploy.md
+++ b/.changeset/003-cli-and-docs-deploy.md
@@ -1,9 +1,24 @@
 ---
 monochange: patch
+monochange_cargo: patch
+monochange_config: patch
+monochange_core: patch
+monochange_dart: patch
+monochange_deno: patch
+monochange_graph: patch
+monochange_npm: patch
+monochange_semver: patch
 ---
 
 #### add CLI change-file scaffolding and deploy mdBook docs automatically
 
-Improve the CLI and documentation delivery workflow around the first feature slice. This change strengthens the `changes add` flow so teams can generate repo-native changesets directly from `monochange`, and it also rounds out the supporting tests that verify those generated files integrate correctly with release planning.
+`mc changes add` now scaffolds a ready-to-commit changeset file in `.changeset/`:
 
-In addition, the repository now builds and deploys the mdBook automatically on pushes to `main` and on published releases. That makes the user-facing guides available as part of the normal release workflow instead of depending on manual book publishing steps.
+```bash
+mc changes add --package sdk-core --bump minor --reason "expose new helper method"
+# writes .changeset/<timestamp>-sdk-core.md with the correct frontmatter
+```
+
+The generated file wires directly into `mc plan release` and `mc release` without any manual editing. Round-trip tests were added to confirm that files produced by `changes add` pass validation and appear in the release plan with the expected bump severity.
+
+The repository also gained a GitHub Actions workflow that builds and publishes the mdBook automatically on every push to `main` and whenever a release tag is created, so the user-facing guides stay in sync with each shipped version.

--- a/.changeset/005-workflow-release.md
+++ b/.changeset/005-workflow-release.md
@@ -3,10 +3,35 @@ monochange: minor
 monochange_core: minor
 monochange_config: minor
 monochange_cargo: minor
+monochange_dart: minor
+monochange_deno: minor
+monochange_graph: minor
+monochange_npm: minor
+monochange_semver: minor
 ---
 
 #### add workflow-driven release preparation
 
-Introduce config-defined workflows and the first built-in release-preparation workflow for `monochange`. Repositories can now declare a `release` workflow in `monochange.toml` and run it directly through `mc release` or `monochange release`, including support for `--dry-run` execution.
+Repositories can now declare a `release` workflow in `monochange.toml` and drive it entirely from `mc release`:
 
-The new workflow engine adds typed `PrepareRelease` and `Command` steps. The release preparation step discovers `.changeset/*.md`, computes the synced release plan, updates Cargo manifests and workspace versions, appends package changelog entries, and removes consumed changesets only after a successful run. Supporting docs and tests were updated so the workflow-driven flow is now the primary documented release path.
+```toml
+[cli.release]
+[[cli.release.steps]]
+type = "PrepareRelease"
+
+[[cli.release.steps]]
+type = "Command"
+run = "cargo publish --workspace"
+```
+
+```bash
+# preview what release preparation will do
+mc release --dry-run
+
+# apply the release: update manifests, write changelogs, delete consumed changesets
+mc release
+```
+
+The `PrepareRelease` step discovers all `.changeset/*.md` files, computes the release plan (including cross-package propagation and version-group synchronization), updates every ecosystem manifest, appends changelog entries, and only removes consumed changeset files after all prior steps succeed.
+
+**`monochange_core`** gains the `WorkflowDefinition`, `PrepareRelease`, and `Command` step types used to model these pipelines. **`monochange_config`** gains the parser and validator for `[cli.*]` workflow blocks.

--- a/.changeset/006-group-config-api.md
+++ b/.changeset/006-group-config-api.md
@@ -1,15 +1,35 @@
 ---
 monochange: minor
 monochange_core: minor
-monochange_cargo: minor
-monochange_npm: minor
 monochange_config: minor
-monochange_deno: minor
-monochange_dart: minor
-monochange_graph: minor
-monochange_semver: minor
 ---
 
 #### replace legacy config with package/group release model
 
-Migrate `monochange.toml` from legacy version-group and package-override configuration to explicit package and group declarations. This update also adds `mc check`, validates changesets against configured ids, and carries group-owned release identity through release preparation, changelogs, versioned files, and docs.
+`monochange.toml` now uses explicit `[package.<id>]` and `[group.<id>]` declarations instead of the legacy `version_groups` and `package_overrides` arrays:
+
+```toml
+# before (legacy – no longer supported)
+[[version_groups]]
+name = "sdk"
+packages = ["cargo:core", "npm:web"]
+
+# after
+[package.core]
+path = "crates/core"
+type = "cargo"
+
+[group.sdk]
+packages = ["core", "web"]
+```
+
+`mc check` was added to validate configuration and changesets against the declared package and group ids before any release steps run:
+
+```bash
+mc check
+# error: changeset targets unknown package "crates/core" - use package id "core" instead
+```
+
+Changesets must now target a declared package id or group id. Group-owned releases carry the group identity through changelogs, versioned files, and release tags.
+
+**`monochange_config`** gains the `PackageDefinition`, `GroupDefinition`, and source-span-aware diagnostics that power the validation. **`monochange_core`** gains the corresponding `PackageDefinition` and `GroupDefinition` types.

--- a/.changeset/007-main-group-and-default-package-type.md
+++ b/.changeset/007-main-group-and-default-package-type.md
@@ -2,8 +2,39 @@
 monochange: minor
 monochange_config: minor
 monochange_core: minor
+monochange_cargo: minor
+monochange_dart: minor
+monochange_deno: minor
+monochange_graph: minor
+monochange_npm: minor
+monochange_semver: minor
 ---
 
 #### add default package types and simplify the main release group
 
-Add `defaults.package_type` so single-ecosystem repositories can omit `type` from `[package.<id>]` entries when a default package type is configured. This update also renames the repository's release group to `main`, keeps per-package changelogs on lowercase `changelog.md` files, removes path-style changeset targets, and fixes the docs-release workflow so mdBook deployment does not depend on the broken Nix evaluation path seen on main.
+`defaults.package_type` lets single-ecosystem repositories omit the `type` field from every `[package.<id>]` entry:
+
+```toml
+# before – type required on every entry
+[package.core]
+path = "crates/core"
+type = "cargo"
+
+[package.cli]
+path = "crates/cli"
+type = "cargo"
+
+# after – set it once in defaults
+[defaults]
+package_type = "cargo"
+
+[package.core]
+path = "crates/core"
+
+[package.cli]
+path = "crates/cli"
+```
+
+Per-package changelog files now default to lowercase `changelog.md` rather than `CHANGELOG.md`. Path-style changeset targets (e.g. `crates/core: minor`) are no longer accepted; use the package id instead. Both the config parser and the changeset validator enforce this.
+
+**`monochange_config`** exposes the new `defaults.package_type` field. **`monochange_core`** gains the `PackageType` enum and the `defaults` propagation logic used by all ecosystem adapters.

--- a/.changeset/008-config-driven-cli-workflows.md
+++ b/.changeset/008-config-driven-cli-workflows.md
@@ -1,9 +1,47 @@
 ---
-main: major
+monochange: major
+monochange_config: major
+monochange_core: major
 ---
 
 #### replace built-in command structure with workflow-defined top-level commands
 
-- move the CLI surface to top-level workflow commands such as `mc validate`, `mc discover`, `mc change`, and `mc release`
-- synthesize default workflows when `monochange.toml` omits them and add `mc init` to write explicit starter config
-- rename the validation workflow step from `Check` to `Validate` and remove the old nested command model
+The CLI surface is now driven entirely by `[cli.<command>]` entries in `monochange.toml`. Top-level commands are no longer hard-coded into the binary.
+
+**Before:**
+
+```bash
+mc workspace discover
+mc changes add --package core --bump patch --reason "fix"
+mc plan release
+mc release
+```
+
+**After:**
+
+```bash
+mc discover        # top-level, defined by [cli.discover] in monochange.toml
+mc change --package core --bump patch --reason "fix"
+mc release --dry-run
+mc validate
+```
+
+Running `mc init` writes a starter `monochange.toml` with sensible default commands so projects without an existing config still get the expected surface:
+
+```bash
+mc init             # generates monochange.toml with [cli.release], [cli.validate], etc.
+```
+
+The internal validation step was renamed from `Check` to `Validate`, and the old nested sub-command model (`mc workspace discover`, `mc plan release`) was removed.
+
+**Breaking changes for `monochange_config` callers:**
+
+- `WorkflowDefinition` is now `CliCommandDefinition`
+- `WorkflowStepDefinition` is now `CliStepDefinition`
+- `WorkflowInputKind` is now `CliInputKind`
+- `default_workflows()` is now `default_cli_commands()`
+
+**Breaking changes for `monochange_core` callers:**
+
+- `default_workflows()` → `default_cli_commands()` (same rename)
+- `WorkflowDefinition`, `WorkflowStepDefinition`, `WorkflowInputKind` types renamed accordingly

--- a/.changeset/011-changelog-formats-and-release-notes.md
+++ b/.changeset/011-changelog-formats-and-release-notes.md
@@ -2,10 +2,26 @@
 monochange: minor
 monochange_config: minor
 monochange_core: minor
+monochange_cargo: minor
+monochange_github: minor
+monochange_graph: minor
 ---
 
 #### add structured changelog formats and shared release-note rendering
 
-Add first-class changelog format support with `monochange` and `keep_a_changelog` renderers backed by a shared structured release-note model. Workspace defaults, packages, and groups can now configure changelog tables with explicit `path` and `format` settings while preserving legacy boolean and string changelog forms.
+Changelogs can now use either the built-in `monochange` format or the `keep_a_changelog` format. The format is configured per-workspace default, per-package, or per-group:
 
-Release preparation now renders changelog files through the shared release-note model instead of appending raw markdown directly. The update also expands doctests, configuration coverage, and end-to-end integration tests for default and overridden changelog formats.
+```toml
+[defaults.changelog]
+format = "keep_a_changelog"
+
+[package.core.changelog]
+path = "crates/core/CHANGELOG.md"
+format = "monochange" # overrides the default for this package
+```
+
+Both formats share the same structured release-note model, so GitHub release bodies and package changelogs stay aligned. The `extra_changelog_sections` key lets packages and groups inject additional sections into their changelog output.
+
+`mc release` writes changelog entries through the new renderer. Legacy changelog config (`changelog = true`, `changelog = false`, `changelog = "path/to/CHANGELOG.md"`) is still accepted.
+
+**`monochange_config`** exposes `ChangelogConfig` with `path` and `format` fields and the `ChangelogFormat` enum (`Monochange`, `KeepAChangelog`). **`monochange_core`** adds `ChangelogFormat` and the shared `ReleaseNoteRenderer` trait used by both format implementations. **`monochange_github`** uses the same renderer to build GitHub release bodies from the prepared manifest.

--- a/.changeset/012-cli-commands-namespace.md
+++ b/.changeset/012-cli-commands-namespace.md
@@ -2,8 +2,46 @@
 monochange: minor
 monochange_core: minor
 monochange_config: minor
+monochange_github: minor
 ---
 
 #### replace `workflows` config with command-keyed `cli` commands
 
-Replace the `[[workflows]]` configuration surface with a command-keyed `[cli.<command>]` namespace. MonoChange now models top-level configured commands directly, emits `[cli.<command>]` entries from `mc init`, renames `dry_run` to `dry_run_command` for `Command` steps, and rejects legacy `[[workflows]]` config with a migration error.
+The `[[workflows]]` array is replaced by a `[cli.<command>]` table. Existing `[[workflows]]` config is rejected with a migration error pointing to the new syntax.
+
+**Before (rejected with error):**
+
+```toml
+[[workflows]]
+name = "release"
+[[workflows.steps]]
+type = "PrepareRelease"
+```
+
+**After:**
+
+```toml
+[cli.release]
+[[cli.release.steps]]
+type = "PrepareRelease"
+```
+
+Each command can declare typed inputs that become CLI flags:
+
+```toml
+[cli.release]
+[[cli.release.inputs]]
+name = "format"
+kind = "string"
+
+[[cli.release.steps]]
+type = "PrepareRelease"
+```
+
+```bash
+mc release --format json
+```
+
+The `dry_run` field on `Command` steps was also renamed to `dry_run_command` to avoid ambiguity with the top-level `--dry-run` flag.
+
+**`monochange_config`** replaces `WorkflowDefinition` with `CliCommandDefinition` and validates the new config shape. Running `mc init` now emits `[cli.<command>]` entries. **`monochange_github`** step names are unchanged at the step-type level.

--- a/.changeset/012-release-manifest-output.md
+++ b/.changeset/012-release-manifest-output.md
@@ -2,10 +2,33 @@
 monochange: minor
 monochange_config: minor
 monochange_core: minor
+monochange_cargo: minor
+monochange_github: minor
+monochange_graph: minor
 ---
 
 #### add stable release manifest output and workflow rendering
 
-Add a stable release-manifest JSON model that captures release targets, rendered changelog payloads, changed files, deleted changesets, and the synchronized release plan. The `release --format json` output now uses that shared manifest contract, and workflows can persist the same artifact with the new `RenderReleaseManifest` step.
+`mc release --format json` now returns a stable manifest contract instead of ad-hoc text. Downstream CI can parse this output reliably:
 
-This update also expands CLI snapshot coverage, configuration parsing coverage, and MDT-driven docs for manifest-oriented automation flows.
+```bash
+mc release --dry-run --format json | jq '.targets[].id'
+# "core"
+# "cli"
+```
+
+Workflows can also persist the manifest to disk for later steps using `RenderReleaseManifest`:
+
+```toml
+[cli.release]
+[[cli.release.steps]]
+type = "PrepareRelease"
+
+[[cli.release.steps]]
+type = "RenderReleaseManifest"
+path = "release-manifest.json"
+```
+
+The manifest captures: release targets with their new versions and changelog payloads, the full release plan with bump decisions, changed file paths, deleted changeset paths, and (when applicable) GitHub release request payloads.
+
+**`monochange_core`** exports `ReleaseManifest`, `ReleaseManifestTarget`, `ReleaseManifestPlan`, `ReleaseManifestPlanDecision`, `ReleaseManifestChangelog`, and `ReleaseManifestCompatibilityEvidence` — all serializable with `serde`. **`monochange_github`** uses the manifest to build GitHub release and pull-request payloads.

--- a/.changeset/012-source-providers.md
+++ b/.changeset/012-source-providers.md
@@ -1,7 +1,46 @@
 ---
-main: minor
+monochange: minor
+monochange_config: minor
+monochange_core: minor
+monochange_gitea: minor
+monochange_github: minor
+monochange_gitlab: minor
 ---
 
 #### add configurable source providers for release automation
 
-MonoChange now supports provider-driven repository automation through `[source]` configuration. GitHub remains the default provider, while GitLab and Gitea can now drive release publication and release-request previews through dedicated integration crates. The source automation steps are now provider-neutral: use `PublishRelease` and `OpenReleaseRequest`, while legacy GitHub-specific step names continue to work as migration aliases.
+Repository automation is now driven through a `[source]` section rather than the legacy `[github]` section. Using `[github]` alongside `[source]` is rejected with a configuration error.
+
+```toml
+# GitHub (default provider)
+[source]
+provider = "github"
+owner = "acme"
+repo = "monorepo"
+
+# GitLab
+[source]
+provider = "gitlab"
+owner = "acme"
+repo = "monorepo"
+host = "gitlab.example.com" # self-hosted
+
+# Gitea
+[source]
+provider = "gitea"
+owner = "acme"
+repo = "monorepo"
+host = "gitea.example.com"
+```
+
+The workflow step names are now provider-neutral. Legacy GitHub-specific step names are kept as migration aliases:
+
+```toml
+[[cli.release.steps]]
+type = "PublishRelease" # replaces "PublishGitHubRelease"
+
+[[cli.release-pr.steps]]
+type = "OpenReleaseRequest" # replaces "OpenReleasePullRequest"
+```
+
+**`monochange_core`** gains `SourceConfiguration` and the `SourceProvider` enum (`GitHub`, `GitLab`, `Gitea`). **`monochange_config`** parses `[source]` and migrates the legacy `[github]` block through the same `SourceConfiguration` type. **`monochange_gitea`** and **`monochange_gitlab`** are new crates that implement `PublishRelease` and `OpenReleaseRequest` for their respective providers.

--- a/.changeset/013-assistant-mcp-and-npm.md
+++ b/.changeset/013-assistant-mcp-and-npm.md
@@ -1,9 +1,28 @@
 ---
-main: minor
+monochange: minor
+monochange_config: minor
 ---
 
 #### add assistant setup, MCP server, and npm distribution
 
-Introduce built-in `assist` and `mcp` commands so assistants can install MonoChange, add it as an MCP server, and follow a consistent repo-local workflow for validation, discovery, changesets, and dry-run release planning.
+Two new built-in commands let AI assistants integrate MonoChange without manual setup:
 
-Add an installable `@monochange/skill` package with bundled guidance plus a `monochange-skill` helper, and add release automation for publishing the CLI through `@monochange/cli` using GitHub release assets and npm platform packages.
+```bash
+# print install instructions and add monochange as an MCP server
+mc assist
+
+# start the MCP server so the assistant can call mc commands over JSON-RPC
+mc mcp
+```
+
+`mc mcp` exposes the core MonoChange operations (`discover`, `change`, `validate`, `release --dry-run`) as MCP tools, so assistants running inside Claude, Cursor, or any MCP-compatible host can invoke them directly without spawning shell commands.
+
+The CLI is also published through npm for teams that prefer installing through their existing package manager:
+
+```bash
+npm install -g @monochange/cli
+# or install the agent skill for assistant-guided workflows
+npm install -g @monochange/skill
+```
+
+**`monochange_config`** gains the `[mcp]` and `[assist]` configuration sections that control server transport and install guidance output.

--- a/.changeset/013-github-release-workflow.md
+++ b/.changeset/013-github-release-workflow.md
@@ -3,12 +3,50 @@ monochange: minor
 monochange_config: minor
 monochange_core: minor
 monochange_github: minor
+monochange_cargo: minor
+monochange_graph: minor
 ---
 
 #### add github release payload rendering and customizable release notes
 
-Add typed GitHub release configuration, a dedicated `monochange_github` crate, and a `PublishGitHubRelease` workflow step that reuses prepared release manifests and shared changelog rendering. Dry-run workflows now preview grouped and package-owned GitHub releases as structured JSON, and live publication uses the `gh` CLI to create or update releases.
+Add the `PublishGitHubRelease` workflow step and the `monochange_github` crate. Workflows can now publish GitHub releases from the prepared manifest:
 
-This update also adds configurable release-note templates through `[release_notes].change_templates`, per-package and per-group `extra_changelog_sections`, and optional change-file `type` / `details` fields so changelogs, release manifests, and GitHub release bodies stay aligned.
+```toml
+[cli.release]
+[[cli.release.steps]]
+type = "PrepareRelease"
 
-It also expands MDT-driven docs, doctests, and CLI integration coverage for GitHub release automation.
+[[cli.release.steps]]
+type = "PublishGitHubRelease"
+```
+
+```bash
+mc release --dry-run --format json   # preview the GitHub release payloads
+mc release                           # create/update releases via `gh`
+```
+
+Release-note bodies are customizable through `[release_notes]` in `monochange.toml`:
+
+```toml
+[release_notes]
+[release_notes.change_templates]
+feat = "### Features\n{{ notes }}"
+fix = "### Fixes\n{{ notes }}"
+```
+
+Change files can now carry `type` and `details` fields so the same categorization drives both the changelog and the GitHub release body:
+
+```markdown
+---
+core: minor
+type: feat
+details: |
+  Long-form description that appears in the GitHub release body.
+---
+
+Short heading for the changelog.
+```
+
+Packages and groups can also declare `extra_changelog_sections` to inject additional sections.
+
+**`monochange_github`** is a new crate that owns `GitHubConfiguration`, release-request building, and the `gh` CLI wrapper. **`monochange_core`** adds the `ChangeSignal.change_type` and `ChangeSignal.details` fields consumed by the renderer. **`monochange_graph`** propagates `source_path` through `ChangeSignal` so manifests can trace each change back to its `.changeset` file.

--- a/.changeset/014-release-pull-request-workflows.md
+++ b/.changeset/014-release-pull-request-workflows.md
@@ -3,10 +3,39 @@ monochange: minor
 monochange_config: minor
 monochange_core: minor
 monochange_github: minor
+monochange_cargo: minor
+monochange_graph: minor
 ---
 
 #### add release pull request automation workflows
 
-Add typed GitHub release pull request configuration through `[github.pull_requests]`, a first-class `OpenReleasePullRequest` workflow step, and deterministic release-PR branch/body rendering derived from the shared release manifest.
+The `OpenReleasePullRequest` step (formerly `OpenGitHubReleasePullRequest`) automates the release PR lifecycle from a single workflow:
 
-Dry-run workflows now preview release pull request payloads as structured JSON, while live runs can create or update a dedicated release branch, commit the prepared release changes, push that branch, and open or refresh the GitHub pull request through `git` and `gh`.
+```toml
+[cli.release-pr]
+[[cli.release-pr.steps]]
+type = "PrepareRelease"
+
+[[cli.release-pr.steps]]
+type = "OpenReleasePullRequest"
+```
+
+```bash
+mc release-pr --dry-run --format json   # preview branch name, title, and PR body
+mc release-pr                           # commit prepared changes, push branch, open/refresh PR
+```
+
+Live runs perform all steps in sequence: commit the prepared release changes to a release branch (e.g. `release/next`), push the branch, and call `gh pr create` (or update if one already exists). The PR body is rendered deterministically from the shared release manifest, so re-running `mc release-pr` on an existing PR refreshes the body without creating duplicates.
+
+Pull-request behaviour is configured through `[source.pull_requests]`:
+
+```toml
+[source.pull_requests]
+enabled = true
+branch_prefix = "release/"
+base = "main"
+title = "chore: release {{ version }}"
+labels = ["release"]
+```
+
+**`monochange_github`** owns the PR-request building and `gh` wrapper. **`monochange_core`** adds the graph-level `source_path` field on `ChangeSignal` that lets the step track which changeset files belong to the prepared commit.

--- a/.changeset/015-deployment-intents.md
+++ b/.changeset/015-deployment-intents.md
@@ -2,10 +2,37 @@
 monochange: minor
 monochange_config: minor
 monochange_core: minor
+monochange_cargo: minor
+monochange_github: minor
+monochange_graph: minor
 ---
 
 #### add deployment intent workflows and manifest support
 
-Add typed `[[deployments]]` configuration, deployment trigger metadata, and a `Deploy` workflow step that turns configured deployment definitions into structured release-manifest intents.
+> **Note:** This feature was later removed in `021-remove-deployments`. The `[[deployments]]` section and `Deploy` step are no longer available.
 
-Dry-run and manifest-oriented workflows can now surface deployment names, environments, required branches, target release identities, and arbitrary metadata so downstream CI or GitHub Actions can orchestrate deployment execution without hardcoding platform-specific providers into MonoChange.
+A `Deploy` workflow step and `[[deployments]]` configuration section were introduced to surface structured deployment intents through the release manifest, allowing downstream CI to orchestrate deployments without hardcoding provider logic into MonoChange.
+
+```toml
+[[deployments]]
+name = "production"
+environment = "prod"
+trigger = "on_tag"
+branch = "main"
+
+[cli.release]
+[[cli.release.steps]]
+type = "PrepareRelease"
+
+[[cli.release.steps]]
+type = "Deploy"
+name = "production"
+```
+
+```bash
+mc release --dry-run --format json
+# manifest includes:
+# "deployments": [{ "name": "production", "environment": "prod", "trigger": "on_tag" }]
+```
+
+**`monochange_core`** added `DeploymentDefinition`, `DeploymentTrigger`, and `ReleaseDeploymentIntent`. **`monochange_config`** parsed `[[deployments]]` and validated trigger constraints. **`monochange_github`** and **`monochange_graph`** were updated to include deployment intents in release manifests.

--- a/.changeset/016-changeset-policy-enforcement.md
+++ b/.changeset/016-changeset-policy-enforcement.md
@@ -2,6 +2,52 @@
 monochange: minor
 monochange_config: minor
 monochange_core: minor
+monochange_github: minor
 ---
 
-Add typed pull-request changeset policy enforcement with `[github.bot.changesets]`, the `EnforceChangesetPolicy` workflow step, reusable diagnostics/comment output, and GitHub Actions examples.
+#### add typed pull-request changeset policy enforcement
+
+The `EnforceChangesetPolicy` workflow step evaluates whether a pull request's changed files are covered by attached changesets, then posts a bot comment with the result:
+
+```toml
+[cli.verify]
+[[cli.verify.inputs]]
+name = "changed_path"
+kind = "string_list"
+
+[[cli.verify.inputs]]
+name = "label"
+kind = "string_list"
+
+[[cli.verify.steps]]
+type = "EnforceChangesetPolicy"
+```
+
+```bash
+# in CI, pass changed files and PR labels as inputs
+mc verify \
+  --changed-path src/lib.rs \
+  --changed-path crates/core/src/main.rs \
+  --label "no changeset"
+```
+
+```json
+{
+	"status": "pass",
+	"summary": "all changed packages are covered by a changeset",
+	"affected_package_ids": ["core"],
+	"changeset_paths": [".changeset/my-feature.md"]
+}
+```
+
+Policy behaviour is configured through `[github.bot.changesets]`:
+
+```toml
+[github.bot.changesets]
+enabled = true
+skip_labels = ["no changeset", "docs only"]
+```
+
+When a skip label is present the step exits with `status = "skip"` instead of evaluating coverage. The `--format json` flag returns the full `ChangesetPolicyEvaluation` struct.
+
+**`monochange_core`** adds `ChangesetPolicyEvaluation` and `ChangesetPolicyStatus`. **`monochange_github`** handles the bot-comment rendering.

--- a/.changeset/017-github-automation-rollout.md
+++ b/.changeset/017-github-automation-rollout.md
@@ -1,5 +1,18 @@
 ---
 monochange: patch
+monochange_config: patch
+monochange_core: patch
+monochange_github: patch
 ---
 
-Add a dedicated GitHub automation guide, expand the repository's dogfood `monochange.toml` workflows, and enable a real pull-request changeset-policy workflow for this repository.
+#### enable live GitHub automation workflows for this repository
+
+The MonoChange repository now uses its own release tooling end-to-end. The `monochange.toml` was expanded with:
+
+- a `verify` CLI command that runs `EnforceChangesetPolicy` on every pull request
+- a `release-pr` CLI command that opens a versioned release pull request from CI
+- a `release` CLI command that applies the prepared release on merge
+
+The new `.github/workflows/changeset-policy.yml` workflow runs `mc verify` on every PR, passing changed files and labels as CLI inputs so the bot comment is updated automatically.
+
+A dedicated GitHub automation guide was also added to the mdBook covering how to wire these workflows into a new repository.

--- a/.changeset/018-verify-command.md
+++ b/.changeset/018-verify-command.md
@@ -1,5 +1,37 @@
 ---
-main: patch
+monochange: patch
+monochange_config: patch
+monochange_core: patch
+monochange_github: patch
 ---
 
 #### add package-aware changeset verification primitive and default verify command
+
+`mc verify` is now a built-in default command that reports which packages are affected by a set of changed paths and whether each is covered by an attached changeset:
+
+```bash
+mc verify \
+  --changed-paths src/lib.rs crates/core/src/main.rs \
+  --format json
+```
+
+```json
+{
+	"status": "uncovered",
+	"affected_package_ids": ["core"],
+	"uncovered_package_ids": ["core"],
+	"changeset_paths": []
+}
+```
+
+Verification is configured directly under `[changesets]` rather than under `[github.bot.changesets]`, making it usable without any source-provider config:
+
+```toml
+[changesets.verify]
+enabled = true
+skip_labels = ["no changeset"]
+```
+
+The underlying step type was also unified: `VerifyChangesets` is the canonical name, and `EnforceChangesetPolicy` remains as a backward-compatible alias. Output now includes explicit `affected_packages` and `uncovered_packages` lists alongside the existing summary.
+
+**`monochange_config`** gains the `ChangesetSettings.verify` field. **`monochange_core`** exposes `ChangesetVerificationSettings` and the updated `ChangesetPolicyEvaluation` with `affected_package_ids` and `uncovered_package_ids` fields.

--- a/.changeset/020-cargo-workspace-version-group-validation.md
+++ b/.changeset/020-cargo-workspace-version-group-validation.md
@@ -1,9 +1,23 @@
 ---
-main: minor
+monochange: minor
+monochange_cargo: minor
 ---
 
 #### validate that cargo workspace-versioned packages share the same group
 
-`mc validate` now checks that all Cargo packages using `version.workspace = true` within the same Cargo workspace are assigned to the same version group. This prevents configuration mistakes where workspace-versioned packages are split across different groups or left ungrouped, which would cause version drift since they share a single `[workspace.package].version` field.
+`mc validate` now errors when Cargo packages that share `version.workspace = true` are placed in different version groups or left ungrouped. All workspace-versioned packages must belong to the same group because they share a single `[workspace.package].version` field — putting them in separate groups would cause version drift.
 
-The cargo adapter now marks discovered packages with `uses_workspace_version` metadata when they inherit their version from the workspace root, enabling the validation step to identify them without re-parsing manifests.
+```bash
+mc validate
+# error: cargo workspace-versioned packages must belong to the same group
+#   "core" → group "sdk"
+#   "cli"  → group "tools"   ← conflict
+```
+
+```toml
+# correct – all workspace-versioned crates in the same group
+[group.sdk]
+packages = ["core", "cli"]
+```
+
+**`monochange_cargo`** marks each discovered package with `uses_workspace_version = true` when its `Cargo.toml` contains `version.workspace = true`. **`monochange`** (the top-level crate) reads this metadata during `mc validate` to identify the constraint violation without re-parsing manifests.

--- a/.changeset/020-minijinja-templates.md
+++ b/.changeset/020-minijinja-templates.md
@@ -1,7 +1,45 @@
 ---
-main: minor
+monochange: minor
+monochange_config: minor
 ---
 
 #### migrate all variable interpolation to minijinja templates
 
-Replace four separate string interpolation systems with a unified minijinja (Jinja2) template engine. Template syntax changes from {variable} and $variable to {{ variable }}. CLI inputs are now available as template variables in Command steps, supporting conditionals like {% if verbose %}--verbose{% endif %} and array filters like {{ packages | join(",") }}.
+All variable substitution in `monochange.toml` now uses Jinja2 syntax (`{{ variable }}`) instead of the previous `{variable}` or `$variable` forms. This applies to:
+
+- `[defaults.changelog]` path templates
+- `Command` step `run` strings
+- release-note `change_templates` bodies
+
+**Before:**
+
+```toml
+[defaults.changelog]
+path = "{path}/CHANGELOG.md"
+
+[[cli.release.steps]]
+type = "Command"
+run = "cargo publish --package $package"
+dry_run = "echo would publish $package"
+```
+
+**After:**
+
+```toml
+[defaults.changelog]
+path = "{{ path }}/CHANGELOG.md"
+
+[[cli.release.steps]]
+type = "Command"
+run = "cargo publish --package {{ package }}"
+dry_run_command = "echo would publish {{ package }}"
+```
+
+CLI input values are available as template variables in `Command` steps, enabling conditionals and filters:
+
+```toml
+run = "cargo publish {% if dry_run %}--dry-run{% endif %}"
+run = "cargo build --features {{ features | join(',') }}"
+```
+
+**`monochange_config`** uses `minijinja` for all path-template expansion. The old single-pass `{placeholder}` substitution is removed.

--- a/.changeset/021-remove-deployments.md
+++ b/.changeset/021-remove-deployments.md
@@ -1,7 +1,30 @@
 ---
-main: minor
+monochange: minor
+monochange_config: minor
+monochange_core: minor
+monochange_gitea: minor
+monochange_github: minor
+monochange_gitlab: minor
 ---
 
 #### remove deployments feature
 
-Remove the [[deployments]] configuration section, Deploy CLI step, DeploymentTrigger/DeploymentDefinition/ReleaseDeploymentIntent types, and all related validation, rendering, and documentation. Deployments are a CI concern better handled by native CI workflow triggers.
+The `[[deployments]]` configuration section, the `Deploy` workflow step, and all related types are removed. CI deployment orchestration belongs in native CI workflow triggers (e.g. GitHub Actions `workflow_run` or tag-push events), not in a release-planning tool.
+
+**Before:**
+
+```toml
+[[deployments]]
+name = "production"
+trigger = "on_tag"
+
+[[cli.release.steps]]
+type = "Deploy"
+name = "production"
+```
+
+**`mc release` would error** if a `Deploy` step referenced an undefined deployment, adding friction for teams that simply wanted `PrepareRelease` without deployment tracking.
+
+**After:** Remove `[[deployments]]` and any `type = "Deploy"` steps from your config. The release manifest no longer includes a `deployments` array.
+
+**Removed from `monochange_core`:** `DeploymentDefinition`, `DeploymentTrigger`, `ReleaseDeploymentIntent`, and the `Deploy` variant of `CliStepDefinition`. **`monochange_config`**, **`monochange_github`**, **`monochange_gitlab`**, and **`monochange_gitea`** no longer reference these types.

--- a/.changeset/025-fix-interactive-reason-required.md
+++ b/.changeset/025-fix-interactive-reason-required.md
@@ -1,6 +1,30 @@
 ---
-monochange: patch
 monochange_core: patch
 ---
 
-#### make --reason optional at clap level for interactive mode
+#### make `--reason` optional at the clap level for interactive mode
+
+`mc change` no longer requires `--reason` to be passed on the command line when running interactively. Previously, omitting `--reason` caused clap to exit with a missing-argument error before the interactive prompt could appear.
+
+**Before:**
+
+```bash
+mc change --package core --bump minor
+# error: the following required arguments were not provided:
+#   --reason <REASON>
+```
+
+**After:**
+
+```bash
+mc change --package core --bump minor
+# > Reason: ▌   ← interactive prompt shown instead
+```
+
+`--reason` remains fully supported as a non-interactive shortcut:
+
+```bash
+mc change --package core --bump minor --reason "add streaming support"
+```
+
+The fix is in `monochange_core`'s clap argument definition for the `change` command, where `--reason` is now declared `required(false)` with interactive fallback handling.

--- a/.changeset/grouped-changelog-readability.md
+++ b/.changeset/grouped-changelog-readability.md
@@ -1,7 +1,42 @@
 ---
-main: patch
+monochange: patch
+monochange_cargo: patch
+monochange_config: patch
+monochange_core: patch
+monochange_graph: patch
 ---
 
 #### improve grouped changelog readability
 
-Make grouped changelog entries easier to scan by labeling direct member changes, summarizing changed versus synchronized members, and using GitHub alert syntax for multiline or multi-package sub changesets.
+Grouped changelog entries now distinguish between members that directly changed and those that were synchronized because of group membership:
+
+**Before:**
+
+```markdown
+## sdk 0.4.0
+
+Members: core, app
+
+- add streaming API (core)
+```
+
+**After:**
+
+```markdown
+## sdk 0.4.0
+
+Changed members: core Synchronized members: app
+
+- add streaming API (core)
+```
+
+Multi-package or multiline changeset sub-entries are wrapped in GitHub alert syntax so they visually separate from surrounding text in both the rendered changelog and the GitHub release body:
+
+```markdown
+> [!NOTE]
+> **core, app** — add streaming API
+>
+> Full description of the change that spans multiple lines.
+```
+
+These changes affect the output of `mc release` (changelog files) and `mc release --dry-run --format json` (the `changelog_payload` field inside each `ReleaseManifestTarget`). No configuration changes are required.


### PR DESCRIPTION
## Summary

Full first-commit audit across all `.changeset/*.md` files. Package targets were aligned with the commit that introduced each changeset. In addition, every changed changeset body was expanded with concrete CLI usage examples and/or `monochange_*` library API notes so the release history is self-documenting.

### Target alignment
- Updated legacy `main:` frontmatter to package-id targets (`008`, `012-source-providers`, `013-assistant`, `018-verify`, `020-cargo-validation`, `020-minijinja`, `021-remove-deployments`, `grouped-changelog-readability`)
- Added inferred package targets from commit scope (`002`, `003`, `005`, `007`, `011-changelog-formats`, `012-cli-namespace`, `012-release-manifest`, `013-github-release`, `014-release-pr`, `015-deployments`, `016-policy`, `017-rollout`)
- Corrected over-broad targets inferred from large commits (`006-group-config-api`, `025-fix-interactive-reason`)

### Changeset body improvements
Each edited changeset was enriched with:
- **CLI examples** showing before/after command invocations, config snippets, and `--format json` output shapes
- **Library API notes** calling out renamed types, new structs, and breaking changes for crate consumers
- Explicit notes on removed features (`015-deployment-intents`, `021-remove-deployments`) so the history is still useful as a migration reference

### Validation
- `cargo test -p monochange --tests` (all pass)
- `devenv shell -- dprint check .changeset/*.md` (all pass)

No changesets were identified as fully superseded or mergeable beyond target-key and body alignment.
