### PR TITLE
fix: enforce lowercase monochange naming convention

### DIFF
--- a/.changeset/041-preserve-cargo-formatting.md
+++ b/.changeset/041-preserve-cargo-formatting.md
@@ -29,7 +29,7 @@ features = [
 workspace = true
 ```
 
-After this change, MonoChange updates only the relevant Cargo version values in place:
+After this change, monochange updates only the relevant Cargo version values in place:
 
 - `package.version`
 - `workspace.package.version`

--- a/.changeset/042-lockfile-commands.md
+++ b/.changeset/042-lockfile-commands.md
@@ -27,13 +27,13 @@ lockfile_commands = [
 ]
 ```
 
-MonoChange now infers default lockfile commands for Cargo, npm-family, and Dart/Flutter workspaces when packages in that ecosystem are released, and stops inferring defaults when explicit `lockfile_commands` are configured for that ecosystem.
+monochange now infers default lockfile commands for Cargo, npm-family, and Dart/Flutter workspaces when packages in that ecosystem are released, and stops inferring defaults when explicit `lockfile_commands` are configured for that ecosystem.
 
 `versioned_files` also now support plain-text regex replacements without an explicit ecosystem `type`, as long as the regex includes a named `version` capture group.
 
 #### Regex versioned files
 
-Regex entries let you version-stamp any plain-text file — README badges, download links, install scripts — without needing an ecosystem-specific parser. The regex must contain a named `version` capture group; MonoChange replaces the captured substring with the new version while preserving the surrounding text.
+Regex entries let you version-stamp any plain-text file — README badges, download links, install scripts — without needing an ecosystem-specific parser. The regex must contain a named `version` capture group; monochange replaces the captured substring with the new version while preserving the surrounding text.
 
 ```toml
 [package.core]

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -64,7 +64,7 @@ format = "monochange"
 
 <!-- {@configurationRegexVersionedFilesSnippet} -->
 
-Regex entries let you version-stamp any plain-text file — README badges, download links, install scripts — without needing an ecosystem-specific parser. The regex must contain a named `version` capture group; MonoChange replaces the captured substring with the new version while preserving the surrounding text.
+Regex entries let you version-stamp any plain-text file — README badges, download links, install scripts — without needing an ecosystem-specific parser. The regex must contain a named `version` capture group; monochange replaces the captured substring with the new version while preserving the surrounding text.
 
 ```toml
 [package.core]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,15 @@
 - Quality/typecheck: `lint:all`
 - Validation: `mc validate`
 
+## Naming convention
+
+- The project name is always written in **all lowercase**: `monochange`.
+- Never use `MonoChange`, `Monochange`, or `MONOCHANGE` in prose, docs, comments, or string literals.
+- **Rust code exception**: standard Rust naming conventions apply.
+  - Structs and enums may use PascalCase (e.g. `MonochangeError`, `MonochangeResult`).
+  - Constants use UPPER_SNAKE_CASE (e.g. `MONOCHANGE_VERSION`).
+  - Variables and functions use snake_case (e.g. `monochange_config`).
+
 ## Git rules
 
 - Never use `--no-verify` with `git commit` or `git push`.

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -2160,7 +2160,7 @@ fn validate_versioned_files(
 						owner_id,
 						"regex versioned_files must capture the version",
 					)],
-					Some("use a named capture like `(?<version>\\d+\\.\\d+\\.\\d+)` so MonoChange knows which substring to replace".to_string()),
+					Some("use a named capture like `(?<version>\\d+\\.\\d+\\.\\d+)` so monochange knows which substring to replace".to_string()),
 				));
 			}
 			continue;

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -194,7 +194,7 @@ Dependency targets in `versioned_files` must reference declared package ids. Gro
 
 <!-- {=configurationRegexVersionedFilesSnippet} -->
 
-Regex entries let you version-stamp any plain-text file — README badges, download links, install scripts — without needing an ecosystem-specific parser. The regex must contain a named `version` capture group; MonoChange replaces the captured substring with the new version while preserving the surrounding text.
+Regex entries let you version-stamp any plain-text file — README badges, download links, install scripts — without needing an ecosystem-specific parser. The regex must contain a named `version` capture group; monochange replaces the captured substring with the new version while preserving the surrounding text.
 
 ```toml
 [package.core]


### PR DESCRIPTION
## Summary

- Replace all instances of `MonoChange` and `Monochange` with `monochange` in prose, docs, comments, and string literals
- Add naming convention rules to `AGENTS.md`
- Update test fixture and snapshot to match

## Test plan

- [ ] CI passes (cargo test, cargo clippy, cargo fmt)
- [ ] Verify no remaining `MonoChange` instances outside of `AGENTS.md` rule documentation