### PR TITLE
test: prove template variables are safe from injection

### DIFF
--- a/.changeset/047-template-safety-test.md
+++ b/.changeset/047-template-safety-test.md
@@ -1,0 +1,5 @@
+---
+monochange: patch
+---
+
+Add test proving that minijinja template variables are safe from injection — changeset content containing curly braces is rendered literally.

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -7523,7 +7523,10 @@ fn apply_versioned_file_definition_reports_missing_ecosystem_type() {
 #[test]
 fn template_rendering_does_not_interpret_variable_content_as_template_syntax() {
 	let mut metadata = BTreeMap::new();
-	metadata.insert("summary", "fix: handle {{ curly_braces }} in output".to_string());
+	metadata.insert(
+		"summary",
+		"fix: handle {{ curly_braces }} in output".to_string(),
+	);
 	metadata.insert("version", "1.0.0".to_string());
 	metadata.insert("package", "core".to_string());
 

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -7519,3 +7519,21 @@ fn apply_versioned_file_definition_reports_missing_ecosystem_type() {
 	.unwrap_or_else(|| panic!("expected missing ecosystem type error"));
 	insta::assert_snapshot!(error.to_string());
 }
+
+#[test]
+fn template_rendering_does_not_interpret_variable_content_as_template_syntax() {
+	let mut metadata = BTreeMap::new();
+	metadata.insert("summary", "fix: handle {{ curly_braces }} in output".to_string());
+	metadata.insert("version", "1.0.0".to_string());
+	metadata.insert("package", "core".to_string());
+
+	let result = crate::changelog::render_message_template(
+		"- {{ summary }} ({{ package }}@{{ version }})",
+		&metadata,
+	);
+
+	assert_eq!(
+		result,
+		"- fix: handle {{ curly_braces }} in output (core@1.0.0)"
+	);
+}


### PR DESCRIPTION
## Summary

The audit flagged changeset content being passed to minijinja templates as a potential injection risk. Investigation shows this is a **false positive** — minijinja does not interpret template syntax inside variable values. `{{ summary }}` outputs the summary string literally, even if it contains `{{ curly_braces }}`.

This PR adds a test proving this safety property so it doesn't regress.

Closes #100

## Test plan

- [x] New test passes: `template_rendering_does_not_interpret_variable_content_as_template_syntax`
- [ ] CI passes