### PR TITLE
fix: preserve version file formatting across ecosystems

### DIFF
--- a/.changeset/041-preserve-cargo-formatting.md
+++ b/.changeset/041-preserve-cargo-formatting.md
@@ -4,6 +4,7 @@
 "monochange_core": patch
 "monochange_dart": patch
 "monochange_deno": patch
+"monochange_npm": patch
 ---
 
 Preserve release-time manifest formatting across ecosystems instead of rewriting files through pretty-printers.
@@ -21,9 +22,9 @@ became
 [dependencies.rmcp]
 default-features = true
 features = [
-    "server",
-    "transport-io",
-    "macros",
+	"server",
+	"transport-io",
+	"macros",
 ]
 workspace = true
 ```
@@ -50,9 +51,10 @@ continues to update the matching root `workspace.dependencies.monochange.version
 { path = "Cargo.toml", type = "cargo", fields = ["workspace.dependencies.{{ name }}.version"] }
 ```
 
-The same release flow now preserves existing formatting for non-TOML manifests too:
+The same release flow now preserves existing formatting for non-TOML manifests and npm-family lockfiles too:
 
 - `package.json`
+- `pnpm-lock.yaml`
 - `deno.json` and `deno.jsonc`
 - `pubspec.yaml`
 

--- a/.changeset/041-preserve-cargo-formatting.md
+++ b/.changeset/041-preserve-cargo-formatting.md
@@ -36,6 +36,20 @@ After this change, MonoChange updates only the relevant Cargo version values in 
 - matching `[workspace.dependencies]` entries for released workspace crates
 - `Cargo.lock` package versions without reformatting the rest of the lockfile
 
+Cargo versioned-file updates also support nested field paths and `{{ name }}` expansion for workspace dependency entries. That means config like:
+
+```toml
+[package.monochange]
+path = "crates/monochange"
+versioned_files = ["Cargo.toml"]
+```
+
+continues to update the matching root `workspace.dependencies.monochange.version` entry automatically, and explicit typed entries can now target object-style fields such as:
+
+```toml
+{ path = "Cargo.toml", type = "cargo", fields = ["workspace.dependencies.{{ name }}.version"] }
+```
+
 The same release flow now preserves existing formatting for non-TOML manifests too:
 
 - `package.json`

--- a/.changeset/041-preserve-cargo-formatting.md
+++ b/.changeset/041-preserve-cargo-formatting.md
@@ -1,0 +1,42 @@
+---
+"monochange": patch
+"monochange_cargo": patch
+"monochange_core": patch
+---
+
+Preserve Cargo TOML formatting during `mc release` instead of rewriting manifests into `toml::to_string_pretty(...)` output.
+
+Before, releasing a workspace could rewrite files like this even when only version fields changed:
+
+```toml
+[dependencies]
+rmcp = { workspace = true, features = ["server", "transport-io", "macros"], default-features = true }
+```
+
+became
+
+```toml
+[dependencies.rmcp]
+default-features = true
+features = [
+    "server",
+    "transport-io",
+    "macros",
+]
+workspace = true
+```
+
+After this change, MonoChange updates only the relevant Cargo version values in place:
+
+- `package.version`
+- `workspace.package.version`
+- dependency `version` fields in `[dependencies]`, `[dev-dependencies]`, `[build-dependencies]`
+- matching `[workspace.dependencies]` entries for released workspace crates
+
+Keep-a-changelog release headings also stop double-wrapping markdown-linked titles. For example:
+
+```md
+## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-09)
+```
+
+now renders without an extra outer pair of brackets.

--- a/.changeset/041-preserve-cargo-formatting.md
+++ b/.changeset/041-preserve-cargo-formatting.md
@@ -2,9 +2,11 @@
 "monochange": patch
 "monochange_cargo": patch
 "monochange_core": patch
+"monochange_dart": patch
+"monochange_deno": patch
 ---
 
-Preserve Cargo TOML formatting during `mc release` instead of rewriting manifests into `toml::to_string_pretty(...)` output.
+Preserve release-time manifest formatting across ecosystems instead of rewriting files through pretty-printers.
 
 Before, releasing a workspace could rewrite files like this even when only version fields changed:
 
@@ -32,6 +34,15 @@ After this change, MonoChange updates only the relevant Cargo version values in 
 - `workspace.package.version`
 - dependency `version` fields in `[dependencies]`, `[dev-dependencies]`, `[build-dependencies]`
 - matching `[workspace.dependencies]` entries for released workspace crates
+- `Cargo.lock` package versions without reformatting the rest of the lockfile
+
+The same release flow now preserves existing formatting for non-TOML manifests too:
+
+- `package.json`
+- `deno.json` and `deno.jsonc`
+- `pubspec.yaml`
+
+Those files now keep their original spacing, ordering, and comments while only changing the targeted version string.
 
 Keep-a-changelog release headings also stop double-wrapping markdown-linked titles. For example:
 

--- a/.templates/crates.t.md
+++ b/.templates/crates.t.md
@@ -193,7 +193,7 @@ let notes = ReleaseNotesDocument {
 
 let rendered = render_release_notes(ChangelogFormat::KeepAChangelog, &notes);
 
-assert!(rendered.contains("## [1.2.3]"));
+assert!(rendered.contains("## 1.2.3"));
 assert!(rendered.contains("### Features"));
 assert!(rendered.contains("- add keep-a-changelog output"));
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1757,6 +1757,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml",
+ "toml_edit",
  "walkdir",
 ]
 
@@ -3399,6 +3400,7 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ tempfile = { version = "^3", default-features = false }
 thiserror = { version = "^2.0.18", default-features = false }
 tokio = { version = "1", default-features = false, features = ["rt", "rt-multi-thread"] }
 toml = { version = "^1.1.2", default-features = false }
+toml_edit = { version = "0.25.10", default-features = false, features = ["parse"] }
 typed-builder = { version = "0.23.2", default-features = false }
 urlencoding = { version = "^2", default-features = false }
 walkdir = { version = "^2", default-features = false }

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -4716,6 +4716,19 @@ fn build_manifest_updates_report_parse_and_io_errors() {
 		Some(Version::parse("1.0.0").unwrap_or_else(|error| panic!("version: {error}"))),
 		monochange_core::PublishState::Public,
 	);
+	let deno_invalid_path = tempdir.path().join("invalid/deno.json");
+	fs::create_dir_all(deno_invalid_path.parent().expect("deno manifest parent"))
+		.unwrap_or_else(|error| panic!("create invalid deno dir: {error}"));
+	fs::write(&deno_invalid_path, "{")
+		.unwrap_or_else(|error| panic!("write invalid deno manifest: {error}"));
+	let deno_invalid = monochange_core::PackageRecord::new(
+		Ecosystem::Deno,
+		"tool-invalid",
+		deno_invalid_path,
+		tempdir.path().to_path_buf(),
+		Some(Version::parse("1.0.0").unwrap_or_else(|error| panic!("version: {error}"))),
+		monochange_core::PublishState::Public,
+	);
 	let dart = monochange_core::PackageRecord::new(
 		Ecosystem::Dart,
 		"mobile",
@@ -4724,9 +4737,23 @@ fn build_manifest_updates_report_parse_and_io_errors() {
 		Some(Version::parse("1.0.0").unwrap_or_else(|error| panic!("version: {error}"))),
 		monochange_core::PublishState::Public,
 	);
+	let dart_missing = monochange_core::PackageRecord::new(
+		Ecosystem::Dart,
+		"mobile-missing",
+		tempdir.path().join("missing/pubspec.yaml"),
+		tempdir.path().to_path_buf(),
+		Some(Version::parse("1.0.0").unwrap_or_else(|error| panic!("version: {error}"))),
+		monochange_core::PublishState::Public,
+	);
 	let plan = monochange_core::ReleasePlan {
 		workspace_root: tempdir.path().to_path_buf(),
-		decisions: vec![npm.id.clone(), deno_missing.id.clone(), dart.id.clone()]
+		decisions: vec![
+			npm.id.clone(),
+			deno_missing.id.clone(),
+			deno_invalid.id.clone(),
+			dart.id.clone(),
+			dart_missing.id.clone(),
+		]
 			.into_iter()
 			.map(|package_id| monochange_core::ReleaseDecision {
 				package_id,
@@ -4747,18 +4774,168 @@ fn build_manifest_updates_report_parse_and_io_errors() {
 		unresolved_items: Vec::new(),
 		compatibility_evidence: Vec::new(),
 	};
-	let npm_error = crate::build_npm_manifest_updates(&[npm.clone()], &plan)
+	let npm_error = crate::build_npm_manifest_updates(std::slice::from_ref(&npm), &plan)
 		.err()
 		.unwrap_or_else(|| panic!("expected npm parse error"));
 	assert!(npm_error.to_string().contains("failed to parse"), "error: {npm_error}");
-	let deno_error = crate::build_deno_manifest_updates(&[deno_missing.clone()], &plan)
+	let deno_error = crate::build_deno_manifest_updates(std::slice::from_ref(&deno_missing), &plan)
 		.err()
 		.unwrap_or_else(|| panic!("expected deno io error"));
 	assert!(deno_error.to_string().contains("failed to read"), "error: {deno_error}");
-	let dart_error = crate::build_dart_manifest_updates(&[dart.clone()], &plan)
+	let deno_parse_error = crate::build_deno_manifest_updates(
+		std::slice::from_ref(&deno_invalid),
+		&plan,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected deno parse error"));
+	assert!(
+		deno_parse_error.to_string().contains("failed to parse"),
+		"error: {deno_parse_error}"
+	);
+	let dart_error = crate::build_dart_manifest_updates(std::slice::from_ref(&dart), &plan)
 		.err()
 		.unwrap_or_else(|| panic!("expected dart parse error"));
 	assert!(dart_error.to_string().contains("failed to parse"), "error: {dart_error}");
+	let dart_read_error = crate::build_dart_manifest_updates(std::slice::from_ref(&dart_missing), &plan)
+		.err()
+		.unwrap_or_else(|| panic!("expected dart read error"));
+	assert!(
+		dart_read_error.to_string().contains("failed to read"),
+		"error: {dart_read_error}"
+	);
+
+	let cargo_missing_dir = tempdir.path().join("cargo-missing-dir");
+	fs::create_dir_all(&cargo_missing_dir)
+		.unwrap_or_else(|error| panic!("create cargo missing dir: {error}"));
+	let cargo_missing = monochange_core::PackageRecord::new(
+		Ecosystem::Cargo,
+		"cargo-missing",
+		cargo_missing_dir,
+		tempdir.path().to_path_buf(),
+		Some(Version::parse("1.0.0").unwrap_or_else(|error| panic!("version: {error}"))),
+		monochange_core::PublishState::Public,
+	);
+	let cargo_invalid_path = tempdir.path().join("invalid-package/Cargo.toml");
+	fs::create_dir_all(cargo_invalid_path.parent().expect("cargo package parent"))
+		.unwrap_or_else(|error| panic!("create invalid cargo package dir: {error}"));
+	fs::write(&cargo_invalid_path, "{")
+		.unwrap_or_else(|error| panic!("write invalid cargo manifest: {error}"));
+	let cargo_invalid = monochange_core::PackageRecord::new(
+		Ecosystem::Cargo,
+		"cargo-invalid",
+		cargo_invalid_path,
+		tempdir.path().join("cargo-invalid-workspace"),
+		Some(Version::parse("1.0.0").unwrap_or_else(|error| panic!("version: {error}"))),
+		monochange_core::PublishState::Public,
+	);
+	let cargo_workspace_dir = tempdir.path().join("cargo-workspace-dir");
+	fs::create_dir_all(cargo_workspace_dir.join("crates/core"))
+		.unwrap_or_else(|error| panic!("create cargo workspace package dir: {error}"));
+	fs::write(
+		cargo_workspace_dir.join("crates/core/Cargo.toml"),
+		"[package]\nname = \"core\"\nversion = \"1.0.0\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write cargo workspace package manifest: {error}"));
+	fs::create_dir_all(cargo_workspace_dir.join("Cargo.toml"))
+		.unwrap_or_else(|error| panic!("create workspace cargo root dir: {error}"));
+	let cargo_workspace_read = monochange_core::PackageRecord::new(
+		Ecosystem::Cargo,
+		"cargo-workspace-read",
+		cargo_workspace_dir.join("crates/core/Cargo.toml"),
+		cargo_workspace_dir.clone(),
+		Some(Version::parse("1.0.0").unwrap_or_else(|error| panic!("version: {error}"))),
+		monochange_core::PublishState::Public,
+	);
+	let cargo_workspace_invalid = tempdir.path().join("cargo-workspace-invalid");
+	fs::create_dir_all(cargo_workspace_invalid.join("crates/core"))
+		.unwrap_or_else(|error| panic!("create cargo workspace invalid dir: {error}"));
+	fs::write(
+		cargo_workspace_invalid.join("crates/core/Cargo.toml"),
+		"[package]\nname = \"core\"\nversion = \"1.0.0\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write valid package manifest: {error}"));
+	fs::write(cargo_workspace_invalid.join("Cargo.toml"), "{")
+		.unwrap_or_else(|error| panic!("write invalid workspace manifest: {error}"));
+	let cargo_workspace_parse = monochange_core::PackageRecord::new(
+		Ecosystem::Cargo,
+		"cargo-workspace-parse",
+		cargo_workspace_invalid.join("crates/core/Cargo.toml"),
+		cargo_workspace_invalid,
+		Some(Version::parse("1.0.0").unwrap_or_else(|error| panic!("version: {error}"))),
+		monochange_core::PublishState::Public,
+	);
+	let cargo_plan = monochange_core::ReleasePlan {
+		workspace_root: tempdir.path().to_path_buf(),
+		decisions: vec![
+			cargo_missing.id.clone(),
+			cargo_invalid.id.clone(),
+			cargo_workspace_read.id.clone(),
+			cargo_workspace_parse.id.clone(),
+		]
+		.into_iter()
+		.map(|package_id| monochange_core::ReleaseDecision {
+			package_id,
+			trigger_type: "changeset".to_string(),
+			recommended_bump: BumpSeverity::Minor,
+			planned_version: Some(
+				Version::parse("1.1.0")
+					.unwrap_or_else(|error| panic!("planned version: {error}")),
+			),
+			group_id: None,
+			reasons: vec!["release".to_string()],
+			upstream_sources: Vec::new(),
+			warnings: Vec::new(),
+		})
+		.collect(),
+		groups: Vec::new(),
+		warnings: Vec::new(),
+		unresolved_items: Vec::new(),
+		compatibility_evidence: Vec::new(),
+	};
+	let cargo_read_error = crate::build_cargo_manifest_updates(
+		std::slice::from_ref(&cargo_missing),
+		&cargo_plan,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected cargo read error"));
+	assert!(
+		cargo_read_error.to_string().contains("failed to read"),
+		"error: {cargo_read_error}"
+	);
+	let cargo_parse_error = crate::build_cargo_manifest_updates(
+		std::slice::from_ref(&cargo_invalid),
+		&cargo_plan,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected cargo parse error"));
+	assert!(
+		cargo_parse_error.to_string().contains("failed to parse"),
+		"error: {cargo_parse_error}"
+	);
+	let cargo_workspace_read_error = crate::build_cargo_manifest_updates(
+		std::slice::from_ref(&cargo_workspace_read),
+		&cargo_plan,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected cargo workspace read error"));
+	assert!(
+		cargo_workspace_read_error
+			.to_string()
+			.contains("failed to read"),
+		"error: {cargo_workspace_read_error}"
+	);
+	let cargo_workspace_parse_error = crate::build_cargo_manifest_updates(
+		std::slice::from_ref(&cargo_workspace_parse),
+		&cargo_plan,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected cargo workspace parse error"));
+	assert!(
+		cargo_workspace_parse_error
+			.to_string()
+			.contains("failed to parse"),
+		"error: {cargo_workspace_parse_error}"
+	);
 
 	let unreleased_plan = monochange_core::ReleasePlan {
 		workspace_root: tempdir.path().to_path_buf(),
@@ -4777,6 +4954,7 @@ fn build_manifest_updates_report_parse_and_io_errors() {
 fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_updaters() {
 	let configuration = versioned_test_configuration();
 	for (file_name, ecosystem_type, contents) in [
+		("Cargo.toml", monochange_core::EcosystemType::Cargo, "{"),
 		("package.json", monochange_core::EcosystemType::Npm, "{"),
 		("deno.json", monochange_core::EcosystemType::Deno, "{"),
 		("pubspec.yaml", monochange_core::EcosystemType::Dart, ": bad"),
@@ -4809,6 +4987,35 @@ fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_update
 		.unwrap_or_else(|| panic!("expected parse error for {file_name}"));
 		assert!(error.to_string().contains("failed to parse"), "error: {error}");
 	}
+
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let path = tempdir.path().join("Cargo.toml");
+	fs::write(&path, "[package]\nname = \"core\"\nversion = \"1.0.0\"\n")
+		.unwrap_or_else(|error| panic!("write cached cargo manifest path: {error}"));
+	let context = versioned_test_context(
+		&configuration,
+		BTreeMap::from([("core".to_string(), "2.0.0".to_string())]),
+		&[],
+	);
+	let definition = monochange_core::VersionedFileDefinition {
+		path: "Cargo.toml".to_string(),
+		ecosystem_type: monochange_core::EcosystemType::Cargo,
+		prefix: None,
+		fields: None,
+		name: None,
+	};
+	let error = crate::apply_versioned_file_definition(
+		tempdir.path(),
+		&mut BTreeMap::from([(path, crate::CachedDocument::Text("{".to_string()))]),
+		&definition,
+		"2.0.0",
+		None,
+		&["core".to_string()],
+		&context,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected cached cargo parse error"));
+	assert!(error.to_string().contains("failed to parse"), "error: {error}");
 }
 
 #[test]

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -4444,13 +4444,29 @@ fn read_cached_document_parses_supported_document_formats() {
 	.unwrap_or_else(|error| panic!("bun lockb: {error}"));
 	assert!(matches!(bun_binary, crate::CachedDocument::Bytes(contents) if !contents.is_empty()));
 
+	let npm_manifest = crate::read_cached_document(
+		&mut BTreeMap::new(),
+		&fixture_path("versioned-file-updates/npm-manifest/package.json"),
+		monochange_core::EcosystemType::Npm,
+	)
+	.unwrap_or_else(|error| panic!("npm manifest: {error}"));
+	assert!(matches!(npm_manifest, crate::CachedDocument::Text(_)));
+
 	let deno_json = crate::read_cached_document(
 		&mut BTreeMap::new(),
 		&fixture_path("monochange/deno-lock-release/packages/app/deno.json"),
 		monochange_core::EcosystemType::Deno,
 	)
 	.unwrap_or_else(|error| panic!("deno json: {error}"));
-	assert!(matches!(deno_json, crate::CachedDocument::Json(_)));
+	assert!(matches!(deno_json, crate::CachedDocument::Text(_)));
+
+	let dart_manifest = crate::read_cached_document(
+		&mut BTreeMap::new(),
+		&fixture_path("dart/workspace-pattern-warnings/packages/app/pubspec.yaml"),
+		monochange_core::EcosystemType::Dart,
+	)
+	.unwrap_or_else(|error| panic!("dart manifest: {error}"));
+	assert!(matches!(dart_manifest, crate::CachedDocument::Text(_)));
 
 	let dart_yaml = crate::read_cached_document(
 		&mut BTreeMap::new(),
@@ -4459,41 +4475,6 @@ fn read_cached_document_parses_supported_document_formats() {
 	)
 	.unwrap_or_else(|error| panic!("dart lock: {error}"));
 	assert!(matches!(dart_yaml, crate::CachedDocument::Yaml(_)));
-}
-
-#[test]
-fn update_json_dependency_fields_updates_only_present_dependency_entries() {
-	let mut value = serde_json::json!({
-		"dependencies": {
-			"core": "^0.1.0",
-			"other": "^0.2.0"
-		},
-		"devDependencies": {
-			"core": "^0.1.0"
-		},
-		"keywords": ["monochange"]
-	});
-	let versions = BTreeMap::from([
-		("core".to_string(), "workspace:1.2.3".to_string()),
-		("missing".to_string(), "workspace:9.9.9".to_string()),
-	]);
-
-	crate::update_json_dependency_fields(
-		&mut value,
-		&[
-			"dependencies",
-			"devDependencies",
-			"keywords",
-			"peerDependencies",
-		],
-		&versions,
-	);
-
-	assert_eq!(value["dependencies"]["core"], "workspace:1.2.3");
-	assert_eq!(value["dependencies"]["other"], "^0.2.0");
-	assert_eq!(value["devDependencies"]["core"], "workspace:1.2.3");
-	assert_eq!(value["keywords"], serde_json::json!(["monochange"]));
-	assert!(value["peerDependencies"].is_null());
 }
 
 #[test]
@@ -4623,6 +4604,231 @@ fn read_cached_document_reports_parse_errors_for_invalid_supported_formats() {
 }
 
 #[test]
+fn build_manifest_updates_preserve_npm_deno_and_dart_formatting() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let npm_path = tempdir.path().join("packages/web/package.json");
+	let deno_path = tempdir.path().join("tools/deno/deno.json");
+	let dart_path = tempdir.path().join("packages/mobile/pubspec.yaml");
+	fs::create_dir_all(npm_path.parent().unwrap_or_else(|| panic!("npm parent")))
+		.unwrap_or_else(|error| panic!("create npm parent: {error}"));
+	fs::create_dir_all(deno_path.parent().unwrap_or_else(|| panic!("deno parent")))
+		.unwrap_or_else(|error| panic!("create deno parent: {error}"));
+	fs::create_dir_all(dart_path.parent().unwrap_or_else(|| panic!("dart parent")))
+		.unwrap_or_else(|error| panic!("create dart parent: {error}"));
+	fs::write(
+		&npm_path,
+		"{\n    \"name\": \"web\",\n    \"version\": \"1.0.0\",\n    \"private\": false\n}\n",
+	)
+	.unwrap_or_else(|error| panic!("write package.json: {error}"));
+	fs::write(
+		&deno_path,
+		"{\n  \"name\": \"tool\",\n  \"version\": \"1.0.0\",\n  \"imports\": {\n    \"core\": \"^1.0.0\"\n  }\n}\n",
+	)
+	.unwrap_or_else(|error| panic!("write deno.json: {error}"));
+	fs::write(
+		&dart_path,
+		"name: mobile\nversion: '1.0.0' # keep quote\n",
+	)
+	.unwrap_or_else(|error| panic!("write pubspec.yaml: {error}"));
+
+	let packages = vec![
+		monochange_core::PackageRecord::new(
+			Ecosystem::Npm,
+			"web",
+			npm_path.clone(),
+			tempdir.path().to_path_buf(),
+			Some(Version::parse("1.0.0").unwrap_or_else(|error| panic!("version: {error}"))),
+			monochange_core::PublishState::Public,
+		),
+		monochange_core::PackageRecord::new(
+			Ecosystem::Deno,
+			"tool",
+			deno_path.clone(),
+			tempdir.path().to_path_buf(),
+			Some(Version::parse("1.0.0").unwrap_or_else(|error| panic!("version: {error}"))),
+			monochange_core::PublishState::Public,
+		),
+		monochange_core::PackageRecord::new(
+			Ecosystem::Dart,
+			"mobile",
+			dart_path.clone(),
+			tempdir.path().to_path_buf(),
+			Some(Version::parse("1.0.0").unwrap_or_else(|error| panic!("version: {error}"))),
+			monochange_core::PublishState::Public,
+		),
+	];
+	let plan = monochange_core::ReleasePlan {
+		workspace_root: tempdir.path().to_path_buf(),
+		decisions: packages
+			.iter()
+			.map(|package| monochange_core::ReleaseDecision {
+				package_id: package.id.clone(),
+				trigger_type: "changeset".to_string(),
+				recommended_bump: BumpSeverity::Minor,
+				planned_version: Some(
+					Version::parse("1.1.0")
+						.unwrap_or_else(|error| panic!("planned version: {error}")),
+				),
+				group_id: None,
+				reasons: vec!["release".to_string()],
+				upstream_sources: Vec::new(),
+				warnings: Vec::new(),
+			})
+			.collect(),
+		groups: Vec::new(),
+		warnings: Vec::new(),
+		unresolved_items: Vec::new(),
+		compatibility_evidence: Vec::new(),
+	};
+
+	let npm_updates = crate::build_npm_manifest_updates(&packages, &plan)
+		.unwrap_or_else(|error| panic!("npm manifest updates: {error}"));
+	let deno_updates = crate::build_deno_manifest_updates(&packages, &plan)
+		.unwrap_or_else(|error| panic!("deno manifest updates: {error}"));
+	let dart_updates = crate::build_dart_manifest_updates(&packages, &plan)
+		.unwrap_or_else(|error| panic!("dart manifest updates: {error}"));
+
+	assert_eq!(String::from_utf8_lossy(&npm_updates[0].content), "{\n    \"name\": \"web\",\n    \"version\": \"1.1.0\",\n    \"private\": false\n}\n");
+	assert_eq!(String::from_utf8_lossy(&deno_updates[0].content), "{\n  \"name\": \"tool\",\n  \"version\": \"1.1.0\",\n  \"imports\": {\n    \"core\": \"^1.0.0\"\n  }\n}\n");
+	assert_eq!(String::from_utf8_lossy(&dart_updates[0].content), "name: mobile\nversion: '1.1.0' # keep quote\n");
+}
+
+#[test]
+fn build_manifest_updates_report_parse_and_io_errors() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let npm_path = tempdir.path().join("package.json");
+	let dart_path = tempdir.path().join("pubspec.yaml");
+	fs::write(&npm_path, "{").unwrap_or_else(|error| panic!("write package.json: {error}"));
+	fs::write(&dart_path, ": bad").unwrap_or_else(|error| panic!("write pubspec.yaml: {error}"));
+	let npm = monochange_core::PackageRecord::new(
+		Ecosystem::Npm,
+		"web",
+		npm_path,
+		tempdir.path().to_path_buf(),
+		Some(Version::parse("1.0.0").unwrap_or_else(|error| panic!("version: {error}"))),
+		monochange_core::PublishState::Public,
+	);
+	let deno_missing = monochange_core::PackageRecord::new(
+		Ecosystem::Deno,
+		"tool",
+		tempdir.path().join("missing/deno.json"),
+		tempdir.path().to_path_buf(),
+		Some(Version::parse("1.0.0").unwrap_or_else(|error| panic!("version: {error}"))),
+		monochange_core::PublishState::Public,
+	);
+	let dart = monochange_core::PackageRecord::new(
+		Ecosystem::Dart,
+		"mobile",
+		dart_path,
+		tempdir.path().to_path_buf(),
+		Some(Version::parse("1.0.0").unwrap_or_else(|error| panic!("version: {error}"))),
+		monochange_core::PublishState::Public,
+	);
+	let plan = monochange_core::ReleasePlan {
+		workspace_root: tempdir.path().to_path_buf(),
+		decisions: vec![npm.id.clone(), deno_missing.id.clone(), dart.id.clone()]
+			.into_iter()
+			.map(|package_id| monochange_core::ReleaseDecision {
+				package_id,
+				trigger_type: "changeset".to_string(),
+				recommended_bump: BumpSeverity::Minor,
+				planned_version: Some(
+					Version::parse("1.1.0")
+						.unwrap_or_else(|error| panic!("planned version: {error}")),
+				),
+				group_id: None,
+				reasons: vec!["release".to_string()],
+				upstream_sources: Vec::new(),
+				warnings: Vec::new(),
+			})
+			.collect(),
+		groups: Vec::new(),
+		warnings: Vec::new(),
+		unresolved_items: Vec::new(),
+		compatibility_evidence: Vec::new(),
+	};
+	let npm_error = crate::build_npm_manifest_updates(&[npm.clone()], &plan)
+		.err()
+		.unwrap_or_else(|| panic!("expected npm parse error"));
+	assert!(npm_error.to_string().contains("failed to parse"), "error: {npm_error}");
+	let deno_error = crate::build_deno_manifest_updates(&[deno_missing.clone()], &plan)
+		.err()
+		.unwrap_or_else(|| panic!("expected deno io error"));
+	assert!(deno_error.to_string().contains("failed to read"), "error: {deno_error}");
+	let dart_error = crate::build_dart_manifest_updates(&[dart.clone()], &plan)
+		.err()
+		.unwrap_or_else(|| panic!("expected dart parse error"));
+	assert!(dart_error.to_string().contains("failed to parse"), "error: {dart_error}");
+
+	let unreleased_plan = monochange_core::ReleasePlan {
+		workspace_root: tempdir.path().to_path_buf(),
+		decisions: Vec::new(),
+		groups: Vec::new(),
+		warnings: Vec::new(),
+		unresolved_items: Vec::new(),
+		compatibility_evidence: Vec::new(),
+	};
+	assert!(crate::build_deno_manifest_updates(&[deno_missing], &unreleased_plan)
+		.unwrap_or_else(|error| panic!("unreleased deno updates: {error}"))
+		.is_empty());
+}
+
+#[test]
+fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_updaters() {
+	let configuration = versioned_test_configuration();
+	for (file_name, ecosystem_type, contents) in [
+		("package.json", monochange_core::EcosystemType::Npm, "{"),
+		("deno.json", monochange_core::EcosystemType::Deno, "{"),
+		("pubspec.yaml", monochange_core::EcosystemType::Dart, ": bad"),
+	] {
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let path = tempdir.path().join(file_name);
+		fs::write(&path, contents).unwrap_or_else(|error| panic!("write {file_name}: {error}"));
+		let context = versioned_test_context(
+			&configuration,
+			BTreeMap::from([("core".to_string(), "2.0.0".to_string())]),
+			&[],
+		);
+		let definition = monochange_core::VersionedFileDefinition {
+			path: file_name.to_string(),
+			ecosystem_type,
+			prefix: None,
+			fields: None,
+			name: None,
+		};
+		let error = crate::apply_versioned_file_definition(
+			tempdir.path(),
+			&mut BTreeMap::new(),
+			&definition,
+			"2.0.0",
+			None,
+			&["core".to_string()],
+			&context,
+		)
+		.err()
+		.unwrap_or_else(|| panic!("expected parse error for {file_name}"));
+		assert!(error.to_string().contains("failed to parse"), "error: {error}");
+	}
+}
+
+#[test]
+fn read_cached_document_reports_parse_errors_for_manifest_text_updaters() {
+	for (file_name, ecosystem, contents) in [
+		("package.json", monochange_core::EcosystemType::Npm, "["),
+		("deno.json", monochange_core::EcosystemType::Deno, "["),
+		("pubspec.yaml", monochange_core::EcosystemType::Dart, ": bad"),
+	] {
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let path = tempdir.path().join(file_name);
+		fs::write(&path, contents).unwrap_or_else(|error| panic!("write {file_name}: {error}"));
+		let error = crate::read_cached_document(&mut BTreeMap::new(), &path, ecosystem)
+			.err()
+			.unwrap_or_else(|| panic!("expected parse error for {}", path.display()));
+		assert!(error.to_string().contains("failed to parse"), "error: {error}");
+	}
+}
+
+#[test]
 fn read_cached_document_rejects_invalid_utf8_in_text_formats() {
 	let cases = [
 		(
@@ -4659,6 +4865,25 @@ fn read_cached_document_rejects_invalid_utf8_in_text_formats() {
 			error.to_string().contains("failed to parse"),
 			"error: {error}"
 		);
+		assert!(error.to_string().contains("as text"), "error: {error}");
+	}
+}
+
+#[test]
+fn read_cached_document_rejects_invalid_utf8_manifest_text_formats() {
+	for (file_name, ecosystem) in [
+		("package.json", monochange_core::EcosystemType::Npm),
+		("deno.json", monochange_core::EcosystemType::Deno),
+		("pubspec.yaml", monochange_core::EcosystemType::Dart),
+	] {
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let path = tempdir.path().join(file_name);
+		fs::write(&path, [0xff_u8, 0xfe_u8])
+			.unwrap_or_else(|error| panic!("write invalid utf8 {file_name}: {error}"));
+		let error = crate::read_cached_document(&mut BTreeMap::new(), &path, ecosystem)
+			.err()
+			.unwrap_or_else(|| panic!("expected utf8 error for {}", path.display()));
+		assert!(error.to_string().contains("failed to parse"), "error: {error}");
 		assert!(error.to_string().contains("as text"), "error: {error}");
 	}
 }
@@ -4788,8 +5013,8 @@ fn apply_versioned_file_definition_updates_npm_manifest_and_lock_variants() {
 		.unwrap_or_else(|| panic!("expected npm manifest update"));
 	assert!(matches!(
 		manifest_document,
-		crate::CachedDocument::Json(value)
-			if value["dependencies"]["core"] == serde_json::Value::String("^2.0.0".to_string())
+		crate::CachedDocument::Text(contents)
+			if contents.contains("\"core\": \"^2.0.0\"")
 	));
 
 	let package_lock_tempdir = setup_fixture("monochange/npm-lock-release");
@@ -4955,8 +5180,8 @@ fn apply_versioned_file_definition_updates_deno_and_dart_variants() {
 		.unwrap_or_else(|| panic!("expected deno manifest update"));
 	assert!(matches!(
 		deno_manifest_document,
-		crate::CachedDocument::Json(value)
-			if value["imports"]["core"] == serde_json::Value::String("^2.0.0".to_string())
+		crate::CachedDocument::Text(contents)
+			if contents.contains("\"core\": \"^2.0.0\"")
 	));
 
 	let deno_lock_tempdir = setup_fixture("monochange/deno-lock-release");
@@ -5026,13 +5251,8 @@ fn apply_versioned_file_definition_updates_deno_and_dart_variants() {
 		.unwrap_or_else(|| panic!("expected dart manifest update"));
 	assert!(matches!(
 		dart_manifest_document,
-		crate::CachedDocument::Yaml(mapping)
-			if mapping
-				.get(serde_yaml_ng::Value::String("dependencies".to_string()))
-				.and_then(serde_yaml_ng::Value::as_mapping)
-				.and_then(|deps| deps.get(serde_yaml_ng::Value::String("shared".to_string())))
-				.and_then(serde_yaml_ng::Value::as_str)
-				== Some("^2.0.0")
+		crate::CachedDocument::Text(contents)
+			if contents.contains("shared: ^2.0.0")
 	));
 
 	let dart_lock_tempdir = setup_fixture("dart/manifest-lockfile-workspace");

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -4625,11 +4625,8 @@ fn build_manifest_updates_preserve_npm_deno_and_dart_formatting() {
 		"{\n  \"name\": \"tool\",\n  \"version\": \"1.0.0\",\n  \"imports\": {\n    \"core\": \"^1.0.0\"\n  }\n}\n",
 	)
 	.unwrap_or_else(|error| panic!("write deno.json: {error}"));
-	fs::write(
-		&dart_path,
-		"name: mobile\nversion: '1.0.0' # keep quote\n",
-	)
-	.unwrap_or_else(|error| panic!("write pubspec.yaml: {error}"));
+	fs::write(&dart_path, "name: mobile\nversion: '1.0.0' # keep quote\n")
+		.unwrap_or_else(|error| panic!("write pubspec.yaml: {error}"));
 
 	let packages = vec![
 		monochange_core::PackageRecord::new(
@@ -4688,9 +4685,15 @@ fn build_manifest_updates_preserve_npm_deno_and_dart_formatting() {
 	let dart_updates = crate::build_dart_manifest_updates(&packages, &plan)
 		.unwrap_or_else(|error| panic!("dart manifest updates: {error}"));
 
-	assert_eq!(String::from_utf8_lossy(&npm_updates[0].content), "{\n    \"name\": \"web\",\n    \"version\": \"1.1.0\",\n    \"private\": false\n}\n");
+	assert_eq!(
+		String::from_utf8_lossy(&npm_updates[0].content),
+		"{\n    \"name\": \"web\",\n    \"version\": \"1.1.0\",\n    \"private\": false\n}\n"
+	);
 	assert_eq!(String::from_utf8_lossy(&deno_updates[0].content), "{\n  \"name\": \"tool\",\n  \"version\": \"1.1.0\",\n  \"imports\": {\n    \"core\": \"^1.0.0\"\n  }\n}\n");
-	assert_eq!(String::from_utf8_lossy(&dart_updates[0].content), "name: mobile\nversion: '1.1.0' # keep quote\n");
+	assert_eq!(
+		String::from_utf8_lossy(&dart_updates[0].content),
+		"name: mobile\nversion: '1.1.0' # keep quote\n"
+	);
 }
 
 #[test]
@@ -4754,21 +4757,20 @@ fn build_manifest_updates_report_parse_and_io_errors() {
 			dart.id.clone(),
 			dart_missing.id.clone(),
 		]
-			.into_iter()
-			.map(|package_id| monochange_core::ReleaseDecision {
-				package_id,
-				trigger_type: "changeset".to_string(),
-				recommended_bump: BumpSeverity::Minor,
-				planned_version: Some(
-					Version::parse("1.1.0")
-						.unwrap_or_else(|error| panic!("planned version: {error}")),
-				),
-				group_id: None,
-				reasons: vec!["release".to_string()],
-				upstream_sources: Vec::new(),
-				warnings: Vec::new(),
-			})
-			.collect(),
+		.into_iter()
+		.map(|package_id| monochange_core::ReleaseDecision {
+			package_id,
+			trigger_type: "changeset".to_string(),
+			recommended_bump: BumpSeverity::Minor,
+			planned_version: Some(
+				Version::parse("1.1.0").unwrap_or_else(|error| panic!("planned version: {error}")),
+			),
+			group_id: None,
+			reasons: vec!["release".to_string()],
+			upstream_sources: Vec::new(),
+			warnings: Vec::new(),
+		})
+		.collect(),
 		groups: Vec::new(),
 		warnings: Vec::new(),
 		unresolved_items: Vec::new(),
@@ -4777,17 +4779,21 @@ fn build_manifest_updates_report_parse_and_io_errors() {
 	let npm_error = crate::build_npm_manifest_updates(std::slice::from_ref(&npm), &plan)
 		.err()
 		.unwrap_or_else(|| panic!("expected npm parse error"));
-	assert!(npm_error.to_string().contains("failed to parse"), "error: {npm_error}");
+	assert!(
+		npm_error.to_string().contains("failed to parse"),
+		"error: {npm_error}"
+	);
 	let deno_error = crate::build_deno_manifest_updates(std::slice::from_ref(&deno_missing), &plan)
 		.err()
 		.unwrap_or_else(|| panic!("expected deno io error"));
-	assert!(deno_error.to_string().contains("failed to read"), "error: {deno_error}");
-	let deno_parse_error = crate::build_deno_manifest_updates(
-		std::slice::from_ref(&deno_invalid),
-		&plan,
-	)
-	.err()
-	.unwrap_or_else(|| panic!("expected deno parse error"));
+	assert!(
+		deno_error.to_string().contains("failed to read"),
+		"error: {deno_error}"
+	);
+	let deno_parse_error =
+		crate::build_deno_manifest_updates(std::slice::from_ref(&deno_invalid), &plan)
+			.err()
+			.unwrap_or_else(|| panic!("expected deno parse error"));
 	assert!(
 		deno_parse_error.to_string().contains("failed to parse"),
 		"error: {deno_parse_error}"
@@ -4795,10 +4801,14 @@ fn build_manifest_updates_report_parse_and_io_errors() {
 	let dart_error = crate::build_dart_manifest_updates(std::slice::from_ref(&dart), &plan)
 		.err()
 		.unwrap_or_else(|| panic!("expected dart parse error"));
-	assert!(dart_error.to_string().contains("failed to parse"), "error: {dart_error}");
-	let dart_read_error = crate::build_dart_manifest_updates(std::slice::from_ref(&dart_missing), &plan)
-		.err()
-		.unwrap_or_else(|| panic!("expected dart read error"));
+	assert!(
+		dart_error.to_string().contains("failed to parse"),
+		"error: {dart_error}"
+	);
+	let dart_read_error =
+		crate::build_dart_manifest_updates(std::slice::from_ref(&dart_missing), &plan)
+			.err()
+			.unwrap_or_else(|| panic!("expected dart read error"));
 	assert!(
 		dart_read_error.to_string().contains("failed to read"),
 		"error: {dart_read_error}"
@@ -4878,8 +4888,7 @@ fn build_manifest_updates_report_parse_and_io_errors() {
 			trigger_type: "changeset".to_string(),
 			recommended_bump: BumpSeverity::Minor,
 			planned_version: Some(
-				Version::parse("1.1.0")
-					.unwrap_or_else(|error| panic!("planned version: {error}")),
+				Version::parse("1.1.0").unwrap_or_else(|error| panic!("planned version: {error}")),
 			),
 			group_id: None,
 			reasons: vec!["release".to_string()],
@@ -4892,22 +4901,18 @@ fn build_manifest_updates_report_parse_and_io_errors() {
 		unresolved_items: Vec::new(),
 		compatibility_evidence: Vec::new(),
 	};
-	let cargo_read_error = crate::build_cargo_manifest_updates(
-		std::slice::from_ref(&cargo_missing),
-		&cargo_plan,
-	)
-	.err()
-	.unwrap_or_else(|| panic!("expected cargo read error"));
+	let cargo_read_error =
+		crate::build_cargo_manifest_updates(std::slice::from_ref(&cargo_missing), &cargo_plan)
+			.err()
+			.unwrap_or_else(|| panic!("expected cargo read error"));
 	assert!(
 		cargo_read_error.to_string().contains("failed to read"),
 		"error: {cargo_read_error}"
 	);
-	let cargo_parse_error = crate::build_cargo_manifest_updates(
-		std::slice::from_ref(&cargo_invalid),
-		&cargo_plan,
-	)
-	.err()
-	.unwrap_or_else(|| panic!("expected cargo parse error"));
+	let cargo_parse_error =
+		crate::build_cargo_manifest_updates(std::slice::from_ref(&cargo_invalid), &cargo_plan)
+			.err()
+			.unwrap_or_else(|| panic!("expected cargo parse error"));
 	assert!(
 		cargo_parse_error.to_string().contains("failed to parse"),
 		"error: {cargo_parse_error}"
@@ -4945,9 +4950,32 @@ fn build_manifest_updates_report_parse_and_io_errors() {
 		unresolved_items: Vec::new(),
 		compatibility_evidence: Vec::new(),
 	};
-	assert!(crate::build_deno_manifest_updates(&[deno_missing], &unreleased_plan)
-		.unwrap_or_else(|error| panic!("unreleased deno updates: {error}"))
-		.is_empty());
+	assert!(
+		crate::build_deno_manifest_updates(&[deno_missing], &unreleased_plan)
+			.unwrap_or_else(|error| panic!("unreleased deno updates: {error}"))
+			.is_empty()
+	);
+}
+
+#[test]
+fn expand_versioned_file_fields_supports_name_templates_and_passthrough_fields() {
+	let definition = monochange_core::VersionedFileDefinition {
+		path: "Cargo.toml".to_string(),
+		ecosystem_type: monochange_core::EcosystemType::Cargo,
+		prefix: None,
+		fields: Some(vec![
+			"workspace.dependencies.{{name}}.version".to_string(),
+			"workspace.version".to_string(),
+		]),
+		name: None,
+	};
+	assert_eq!(
+		crate::versioned_files::expand_versioned_file_fields(&definition, &["core".to_string()]),
+		vec![
+			"workspace.dependencies.core.version".to_string(),
+			"workspace.version".to_string(),
+		]
+	);
 }
 
 #[test]
@@ -4957,7 +4985,11 @@ fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_update
 		("Cargo.toml", monochange_core::EcosystemType::Cargo, "{"),
 		("package.json", monochange_core::EcosystemType::Npm, "{"),
 		("deno.json", monochange_core::EcosystemType::Deno, "{"),
-		("pubspec.yaml", monochange_core::EcosystemType::Dart, ": bad"),
+		(
+			"pubspec.yaml",
+			monochange_core::EcosystemType::Dart,
+			": bad",
+		),
 	] {
 		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 		let path = tempdir.path().join(file_name);
@@ -4985,7 +5017,10 @@ fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_update
 		)
 		.err()
 		.unwrap_or_else(|| panic!("expected parse error for {file_name}"));
-		assert!(error.to_string().contains("failed to parse"), "error: {error}");
+		assert!(
+			error.to_string().contains("failed to parse"),
+			"error: {error}"
+		);
 	}
 
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
@@ -5015,7 +5050,38 @@ fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_update
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected cached cargo parse error"));
-	assert!(error.to_string().contains("failed to parse"), "error: {error}");
+	assert!(
+		error.to_string().contains("failed to parse"),
+		"error: {error}"
+	);
+
+	let cached_dart_tempdir = tempfile::tempdir()
+		.unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let path = cached_dart_tempdir.path().join("pubspec.yaml");
+	fs::write(&path, "name: app\nversion: 1.0.0\n")
+		.unwrap_or_else(|error| panic!("write cached dart manifest path: {error}"));
+	let definition = monochange_core::VersionedFileDefinition {
+		path: "pubspec.yaml".to_string(),
+		ecosystem_type: monochange_core::EcosystemType::Dart,
+		prefix: None,
+		fields: None,
+		name: None,
+	};
+	let error = crate::apply_versioned_file_definition(
+		cached_dart_tempdir.path(),
+		&mut BTreeMap::from([(path, crate::CachedDocument::Text(": bad".to_string()))]),
+		&definition,
+		"2.0.0",
+		None,
+		&["core".to_string()],
+		&context,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected cached dart parse error"));
+	assert!(
+		error.to_string().contains("failed to parse"),
+		"error: {error}"
+	);
 }
 
 #[test]
@@ -5023,7 +5089,11 @@ fn read_cached_document_reports_parse_errors_for_manifest_text_updaters() {
 	for (file_name, ecosystem, contents) in [
 		("package.json", monochange_core::EcosystemType::Npm, "["),
 		("deno.json", monochange_core::EcosystemType::Deno, "["),
-		("pubspec.yaml", monochange_core::EcosystemType::Dart, ": bad"),
+		(
+			"pubspec.yaml",
+			monochange_core::EcosystemType::Dart,
+			": bad",
+		),
 	] {
 		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 		let path = tempdir.path().join(file_name);
@@ -5031,7 +5101,10 @@ fn read_cached_document_reports_parse_errors_for_manifest_text_updaters() {
 		let error = crate::read_cached_document(&mut BTreeMap::new(), &path, ecosystem)
 			.err()
 			.unwrap_or_else(|| panic!("expected parse error for {}", path.display()));
-		assert!(error.to_string().contains("failed to parse"), "error: {error}");
+		assert!(
+			error.to_string().contains("failed to parse"),
+			"error: {error}"
+		);
 	}
 }
 
@@ -5090,7 +5163,10 @@ fn read_cached_document_rejects_invalid_utf8_manifest_text_formats() {
 		let error = crate::read_cached_document(&mut BTreeMap::new(), &path, ecosystem)
 			.err()
 			.unwrap_or_else(|| panic!("expected utf8 error for {}", path.display()));
-		assert!(error.to_string().contains("failed to parse"), "error: {error}");
+		assert!(
+			error.to_string().contains("failed to parse"),
+			"error: {error}"
+		);
 		assert!(error.to_string().contains("as text"), "error: {error}");
 	}
 }
@@ -5162,27 +5238,134 @@ fn apply_versioned_file_definition_rejects_unsupported_glob_matches() {
 		BTreeMap::from([("core".to_string(), "2.0.0".to_string())]),
 		&[],
 	);
+	let dep_names = vec!["core".to_string()];
+	for ecosystem_type in [
+		monochange_core::EcosystemType::Cargo,
+		monochange_core::EcosystemType::Npm,
+		monochange_core::EcosystemType::Deno,
+	] {
+		let definition = monochange_core::VersionedFileDefinition {
+			path: "*.txt".to_string(),
+			ecosystem_type,
+			prefix: None,
+			fields: None,
+			name: None,
+		};
+		let error = crate::apply_versioned_file_definition(
+			tempdir.path(),
+			&mut BTreeMap::new(),
+			&definition,
+			"2.0.0",
+			None,
+			&dep_names,
+			&context,
+		)
+		.err()
+		.unwrap_or_else(|| panic!("expected unsupported match error"));
+		assert!(error.to_string().contains("matched unsupported file"));
+		assert!(error.to_string().contains("root.txt"), "error: {error}");
+	}
+}
+
+#[test]
+fn apply_versioned_file_definition_updates_cargo_workspace_dependencies_from_shorthand() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	fs::write(
+		tempdir.path().join("Cargo.toml"),
+		r#"[workspace.dependencies]
+monochange = { path = "crates/monochange", version = "1.0.0" }
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write root cargo manifest: {error}"));
+	let configuration = versioned_test_configuration();
+	let context = versioned_test_context(
+		&configuration,
+		BTreeMap::from([("monochange".to_string(), "2.0.0".to_string())]),
+		&[],
+	);
 	let definition = monochange_core::VersionedFileDefinition {
-		path: "*.txt".to_string(),
+		path: "Cargo.toml".to_string(),
 		ecosystem_type: monochange_core::EcosystemType::Cargo,
 		prefix: None,
 		fields: None,
 		name: None,
 	};
-	let dep_names = vec!["core".to_string()];
-	let error = crate::apply_versioned_file_definition(
+	let mut updates = BTreeMap::new();
+	crate::apply_versioned_file_definition(
 		tempdir.path(),
-		&mut BTreeMap::new(),
+		&mut updates,
 		&definition,
 		"2.0.0",
 		None,
-		&dep_names,
+		&["monochange".to_string()],
 		&context,
 	)
-	.err()
-	.unwrap_or_else(|| panic!("expected unsupported match error"));
-	assert!(error.to_string().contains("matched unsupported file"));
-	assert!(error.to_string().contains("root.txt"), "error: {error}");
+	.unwrap_or_else(|error| panic!("cargo shorthand update: {error}"));
+	let document = updates
+		.remove(&tempdir.path().join("Cargo.toml"))
+		.unwrap_or_else(|| panic!("expected cargo manifest update"));
+	assert!(matches!(
+		document,
+		crate::CachedDocument::Text(contents)
+			if contents.contains("monochange = { path = \"crates/monochange\", version = \"2.0.0\" }")
+	));
+}
+
+#[test]
+fn apply_versioned_file_definition_expands_cargo_name_templates_in_fields() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	fs::write(
+		tempdir.path().join("Cargo.toml"),
+		r#"[workspace.package]
+version = "1.0.0"
+
+[workspace.dependencies]
+core = { path = "crates/core", version = "1.0.0" }
+extra = { path = "crates/extra", version = "1.0.0" }
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write root cargo manifest: {error}"));
+	let configuration = versioned_test_configuration();
+	let context = versioned_test_context(
+		&configuration,
+		BTreeMap::from([
+			("core".to_string(), "2.0.0".to_string()),
+			("extra".to_string(), "3.0.0".to_string()),
+		]),
+		&[],
+	);
+	let definition = monochange_core::VersionedFileDefinition {
+		path: "Cargo.toml".to_string(),
+		ecosystem_type: monochange_core::EcosystemType::Cargo,
+		prefix: None,
+		fields: Some(vec![
+			"workspace.version".to_string(),
+			"workspace.dependencies.{{ name }}.version".to_string(),
+		]),
+		name: None,
+	};
+	let mut updates = BTreeMap::new();
+	let shared_version = "4.0.0".to_string();
+	crate::apply_versioned_file_definition(
+		tempdir.path(),
+		&mut updates,
+		&definition,
+		"2.0.0",
+		Some(&shared_version),
+		&["core".to_string(), "extra".to_string()],
+		&context,
+	)
+	.unwrap_or_else(|error| panic!("cargo field template update: {error}"));
+	let document = updates
+		.remove(&tempdir.path().join("Cargo.toml"))
+		.unwrap_or_else(|| panic!("expected cargo manifest update"));
+	assert!(matches!(
+		document,
+		crate::CachedDocument::Text(contents)
+			if contents.contains("[workspace.package]\nversion = \"4.0.0\"")
+				&& contents.contains("core = { path = \"crates/core\", version = \"2.0.0\" }")
+				&& contents.contains("extra = { path = \"crates/extra\", version = \"3.0.0\" }")
+	));
 }
 
 #[test]

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -4424,7 +4424,10 @@ fn read_cached_document_parses_supported_document_formats() {
 		monochange_core::EcosystemType::Npm,
 	)
 	.unwrap_or_else(|error| panic!("pnpm lock: {error}"));
-	assert!(matches!(npm_yaml, crate::CachedDocument::Yaml(_)));
+	assert!(matches!(
+		npm_yaml,
+		crate::CachedDocument::Text(contents) if contents.contains("lockfileVersion")
+	));
 
 	let bun_text = crate::read_cached_document(
 		&mut BTreeMap::new(),
@@ -5055,8 +5058,35 @@ fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_update
 		"error: {error}"
 	);
 
-	let cached_dart_tempdir = tempfile::tempdir()
-		.unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let pnpm_tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let pnpm_path = pnpm_tempdir.path().join("pnpm-lock.yaml");
+	fs::write(&pnpm_path, "lockfileVersion: '9.0'\n")
+		.unwrap_or_else(|error| panic!("write cached pnpm lock path: {error}"));
+	let pnpm_definition = monochange_core::VersionedFileDefinition {
+		path: "pnpm-lock.yaml".to_string(),
+		ecosystem_type: monochange_core::EcosystemType::Npm,
+		prefix: None,
+		fields: None,
+		name: None,
+	};
+	let error = crate::apply_versioned_file_definition(
+		pnpm_tempdir.path(),
+		&mut BTreeMap::from([(pnpm_path, crate::CachedDocument::Text(": bad".to_string()))]),
+		&pnpm_definition,
+		"2.0.0",
+		None,
+		&["core".to_string()],
+		&context,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected cached pnpm parse error"));
+	assert!(
+		error.to_string().contains("failed to parse"),
+		"error: {error}"
+	);
+
+	let cached_dart_tempdir =
+		tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	let path = cached_dart_tempdir.path().join("pubspec.yaml");
 	fs::write(&path, "name: app\nversion: 1.0.0\n")
 		.unwrap_or_else(|error| panic!("write cached dart manifest path: {error}"));
@@ -5369,6 +5399,87 @@ extra = { path = "crates/extra", version = "1.0.0" }
 }
 
 #[test]
+fn apply_versioned_file_definition_updates_bun_lockb_and_deno_text_variants() {
+	let configuration = versioned_test_configuration();
+
+	let bun_tempdir = setup_fixture("monochange/bun-lock-release");
+	let bun_package = monochange_core::PackageRecord::new(
+		Ecosystem::Npm,
+		"app",
+		bun_tempdir.path().join("packages/app/package.json"),
+		bun_tempdir.path().to_path_buf(),
+		Some(Version::parse("1.0.0").unwrap_or_else(|error| panic!("version: {error}"))),
+		monochange_core::PublishState::Public,
+	);
+	let bun_context = versioned_test_context(
+		&configuration,
+		BTreeMap::from([("app".to_string(), "2.0.0".to_string())]),
+		std::slice::from_ref(&bun_package),
+	);
+	let bun_definition = monochange_core::VersionedFileDefinition {
+		path: "packages/app/bun.lockb".to_string(),
+		ecosystem_type: monochange_core::EcosystemType::Npm,
+		prefix: None,
+		fields: None,
+		name: None,
+	};
+	let bun_path = bun_tempdir.path().join("packages/app/bun.lockb");
+	let original_bun =
+		fs::read(&bun_path).unwrap_or_else(|error| panic!("read bun lockb: {error}"));
+	let mut bun_updates = BTreeMap::new();
+	crate::apply_versioned_file_definition(
+		bun_tempdir.path(),
+		&mut bun_updates,
+		&bun_definition,
+		"2.0.0",
+		None,
+		&["app".to_string()],
+		&bun_context,
+	)
+	.unwrap_or_else(|error| panic!("bun lockb update: {error}"));
+	let bun_document = bun_updates
+		.remove(&bun_path)
+		.unwrap_or_else(|| panic!("expected bun lockb update"));
+	assert!(matches!(
+		bun_document,
+		crate::CachedDocument::Bytes(contents) if !contents.is_empty() && contents != original_bun
+	));
+
+	let deno_tempdir = setup_fixture("versioned-file-updates/deno-manifest");
+	let deno_context = versioned_test_context(
+		&configuration,
+		BTreeMap::from([("core".to_string(), "2.0.0".to_string())]),
+		&[],
+	);
+	let deno_definition = monochange_core::VersionedFileDefinition {
+		path: "deno.json".to_string(),
+		ecosystem_type: monochange_core::EcosystemType::Deno,
+		prefix: None,
+		fields: None,
+		name: None,
+	};
+	let mut deno_updates = BTreeMap::new();
+	crate::apply_versioned_file_definition(
+		deno_tempdir.path(),
+		&mut deno_updates,
+		&deno_definition,
+		"2.0.0",
+		None,
+		&["core".to_string()],
+		&deno_context,
+	)
+	.unwrap_or_else(|error| panic!("deno manifest text update: {error}"));
+	let deno_document = deno_updates
+		.remove(&deno_tempdir.path().join("deno.json"))
+		.unwrap_or_else(|| panic!("expected deno manifest text update"));
+	assert!(matches!(
+		deno_document,
+		crate::CachedDocument::Text(contents)
+			if contents.contains("\"core\": \"^2.0.0\"")
+	));
+}
+
+#[test]
 fn apply_versioned_file_definition_updates_npm_manifest_and_lock_variants() {
 	let configuration = versioned_test_configuration();
 
@@ -5487,17 +5598,9 @@ fn apply_versioned_file_definition_updates_npm_manifest_and_lock_variants() {
 		.unwrap_or_else(|| panic!("expected pnpm lock update"));
 	assert!(matches!(
 		pnpm_document,
-		crate::CachedDocument::Yaml(mapping)
-			if mapping
-				.get(serde_yaml_ng::Value::String("importers".to_string()))
-				.and_then(serde_yaml_ng::Value::as_mapping)
-				.and_then(|importers| importers.get(serde_yaml_ng::Value::String(".".to_string())))
-				.and_then(serde_yaml_ng::Value::as_mapping)
-				.and_then(|entry| entry.get(serde_yaml_ng::Value::String("dependencies".to_string())))
-				.and_then(serde_yaml_ng::Value::as_mapping)
-				.and_then(|deps| deps.get(serde_yaml_ng::Value::String("core".to_string())))
-				.and_then(serde_yaml_ng::Value::as_str)
-				== Some("2.0.0")
+		crate::CachedDocument::Text(contents)
+			if contents.contains("core: 2.0.0")
+				&& contents.contains("lockfileVersion: '9.0'")
 	));
 
 	let bun_tempdir = setup_fixture("npm/bun-text-lock");

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -4406,7 +4406,9 @@ fn read_cached_document_parses_supported_document_formats() {
 		monochange_core::EcosystemType::Cargo,
 	)
 	.unwrap_or_else(|error| panic!("cargo manifest: {error}"));
-	assert!(matches!(cargo, crate::CachedDocument::Toml(_)));
+	assert!(
+		matches!(cargo, crate::CachedDocument::Text(contents) if contents.contains("[package]"))
+	);
 
 	let npm_json = crate::read_cached_document(
 		&mut BTreeMap::new(),

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -136,7 +136,6 @@ use monochange_semver::collect_assessments;
 use monochange_semver::CompatibilityProvider;
 use serde::Serialize;
 use serde_json::json;
-use toml::Value;
 
 use assist::run_assist;
 use cli::build_command_with_cli;

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -518,18 +518,14 @@ pub(crate) fn build_dart_manifest_updates(
 				package.manifest_path.display()
 			))
 		})?;
-		let rendered = monochange_dart::update_manifest_text(
-			&contents,
-			Some(version),
-			&[],
-			&BTreeMap::new(),
-		)
-		.map_err(|error| {
-			MonochangeError::Config(format!(
-				"failed to parse {}: {error}",
-				package.manifest_path.display()
-			))
-		})?;
+		let rendered =
+			monochange_dart::update_manifest_text(&contents, Some(version), &[], &BTreeMap::new())
+				.map_err(|error| {
+					MonochangeError::Config(format!(
+						"failed to parse {}: {error}",
+						package.manifest_path.display()
+					))
+				})?;
 		updates.push(FileUpdate {
 			path: package.manifest_path.clone(),
 			content: rendered.into_bytes(),

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -441,21 +441,57 @@ pub(crate) fn build_npm_manifest_updates(
 				package.manifest_path.display()
 			))
 		})?;
-		let mut parsed = serde_json::from_str::<serde_json::Value>(&contents).map_err(|error| {
+		let rendered = monochange_core::update_json_manifest_text(
+			&contents,
+			Some(version),
+			&[],
+			&BTreeMap::new(),
+		)
+		.map_err(|error| {
 			MonochangeError::Config(format!(
 				"failed to parse {}: {error}",
 				package.manifest_path.display()
 			))
 		})?;
-		if let Some(obj) = parsed.as_object_mut() {
-			obj.insert(
-				"version".to_string(),
-				serde_json::Value::String(version.clone()),
-			);
-		}
-		let mut rendered = serde_json::to_string_pretty(&parsed)
-			.map_err(|error| MonochangeError::Config(error.to_string()))?;
-		rendered.push('\n');
+		updates.push(FileUpdate {
+			path: package.manifest_path.clone(),
+			content: rendered.into_bytes(),
+		});
+	}
+	Ok(updates)
+}
+
+pub(crate) fn build_deno_manifest_updates(
+	packages: &[PackageRecord],
+	plan: &ReleasePlan,
+) -> MonochangeResult<Vec<FileUpdate>> {
+	let released_versions = released_versions_by_record_id(plan);
+	let mut updates = Vec::new();
+	for package in packages
+		.iter()
+		.filter(|package| package.ecosystem == Ecosystem::Deno)
+	{
+		let Some(version) = released_versions.get(&package.id) else {
+			continue;
+		};
+		let contents = fs::read_to_string(&package.manifest_path).map_err(|error| {
+			MonochangeError::Io(format!(
+				"failed to read {}: {error}",
+				package.manifest_path.display()
+			))
+		})?;
+		let rendered = monochange_core::update_json_manifest_text(
+			&contents,
+			Some(version),
+			&[],
+			&BTreeMap::new(),
+		)
+		.map_err(|error| {
+			MonochangeError::Config(format!(
+				"failed to parse {}: {error}",
+				package.manifest_path.display()
+			))
+		})?;
 		updates.push(FileUpdate {
 			path: package.manifest_path.clone(),
 			content: rendered.into_bytes(),
@@ -482,19 +518,18 @@ pub(crate) fn build_dart_manifest_updates(
 				package.manifest_path.display()
 			))
 		})?;
-		let mut mapping =
-			serde_yaml_ng::from_str::<serde_yaml_ng::Mapping>(&contents).map_err(|error| {
-				MonochangeError::Config(format!(
-					"failed to parse {}: {error}",
-					package.manifest_path.display()
-				))
-			})?;
-		mapping.insert(
-			serde_yaml_ng::Value::String("version".to_string()),
-			serde_yaml_ng::Value::String(version.clone()),
-		);
-		let rendered = serde_yaml_ng::to_string(&mapping)
-			.map_err(|error| MonochangeError::Config(error.to_string()))?;
+		let rendered = monochange_dart::update_manifest_text(
+			&contents,
+			Some(version),
+			&[],
+			&BTreeMap::new(),
+		)
+		.map_err(|error| {
+			MonochangeError::Config(format!(
+				"failed to parse {}: {error}",
+				package.manifest_path.display()
+			))
+		})?;
 		updates.push(FileUpdate {
 			path: package.manifest_path.clone(),
 			content: rendered.into_bytes(),

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -319,7 +319,7 @@ pub(crate) fn build_cargo_manifest_updates(
 		return Ok(Vec::new());
 	}
 
-	let mut updated_documents = BTreeMap::<PathBuf, Value>::new();
+	let mut updated_documents = BTreeMap::<PathBuf, String>::new();
 	for package in packages
 		.iter()
 		.filter(|package| package.ecosystem == Ecosystem::Cargo)
@@ -333,14 +333,28 @@ pub(crate) fn build_cargo_manifest_updates(
 			continue;
 		}
 
-		let mut document = read_toml_document(&package.manifest_path)?;
-		update_cargo_manifest(
-			&mut document,
-			package,
-			&released_versions,
+		let contents = fs::read_to_string(&package.manifest_path).map_err(|error| {
+			MonochangeError::Io(format!(
+				"failed to read {}: {error}",
+				package.manifest_path.display()
+			))
+		})?;
+		let updated = monochange_cargo::update_versioned_file_text(
+			&contents,
+			monochange_cargo::CargoVersionedFileKind::Manifest,
+			&["dependencies", "dev-dependencies", "build-dependencies"],
+			released_versions.get(&package.id).map(String::as_str),
+			None,
 			&released_versions_by_name,
-		);
-		updated_documents.insert(package.manifest_path.clone(), document);
+			&BTreeMap::new(),
+		)
+		.map_err(|error| {
+			MonochangeError::Config(format!(
+				"failed to parse {}: {error}",
+				package.manifest_path.display()
+			))
+		})?;
+		updated_documents.insert(package.manifest_path.clone(), updated);
 	}
 
 	for workspace_root in packages
@@ -371,30 +385,41 @@ pub(crate) fn build_cargo_manifest_updates(
 		if !workspace_manifest.exists() {
 			continue;
 		}
-		let mut document = if let Some(document) = updated_documents.remove(&workspace_manifest) {
+		let contents = if let Some(document) = updated_documents.remove(&workspace_manifest) {
 			document
 		} else {
-			read_toml_document(&workspace_manifest)?
+			fs::read_to_string(&workspace_manifest).map_err(|error| {
+				MonochangeError::Io(format!(
+					"failed to read {}: {error}",
+					workspace_manifest.display()
+				))
+			})?
 		};
-		update_workspace_manifest(
-			&mut document,
-			&shared_workspace_version,
+		let updated = monochange_cargo::update_versioned_file_text(
+			&contents,
+			monochange_cargo::CargoVersionedFileKind::Manifest,
+			&["dependencies", "dev-dependencies", "build-dependencies"],
+			None,
+			Some(shared_workspace_version.as_str()),
 			&released_versions_by_name,
-		);
-		updated_documents.insert(workspace_manifest, document);
+			&BTreeMap::new(),
+		)
+		.map_err(|error| {
+			MonochangeError::Config(format!(
+				"failed to parse {}: {error}",
+				workspace_manifest.display()
+			))
+		})?;
+		updated_documents.insert(workspace_manifest, updated);
 	}
 
-	updated_documents
+	Ok(updated_documents
 		.into_iter()
-		.map(|(path, document)| {
-			toml::to_string_pretty(&document)
-				.map(|content| FileUpdate {
-					path,
-					content: content.into_bytes(),
-				})
-				.map_err(|error| MonochangeError::Config(error.to_string()))
+		.map(|(path, document)| FileUpdate {
+			path,
+			content: document.into_bytes(),
 		})
-		.collect()
+		.collect())
 }
 
 pub(crate) fn build_npm_manifest_updates(
@@ -476,99 +501,6 @@ pub(crate) fn build_dart_manifest_updates(
 		});
 	}
 	Ok(updates)
-}
-
-fn read_toml_document(path: &Path) -> MonochangeResult<Value> {
-	let contents = fs::read_to_string(path).map_err(|error| {
-		MonochangeError::Io(format!("failed to read {}: {error}", path.display()))
-	})?;
-	toml::from_str::<Value>(&contents).map_err(|error| {
-		MonochangeError::Config(format!("failed to parse {}: {error}", path.display()))
-	})
-}
-
-fn update_cargo_manifest(
-	document: &mut Value,
-	package: &PackageRecord,
-	released_versions: &BTreeMap<String, String>,
-	released_versions_by_name: &BTreeMap<String, String>,
-) {
-	if let Some(version) = released_versions.get(&package.id) {
-		if let Some(package_table) = document.get_mut("package").and_then(Value::as_table_mut) {
-			let uses_workspace_version = package_table
-				.get("version")
-				.and_then(Value::as_table)
-				.and_then(|version_table| version_table.get("workspace"))
-				.and_then(Value::as_bool)
-				== Some(true);
-			if !uses_workspace_version {
-				package_table.insert("version".to_string(), Value::String(version.clone()));
-			}
-		}
-	}
-
-	for section in ["dependencies", "dev-dependencies", "build-dependencies"] {
-		update_dependency_table(document, section, released_versions_by_name);
-	}
-}
-
-fn update_dependency_table(
-	document: &mut Value,
-	section: &str,
-	released_versions_by_name: &BTreeMap<String, String>,
-) {
-	let Some(table) = document.get_mut(section).and_then(Value::as_table_mut) else {
-		return;
-	};
-	for (dependency_name, version) in released_versions_by_name {
-		let Some(entry) = table.get_mut(dependency_name) else {
-			continue;
-		};
-		if let Some(version_value) = entry.as_str() {
-			let _ = version_value;
-			*entry = Value::String(version.clone());
-			continue;
-		}
-		let Some(entry_table) = entry.as_table_mut() else {
-			continue;
-		};
-		let uses_workspace_dependency =
-			entry_table.get("workspace").and_then(Value::as_bool) == Some(true);
-		if !uses_workspace_dependency {
-			entry_table.insert("version".to_string(), Value::String(version.clone()));
-		}
-	}
-}
-
-fn update_workspace_manifest(
-	document: &mut Value,
-	shared_workspace_version: &str,
-	released_versions_by_name: &BTreeMap<String, String>,
-) {
-	if let Some(workspace_table) = document.get_mut("workspace").and_then(Value::as_table_mut) {
-		if let Some(workspace_package_table) = workspace_table
-			.get_mut("package")
-			.and_then(Value::as_table_mut)
-		{
-			workspace_package_table.insert(
-				"version".to_string(),
-				Value::String(shared_workspace_version.to_string()),
-			);
-		}
-		if let Some(workspace_dependency_table) = workspace_table
-			.get_mut("dependencies")
-			.and_then(Value::as_table_mut)
-		{
-			for (package_name, version) in released_versions_by_name {
-				let Some(entry) = workspace_dependency_table.get_mut(package_name) else {
-					continue;
-				};
-				if let Some(entry_table) = entry.as_table_mut() {
-					entry_table.insert("version".to_string(), Value::String(version.clone()));
-				}
-			}
-		}
-	}
 }
 
 pub(crate) fn apply_file_updates(updates: &[FileUpdate]) -> MonochangeResult<()> {

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -286,7 +286,7 @@ pub(crate) fn read_cached_document(
 			Ok(CachedDocument::Text(contents))
 		}
 		VersionedFileKind::Npm(monochange_npm::NpmVersionedFileKind::PnpmLock)
-		| VersionedFileKind::Dart(_) => {
+		| VersionedFileKind::Dart(monochange_dart::DartVersionedFileKind::Lock) => {
 			let Some(contents) = text_contents.as_ref() else {
 				return Err(MonochangeError::Config(format!(
 					"failed to parse {} as text",
@@ -311,6 +311,24 @@ pub(crate) fn read_cached_document(
 		VersionedFileKind::Npm(monochange_npm::NpmVersionedFileKind::BunLockBinary) => {
 			Ok(CachedDocument::Bytes(contents))
 		}
+		VersionedFileKind::Npm(monochange_npm::NpmVersionedFileKind::Manifest)
+		| VersionedFileKind::Deno(monochange_deno::DenoVersionedFileKind::Manifest)
+		| VersionedFileKind::Dart(monochange_dart::DartVersionedFileKind::Manifest) => {
+			let Some(contents) = text_contents else {
+				return Err(MonochangeError::Config(format!(
+					"failed to parse {} as text",
+					path.display()
+				)));
+			};
+			if kind == VersionedFileKind::Dart(monochange_dart::DartVersionedFileKind::Manifest) {
+				monochange_dart::update_manifest_text(&contents, None, &[], &BTreeMap::new())
+					.map_err(|error| MonochangeError::Config(format!("failed to parse {}: {error}", path.display())))?;
+			} else {
+				monochange_core::update_json_manifest_text(&contents, None, &[], &BTreeMap::new())
+					.map_err(|error| MonochangeError::Config(format!("failed to parse {}: {error}", path.display())))?;
+			}
+			Ok(CachedDocument::Text(contents))
+		}
 		VersionedFileKind::Npm(_) | VersionedFileKind::Deno(_) => {
 			let Some(contents) = text_contents.as_ref() else {
 				return Err(MonochangeError::Config(format!(
@@ -322,28 +340,6 @@ pub(crate) fn read_cached_document(
 				MonochangeError::Config(format!("failed to parse {}: {error}", path.display()))
 			})?;
 			Ok(CachedDocument::Json(value))
-		}
-	}
-}
-
-pub(crate) fn update_json_dependency_fields(
-	value: &mut serde_json::Value,
-	fields: &[&str],
-	versioned_deps: &BTreeMap<String, String>,
-) {
-	for field in fields {
-		if let Some(section) = value
-			.get_mut(*field)
-			.and_then(serde_json::Value::as_object_mut)
-		{
-			for (dep_name, dep_version) in versioned_deps {
-				if section.contains_key(dep_name) {
-					section.insert(
-						dep_name.clone(),
-						serde_json::Value::String(dep_version.clone()),
-					);
-				}
-			}
 		}
 	}
 }
@@ -481,29 +477,36 @@ pub(crate) fn apply_versioned_file_definition(
 					))
 				})?;
 			}
-			(CachedDocument::Json(value), VersionedFileKind::Npm(kind)) => match kind {
-				monochange_npm::NpmVersionedFileKind::Manifest => {
-					monochange_npm::update_json_dependency_fields(value, &fields, &versioned_deps);
+			(CachedDocument::Text(contents), VersionedFileKind::Npm(kind)) => {
+				if kind == monochange_npm::NpmVersionedFileKind::Manifest {
+					*contents = monochange_core::update_json_manifest_text(
+						contents,
+						None,
+						&fields,
+						&versioned_deps,
+					)
+					.map_err(|error| {
+						MonochangeError::Config(format!(
+							"failed to parse {}: {error}",
+							resolved_path.display()
+						))
+					})?;
+				} else if kind == monochange_npm::NpmVersionedFileKind::BunLock {
+					*contents = monochange_npm::update_bun_lock(contents, &raw_versions);
 				}
-				monochange_npm::NpmVersionedFileKind::PackageLock => {
+			},
+			(CachedDocument::Json(value), VersionedFileKind::Npm(kind)) => {
+				if kind == monochange_npm::NpmVersionedFileKind::PackageLock {
 					monochange_npm::update_package_lock(
 						value,
 						&package_paths_by_name,
 						&raw_versions,
 					);
 				}
-				monochange_npm::NpmVersionedFileKind::PnpmLock
-				| monochange_npm::NpmVersionedFileKind::BunLock
-				| monochange_npm::NpmVersionedFileKind::BunLockBinary => {}
 			},
 			(CachedDocument::Yaml(mapping), VersionedFileKind::Npm(kind)) => {
 				if kind == monochange_npm::NpmVersionedFileKind::PnpmLock {
 					monochange_npm::update_pnpm_lock(mapping, &raw_versions);
-				}
-			}
-			(CachedDocument::Text(contents), VersionedFileKind::Npm(kind)) => {
-				if kind == monochange_npm::NpmVersionedFileKind::BunLock {
-					*contents = monochange_npm::update_bun_lock(contents, &raw_versions);
 				}
 			}
 			(CachedDocument::Bytes(contents), VersionedFileKind::Npm(kind)) => {
@@ -530,19 +533,40 @@ pub(crate) fn apply_versioned_file_definition(
 					);
 				}
 			}
-			(CachedDocument::Json(value), VersionedFileKind::Deno(kind)) => match kind {
-				monochange_deno::DenoVersionedFileKind::Manifest => {
-					update_json_dependency_fields(value, &fields, &versioned_deps);
+			(CachedDocument::Text(contents), VersionedFileKind::Deno(kind)) => {
+				if kind == monochange_deno::DenoVersionedFileKind::Manifest {
+					*contents = monochange_core::update_json_manifest_text(
+						contents,
+						None,
+						&fields,
+						&versioned_deps,
+					)
+					.map_err(|error| {
+						MonochangeError::Config(format!(
+							"failed to parse {}: {error}",
+							resolved_path.display()
+						))
+					})?;
 				}
-				monochange_deno::DenoVersionedFileKind::Lock => {
+			},
+			(CachedDocument::Json(value), VersionedFileKind::Deno(kind)) => {
+				if kind == monochange_deno::DenoVersionedFileKind::Lock {
 					monochange_deno::update_lockfile(value, &raw_versions);
 				}
 			},
-			(CachedDocument::Yaml(mapping), VersionedFileKind::Dart(kind)) => match kind {
-				monochange_dart::DartVersionedFileKind::Manifest => {
-					monochange_dart::update_dependency_fields(mapping, &fields, &versioned_deps);
+			(CachedDocument::Text(contents), VersionedFileKind::Dart(kind)) => {
+				if kind == monochange_dart::DartVersionedFileKind::Manifest {
+					*contents = monochange_dart::update_manifest_text(
+						contents,
+						None,
+						&fields,
+						&versioned_deps,
+					)
+					.map_err(|error| MonochangeError::Config(format!("failed to parse {}: {error}", resolved_path.display())))?;
 				}
-				monochange_dart::DartVersionedFileKind::Lock => {
+			},
+			(CachedDocument::Yaml(mapping), VersionedFileKind::Dart(kind)) => {
+				if kind == monochange_dart::DartVersionedFileKind::Lock {
 					monochange_dart::update_pubspec_lock(mapping, &raw_versions);
 				}
 			},

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -322,10 +322,20 @@ pub(crate) fn read_cached_document(
 			};
 			if kind == VersionedFileKind::Dart(monochange_dart::DartVersionedFileKind::Manifest) {
 				monochange_dart::update_manifest_text(&contents, None, &[], &BTreeMap::new())
-					.map_err(|error| MonochangeError::Config(format!("failed to parse {}: {error}", path.display())))?;
+					.map_err(|error| {
+						MonochangeError::Config(format!(
+							"failed to parse {}: {error}",
+							path.display()
+						))
+					})?;
 			} else {
 				monochange_core::update_json_manifest_text(&contents, None, &[], &BTreeMap::new())
-					.map_err(|error| MonochangeError::Config(format!("failed to parse {}: {error}", path.display())))?;
+					.map_err(|error| {
+						MonochangeError::Config(format!(
+							"failed to parse {}: {error}",
+							path.display()
+						))
+					})?;
 			}
 			Ok(CachedDocument::Text(contents))
 		}
@@ -370,6 +380,44 @@ pub(crate) fn resolve_versioned_prefix(
 	ecosystem_prefix.unwrap_or_else(|| definition.ecosystem_type.default_prefix().to_string())
 }
 
+pub(crate) fn expand_versioned_file_fields(
+	definition: &VersionedFileDefinition,
+	dep_names: &[String],
+) -> Vec<String> {
+	let field_templates = definition.fields.as_ref().map_or_else(
+		|| {
+			definition
+				.ecosystem_type
+				.default_fields()
+				.iter()
+				.map(ToString::to_string)
+				.collect::<Vec<_>>()
+		},
+		Clone::clone,
+	);
+	let mut fields = Vec::new();
+	for field_template in field_templates {
+		if field_template.contains("{{ name }}") {
+			fields.extend(
+				dep_names
+					.iter()
+					.map(|name| field_template.replace("{{ name }}", name)),
+			);
+			continue;
+		}
+		if field_template.contains("{{name}}") {
+			fields.extend(
+				dep_names
+					.iter()
+					.map(|name| field_template.replace("{{name}}", name)),
+			);
+			continue;
+		}
+		fields.push(field_template);
+	}
+	fields
+}
+
 pub(crate) fn apply_versioned_file_definition(
 	root: &Path,
 	updates: &mut BTreeMap<PathBuf, CachedDocument>,
@@ -380,10 +428,11 @@ pub(crate) fn apply_versioned_file_definition(
 	context: &VersionedFileUpdateContext<'_>,
 ) -> MonochangeResult<()> {
 	let prefix = resolve_versioned_prefix(definition, context);
-	let fields = definition.fields.as_deref().map_or_else(
-		|| definition.ecosystem_type.default_fields().to_vec(),
-		|fields| fields.iter().map(String::as_str).collect::<Vec<_>>(),
-	);
+	let expanded_fields = expand_versioned_file_fields(definition, dep_names);
+	let fields = expanded_fields
+		.iter()
+		.map(String::as_str)
+		.collect::<Vec<_>>();
 	let versioned_deps: BTreeMap<String, String> = dep_names
 		.iter()
 		.filter_map(|name| {
@@ -494,7 +543,7 @@ pub(crate) fn apply_versioned_file_definition(
 				} else if kind == monochange_npm::NpmVersionedFileKind::BunLock {
 					*contents = monochange_npm::update_bun_lock(contents, &raw_versions);
 				}
-			},
+			}
 			(CachedDocument::Json(value), VersionedFileKind::Npm(kind)) => {
 				if kind == monochange_npm::NpmVersionedFileKind::PackageLock {
 					monochange_npm::update_package_lock(
@@ -503,7 +552,7 @@ pub(crate) fn apply_versioned_file_definition(
 						&raw_versions,
 					);
 				}
-			},
+			}
 			(CachedDocument::Yaml(mapping), VersionedFileKind::Npm(kind)) => {
 				if kind == monochange_npm::NpmVersionedFileKind::PnpmLock {
 					monochange_npm::update_pnpm_lock(mapping, &raw_versions);
@@ -548,12 +597,12 @@ pub(crate) fn apply_versioned_file_definition(
 						))
 					})?;
 				}
-			},
+			}
 			(CachedDocument::Json(value), VersionedFileKind::Deno(kind)) => {
 				if kind == monochange_deno::DenoVersionedFileKind::Lock {
 					monochange_deno::update_lockfile(value, &raw_versions);
 				}
-			},
+			}
 			(CachedDocument::Text(contents), VersionedFileKind::Dart(kind)) => {
 				if kind == monochange_dart::DartVersionedFileKind::Manifest {
 					*contents = monochange_dart::update_manifest_text(
@@ -562,14 +611,19 @@ pub(crate) fn apply_versioned_file_definition(
 						&fields,
 						&versioned_deps,
 					)
-					.map_err(|error| MonochangeError::Config(format!("failed to parse {}: {error}", resolved_path.display())))?;
+					.map_err(|error| {
+						MonochangeError::Config(format!(
+							"failed to parse {}: {error}",
+							resolved_path.display()
+						))
+					})?;
 				}
-			},
+			}
 			(CachedDocument::Yaml(mapping), VersionedFileKind::Dart(kind)) => {
 				if kind == monochange_dart::DartVersionedFileKind::Lock {
 					monochange_dart::update_pubspec_lock(mapping, &raw_versions);
 				}
-			},
+			}
 			_ => {}
 		}
 		updates.insert(resolved_path, document);

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -8,7 +8,6 @@ pub(crate) struct VersionedFileUpdateContext<'a> {
 
 #[derive(Debug)]
 pub(crate) enum CachedDocument {
-	Toml(Value),
 	Json(serde_json::Value),
 	Yaml(serde_yaml_ng::Mapping),
 	Text(String),
@@ -215,9 +214,6 @@ pub(crate) fn serialize_cached_document(
 	document: CachedDocument,
 ) -> MonochangeResult<FileUpdate> {
 	let content = match document {
-		CachedDocument::Toml(value) => toml::to_string_pretty(&value)
-			.map(String::into_bytes)
-			.map_err(|error| MonochangeError::Config(error.to_string()))?,
 		CachedDocument::Json(value) => {
 			let mut rendered = serde_json::to_string_pretty(&value)
 				.map_err(|error| MonochangeError::Config(error.to_string()))?;
@@ -268,17 +264,26 @@ pub(crate) fn read_cached_document(
 		})
 		.ok();
 	match kind {
-		VersionedFileKind::Cargo(_) => {
-			let Some(contents) = text_contents.as_ref() else {
+		VersionedFileKind::Cargo(kind) => {
+			let Some(contents) = text_contents else {
 				return Err(MonochangeError::Config(format!(
 					"failed to parse {} as text",
 					path.display()
 				)));
 			};
-			let value = toml::from_str::<Value>(contents).map_err(|error| {
+			monochange_cargo::update_versioned_file_text(
+				&contents,
+				kind,
+				&[],
+				None,
+				None,
+				&BTreeMap::new(),
+				&BTreeMap::new(),
+			)
+			.map_err(|error| {
 				MonochangeError::Config(format!("failed to parse {}: {error}", path.display()))
 			})?;
-			Ok(CachedDocument::Toml(value))
+			Ok(CachedDocument::Text(contents))
 		}
 		VersionedFileKind::Npm(monochange_npm::NpmVersionedFileKind::PnpmLock)
 		| VersionedFileKind::Dart(_) => {
@@ -459,16 +464,22 @@ pub(crate) fn apply_versioned_file_definition(
 		let mut document =
 			read_cached_document(updates, &resolved_path, definition.ecosystem_type)?;
 		match (&mut document, kind) {
-			(CachedDocument::Toml(value), VersionedFileKind::Cargo(kind)) => {
-				monochange_cargo::update_versioned_file(
-					value,
+			(CachedDocument::Text(contents), VersionedFileKind::Cargo(kind)) => {
+				*contents = monochange_cargo::update_versioned_file_text(
+					contents,
 					kind,
 					&fields,
-					owner_version,
-					shared_release_version,
+					Some(owner_version),
+					shared_release_version.map(String::as_str),
 					&versioned_deps,
 					&raw_versions,
-				);
+				)
+				.map_err(|error| {
+					MonochangeError::Config(format!(
+						"failed to parse {}: {error}",
+						resolved_path.display()
+					))
+				})?;
 			}
 			(CachedDocument::Json(value), VersionedFileKind::Npm(kind)) => match kind {
 				monochange_npm::NpmVersionedFileKind::Manifest => {

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -285,8 +285,21 @@ pub(crate) fn read_cached_document(
 			})?;
 			Ok(CachedDocument::Text(contents))
 		}
-		VersionedFileKind::Npm(monochange_npm::NpmVersionedFileKind::PnpmLock)
-		| VersionedFileKind::Dart(monochange_dart::DartVersionedFileKind::Lock) => {
+		VersionedFileKind::Npm(monochange_npm::NpmVersionedFileKind::PnpmLock) => {
+			let Some(contents) = text_contents else {
+				return Err(MonochangeError::Config(format!(
+					"failed to parse {} as text",
+					path.display()
+				)));
+			};
+			monochange_npm::update_pnpm_lock_text(&contents, &BTreeMap::new()).map_err(
+				|error| {
+					MonochangeError::Config(format!("failed to parse {}: {error}", path.display()))
+				},
+			)?;
+			Ok(CachedDocument::Text(contents))
+		}
+		VersionedFileKind::Dart(monochange_dart::DartVersionedFileKind::Lock) => {
 			let Some(contents) = text_contents.as_ref() else {
 				return Err(MonochangeError::Config(format!(
 					"failed to parse {} as text",
@@ -542,6 +555,14 @@ pub(crate) fn apply_versioned_file_definition(
 					})?;
 				} else if kind == monochange_npm::NpmVersionedFileKind::BunLock {
 					*contents = monochange_npm::update_bun_lock(contents, &raw_versions);
+				} else if kind == monochange_npm::NpmVersionedFileKind::PnpmLock {
+					*contents = monochange_npm::update_pnpm_lock_text(contents, &raw_versions)
+						.map_err(|error| {
+							MonochangeError::Config(format!(
+								"failed to parse {}: {error}",
+								resolved_path.display()
+							))
+						})?;
 				}
 			}
 			(CachedDocument::Json(value), VersionedFileKind::Npm(kind)) => {
@@ -553,50 +574,44 @@ pub(crate) fn apply_versioned_file_definition(
 					);
 				}
 			}
-			(CachedDocument::Yaml(mapping), VersionedFileKind::Npm(kind)) => {
-				if kind == monochange_npm::NpmVersionedFileKind::PnpmLock {
-					monochange_npm::update_pnpm_lock(mapping, &raw_versions);
-				}
-			}
-			(CachedDocument::Bytes(contents), VersionedFileKind::Npm(kind)) => {
-				if kind == monochange_npm::NpmVersionedFileKind::BunLockBinary {
-					let old_versions = dep_names
-						.iter()
-						.filter_map(|name| {
-							context.package_by_record_id.values().find_map(|package| {
-								(package.name == *name)
-									.then_some(
-										package
-											.current_version
-											.as_ref()
-											.map(|version| (name.clone(), version.to_string())),
-									)
-									.flatten()
-							})
+			(
+				CachedDocument::Bytes(contents),
+				VersionedFileKind::Npm(monochange_npm::NpmVersionedFileKind::BunLockBinary),
+			) => {
+				let old_versions = dep_names
+					.iter()
+					.filter_map(|name| {
+						context.package_by_record_id.values().find_map(|package| {
+							(package.name == *name)
+								.then_some(
+									package
+										.current_version
+										.as_ref()
+										.map(|version| (name.clone(), version.to_string())),
+								)
+								.flatten()
 						})
-						.collect::<BTreeMap<_, _>>();
-					*contents = monochange_npm::update_bun_lock_binary(
-						contents,
-						&old_versions,
-						&raw_versions,
-					);
-				}
+					})
+					.collect::<BTreeMap<_, _>>();
+				*contents =
+					monochange_npm::update_bun_lock_binary(contents, &old_versions, &raw_versions);
 			}
-			(CachedDocument::Text(contents), VersionedFileKind::Deno(kind)) => {
-				if kind == monochange_deno::DenoVersionedFileKind::Manifest {
-					*contents = monochange_core::update_json_manifest_text(
-						contents,
-						None,
-						&fields,
-						&versioned_deps,
-					)
-					.map_err(|error| {
-						MonochangeError::Config(format!(
-							"failed to parse {}: {error}",
-							resolved_path.display()
-						))
-					})?;
-				}
+			(
+				CachedDocument::Text(contents),
+				VersionedFileKind::Deno(monochange_deno::DenoVersionedFileKind::Manifest),
+			) => {
+				*contents = monochange_core::update_json_manifest_text(
+					contents,
+					None,
+					&fields,
+					&versioned_deps,
+				)
+				.map_err(|error| {
+					MonochangeError::Config(format!(
+						"failed to parse {}: {error}",
+						resolved_path.display()
+					))
+				})?;
 			}
 			(CachedDocument::Json(value), VersionedFileKind::Deno(kind)) => {
 				if kind == monochange_deno::DenoVersionedFileKind::Lock {

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -466,8 +466,9 @@ pub(crate) fn prepare_release_execution(
 	let changelog_targets = resolve_changelog_targets(&configuration, &discovery.packages)?;
 	let cargo_updates = build_cargo_manifest_updates(&discovery.packages, &plan)?;
 	let npm_updates = build_npm_manifest_updates(&discovery.packages, &plan)?;
+	let deno_updates = build_deno_manifest_updates(&discovery.packages, &plan)?;
 	let dart_updates = build_dart_manifest_updates(&discovery.packages, &plan)?;
-	let manifest_updates = [cargo_updates, npm_updates, dart_updates].concat();
+	let manifest_updates = [cargo_updates, npm_updates, deno_updates, dart_updates].concat();
 	let versioned_file_updates =
 		build_versioned_file_updates(root, &configuration, &discovery.packages, &plan)?;
 	let release_targets =

--- a/crates/monochange/tests/changelog_formats.rs
+++ b/crates/monochange/tests/changelog_formats.rs
@@ -66,6 +66,25 @@ fn release_group_alert_snapshots_match_expected_output(#[case] scenario: &str) {
 }
 
 #[test]
+fn release_uses_linked_keep_a_changelog_titles_without_double_wrapping() {
+	let tempdir = setup_scenario_workspace("changelog-formats/linked-title");
+	let output = monochange_command(Some("2026-04-06"))
+		.current_dir(tempdir.path())
+		.arg("release")
+		.output()
+		.unwrap_or_else(|error| panic!("release output: {error}"));
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+
+	let core_changelog = fs::read_to_string(tempdir.path().join("crates/core/CHANGELOG.md"))
+		.unwrap_or_else(|error| panic!("core changelog: {error}"));
+	assert_snapshot!(core_changelog);
+}
+
+#[test]
 fn release_filters_group_changelog_entries_to_selected_member_packages() {
 	let tempdir = setup_scenario_workspace("changelog-formats/group-include-selected");
 

--- a/crates/monochange/tests/manifest_formatting.rs
+++ b/crates/monochange/tests/manifest_formatting.rs
@@ -29,14 +29,47 @@ fn release_preserves_cargo_manifest_formatting_while_updating_versions() {
 		.unwrap_or_else(|error| panic!("core manifest: {error}"));
 	let app_manifest = fs::read_to_string(tempdir.path().join("crates/app/Cargo.toml"))
 		.unwrap_or_else(|error| panic!("app manifest: {error}"));
+	let root_lock = fs::read_to_string(tempdir.path().join("Cargo.lock"))
+		.unwrap_or_else(|error| panic!("root lock: {error}"));
 	let group_file = fs::read_to_string(tempdir.path().join("group.toml"))
 		.unwrap_or_else(|error| panic!("group file: {error}"));
 	let extra_file = fs::read_to_string(tempdir.path().join("crates/core/extra.toml"))
 		.unwrap_or_else(|error| panic!("extra file: {error}"));
 
 	assert_snapshot!("root_manifest", root_manifest);
+	assert_snapshot!("root_lock", root_lock);
 	assert_snapshot!("core_manifest", core_manifest);
 	assert_snapshot!("app_manifest", app_manifest);
 	assert_snapshot!("group_file", group_file);
 	assert_snapshot!("extra_file", extra_file);
+}
+
+#[test]
+fn release_preserves_non_cargo_manifest_formatting_while_updating_versions() {
+	let mut settings = snapshot_settings();
+	settings.set_snapshot_suffix("preserve_ecosystem_manifests");
+	let _guard = settings.bind_to_scope();
+
+	let tempdir = setup_scenario_workspace("manifest-formatting/preserve-ecosystem-manifests");
+	let output = monochange_command(Some("2026-04-09"))
+		.current_dir(tempdir.path())
+		.arg("release")
+		.output()
+		.unwrap_or_else(|error| panic!("release output: {error}"));
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+
+	let package_json = fs::read_to_string(tempdir.path().join("packages/web/package.json"))
+		.unwrap_or_else(|error| panic!("package.json: {error}"));
+	let deno_json = fs::read_to_string(tempdir.path().join("tools/deno/deno.json"))
+		.unwrap_or_else(|error| panic!("deno.json: {error}"));
+	let pubspec = fs::read_to_string(tempdir.path().join("packages/mobile/pubspec.yaml"))
+		.unwrap_or_else(|error| panic!("pubspec.yaml: {error}"));
+
+	assert_snapshot!("package_json", package_json);
+	assert_snapshot!("deno_json", deno_json);
+	assert_snapshot!("pubspec", pubspec);
 }

--- a/crates/monochange/tests/manifest_formatting.rs
+++ b/crates/monochange/tests/manifest_formatting.rs
@@ -1,0 +1,42 @@
+use std::fs;
+
+use insta::assert_snapshot;
+
+mod test_support;
+use test_support::{monochange_command, setup_scenario_workspace, snapshot_settings};
+
+#[test]
+fn release_preserves_cargo_manifest_formatting_while_updating_versions() {
+	let mut settings = snapshot_settings();
+	settings.set_snapshot_suffix("preserve_cargo");
+	let _guard = settings.bind_to_scope();
+
+	let tempdir = setup_scenario_workspace("manifest-formatting/preserve-cargo");
+	let output = monochange_command(Some("2026-04-09"))
+		.current_dir(tempdir.path())
+		.arg("release")
+		.output()
+		.unwrap_or_else(|error| panic!("release output: {error}"));
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+
+	let root_manifest = fs::read_to_string(tempdir.path().join("Cargo.toml"))
+		.unwrap_or_else(|error| panic!("root manifest: {error}"));
+	let core_manifest = fs::read_to_string(tempdir.path().join("crates/core/Cargo.toml"))
+		.unwrap_or_else(|error| panic!("core manifest: {error}"));
+	let app_manifest = fs::read_to_string(tempdir.path().join("crates/app/Cargo.toml"))
+		.unwrap_or_else(|error| panic!("app manifest: {error}"));
+	let group_file = fs::read_to_string(tempdir.path().join("group.toml"))
+		.unwrap_or_else(|error| panic!("group file: {error}"));
+	let extra_file = fs::read_to_string(tempdir.path().join("crates/core/extra.toml"))
+		.unwrap_or_else(|error| panic!("extra file: {error}"));
+
+	assert_snapshot!("root_manifest", root_manifest);
+	assert_snapshot!("core_manifest", core_manifest);
+	assert_snapshot!("app_manifest", app_manifest);
+	assert_snapshot!("group_file", group_file);
+	assert_snapshot!("extra_file", extra_file);
+}

--- a/crates/monochange/tests/snapshots/changelog_formats__app@defaults_keep_a.snap
+++ b/crates/monochange/tests/snapshots/changelog_formats__app@defaults_keep_a.snap
@@ -2,7 +2,7 @@
 source: crates/monochange/tests/changelog_formats.rs
 expression: app_changelog
 ---
-## [1.1.0 ([DATE])]
+## 1.1.0 ([DATE])
 
 ### Features
 

--- a/crates/monochange/tests/snapshots/changelog_formats__core@defaults_keep_a.snap
+++ b/crates/monochange/tests/snapshots/changelog_formats__core@defaults_keep_a.snap
@@ -2,7 +2,7 @@
 source: crates/monochange/tests/changelog_formats.rs
 expression: core_changelog
 ---
-## [1.1.0 ([DATE])]
+## 1.1.0 ([DATE])
 
 ### Features
 

--- a/crates/monochange/tests/snapshots/changelog_formats__core@defaults_then_package_override.snap
+++ b/crates/monochange/tests/snapshots/changelog_formats__core@defaults_then_package_override.snap
@@ -2,7 +2,7 @@
 source: crates/monochange/tests/changelog_formats.rs
 expression: core_changelog
 ---
-## [1.1.0 ([DATE])]
+## 1.1.0 ([DATE])
 
 ### Features
 

--- a/crates/monochange/tests/snapshots/changelog_formats__group@defaults_keep_a.snap
+++ b/crates/monochange/tests/snapshots/changelog_formats__group@defaults_keep_a.snap
@@ -2,7 +2,7 @@
 source: crates/monochange/tests/changelog_formats.rs
 expression: group_changelog
 ---
-## [1.1.0 ([DATE])]
+## 1.1.0 ([DATE])
 
 Grouped release for `sdk`.
 

--- a/crates/monochange/tests/snapshots/changelog_formats__release_uses_linked_keep_a_changelog_titles_without_double_wrapping.snap
+++ b/crates/monochange/tests/snapshots/changelog_formats__release_uses_linked_keep_a_changelog_titles_without_double_wrapping.snap
@@ -1,0 +1,9 @@
+---
+source: crates/monochange/tests/changelog_formats.rs
+expression: core_changelog
+---
+## [1.1.0](https://github.com/ifiokjr/monochange/releases/tag/v1.1.0) (2026-04-06)
+
+### Features
+
+- render linked keep a changelog titles

--- a/crates/monochange/tests/snapshots/cli_output__release_dry_run_cli_json_renders_diff_preview@release_dry_run_cli_json_renders_diff_preview.snap
+++ b/crates/monochange/tests/snapshots/cli_output__release_dry_run_cli_json_renders_diff_preview@release_dry_run_cli_json_renders_diff_preview.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/monochange/tests/cli_output.rs
-assertion_line: 172
 info:
   program: mc
   args:
@@ -19,7 +18,7 @@ exit_code: 0
 {
   "fileDiffs": [
     {
-      "diff": "--- a/Cargo.toml\n+++ b/Cargo.toml\n@@ -1,10 +1,14 @@\n [workspace]\n members = [\"crates/*\"]\n resolver = \"2\"\n \n-[workspace.package]\n-version = \"1.0.0\"\n+[workspace.dependencies.workflow-app]\n+path = \"./crates/app\"\n+version = \"1.1.0\"\n+\n+[workspace.dependencies.workflow-core]\n+path = \"./crates/core\"\n+version = \"1.1.0\"\n \n-[workspace.dependencies]\n-workflow-core = { path = \"./crates/core\", version = \"1.0.0\" }\n-workflow-app = { path = \"./crates/app\", version = \"1.0.0\" }\n+[workspace.package]\n+version = \"1.1.0\"",
+      "diff": "--- a/Cargo.toml\n+++ b/Cargo.toml\n@@ -1,10 +1,10 @@\n [workspace]\n members = [\"crates/*\"]\n resolver = \"2\"\n \n [workspace.package]\n-version = \"1.0.0\"\n+version = \"1.1.0\"\n \n [workspace.dependencies]\n-workflow-core = { path = \"./crates/core\", version = \"1.0.0\" }\n-workflow-app = { path = \"./crates/app\", version = \"1.0.0\" }\n+workflow-core = { path = \"./crates/core\", version = \"1.1.0\" }\n+workflow-app = { path = \"./crates/app\", version = \"1.1.0\" }",
       "path": "Cargo.toml"
     },
     {
@@ -27,19 +26,11 @@ exit_code: 0
       "path": "changelog.md"
     },
     {
-      "diff": "--- a/crates/app/Cargo.toml\n+++ b/crates/app/Cargo.toml\n@@ -1,7 +1,9 @@\n+[dependencies.workflow-core]\n+workspace = true\n+\n [package]\n+edition = \"2021\"\n name = \"workflow-app\"\n-version = { workspace = true }\n-edition = \"2021\"\n \n-[dependencies]\n-workflow-core = { workspace = true }\n+[package.version]\n+workspace = true",
-      "path": "crates/app/Cargo.toml"
-    },
-    {
       "diff": "--- a/crates/core/CHANGELOG.md\n+++ b/crates/core/CHANGELOG.md\n@@ -1 +1,7 @@\n # Changelog\n+\n+## 1.1.0 ([DATE])\n+\n+### Features\n+\n+- add feature",
       "path": "crates/core/CHANGELOG.md"
     },
     {
-      "diff": "--- a/crates/core/Cargo.toml\n+++ b/crates/core/Cargo.toml\n@@ -1,4 +1,6 @@\n [package]\n+edition = \"2021\"\n name = \"workflow-core\"\n-version = { workspace = true }\n-edition = \"2021\"\n+\n+[package.version]\n+workspace = true",
-      "path": "crates/core/Cargo.toml"
-    },
-    {
-      "diff": "--- a/group.toml\n+++ b/group.toml\n@@ -1,6 +1,8 @@\n+[workspace.dependencies.workflow-app]\n+version = \"1.1.0\"\n+\n+[workspace.dependencies.workflow-core]\n+version = \"1.1.0\"\n+\n [workspace.package]\n-version = \"1.0.0\"\n-\n-[workspace.dependencies]\n-workflow-core = { version = \"1.0.0\" }\n-workflow-app = { version = \"1.0.0\" }\n+version = \"1.1.0\"",
+      "diff": "--- a/group.toml\n+++ b/group.toml\n@@ -1,6 +1,6 @@\n [workspace.package]\n-version = \"1.0.0\"\n+version = \"1.1.0\"\n \n [workspace.dependencies]\n-workflow-core = { version = \"1.0.0\" }\n-workflow-app = { version = \"1.0.0\" }\n+workflow-core = { version = \"1.1.0\" }\n+workflow-app = { version = \"1.1.0\" }",
       "path": "group.toml"
     }
   ],

--- a/crates/monochange/tests/snapshots/cli_output__release_dry_run_cli_text_renders_diff_preview@release_dry_run_cli_text_renders_diff_preview.snap
+++ b/crates/monochange/tests/snapshots/cli_output__release_dry_run_cli_text_renders_diff_preview@release_dry_run_cli_text_renders_diff_preview.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/monochange/tests/cli_output.rs
-assertion_line: 156
 info:
   program: mc
   args:
@@ -31,26 +30,20 @@ changed files:
 file diffs:
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -1,10 +1,14 @@
+@@ -1,10 +1,10 @@
  [workspace]
  members = ["crates/*"]
  resolver = "2"
  
--[workspace.package]
+ [workspace.package]
 -version = "1.0.0"
-+[workspace.dependencies.workflow-app]
-+path = "./crates/app"
-+version = "1.1.0"
-+
-+[workspace.dependencies.workflow-core]
-+path = "./crates/core"
 +version = "1.1.0"
  
--[workspace.dependencies]
+ [workspace.dependencies]
 -workflow-core = { path = "./crates/core", version = "1.0.0" }
 -workflow-app = { path = "./crates/app", version = "1.0.0" }
-+[workspace.package]
-+version = "1.1.0"
++workflow-core = { path = "./crates/core", version = "1.1.0" }
++workflow-app = { path = "./crates/app", version = "1.1.0" }
 
 --- a/changelog.md
 +++ b/changelog.md
@@ -69,23 +62,6 @@ file diffs:
 +
 +- **core**: add feature
 
---- a/crates/app/Cargo.toml
-+++ b/crates/app/Cargo.toml
-@@ -1,7 +1,9 @@
-+[dependencies.workflow-core]
-+workspace = true
-+
- [package]
-+edition = "2021"
- name = "workflow-app"
--version = { workspace = true }
--edition = "2021"
- 
--[dependencies]
--workflow-core = { workspace = true }
-+[package.version]
-+workspace = true
-
 --- a/crates/core/CHANGELOG.md
 +++ b/crates/core/CHANGELOG.md
 @@ -1 +1,7 @@
@@ -97,33 +73,17 @@ file diffs:
 +
 +- add feature
 
---- a/crates/core/Cargo.toml
-+++ b/crates/core/Cargo.toml
-@@ -1,4 +1,6 @@
- [package]
-+edition = "2021"
- name = "workflow-core"
--version = { workspace = true }
--edition = "2021"
-+
-+[package.version]
-+workspace = true
-
 --- a/group.toml
 +++ b/group.toml
-@@ -1,6 +1,8 @@
-+[workspace.dependencies.workflow-app]
-+version = "1.1.0"
-+
-+[workspace.dependencies.workflow-core]
-+version = "1.1.0"
-+
+@@ -1,6 +1,6 @@
  [workspace.package]
 -version = "1.0.0"
--
--[workspace.dependencies]
++version = "1.1.0"
+ 
+ [workspace.dependencies]
 -workflow-core = { version = "1.0.0" }
 -workflow-app = { version = "1.0.0" }
-+version = "1.1.0"
++workflow-core = { version = "1.1.0" }
++workflow-app = { version = "1.1.0" }
 
 ----- stderr -----

--- a/crates/monochange/tests/snapshots/manifest_formatting__app_manifest@preserve_cargo.snap
+++ b/crates/monochange/tests/snapshots/manifest_formatting__app_manifest@preserve_cargo.snap
@@ -1,0 +1,12 @@
+---
+source: crates/monochange/tests/manifest_formatting.rs
+expression: app_manifest
+---
+[package]
+name = "workflow-app"
+version = { workspace = true }
+edition = "2021"
+description = "app package"
+
+[dependencies]
+workflow-core = { workspace = true }

--- a/crates/monochange/tests/snapshots/manifest_formatting__core_manifest@preserve_cargo.snap
+++ b/crates/monochange/tests/snapshots/manifest_formatting__core_manifest@preserve_cargo.snap
@@ -1,0 +1,13 @@
+---
+source: crates/monochange/tests/manifest_formatting.rs
+expression: core_manifest
+---
+[package]
+name = "workflow-core"
+version = { workspace = true }
+edition = "2021"
+# Keep these fields in place.
+description = "core package"
+
+[dependencies]
+serde = { workspace = true }

--- a/crates/monochange/tests/snapshots/manifest_formatting__deno_json@preserve_ecosystem_manifests.snap
+++ b/crates/monochange/tests/snapshots/manifest_formatting__deno_json@preserve_ecosystem_manifests.snap
@@ -1,0 +1,11 @@
+---
+source: crates/monochange/tests/manifest_formatting.rs
+expression: deno_json
+---
+{
+  "name": "tool",
+  "version": "1.1.0",
+  "imports": {
+    "core": "^1.0.0"
+  }
+}

--- a/crates/monochange/tests/snapshots/manifest_formatting__extra_file@preserve_cargo.snap
+++ b/crates/monochange/tests/snapshots/manifest_formatting__extra_file@preserve_cargo.snap
@@ -1,0 +1,10 @@
+---
+source: crates/monochange/tests/manifest_formatting.rs
+expression: extra_file
+---
+[package]
+name = "workflow-core"
+version = "1.1.0"
+
+[dependencies]
+workflow-app = { version = "1.0.0", path = "../app" }

--- a/crates/monochange/tests/snapshots/manifest_formatting__group_file@preserve_cargo.snap
+++ b/crates/monochange/tests/snapshots/manifest_formatting__group_file@preserve_cargo.snap
@@ -1,0 +1,11 @@
+---
+source: crates/monochange/tests/manifest_formatting.rs
+expression: group_file
+---
+[workspace.package]
+# group file should keep this comment and layout
+version = "1.1.0"
+
+[workspace.dependencies]
+workflow-core = { path = "./crates/core", version = "1.1.0" }
+workflow-app = { path = "./crates/app", version = "1.1.0", features = ["cli"] }

--- a/crates/monochange/tests/snapshots/manifest_formatting__package_json@preserve_ecosystem_manifests.snap
+++ b/crates/monochange/tests/snapshots/manifest_formatting__package_json@preserve_ecosystem_manifests.snap
@@ -1,0 +1,10 @@
+---
+source: crates/monochange/tests/manifest_formatting.rs
+expression: package_json
+---
+{
+    "name": "web",
+    "version": "1.1.0",
+    "dependencies": { "shared": "^1.0.0" },
+    "private": false
+}

--- a/crates/monochange/tests/snapshots/manifest_formatting__pubspec@preserve_ecosystem_manifests.snap
+++ b/crates/monochange/tests/snapshots/manifest_formatting__pubspec@preserve_ecosystem_manifests.snap
@@ -1,0 +1,12 @@
+---
+source: crates/monochange/tests/manifest_formatting.rs
+expression: pubspec
+---
+name: mobile
+version: '1.1.0' # keep quote
+publish_to: none
+
+dependencies:
+  shared:
+    path: ../shared
+    version: ^1.0.0

--- a/crates/monochange/tests/snapshots/manifest_formatting__root_lock@preserve_cargo.snap
+++ b/crates/monochange/tests/snapshots/manifest_formatting__root_lock@preserve_cargo.snap
@@ -1,0 +1,15 @@
+---
+source: crates/monochange/tests/manifest_formatting.rs
+expression: root_lock
+---
+version = 4
+
+[[package]]
+name = "workflow-core"
+version = "1.1.0"
+source = "registry+https://example.test"
+
+[[package]]
+name = "workflow-app"
+version = "1.1.0"
+dependencies = ["workflow-core"]

--- a/crates/monochange/tests/snapshots/manifest_formatting__root_manifest@preserve_cargo.snap
+++ b/crates/monochange/tests/snapshots/manifest_formatting__root_manifest@preserve_cargo.snap
@@ -1,0 +1,17 @@
+---
+source: crates/monochange/tests/manifest_formatting.rs
+expression: root_manifest
+---
+[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+# Keep this comment exactly where it is.
+[workspace.package]
+version = "1.1.0"
+authors = ["Monochange Maintainers"]
+
+[workspace.dependencies]
+workflow-core = { path = "./crates/core", version = "1.1.0", default-features = false }
+workflow-app = { path = "./crates/app", version = "1.1.0" }
+serde = { version = "1.0.219", features = ["derive"] }

--- a/crates/monochange/tests/snapshots/release_group_propagation__grouped_member_changes_patch_dependents_outside_the_group@grouped_member_changes_patch_dependents_outside_the_group.snap
+++ b/crates/monochange/tests/snapshots/release_group_propagation__grouped_member_changes_patch_dependents_outside_the_group@grouped_member_changes_patch_dependents_outside_the_group.snap
@@ -6,6 +6,7 @@ expression: json
   "changedFiles": [
     "cargo/sdk-core/Cargo.toml",
     "dart/mobile_sdk/pubspec.yaml",
+    "deno/tool/deno.json",
     "packages/web-sdk/package.json"
   ],
   "changelogs": [],

--- a/crates/monochange_cargo/Cargo.toml
+++ b/crates/monochange_cargo/Cargo.toml
@@ -20,6 +20,7 @@ semver = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }
 thiserror = { workspace = true, default-features = true }
 toml = { workspace = true, default-features = true }
+toml_edit = { workspace = true, default-features = true }
 walkdir = { workspace = true, default-features = true }
 
 [dev-dependencies]

--- a/crates/monochange_cargo/src/__tests.rs
+++ b/crates/monochange_cargo/src/__tests.rs
@@ -395,6 +395,39 @@ version = "1.0.0"
 }
 
 #[test]
+fn update_versioned_file_preserves_lock_formatting() {
+	let lock = r#"version = 4
+
+[[package]]
+name = "core"
+version = "1.0.0"
+source = "registry+https://example.test"
+
+[[package]]
+name = "app"
+version = "1.0.0"
+dependencies = ["core"]
+"#;
+	let updated = update_versioned_file_text(
+		lock,
+		CargoVersionedFileKind::Lock,
+		&[],
+		None,
+		None,
+		&BTreeMap::new(),
+		&BTreeMap::from([
+			("core".to_string(), "2.0.0".to_string()),
+			("app".to_string(), "2.0.0".to_string()),
+		]),
+	)
+	.unwrap_or_else(|error| panic!("update lock: {error}"));
+	assert!(updated.contains("source = \"registry+https://example.test\""));
+	assert!(updated.contains("dependencies = [\"core\"]"));
+	assert!(updated.contains("name = \"core\"\nversion = \"2.0.0\""));
+	assert!(updated.contains("name = \"app\"\nversion = \"2.0.0\""));
+}
+
+#[test]
 fn update_versioned_file_covers_workspace_owned_and_unstructured_entries() {
 	let manifest = r#"
 [package]

--- a/crates/monochange_cargo/src/__tests.rs
+++ b/crates/monochange_cargo/src/__tests.rs
@@ -612,6 +612,303 @@ fn cargo_versioned_file_helpers_cover_non_table_and_insertion_paths() {
 }
 
 #[test]
+fn update_versioned_file_supports_nested_manifest_field_paths() {
+	let manifest = r#"
+[package]
+name = "app"
+version = "1.0.0"
+
+[dependencies]
+core = { version = "1.0.0", path = "../core" }
+serde = "1.0.0"
+
+[dev-dependencies]
+core = { version = "1.0.0" }
+
+[workspace.package]
+version = "1.0.0"
+
+[workspace.dependencies]
+core = { path = "crates/core", version = "1.0.0" }
+"#;
+	let updated = update_versioned_file_text(
+		manifest,
+		CargoVersionedFileKind::Manifest,
+		&[
+			"workspace.version",
+			"workspace.dependencies.core.version",
+			"dependencies.core.version",
+			"dev_dependencies.core.version",
+		],
+		Some("2.0.0"),
+		Some("3.0.0"),
+		&BTreeMap::from([("core".to_string(), "2.0.0".to_string())]),
+		&BTreeMap::new(),
+	)
+	.unwrap_or_else(|error| panic!("update manifest: {error}"));
+	let manifest: Value =
+		toml::from_str(&updated).unwrap_or_else(|error| panic!("manifest toml: {error}"));
+
+	assert_eq!(
+		manifest
+			.get("package")
+			.and_then(Value::as_table)
+			.and_then(|table| table.get("version"))
+			.and_then(Value::as_str),
+		Some("2.0.0")
+	);
+	assert_eq!(
+		manifest
+			.get("workspace")
+			.and_then(Value::as_table)
+			.and_then(|table| table.get("package"))
+			.and_then(Value::as_table)
+			.and_then(|table| table.get("version"))
+			.and_then(Value::as_str),
+		Some("3.0.0")
+	);
+	assert_eq!(
+		manifest
+			.get("workspace")
+			.and_then(Value::as_table)
+			.and_then(|table| table.get("dependencies"))
+			.and_then(Value::as_table)
+			.and_then(|table| table.get("core"))
+			.and_then(Value::as_table)
+			.and_then(|table| table.get("version"))
+			.and_then(Value::as_str),
+		Some("2.0.0")
+	);
+	assert_eq!(
+		manifest
+			.get("dependencies")
+			.and_then(Value::as_table)
+			.and_then(|table| table.get("core"))
+			.and_then(Value::as_table)
+			.and_then(|table| table.get("version"))
+			.and_then(Value::as_str),
+		Some("2.0.0")
+	);
+	assert_eq!(
+		manifest
+			.get("dev-dependencies")
+			.and_then(Value::as_table)
+			.and_then(|table| table.get("core"))
+			.and_then(Value::as_table)
+			.and_then(|table| table.get("version"))
+			.and_then(Value::as_str),
+		Some("2.0.0")
+	);
+	assert_eq!(
+		manifest
+			.get("dependencies")
+			.and_then(Value::as_table)
+			.and_then(|table| table.get("serde"))
+			.and_then(Value::as_str),
+		Some("1.0.0")
+	);
+}
+
+#[test]
+fn update_versioned_file_version_field_paths_leave_string_entries_unchanged() {
+	let manifest = r#"
+[dependencies]
+core = "1.0.0"
+
+[workspace.dependencies]
+core = "1.0.0"
+"#;
+	let updated = update_versioned_file_text(
+		manifest,
+		CargoVersionedFileKind::Manifest,
+		&[
+			"dependencies.core.version",
+			"workspace.dependencies.core.version",
+		],
+		None,
+		None,
+		&BTreeMap::from([("core".to_string(), "2.0.0".to_string())]),
+		&BTreeMap::new(),
+	)
+	.unwrap_or_else(|error| panic!("update manifest: {error}"));
+	let manifest: Value =
+		toml::from_str(&updated).unwrap_or_else(|error| panic!("manifest toml: {error}"));
+
+	assert_eq!(
+		manifest
+			.get("dependencies")
+			.and_then(Value::as_table)
+			.and_then(|table| table.get("core"))
+			.and_then(Value::as_str),
+		Some("1.0.0")
+	);
+	assert_eq!(
+		manifest
+			.get("workspace")
+			.and_then(Value::as_table)
+			.and_then(|table| table.get("dependencies"))
+			.and_then(Value::as_table)
+			.and_then(|table| table.get("core"))
+			.and_then(Value::as_str),
+		Some("1.0.0")
+	);
+}
+
+#[test]
+fn cargo_manifest_field_helpers_cover_direct_path_updates() {
+	let mut document = r#"
+[package]
+name = "app"
+version = "1.0.0"
+
+[dependencies]
+core = { version = "1.0.0" }
+
+[workspace.dependencies]
+core = { version = "1.0.0" }
+"#
+	.parse::<DocumentMut>()
+	.unwrap_or_else(|error| panic!("parse field helper document: {error}"));
+	let versions = BTreeMap::from([("core".to_string(), "2.0.0".to_string())]);
+
+	crate::update_manifest_field(&mut document, "package.version", Some("2.0.0"), None, &versions);
+	crate::update_manifest_field(
+		&mut document,
+		"workspace.dependencies",
+		None,
+		None,
+		&versions,
+	);
+	crate::update_manifest_field(&mut document, "dependencies.core", None, None, &versions);
+	crate::update_manifest_field(
+		&mut document,
+		"dependencies.core.version",
+		None,
+		None,
+		&versions,
+	);
+	crate::update_manifest_field(
+		&mut document,
+		"workspace.dependencies.core",
+		None,
+		None,
+		&versions,
+	);
+	crate::update_manifest_field(
+		&mut document,
+		"workspace.dependencies.core.version",
+		None,
+		None,
+		&versions,
+	);
+	crate::update_manifest_field(&mut document, "unknown.field", None, None, &versions);
+
+	assert_eq!(
+		document
+			.get("package")
+			.and_then(Item::as_table_like)
+			.and_then(|table| table.get("version"))
+			.and_then(Item::as_str),
+		Some("2.0.0")
+	);
+	assert_eq!(
+		document
+			.get("dependencies")
+			.and_then(Item::as_table_like)
+			.and_then(|table| table.get("core"))
+			.and_then(Item::as_table_like)
+			.and_then(|table| table.get("version"))
+			.and_then(Item::as_str),
+		Some("2.0.0")
+	);
+	assert_eq!(
+		document
+			.get("workspace")
+			.and_then(Item::as_table_like)
+			.and_then(|table| table.get("dependencies"))
+			.and_then(Item::as_table_like)
+			.and_then(|table| table.get("core"))
+			.and_then(Item::as_table_like)
+			.and_then(|table| table.get("version"))
+			.and_then(Item::as_str),
+		Some("2.0.0")
+	);
+
+	let mut empty_document = ""
+		.parse::<DocumentMut>()
+		.unwrap_or_else(|error| panic!("parse empty document: {error}"));
+	crate::update_manifest_field(
+		&mut empty_document,
+		"dependencies.missing",
+		None,
+		None,
+		&BTreeMap::new(),
+	);
+	crate::update_manifest_field(
+		&mut empty_document,
+		"dependencies.missing.version",
+		None,
+		None,
+		&BTreeMap::new(),
+	);
+	crate::update_manifest_field(
+		&mut empty_document,
+		"workspace.dependencies.missing",
+		None,
+		None,
+		&BTreeMap::new(),
+	);
+	crate::update_manifest_field(
+		&mut empty_document,
+		"workspace.dependencies.missing.version",
+		None,
+		None,
+		&BTreeMap::new(),
+	);
+	crate::update_manifest_field(
+		&mut empty_document,
+		"dependencies.core",
+		None,
+		None,
+		&versions,
+	);
+	crate::update_manifest_field(
+		&mut empty_document,
+		"dependencies.core.version",
+		None,
+		None,
+		&versions,
+	);
+	crate::update_manifest_field(
+		&mut empty_document,
+		"workspace.dependencies.core",
+		None,
+		None,
+		&versions,
+	);
+	crate::update_manifest_field(
+		&mut empty_document,
+		"workspace.dependencies.core.version",
+		None,
+		None,
+		&versions,
+	);
+
+	assert!(crate::fields_target_workspace_dependencies(&["workspace.dependencies"]));
+	assert!(!crate::fields_target_workspace_dependencies(&["dependencies"]));
+
+	let mut helpers_document = "[dependencies]\n"
+		.parse::<DocumentMut>()
+		.unwrap_or_else(|error| panic!("parse helpers document: {error}"));
+	let helpers_table = helpers_document
+		.get_mut("dependencies")
+		.and_then(Item::as_table_like_mut)
+		.unwrap_or_else(|| panic!("expected helpers dependency table"));
+	crate::update_dependency_by_name(helpers_table, "missing", "2.0.0");
+	crate::update_dependency_version_by_name(helpers_table, "missing", "2.0.0");
+}
+
+#[test]
 fn adapter_discover_matches_direct_cargo_discovery() {
 	let fixture_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/cargo/workspace");
 	let from_adapter = adapter()

--- a/crates/monochange_cargo/src/__tests.rs
+++ b/crates/monochange_cargo/src/__tests.rs
@@ -12,6 +12,8 @@ use monochange_core::PublishState;
 use monochange_semver::CompatibilityProvider;
 use tempfile::tempdir;
 use toml::Value;
+use toml_edit::DocumentMut;
+use toml_edit::Item;
 
 use crate::adapter;
 use crate::dependency_constraint;
@@ -570,6 +572,43 @@ version = "0.1.0"
 		package.get("name").and_then(Value::as_str) == Some("ignored")
 			&& package.get("version").and_then(Value::as_str) == Some("0.1.0")
 	}));
+}
+
+#[test]
+fn cargo_versioned_file_helpers_cover_non_table_and_insertion_paths() {
+	let mut dependency_document = "[dependencies]\nweird = true\n"
+		.parse::<DocumentMut>()
+		.unwrap_or_else(|error| panic!("parse dependency document: {error}"));
+	let dependency_table = dependency_document
+		.get_mut("dependencies")
+		.and_then(Item::as_table_like_mut)
+		.unwrap_or_else(|| panic!("expected dependencies table"));
+	let weird_entry = dependency_table
+		.get_mut("weird")
+		.unwrap_or_else(|| panic!("expected weird entry"));
+	crate::update_dependency_entry(weird_entry, "2.0.0");
+	assert_eq!(weird_entry.as_bool(), Some(true));
+
+	let mut insert_document = "[dependencies]\n"
+		.parse::<DocumentMut>()
+		.unwrap_or_else(|error| panic!("parse insert document: {error}"));
+	let insert_table = insert_document
+		.get_mut("dependencies")
+		.and_then(Item::as_table_like_mut)
+		.unwrap_or_else(|| panic!("expected insert dependencies table"));
+	crate::set_table_value(insert_table, "core", "2.0.0");
+	assert_eq!(
+		insert_document
+			.get("dependencies")
+			.and_then(Item::as_table_like)
+			.and_then(|table| table.get("core"))
+			.and_then(Item::as_str),
+		Some("2.0.0")
+	);
+
+	let mut empty_item = Item::None;
+	crate::set_item_string(&mut empty_item, "3.0.0");
+	assert_eq!(empty_item.as_str(), Some("3.0.0"));
 }
 
 #[test]

--- a/crates/monochange_cargo/src/__tests.rs
+++ b/crates/monochange_cargo/src/__tests.rs
@@ -771,7 +771,13 @@ core = { version = "1.0.0" }
 	.unwrap_or_else(|error| panic!("parse field helper document: {error}"));
 	let versions = BTreeMap::from([("core".to_string(), "2.0.0".to_string())]);
 
-	crate::update_manifest_field(&mut document, "package.version", Some("2.0.0"), None, &versions);
+	crate::update_manifest_field(
+		&mut document,
+		"package.version",
+		Some("2.0.0"),
+		None,
+		&versions,
+	);
 	crate::update_manifest_field(
 		&mut document,
 		"workspace.dependencies",
@@ -894,8 +900,12 @@ core = { version = "1.0.0" }
 		&versions,
 	);
 
-	assert!(crate::fields_target_workspace_dependencies(&["workspace.dependencies"]));
-	assert!(!crate::fields_target_workspace_dependencies(&["dependencies"]));
+	assert!(crate::fields_target_workspace_dependencies(&[
+		"workspace.dependencies"
+	]));
+	assert!(!crate::fields_target_workspace_dependencies(&[
+		"dependencies"
+	]));
 
 	let mut helpers_document = "[dependencies]\n"
 		.parse::<DocumentMut>()

--- a/crates/monochange_cargo/src/__tests.rs
+++ b/crates/monochange_cargo/src/__tests.rs
@@ -22,7 +22,7 @@ use crate::has_workspace_section;
 use crate::parse_package_manifest;
 use crate::parse_package_version;
 use crate::supported_versioned_file_kind;
-use crate::update_versioned_file;
+use crate::update_versioned_file_text;
 use crate::validate_workspace_version_groups;
 use crate::workspace_package_version;
 use crate::CargoVersionedFileKind;
@@ -274,8 +274,7 @@ fn discover_lockfiles_falls_back_to_manifest_directory() {
 
 #[test]
 fn update_versioned_file_updates_manifest_and_workspace_dependencies() {
-	let mut manifest: Value = toml::from_str(
-		r#"
+	let manifest = r#"
 [package]
 name = "app"
 version = "1.0.0"
@@ -289,22 +288,21 @@ version = "1.0.0"
 
 [workspace.dependencies]
 core = { version = "1.0.0" }
-"#,
-	)
-	.unwrap_or_else(|error| panic!("manifest toml: {error}"));
+"#;
 	let versioned_deps = BTreeMap::from([("core".to_string(), "2.0.0".to_string())]);
 	let raw_versions = BTreeMap::from([("core".to_string(), "2.0.0".to_string())]);
-	let shared_release_version = Some("3.0.0".to_string());
-
-	update_versioned_file(
-		&mut manifest,
+	let updated = update_versioned_file_text(
+		manifest,
 		CargoVersionedFileKind::Manifest,
 		&["dependencies"],
-		"2.0.0",
-		shared_release_version.as_ref(),
+		Some("2.0.0"),
+		Some("3.0.0"),
 		&versioned_deps,
 		&raw_versions,
-	);
+	)
+	.unwrap_or_else(|error| panic!("update manifest: {error}"));
+	let manifest: Value =
+		toml::from_str(&updated).unwrap_or_else(|error| panic!("manifest toml: {error}"));
 
 	assert_eq!(
 		manifest
@@ -358,8 +356,7 @@ core = { version = "1.0.0" }
 
 #[test]
 fn update_versioned_file_updates_lock_packages() {
-	let mut lock: Value = toml::from_str(
-		r#"
+	let lock = r#"
 [[package]]
 name = "core"
 version = "1.0.0"
@@ -367,23 +364,23 @@ version = "1.0.0"
 [[package]]
 name = "app"
 version = "1.0.0"
-"#,
-	)
-	.unwrap_or_else(|error| panic!("lock toml: {error}"));
+"#;
 	let raw_versions = BTreeMap::from([
 		("core".to_string(), "2.0.0".to_string()),
 		("app".to_string(), "1.1.0".to_string()),
 	]);
 
-	update_versioned_file(
-		&mut lock,
+	let updated = update_versioned_file_text(
+		lock,
 		CargoVersionedFileKind::Lock,
 		&[],
-		"1.0.0",
+		None,
 		None,
 		&BTreeMap::new(),
 		&raw_versions,
-	);
+	)
+	.unwrap_or_else(|error| panic!("update lock: {error}"));
+	let lock: Value = toml::from_str(&updated).unwrap_or_else(|error| panic!("lock toml: {error}"));
 
 	let packages = lock
 		.get("package")
@@ -399,8 +396,7 @@ version = "1.0.0"
 
 #[test]
 fn update_versioned_file_covers_workspace_owned_and_unstructured_entries() {
-	let mut manifest: Value = toml::from_str(
-		r#"
+	let manifest = r#"
 [package]
 name = "app"
 version = { workspace = true }
@@ -416,23 +412,24 @@ version = "1.0.0"
 [workspace.dependencies]
 core = "1.0.0"
 serde = { version = "1.0.0" }
-"#,
-	)
-	.unwrap_or_else(|error| panic!("manifest toml: {error}"));
+"#;
 	let versioned_deps = BTreeMap::from([
 		("core".to_string(), "2.0.0".to_string()),
 		("serde".to_string(), "1.1.0".to_string()),
 	]);
 
-	update_versioned_file(
-		&mut manifest,
+	let updated = update_versioned_file_text(
+		manifest,
 		CargoVersionedFileKind::Manifest,
 		&["dependencies", "dev-dependencies"],
-		"9.9.9",
+		Some("9.9.9"),
 		None,
 		&versioned_deps,
 		&BTreeMap::new(),
-	);
+	)
+	.unwrap_or_else(|error| panic!("update manifest: {error}"));
+	let manifest: Value =
+		toml::from_str(&updated).unwrap_or_else(|error| panic!("manifest toml: {error}"));
 
 	assert_eq!(
 		manifest
@@ -505,8 +502,7 @@ serde = { version = "1.0.0" }
 		Some("1.1.0")
 	);
 
-	let mut lock: Value = toml::from_str(
-		r#"
+	let lock = r#"
 [[package]]
 version = "1.0.0"
 
@@ -517,18 +513,18 @@ version = "1.0.0"
 [[package]]
 name = "ignored"
 version = "0.1.0"
-"#,
-	)
-	.unwrap_or_else(|error| panic!("lock toml: {error}"));
-	update_versioned_file(
-		&mut lock,
+"#;
+	let updated = update_versioned_file_text(
+		lock,
 		CargoVersionedFileKind::Lock,
 		&[],
-		"1.0.0",
+		None,
 		None,
 		&BTreeMap::new(),
 		&BTreeMap::from([("core".to_string(), "2.0.0".to_string())]),
-	);
+	)
+	.unwrap_or_else(|error| panic!("update lock: {error}"));
+	let lock: Value = toml::from_str(&updated).unwrap_or_else(|error| panic!("lock toml: {error}"));
 	let packages = lock
 		.get("package")
 		.and_then(Value::as_array)

--- a/crates/monochange_cargo/src/lib.rs
+++ b/crates/monochange_cargo/src/lib.rs
@@ -214,7 +214,7 @@ pub fn update_versioned_file(
 				}
 			}
 			for field in fields {
-				if let Some(table) = document.get_mut(*field).and_then(Item::as_table_like_mut) {
+				if let Some(table) = document.get_mut(field).and_then(Item::as_table_like_mut) {
 					for (dep_name, dep_version) in versioned_deps {
 						let Some(entry) = table.get_mut(dep_name) else {
 							continue;

--- a/crates/monochange_cargo/src/lib.rs
+++ b/crates/monochange_cargo/src/lib.rs
@@ -58,6 +58,11 @@ use monochange_core::PublishState;
 use monochange_semver::CompatibilityProvider;
 use semver::Version;
 use toml::Value;
+use toml_edit::value;
+use toml_edit::DocumentMut;
+use toml_edit::Item;
+use toml_edit::TableLike;
+use toml_edit::Value as EditValue;
 use walkdir::DirEntry;
 use walkdir::WalkDir;
 
@@ -170,97 +175,144 @@ pub fn validate_workspace_version_groups(packages: &[PackageRecord]) -> Monochan
 }
 
 pub fn update_versioned_file(
-	value: &mut Value,
+	document: &mut DocumentMut,
 	kind: CargoVersionedFileKind,
 	fields: &[&str],
-	owner_version: &str,
-	shared_release_version: Option<&String>,
+	owner_version: Option<&str>,
+	shared_release_version: Option<&str>,
 	versioned_deps: &BTreeMap<String, String>,
 	raw_versions: &BTreeMap<String, String>,
 ) {
 	match kind {
 		CargoVersionedFileKind::Lock => {
-			if let Some(packages) = value.get_mut("package").and_then(Value::as_array_mut) {
-				for package in packages {
-					let Some(package_table) = package.as_table_mut() else {
-						continue;
-					};
-					let Some(package_name) = package_table.get("name").and_then(Value::as_str)
-					else {
+			if let Some(packages) = document
+				.get_mut("package")
+				.and_then(Item::as_array_of_tables_mut)
+			{
+				for package in packages.iter_mut() {
+					let Some(package_name) = package.get("name").and_then(Item::as_str) else {
 						continue;
 					};
 					if let Some(version) = raw_versions.get(package_name) {
-						package_table.insert("version".to_string(), Value::String(version.clone()));
+						set_table_value(package, "version", version);
 					}
 				}
 			}
 		}
 		CargoVersionedFileKind::Manifest => {
-			if let Some(package_table) = value.get_mut("package").and_then(Value::as_table_mut) {
-				let uses_workspace_version = package_table
-					.get("version")
-					.and_then(Value::as_table)
-					.and_then(|t| t.get("workspace"))
-					.and_then(Value::as_bool)
-					== Some(true);
-				if !uses_workspace_version {
-					package_table.insert(
-						"version".to_string(),
-						Value::String(owner_version.to_string()),
-					);
-				}
-			}
-			for field in fields {
-				if let Some(table) = value.get_mut(*field).and_then(Value::as_table_mut) {
-					for (dep_name, dep_version) in versioned_deps {
-						if let Some(entry) = table.get_mut(dep_name) {
-							if entry.is_str() {
-								*entry = Value::String(dep_version.clone());
-							} else if let Some(entry_table) = entry.as_table_mut() {
-								let uses_workspace = entry_table
-									.get("workspace")
-									.and_then(Value::as_bool) == Some(true);
-								if !uses_workspace {
-									entry_table.insert(
-										"version".to_string(),
-										Value::String(dep_version.clone()),
-									);
-								}
-							}
-						}
+			if let Some(owner_version) = owner_version {
+				if let Some(package_table) = document
+					.get_mut("package")
+					.and_then(Item::as_table_like_mut)
+				{
+					let uses_workspace_version = package_table
+						.get("version")
+						.is_some_and(uses_workspace_marker);
+					if !uses_workspace_version {
+						set_table_value(package_table, "version", owner_version);
 					}
 				}
 			}
-			if let Some(workspace_table) = value.get_mut("workspace").and_then(Value::as_table_mut)
+			for field in fields {
+				if let Some(table) = document.get_mut(*field).and_then(Item::as_table_like_mut) {
+					for (dep_name, dep_version) in versioned_deps {
+						let Some(entry) = table.get_mut(dep_name) else {
+							continue;
+						};
+						update_dependency_entry(entry, dep_version);
+					}
+				}
+			}
+			if let Some(workspace_table) = document
+				.get_mut("workspace")
+				.and_then(Item::as_table_like_mut)
 			{
-				if let Some(workspace_package) = workspace_table
-					.get_mut("package")
-					.and_then(Value::as_table_mut)
-				{
-					if let Some(shared) = shared_release_version {
-						workspace_package
-							.insert("version".to_string(), Value::String(shared.clone()));
+				if let Some(shared) = shared_release_version {
+					if let Some(workspace_package) = workspace_table
+						.get_mut("package")
+						.and_then(Item::as_table_like_mut)
+					{
+						set_table_value(workspace_package, "version", shared);
 					}
 				}
 				if let Some(workspace_deps) = workspace_table
 					.get_mut("dependencies")
-					.and_then(Value::as_table_mut)
+					.and_then(Item::as_table_like_mut)
 				{
 					for (dep_name, dep_version) in versioned_deps {
-						if let Some(entry) = workspace_deps.get_mut(dep_name) {
-							if let Some(entry_table) = entry.as_table_mut() {
-								entry_table.insert(
-									"version".to_string(),
-									Value::String(dep_version.clone()),
-								);
-							} else {
-								*entry = Value::String(dep_version.clone());
-							}
-						}
+						let Some(entry) = workspace_deps.get_mut(dep_name) else {
+							continue;
+						};
+						update_dependency_entry(entry, dep_version);
 					}
 				}
 			}
 		}
+	}
+}
+
+pub fn update_versioned_file_text(
+	contents: &str,
+	kind: CargoVersionedFileKind,
+	fields: &[&str],
+	owner_version: Option<&str>,
+	shared_release_version: Option<&str>,
+	versioned_deps: &BTreeMap<String, String>,
+	raw_versions: &BTreeMap<String, String>,
+) -> Result<String, toml_edit::TomlError> {
+	let mut document = contents.parse::<DocumentMut>()?;
+	update_versioned_file(
+		&mut document,
+		kind,
+		fields,
+		owner_version,
+		shared_release_version,
+		versioned_deps,
+		raw_versions,
+	);
+	Ok(document.to_string())
+}
+
+fn update_dependency_entry(entry: &mut Item, version: &str) {
+	if entry.is_str() {
+		set_item_string(entry, version);
+		return;
+	}
+	let Some(entry_table) = entry.as_table_like_mut() else {
+		return;
+	};
+	let uses_workspace = entry_table
+		.get("workspace")
+		.is_some_and(uses_workspace_marker);
+	if !uses_workspace {
+		set_table_value(entry_table, "version", version);
+	}
+}
+
+fn uses_workspace_marker(item: &Item) -> bool {
+	item.as_bool() == Some(true)
+		|| item
+			.as_inline_table()
+			.and_then(|table| table.get("workspace"))
+			.and_then(EditValue::as_bool)
+			== Some(true)
+}
+
+fn set_table_value(table: &mut dyn TableLike, key: &str, version: &str) {
+	if let Some(item) = table.get_mut(key) {
+		set_item_string(item, version);
+	} else {
+		table.insert(key, value(version));
+	}
+}
+
+fn set_item_string(item: &mut Item, version: &str) {
+	if let Some(existing_value) = item.as_value() {
+		let mut new_value = EditValue::from(version);
+		*new_value.decor_mut() = existing_value.decor().clone();
+		*item = Item::Value(new_value);
+	} else {
+		*item = value(version);
 	}
 }
 

--- a/crates/monochange_cargo/src/lib.rs
+++ b/crates/monochange_cargo/src/lib.rs
@@ -200,52 +200,19 @@ pub fn update_versioned_file(
 			}
 		}
 		CargoVersionedFileKind::Manifest => {
-			if let Some(owner_version) = owner_version {
-				if let Some(package_table) = document
-					.get_mut("package")
-					.and_then(Item::as_table_like_mut)
-				{
-					let uses_workspace_version = package_table
-						.get("version")
-						.is_some_and(uses_workspace_marker);
-					if !uses_workspace_version {
-						set_table_value(package_table, "version", owner_version);
-					}
-				}
-			}
+			update_manifest_owner_version(document, owner_version);
 			for field in fields {
-				if let Some(table) = document.get_mut(field).and_then(Item::as_table_like_mut) {
-					for (dep_name, dep_version) in versioned_deps {
-						let Some(entry) = table.get_mut(dep_name) else {
-							continue;
-						};
-						update_dependency_entry(entry, dep_version);
-					}
-				}
+				update_manifest_field(
+					document,
+					field,
+					owner_version,
+					shared_release_version,
+					versioned_deps,
+				);
 			}
-			if let Some(workspace_table) = document
-				.get_mut("workspace")
-				.and_then(Item::as_table_like_mut)
-			{
-				if let Some(shared) = shared_release_version {
-					if let Some(workspace_package) = workspace_table
-						.get_mut("package")
-						.and_then(Item::as_table_like_mut)
-					{
-						set_table_value(workspace_package, "version", shared);
-					}
-				}
-				if let Some(workspace_deps) = workspace_table
-					.get_mut("dependencies")
-					.and_then(Item::as_table_like_mut)
-				{
-					for (dep_name, dep_version) in versioned_deps {
-						let Some(entry) = workspace_deps.get_mut(dep_name) else {
-							continue;
-						};
-						update_dependency_entry(entry, dep_version);
-					}
-				}
+			update_manifest_workspace_version(document, shared_release_version);
+			if !fields_target_workspace_dependencies(fields) {
+				update_workspace_dependencies(document, versioned_deps);
 			}
 		}
 	}
@@ -273,11 +240,198 @@ pub fn update_versioned_file_text(
 	Ok(document.to_string())
 }
 
+fn update_manifest_owner_version(document: &mut DocumentMut, owner_version: Option<&str>) {
+	let Some(owner_version) = owner_version else {
+		return;
+	};
+	let Some(package_table) = document
+		.get_mut("package")
+		.and_then(Item::as_table_like_mut)
+	else {
+		return;
+	};
+	let uses_workspace_version = package_table
+		.get("version")
+		.is_some_and(uses_workspace_marker);
+	if !uses_workspace_version {
+		set_table_value(package_table, "version", owner_version);
+	}
+}
+
+fn update_manifest_workspace_version(
+	document: &mut DocumentMut,
+	shared_release_version: Option<&str>,
+) {
+	let Some(shared_release_version) = shared_release_version else {
+		return;
+	};
+	let Some(workspace_package) = document
+		.get_mut("workspace")
+		.and_then(Item::as_table_like_mut)
+		.and_then(|workspace| workspace.get_mut("package"))
+		.and_then(Item::as_table_like_mut)
+	else {
+		return;
+	};
+	set_table_value(workspace_package, "version", shared_release_version);
+}
+
+fn update_workspace_dependencies(
+	document: &mut DocumentMut,
+	versioned_deps: &BTreeMap<String, String>,
+) {
+	let Some(workspace_deps) = document
+		.get_mut("workspace")
+		.and_then(Item::as_table_like_mut)
+		.and_then(|workspace| workspace.get_mut("dependencies"))
+		.and_then(Item::as_table_like_mut)
+	else {
+		return;
+	};
+	for (dep_name, dep_version) in versioned_deps {
+		update_dependency_by_name(workspace_deps, dep_name, dep_version);
+	}
+}
+
+fn update_manifest_field(
+	document: &mut DocumentMut,
+	field: &str,
+	owner_version: Option<&str>,
+	shared_release_version: Option<&str>,
+	versioned_deps: &BTreeMap<String, String>,
+) {
+	let segments = normalized_manifest_field_segments(field);
+	match segments.as_slice() {
+		["package", "version"] => update_manifest_owner_version(document, owner_version),
+		["workspace", "package", "version"] => {
+			update_manifest_workspace_version(document, shared_release_version.or(owner_version));
+		}
+		[table] if is_dependency_table(table) => {
+			let Some(table) = document.get_mut(table).and_then(Item::as_table_like_mut) else {
+				return;
+			};
+			for (dep_name, dep_version) in versioned_deps {
+				update_dependency_by_name(table, dep_name, dep_version);
+			}
+		}
+		["workspace", "dependencies"] => update_workspace_dependencies(document, versioned_deps),
+		[table, dep_name] if is_dependency_table(table) => {
+			let Some(dep_version) = versioned_deps.get(*dep_name) else {
+				return;
+			};
+			let Some(table) = document.get_mut(table).and_then(Item::as_table_like_mut) else {
+				return;
+			};
+			update_dependency_by_name(table, dep_name, dep_version);
+		}
+		[table, dep_name, "version"] if is_dependency_table(table) => {
+			let Some(dep_version) = versioned_deps.get(*dep_name) else {
+				return;
+			};
+			let Some(table) = document.get_mut(table).and_then(Item::as_table_like_mut) else {
+				return;
+			};
+			update_dependency_version_by_name(table, dep_name, dep_version);
+		}
+		["workspace", "dependencies", dep_name] => {
+			let Some(dep_version) = versioned_deps.get(*dep_name) else {
+				return;
+			};
+			let Some(workspace_deps) = document
+				.get_mut("workspace")
+				.and_then(Item::as_table_like_mut)
+				.and_then(|workspace| workspace.get_mut("dependencies"))
+				.and_then(Item::as_table_like_mut)
+			else {
+				return;
+			};
+			update_dependency_by_name(workspace_deps, dep_name, dep_version);
+		}
+		["workspace", "dependencies", dep_name, "version"] => {
+			let Some(dep_version) = versioned_deps.get(*dep_name) else {
+				return;
+			};
+			let Some(workspace_deps) = document
+				.get_mut("workspace")
+				.and_then(Item::as_table_like_mut)
+				.and_then(|workspace| workspace.get_mut("dependencies"))
+				.and_then(Item::as_table_like_mut)
+			else {
+				return;
+			};
+			update_dependency_version_by_name(workspace_deps, dep_name, dep_version);
+		}
+		_ => {}
+	}
+}
+
+fn fields_target_workspace_dependencies(fields: &[&str]) -> bool {
+	fields.iter().any(|field| {
+		matches!(
+			normalized_manifest_field_segments(field).as_slice(),
+			["workspace", "dependencies"] | ["workspace", "dependencies", ..]
+		)
+	})
+}
+
+fn normalized_manifest_field_segments(field: &str) -> Vec<&str> {
+	let mut segments = field
+		.split('.')
+		.filter(|segment| !segment.is_empty())
+		.map(normalize_manifest_field_segment)
+		.collect::<Vec<_>>();
+	if matches!(segments.as_slice(), ["workspace", "version"]) {
+		segments = vec!["workspace", "package", "version"];
+	}
+	segments
+}
+
+fn normalize_manifest_field_segment(segment: &str) -> &str {
+	match segment {
+		"dev_dependencies" => "dev-dependencies",
+		"build_dependencies" => "build-dependencies",
+		_ => segment,
+	}
+}
+
+fn is_dependency_table(segment: &str) -> bool {
+	matches!(
+		segment,
+		"dependencies" | "dev-dependencies" | "build-dependencies"
+	)
+}
+
+fn update_dependency_by_name(table: &mut dyn TableLike, dep_name: &str, version: &str) {
+	let Some(entry) = table.get_mut(dep_name) else {
+		return;
+	};
+	update_dependency_entry(entry, version);
+}
+
+fn update_dependency_version_by_name(table: &mut dyn TableLike, dep_name: &str, version: &str) {
+	let Some(entry) = table.get_mut(dep_name) else {
+		return;
+	};
+	update_dependency_version_field(entry, version);
+}
+
 fn update_dependency_entry(entry: &mut Item, version: &str) {
 	if entry.is_str() {
 		set_item_string(entry, version);
 		return;
 	}
+	let Some(entry_table) = entry.as_table_like_mut() else {
+		return;
+	};
+	let uses_workspace = entry_table
+		.get("workspace")
+		.is_some_and(uses_workspace_marker);
+	if !uses_workspace {
+		set_table_value(entry_table, "version", version);
+	}
+}
+
+fn update_dependency_version_field(entry: &mut Item, version: &str) {
 	let Some(entry_table) = entry.as_table_like_mut() else {
 		return;
 	};

--- a/crates/monochange_core/readme.md
+++ b/crates/monochange_core/readme.md
@@ -55,7 +55,7 @@ let notes = ReleaseNotesDocument {
 
 let rendered = render_release_notes(ChangelogFormat::KeepAChangelog, &notes);
 
-assert!(rendered.contains("## [1.2.3]"));
+assert!(rendered.contains("## 1.2.3"));
 assert!(rendered.contains("### Features"));
 assert!(rendered.contains("- add keep-a-changelog output"));
 ```

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -1367,3 +1367,172 @@ fn retarget_plan_and_result_serialize_with_camel_case_keys() {
 		"planned"
 	);
 }
+
+#[test]
+fn update_json_manifest_text_preserves_existing_formatting() {
+	let contents = r#"{
+  // keep comment
+  "name": "tool",
+  "version": "1.0.0",
+  "imports": {
+    "core": "^1.0.0"
+  },
+  "dependencies": { "left-pad": "^1.0.0" }
+}
+"#;
+	let updated = crate::update_json_manifest_text(
+		contents,
+		Some("2.0.0"),
+		&["imports"],
+		&BTreeMap::from([("core".to_string(), "^2.0.0".to_string())]),
+	)
+	.unwrap_or_else(|error| panic!("update json manifest: {error}"));
+
+	assert!(updated.contains("// keep comment"));
+	assert!(updated.contains("\"version\": \"2.0.0\""));
+	assert!(updated.contains("\"core\": \"^2.0.0\""));
+	assert!(updated.contains("\"left-pad\": \"^1.0.0\""));
+	assert!(updated.contains("  \"dependencies\": { \"left-pad\": \"^1.0.0\" }"));
+}
+
+#[test]
+fn update_json_manifest_text_ignores_missing_or_non_object_sections() {
+	let contents = r#"{
+  "version": "1.0.0",
+  "dependencies": ["core"],
+  "imports": {
+    "core": "^1.0.0"
+  }
+}
+"#;
+	let updated = crate::update_json_manifest_text(
+		contents,
+		None,
+		&["dependencies", "imports"],
+		&BTreeMap::from([("core".to_string(), "^2.0.0".to_string())]),
+	)
+	.unwrap_or_else(|error| panic!("update json manifest: {error}"));
+
+	assert!(updated.contains("\"dependencies\": [\"core\"]"));
+	assert!(updated.contains("\"core\": \"^2.0.0\""));
+}
+
+#[test]
+fn strip_json_comments_removes_comments_but_preserves_string_literals() {
+	let stripped = crate::strip_json_comments(
+		r#"{
+  // comment
+  "text": "https://example.com//still-string",
+  "escaped": "quote: \" // still string",
+  /* block */
+  "value": 1
+}
+"#,
+	);
+	assert!(!stripped.contains("// comment"));
+	assert!(!stripped.contains("/* block */"));
+	assert!(stripped.contains("https://example.com//still-string"));
+	assert!(stripped.contains("quote: \\\" // still string"));
+}
+
+#[test]
+fn json_helper_functions_cover_error_paths() {
+	let range_error = crate::apply_json_replacements(
+		"{}",
+		vec![(crate::JsonSpan { start: 10, end: 11 }, "\"x\"".to_string())],
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected range error"));
+	assert!(range_error.to_string().contains("out of bounds"));
+
+	let root_error = crate::json_root_object_start("[]")
+		.err()
+		.unwrap_or_else(|| panic!("expected root error"));
+	assert!(root_error.to_string().contains("expected JSON object"));
+
+	let locate_error = crate::find_json_object_field_value_span("[]", 0, "name")
+		.err()
+		.unwrap_or_else(|| panic!("expected locate error"));
+	assert!(locate_error.to_string().contains("expected JSON object when locating field"));
+
+	for (contents, key) in [
+		("{1:2}", "a"),
+		("{\"a\" 1}", "a"),
+		("{\"a\":1 !}", "missing"),
+		("{\"a\":1", "missing"),
+	] {
+		assert!(
+			crate::find_json_object_field_value_span(contents, 0, key).is_err(),
+			"contents: {contents}"
+		);
+	}
+
+	assert!(crate::skip_json_value("", 0).is_err());
+	assert!(crate::skip_json_array("[1 !]", 0).is_err());
+	assert!(crate::skip_json_array("[1", 0).is_err());
+	assert!(crate::skip_json_array("[", 0).is_err());
+	assert!(crate::skip_json_object("{\"a\":1 !}", 0).is_err());
+	assert!(crate::skip_json_object("{\"a\":1", 0).is_err());
+	assert!(crate::skip_json_object("{", 0).is_err());
+	assert!(crate::skip_json_object("{1}", 0).is_err());
+	assert!(crate::skip_json_object("{\"a\" 1}", 0).is_err());
+	assert!(crate::parse_json_string_span("abc", 0).is_err());
+	assert!(crate::parse_json_string_span("\"abc", 0).is_err());
+}
+
+#[test]
+fn json_helper_functions_cover_success_paths() {
+	let (string_span, next) = crate::parse_json_string_span("\"a\\\"b\"", 0)
+		.unwrap_or_else(|error| panic!("parse string span: {error}"));
+	assert_eq!(string_span, crate::JsonSpan { start: 1, end: 5 });
+	assert_eq!(next, 6);
+
+	assert_eq!(
+		crate::skip_json_value("\"text\"", 0)
+			.unwrap_or_else(|error| panic!("skip string value: {error}")),
+		6
+	);
+	assert_eq!(
+		crate::skip_json_value("{\"a\":1}", 0)
+			.unwrap_or_else(|error| panic!("skip object value: {error}")),
+		7
+	);
+	assert_eq!(
+		crate::skip_json_value("[1,2]", 0)
+			.unwrap_or_else(|error| panic!("skip array value: {error}")),
+		5
+	);
+	assert_eq!(crate::skip_json_primitive("true /* comment */", 0), 4);
+	assert_eq!(crate::skip_json_primitive("true//comment", 0), 4);
+	assert_eq!(
+		crate::skip_json_ws_and_comments(" // comment\n /* block */ {", 0),
+		25
+	);
+	assert_eq!(crate::skip_json_object("{}", 0).unwrap_or_else(|error| panic!("skip empty object: {error}")), 2);
+	assert_eq!(crate::skip_json_object("{\"a\":1,\"b\":2}", 0).unwrap_or_else(|error| panic!("skip object with comma: {error}")), 13);
+	assert_eq!(crate::skip_json_array("[]", 0).unwrap_or_else(|error| panic!("skip empty array: {error}")), 2);
+	assert_eq!(
+		crate::find_json_object_field_value_span("{}", 0, "name")
+			.unwrap_or_else(|error| panic!("find empty object field: {error}")),
+		None
+	);
+	let field_span = crate::find_json_object_field_value_span(
+		r#"{"name":"tool","deps":{"core":"^1.0.0"}}"#,
+		0,
+		"deps",
+	)
+	.unwrap_or_else(|error| panic!("find field span: {error}"))
+	.unwrap_or_else(|| panic!("expected deps field"));
+	assert!(crate::json_span_is_object(
+		r#"{"name":"tool","deps":{"core":"^1.0.0"}}"#,
+		field_span
+	));
+	let updated = crate::update_json_manifest_text(
+		r#"{"version":1,"imports":{"core":{"path":"./core"}}}"#,
+		Some("2.0.0"),
+		&["imports"],
+		&BTreeMap::from([("core".to_string(), "^2.0.0".to_string())]),
+	)
+	.unwrap_or_else(|error| panic!("update json manifest with non-string values: {error}"));
+	assert_eq!(updated, r#"{"version":1,"imports":{"core":{"path":"./core"}}}"#);
+}

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -1453,7 +1453,9 @@ fn json_helper_functions_cover_error_paths() {
 	let locate_error = crate::find_json_object_field_value_span("[]", 0, "name")
 		.err()
 		.unwrap_or_else(|| panic!("expected locate error"));
-	assert!(locate_error.to_string().contains("expected JSON object when locating field"));
+	assert!(locate_error
+		.to_string()
+		.contains("expected JSON object when locating field"));
 
 	for (contents, key) in [
 		("{1:2}", "a"),
@@ -1508,9 +1510,20 @@ fn json_helper_functions_cover_success_paths() {
 		crate::skip_json_ws_and_comments(" // comment\n /* block */ {", 0),
 		25
 	);
-	assert_eq!(crate::skip_json_object("{}", 0).unwrap_or_else(|error| panic!("skip empty object: {error}")), 2);
-	assert_eq!(crate::skip_json_object("{\"a\":1,\"b\":2}", 0).unwrap_or_else(|error| panic!("skip object with comma: {error}")), 13);
-	assert_eq!(crate::skip_json_array("[]", 0).unwrap_or_else(|error| panic!("skip empty array: {error}")), 2);
+	assert_eq!(
+		crate::skip_json_object("{}", 0)
+			.unwrap_or_else(|error| panic!("skip empty object: {error}")),
+		2
+	);
+	assert_eq!(
+		crate::skip_json_object("{\"a\":1,\"b\":2}", 0)
+			.unwrap_or_else(|error| panic!("skip object with comma: {error}")),
+		13
+	);
+	assert_eq!(
+		crate::skip_json_array("[]", 0).unwrap_or_else(|error| panic!("skip empty array: {error}")),
+		2
+	);
 	assert_eq!(
 		crate::find_json_object_field_value_span("{}", 0, "name")
 			.unwrap_or_else(|error| panic!("find empty object field: {error}")),
@@ -1534,5 +1547,8 @@ fn json_helper_functions_cover_success_paths() {
 		&BTreeMap::from([("core".to_string(), "^2.0.0".to_string())]),
 	)
 	.unwrap_or_else(|error| panic!("update json manifest with non-string values: {error}"));
-	assert_eq!(updated, r#"{"version":1,"imports":{"core":{"path":"./core"}}}"#);
+	assert_eq!(
+		updated,
+		r#"{"version":1,"imports":{"core":{"path":"./core"}}}"#
+	);
 }

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -963,7 +963,7 @@ fn render_monochange_release_notes(document: &ReleaseNotesDocument) -> String {
 }
 
 fn render_keep_a_changelog_release_notes(document: &ReleaseNotesDocument) -> String {
-	let mut lines = vec![format!("## [{}]", document.title), String::new()];
+	let mut lines = vec![format!("## {}", document.title), String::new()];
 	for (index, paragraph) in document.summary.iter().enumerate() {
 		if index > 0 {
 			lines.push(String::new());

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -47,7 +47,7 @@
 //!
 //! let rendered = render_release_notes(ChangelogFormat::KeepAChangelog, &notes);
 //!
-//! assert!(rendered.contains("## [1.2.3]"));
+//! assert!(rendered.contains("## 1.2.3"));
 //! assert!(rendered.contains("### Features"));
 //! assert!(rendered.contains("- add keep-a-changelog output"));
 //! ```
@@ -470,15 +470,17 @@ pub fn update_json_manifest_text(
 		}
 	}
 	for field in fields {
-		let Some(section_span) = find_json_object_field_value_span(contents, root_start, field)? else {
+		let Some(section_span) = find_json_object_field_value_span(contents, root_start, field)?
+		else {
 			continue;
 		};
 		if !json_span_is_object(contents, section_span) {
 			continue;
 		}
 		for (dep_name, dep_version) in versioned_deps {
-			let Some(dep_span) = find_json_object_field_value_span(contents, section_span.start, dep_name)?
-				.filter(|span| json_span_is_string(contents, *span))
+			let Some(dep_span) =
+				find_json_object_field_value_span(contents, section_span.start, dep_name)?
+					.filter(|span| json_span_is_string(contents, *span))
 			else {
 				continue;
 			};
@@ -607,8 +609,16 @@ fn skip_json_object(contents: &str, object_start: usize) -> MonochangeResult<usi
 		match bytes.get(cursor) {
 			Some(b'}') => return Ok(cursor + 1),
 			Some(b'"') => {}
-			Some(_) => return Err(MonochangeError::Config("expected JSON object key".to_string())),
-			None => return Err(MonochangeError::Config("unterminated JSON object".to_string())),
+			Some(_) => {
+				return Err(MonochangeError::Config(
+					"expected JSON object key".to_string(),
+				))
+			}
+			None => {
+				return Err(MonochangeError::Config(
+					"unterminated JSON object".to_string(),
+				))
+			}
 		}
 		let (_, next) = parse_json_string_span(contents, cursor)?;
 		cursor = skip_json_ws_and_comments(contents, next);
@@ -658,10 +668,18 @@ fn skip_json_array(contents: &str, array_start: usize) -> MonochangeResult<usize
 							"expected `,` or `]` after JSON array value".to_string(),
 						));
 					}
-					None => return Err(MonochangeError::Config("unterminated JSON array".to_string())),
+					None => {
+						return Err(MonochangeError::Config(
+							"unterminated JSON array".to_string(),
+						))
+					}
 				}
 			}
-			None => return Err(MonochangeError::Config("unterminated JSON array".to_string())),
+			None => {
+				return Err(MonochangeError::Config(
+					"unterminated JSON array".to_string(),
+				))
+			}
 		}
 	}
 }
@@ -684,9 +702,7 @@ fn skip_json_primitive(contents: &str, start: usize) -> usize {
 fn parse_json_string_span(contents: &str, start: usize) -> MonochangeResult<(JsonSpan, usize)> {
 	let bytes = contents.as_bytes();
 	if bytes.get(start) != Some(&b'"') {
-		return Err(MonochangeError::Config(
-			"expected JSON string".to_string(),
-		));
+		return Err(MonochangeError::Config("expected JSON string".to_string()));
 	}
 	let mut cursor = start + 1;
 	while let Some(&byte) = bytes.get(cursor) {

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -673,7 +673,7 @@ fn skip_json_primitive(contents: &str, start: usize) -> usize {
 		if matches!(byte, b',' | b'}' | b']') || byte.is_ascii_whitespace() {
 			break;
 		}
-		if byte == b'/' && matches!(bytes.get(cursor + 1), Some(b'/') | Some(b'*')) {
+		if byte == b'/' && matches!(bytes.get(cursor + 1), Some(b'/' | b'*')) {
 			break;
 		}
 		cursor += 1;

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -400,6 +400,364 @@ impl EcosystemType {
 	}
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct JsonSpan {
+	start: usize,
+	end: usize,
+}
+
+pub fn strip_json_comments(contents: &str) -> String {
+	let bytes = contents.as_bytes();
+	let mut output = String::with_capacity(contents.len());
+	let mut cursor = 0usize;
+	while let Some(&byte) = bytes.get(cursor) {
+		if byte == b'"' {
+			let start = cursor;
+			cursor += 1;
+			while let Some(&string_byte) = bytes.get(cursor) {
+				cursor += 1;
+				if string_byte == b'\\' {
+					cursor += usize::from(bytes.get(cursor).is_some());
+					continue;
+				}
+				if string_byte == b'"' {
+					break;
+				}
+			}
+			output.push_str(&contents[start..cursor]);
+			continue;
+		}
+		if byte == b'/' && bytes.get(cursor + 1) == Some(&b'/') {
+			cursor += 2;
+			while let Some(&line_byte) = bytes.get(cursor) {
+				if line_byte == b'\n' {
+					break;
+				}
+				cursor += 1;
+			}
+			continue;
+		}
+		if byte == b'/' && bytes.get(cursor + 1) == Some(&b'*') {
+			cursor += 2;
+			while bytes.get(cursor).is_some() {
+				if bytes.get(cursor) == Some(&b'*') && bytes.get(cursor + 1) == Some(&b'/') {
+					cursor += 2;
+					break;
+				}
+				cursor += 1;
+			}
+			continue;
+		}
+		output.push(char::from(byte));
+		cursor += 1;
+	}
+	output
+}
+
+pub fn update_json_manifest_text(
+	contents: &str,
+	owner_version: Option<&str>,
+	fields: &[&str],
+	versioned_deps: &BTreeMap<String, String>,
+) -> MonochangeResult<String> {
+	let root_start = json_root_object_start(contents)?;
+	let mut replacements = Vec::<(JsonSpan, String)>::new();
+	if let Some(owner_version) = owner_version {
+		if let Some(span) = find_json_object_field_value_span(contents, root_start, "version")?
+			.filter(|span| json_span_is_string(contents, *span))
+		{
+			replacements.push((span, render_json_string(owner_version)?));
+		}
+	}
+	for field in fields {
+		let Some(section_span) = find_json_object_field_value_span(contents, root_start, field)? else {
+			continue;
+		};
+		if !json_span_is_object(contents, section_span) {
+			continue;
+		}
+		for (dep_name, dep_version) in versioned_deps {
+			let Some(dep_span) = find_json_object_field_value_span(contents, section_span.start, dep_name)?
+				.filter(|span| json_span_is_string(contents, *span))
+			else {
+				continue;
+			};
+			replacements.push((dep_span, render_json_string(dep_version)?));
+		}
+	}
+	apply_json_replacements(contents, replacements)
+}
+
+fn render_json_string(value: &str) -> MonochangeResult<String> {
+	serde_json::to_string(value).map_err(|error| MonochangeError::Config(error.to_string()))
+}
+
+fn apply_json_replacements(
+	contents: &str,
+	mut replacements: Vec<(JsonSpan, String)>,
+) -> MonochangeResult<String> {
+	replacements.sort_by(|left, right| right.0.start.cmp(&left.0.start));
+	let mut updated = contents.to_string();
+	for (span, replacement) in replacements {
+		if span.start > span.end || span.end > updated.len() {
+			return Err(MonochangeError::Config(
+				"json edit range was out of bounds".to_string(),
+			));
+		}
+		updated.replace_range(span.start..span.end, &replacement);
+	}
+	Ok(updated)
+}
+
+fn json_root_object_start(contents: &str) -> MonochangeResult<usize> {
+	let start = skip_json_ws_and_comments(contents, 0);
+	if contents.as_bytes().get(start) == Some(&b'{') {
+		Ok(start)
+	} else {
+		Err(MonochangeError::Config(
+			"expected JSON object at document root".to_string(),
+		))
+	}
+}
+
+fn find_json_object_field_value_span(
+	contents: &str,
+	object_start: usize,
+	key: &str,
+) -> MonochangeResult<Option<JsonSpan>> {
+	let bytes = contents.as_bytes();
+	if bytes.get(object_start) != Some(&b'{') {
+		return Err(MonochangeError::Config(
+			"expected JSON object when locating field".to_string(),
+		));
+	}
+	let mut cursor = object_start + 1;
+	loop {
+		cursor = skip_json_ws_and_comments(contents, cursor);
+		match bytes.get(cursor) {
+			Some(b'}') => return Ok(None),
+			Some(b'"') => {}
+			Some(_) => {
+				return Err(MonochangeError::Config(
+					"expected JSON object key".to_string(),
+				));
+			}
+			None => {
+				return Err(MonochangeError::Config(
+					"unterminated JSON object".to_string(),
+				));
+			}
+		}
+		let (key_span, next) = parse_json_string_span(contents, cursor)?;
+		let key_text = &contents[key_span.start..key_span.end];
+		cursor = skip_json_ws_and_comments(contents, next);
+		if bytes.get(cursor) != Some(&b':') {
+			return Err(MonochangeError::Config(
+				"expected `:` after JSON object key".to_string(),
+			));
+		}
+		cursor = skip_json_ws_and_comments(contents, cursor + 1);
+		let value_start = cursor;
+		let value_end = skip_json_value(contents, value_start)?;
+		if key_text == key {
+			return Ok(Some(JsonSpan {
+				start: value_start,
+				end: value_end,
+			}));
+		}
+		cursor = skip_json_ws_and_comments(contents, value_end);
+		match bytes.get(cursor) {
+			Some(b',') => {
+				cursor += 1;
+			}
+			Some(b'}') => return Ok(None),
+			Some(_) => {
+				return Err(MonochangeError::Config(
+					"expected `,` or `}` after JSON object value".to_string(),
+				));
+			}
+			None => {
+				return Err(MonochangeError::Config(
+					"unterminated JSON object".to_string(),
+				));
+			}
+		}
+	}
+}
+
+fn skip_json_value(contents: &str, start: usize) -> MonochangeResult<usize> {
+	let bytes = contents.as_bytes();
+	let cursor = skip_json_ws_and_comments(contents, start);
+	match bytes.get(cursor) {
+		Some(b'"') => parse_json_string_span(contents, cursor).map(|(_, next)| next),
+		Some(b'{') => skip_json_object(contents, cursor),
+		Some(b'[') => skip_json_array(contents, cursor),
+		Some(_) => Ok(skip_json_primitive(contents, cursor)),
+		None => Err(MonochangeError::Config(
+			"unexpected end of JSON input".to_string(),
+		)),
+	}
+}
+
+fn skip_json_object(contents: &str, object_start: usize) -> MonochangeResult<usize> {
+	let bytes = contents.as_bytes();
+	let mut cursor = object_start + 1;
+	loop {
+		cursor = skip_json_ws_and_comments(contents, cursor);
+		match bytes.get(cursor) {
+			Some(b'}') => return Ok(cursor + 1),
+			Some(b'"') => {}
+			Some(_) => return Err(MonochangeError::Config("expected JSON object key".to_string())),
+			None => return Err(MonochangeError::Config("unterminated JSON object".to_string())),
+		}
+		let (_, next) = parse_json_string_span(contents, cursor)?;
+		cursor = skip_json_ws_and_comments(contents, next);
+		if bytes.get(cursor) != Some(&b':') {
+			return Err(MonochangeError::Config(
+				"expected `:` after JSON object key".to_string(),
+			));
+		}
+		cursor = skip_json_value(contents, cursor + 1)?;
+		cursor = skip_json_ws_and_comments(contents, cursor);
+		match bytes.get(cursor) {
+			Some(b',') => {
+				cursor += 1;
+			}
+			Some(b'}') => return Ok(cursor + 1),
+			Some(_) => {
+				return Err(MonochangeError::Config(
+					"expected `,` or `}` after JSON object value".to_string(),
+				));
+			}
+			None => {
+				return Err(MonochangeError::Config(
+					"unterminated JSON object".to_string(),
+				));
+			}
+		}
+	}
+}
+
+fn skip_json_array(contents: &str, array_start: usize) -> MonochangeResult<usize> {
+	let bytes = contents.as_bytes();
+	let mut cursor = array_start + 1;
+	loop {
+		cursor = skip_json_ws_and_comments(contents, cursor);
+		match bytes.get(cursor) {
+			Some(b']') => return Ok(cursor + 1),
+			Some(_) => {
+				cursor = skip_json_value(contents, cursor)?;
+				cursor = skip_json_ws_and_comments(contents, cursor);
+				match bytes.get(cursor) {
+					Some(b',') => {
+						cursor += 1;
+					}
+					Some(b']') => return Ok(cursor + 1),
+					Some(_) => {
+						return Err(MonochangeError::Config(
+							"expected `,` or `]` after JSON array value".to_string(),
+						));
+					}
+					None => return Err(MonochangeError::Config("unterminated JSON array".to_string())),
+				}
+			}
+			None => return Err(MonochangeError::Config("unterminated JSON array".to_string())),
+		}
+	}
+}
+
+fn skip_json_primitive(contents: &str, start: usize) -> usize {
+	let bytes = contents.as_bytes();
+	let mut cursor = start;
+	while let Some(&byte) = bytes.get(cursor) {
+		if matches!(byte, b',' | b'}' | b']') || byte.is_ascii_whitespace() {
+			break;
+		}
+		if byte == b'/' && matches!(bytes.get(cursor + 1), Some(b'/') | Some(b'*')) {
+			break;
+		}
+		cursor += 1;
+	}
+	cursor
+}
+
+fn parse_json_string_span(contents: &str, start: usize) -> MonochangeResult<(JsonSpan, usize)> {
+	let bytes = contents.as_bytes();
+	if bytes.get(start) != Some(&b'"') {
+		return Err(MonochangeError::Config(
+			"expected JSON string".to_string(),
+		));
+	}
+	let mut cursor = start + 1;
+	while let Some(&byte) = bytes.get(cursor) {
+		if byte == b'\\' {
+			cursor += 2;
+			continue;
+		}
+		if byte == b'"' {
+			return Ok((
+				JsonSpan {
+					start: start + 1,
+					end: cursor,
+				},
+				cursor + 1,
+			));
+		}
+		cursor += 1;
+	}
+	Err(MonochangeError::Config(
+		"unterminated JSON string".to_string(),
+	))
+}
+
+fn skip_json_ws_and_comments(contents: &str, start: usize) -> usize {
+	let bytes = contents.as_bytes();
+	let mut cursor = start;
+	loop {
+		while let Some(&byte) = bytes.get(cursor) {
+			if !byte.is_ascii_whitespace() {
+				break;
+			}
+			cursor += 1;
+		}
+		if bytes.get(cursor) == Some(&b'/') && bytes.get(cursor + 1) == Some(&b'/') {
+			cursor += 2;
+			while let Some(&byte) = bytes.get(cursor) {
+				if byte == b'\n' {
+					break;
+				}
+				cursor += 1;
+			}
+			continue;
+		}
+		if bytes.get(cursor) == Some(&b'/') && bytes.get(cursor + 1) == Some(&b'*') {
+			cursor += 2;
+			while bytes.get(cursor).is_some() {
+				if bytes.get(cursor) == Some(&b'*') && bytes.get(cursor + 1) == Some(&b'/') {
+					cursor += 2;
+					break;
+				}
+				cursor += 1;
+			}
+			continue;
+		}
+		break;
+	}
+	cursor
+}
+
+fn json_span_is_string(contents: &str, span: JsonSpan) -> bool {
+	contents.as_bytes().get(span.start) == Some(&b'"')
+		&& span.end > span.start
+		&& contents.as_bytes().get(span.end - 1) == Some(&b'"')
+}
+
+fn json_span_is_object(contents: &str, span: JsonSpan) -> bool {
+	contents.as_bytes().get(span.start) == Some(&b'{')
+		&& span.end > span.start
+		&& contents.as_bytes().get(span.end - 1) == Some(&b'}')
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct VersionedFileDefinition {
 	pub path: String,

--- a/crates/monochange_core/src/snapshots/monochange_core____tests__render_release_notes_supports_monochange_and_keep_a_changelog_formats__keep_a_changelog.snap
+++ b/crates/monochange_core/src/snapshots/monochange_core____tests__render_release_notes_supports_monochange_and_keep_a_changelog_formats__keep_a_changelog.snap
@@ -2,7 +2,7 @@
 source: crates/monochange_core/src/__tests.rs
 expression: keep_a_changelog
 ---
-## [1.2.3]
+## 1.2.3
 
 Grouped release for `sdk`.
 

--- a/crates/monochange_dart/src/__tests.rs
+++ b/crates/monochange_dart/src/__tests.rs
@@ -148,7 +148,7 @@ dev_dependencies:
 
 #[test]
 fn update_manifest_text_preserves_pubspec_formatting() {
-	let manifest = r#"name: sample_app
+	let manifest = r"name: sample_app
 version: '1.0.0' # keep quote
 
 dependencies:
@@ -159,7 +159,7 @@ dependencies:
 
 dev_dependencies:
   test: ^1.0.0
-"#;
+";
 	let updated = update_manifest_text(
 		manifest,
 		Some("2.0.0"),
@@ -182,7 +182,7 @@ fn yaml_helper_functions_cover_missing_and_inline_paths() {
 	let contents = "version: # comment only\n\n  nested: value\nshared:\n  path: ../shared\n";
 	let ranges = crate::yaml_line_ranges(contents);
 	assert_eq!(ranges.len(), 6);
-	assert!(crate::parse_yaml_line(contents, ranges[1]).is_none());
+	assert!(crate::parse_yaml_line(contents, *ranges.get(1).expect("blank line range")).is_none());
 	assert!(crate::parse_yaml_line(": nope", (0, 6)).is_none());
 	assert!(crate::yaml_value_span("version: # comment", 0, 8).is_none());
 	assert_eq!(crate::find_yaml_quote_end("\"1.0.0\"", '"'), Some(6));
@@ -191,13 +191,13 @@ fn yaml_helper_functions_cover_missing_and_inline_paths() {
 	assert_eq!(crate::render_yaml_scalar("'1.0.0'", "2.0.0"), "'2.0.0'");
 	assert_eq!(crate::render_yaml_scalar("1.0.0", "2.0.0"), "2.0.0");
 
-	let nested = r#"dependencies:
+	let nested = r"dependencies:
   shared:
     path: ../shared
 
     # keep spacing
   other: ^1.0.0
-"#;
+";
 	let nested_ranges = crate::yaml_line_ranges(nested);
 	let section_index = crate::find_yaml_key_line(nested, &nested_ranges, 0, "dependencies")
 		.unwrap_or_else(|| panic!("expected dependencies section"));

--- a/crates/monochange_dart/src/__tests.rs
+++ b/crates/monochange_dart/src/__tests.rs
@@ -17,6 +17,7 @@ use crate::parse_manifest;
 use crate::parse_yaml_manifest;
 use crate::supported_versioned_file_kind;
 use crate::update_dependency_fields;
+use crate::update_manifest_text;
 use crate::update_pubspec_lock;
 use crate::yaml_array_strings;
 use crate::yaml_bool;
@@ -143,6 +144,67 @@ dev_dependencies:
 		.unwrap_or_else(|error| panic!("render manifest: {error}"));
 	assert!(rendered.contains("core: 2.0.0"));
 	assert!(rendered.contains("test: ^1.0.0"));
+}
+
+#[test]
+fn update_manifest_text_preserves_pubspec_formatting() {
+	let manifest = r#"name: sample_app
+version: '1.0.0' # keep quote
+
+dependencies:
+  shared:
+    path: ../shared
+    version: ^1.0.0
+  http: ^1.0.0
+
+dev_dependencies:
+  test: ^1.0.0
+"#;
+	let updated = update_manifest_text(
+		manifest,
+		Some("2.0.0"),
+		&["dependencies", "dev_dependencies"],
+		&BTreeMap::from([
+			("shared".to_string(), "^2.0.0".to_string()),
+			("test".to_string(), "^2.0.0".to_string()),
+		]),
+	)
+	.unwrap_or_else(|error| panic!("update pubspec text: {error}"));
+	assert!(updated.contains("version: '2.0.0' # keep quote"));
+	assert!(updated.contains("path: ../shared"));
+	assert!(updated.contains("version: ^2.0.0"));
+	assert!(updated.contains("test: ^2.0.0"));
+	assert!(updated.contains("http: ^1.0.0"));
+}
+
+#[test]
+fn yaml_helper_functions_cover_missing_and_inline_paths() {
+	let contents = "version: # comment only\n\n  nested: value\nshared:\n  path: ../shared\n";
+	let ranges = crate::yaml_line_ranges(contents);
+	assert_eq!(ranges.len(), 6);
+	assert!(crate::parse_yaml_line(contents, ranges[1]).is_none());
+	assert!(crate::parse_yaml_line(": nope", (0, 6)).is_none());
+	assert!(crate::yaml_value_span("version: # comment", 0, 8).is_none());
+	assert_eq!(crate::find_yaml_quote_end("\"1.0.0\"", '"'), Some(6));
+	assert_eq!(crate::find_yaml_quote_end("\"1.0.0", '"'), None);
+	assert_eq!(crate::render_yaml_scalar("\"1.0.0\"", "2.0.0"), "\"2.0.0\"");
+	assert_eq!(crate::render_yaml_scalar("'1.0.0'", "2.0.0"), "'2.0.0'");
+	assert_eq!(crate::render_yaml_scalar("1.0.0", "2.0.0"), "2.0.0");
+
+	let nested = r#"dependencies:
+  shared:
+    path: ../shared
+
+    # keep spacing
+  other: ^1.0.0
+"#;
+	let nested_ranges = crate::yaml_line_ranges(nested);
+	let section_index = crate::find_yaml_key_line(nested, &nested_ranges, 0, "dependencies")
+		.unwrap_or_else(|| panic!("expected dependencies section"));
+	assert_eq!(
+		crate::find_yaml_dependency_scalar(nested, &nested_ranges, section_index, "shared"),
+		None
+	);
 }
 
 #[test]

--- a/crates/monochange_dart/src/lib.rs
+++ b/crates/monochange_dart/src/lib.rs
@@ -134,7 +134,10 @@ pub fn update_manifest_text(
 	let mut replacements = Vec::<((usize, usize), String)>::new();
 	if let Some(owner_version) = owner_version {
 		if let Some(span) = find_yaml_scalar_for_key(contents, &line_ranges, 0, "version") {
-			replacements.push((span, render_yaml_scalar(&contents[span.0..span.1], owner_version)));
+			replacements.push((
+				span,
+				render_yaml_scalar(&contents[span.0..span.1], owner_version),
+			));
 		}
 	}
 	for field in fields {
@@ -142,13 +145,13 @@ pub fn update_manifest_text(
 			continue;
 		};
 		for (dep_name, dep_version) in versioned_deps {
-			if let Some(span) = find_yaml_dependency_scalar(
-				contents,
-				&line_ranges,
-				section_index,
-				dep_name,
-			) {
-				replacements.push((span, render_yaml_scalar(&contents[span.0..span.1], dep_version)));
+			if let Some(span) =
+				find_yaml_dependency_scalar(contents, &line_ranges, section_index, dep_name)
+			{
+				replacements.push((
+					span,
+					render_yaml_scalar(&contents[span.0..span.1], dep_version),
+				));
 			}
 		}
 	}

--- a/crates/monochange_dart/src/lib.rs
+++ b/crates/monochange_dart/src/lib.rs
@@ -121,6 +121,199 @@ pub fn update_dependency_fields(
 	}
 }
 
+pub fn update_manifest_text(
+	contents: &str,
+	owner_version: Option<&str>,
+	fields: &[&str],
+	versioned_deps: &std::collections::BTreeMap<String, String>,
+) -> MonochangeResult<String> {
+	serde_yaml_ng::from_str::<Mapping>(contents).map_err(|error| {
+		MonochangeError::Config(format!("failed to parse pubspec yaml: {error}"))
+	})?;
+	let line_ranges = yaml_line_ranges(contents);
+	let mut replacements = Vec::<((usize, usize), String)>::new();
+	if let Some(owner_version) = owner_version {
+		if let Some(span) = find_yaml_scalar_for_key(contents, &line_ranges, 0, "version") {
+			replacements.push((span, render_yaml_scalar(&contents[span.0..span.1], owner_version)));
+		}
+	}
+	for field in fields {
+		let Some(section_index) = find_yaml_key_line(contents, &line_ranges, 0, field) else {
+			continue;
+		};
+		for (dep_name, dep_version) in versioned_deps {
+			if let Some(span) = find_yaml_dependency_scalar(
+				contents,
+				&line_ranges,
+				section_index,
+				dep_name,
+			) {
+				replacements.push((span, render_yaml_scalar(&contents[span.0..span.1], dep_version)));
+			}
+		}
+	}
+	replacements.sort_by(|left, right| right.0 .0.cmp(&left.0 .0));
+	let mut updated = contents.to_string();
+	for ((start, end), replacement) in replacements {
+		updated.replace_range(start..end, &replacement);
+	}
+	Ok(updated)
+}
+
+fn yaml_line_ranges(contents: &str) -> Vec<(usize, usize)> {
+	let mut ranges = Vec::new();
+	let mut start = 0usize;
+	for (index, ch) in contents.char_indices() {
+		if ch == '\n' {
+			ranges.push((start, index));
+			start = index + 1;
+		}
+	}
+	if start <= contents.len() {
+		ranges.push((start, contents.len()));
+	}
+	ranges
+}
+
+fn find_yaml_scalar_for_key(
+	contents: &str,
+	line_ranges: &[(usize, usize)],
+	indent: usize,
+	key: &str,
+) -> Option<(usize, usize)> {
+	let line_index = find_yaml_key_line(contents, line_ranges, indent, key)?;
+	parse_yaml_line(contents, line_ranges[line_index]).and_then(|line| line.value_span)
+}
+
+fn find_yaml_key_line(
+	contents: &str,
+	line_ranges: &[(usize, usize)],
+	indent: usize,
+	key: &str,
+) -> Option<usize> {
+	line_ranges.iter().position(|range| {
+		parse_yaml_line(contents, *range)
+			.is_some_and(|line| line.indent == indent && line.key == key)
+	})
+}
+
+fn find_yaml_dependency_scalar(
+	contents: &str,
+	line_ranges: &[(usize, usize)],
+	section_index: usize,
+	dep_name: &str,
+) -> Option<(usize, usize)> {
+	let section = parse_yaml_line(contents, line_ranges[section_index])?;
+	let section_indent = section.indent;
+	let mut index = section_index + 1;
+	while let Some(range) = line_ranges.get(index) {
+		let Some(line) = parse_yaml_line(contents, *range) else {
+			index += 1;
+			continue;
+		};
+		if line.indent <= section_indent {
+			break;
+		}
+		if line.key == dep_name {
+			if let Some(value_span) = line.value_span {
+				return Some(value_span);
+			}
+			let dep_indent = line.indent;
+			let mut nested_index = index + 1;
+			while let Some(nested_range) = line_ranges.get(nested_index) {
+				let Some(nested_line) = parse_yaml_line(contents, *nested_range) else {
+					nested_index += 1;
+					continue;
+				};
+				if nested_line.indent <= dep_indent {
+					break;
+				}
+				if nested_line.key == "version" {
+					return nested_line.value_span;
+				}
+				nested_index += 1;
+			}
+			return None;
+		}
+		index += 1;
+	}
+	None
+}
+
+struct ParsedYamlLine<'a> {
+	indent: usize,
+	key: &'a str,
+	value_span: Option<(usize, usize)>,
+}
+
+fn parse_yaml_line(contents: &str, range: (usize, usize)) -> Option<ParsedYamlLine<'_>> {
+	let line = &contents[range.0..range.1];
+	let trimmed = line.trim_start_matches([' ', '\t']);
+	if trimmed.is_empty() || trimmed.starts_with('#') {
+		return None;
+	}
+	let indent = line.len() - trimmed.len();
+	let colon = trimmed.find(':')?;
+	let key = trimmed[..colon].trim();
+	if key.is_empty() {
+		return None;
+	}
+	let value_span = yaml_value_span(line, range.0, indent + colon + 1);
+	Some(ParsedYamlLine {
+		indent,
+		key,
+		value_span,
+	})
+}
+
+fn yaml_value_span(
+	line: &str,
+	line_start: usize,
+	value_start_in_line: usize,
+) -> Option<(usize, usize)> {
+	let suffix = line.get(value_start_in_line..)?;
+	let value_offset = suffix.find(|ch: char| !matches!(ch, ' ' | '\t'))?;
+	let value = &suffix[value_offset..];
+	if value.starts_with('#') {
+		return None;
+	}
+	let span_start = line_start + value_start_in_line + value_offset;
+	let span_end = if let Some(quote) = value
+		.chars()
+		.next()
+		.filter(|quote| *quote == '"' || *quote == '\'')
+	{
+		let quote_end = find_yaml_quote_end(value, quote)?;
+		span_start + quote_end + 1
+	} else {
+		let comment_index = value.find('#').unwrap_or(value.len());
+		let trimmed_end = value[..comment_index].trim_end_matches([' ', '\t']).len();
+		span_start + trimmed_end
+	};
+	(span_end > span_start).then_some((span_start, span_end))
+}
+
+fn find_yaml_quote_end(value: &str, quote: char) -> Option<usize> {
+	let mut chars = value.char_indices();
+	chars.next()?;
+	for (index, ch) in chars {
+		if ch == quote {
+			return Some(index);
+		}
+	}
+	None
+}
+
+fn render_yaml_scalar(existing: &str, value: &str) -> String {
+	if existing.starts_with('"') && existing.ends_with('"') {
+		return format!("\"{value}\"");
+	}
+	if existing.starts_with('\'') && existing.ends_with('\'') {
+		return format!("'{value}'");
+	}
+	value.to_string()
+}
+
 pub fn update_pubspec_lock(
 	mapping: &mut Mapping,
 	raw_versions: &std::collections::BTreeMap<String, String>,

--- a/crates/monochange_dart/src/lib.rs
+++ b/crates/monochange_dart/src/lib.rs
@@ -182,7 +182,8 @@ fn find_yaml_scalar_for_key(
 	key: &str,
 ) -> Option<(usize, usize)> {
 	let line_index = find_yaml_key_line(contents, line_ranges, indent, key)?;
-	parse_yaml_line(contents, line_ranges[line_index]).and_then(|line| line.value_span)
+	let range = *line_ranges.get(line_index)?;
+	parse_yaml_line(contents, range).and_then(|line| line.value_span)
 }
 
 fn find_yaml_key_line(
@@ -203,7 +204,7 @@ fn find_yaml_dependency_scalar(
 	section_index: usize,
 	dep_name: &str,
 ) -> Option<(usize, usize)> {
-	let section = parse_yaml_line(contents, line_ranges[section_index])?;
+	let section = parse_yaml_line(contents, *line_ranges.get(section_index)?)?;
 	let section_indent = section.indent;
 	let mut index = section_index + 1;
 	while let Some(range) = line_ranges.get(index) {

--- a/crates/monochange_deno/src/__tests.rs
+++ b/crates/monochange_deno/src/__tests.rs
@@ -59,6 +59,45 @@ fn supported_versioned_file_kind_recognizes_manifest_and_lockfiles() {
 }
 
 #[test]
+fn discovers_deno_jsonc_manifests_with_comments() {
+	let tempdir = std::env::temp_dir().join(format!(
+		"monochange-deno-jsonc-{}-{}",
+		std::process::id(),
+		std::thread::current().name().unwrap_or("unnamed")
+	));
+	let _ = std::fs::remove_dir_all(&tempdir);
+	std::fs::create_dir_all(&tempdir)
+		.unwrap_or_else(|error| panic!("create tempdir {}: {error}", tempdir.display()));
+	std::fs::write(
+		tempdir.join("deno.jsonc"),
+		r#"{
+  // keep comment
+  "name": "jsonc-tool",
+  "version": "1.0.0",
+  "imports": {
+    "core": "^1.0.0"
+  }
+}
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write deno.jsonc: {error}"));
+	let discovery = discover_deno_packages(&tempdir)
+		.unwrap_or_else(|error| panic!("discover deno jsonc: {error}"));
+	assert_eq!(discovery.packages.len(), 1);
+	assert_eq!(discovery.packages[0].name, "jsonc-tool");
+	assert_eq!(
+		discovery.packages[0]
+			.current_version
+			.as_ref()
+			.map(ToString::to_string)
+			.as_deref(),
+		Some("1.0.0")
+	);
+	std::fs::remove_dir_all(&tempdir)
+		.unwrap_or_else(|error| panic!("cleanup tempdir {}: {error}", tempdir.display()));
+}
+
+#[test]
 fn update_lockfile_rewrites_npm_dependency_versions() {
 	let mut lock = json!({
 		"packages": {

--- a/crates/monochange_deno/src/__tests.rs
+++ b/crates/monochange_deno/src/__tests.rs
@@ -84,9 +84,10 @@ fn discovers_deno_jsonc_manifests_with_comments() {
 	let discovery = discover_deno_packages(&tempdir)
 		.unwrap_or_else(|error| panic!("discover deno jsonc: {error}"));
 	assert_eq!(discovery.packages.len(), 1);
-	assert_eq!(discovery.packages[0].name, "jsonc-tool");
+	let package = discovery.packages.first().expect("discovered deno package");
+	assert_eq!(package.name, "jsonc-tool");
 	assert_eq!(
-		discovery.packages[0]
+		package
 			.current_version
 			.as_ref()
 			.map(ToString::to_string)

--- a/crates/monochange_deno/src/lib.rs
+++ b/crates/monochange_deno/src/lib.rs
@@ -326,7 +326,8 @@ fn parse_json_manifest(manifest_path: &Path) -> MonochangeResult<Value> {
 			manifest_path.display()
 		))
 	})?;
-	serde_json::from_str::<Value>(&contents).map_err(|error| {
+	let normalized = monochange_core::strip_json_comments(&contents);
+	serde_json::from_str::<Value>(&normalized).map_err(|error| {
 		MonochangeError::Discovery(format!(
 			"failed to parse {}: {error}",
 			manifest_path.display()

--- a/crates/monochange_npm/src/__tests.rs
+++ b/crates/monochange_npm/src/__tests.rs
@@ -26,6 +26,7 @@ use crate::update_bun_lock_binary;
 use crate::update_json_dependency_fields;
 use crate::update_package_lock;
 use crate::update_pnpm_lock;
+use crate::update_pnpm_lock_text;
 use crate::workspace_patterns_from_package_json;
 use crate::NpmVersionedFileKind;
 
@@ -273,6 +274,171 @@ snapshots:
 	assert!(rendered.contains("core: 2.0.0"));
 	assert!(rendered.contains("linked: link:../linked"));
 	assert!(rendered.contains("workspace_dep: workspace:*"));
+}
+
+#[test]
+fn update_pnpm_lock_text_preserves_existing_formatting() {
+	let lock = r#"lockfileVersion: "9.0"
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .:
+    dependencies:
+      core: 1.0.0
+      linked: link:../linked
+
+  npm/skill: {}
+"#;
+	let updated = update_pnpm_lock_text(
+		lock,
+		&BTreeMap::from([("core".to_string(), "2.0.0".to_string())]),
+	)
+	.unwrap_or_else(|error| panic!("update pnpm lock text: {error}"));
+	assert_eq!(
+		updated,
+		r#"lockfileVersion: "9.0"
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .:
+    dependencies:
+      core: 2.0.0
+      linked: link:../linked
+
+  npm/skill: {}
+"#
+	);
+}
+
+#[test]
+fn update_pnpm_lock_text_returns_original_contents_when_no_entries_match() {
+	let lock = "lockfileVersion: \"9.0\"\n\nimporters:\n  .: {}\n";
+	let updated = update_pnpm_lock_text(
+		lock,
+		&BTreeMap::from([("core".to_string(), "2.0.0".to_string())]),
+	)
+	.unwrap_or_else(|error| panic!("update pnpm lock text: {error}"));
+	assert_eq!(updated, lock);
+}
+
+#[test]
+fn pnpm_text_helper_functions_cover_edge_cases() {
+	let contents = "importers:\n\n  # comment\n";
+	let ranges = crate::yaml_line_ranges(contents);
+	assert_eq!(
+		crate::find_yaml_key_line(contents, &ranges, 0, "importers"),
+		Some(0)
+	);
+	assert!(crate::parse_yaml_line(contents, *ranges.get(1).expect("blank line range")).is_none());
+	assert!(crate::parse_yaml_line(": nope", (0, 6)).is_none());
+	let mut replacements = Vec::new();
+	crate::collect_pnpm_section_replacements(
+		contents,
+		&ranges,
+		1,
+		&BTreeMap::new(),
+		&mut replacements,
+	);
+	let outer_blank = "importers:\n\n  .:\n";
+	let outer_blank_ranges = crate::yaml_line_ranges(outer_blank);
+	let outer_blank_index =
+		crate::find_yaml_key_line(outer_blank, &outer_blank_ranges, 0, "importers")
+			.unwrap_or_else(|| panic!("expected importers section"));
+	crate::collect_pnpm_section_replacements(
+		outer_blank,
+		&outer_blank_ranges,
+		outer_blank_index,
+		&BTreeMap::new(),
+		&mut replacements,
+	);
+	crate::collect_pnpm_dependency_replacements(
+		contents,
+		&ranges,
+		1,
+		&BTreeMap::new(),
+		&mut replacements,
+	);
+	assert!(replacements.is_empty());
+	assert!(crate::yaml_value_span("version: # comment", 0, 8).is_none());
+	assert_eq!(crate::find_yaml_quote_end("\"1.0.0\"", '"'), Some(6));
+	assert_eq!(crate::find_yaml_quote_end("\"1.0.0", '"'), None);
+	assert_eq!(crate::render_yaml_scalar("\"1.0.0\"", "2.0.0"), "\"2.0.0\"");
+	assert_eq!(crate::render_yaml_scalar("'1.0.0'", "2.0.0"), "'2.0.0'");
+	assert_eq!(crate::render_yaml_scalar("1.0.0", "2.0.0"), "2.0.0");
+	assert!(crate::yaml_scalar_is_updatable("1.0.0"));
+	assert!(!crate::yaml_scalar_is_updatable("1"));
+	assert!(!crate::yaml_scalar_is_updatable("link:../linked"));
+	assert!(crate::is_pnpm_dependency_field("dependencies"));
+	assert!(!crate::is_pnpm_dependency_field("resolution"));
+}
+
+#[test]
+fn update_pnpm_lock_text_updates_nested_versions_and_preserves_quotes() {
+	let lock = r#"lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      core:
+        version: "1.0.0"
+      linked:
+        version: link:../linked
+      numeric:
+        version: 1
+      missing:
+        path: ../missing
+
+snapshots:
+  core@1.0.0:
+    optionalDependencies:
+      core: '1.0.0'
+"#;
+	let updated = update_pnpm_lock_text(
+		lock,
+		&BTreeMap::from([("core".to_string(), "2.0.0".to_string())]),
+	)
+	.unwrap_or_else(|error| panic!("update pnpm lock text: {error}"));
+	assert!(updated.contains("version: \"2.0.0\""));
+	assert!(updated.contains("core: '2.0.0'"));
+	assert!(updated.contains("version: link:../linked"));
+	assert!(updated.contains("version: 1"));
+	assert!(updated.contains("path: ../missing"));
+}
+
+#[test]
+fn pnpm_replacement_helpers_skip_invalid_spans_and_blank_lines() {
+	let mut replacements = Vec::new();
+	crate::push_pnpm_scalar_replacement("link:../linked", (0, 14), "2.0.0", &mut replacements);
+	crate::push_pnpm_scalar_replacement("1.0.0", (0, 99), "2.0.0", &mut replacements);
+	assert!(replacements.is_empty());
+
+	let contents = r"importers:
+  .:
+
+    dependencies:
+      other: 1.0.0
+      core:
+        path: ../core
+
+      next: 1.0.0
+";
+	let ranges = crate::yaml_line_ranges(contents);
+	let section_index = crate::find_yaml_key_line(contents, &ranges, 0, "importers")
+		.unwrap_or_else(|| panic!("expected importers section"));
+	crate::collect_pnpm_section_replacements(
+		contents,
+		&ranges,
+		section_index,
+		&BTreeMap::from([("core".to_string(), "2.0.0".to_string())]),
+		&mut replacements,
+	);
+	assert!(replacements.is_empty());
 }
 
 #[test]

--- a/crates/monochange_npm/src/lib.rs
+++ b/crates/monochange_npm/src/lib.rs
@@ -225,6 +225,270 @@ pub fn update_pnpm_lock(
 	}
 }
 
+pub fn update_pnpm_lock_text(
+	contents: &str,
+	raw_versions: &BTreeMap<String, String>,
+) -> MonochangeResult<String> {
+	serde_yaml_ng::from_str::<serde_yaml_ng::Value>(contents).map_err(|error| {
+		MonochangeError::Config(format!("failed to parse pnpm lock yaml: {error}"))
+	})?;
+	let line_ranges = yaml_line_ranges(contents);
+	let mut replacements = Vec::<((usize, usize), String)>::new();
+	for section_name in ["importers", "packages", "snapshots"] {
+		let Some(section_index) = find_yaml_key_line(contents, &line_ranges, 0, section_name)
+		else {
+			continue;
+		};
+		collect_pnpm_section_replacements(
+			contents,
+			&line_ranges,
+			section_index,
+			raw_versions,
+			&mut replacements,
+		);
+	}
+	replacements.sort_by(|left, right| right.0 .0.cmp(&left.0 .0));
+	let mut updated = contents.to_string();
+	for ((start, end), replacement) in replacements {
+		updated.replace_range(start..end, &replacement);
+	}
+	Ok(updated)
+}
+
+fn collect_pnpm_section_replacements(
+	contents: &str,
+	line_ranges: &[(usize, usize)],
+	section_index: usize,
+	raw_versions: &BTreeMap<String, String>,
+	replacements: &mut Vec<((usize, usize), String)>,
+) {
+	let Some(section) = line_ranges
+		.get(section_index)
+		.and_then(|range| parse_yaml_line(contents, *range))
+	else {
+		return;
+	};
+	let mut index = section_index + 1;
+	while let Some(range) = line_ranges.get(index) {
+		let Some(line) = parse_yaml_line(contents, *range) else {
+			index += 1;
+			continue;
+		};
+		if line.indent <= section.indent {
+			break;
+		}
+		let entry_indent = line.indent;
+		index += 1;
+		while let Some(nested_range) = line_ranges.get(index) {
+			let Some(nested_line) = parse_yaml_line(contents, *nested_range) else {
+				index += 1;
+				continue;
+			};
+			if nested_line.indent <= entry_indent {
+				break;
+			}
+			if is_pnpm_dependency_field(nested_line.key) {
+				collect_pnpm_dependency_replacements(
+					contents,
+					line_ranges,
+					index,
+					raw_versions,
+					replacements,
+				);
+			}
+			index += 1;
+		}
+	}
+}
+
+fn collect_pnpm_dependency_replacements(
+	contents: &str,
+	line_ranges: &[(usize, usize)],
+	section_index: usize,
+	raw_versions: &BTreeMap<String, String>,
+	replacements: &mut Vec<((usize, usize), String)>,
+) {
+	let Some(section) = line_ranges
+		.get(section_index)
+		.and_then(|range| parse_yaml_line(contents, *range))
+	else {
+		return;
+	};
+	let mut index = section_index + 1;
+	while let Some(range) = line_ranges.get(index) {
+		let Some(line) = parse_yaml_line(contents, *range) else {
+			index += 1;
+			continue;
+		};
+		if line.indent <= section.indent {
+			break;
+		}
+		let Some(version) = raw_versions.get(line.key) else {
+			index += 1;
+			continue;
+		};
+		if let Some(value_span) = line.value_span {
+			push_pnpm_scalar_replacement(contents, value_span, version, replacements);
+			index += 1;
+			continue;
+		}
+		let dependency_indent = line.indent;
+		index += 1;
+		while let Some(nested_range) = line_ranges.get(index) {
+			let Some(nested_line) = parse_yaml_line(contents, *nested_range) else {
+				index += 1;
+				continue;
+			};
+			if nested_line.indent <= dependency_indent {
+				break;
+			}
+			if nested_line.key == "version" {
+				if let Some(value_span) = nested_line.value_span {
+					push_pnpm_scalar_replacement(contents, value_span, version, replacements);
+				}
+				break;
+			}
+			index += 1;
+		}
+	}
+}
+
+fn push_pnpm_scalar_replacement(
+	contents: &str,
+	span: (usize, usize),
+	version: &str,
+	replacements: &mut Vec<((usize, usize), String)>,
+) {
+	let Some(existing) = contents.get(span.0..span.1) else {
+		return;
+	};
+	if !yaml_scalar_is_updatable(existing) {
+		return;
+	}
+	let replacement = render_yaml_scalar(existing, version);
+	if replacement != existing {
+		replacements.push((span, replacement));
+	}
+}
+
+fn yaml_scalar_is_updatable(existing: &str) -> bool {
+	serde_yaml_ng::from_str::<serde_yaml_ng::Value>(existing)
+		.ok()
+		.and_then(|value| value.as_str().map(str::to_string))
+		.is_some_and(|text| !text.starts_with("link:") && !text.starts_with("workspace:"))
+}
+
+fn is_pnpm_dependency_field(key: &str) -> bool {
+	matches!(
+		key,
+		"dependencies" | "devDependencies" | "optionalDependencies" | "peerDependencies"
+	)
+}
+
+fn yaml_line_ranges(contents: &str) -> Vec<(usize, usize)> {
+	let mut ranges = Vec::new();
+	let mut start = 0usize;
+	for (index, ch) in contents.char_indices() {
+		if ch == '\n' {
+			ranges.push((start, index));
+			start = index + 1;
+		}
+	}
+	if start <= contents.len() {
+		ranges.push((start, contents.len()));
+	}
+	ranges
+}
+
+fn find_yaml_key_line(
+	contents: &str,
+	line_ranges: &[(usize, usize)],
+	indent: usize,
+	key: &str,
+) -> Option<usize> {
+	line_ranges.iter().position(|range| {
+		parse_yaml_line(contents, *range)
+			.is_some_and(|line| line.indent == indent && line.key == key)
+	})
+}
+
+struct ParsedYamlLine<'a> {
+	indent: usize,
+	key: &'a str,
+	value_span: Option<(usize, usize)>,
+}
+
+fn parse_yaml_line(contents: &str, range: (usize, usize)) -> Option<ParsedYamlLine<'_>> {
+	let line = contents.get(range.0..range.1)?;
+	let trimmed = line.trim_start_matches([' ', '\t']);
+	if trimmed.is_empty() || trimmed.starts_with('#') {
+		return None;
+	}
+	let indent = line.len() - trimmed.len();
+	let colon = trimmed.find(':')?;
+	let key = trimmed.get(..colon)?.trim();
+	if key.is_empty() {
+		return None;
+	}
+	let value_span = yaml_value_span(line, range.0, indent + colon + 1);
+	Some(ParsedYamlLine {
+		indent,
+		key,
+		value_span,
+	})
+}
+
+fn yaml_value_span(
+	line: &str,
+	line_start: usize,
+	value_start_in_line: usize,
+) -> Option<(usize, usize)> {
+	let suffix = line.get(value_start_in_line..)?;
+	let value_offset = suffix.find(|ch: char| !matches!(ch, ' ' | '\t'))?;
+	let value = suffix.get(value_offset..)?;
+	if value.starts_with('#') {
+		return None;
+	}
+	let span_start = line_start + value_start_in_line + value_offset;
+	let span_end = if let Some(quote) = value
+		.chars()
+		.next()
+		.filter(|quote| *quote == '"' || *quote == '\'')
+	{
+		let quote_end = find_yaml_quote_end(value, quote)?;
+		span_start + quote_end + 1
+	} else {
+		let comment_index = value.find('#').unwrap_or(value.len());
+		let trimmed_end = value
+			.get(..comment_index)?
+			.trim_end_matches([' ', '\t'])
+			.len();
+		span_start + trimmed_end
+	};
+	(span_end > span_start).then_some((span_start, span_end))
+}
+
+fn find_yaml_quote_end(value: &str, quote: char) -> Option<usize> {
+	let mut chars = value.char_indices();
+	chars.next()?;
+	for (index, ch) in chars {
+		if ch == quote {
+			return Some(index);
+		}
+	}
+	None
+}
+
+fn render_yaml_scalar(existing: &str, value: &str) -> String {
+	if existing.starts_with('"') && existing.ends_with('"') {
+		return format!("\"{value}\"");
+	}
+	if existing.starts_with('\'') && existing.ends_with('\'') {
+		return format!("'{value}'");
+	}
+	value.to_string()
+}
+
 pub fn update_bun_lock(contents: &str, raw_versions: &BTreeMap<String, String>) -> String {
 	let mut updated = contents.to_string();
 	for (name, version) in raw_versions {

--- a/devenv.nix
+++ b/devenv.nix
@@ -42,7 +42,7 @@ in
   dotenv.disableHint = true;
 
   git-hooks = {
-    package = pkgs.prek;
+    # package = pkgs.prek;
 
     hooks = {
       "secrets:commit" = {
@@ -58,7 +58,6 @@ in
         enable = true;
         verbose = true;
         pass_filenames = true;
-        after = [ "secrets:commit" ];
         name = "dprint check";
         description = "Run workspace autofixes before commit and restage the results.";
         entry = "${pkgs.dprint}/bin/dprint check --allow-no-files";
@@ -77,7 +76,6 @@ in
         enable = true;
         verbose = true;
         pass_filenames = false;
-        after = [ "secrets:push" ];
         name = "lint";
         description = "Run the local CI lint rules suite before push.";
         entry = "${config.env.DEVENV_PROFILE}/bin/lint:all";

--- a/fixtures/tests/changelog-formats/linked-title/.changeset/feature.md
+++ b/fixtures/tests/changelog-formats/linked-title/.changeset/feature.md
@@ -1,0 +1,5 @@
+---
+core: minor
+---
+
+#### render linked keep a changelog titles

--- a/fixtures/tests/changelog-formats/linked-title/Cargo.toml
+++ b/fixtures/tests/changelog-formats/linked-title/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[workspace.package]
+version = "1.0.0"
+
+[workspace.dependencies]
+workflow-core = { path = "./crates/core", version = "1.0.0" }

--- a/fixtures/tests/changelog-formats/linked-title/crates/core/Cargo.toml
+++ b/fixtures/tests/changelog-formats/linked-title/crates/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "workflow-core"
+version = { workspace = true }
+edition = "2021"

--- a/fixtures/tests/changelog-formats/linked-title/monochange.toml
+++ b/fixtures/tests/changelog-formats/linked-title/monochange.toml
@@ -1,0 +1,26 @@
+[defaults]
+parent_bump = "patch"
+package_type = "cargo"
+
+[defaults.changelog]
+path = "{{ path }}/CHANGELOG.md"
+format = "keep_a_changelog"
+
+[package.core]
+path = "crates/core"
+tag = true
+release = true
+version_format = "primary"
+
+[source]
+provider = "github"
+owner = "ifiokjr"
+repo = "monochange"
+
+[ecosystems.cargo]
+enabled = true
+
+[cli.release]
+
+[[cli.release.steps]]
+type = "PrepareRelease"

--- a/fixtures/tests/manifest-formatting/preserve-cargo/.changeset/feature.md
+++ b/fixtures/tests/manifest-formatting/preserve-cargo/.changeset/feature.md
@@ -1,0 +1,5 @@
+---
+main: minor
+---
+
+#### preserve cargo formatting

--- a/fixtures/tests/manifest-formatting/preserve-cargo/Cargo.lock
+++ b/fixtures/tests/manifest-formatting/preserve-cargo/Cargo.lock
@@ -1,0 +1,11 @@
+version = 4
+
+[[package]]
+name = "workflow-core"
+version = "1.0.0"
+source = "registry+https://example.test"
+
+[[package]]
+name = "workflow-app"
+version = "1.0.0"
+dependencies = ["workflow-core"]

--- a/fixtures/tests/manifest-formatting/preserve-cargo/Cargo.toml
+++ b/fixtures/tests/manifest-formatting/preserve-cargo/Cargo.toml
@@ -1,0 +1,13 @@
+[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+# Keep this comment exactly where it is.
+[workspace.package]
+version = "1.0.0"
+authors = ["Monochange Maintainers"]
+
+[workspace.dependencies]
+workflow-core = { path = "./crates/core", version = "1.0.0", default-features = false }
+workflow-app = { path = "./crates/app", version = "1.0.0" }
+serde = { version = "1.0.219", features = ["derive"] }

--- a/fixtures/tests/manifest-formatting/preserve-cargo/crates/app/Cargo.toml
+++ b/fixtures/tests/manifest-formatting/preserve-cargo/crates/app/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "workflow-app"
+version = { workspace = true }
+edition = "2021"
+description = "app package"
+
+[dependencies]
+workflow-core = { workspace = true }

--- a/fixtures/tests/manifest-formatting/preserve-cargo/crates/app/src/lib.rs
+++ b/fixtures/tests/manifest-formatting/preserve-cargo/crates/app/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn app() -> &'static str {
+    "app"
+}

--- a/fixtures/tests/manifest-formatting/preserve-cargo/crates/core/Cargo.toml
+++ b/fixtures/tests/manifest-formatting/preserve-cargo/crates/core/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "workflow-core"
+version = { workspace = true }
+edition = "2021"
+# Keep these fields in place.
+description = "core package"
+
+[dependencies]
+serde = { workspace = true }

--- a/fixtures/tests/manifest-formatting/preserve-cargo/crates/core/extra.toml
+++ b/fixtures/tests/manifest-formatting/preserve-cargo/crates/core/extra.toml
@@ -1,0 +1,6 @@
+[package]
+name = "workflow-core"
+version = "1.0.0"
+
+[dependencies]
+workflow-app = { version = "1.0.0", path = "../app" }

--- a/fixtures/tests/manifest-formatting/preserve-cargo/crates/core/src/lib.rs
+++ b/fixtures/tests/manifest-formatting/preserve-cargo/crates/core/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn core() -> &'static str {
+    "core"
+}

--- a/fixtures/tests/manifest-formatting/preserve-cargo/group.toml
+++ b/fixtures/tests/manifest-formatting/preserve-cargo/group.toml
@@ -1,0 +1,7 @@
+[workspace.package]
+# group file should keep this comment and layout
+version = "1.0.0"
+
+[workspace.dependencies]
+workflow-core = { path = "./crates/core", version = "1.0.0" }
+workflow-app = { path = "./crates/app", version = "1.0.0", features = ["cli"] }

--- a/fixtures/tests/manifest-formatting/preserve-cargo/monochange.toml
+++ b/fixtures/tests/manifest-formatting/preserve-cargo/monochange.toml
@@ -1,0 +1,26 @@
+[defaults]
+parent_bump = "patch"
+package_type = "cargo"
+changelog = false
+
+[package.core]
+path = "crates/core"
+versioned_files = [{ path = "crates/core/extra.toml", type = "cargo" }]
+
+[package.app]
+path = "crates/app"
+
+[group.main]
+packages = ["core", "app"]
+versioned_files = [{ path = "group.toml", type = "cargo" }]
+tag = true
+release = true
+version_format = "primary"
+
+[ecosystems.cargo]
+enabled = true
+
+[cli.release]
+
+[[cli.release.steps]]
+type = "PrepareRelease"

--- a/fixtures/tests/manifest-formatting/preserve-ecosystem-manifests/.changeset/feature.md
+++ b/fixtures/tests/manifest-formatting/preserve-ecosystem-manifests/.changeset/feature.md
@@ -1,0 +1,7 @@
+---
+web: minor
+tool: minor
+mobile: minor
+---
+
+#### preserve manifest formatting across ecosystems

--- a/fixtures/tests/manifest-formatting/preserve-ecosystem-manifests/monochange.toml
+++ b/fixtures/tests/manifest-formatting/preserve-ecosystem-manifests/monochange.toml
@@ -1,0 +1,29 @@
+[defaults]
+parent_bump = "patch"
+changelog = false
+
+[package.web]
+path = "packages/web"
+type = "npm"
+
+[package.tool]
+path = "tools/deno"
+type = "deno"
+
+[package.mobile]
+path = "packages/mobile"
+type = "dart"
+
+[ecosystems.npm]
+enabled = true
+
+[ecosystems.deno]
+enabled = true
+
+[ecosystems.dart]
+enabled = true
+
+[cli.release]
+
+[[cli.release.steps]]
+type = "PrepareRelease"

--- a/fixtures/tests/manifest-formatting/preserve-ecosystem-manifests/packages/mobile/lib/mobile.dart
+++ b/fixtures/tests/manifest-formatting/preserve-ecosystem-manifests/packages/mobile/lib/mobile.dart
@@ -1,0 +1,1 @@
+String mobile() => 'mobile';

--- a/fixtures/tests/manifest-formatting/preserve-ecosystem-manifests/packages/mobile/pubspec.yaml
+++ b/fixtures/tests/manifest-formatting/preserve-ecosystem-manifests/packages/mobile/pubspec.yaml
@@ -1,0 +1,8 @@
+name: mobile
+version: '1.0.0' # keep quote
+publish_to: none
+
+dependencies:
+  shared:
+    path: ../shared
+    version: ^1.0.0

--- a/fixtures/tests/manifest-formatting/preserve-ecosystem-manifests/packages/web/index.js
+++ b/fixtures/tests/manifest-formatting/preserve-ecosystem-manifests/packages/web/index.js
@@ -1,0 +1,1 @@
+export const web = 'web';

--- a/fixtures/tests/manifest-formatting/preserve-ecosystem-manifests/packages/web/package.json
+++ b/fixtures/tests/manifest-formatting/preserve-ecosystem-manifests/packages/web/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "web",
+    "version": "1.0.0",
+    "dependencies": { "shared": "^1.0.0" },
+    "private": false
+}

--- a/fixtures/tests/manifest-formatting/preserve-ecosystem-manifests/tools/deno/deno.json
+++ b/fixtures/tests/manifest-formatting/preserve-ecosystem-manifests/tools/deno/deno.json
@@ -1,0 +1,7 @@
+{
+  "name": "tool",
+  "version": "1.0.0",
+  "imports": {
+    "core": "^1.0.0"
+  }
+}

--- a/fixtures/tests/manifest-formatting/preserve-ecosystem-manifests/tools/deno/mod.ts
+++ b/fixtures/tests/manifest-formatting/preserve-ecosystem-manifests/tools/deno/mod.ts
@@ -1,0 +1,1 @@
+export const tool = 'tool';

--- a/monochange.toml
+++ b/monochange.toml
@@ -265,7 +265,7 @@ extra_changelog_sections = [
 tag = true
 release = true
 version_format = "primary"
-versioned_files = [{ path = "Cargo.toml", type = "cargo", fields = ["workspace.version"] }]
+versioned_files = [{ path = "Cargo.toml", type = "cargo", fields = ["workspace.package.version"] }]
 # Optional: filter member-targeted notes in the group changelog.
 # Omit `include` (or set it to "all") to keep current behavior.
 # Use "group-only" to show only direct group-targeted changesets.
@@ -324,6 +324,7 @@ comment_on_failure = true
 
 [ecosystems.cargo]
 enabled = true
+versioned_files = ["Cargo.toml"]
 
 [ecosystems.npm]
 enabled = true

--- a/monochange.toml
+++ b/monochange.toml
@@ -265,7 +265,7 @@ extra_changelog_sections = [
 tag = true
 release = true
 version_format = "primary"
-versioned_files = [{ path = "Cargo.toml", type = "cargo", keys = ["workspace.version"] }]
+versioned_files = [{ path = "Cargo.toml", type = "cargo", fields = ["workspace.version"] }]
 # Optional: filter member-targeted notes in the group changelog.
 # Omit `include` (or set it to "all") to keep current behavior.
 # Use "group-only" to show only direct group-targeted changesets.

--- a/monochange.toml
+++ b/monochange.toml
@@ -265,15 +265,13 @@ extra_changelog_sections = [
 tag = true
 release = true
 version_format = "primary"
-
-[group.main.changelog]
-path = "changelog.md"
-format = "monochange"
+versioned_files = [{ path = "Cargo.toml", type = "cargo", keys = ["workspace.version"] }]
 # Optional: filter member-targeted notes in the group changelog.
 # Omit `include` (or set it to "all") to keep current behavior.
 # Use "group-only" to show only direct group-targeted changesets.
 # Use an array to allow only specific group members to contribute notes.
 # include = ["monochange"]
+changelog = { path = "changelog.md", format = "monochange" }
 
 # =============================================================================
 # [changesets.verify] — changeset verification settings


### PR DESCRIPTION
## Summary
- preserve release-time formatting for Cargo manifests and `Cargo.lock` by updating only version values in place
- preserve formatting for `package.json`, `deno.json`/`deno.jsonc`, and `pubspec.yaml` instead of reserializing whole manifests
- add regression fixtures, snapshots, and error-path coverage for cross-ecosystem manifest updates

## Validation
- `cargo clippy -p monochange_core -p monochange_cargo -p monochange_dart -p monochange_deno -p monochange --all-targets -- -D warnings`
- `mc validate`
- `mc affected --changed-paths ...`
- `cargo llvm-cov test -p monochange_core -p monochange_cargo -p monochange_dart -p monochange_deno -p monochange --tests --lib --no-report`
- branch diff coverage vs `origin/main`: `1212 / 1212` executable added lines covered
