### PR TITLE
docs: sync github crate example with rendered target fields

### DIFF
--- a/.changeset/013-release-title-doctest-sync.md
+++ b/.changeset/013-release-title-doctest-sync.md
@@ -1,0 +1,7 @@
+---
+monochange: patch
+---
+
+#### sync github docs template with rendered title fields
+
+Update shared `monochange_github` documentation examples so `ReleaseManifestTarget` struct literals include `rendered_title` and `rendered_changelog_title`, keeping doctests aligned with the updated required fields and avoiding CI doc compile failures.

--- a/.templates/crates.t.md
+++ b/.templates/crates.t.md
@@ -393,6 +393,8 @@ let manifest = ReleaseManifest {
         version_format: VersionFormat::Primary,
         tag_name: "v1.2.0".to_string(),
         members: vec!["core".to_string(), "app".to_string()],
+        rendered_title: "1.2.0 (2026-04-06)".to_string(),
+        rendered_changelog_title: "[1.2.0](https://example.com) (2026-04-06)".to_string(),
     }],
     released_packages: vec!["workflow-core".to_string(), "workflow-app".to_string()],
     changed_files: Vec::new(),

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -1480,16 +1480,16 @@ fn build_cli_template_context(
 	if !context.step_outputs.is_empty() {
 		let mut steps_map = serde_json::Map::new();
 		for (id, output) in &context.step_outputs {
-			let mut step_map = serde_json::Map::new();
-			step_map.insert(
+			let mut output_map = serde_json::Map::new();
+			output_map.insert(
 				"stdout".to_string(),
 				serde_json::Value::String(output.stdout.clone()),
 			);
-			step_map.insert(
+			output_map.insert(
 				"stderr".to_string(),
 				serde_json::Value::String(output.stderr.clone()),
 			);
-			steps_map.insert(id.clone(), serde_json::Value::Object(step_map));
+			steps_map.insert(id.clone(), serde_json::Value::Object(output_map));
 		}
 		template_context.insert("steps".to_string(), serde_json::Value::Object(steps_map));
 	}


### PR DESCRIPTION
Follow-up fix for #57: ensure mdt template example includes rendered_title and rendered_changelog_title fields required by ReleaseManifestTarget doctest.