### PR TITLE
feat: add structured step outputs and cross-step template interpolation

### DIFF
--- a/.changeset/032-step-outputs.md
+++ b/.changeset/032-step-outputs.md
@@ -1,0 +1,34 @@
+---
+monochange: minor
+monochange_config: minor
+monochange_core: minor
+---
+
+#### add structured step outputs and cross-step template interpolation
+
+CLI steps now expose structured outputs that later steps can reference via Jinja template expressions.
+
+**Command step `id` and output capture:**
+
+- Command steps accept an optional `id` field. When set, stdout and stderr are captured and available to later steps via `{{ steps.<id>.stdout }}` and `{{ steps.<id>.stderr }}`.
+- Duplicate `id` values within the same CLI command are rejected at config validation time.
+
+**Structured `release.*` namespace:**
+
+- After `PrepareRelease`, Command steps can reference `{{ release.version }}`, `{{ release.updated_changelogs }}`, `{{ release.changed_files }}`, `{{ release.released_packages }}`, `{{ release.targets }}`, and other release fields.
+- Example: `dprint fmt {{ release.updated_changelogs | join(' ') }}` formats only the changelog files that were written during release preparation.
+
+**Additional namespaces:**
+
+- `{{ manifest.path }}` — path written by `RenderReleaseManifest`
+- `{{ affected.status }}`, `{{ affected.summary }}` — from `AffectedPackages`
+
+**`shell` accepts a string:**
+
+- `shell = true` still means `sh -c` (backward compatible)
+- `shell = "bash"` means `bash -c`, `shell = "zsh"` means `zsh -c`
+- Omitting `shell` or `shell = false` keeps direct exec behavior
+
+**Backward compatibility:**
+
+- Legacy flat variables (`{{ version }}`, `{{ changed_files }}`, etc.) remain available alongside the new structured namespaces.

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -2388,3 +2388,76 @@ fn template_value_to_input_values_object_returns_json_serialization() {
 	assert_eq!(result.len(), 1);
 	assert!(result[0].contains('"'));
 }
+
+#[test]
+fn command_step_with_id_captures_stdout_for_later_steps() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	seed_step_outputs_fixture(tempdir.path());
+
+	let output = run_cli(
+		tempdir.path(),
+		[OsString::from("mc"), OsString::from("echo-test")],
+	)
+	.unwrap_or_else(|error| panic!("command output: {error}"));
+
+	assert!(
+		output.contains("got:hello-world"),
+		"expected stdout interpolation, got: {output}"
+	);
+}
+
+#[test]
+fn command_step_with_shell_string_uses_custom_shell() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	seed_step_outputs_fixture(tempdir.path());
+
+	let output = run_cli(
+		tempdir.path(),
+		[OsString::from("mc"), OsString::from("shell-bash")],
+	)
+	.unwrap_or_else(|error| panic!("command output: {error}"));
+
+	assert!(
+		output.contains("result:bash-works"),
+		"expected bash shell output, got: {output}"
+	);
+}
+
+#[test]
+fn release_step_exposes_updated_changelogs_to_command_steps() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	seed_step_outputs_fixture(tempdir.path());
+
+	let output = run_cli(
+		tempdir.path(),
+		[OsString::from("mc"), OsString::from("release")],
+	)
+	.unwrap_or_else(|error| panic!("command output: {error}"));
+
+	assert!(
+		output.contains("crates/core/CHANGELOG.md"),
+		"expected changelog path in output, got: {output}"
+	);
+}
+
+fn seed_step_outputs_fixture(root: &Path) {
+	let fixture_dir =
+		Path::new(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/tests/step-outputs/base");
+	let files = [
+		"Cargo.toml",
+		"monochange.toml",
+		"crates/core/Cargo.toml",
+		"crates/core/src/lib.rs",
+		"crates/core/CHANGELOG.md",
+		".changeset/feature.md",
+	];
+	for file in &files {
+		let source = fixture_dir.join(file);
+		let target = root.join(file);
+		if let Some(parent) = target.parent() {
+			fs::create_dir_all(parent).unwrap_or_else(|error| panic!("create dir: {error}"));
+		}
+		fs::copy(&source, &target)
+			.unwrap_or_else(|error| panic!("copy {}: {error}", source.display()));
+	}
+}

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -90,6 +90,7 @@ use monochange_core::CliInputKind;
 use monochange_core::CliStepDefinition;
 use monochange_core::CliStepInputValue;
 use monochange_core::CommandVariable;
+use monochange_core::ShellConfig;
 
 use monochange_core::DiscoveryReport;
 use monochange_core::Ecosystem;
@@ -329,7 +330,14 @@ struct CliContext {
 	issue_comment_results: Vec<String>,
 	changeset_policy_evaluation: Option<ChangesetPolicyEvaluation>,
 	changeset_diagnostics: Option<ChangesetDiagnosticsReport>,
+	step_outputs: BTreeMap<String, CommandStepOutput>,
 	command_logs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct CommandStepOutput {
+	stdout: String,
+	stderr: String,
 }
 
 const CHANGESET_DIR: &str = ".changeset";
@@ -889,6 +897,7 @@ fn execute_cli_command(
 		issue_comment_results: Vec::new(),
 		changeset_policy_evaluation: None,
 		changeset_diagnostics: None,
+		step_outputs: BTreeMap::new(),
 		command_logs: Vec::new(),
 	};
 	let mut output = None;
@@ -1183,13 +1192,15 @@ fn execute_cli_command(
 				command,
 				dry_run_command,
 				shell,
+				id,
 				variables,
 				..
 			} => run_cli_command_command(
 				&mut context,
 				command,
 				dry_run_command.as_deref(),
-				*shell,
+				shell,
+				id.as_deref(),
 				variables.as_ref(),
 				&step_inputs,
 			)?,
@@ -1261,7 +1272,8 @@ fn run_cli_command_command(
 	context: &mut CliContext,
 	command: &str,
 	dry_run_command: Option<&str>,
-	shell: bool,
+	shell: &ShellConfig,
+	step_id: Option<&str>,
 	variables: Option<&BTreeMap<String, CommandVariable>>,
 	step_inputs: &BTreeMap<String, Vec<String>>,
 ) -> MonochangeResult<()> {
@@ -1281,8 +1293,8 @@ fn run_cli_command_command(
 	let interpolated =
 		interpolate_cli_command_command(context, command_to_run, variables, step_inputs);
 
-	let output = if shell {
-		ProcessCommand::new("sh")
+	let output = if let Some(shell_binary) = shell.shell_binary() {
+		ProcessCommand::new(shell_binary)
 			.arg("-c")
 			.arg(&interpolated)
 			.current_dir(&context.root)
@@ -1317,6 +1329,18 @@ fn run_cli_command_command(
 	}
 
 	let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+	let stderr_text = String::from_utf8_lossy(&output.stderr).trim().to_string();
+
+	if let Some(id) = step_id {
+		context.step_outputs.insert(
+			id.to_string(),
+			CommandStepOutput {
+				stdout: stdout.clone(),
+				stderr: stderr_text,
+			},
+		);
+	}
+
 	if stdout.is_empty() {
 		context.command_logs.push(format!("ran `{interpolated}`"));
 	} else {
@@ -1413,6 +1437,57 @@ fn build_cli_template_context(
 		);
 	}
 
+	// Structured release.* namespace
+	template_context.insert("release".to_string(), build_release_template_value(context));
+
+	// Structured manifest.* namespace
+	if let Some(path) = &context.release_manifest_path {
+		let mut manifest_map = serde_json::Map::new();
+		manifest_map.insert(
+			"path".to_string(),
+			serde_json::Value::String(path.display().to_string()),
+		);
+		template_context.insert(
+			"manifest".to_string(),
+			serde_json::Value::Object(manifest_map),
+		);
+	}
+
+	// Structured affected.* namespace
+	if let Some(evaluation) = &context.changeset_policy_evaluation {
+		let mut affected_map = serde_json::Map::new();
+		affected_map.insert(
+			"status".to_string(),
+			serde_json::Value::String(evaluation.status.to_string()),
+		);
+		affected_map.insert(
+			"summary".to_string(),
+			serde_json::Value::String(evaluation.summary.clone()),
+		);
+		template_context.insert(
+			"affected".to_string(),
+			serde_json::Value::Object(affected_map),
+		);
+	}
+
+	// Structured steps.<id>.* namespace from command step outputs
+	if !context.step_outputs.is_empty() {
+		let mut steps_map = serde_json::Map::new();
+		for (id, output) in &context.step_outputs {
+			let mut step_map = serde_json::Map::new();
+			step_map.insert(
+				"stdout".to_string(),
+				serde_json::Value::String(output.stdout.clone()),
+			);
+			step_map.insert(
+				"stderr".to_string(),
+				serde_json::Value::String(output.stderr.clone()),
+			);
+			steps_map.insert(id.clone(), serde_json::Value::Object(step_map));
+		}
+		template_context.insert("steps".to_string(), serde_json::Value::Object(steps_map));
+	}
+
 	let input_context = cli_inputs_template_value(inputs);
 	for (input_name, input_value) in &input_context {
 		template_context.insert(input_name.clone(), input_value.clone());
@@ -1432,6 +1507,112 @@ fn build_cli_template_context(
 	}
 
 	template_context
+}
+
+fn build_release_template_value(context: &CliContext) -> serde_json::Value {
+	let Some(prepared) = &context.prepared_release else {
+		return serde_json::Value::Null;
+	};
+
+	let mut release_map = serde_json::Map::new();
+	release_map.insert(
+		"version".to_string(),
+		prepared
+			.version
+			.as_deref()
+			.map_or(serde_json::Value::Null, |v| {
+				serde_json::Value::String(v.to_string())
+			}),
+	);
+	release_map.insert(
+		"group_version".to_string(),
+		prepared
+			.group_version
+			.as_deref()
+			.map_or(serde_json::Value::Null, |v| {
+				serde_json::Value::String(v.to_string())
+			}),
+	);
+	release_map.insert(
+		"dry_run".to_string(),
+		serde_json::Value::Bool(prepared.dry_run),
+	);
+	release_map.insert(
+		"released_packages".to_string(),
+		serde_json::Value::Array(
+			prepared
+				.released_packages
+				.iter()
+				.cloned()
+				.map(serde_json::Value::String)
+				.collect(),
+		),
+	);
+	release_map.insert(
+		"changed_files".to_string(),
+		serde_json::Value::Array(
+			prepared
+				.changed_files
+				.iter()
+				.map(|p| serde_json::Value::String(p.display().to_string()))
+				.collect(),
+		),
+	);
+	release_map.insert(
+		"updated_changelogs".to_string(),
+		serde_json::Value::Array(
+			prepared
+				.updated_changelogs
+				.iter()
+				.map(|p| serde_json::Value::String(p.display().to_string()))
+				.collect(),
+		),
+	);
+	release_map.insert(
+		"deleted_changesets".to_string(),
+		serde_json::Value::Array(
+			prepared
+				.deleted_changesets
+				.iter()
+				.map(|p| serde_json::Value::String(p.display().to_string()))
+				.collect(),
+		),
+	);
+	release_map.insert(
+		"changeset_paths".to_string(),
+		serde_json::Value::Array(
+			prepared
+				.changeset_paths
+				.iter()
+				.map(|p| serde_json::Value::String(p.display().to_string()))
+				.collect(),
+		),
+	);
+
+	let targets: Vec<serde_json::Value> = prepared
+		.release_targets
+		.iter()
+		.map(|target| {
+			let mut target_map = serde_json::Map::new();
+			target_map.insert(
+				"id".to_string(),
+				serde_json::Value::String(target.id.clone()),
+			);
+			target_map.insert(
+				"version".to_string(),
+				serde_json::Value::String(target.tag_name.clone()),
+			);
+			target_map.insert(
+				"kind".to_string(),
+				serde_json::Value::String(target.kind.to_string()),
+			);
+			target_map.insert("tag".to_string(), serde_json::Value::Bool(target.tag));
+			serde_json::Value::Object(target_map)
+		})
+		.collect();
+	release_map.insert("targets".to_string(), serde_json::Value::Array(targets));
+
+	serde_json::Value::Object(release_map)
 }
 
 fn interpolate_cli_command_command(

--- a/crates/monochange/src/monochange.init.toml
+++ b/crates/monochange/src/monochange.init.toml
@@ -463,8 +463,20 @@ comment_on_failure = true
 #   command         — the command to run (supports minijinja interpolation)
 #   dry_run_command — alternative command for --dry-run mode (optional;
 #                     if omitted, the step is skipped in dry-run)
-#   shell           — run through sh -c (default: false)
+#   shell           — run through a shell: true (sh -c), "bash" (bash -c),
+#                     "zsh" (zsh -c), or false/omitted (direct exec)
+#   id              — optional step identifier; when set, stdout and stderr are
+#                     captured and available to later steps via
+#                     steps.ID.stdout and steps.ID.stderr
 #   variables       — map of placeholder → variable for interpolation
+#
+# Step output namespaces (available in Command step templates):
+#   release.*       — from PrepareRelease: version, group_version, dry_run,
+#                     released_packages, changed_files, updated_changelogs,
+#                     deleted_changesets, changeset_paths, targets
+#   manifest.path   — from RenderReleaseManifest: path to the written manifest
+#   affected.*      — from AffectedPackages: status, summary
+#   steps.ID.*      — from Command steps with id: stdout, stderr
 #
 {% raw -%}
 # Built-in command variables (available as {{ var }} in command templates):

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -10,6 +10,7 @@ use monochange_core::Ecosystem;
 use monochange_core::EcosystemType;
 use monochange_core::PackageRecord;
 use monochange_core::PublishState;
+use monochange_core::ShellConfig;
 use semver::Version;
 use tempfile::tempdir;
 
@@ -2827,4 +2828,113 @@ fn write_npm_package(root: &Path, relative_dir: &str, name: &str) {
 		format!("{{\"name\":\"{name}\",\"version\":\"1.0.0\"}}"),
 	)
 	.unwrap_or_else(|error| panic!("package.json: {error}"));
+}
+
+#[test]
+fn load_workspace_configuration_rejects_duplicate_command_step_ids() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	write_cargo_package(tempdir.path(), "crates/core", "core");
+	fs::write(
+		tempdir.path().join("monochange.toml"),
+		r#"
+[defaults]
+package_type = "cargo"
+
+[package.core]
+path = "crates/core"
+
+[cli.test]
+help_text = "test"
+
+[[cli.test.steps]]
+type = "Command"
+command = "echo a"
+id = "step1"
+
+[[cli.test.steps]]
+type = "Command"
+command = "echo b"
+id = "step1"
+"#,
+	)
+	.unwrap_or_else(|error| panic!("config write: {error}"));
+
+	let error = load_workspace_configuration(tempdir.path())
+		.err()
+		.unwrap_or_else(|| panic!("expected error for duplicate step ids"));
+	assert!(
+		error.to_string().contains("duplicate step id"),
+		"error: {error}"
+	);
+}
+
+#[test]
+fn load_workspace_configuration_rejects_empty_command_step_id() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	write_cargo_package(tempdir.path(), "crates/core", "core");
+	fs::write(
+		tempdir.path().join("monochange.toml"),
+		r#"
+[defaults]
+package_type = "cargo"
+
+[package.core]
+path = "crates/core"
+
+[cli.test]
+help_text = "test"
+
+[[cli.test.steps]]
+type = "Command"
+command = "echo a"
+id = "  "
+"#,
+	)
+	.unwrap_or_else(|error| panic!("config write: {error}"));
+
+	let error = load_workspace_configuration(tempdir.path())
+		.err()
+		.unwrap_or_else(|| panic!("expected error for empty step id"));
+	assert!(error.to_string().contains("empty id"), "error: {error}");
+}
+
+#[test]
+fn load_workspace_configuration_accepts_command_step_with_shell_string_and_id() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	write_cargo_package(tempdir.path(), "crates/core", "core");
+	fs::write(
+		tempdir.path().join("monochange.toml"),
+		r#"
+[defaults]
+package_type = "cargo"
+
+[package.core]
+path = "crates/core"
+
+[cli.test]
+help_text = "test"
+
+[[cli.test.steps]]
+type = "Command"
+command = "echo hello"
+shell = "bash"
+id = "greet"
+"#,
+	)
+	.unwrap_or_else(|error| panic!("config write: {error}"));
+
+	let configuration = load_workspace_configuration(tempdir.path())
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+	let test_cmd = configuration
+		.cli
+		.iter()
+		.find(|c| c.name == "test")
+		.unwrap_or_else(|| panic!("expected test command"));
+	match test_cmd.steps.first() {
+		Some(CliStepDefinition::Command { shell, id, .. }) => {
+			assert_eq!(*shell, ShellConfig::Custom("bash".to_string()));
+			assert_eq!(id.as_deref(), Some("greet"));
+		}
+		_ => panic!("expected Command step"),
+	}
 }

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -2227,6 +2227,7 @@ fn validate_cli(cli: &[CliCommandDefinition]) -> MonochangeResult<()> {
 			}
 		}
 
+		let mut seen_step_ids: BTreeSet<String> = BTreeSet::new();
 		for step in &cli_command.steps {
 			for input_name in step.inputs().keys() {
 				if input_name.trim().is_empty() {
@@ -2241,8 +2242,23 @@ fn validate_cli(cli: &[CliCommandDefinition]) -> MonochangeResult<()> {
 				CliStepDefinition::Command {
 					command,
 					dry_run_command,
+					id,
 					..
 				} => {
+					if let Some(step_id) = id {
+						if step_id.trim().is_empty() {
+							return Err(MonochangeError::Config(format!(
+								"CLI command `{}` has a command step with an empty id",
+								cli_command.name
+							)));
+						}
+						if !seen_step_ids.insert(step_id.clone()) {
+							return Err(MonochangeError::Config(format!(
+								"CLI command `{}` has duplicate step id `{}`",
+								cli_command.name, step_id
+							)));
+						}
+					}
 					if command.trim().is_empty() {
 						return Err(MonochangeError::Config(format!(
 							"CLI command `{}` command steps must provide a non-empty command",

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -27,6 +27,7 @@ use crate::ReleaseNotesDocument;
 use crate::ReleaseNotesSection;
 use crate::ReleaseNotesSettings;
 use crate::ReleaseOwnerKind;
+use crate::ShellConfig;
 use crate::VersionFormat;
 use crate::WorkspaceConfiguration;
 use crate::WorkspaceDefaults;
@@ -317,7 +318,8 @@ fn cli_step_definition_kind_name_covers_all_variants() {
 			CliStepDefinition::Command {
 				command: "echo".into(),
 				dry_run_command: None,
-				shell: false,
+				shell: ShellConfig::None,
+				id: None,
 				variables: None,
 				inputs: BTreeMap::new(),
 			},
@@ -334,7 +336,8 @@ fn valid_input_names_returns_none_for_command_steps() {
 	let step = CliStepDefinition::Command {
 		command: "echo hi".into(),
 		dry_run_command: None,
-		shell: false,
+		shell: ShellConfig::None,
+		id: None,
 		variables: None,
 		inputs: BTreeMap::new(),
 	};
@@ -417,7 +420,8 @@ fn expected_input_kind_returns_none_for_command_steps() {
 	let step = CliStepDefinition::Command {
 		command: "echo".into(),
 		dry_run_command: None,
-		shell: false,
+		shell: ShellConfig::None,
+		id: None,
 		variables: None,
 		inputs: BTreeMap::new(),
 	};
@@ -675,5 +679,69 @@ fn sample_workspace_configuration() -> WorkspaceConfiguration {
 		npm: EcosystemSettings::default(),
 		deno: EcosystemSettings::default(),
 		dart: EcosystemSettings::default(),
+	}
+}
+
+#[test]
+fn shell_config_deserializes_from_bool_and_string() {
+	let from_true: ShellConfig = serde_json::from_str("true").unwrap();
+	assert_eq!(from_true, ShellConfig::Default);
+	assert_eq!(from_true.shell_binary(), Some("sh"));
+
+	let from_false: ShellConfig = serde_json::from_str("false").unwrap();
+	assert_eq!(from_false, ShellConfig::None);
+	assert_eq!(from_false.shell_binary(), None);
+
+	let from_bash: ShellConfig = serde_json::from_str(r#""bash""#).unwrap();
+	assert_eq!(from_bash, ShellConfig::Custom("bash".to_string()));
+	assert_eq!(from_bash.shell_binary(), Some("bash"));
+
+	let from_empty: Result<ShellConfig, _> = serde_json::from_str(r#""""#);
+	assert!(from_empty.is_err());
+
+	assert_eq!(ShellConfig::default(), ShellConfig::None);
+}
+
+#[test]
+fn shell_config_serializes_roundtrip() {
+	assert_eq!(serde_json::to_string(&ShellConfig::None).unwrap(), "false");
+	assert_eq!(
+		serde_json::to_string(&ShellConfig::Default).unwrap(),
+		"true"
+	);
+	assert_eq!(
+		serde_json::to_string(&ShellConfig::Custom("bash".into())).unwrap(),
+		r#""bash""#
+	);
+}
+
+#[test]
+fn cli_step_command_with_id_deserializes() {
+	let json_str = r#"{"type":"Command","command":"echo hello","id":"greet","shell":"bash"}"#;
+	let step: CliStepDefinition =
+		serde_json::from_str(json_str).unwrap_or_else(|error| panic!("deserialize: {error}"));
+	match &step {
+		CliStepDefinition::Command {
+			command, id, shell, ..
+		} => {
+			assert_eq!(command, "echo hello");
+			assert_eq!(id.as_deref(), Some("greet"));
+			assert_eq!(shell, &ShellConfig::Custom("bash".to_string()));
+		}
+		_ => panic!("expected Command step"),
+	}
+}
+
+#[test]
+fn cli_step_command_without_id_has_none() {
+	let json_str = r#"{"type":"Command","command":"echo hello","shell":true}"#;
+	let step: CliStepDefinition =
+		serde_json::from_str(json_str).unwrap_or_else(|error| panic!("deserialize: {error}"));
+	match &step {
+		CliStepDefinition::Command { id, shell, .. } => {
+			assert!(id.is_none());
+			assert_eq!(shell, &ShellConfig::Default);
+		}
+		_ => panic!("expected Command step"),
 	}
 }

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -566,6 +566,76 @@ pub enum CommandVariable {
 	Changesets,
 }
 
+/// Shell configuration for `Command` steps.
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub enum ShellConfig {
+	#[default]
+	None,
+	Default,
+	Custom(String),
+}
+
+impl ShellConfig {
+	#[must_use]
+	pub fn shell_binary(&self) -> Option<&str> {
+		match self {
+			Self::None => None,
+			Self::Default => Some("sh"),
+			Self::Custom(shell) => Some(shell),
+		}
+	}
+}
+
+impl Serialize for ShellConfig {
+	fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+		match self {
+			Self::None => serializer.serialize_bool(false),
+			Self::Default => serializer.serialize_bool(true),
+			Self::Custom(shell) => serializer.serialize_str(shell),
+		}
+	}
+}
+
+impl<'de> Deserialize<'de> for ShellConfig {
+	fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+		use serde::de;
+
+		struct ShellConfigVisitor;
+
+		impl de::Visitor<'_> for ShellConfigVisitor {
+			type Value = ShellConfig;
+
+			fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+				formatter.write_str("a boolean or a shell name string")
+			}
+
+			fn visit_bool<E: de::Error>(self, value: bool) -> Result<ShellConfig, E> {
+				Ok(if value {
+					ShellConfig::Default
+				} else {
+					ShellConfig::None
+				})
+			}
+
+			fn visit_str<E: de::Error>(self, value: &str) -> Result<ShellConfig, E> {
+				if value.is_empty() {
+					return Err(de::Error::invalid_value(
+						de::Unexpected::Str(value),
+						&"a non-empty shell name",
+					));
+				}
+				Ok(ShellConfig::Custom(value.to_string()))
+			}
+
+			fn visit_string<E: de::Error>(self, value: String) -> Result<ShellConfig, E> {
+				self.visit_str(&value)
+			}
+		}
+
+		deserializer.deserialize_any(ShellConfigVisitor)
+	}
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum CliStepDefinition {
@@ -619,7 +689,9 @@ pub enum CliStepDefinition {
 		#[serde(default, alias = "dry_run")]
 		dry_run_command: Option<String>,
 		#[serde(default)]
-		shell: bool,
+		shell: ShellConfig,
+		#[serde(default)]
+		id: Option<String>,
 		#[serde(default)]
 		variables: Option<BTreeMap<String, CommandVariable>>,
 		#[serde(default)]

--- a/fixtures/tests/config-validation/duplicate-step-ids/crates/core/Cargo.toml
+++ b/fixtures/tests/config-validation/duplicate-step-ids/crates/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "core"
+version = "0.1.0"
+edition = "2024"

--- a/fixtures/tests/config-validation/duplicate-step-ids/crates/core/src/lib.rs
+++ b/fixtures/tests/config-validation/duplicate-step-ids/crates/core/src/lib.rs
@@ -1,0 +1,1 @@
+// placeholder

--- a/fixtures/tests/config-validation/duplicate-step-ids/monochange.toml
+++ b/fixtures/tests/config-validation/duplicate-step-ids/monochange.toml
@@ -1,0 +1,18 @@
+[defaults]
+package_type = "cargo"
+
+[package.core]
+path = "crates/core"
+
+[cli.test]
+help_text = "test"
+
+[[cli.test.steps]]
+type = "Command"
+command = "echo a"
+id = "step1"
+
+[[cli.test.steps]]
+type = "Command"
+command = "echo b"
+id = "step1"

--- a/fixtures/tests/config-validation/empty-step-id/crates/core/Cargo.toml
+++ b/fixtures/tests/config-validation/empty-step-id/crates/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "core"
+version = "0.1.0"
+edition = "2024"

--- a/fixtures/tests/config-validation/empty-step-id/crates/core/src/lib.rs
+++ b/fixtures/tests/config-validation/empty-step-id/crates/core/src/lib.rs
@@ -1,0 +1,1 @@
+// placeholder

--- a/fixtures/tests/config-validation/empty-step-id/monochange.toml
+++ b/fixtures/tests/config-validation/empty-step-id/monochange.toml
@@ -1,0 +1,13 @@
+[defaults]
+package_type = "cargo"
+
+[package.core]
+path = "crates/core"
+
+[cli.test]
+help_text = "test"
+
+[[cli.test.steps]]
+type = "Command"
+command = "echo a"
+id = "  "

--- a/fixtures/tests/config-validation/shell-string-and-id/crates/core/Cargo.toml
+++ b/fixtures/tests/config-validation/shell-string-and-id/crates/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "core"
+version = "0.1.0"
+edition = "2024"

--- a/fixtures/tests/config-validation/shell-string-and-id/crates/core/src/lib.rs
+++ b/fixtures/tests/config-validation/shell-string-and-id/crates/core/src/lib.rs
@@ -1,0 +1,1 @@
+// placeholder

--- a/fixtures/tests/config-validation/shell-string-and-id/monochange.toml
+++ b/fixtures/tests/config-validation/shell-string-and-id/monochange.toml
@@ -1,0 +1,14 @@
+[defaults]
+package_type = "cargo"
+
+[package.core]
+path = "crates/core"
+
+[cli.test]
+help_text = "test"
+
+[[cli.test.steps]]
+type = "Command"
+command = "echo hello"
+shell = "bash"
+id = "greet"

--- a/fixtures/tests/step-outputs/base/.changeset/feature.md
+++ b/fixtures/tests/step-outputs/base/.changeset/feature.md
@@ -1,0 +1,5 @@
+---
+core: minor
+---
+
+#### add step outputs

--- a/fixtures/tests/step-outputs/base/Cargo.toml
+++ b/fixtures/tests/step-outputs/base/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["crates/core"]
+resolver = "2"

--- a/fixtures/tests/step-outputs/base/crates/core/CHANGELOG.md
+++ b/fixtures/tests/step-outputs/base/crates/core/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/fixtures/tests/step-outputs/base/crates/core/Cargo.toml
+++ b/fixtures/tests/step-outputs/base/crates/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "core"
+version = "0.1.0"
+edition = "2021"

--- a/fixtures/tests/step-outputs/base/crates/core/src/lib.rs
+++ b/fixtures/tests/step-outputs/base/crates/core/src/lib.rs
@@ -1,0 +1,1 @@
+// placeholder

--- a/fixtures/tests/step-outputs/base/monochange.toml
+++ b/fixtures/tests/step-outputs/base/monochange.toml
@@ -1,0 +1,56 @@
+[defaults]
+package_type = "cargo"
+changelog = "{{ path }}/CHANGELOG.md"
+
+[package.core]
+path = "crates/core"
+
+[cli.release]
+help_text = "Prepare a release"
+
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
+[[cli.release.steps]]
+type = "PrepareRelease"
+
+[[cli.release.steps]]
+type = "Command"
+id = "list_changelogs"
+command = "echo {{ release.updated_changelogs | join(' ') }}"
+shell = true
+
+[[cli.release.steps]]
+type = "Command"
+command = "echo changelogs:{{ steps.list_changelogs.stdout }}"
+shell = true
+
+[cli.echo-test]
+help_text = "Test command step outputs"
+
+[[cli.echo-test.steps]]
+type = "Command"
+id = "greet"
+command = "echo hello-world"
+
+[[cli.echo-test.steps]]
+type = "Command"
+command = "echo got:{{ steps.greet.stdout }}"
+shell = true
+
+[cli.shell-bash]
+help_text = "Test bash shell config"
+
+[[cli.shell-bash.steps]]
+type = "Command"
+id = "bash_cmd"
+command = "echo bash-works"
+shell = "bash"
+
+[[cli.shell-bash.steps]]
+type = "Command"
+command = "echo result:{{ steps.bash_cmd.stdout }}"
+shell = true


### PR DESCRIPTION
## Summary

Implements [issue #56](https://github.com/ifiokjr/monochange/issues/56) — structured step outputs and cross-step template interpolation.

### Command step `id` and output capture
- Command steps accept an optional `id` field. When set, stdout and stderr are captured and available to later steps via `{{ steps.<id>.stdout }}` and `{{ steps.<id>.stderr }}`.
- Duplicate `id` values within the same CLI command are rejected at config validation time.

### Structured `release.*` namespace
- After `PrepareRelease`, Command steps can reference `{{ release.version }}`, `{{ release.updated_changelogs }}`, `{{ release.changed_files }}`, `{{ release.released_packages }}`, `{{ release.targets }}`, and other release fields.
- Example: `dprint fmt {{ release.updated_changelogs | join(' ') }}` formats only the changelog files that were written during release preparation.

### Additional namespaces
- `{{ manifest.path }}` — path written by `RenderReleaseManifest`
- `{{ affected.status }}`, `{{ affected.summary }}` — from `AffectedPackages`

### `shell` accepts a string
- `shell = true` still means `sh -c` (backward compatible)
- `shell = "bash"` means `bash -c`, `shell = "zsh"` means `zsh -c`

### Backward compatibility
Legacy flat variables (`{{ version }}`, `{{ changed_files }}`, etc.) remain available alongside the new structured namespaces.

## Validation
- `cargo clippy --all-targets` — clean
- `cargo test -p monochange_core -p monochange_config -p monochange` — all pass
- `mc validate` — pass
- `dprint check` — pass

Closes #56