### PR TITLE
docs: document mc init --force flag

### DIFF
--- a/docs/src/guide/00-start-here.md
+++ b/docs/src/guide/00-start-here.md
@@ -92,7 +92,7 @@ That is why most beginner flows should start with package ids, not groups.
 
 ## If you hit a problem
 
-- `mc init` says a config already exists: keep the existing `monochange.toml` and continue with `mc validate`.
+- `mc init` says a config already exists: keep the existing `monochange.toml` and continue with `mc validate`, or pass `--force` to regenerate.
 - `mc validate` reports problems: fix the reported config or changeset issue, then rerun `mc validate`.
 - `mc change` rejects your target: rerun `mc discover --format json` and copy a valid package id.
 - You are not sure what to do next: continue with [Your first release plan](./02-setup.md).

--- a/docs/src/guide/02-setup.md
+++ b/docs/src/guide/02-setup.md
@@ -78,7 +78,11 @@ That keeps your first changes simple while still letting monochange synchronize 
 
 ### `mc init` says a config already exists
 
-Keep the existing `monochange.toml`, inspect it, and continue with `mc validate`.
+Keep the existing `monochange.toml`, inspect it, and continue with `mc validate`. If you want to regenerate the config from scratch, pass the `--force` flag:
+
+```sh
+mc init --force
+```
 
 ### `mc validate` reports config or changeset errors
 


### PR DESCRIPTION
## Summary

- Document the `--force` flag for `mc init` in `docs/src/guide/02-setup.md`
- Update `docs/src/guide/00-start-here.md` troubleshooting section

Closes #110

## Test plan

- [x] Documentation only change
- [ ] CI passes