### PR TITLE
feat: remove `mc commit-release` and improve `mc validate`

### DIFF
--- a/.changeset/043-validate-and-cleanup.md
+++ b/.changeset/043-validate-and-cleanup.md
@@ -1,0 +1,9 @@
+---
+monochange: patch
+monochange_config: patch
+monochange_core: patch
+---
+
+Remove `mc commit-release` from default CLI commands. Users who need this workflow can define it in their `monochange.toml` using `PrepareRelease` and `CommitRelease` steps.
+
+Add content-level validation to `mc validate` for versioned files: checks that referenced files exist on disk, ecosystem-typed files contain a readable version field, regex patterns match actual file content, and warns when glob patterns match no files.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1784,6 +1784,7 @@ dependencies = [
  "rstest",
  "semver",
  "serde",
+ "serde_json",
  "serde_yaml_ng",
  "similar-asserts",
  "tempfile",

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -117,30 +117,11 @@ fn cli_help_returns_success_output() {
 	assert!(output.contains("assist"));
 	assert!(output.contains("mcp"));
 	assert!(output.contains("change"));
-	assert!(output.contains("commit-release"));
 	assert!(output.contains("diagnostics"));
 	assert!(output.contains("repair-release"));
 	assert!(output.contains("release-record"));
 }
 
-#[test]
-fn commit_release_help_describes_local_commit_workflow() {
-	let output = run_with_args(
-		"mc",
-		[
-			OsString::from("mc"),
-			OsString::from("commit-release"),
-			OsString::from("--help"),
-		],
-	)
-	.unwrap_or_else(|error| panic!("commit-release help: {error}"));
-
-	assert!(output.contains("Prepare a release and create a local release commit"));
-	assert!(output.contains("mc commit-release --dry-run --format json"));
-	assert!(output.contains("mc commit-release --dry-run --diff"));
-	assert!(output.contains("--diff"));
-	assert!(output.contains("Embeds a durable release record block in the commit body"));
-}
 
 #[test]
 fn repair_release_help_describes_retargeting_workflow() {

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -235,6 +235,10 @@ pub(crate) fn execute_cli_command_with_options(
 			CliStepDefinition::Validate { .. } => {
 				validate_workspace(root)?;
 				validate_cargo_workspace_version_groups(root)?;
+				let warnings = validate_versioned_files_content(root)?;
+				for warning in &warnings {
+					eprintln!("warning: {warning}");
+				}
 				output = Some(format!(
 					"workspace validation passed for {}",
 					root_relative(root, root).display()

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -61,6 +61,7 @@ use monochange_cargo::RustSemverProvider;
 use monochange_config::load_changeset_file;
 use monochange_config::load_workspace_configuration;
 use monochange_config::resolve_package_reference;
+use monochange_config::validate_versioned_files_content;
 use monochange_config::validate_workspace;
 use monochange_core::materialize_dependency_edges;
 use monochange_core::relative_to_root;

--- a/crates/monochange/src/monochange.init.toml
+++ b/crates/monochange/src/monochange.init.toml
@@ -624,21 +624,6 @@ default = "text"
 [[cli.release.steps]]
 type = "PrepareRelease"
 
-[cli.commit-release]
-help_text = "Prepare a release and create a local release commit"
-
-[[cli.commit-release.inputs]]
-name = "format"
-type = "choice"
-choices = ["text", "json"]
-default = "text"
-
-[[cli.commit-release.steps]]
-type = "PrepareRelease"
-
-[[cli.commit-release.steps]]
-type = "CommitRelease"
-
 [cli.affected]
 help_text = "Evaluate pull-request changeset policy"
 

--- a/crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_prints_help.snap
+++ b/crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_prints_help.snap
@@ -24,7 +24,6 @@ Commands:
   discover        Discover packages across supported ecosystems
   change          Create a change file for one or more packages
   release         Prepare a release from discovered change files
-  commit-release  Prepare a release and create a local release commit with an embedded monochange release record
   affected        Show packages affected by file changes and their changeset coverage
   diagnostics     Show per-changeset diagnostics including context and commit/PR context
   repair-release  Repair a recent release by moving its release tags to a later commit

--- a/crates/monochange_config/Cargo.toml
+++ b/crates/monochange_config/Cargo.toml
@@ -28,6 +28,7 @@ monochange_npm = { workspace = true }
 regex = { workspace = true, default-features = true }
 semver = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }
+serde_json = { workspace = true, default-features = true }
 serde_yaml_ng = { workspace = true, default-features = true }
 thiserror = { workspace = true, default-features = true }
 toml = { workspace = true, default-features = true }

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -83,7 +83,7 @@ fn load_workspace_configuration_uses_defaults_when_file_is_missing() {
 	assert_eq!(configuration.defaults.empty_update_message, None);
 	assert!(configuration.packages.is_empty());
 	assert!(configuration.groups.is_empty());
-	assert_eq!(configuration.cli.len(), 8);
+	assert_eq!(configuration.cli.len(), 7);
 	let cli_command_names = configuration
 		.cli
 		.iter()
@@ -96,7 +96,6 @@ fn load_workspace_configuration_uses_defaults_when_file_is_missing() {
 			"discover",
 			"change",
 			"release",
-			"commit-release",
 			"affected",
 			"diagnostics",
 			"repair-release"
@@ -2474,4 +2473,51 @@ fn load_workspace_configuration_rejects_versioned_file_without_type_or_regex() {
 
 	assert!(rendered.contains("versioned_files must set `type`"));
 	assert!(rendered.contains("versioned_files entry is missing `type`"));
+}
+
+// -- validate_versioned_files_content tests --
+
+#[test]
+fn validate_versioned_files_content_rejects_missing_file() {
+	let root = fixture_path("config/versioned-file-missing");
+	let error = crate::validate_versioned_files_content(&root)
+		.err()
+		.unwrap_or_else(|| panic!("expected error for missing versioned file"));
+	assert!(
+		error
+			.to_string()
+			.contains("does-not-exist.toml")
+	);
+	assert!(error.to_string().contains("does not exist"));
+}
+
+#[test]
+fn validate_versioned_files_content_rejects_regex_without_match() {
+	let root = fixture_path("config/versioned-file-regex-no-match");
+	let error = crate::validate_versioned_files_content(&root)
+		.err()
+		.unwrap_or_else(|| panic!("expected error for regex without match"));
+	assert!(error.to_string().contains("does not match any content"));
+}
+
+#[test]
+fn validate_versioned_files_content_rejects_unparseable_version() {
+	let root = fixture_path("config/versioned-file-unparseable-version");
+	let error = crate::validate_versioned_files_content(&root)
+		.err()
+		.unwrap_or_else(|| panic!("expected error for missing version field"));
+	assert!(
+		error
+			.to_string()
+			.contains("does not contain a readable version field")
+	);
+}
+
+#[test]
+fn validate_versioned_files_content_warns_on_empty_glob() {
+	let root = fixture_path("config/versioned-file-empty-glob");
+	let warnings = crate::validate_versioned_files_content(&root)
+		.unwrap_or_else(|error| panic!("expected Ok with warnings, got error: {error}"));
+	assert_eq!(warnings.len(), 1);
+	assert!(warnings.first().unwrap().contains("matches no files"));
 }

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -3396,6 +3396,217 @@ pub fn validate_workspace(root: &Path) -> MonochangeResult<()> {
 	Ok(())
 }
 
+/// Validate that versioned file paths exist on disk, ecosystem-typed files
+/// contain a readable version field, and regex patterns match actual file
+/// content. Returns a list of non-fatal warnings (e.g. empty glob matches).
+///
+/// This is separate from the structural validation in
+/// `validate_versioned_files()` because it performs file I/O and should only
+/// run during the explicit `mc validate` command, not on every config load.
+pub fn validate_versioned_files_content(root: &Path) -> MonochangeResult<Vec<String>> {
+	let configuration = load_workspace_configuration(root)?;
+	let mut warnings = Vec::new();
+
+	// Collect all (owner_kind, owner_id, definitions) triples.
+	let mut sources: Vec<(&str, String, &[VersionedFileDefinition])> = Vec::new();
+
+	for package in &configuration.packages {
+		sources.push(("package", package.id.clone(), &package.versioned_files));
+	}
+	for group in &configuration.groups {
+		sources.push(("group", group.id.clone(), &group.versioned_files));
+	}
+
+	let ecosystem_entries: &[(&str, &EcosystemSettings)] = &[
+		("cargo", &configuration.cargo),
+		("npm", &configuration.npm),
+		("deno", &configuration.deno),
+		("dart", &configuration.dart),
+	];
+	for &(eco_name, settings) in ecosystem_entries {
+		if !settings.versioned_files.is_empty() {
+			sources.push(("ecosystem", eco_name.to_string(), &settings.versioned_files));
+		}
+	}
+
+	for (owner_kind, owner_id, definitions) in &sources {
+		for definition in *definitions {
+			validate_single_versioned_file_content(
+				root,
+				definition,
+				owner_kind,
+				owner_id,
+				&mut warnings,
+			)?;
+		}
+	}
+
+	Ok(warnings)
+}
+
+fn validate_single_versioned_file_content(
+	root: &Path,
+	definition: &VersionedFileDefinition,
+	owner_kind: &str,
+	owner_id: &str,
+	warnings: &mut Vec<String>,
+) -> MonochangeResult<()> {
+	if path_uses_glob(&definition.path) {
+		// Glob path: warn if zero files match.
+		let pattern = root
+			.join(&definition.path)
+			.to_string_lossy()
+			.to_string();
+		let matches = glob::glob(&pattern)
+			.map_err(|error| {
+				MonochangeError::Config(format!(
+					"invalid glob pattern `{}`: {error}",
+					definition.path
+				))
+			})?
+			.filter_map(Result::ok)
+			.collect::<Vec<_>>();
+		if matches.is_empty() {
+			warnings.push(format!(
+				"{owner_kind} `{owner_id}` versioned file glob `{}` matches no files",
+				definition.path
+			));
+		}
+		// For globs we skip per-file content validation since the set of
+		// matched files may change between validation and release time.
+		return Ok(());
+	}
+
+	let full_path = root.join(&definition.path);
+	if !full_path.exists() {
+		return Err(MonochangeError::Config(format!(
+			"{owner_kind} `{owner_id}` versioned file `{}` does not exist",
+			definition.path
+		)));
+	}
+
+	if let Some(regex_pattern) = &definition.regex {
+		// Regex versioned file: verify pattern matches file content.
+		let contents = fs::read_to_string(&full_path).map_err(|error| {
+			MonochangeError::Io(format!(
+				"failed to read `{}`: {error}",
+				definition.path
+			))
+		})?;
+		let compiled = Regex::new(regex_pattern).map_err(|error| {
+			MonochangeError::Config(format!(
+				"{owner_kind} `{owner_id}` regex `{regex_pattern}` is invalid: {error}"
+			))
+		})?;
+		if !compiled.is_match(&contents) {
+			return Err(MonochangeError::Config(format!(
+				"{owner_kind} `{owner_id}` versioned file `{}` regex `{regex_pattern}` does not match any content in the file",
+				definition.path
+			)));
+		}
+		return Ok(());
+	}
+
+	if let Some(ecosystem_type) = definition.ecosystem_type {
+		// Ecosystem-typed versioned file: verify version field is readable.
+		validate_ecosystem_version_readable(
+			&full_path,
+			&definition.path,
+			ecosystem_type,
+			definition.fields.as_deref(),
+			owner_kind,
+			owner_id,
+		)?;
+	}
+
+	Ok(())
+}
+
+fn validate_ecosystem_version_readable(
+	full_path: &Path,
+	display_path: &str,
+	ecosystem_type: EcosystemType,
+	fields: Option<&[String]>,
+	owner_kind: &str,
+	owner_id: &str,
+) -> MonochangeResult<()> {
+	let contents = fs::read_to_string(full_path).map_err(|error| {
+		MonochangeError::Io(format!("failed to read `{display_path}`: {error}"))
+	})?;
+
+	match ecosystem_type {
+		EcosystemType::Cargo => {
+			let doc: toml::Value = toml::from_str(&contents).map_err(|error| {
+				MonochangeError::Config(format!(
+					"{owner_kind} `{owner_id}` versioned file `{display_path}` is not valid TOML: {error}"
+				))
+			})?;
+
+			// Check the configured fields, or fall back to common Cargo version
+			// paths including a bare root-level `version` (used by custom TOML
+			// files like group.toml).
+			let field_paths: Vec<&str> = match fields {
+				Some(f) if !f.is_empty() => f.iter().map(String::as_str).collect(),
+				_ => vec!["package.version", "workspace.package.version", "version"],
+			};
+
+			let found = field_paths.iter().any(|field_path| {
+				let parts: Vec<&str> = field_path.split('.').collect();
+				let mut current = &doc;
+				for part in &parts {
+					match current.get(part) {
+						Some(next) => current = next,
+						None => return false,
+					}
+				}
+				current.is_str()
+			});
+
+			if !found {
+				return Err(MonochangeError::Config(format!(
+					"{owner_kind} `{owner_id}` versioned file `{display_path}` does not contain a readable version field (checked: {})",
+					field_paths.join(", ")
+				)));
+			}
+		}
+		EcosystemType::Npm | EcosystemType::Deno => {
+			let json: serde_json::Value =
+				serde_json::from_str(&contents).map_err(|error| {
+					MonochangeError::Config(format!(
+						"{owner_kind} `{owner_id}` versioned file `{display_path}` is not valid JSON: {error}"
+					))
+				})?;
+
+			let field_name = match fields {
+				Some(f) if !f.is_empty() => f.first().map(String::as_str).unwrap_or("version"),
+				_ => "version",
+			};
+
+			if json.get(field_name).and_then(|v| v.as_str()).is_none() {
+				return Err(MonochangeError::Config(format!(
+					"{owner_kind} `{owner_id}` versioned file `{display_path}` does not contain a `{field_name}` string field"
+				)));
+			}
+		}
+		EcosystemType::Dart => {
+			let yaml: serde_yaml_ng::Value =
+				serde_yaml_ng::from_str(&contents).map_err(|error| {
+					MonochangeError::Config(format!(
+						"{owner_kind} `{owner_id}` versioned file `{display_path}` is not valid YAML: {error}"
+					))
+				})?;
+
+			if yaml.get("version").and_then(|v| v.as_str()).is_none() {
+				return Err(MonochangeError::Config(format!(
+					"{owner_kind} `{owner_id}` versioned file `{display_path}` does not contain a `version` string field"
+				)));
+			}
+		}
+	}
+
+	Ok(())
+}
+
 fn validate_changeset_targets(
 	configuration: &WorkspaceConfiguration,
 	changeset_path: &Path,

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -2586,30 +2586,6 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 			}],
 		},
 		CliCommandDefinition {
-			name: "commit-release".to_string(),
-			help_text: Some(
-				"Prepare a release and create a local release commit with an embedded monochange release record"
-					.to_string(),
-			),
-			inputs: vec![CliInputDefinition {
-				name: "format".to_string(),
-				kind: CliInputKind::Choice,
-				help_text: Some("Output format".to_string()),
-				required: false,
-				default: Some("text".to_string()),
-				choices: vec!["text".to_string(), "json".to_string()],
-				short: None,
-			}],
-			steps: vec![
-				CliStepDefinition::PrepareRelease {
-					inputs: BTreeMap::new(),
-				},
-				CliStepDefinition::CommitRelease {
-					inputs: BTreeMap::new(),
-				},
-			],
-		},
-		CliCommandDefinition {
 			name: "affected".to_string(),
 			help_text: Some(
 				"Show packages affected by file changes and their changeset coverage".to_string(),

--- a/fixtures/tests/config/versioned-file-empty-glob/crates/core/Cargo.toml
+++ b/fixtures/tests/config/versioned-file-empty-glob/crates/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "workflow-core"
+version = "1.0.0"
+edition = "2021"

--- a/fixtures/tests/config/versioned-file-empty-glob/monochange.toml
+++ b/fixtures/tests/config/versioned-file-empty-glob/monochange.toml
@@ -1,0 +1,8 @@
+[defaults]
+package_type = "cargo"
+
+[package.core]
+path = "crates/core"
+versioned_files = [
+    { path = "nonexistent/**/*.toml", type = "cargo" }
+]

--- a/fixtures/tests/config/versioned-file-missing/crates/core/Cargo.toml
+++ b/fixtures/tests/config/versioned-file-missing/crates/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "workflow-core"
+version = "1.0.0"
+edition = "2021"

--- a/fixtures/tests/config/versioned-file-missing/monochange.toml
+++ b/fixtures/tests/config/versioned-file-missing/monochange.toml
@@ -1,0 +1,8 @@
+[defaults]
+package_type = "cargo"
+
+[package.core]
+path = "crates/core"
+versioned_files = [
+    { path = "does-not-exist.toml", type = "cargo" }
+]

--- a/fixtures/tests/config/versioned-file-regex-no-match/crates/core/Cargo.toml
+++ b/fixtures/tests/config/versioned-file-regex-no-match/crates/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "workflow-core"
+version = "1.0.0"
+edition = "2021"

--- a/fixtures/tests/config/versioned-file-regex-no-match/crates/core/README.md
+++ b/fixtures/tests/config/versioned-file-regex-no-match/crates/core/README.md
@@ -1,0 +1,3 @@
+# workflow-core
+
+This file has no download link matching the regex.

--- a/fixtures/tests/config/versioned-file-regex-no-match/monochange.toml
+++ b/fixtures/tests/config/versioned-file-regex-no-match/monochange.toml
@@ -1,0 +1,8 @@
+[defaults]
+package_type = "cargo"
+
+[package.core]
+path = "crates/core"
+versioned_files = [
+    { path = "crates/core/README.md", regex = 'download/v(?<version>\d+\.\d+\.\d+)\.tgz' }
+]

--- a/fixtures/tests/config/versioned-file-unparseable-version/crates/core/Cargo.toml
+++ b/fixtures/tests/config/versioned-file-unparseable-version/crates/core/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "workflow-core"
+edition = "2021"

--- a/fixtures/tests/config/versioned-file-unparseable-version/monochange.toml
+++ b/fixtures/tests/config/versioned-file-unparseable-version/monochange.toml
@@ -1,0 +1,8 @@
+[defaults]
+package_type = "cargo"
+
+[package.core]
+path = "crates/core"
+versioned_files = [
+    { path = "crates/core/Cargo.toml", type = "cargo" }
+]


### PR DESCRIPTION
## Summary

- Remove `mc commit-release` from default CLI commands and init template — users can still define it in their own `monochange.toml` using `PrepareRelease` + `CommitRelease` steps
- Add `validate_versioned_files_content()` to `mc validate` that checks versioned files exist on disk, ecosystem-typed files contain a readable version field, and regex patterns match actual file content
- Content validation runs only during the `Validate` step (not on every config load) to avoid slowing down other commands

## Test plan

- [x] All 127 monochange_config tests pass (including 4 new content validation tests)
- [x] All 270 monochange tests pass
- [x] Full workspace test suite passes (zero failures)
- [x] CI checks pass