### PR TITLE
fix: reject insecure http:// schemes for source api_url and host

### DIFF
--- a/.changeset/046-api-url-validation.md
+++ b/.changeset/046-api-url-validation.md
@@ -1,0 +1,6 @@
+---
+monochange_config: patch
+monochange_core: patch
+---
+
+Reject insecure http:// schemes for [source].api_url and [source].host to prevent API tokens from being transmitted in cleartext. Warn when GitHub api_url points to a non-standard host.

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -2565,3 +2565,23 @@ fn validate_versioned_files_content_warns_on_empty_glob() {
 	assert_eq!(warnings.len(), 1);
 	assert!(warnings.first().unwrap().contains("matches no files"));
 }
+
+#[test]
+fn validate_api_url_host_rejects_insecure_http_scheme() {
+	let error = crate::validate_api_url_host(
+		"http://attacker.com/api/v3",
+		monochange_core::SourceProvider::GitHub,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected error for http://"));
+	assert!(error.to_string().contains("insecure scheme"));
+}
+
+#[test]
+fn validate_api_url_host_accepts_https_scheme() {
+	crate::validate_api_url_host(
+		"https://api.github.com",
+		monochange_core::SourceProvider::GitHub,
+	)
+	.unwrap_or_else(|error| panic!("expected Ok for https://: {error}"));
+}

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -2520,11 +2520,46 @@ fn validate_source_configuration(source: Option<&SourceConfiguration>) -> Monoch
 			"[source].repo must not be empty".to_string(),
 		));
 	}
+	if let Some(api_url) = &source.api_url {
+		validate_api_url_host(api_url, source.provider)?;
+	}
+	if let Some(host) = &source.host {
+		validate_api_url_host(host, source.provider)?;
+	}
 	match source.provider {
 		SourceProvider::GitHub => monochange_github::validate_source_configuration(source),
 		SourceProvider::GitLab => monochange_gitlab::validate_source_configuration(source),
 		SourceProvider::Gitea => monochange_gitea::validate_source_configuration(source),
 	}
+}
+
+/// Reject `api_url` or `host` values that use insecure schemes. API tokens are
+/// sent as Authorization headers, so an `http://` endpoint would transmit them
+/// in cleartext.
+fn validate_api_url_host(url: &str, provider: SourceProvider) -> MonochangeResult<()> {
+	let lower = url.to_lowercase();
+	if lower.starts_with("http://") {
+		return Err(MonochangeError::Config(format!(
+			"[source] url `{url}` uses an insecure scheme (http://); \
+			 API tokens would be transmitted in cleartext — use https:// instead"
+		)));
+	}
+	// Warn about non-standard hosts for GitHub — GitLab and Gitea are commonly
+	// self-hosted, so custom hosts are expected for those providers.
+	if provider == SourceProvider::GitHub && lower.starts_with("https://") {
+		let without_scheme = &lower["https://".len()..];
+		let host_part = without_scheme.split('/').next().unwrap_or("");
+		let is_standard = host_part == "api.github.com"
+			|| host_part.ends_with(".github.com")
+			|| host_part.ends_with(".githubusercontent.com");
+		if !is_standard {
+			eprintln!(
+				"warning: [source] url points to non-standard GitHub host `{url}`; \
+				 verify this is intentional — API tokens will be sent to this host"
+			);
+		}
+	}
+	Ok(())
 }
 
 fn validate_changesets_configuration(


### PR DESCRIPTION
## Summary

- Reject `http://` schemes for `[source].api_url` and `[source].host` — API tokens would be transmitted in cleartext
- Warn when GitHub `api_url` points to a non-standard host (GitLab/Gitea are expected to be self-hosted)
- Add tests for both rejection and acceptance cases

Closes #102

## Test plan

- [x] `validate_api_url_host_rejects_insecure_http_scheme` passes
- [x] `validate_api_url_host_accepts_https_scheme` passes
- [ ] CI passes