### PR TITLE
fix: propagate errors from version group member resolution

### DIFF
--- a/.changeset/045-version-group-errors.md
+++ b/.changeset/045-version-group-errors.md
@@ -1,0 +1,6 @@
+---
+monochange_config: patch
+monochange_core: patch
+---
+
+Propagate errors from version group member resolution instead of silently dropping unresolvable members.

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -2313,7 +2313,7 @@ fn infer_bump_helpers_cover_major_minor_patch_and_none() {
 	);
 	let group = monochange_core::GroupDefinition {
 		id: "sdk".to_string(),
-		packages: vec![core.id.clone(), "missing".to_string(), app.id.clone()],
+		packages: vec![core.id.clone(), app.id.clone()],
 		changelog: None,
 		changelog_include: GroupChangelogInclude::All,
 		extra_changelog_sections: Vec::new(),
@@ -2331,9 +2331,36 @@ fn infer_bump_helpers_cover_major_minor_patch_and_none() {
 			&workspace_root,
 			&[core.clone(), app.clone()],
 			Some(&Version::new(2, 1, 0))
-		),
+		)
+		.unwrap_or_else(|error| panic!("expected Ok, got: {error}")),
 		Some(BumpSeverity::Minor)
 	);
+
+	// A group with an unresolvable member should now produce an error
+	// instead of silently dropping the member.
+	let group_with_missing = monochange_core::GroupDefinition {
+		id: "sdk-missing".to_string(),
+		packages: vec![core.id.clone(), "missing".to_string(), app.id.clone()],
+		changelog: None,
+		changelog_include: GroupChangelogInclude::All,
+		extra_changelog_sections: Vec::new(),
+		empty_update_message: None,
+		release_title: None,
+		changelog_version_title: None,
+		versioned_files: Vec::new(),
+		tag: true,
+		release: true,
+		version_format: monochange_core::VersionFormat::Primary,
+	};
+	let error = crate::infer_group_bump_from_explicit_version(
+		&group_with_missing,
+		&workspace_root,
+		&[core.clone(), app.clone()],
+		Some(&Version::new(2, 1, 0)),
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected error for unresolvable group member"));
+	assert!(error.to_string().contains("missing"));
 	let core_id = core.id.clone();
 	assert_eq!(
 		crate::infer_package_bump_from_explicit_version(

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -1459,8 +1459,7 @@ fn infer_group_bump_from_explicit_version(
 	};
 	let mut max_version: Option<&Version> = None;
 	for member_id in &group.packages {
-		let package_id =
-			resolve_package_reference(member_id, workspace_root, packages)?;
+		let package_id = resolve_package_reference(member_id, workspace_root, packages)?;
 		if let Some(current_version) = packages
 			.iter()
 			.find(|package| package.id == package_id)
@@ -1473,7 +1472,8 @@ fn infer_group_bump_from_explicit_version(
 			});
 		}
 	}
-	Ok(max_version.map(|current_version| infer_bump_from_versions(current_version, explicit_version)))
+	Ok(max_version
+		.map(|current_version| infer_bump_from_versions(current_version, explicit_version)))
 }
 
 fn infer_bump_from_versions(current_version: &Version, explicit_version: &Version) -> BumpSeverity {

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -1324,14 +1324,15 @@ pub fn load_changeset_file(
 	for change in raw.changes {
 		if let Some(group) = groups_by_id.get(change.package.as_str()) {
 			let explicit_version = change.version.clone();
-			let inferred_bump = change.bump.or_else(|| {
-				infer_group_bump_from_explicit_version(
+			let inferred_bump = match change.bump {
+				Some(bump) => Some(bump),
+				None => infer_group_bump_from_explicit_version(
 					group,
 					&configuration.root_path,
 					packages,
 					explicit_version.as_ref(),
-				)
-			});
+				)?,
+			};
 			targets.push(LoadedChangesetTarget {
 				id: change.package.clone(),
 				kind: ChangesetTargetKind::Group,
@@ -1452,20 +1453,27 @@ fn infer_group_bump_from_explicit_version(
 	workspace_root: &Path,
 	packages: &[PackageRecord],
 	explicit_version: Option<&Version>,
-) -> Option<BumpSeverity> {
-	let explicit_version = explicit_version?;
-	group
-		.packages
-		.iter()
-		.filter_map(|member_id| resolve_package_reference(member_id, workspace_root, packages).ok())
-		.filter_map(|package_id| {
-			packages
-				.iter()
-				.find(|package| package.id == package_id)
-				.and_then(|package| package.current_version.as_ref())
-		})
-		.max()
-		.map(|current_version| infer_bump_from_versions(current_version, explicit_version))
+) -> MonochangeResult<Option<BumpSeverity>> {
+	let Some(explicit_version) = explicit_version else {
+		return Ok(None);
+	};
+	let mut max_version: Option<&Version> = None;
+	for member_id in &group.packages {
+		let package_id =
+			resolve_package_reference(member_id, workspace_root, packages)?;
+		if let Some(current_version) = packages
+			.iter()
+			.find(|package| package.id == package_id)
+			.and_then(|package| package.current_version.as_ref())
+		{
+			max_version = Some(match max_version {
+				Some(current_max) if current_version > current_max => current_version,
+				Some(current_max) => current_max,
+				None => current_version,
+			});
+		}
+	}
+	Ok(max_version.map(|current_version| infer_bump_from_versions(current_version, explicit_version)))
 }
 
 fn infer_bump_from_versions(current_version: &Version, explicit_version: &Version) -> BumpSeverity {


### PR DESCRIPTION
## Summary

- Change `infer_group_bump_from_explicit_version()` to return `MonochangeResult<Option<BumpSeverity>>` instead of `Option<BumpSeverity>`
- Errors from `resolve_package_reference()` now propagate instead of being silently dropped via `.ok()`
- A typo in a group member ID will now produce a clear error instead of silently excluding that package from bump calculations
- Update tests to verify both success and error cases

Closes #104

## Test plan

- [x] `cargo test -p monochange_config -p monochange_core` passes (128 + 69 tests)
- [ ] CI passes