### PR TITLE
chore: document why toml_edit is pinned to 0.25.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,8 @@ tempfile = { version = "^3", default-features = false }
 thiserror = { version = "^2.0.18", default-features = false }
 tokio = { version = "1", default-features = false, features = ["rt", "rt-multi-thread"] }
 toml = { version = "^1.1.2", default-features = false }
+# Pinned: format-preserving edits in Cargo.toml files depend on this version's
+# whitespace and comment handling. Bumping requires verifying manifest output.
 toml_edit = { version = "0.25.10", default-features = false, features = ["parse"] }
 typed-builder = { version = "0.23.2", default-features = false }
 urlencoding = { version = "^2", default-features = false }


### PR DESCRIPTION
## Summary

Add an inline comment explaining the toml_edit version pin is required for format-preserving Cargo.toml edits.

Closes #112

## Test plan

- [x] Comment-only change
- [ ] CI passes