### PR TITLE
fix: add bounds check for JSON string escape sequences

### DIFF
--- a/.changeset/044-json-parser-bounds.md
+++ b/.changeset/044-json-parser-bounds.md
@@ -1,0 +1,5 @@
+---
+monochange_core: patch
+---
+
+Add bounds check for JSON string escape sequences to prevent confusing error messages on truncated input.

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -1534,6 +1534,23 @@ fn json_helper_functions_cover_error_paths() {
 	assert!(crate::skip_json_object("{\"a\" 1}", 0).is_err());
 	assert!(crate::parse_json_string_span("abc", 0).is_err());
 	assert!(crate::parse_json_string_span("\"abc", 0).is_err());
+	// Truncated escape: backslash at end of input.
+	let error = crate::parse_json_string_span("\"abc\\", 0)
+		.err()
+		.unwrap_or_else(|| panic!("expected error for truncated escape"));
+	assert!(
+		error
+			.to_string()
+			.contains("unterminated escape sequence"),
+		"expected truncated-escape error, got: {error}"
+	);
+	// Escaped quote should not close the string.
+	assert!(crate::parse_json_string_span("\"abc\\\"", 0).is_err());
+	// Double backslash followed by closing quote should work.
+	let (span, next) = crate::parse_json_string_span("\"abc\\\\\"", 0)
+		.unwrap_or_else(|error| panic!("double-backslash: {error}"));
+	assert_eq!(span, crate::JsonSpan { start: 1, end: 6 });
+	assert_eq!(next, 7);
 }
 
 #[test]

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -1539,9 +1539,7 @@ fn json_helper_functions_cover_error_paths() {
 		.err()
 		.unwrap_or_else(|| panic!("expected error for truncated escape"));
 	assert!(
-		error
-			.to_string()
-			.contains("unterminated escape sequence"),
+		error.to_string().contains("unterminated escape sequence"),
 		"expected truncated-escape error, got: {error}"
 	);
 	// Escaped quote should not close the string.

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -707,6 +707,12 @@ fn parse_json_string_span(contents: &str, start: usize) -> MonochangeResult<(Jso
 	let mut cursor = start + 1;
 	while let Some(&byte) = bytes.get(cursor) {
 		if byte == b'\\' {
+			// Escape sequence: verify there is a character after the backslash.
+			if cursor + 1 >= bytes.len() {
+				return Err(MonochangeError::Config(
+					"unterminated escape sequence in JSON string".to_string(),
+				));
+			}
 			cursor += 2;
 			continue;
 		}


### PR DESCRIPTION
## Summary

- Add explicit bounds check in `parse_json_string_span()` for backslash escapes at end of input
- Return descriptive "unterminated escape sequence" error instead of generic "unterminated string"
- Add tests for truncated escapes, escaped quotes, and double-backslash edge cases

Closes #99

## Test plan

- [x] `cargo test -p monochange_core` passes
- [ ] CI passes