### PR TITLE
perf: load workspace configuration once per command

### DIFF
--- a/.changeset/048-single-config-load.md
+++ b/.changeset/048-single-config-load.md
@@ -1,0 +1,5 @@
+---
+monochange: patch
+---
+
+Load workspace configuration once per command instead of twice, reducing startup overhead.

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -58,14 +58,23 @@ pub(crate) fn apply_runtime_change_type_choices(
 }
 
 pub(crate) fn cli_commands_for_root(root: &Path) -> Vec<CliCommandDefinition> {
-	load_workspace_configuration(root).map_or_else(
-		|_| default_cli_commands(),
-		|configuration| {
+	let configuration = load_workspace_configuration(root);
+	cli_commands_from_config(&configuration)
+}
+
+/// Extract CLI commands from an already-loaded configuration result, avoiding
+/// a redundant config load when the caller has already parsed the config.
+pub(crate) fn cli_commands_from_config(
+	configuration: &Result<monochange_core::WorkspaceConfiguration, monochange_core::MonochangeError>,
+) -> Vec<CliCommandDefinition> {
+	match configuration {
+		Ok(configuration) => {
 			let mut cli = configuration.cli.clone();
-			apply_runtime_change_type_choices(&mut cli, &configuration);
+			apply_runtime_change_type_choices(&mut cli, configuration);
 			cli
-		},
-	)
+		}
+		Err(_) => default_cli_commands(),
+	}
 }
 
 pub(crate) fn build_command_for_root(bin_name: &'static str, root: &Path) -> Command {

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -65,7 +65,10 @@ pub(crate) fn cli_commands_for_root(root: &Path) -> Vec<CliCommandDefinition> {
 /// Extract CLI commands from an already-loaded configuration result, avoiding
 /// a redundant config load when the caller has already parsed the config.
 pub(crate) fn cli_commands_from_config(
-	configuration: &Result<monochange_core::WorkspaceConfiguration, monochange_core::MonochangeError>,
+	configuration: &Result<
+		monochange_core::WorkspaceConfiguration,
+		monochange_core::MonochangeError,
+	>,
 ) -> Vec<CliCommandDefinition> {
 	match configuration {
 		Ok(configuration) => {

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -140,9 +140,9 @@ use serde_json::json;
 
 use assist::run_assist;
 use cli::build_command_with_cli;
-use cli::cli_commands_from_config;
 #[cfg(test)]
 use cli::cli_commands_for_root;
+use cli::cli_commands_from_config;
 use cli::current_dir_or_dot;
 use cli_runtime::execute_matches;
 use git_support::git_commit_paths;

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -140,6 +140,8 @@ use serde_json::json;
 
 use assist::run_assist;
 use cli::build_command_with_cli;
+use cli::cli_commands_from_config;
+#[cfg(test)]
 use cli::cli_commands_for_root;
 use cli::current_dir_or_dot;
 use cli_runtime::execute_matches;
@@ -522,7 +524,7 @@ where
 {
 	let args = args.into_iter().collect::<Vec<_>>();
 	let configuration = load_workspace_configuration(root);
-	let cli = cli_commands_for_root(root);
+	let cli = cli_commands_from_config(&configuration);
 	let matches = match build_command_with_cli(bin_name, &cli).try_get_matches_from(args) {
 		Ok(matches) => matches,
 		Err(error)


### PR DESCRIPTION
## Summary

- Extract `cli_commands_from_config()` that accepts an already-loaded config `Result`, avoiding a redundant `load_workspace_configuration()` call during startup
- Every command now parses the TOML file once instead of twice
- `cli_commands_for_root()` still exists for callers that don't have a pre-loaded config

Closes #101

## Test plan

- [x] All 270 monochange lib tests pass
- [ ] CI passes