### PR TITLE
fix: use atomic write pattern for release file updates

### DIFF
--- a/.changeset/051-atomic-writes.md
+++ b/.changeset/051-atomic-writes.md
@@ -1,0 +1,5 @@
+---
+monochange: patch
+---
+
+Use atomic temp-file-then-rename pattern for release file updates so files are never left partially written.

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -539,13 +539,34 @@ pub(crate) fn apply_file_updates(updates: &[FileUpdate]) -> MonochangeResult<()>
 				MonochangeError::Io(format!("failed to create {}: {error}", parent.display()))
 			})?;
 		}
-		fs::write(&update.path, &update.content).map_err(|error| {
-			MonochangeError::Io(format!(
-				"failed to write {}: {error}",
-				update.path.display()
-			))
-		})?;
+		atomic_write(&update.path, &update.content)?;
 	}
+	Ok(())
+}
+
+/// Write file content atomically: write to a temporary file in the same
+/// directory, then rename into place. On Unix the rename is atomic within the
+/// same filesystem, so the file is either fully written or untouched.
+fn atomic_write(path: &Path, content: &[u8]) -> MonochangeResult<()> {
+	let parent = path.parent().unwrap_or(path);
+	let mut temp = tempfile::NamedTempFile::new_in(parent).map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to create temp file in {}: {error}",
+			parent.display()
+		))
+	})?;
+	std::io::Write::write_all(&mut temp, content).map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to write temp file for {}: {error}",
+			path.display()
+		))
+	})?;
+	temp.persist(path).map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to rename temp file to {}: {error}",
+			path.display()
+		))
+	})?;
 	Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Replace direct `fs::write` in `apply_file_updates()` with an atomic temp-file-then-rename pattern
- Uses `tempfile::NamedTempFile` for safe temp file creation and `persist()` for atomic rename
- Files are either fully written or untouched if the process is interrupted mid-write

Closes #111

## Test plan

- [x] All 271 monochange lib tests pass
- [ ] CI passes