### PR TITLE
docs: comprehensive skill, MCP, and docs update

### DIFF
--- a/.changeset/docs-skill-audit.md
+++ b/.changeset/docs-skill-audit.md
@@ -1,0 +1,21 @@
+---
+"@monochange/skill": minor
+monochange: patch
+---
+
+#### update skill and docs to reflect current features
+
+The bundled agent skill (`SKILL.md` and `REFERENCE.md`) has been comprehensively updated to cover all current monochange features:
+
+- **CLI commands**: added `mc init`, `mc diagnostics`, `mc assist`, `mc mcp`, `mc commit-release`, `mc release-pr`, `mc affected`, and `mc repair-release` to the command reference table
+- **CLI step types**: documented all 13 step types (`Validate`, `Discover`, `CreateChangeFile`, `PrepareRelease`, `CommitRelease`, `RenderReleaseManifest`, `PublishRelease`, `OpenReleaseRequest`, `CommentReleasedIssues`, `AffectedPackages`, `DiagnoseChangesets`, `RetargetRelease`, `Command`) with prerequisite guidance
+- **MCP tools**: replaced the outdated "planned MCP setup" placeholder with the actual 6 implemented tools (`monochange_validate`, `monochange_discover`, `monochange_change`, `monochange_release_preview`, `monochange_release_manifest`, `monochange_affected_packages`)
+- **CLI step composition**: added input types (`string`, `string_list`, `path`, `choice`, `boolean`), `Command` step template interpolation, `shell` options, and step output references
+- **Changeset authoring**: documented object syntax with `bump`, `version`, and `type` fields
+- **Configuration**: added regex `versioned_files`, lockfile commands, `release_title`/`changelog_version_title` templates, group changelog `include` filters, and `[changesets.verify]`
+
+The assistant setup guide (`docs/src/guide/09-assistant-setup.md`) now uses the correct MCP tool name (`monochange_affected_packages` instead of the outdated `monochange_verify_changesets`).
+
+Six new reusable mdt snippets (`mcpToolsList`, `mcpConfigSnippet`, `recommendedCommandFlow`, `assistantRepoGuidance`, `cliStepTypes`, `releaseTitleConfig`) are shared between the skill files and docs book so these sections stay in sync automatically.
+
+The `monochange.init.toml` template now documents `release_title` and `changelog_version_title` with full placeholder reference and migration guidance for the breaking changelog heading format change.

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -779,3 +779,100 @@ The monochange repository itself can dogfood this model by:
 - running a real `changeset-policy` GitHub Actions workflow that shells into `mc affected`
 
 <!-- {/githubAutomationDogfoodNotes} -->
+
+<!-- {@mcpToolsList} -->
+
+- `monochange_validate` — validate `monochange.toml` and `.changeset` targets
+- `monochange_discover` — discover packages, dependencies, and groups across the repository
+- `monochange_change` — write a `.changeset` markdown file for one or more package or group ids
+- `monochange_release_preview` — prepare a dry-run release preview from discovered `.changeset` files
+- `monochange_release_manifest` — generate a dry-run release manifest JSON document for downstream automation
+- `monochange_affected_packages` — evaluate changeset policy from changed paths and optional labels
+
+<!-- {/mcpToolsList} -->
+
+<!-- {@mcpConfigSnippet} -->
+
+```json
+{
+	"mcpServers": {
+		"monochange": {
+			"command": "monochange",
+			"args": ["mcp"]
+		}
+	}
+}
+```
+
+<!-- {/mcpConfigSnippet} -->
+
+<!-- {@recommendedCommandFlow} -->
+
+1. **Validate** — `mc validate` checks config and changeset targets.
+2. **Discover** — `mc discover --format json` inspects the workspace model.
+3. **Create changesets** — `mc change --package <id> --bump <severity> --reason "..."` writes explicit release intent.
+4. **Preview release** — `mc release --dry-run --format json` shows planned bumps, changelog output, and changed files.
+5. **Inspect changeset context** — `mc diagnostics --format json` shows git provenance and linked review metadata for all pending changesets.
+6. **Generate manifest** — `mc release-manifest --dry-run` writes a stable JSON artifact for downstream automation.
+7. **Publish** — `mc publish-release --format json` creates provider releases after human review.
+
+<!-- {/recommendedCommandFlow} -->
+
+<!-- {@assistantRepoGuidance} -->
+
+- Read `monochange.toml` before proposing release workflow changes.
+- Run `mc validate` before and after release-affecting edits.
+- Use `mc discover --format json` to inspect package ids, group ownership, and dependency edges.
+- Use `mc diagnostics --format json` for a structured view of all pending changesets with git and review context.
+- Prefer `mc change` plus `.changeset/*.md` files over ad hoc release notes.
+- Use `mc release --dry-run --format json` before mutating release state.
+
+<!-- {/assistantRepoGuidance} -->
+
+<!-- {@cliStepTypes} -->
+
+**Standalone steps** (no prerequisites):
+
+- `Validate` — validate config and changeset targets
+- `Discover` — discover packages across ecosystems
+- `CreateChangeFile` — write a `.changeset/*.md` file
+- `AffectedPackages` — evaluate changeset policy from CI-supplied paths and labels
+- `DiagnoseChangesets` — show changeset context and review metadata
+- `RetargetRelease` — repair a recent release by moving its tags
+
+**Release-state consumer steps** (require `PrepareRelease`):
+
+- `PrepareRelease` — compute release plan, update versions, changelogs, and versioned files
+- `CommitRelease` — create a local release commit
+- `RenderReleaseManifest` — write a stable JSON manifest
+- `PublishRelease` — create provider releases
+- `OpenReleaseRequest` — open or update a release pull request
+- `CommentReleasedIssues` — comment on issues referenced in changesets
+
+**Generic step:**
+
+- `Command` — run an arbitrary shell command with template interpolation
+
+<!-- {/cliStepTypes} -->
+
+<!-- {@releaseTitleConfig} -->
+
+Two template fields control how release names and changelog version headings render:
+
+- **`release_title`** — plain text title for provider releases (GitHub, GitLab, Gitea)
+- **`changelog_version_title`** — markdown-capable title for changelog version headings
+
+Both are configurable at `[defaults]`, `[package.*]`, and `[group.*]` levels.
+
+Available template variables: `{{ version }}`, `{{ id }}`, `{{ date }}`, `{{ time }}`, `{{ datetime }}`, `{{ changes_count }}`, `{{ tag_url }}`, `{{ compare_url }}`.
+
+```toml
+[defaults]
+release_title = "{{ version }} ({{ date }})"
+changelog_version_title = "[{{ version }}]({{ tag_url }}) ({{ date }})"
+
+[group.main]
+release_title = "v{{ version }} — released {{ date }}"
+```
+
+<!-- {/releaseTitleConfig} -->

--- a/crates/monochange/src/monochange.init.toml
+++ b/crates/monochange/src/monochange.init.toml
@@ -110,6 +110,41 @@ warn_on_group_mismatch = true
 # empty_update_message = "No direct changes; {{ package }} updated to {{ version }}."
 {% endraw %}
 
+# Default release_title applied when creating provider releases.
+# This is a plain-text title used for GitHub, GitLab, and Gitea releases.
+#
+# Available placeholders:
+{% raw -%}
+#   {{ version }}, {{ id }}, {{ date }}, {{ time }}, {{ datetime }}
+#   {{ changes_count }}, {{ tag_url }}, {{ compare_url }}
+{% endraw -%}
+#
+# Defaults:
+#   Primary versioning:    "{{ version }} ({{ date }})"
+#   Namespaced versioning: "{{ id }} {{ version }} ({{ date }})"
+#
+{% raw -%}
+# release_title = "{{ version }} ({{ date }})"
+{% endraw %}
+
+# Default changelog_version_title controls how changelog version headings render.
+# This is markdown-capable and supports links.
+#
+# Available placeholders: same as release_title above.
+#
+# Defaults:
+#   Primary:    "[{{ version }}]({{ tag_url }}) ({{ date }})" (linked when source configured)
+#   Namespaced: "{{ id }} [{{ version }}]({{ tag_url }}) ({{ date }})"
+#
+# To restore headings without dates (the previous default), set:
+{% raw -%}
+#   changelog_version_title = "{{ version }}"
+{% endraw -%}
+#
+{% raw -%}
+# changelog_version_title = "[{{ version }}]({{ tag_url }}) ({{ date }})"
+{% endraw %}
+
 # =============================================================================
 # [release_notes] — workspace-wide release-note rendering settings
 # =============================================================================

--- a/docs/src/guide/09-assistant-setup.md
+++ b/docs/src/guide/09-assistant-setup.md
@@ -44,6 +44,8 @@ The profile includes:
 
 Typical client configuration:
 
+<!-- {=mcpConfigSnippet} -->
+
 ```json
 {
 	"mcpServers": {
@@ -55,6 +57,8 @@ Typical client configuration:
 }
 ```
 
+<!-- {/mcpConfigSnippet} -->
+
 Start the server manually with:
 
 ```bash
@@ -65,23 +69,31 @@ mc mcp
 
 Keep instructions like these close to your project guidance:
 
+<!-- {=assistantRepoGuidance} -->
+
 - Read `monochange.toml` before proposing release workflow changes.
 - Run `mc validate` before and after release-affecting edits.
 - Use `mc discover --format json` to inspect package ids, group ownership, and dependency edges.
-- Use `mc diagnostics --format json` to get a structured view of all pending changesets with git and review context — useful for auditing what has changed before a release or PR review.
+- Use `mc diagnostics --format json` for a structured view of all pending changesets with git and review context.
 - Prefer `mc change` plus `.changeset/*.md` files over ad hoc release notes.
 - Use `mc release --dry-run --format json` before mutating release state.
 
+<!-- {/assistantRepoGuidance} -->
+
 ## Current MCP tools
 
-The first MCP slice is JSON-first and focuses on reviewable operations:
+The MCP server is JSON-first and focuses on reviewable operations:
 
-- `monochange_validate`
-- `monochange_discover`
-- `monochange_change`
-- `monochange_release_preview`
-- `monochange_release_manifest`
-- `monochange_verify_changesets`
+<!-- {=mcpToolsList} -->
+
+- `monochange_validate` — validate `monochange.toml` and `.changeset` targets
+- `monochange_discover` — discover packages, dependencies, and groups across the repository
+- `monochange_change` — write a `.changeset` markdown file for one or more package or group ids
+- `monochange_release_preview` — prepare a dry-run release preview from discovered `.changeset` files
+- `monochange_release_manifest` — generate a dry-run release manifest JSON document for downstream automation
+- `monochange_affected_packages` — evaluate changeset policy from changed paths and optional labels
+
+<!-- {/mcpToolsList} -->
 
 These tools are designed to help assistants inspect the workspace, write explicit release intent, and preview release effects before a human or CI system performs mutating follow-up commands.
 

--- a/skills/monochange/REFERENCE.md
+++ b/skills/monochange/REFERENCE.md
@@ -38,55 +38,214 @@ npm install -g @monochange/skill
 monochange-skill --print-install
 ```
 
-The `@monochange/skill` package should provide a helper that can print or copy the bundled skill files for agent setups.
-
 ## Recommended command flow
 
-### Validate first
+<!-- {=recommendedCommandFlow} -->
 
-```bash
-mc validate
+1. **Validate** — `mc validate` checks config and changeset targets.
+2. **Discover** — `mc discover --format json` inspects the workspace model.
+3. **Create changesets** — `mc change --package <id> --bump <severity> --reason "..."` writes explicit release intent.
+4. **Preview release** — `mc release --dry-run --format json` shows planned bumps, changelog output, and changed files.
+5. **Inspect changeset context** — `mc diagnostics --format json` shows git provenance and linked review metadata for all pending changesets.
+6. **Generate manifest** — `mc release-manifest --dry-run` writes a stable JSON artifact for downstream automation.
+7. **Publish** — `mc publish-release --format json` creates provider releases after human review.
+
+<!-- {/recommendedCommandFlow} -->
+
+## Changeset authoring
+
+Changesets are markdown files in `.changeset/` with YAML frontmatter:
+
+```markdown
+---
+core: minor
+---
+
+#### add release automation
+
+Introduce automated release preparation with changelog rendering and version bumps.
 ```
 
-Run this before changing config, changesets, or release workflows.
+Frontmatter keys are package or group ids. Values are bump severities (`none`, `patch`, `minor`, `major`) or configured change types. Object syntax supports `bump`, `version`, and `type`:
 
-### Discover the workspace model
+```markdown
+---
+core:
+  bump: major
+  version: "2.0.0"
+  type: security
+---
 
-```bash
-mc discover --format json
+#### breaking API change
+
+Redesign the public API surface.
 ```
 
-Use this to inspect configured package ids, inferred packages, paths, dependency edges, and group ownership.
+## CLI step types and composition
 
-### Create explicit release intent
+`monochange.toml` defines top-level CLI commands with `[cli.<command>]` entries. Each command has `help_text`, optional `inputs`, and ordered `steps`.
 
-```bash
-mc change --package monochange --bump minor --reason "describe the change"
+### Input types
+
+| Type          | Description                            |
+| ------------- | -------------------------------------- |
+| `string`      | Single string value                    |
+| `string_list` | Repeatable value (`--flag a --flag b`) |
+| `path`        | File path value                        |
+| `choice`      | Constrained to a set of `choices`      |
+| `boolean`     | Boolean flag (`true`/`false`)          |
+
+### Step types
+
+<!-- {=cliStepTypes} -->
+
+**Standalone steps** (no prerequisites):
+
+- `Validate` — validate config and changeset targets
+- `Discover` — discover packages across ecosystems
+- `CreateChangeFile` — write a `.changeset/*.md` file
+- `AffectedPackages` — evaluate changeset policy from CI-supplied paths and labels
+- `DiagnoseChangesets` — show changeset context and review metadata
+- `RetargetRelease` — repair a recent release by moving its tags
+
+**Release-state consumer steps** (require `PrepareRelease`):
+
+- `PrepareRelease` — compute release plan, update versions, changelogs, and versioned files
+- `CommitRelease` — create a local release commit
+- `RenderReleaseManifest` — write a stable JSON manifest
+- `PublishRelease` — create provider releases
+- `OpenReleaseRequest` — open or update a release pull request
+- `CommentReleasedIssues` — comment on issues referenced in changesets
+
+**Generic step:**
+
+- `Command` — run an arbitrary shell command with template interpolation
+
+<!-- {/cliStepTypes} -->
+
+### Command step features
+
+`Command` steps support template interpolation with built-in variables (`{{ version }}`, `{{ group_version }}`, `{{ released_packages }}`, `{{ changed_files }}`, `{{ changesets }}`), CLI input forwarding via `{{ inputs.name }}`, and step output references via `{{ steps.ID.stdout }}`.
+
+```toml
+[cli.post-release]
+help_text = "Release and run post-release commands"
+
+[[cli.post-release.steps]]
+type = "PrepareRelease"
+
+[[cli.post-release.steps]]
+type = "Command"
+id = "notify"
+command = "echo Released {{ version }}"
+shell = true
 ```
 
-Prefer explicit change files over ad hoc notes. Keep `.changeset/*.md` aligned with configured package or group ids.
+`shell` accepts `true` (uses `sh -c`), a shell name like `"bash"`, or `false`/omitted for direct execution.
 
-### Preview release effects
+## Configuration reference
 
-```bash
-mc release --dry-run --format json
+### Defaults
+
+```toml
+[defaults]
+parent_bump = "patch"
+include_private = false
+warn_on_group_mismatch = true
+strict_version_conflicts = false
+# package_type = "cargo"
+
+[defaults.changelog]
+path = "{{ path }}/changelog.md"
+format = "keep_a_changelog"
 ```
 
-Use dry-run output before real release preparation. Review:
+### Release titles
 
-- release targets
-- propagated bumps
-- changelog output
-- deleted changesets
-- changed files
+<!-- {=releaseTitleConfig} -->
 
-### Generate downstream automation input
+Two template fields control how release names and changelog version headings render:
 
-```bash
-mc release-manifest --dry-run
+- **`release_title`** — plain text title for provider releases (GitHub, GitLab, Gitea)
+- **`changelog_version_title`** — markdown-capable title for changelog version headings
+
+Both are configurable at `[defaults]`, `[package.*]`, and `[group.*]` levels.
+
+Available template variables: `{{ version }}`, `{{ id }}`, `{{ date }}`, `{{ time }}`, `{{ datetime }}`, `{{ changes_count }}`, `{{ tag_url }}`, `{{ compare_url }}`.
+
+```toml
+[defaults]
+release_title = "{{ version }} ({{ date }})"
+changelog_version_title = "[{{ version }}]({{ tag_url }}) ({{ date }})"
+
+[group.main]
+release_title = "v{{ version }} — released {{ date }}"
 ```
 
-Use this when downstream CI or source-provider automation needs stable machine-readable release data.
+<!-- {/releaseTitleConfig} -->
+
+### Versioned files
+
+`versioned_files` update additional managed files beyond native manifests when versions change:
+
+```toml
+# package-scoped shorthand infers the package ecosystem
+versioned_files = ["Cargo.toml"]
+versioned_files = ["**/crates/*/Cargo.toml"]
+
+# explicit typed entries
+versioned_files = [{ path = "group.toml", type = "cargo", name = "sdk-core" }]
+
+# regex entries update plain-text files (must include (?<version>...) capture)
+versioned_files = [
+	{ path = "README.md", regex = 'v(?<version>\d+\.\d+\.\d+)' },
+]
+```
+
+### Lockfile commands
+
+Lockfile refresh is command-driven. monochange infers defaults when not configured:
+
+- Cargo: `cargo generate-lockfile`
+- npm-family: detects owned lockfiles and runs the matching command (`npm install --package-lock-only`, `pnpm install --lockfile-only`, `bun install --lockfile-only`)
+- Dart / Flutter: `dart pub get` or `flutter pub get`
+- Deno: no inferred default
+
+Explicit configuration overrides inference:
+
+```toml
+[ecosystems.npm]
+lockfile_commands = [
+	{ command = "pnpm install --lockfile-only", cwd = "packages/web" },
+	{ command = "npm install --package-lock-only", cwd = "packages/legacy", shell = true },
+]
+```
+
+### Groups
+
+Groups synchronize versions across packages:
+
+```toml
+[group.sdk]
+packages = ["sdk-core", "web-sdk"]
+tag = true
+release = true
+version_format = "primary"
+
+[group.sdk.changelog]
+path = "changelog.md"
+include = ["sdk-cli"]
+```
+
+### Changeset verification
+
+```toml
+[changesets.verify]
+enabled = true
+required = true
+skip_labels = ["no-changeset-required"]
+comment_on_failure = true
+```
 
 ## Important modeling rules
 
@@ -94,21 +253,28 @@ Use this when downstream CI or source-provider automation needs stable machine-r
 - Groups own outward release identity for their member packages.
 - Package changelogs and package versioned files may still apply even when a group owns versioning.
 - Changesets should reference configured package ids or group ids.
+- Prefer package ids over group ids when the change is package-specific — monochange propagates to dependents and groups automatically.
 - Source-provider release publishing is downstream from prepared release data, not a substitute for planning.
+- Changelog version headings now include the release date by default. Set `changelog_version_title = "{{ version }}"` to restore the previous format.
 
-## Assistant setup guidance
+## MCP server
 
-Recommended repo-local guidance for agents:
+The MCP server exposes reviewable, JSON-first tools for workspace inspection and release planning:
 
-- Read `monochange.toml` before proposing release changes.
-- Prefer `mc validate` before and after config edits.
-- Use `mc discover --format json` to verify package ids and group ownership.
-- Use `mc release --dry-run --format json` before mutating release state.
-- Keep docs, templates, changelog behavior, and CLI config examples synchronized with code changes.
+<!-- {=mcpToolsList} -->
 
-## MCP setup target
+- `monochange_validate` — validate `monochange.toml` and `.changeset` targets
+- `monochange_discover` — discover packages, dependencies, and groups across the repository
+- `monochange_change` — write a `.changeset` markdown file for one or more package or group ids
+- `monochange_release_preview` — prepare a dry-run release preview from discovered `.changeset` files
+- `monochange_release_manifest` — generate a dry-run release manifest JSON document for downstream automation
+- `monochange_affected_packages` — evaluate changeset policy from changed paths and optional labels
 
-The planned MCP setup should look like:
+<!-- {/mcpToolsList} -->
+
+### MCP configuration
+
+<!-- {=mcpConfigSnippet} -->
 
 ```json
 {
@@ -121,4 +287,23 @@ The planned MCP setup should look like:
 }
 ```
 
-The initial MCP server should focus on safe, reviewable tools such as validation, discovery, changeset verification, release preview, and release-manifest generation.
+<!-- {/mcpConfigSnippet} -->
+
+Start the server manually: `mc mcp`
+
+Print assistant-specific setup guidance: `mc assist claude`, `mc assist generic`, `mc assist pi`
+
+## Repo-local guidance for assistants
+
+<!-- {=assistantRepoGuidance} -->
+
+- Read `monochange.toml` before proposing release workflow changes.
+- Run `mc validate` before and after release-affecting edits.
+- Use `mc discover --format json` to inspect package ids, group ownership, and dependency edges.
+- Use `mc diagnostics --format json` for a structured view of all pending changesets with git and review context.
+- Prefer `mc change` plus `.changeset/*.md` files over ad hoc release notes.
+- Use `mc release --dry-run --format json` before mutating release state.
+
+<!-- {/assistantRepoGuidance} -->
+
+When you need full changeset context — introduced commit, linked PR, related issues — use `mc diagnostics --format json` directly. It returns stable workspace-relative paths and structured records that agents can parse without reading raw markdown files.

--- a/skills/monochange/SKILL.md
+++ b/skills/monochange/SKILL.md
@@ -1,34 +1,148 @@
 ---
 name: monochange
-description: Guides agents through monochange discovery, changesets, release planning, and provider-aware release workflows. Use when working on `monochange.toml`, `.changeset/*.md`, release automation, grouped versions, or cross-ecosystem monorepo releases.
+description: Guides agents through monochange discovery, changesets, release planning, and provider-aware release workflows. Use when working on `monochange.toml`, `.changeset/*.md`, release automation, grouped versions, cross-ecosystem monorepo releases, CLI step composition, or MCP tool interactions.
 ---
 
 # monochange
 
 ## Quick start
 
-1. Read `monochange.toml` first.
+1. Read `monochange.toml` first — it is the single source of truth.
 2. Run `mc validate` before making release-affecting edits.
 3. Use `mc discover --format json` to inspect the workspace model.
-4. Use `mc change` and `mc release --dry-run --format json` before mutating release state.
+4. Use `mc change` to write explicit release intent as `.changeset/*.md` files.
+5. Use `mc release --dry-run --format json` before mutating release state.
+6. Use `mc diagnostics --format json` to inspect changeset context and git provenance.
 
 ## Working rules
 
-- Treat `monochange.toml` as the source of truth for packages, groups, source providers, and `[cli.<command>]` entries.
+- Treat `monochange.toml` as the source of truth for packages, groups, source providers, ecosystems, and `[cli.<command>]` entries.
 - Prefer configured package or group ids over guessing manifest names.
-- Use `.changeset/*.md` files for explicit release intent.
+- Use `.changeset/*.md` files for explicit release intent — each targets one or more package/group ids with a bump severity, optional `type`, optional explicit `version`, and a human-readable summary.
 - Run dry-run flows before real release commands.
 - Keep docs, templates, and changelog behavior aligned with config changes.
+- Use `mc diagnostics --format json` to audit changesets before release — it shows git provenance, linked PRs, related issues, and introduced/last-updated commits.
 
-## Release workflow
+## Recommended command flow
 
-- Validate with `mc validate`.
-- Inspect workspace state with `mc discover --format json`.
-- Add or update changesets with `mc change`.
-- Preview release effects with `mc release --dry-run --format json`.
-- Use `mc release-manifest --dry-run` for downstream automation inputs.
-- Only use source-provider publishing after reviewing prepared release data.
+<!-- {=recommendedCommandFlow} -->
+
+1. **Validate** — `mc validate` checks config and changeset targets.
+2. **Discover** — `mc discover --format json` inspects the workspace model.
+3. **Create changesets** — `mc change --package <id> --bump <severity> --reason "..."` writes explicit release intent.
+4. **Preview release** — `mc release --dry-run --format json` shows planned bumps, changelog output, and changed files.
+5. **Inspect changeset context** — `mc diagnostics --format json` shows git provenance and linked review metadata for all pending changesets.
+6. **Generate manifest** — `mc release-manifest --dry-run` writes a stable JSON artifact for downstream automation.
+7. **Publish** — `mc publish-release --format json` creates provider releases after human review.
+
+<!-- {/recommendedCommandFlow} -->
+
+## CLI commands
+
+| Command               | Purpose                                                     |
+| --------------------- | ----------------------------------------------------------- |
+| `mc init`             | Generate a starter `monochange.toml` from detected packages |
+| `mc validate`         | Validate config and changeset targets                       |
+| `mc discover`         | Discover packages across ecosystems                         |
+| `mc change`           | Create a `.changeset/*.md` file                             |
+| `mc release`          | Prepare a release plan from changesets                      |
+| `mc commit-release`   | Prepare a release and create a local commit                 |
+| `mc release-manifest` | Write a stable JSON manifest for automation                 |
+| `mc publish-release`  | Create provider releases                                    |
+| `mc release-pr`       | Open or update a release pull request                       |
+| `mc affected`         | Evaluate changeset policy from changed paths                |
+| `mc diagnostics`      | Show changeset context with git and review metadata         |
+| `mc repair-release`   | Repair a recent release by retargeting tags                 |
+| `mc assist`           | Print assistant install and MCP setup guidance              |
+| `mc mcp`              | Start the stdio MCP server                                  |
+
+## CLI step types
+
+<!-- {=cliStepTypes} -->
+
+**Standalone steps** (no prerequisites):
+
+- `Validate` — validate config and changeset targets
+- `Discover` — discover packages across ecosystems
+- `CreateChangeFile` — write a `.changeset/*.md` file
+- `AffectedPackages` — evaluate changeset policy from CI-supplied paths and labels
+- `DiagnoseChangesets` — show changeset context and review metadata
+- `RetargetRelease` — repair a recent release by moving its tags
+
+**Release-state consumer steps** (require `PrepareRelease`):
+
+- `PrepareRelease` — compute release plan, update versions, changelogs, and versioned files
+- `CommitRelease` — create a local release commit
+- `RenderReleaseManifest` — write a stable JSON manifest
+- `PublishRelease` — create provider releases
+- `OpenReleaseRequest` — open or update a release pull request
+- `CommentReleasedIssues` — comment on issues referenced in changesets
+
+**Generic step:**
+
+- `Command` — run an arbitrary shell command with template interpolation
+
+<!-- {/cliStepTypes} -->
+
+## MCP tools
+
+<!-- {=mcpToolsList} -->
+
+- `monochange_validate` — validate `monochange.toml` and `.changeset` targets
+- `monochange_discover` — discover packages, dependencies, and groups across the repository
+- `monochange_change` — write a `.changeset` markdown file for one or more package or group ids
+- `monochange_release_preview` — prepare a dry-run release preview from discovered `.changeset` files
+- `monochange_release_manifest` — generate a dry-run release manifest JSON document for downstream automation
+- `monochange_affected_packages` — evaluate changeset policy from changed paths and optional labels
+
+<!-- {/mcpToolsList} -->
+
+## Key configuration concepts
+
+### Versioned files
+
+`versioned_files` update additional managed files beyond native manifests when versions change. Three forms:
+
+- **Package-scoped shorthand**: `versioned_files = ["Cargo.toml"]` — infers the package ecosystem
+- **Explicit typed entries**: `versioned_files = [{ path = "group.toml", type = "cargo" }]`
+- **Regex entries**: `versioned_files = [{ path = "README.md", regex = 'v(?<version>\d+\.\d+\.\d+)' }]` — for plain-text files; must include a named `version` capture
+
+### Lockfile commands
+
+Lockfile refresh is command-driven via `[ecosystems.<name>].lockfile_commands`. monochange infers sensible defaults for Cargo, npm-family, and Dart/Flutter. Explicit configuration overrides inference.
+
+### Release titles
+
+<!-- {=releaseTitleConfig} -->
+
+Two template fields control how release names and changelog version headings render:
+
+- **`release_title`** — plain text title for provider releases (GitHub, GitLab, Gitea)
+- **`changelog_version_title`** — markdown-capable title for changelog version headings
+
+Both are configurable at `[defaults]`, `[package.*]`, and `[group.*]` levels.
+
+Available template variables: `{{ version }}`, `{{ id }}`, `{{ date }}`, `{{ time }}`, `{{ datetime }}`, `{{ changes_count }}`, `{{ tag_url }}`, `{{ compare_url }}`.
+
+```toml
+[defaults]
+release_title = "{{ version }} ({{ date }})"
+changelog_version_title = "[{{ version }}]({{ tag_url }}) ({{ date }})"
+
+[group.main]
+release_title = "v{{ version }} — released {{ date }}"
+```
+
+<!-- {/releaseTitleConfig} -->
+
+### Groups and changelog filtering
+
+Groups synchronize versions across packages. Group changelogs can filter included entries:
+
+- `include = "all"` — all member changesets (default)
+- `include = "group-only"` — only direct group-targeted changesets
+- `include = ["package-id"]` — specific member changesets plus group-targeted ones
 
 ## Guidance
 
-See [REFERENCE.md](REFERENCE.md) for install steps, command selection, grouped release rules, and assistant setup guidance.
+See [REFERENCE.md](REFERENCE.md) for install steps, changeset authoring, grouped release rules, input types, step composition, and assistant setup guidance.


### PR DESCRIPTION
## Summary

- Update the monochange agent skill (`SKILL.md`, `REFERENCE.md`) with all current features: CLI step types and composition, MCP tools, `mc diagnostics`, `mc assist`, `mc init`, regex `versioned_files`, lockfile commands, `release_title`/`changelog_version_title`, group changelog include filters, changeset object syntax, and `Command` step interpolation
- Fix `docs/src/guide/09-assistant-setup.md` to use the correct MCP tool name (`monochange_affected_packages` instead of `monochange_verify_changesets`)
- Add 6 reusable mdt snippets to `.templates/guides.t.md` shared between skill files and docs book
- Add `release_title` and `changelog_version_title` documentation to `monochange.init.toml`

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test -p monochange --lib` passes (271 tests)
- [x] `cargo test -p monochange_book` passes
- [x] `mdt check` — all consumer blocks in sync
- [x] `mdt doctor` — 10 pass, 0 fail
- [x] `dprint check` — formatting clean