### PR TITLE
feat: add conditional execution for cli steps

### DIFF
--- a/.changeset/053-cli-step-when-condition.md
+++ b/.changeset/053-cli-step-when-condition.md
@@ -1,0 +1,25 @@
+---
+monochange: minor
+monochange_core: minor
+monochange_config: minor
+---
+
+#### add conditional execution support for all CLI steps
+
+`when` conditions are now supported on all `CliStepDefinition` variants (not just `Command`) via a shared `when: "..."` field and runtime evaluation in the command dispatcher.
+
+Before, only `Command`-specific behavior had first-class examples in docs, and users had to rely on wrapper commands for conditional behavior elsewhere. Now every step can be skipped by condition:
+
+```toml
+[[cli.release.steps]]
+type = "Validate"
+when = "{{ inputs.publish }}"
+```
+
+The `when` evaluator now also accepts common falsey values consistently for template-rendered conditions, including:
+
+- `false`
+- `""` (empty string)
+- `0`
+
+This release also updates runtime docs and the `mc init` template guidance so all CLI step reference pages reflect the new conditional behavior.

--- a/.changeset/054-cli-boolean-defaults.md
+++ b/.changeset/054-cli-boolean-defaults.md
@@ -1,0 +1,9 @@
+---
+monochange: patch
+monochange_config: patch
+monochange_core: patch
+---
+
+CLI boolean inputs now accept TOML boolean defaults such as `default = true` and `default = false` in addition to string defaults.
+
+This also preserves numeric truthiness for conditional evaluation, so values like `"1"` still resolve as truthy while `"0"` resolves as false.

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -2450,6 +2450,40 @@ fn should_execute_cli_step_skips_when_condition_is_false() {
 }
 
 #[test]
+fn should_execute_cli_step_skips_for_zero_value() {
+	let context = cli_context_for_when_evaluation_tests();
+	let step_inputs = BTreeMap::from([("run".to_string(), vec!["0".to_string()])]);
+	let step = monochange_core::CliStepDefinition::Command {
+		when: Some("{{ inputs.run }}".to_string()),
+		command: "printf hi".to_string(),
+		dry_run_command: None,
+		shell: monochange_core::ShellConfig::default(),
+		id: None,
+		variables: None,
+		inputs: BTreeMap::new(),
+	};
+	assert!(!should_execute_cli_step(&step, &context, &step_inputs)
+		.unwrap_or_else(|error| { panic!("when condition: {error}") }));
+}
+
+#[test]
+fn should_execute_cli_step_trims_and_treats_1_as_true() {
+	let context = cli_context_for_when_evaluation_tests();
+	let step_inputs = BTreeMap::from([("run".to_string(), vec![" 1 ".to_string()])]);
+	let step = monochange_core::CliStepDefinition::Command {
+		when: Some("{{ inputs.run }}".to_string()),
+		command: "printf hi".to_string(),
+		dry_run_command: None,
+		shell: monochange_core::ShellConfig::default(),
+		id: None,
+		variables: None,
+		inputs: BTreeMap::new(),
+	};
+	assert!(should_execute_cli_step(&step, &context, &step_inputs)
+		.unwrap_or_else(|error| { panic!("when condition: {error}") }));
+}
+
+#[test]
 fn should_execute_cli_step_skips_with_not_operator() {
 	let context = cli_context_for_when_evaluation_tests();
 	let step_inputs = BTreeMap::from([("skip".to_string(), vec!["true".to_string()])]);

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -30,6 +30,7 @@ use crate::add_interactive_change_file;
 use crate::affected_packages;
 use crate::build_command_for_root;
 use crate::build_lockfile_command_executions;
+use crate::cli_runtime::{normalize_when_expression, should_execute_cli_step};
 use crate::discover_workspace;
 use crate::interactive::InteractiveChangeResult;
 use crate::interactive::InteractiveTarget;
@@ -1487,6 +1488,7 @@ fn command_step_without_dry_run_override_reports_skipped_command() {
 		help_text: None,
 		inputs: Vec::new(),
 		steps: vec![monochange_core::CliStepDefinition::Command {
+			when: None,
 			command: "echo hello".to_string(),
 			dry_run_command: None,
 			shell: monochange_core::ShellConfig::default(),
@@ -1517,6 +1519,7 @@ fn command_step_rejects_unparseable_commands() {
 		help_text: None,
 		inputs: Vec::new(),
 		steps: vec![monochange_core::CliStepDefinition::Command {
+			when: None,
 			command: "\"unterminated".to_string(),
 			dry_run_command: None,
 			shell: monochange_core::ShellConfig::default(),
@@ -1550,6 +1553,7 @@ fn command_step_rejects_empty_commands() {
 		help_text: None,
 		inputs: Vec::new(),
 		steps: vec![monochange_core::CliStepDefinition::Command {
+			when: None,
 			command: String::new(),
 			dry_run_command: None,
 			shell: monochange_core::ShellConfig::default(),
@@ -1581,6 +1585,7 @@ fn command_step_reports_process_spawn_failures() {
 		help_text: None,
 		inputs: Vec::new(),
 		steps: vec![monochange_core::CliStepDefinition::Command {
+			when: None,
 			command: "definitely-not-a-real-command-12345".to_string(),
 			dry_run_command: None,
 			shell: monochange_core::ShellConfig::default(),
@@ -1614,6 +1619,7 @@ fn command_step_reports_nonzero_exit_status_without_stderr() {
 		help_text: None,
 		inputs: Vec::new(),
 		steps: vec![monochange_core::CliStepDefinition::Command {
+			when: None,
 			command: "sh -c 'exit 7'".to_string(),
 			dry_run_command: None,
 			shell: monochange_core::ShellConfig::default(),
@@ -1648,6 +1654,7 @@ fn command_step_reports_stderr_text_for_nonzero_exit_status() {
 		help_text: None,
 		inputs: Vec::new(),
 		steps: vec![monochange_core::CliStepDefinition::Command {
+			when: None,
 			command: "sh -c 'echo boom 1>&2; exit 1'".to_string(),
 			dry_run_command: None,
 			shell: monochange_core::ShellConfig::default(),
@@ -2370,6 +2377,130 @@ fn parse_direct_template_reference_returns_none_when_not_a_bare_ref() {
 	use super::parse_direct_template_reference;
 	assert_eq!(parse_direct_template_reference("prefix-{{ foo }}"), None);
 	assert_eq!(parse_direct_template_reference("hello world"), None);
+}
+
+#[test]
+fn normalize_when_expression_supports_logical_operators() {
+	assert_eq!(
+		normalize_when_expression("{{ flag_a && !flag_b || flag_c }}"),
+		"{{ flag_a  and  not flag_b  or  flag_c }}"
+	);
+}
+
+fn cli_context_for_when_evaluation_tests() -> CliContext {
+	CliContext {
+		root: PathBuf::from("."),
+		dry_run: false,
+		show_diff: false,
+		inputs: BTreeMap::new(),
+		last_step_inputs: BTreeMap::new(),
+		prepared_release: None,
+		prepared_file_diffs: Vec::new(),
+		release_manifest_path: None,
+		release_requests: Vec::new(),
+		release_results: Vec::new(),
+		release_request: None,
+		release_request_result: None,
+		release_commit_report: None,
+		issue_comment_plans: Vec::new(),
+		issue_comment_results: Vec::new(),
+		changeset_policy_evaluation: None,
+		changeset_diagnostics: None,
+		retarget_report: None,
+		step_outputs: BTreeMap::new(),
+		command_logs: Vec::new(),
+	}
+}
+
+#[test]
+fn should_execute_cli_step_runs_when_condition_is_true() {
+	let context = cli_context_for_when_evaluation_tests();
+	let step_inputs = BTreeMap::from([
+		("run".to_string(), vec!["true".to_string()]),
+		("extra".to_string(), vec!["true".to_string()]),
+	]);
+	let step = monochange_core::CliStepDefinition::Command {
+		when: Some("{{ inputs.run && inputs.extra }}".to_string()),
+		command: "printf hi".to_string(),
+		dry_run_command: None,
+		shell: monochange_core::ShellConfig::default(),
+		id: None,
+		variables: None,
+		inputs: BTreeMap::new(),
+	};
+	assert!(should_execute_cli_step(&step, &context, &step_inputs)
+		.unwrap_or_else(|error| { panic!("when condition: {error}") }));
+}
+
+#[test]
+fn should_execute_cli_step_skips_when_condition_is_false() {
+	let context = cli_context_for_when_evaluation_tests();
+	let step_inputs = BTreeMap::from([("run".to_string(), vec!["false".to_string()])]);
+	let step = monochange_core::CliStepDefinition::Command {
+		when: Some("{{ inputs.run }}".to_string()),
+		command: "printf hi".to_string(),
+		dry_run_command: None,
+		shell: monochange_core::ShellConfig::default(),
+		id: None,
+		variables: None,
+		inputs: BTreeMap::new(),
+	};
+	assert!(!should_execute_cli_step(&step, &context, &step_inputs)
+		.unwrap_or_else(|error| { panic!("when condition: {error}") }));
+}
+
+#[test]
+fn should_execute_cli_step_skips_with_not_operator() {
+	let context = cli_context_for_when_evaluation_tests();
+	let step_inputs = BTreeMap::from([("skip".to_string(), vec!["true".to_string()])]);
+	let step = monochange_core::CliStepDefinition::Command {
+		when: Some("{{ ! inputs.skip }}".to_string()),
+		command: "printf hi".to_string(),
+		dry_run_command: None,
+		shell: monochange_core::ShellConfig::default(),
+		id: None,
+		variables: None,
+		inputs: BTreeMap::new(),
+	};
+	assert!(!should_execute_cli_step(&step, &context, &step_inputs)
+		.unwrap_or_else(|error| { panic!("when condition: {error}") }));
+}
+
+#[test]
+fn should_execute_cli_step_rejects_unknown_template_reference() {
+	let context = cli_context_for_when_evaluation_tests();
+	let step_inputs = BTreeMap::from([("run".to_string(), vec!["true".to_string()])]);
+	let step = monochange_core::CliStepDefinition::Command {
+		when: Some("{{ inputs.missing }}".to_string()),
+		command: "printf hi".to_string(),
+		dry_run_command: None,
+		shell: monochange_core::ShellConfig::default(),
+		id: None,
+		variables: None,
+		inputs: BTreeMap::new(),
+	};
+	let error = should_execute_cli_step(&step, &context, &step_inputs).unwrap_err();
+	assert!(error
+		.to_string()
+		.contains("failed to evaluate `when` condition `{{ inputs.missing }}`"));
+}
+
+#[test]
+fn should_execute_cli_step_rejects_non_scalar_condition_value() {
+	let context = cli_context_for_when_evaluation_tests();
+	let step_inputs =
+		BTreeMap::from([("list".to_string(), vec!["a".to_string(), "b".to_string()])]);
+	let step = monochange_core::CliStepDefinition::Command {
+		when: Some("{{ inputs.list }}".to_string()),
+		command: "printf hi".to_string(),
+		dry_run_command: None,
+		shell: monochange_core::ShellConfig::default(),
+		id: None,
+		variables: None,
+		inputs: BTreeMap::new(),
+	};
+	let error = should_execute_cli_step(&step, &context, &step_inputs).unwrap_err();
+	assert!(error.to_string().contains("is not a scalar boolean value"));
 }
 
 #[test]
@@ -3149,6 +3280,7 @@ fn execute_cli_command_retarget_release_requires_from_input() {
 		help_text: None,
 		inputs: Vec::new(),
 		steps: vec![monochange_core::CliStepDefinition::RetargetRelease {
+			when: None,
 			inputs: BTreeMap::new(),
 		}],
 	};
@@ -3176,6 +3308,7 @@ fn execute_cli_command_release_follow_up_steps_require_prepare_release() {
 		(
 			"release-manifest",
 			monochange_core::CliStepDefinition::RenderReleaseManifest {
+				when: None,
 				path: None,
 				inputs: BTreeMap::new(),
 			},
@@ -3184,6 +3317,7 @@ fn execute_cli_command_release_follow_up_steps_require_prepare_release() {
 		(
 			"publish-release",
 			monochange_core::CliStepDefinition::PublishRelease {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 			"`PublishRelease` requires a previous `PrepareRelease` step",
@@ -3191,6 +3325,7 @@ fn execute_cli_command_release_follow_up_steps_require_prepare_release() {
 		(
 			"release-pr",
 			monochange_core::CliStepDefinition::OpenReleaseRequest {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 			"`OpenReleaseRequest` requires a previous `PrepareRelease` step",
@@ -3198,6 +3333,7 @@ fn execute_cli_command_release_follow_up_steps_require_prepare_release() {
 		(
 			"release-comments",
 			monochange_core::CliStepDefinition::CommentReleasedIssues {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 			"`CommentReleasedIssues` requires a previous `PrepareRelease` step",
@@ -3244,9 +3380,11 @@ fn execute_cli_command_source_follow_up_steps_require_source_configuration() {
 		inputs: Vec::new(),
 		steps: vec![
 			monochange_core::CliStepDefinition::PrepareRelease {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 			monochange_core::CliStepDefinition::CommentReleasedIssues {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 		],
@@ -3276,6 +3414,7 @@ fn execute_cli_command_publish_and_request_steps_require_source_configuration() 
 		(
 			"publish-release",
 			monochange_core::CliStepDefinition::PublishRelease {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 			"`PublishRelease` requires `[source]` configuration",
@@ -3283,6 +3422,7 @@ fn execute_cli_command_publish_and_request_steps_require_source_configuration() 
 		(
 			"release-pr",
 			monochange_core::CliStepDefinition::OpenReleaseRequest {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 			"`OpenReleaseRequest` requires `[source]` configuration",
@@ -3296,6 +3436,7 @@ fn execute_cli_command_publish_and_request_steps_require_source_configuration() 
 			inputs: Vec::new(),
 			steps: vec![
 				monochange_core::CliStepDefinition::PrepareRelease {
+					when: None,
 					inputs: BTreeMap::new(),
 				},
 				step,
@@ -3319,6 +3460,7 @@ fn execute_cli_command_change_step_requires_reason_input() {
 		help_text: None,
 		inputs: Vec::new(),
 		steps: vec![monochange_core::CliStepDefinition::CreateChangeFile {
+			when: None,
 			inputs: BTreeMap::new(),
 		}],
 	};
@@ -3362,9 +3504,11 @@ fn execute_cli_command_release_follow_up_steps_render_dry_run_outputs() {
 		inputs: Vec::new(),
 		steps: vec![
 			monochange_core::CliStepDefinition::PrepareRelease {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 			monochange_core::CliStepDefinition::RenderReleaseManifest {
+				when: None,
 				path: Some(PathBuf::from("target/release-manifest.json")),
 				inputs: BTreeMap::new(),
 			},
@@ -3389,9 +3533,11 @@ fn execute_cli_command_release_follow_up_steps_render_dry_run_outputs() {
 		inputs: Vec::new(),
 		steps: vec![
 			monochange_core::CliStepDefinition::PrepareRelease {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 			monochange_core::CliStepDefinition::PublishRelease {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 		],
@@ -3413,9 +3559,11 @@ fn execute_cli_command_release_follow_up_steps_render_dry_run_outputs() {
 		inputs: Vec::new(),
 		steps: vec![
 			monochange_core::CliStepDefinition::PrepareRelease {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 			monochange_core::CliStepDefinition::OpenReleaseRequest {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 		],
@@ -3437,9 +3585,11 @@ fn execute_cli_command_release_follow_up_steps_render_dry_run_outputs() {
 		inputs: Vec::new(),
 		steps: vec![
 			monochange_core::CliStepDefinition::PrepareRelease {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 			monochange_core::CliStepDefinition::CommentReleasedIssues {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 		],
@@ -4295,6 +4445,7 @@ fn execute_cli_command_commit_release_requires_prepare_release() {
 		help_text: None,
 		inputs: Vec::new(),
 		steps: vec![monochange_core::CliStepDefinition::CommitRelease {
+			when: None,
 			inputs: BTreeMap::new(),
 		}],
 	};

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -775,10 +775,13 @@ pub(crate) fn normalize_when_expression(condition: &str) -> String {
 }
 
 fn parse_string_as_boolean(value: &str, condition: &str) -> MonochangeResult<bool> {
-	match value.trim().to_ascii_lowercase().as_str() {
+	let value = value.trim().to_ascii_lowercase();
+	if let Ok(number) = value.parse::<i64>() {
+		return Ok(number != 0);
+	}
+	match value.as_str() {
 		"true" => Ok(true),
-		"false" => Ok(false),
-		"" => Ok(false),
+		"false" | "0" | "" => Ok(false),
 		other => Err(MonochangeError::Config(format!(
 			"`when` condition `{condition}` must be a boolean, got `{other}`"
 		))),

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -231,6 +231,17 @@ pub(crate) fn execute_cli_command_with_options(
 	for step in &cli_command.steps {
 		let step_inputs = resolve_step_inputs(&context, step)?;
 		context.last_step_inputs = step_inputs.clone();
+
+		if !should_execute_cli_step(step, &context, &step_inputs)? {
+			if let Some(condition) = step.when() {
+				context.command_logs.push(format!(
+					"skipped step `{}` because when condition `{condition}` is false",
+					step.kind_name()
+				));
+			}
+			continue;
+		}
+
 		match step {
 			CliStepDefinition::Validate { .. } => {
 				validate_workspace(root)?;
@@ -678,6 +689,100 @@ pub(crate) fn execute_cli_command_with_options(
 			if dry_run { " (dry-run)" } else { "" }
 		)
 	}))
+}
+
+pub(crate) fn should_execute_cli_step(
+	step: &CliStepDefinition,
+	context: &CliContext,
+	step_inputs: &BTreeMap<String, Vec<String>>,
+) -> MonochangeResult<bool> {
+	let Some(condition) = step.when() else {
+		return Ok(true);
+	};
+	evaluate_cli_step_condition(condition, context, step_inputs)
+}
+
+fn evaluate_cli_step_condition(
+	condition: &str,
+	context: &CliContext,
+	step_inputs: &BTreeMap<String, Vec<String>>,
+) -> MonochangeResult<bool> {
+	let trimmed = condition.trim();
+	if trimmed.is_empty() {
+		return Ok(false);
+	}
+	let template_context = build_cli_template_context(context, step_inputs, None);
+	let template_context_json = serde_json::Value::Object(template_context.clone());
+	if let Some(path) = parse_direct_template_reference(trimmed) {
+		let Some(value) = lookup_template_value(&template_context_json, path) else {
+			return Err(MonochangeError::Config(format!(
+				"failed to evaluate `when` condition `{condition}`: unknown template path `{path}`"
+			)));
+		};
+		return parse_template_as_boolean(value, condition);
+	}
+	let normalized = normalize_when_expression(trimmed);
+	let jinja_context =
+		minijinja::Value::from_serialize(serde_json::Value::Object(template_context));
+	let rendered = render_jinja_template(&normalized, &jinja_context)?;
+	parse_string_as_boolean(&rendered, condition)
+}
+
+fn parse_template_as_boolean(value: &serde_json::Value, condition: &str) -> MonochangeResult<bool> {
+	match value {
+		serde_json::Value::Bool(value) => Ok(*value),
+		serde_json::Value::Number(value) => parse_string_as_boolean(&value.to_string(), condition),
+		serde_json::Value::String(value) => parse_string_as_boolean(value, condition),
+		serde_json::Value::Null => Ok(false),
+		serde_json::Value::Array(values) => {
+			if values.len() == 1 {
+				parse_template_as_boolean(&values[0], condition)
+			} else {
+				Err(MonochangeError::Config(format!(
+					"`when` condition `{condition}` is not a scalar boolean value"
+				)))
+			}
+		}
+		serde_json::Value::Object(_) => Err(MonochangeError::Config(format!(
+			"`when` condition `{condition}` is not a scalar boolean value"
+		))),
+	}
+}
+
+pub(crate) fn normalize_when_expression(condition: &str) -> String {
+	let expression = condition.replace("&&", " and ").replace("||", " or ");
+	let mut normalized = String::with_capacity(expression.len());
+	let mut chars = expression.chars().peekable();
+	while let Some(ch) = chars.next() {
+		if ch == '!' {
+			if let Some('=') = chars.peek() {
+				normalized.push('!');
+				continue;
+			}
+			let previous_was_expression_boundary = normalized.chars().last().is_none_or(|prev| {
+				prev.is_whitespace() || prev == '(' || prev == ',' || prev == '>' || prev == '<'
+			});
+			if previous_was_expression_boundary {
+				normalized.push_str("not ");
+			} else {
+				normalized.push('!');
+			}
+			continue;
+		}
+		normalized.push(ch);
+	}
+	normalized
+}
+
+fn parse_string_as_boolean(value: &str, condition: &str) -> MonochangeResult<bool> {
+	match value.trim().to_ascii_lowercase().as_str() {
+		"true" => Ok(true),
+		"false" => Ok(false),
+		"" => Ok(false),
+		other => Err(MonochangeError::Config(format!(
+			"`when` condition `{condition}` must be a boolean, got `{other}`"
+		))),
+	}
 }
 
 fn run_cli_command_command(

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -1523,3 +1523,86 @@ pub(crate) fn parse_change_bump(value: &str) -> MonochangeResult<ChangeBump> {
 		))),
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::{collections::BTreeMap, path::PathBuf};
+
+	fn cli_context() -> CliContext {
+		CliContext {
+			root: PathBuf::from("."),
+			dry_run: false,
+			show_diff: false,
+			inputs: BTreeMap::new(),
+			last_step_inputs: BTreeMap::new(),
+			prepared_release: None,
+			prepared_file_diffs: Vec::new(),
+			release_manifest_path: None,
+			release_requests: Vec::new(),
+			release_results: Vec::new(),
+			release_request: None,
+			release_request_result: None,
+			release_commit_report: None,
+			issue_comment_plans: Vec::new(),
+			issue_comment_results: Vec::new(),
+			changeset_policy_evaluation: None,
+			changeset_diagnostics: None,
+			retarget_report: None,
+			step_outputs: BTreeMap::new(),
+			command_logs: Vec::new(),
+		}
+	}
+
+	#[test]
+	fn evaluate_cli_step_condition_returns_false_for_blank_conditions() {
+		assert!(
+			!evaluate_cli_step_condition("   ", &cli_context(), &BTreeMap::new()).unwrap_or_else(
+				|error| panic!("blank conditions should be treated as false: {error}")
+			)
+		);
+	}
+
+	#[test]
+	fn parse_template_as_boolean_supports_number_null_and_single_item_arrays() {
+		assert!(
+			parse_template_as_boolean(&serde_json::json!(2), "{{ count }}")
+				.unwrap_or_else(|error| panic!("non-zero numbers should be truthy: {error}"))
+		);
+		assert!(
+			!parse_template_as_boolean(&serde_json::Value::Null, "{{ release }}")
+				.unwrap_or_else(|error| panic!("null values should be falsey: {error}"))
+		);
+		assert!(
+			!parse_template_as_boolean(&serde_json::json!([""]), "{{ items }}").unwrap_or_else(
+				|error| panic!("single-item arrays should recurse into the item value: {error}")
+			)
+		);
+	}
+
+	#[test]
+	fn parse_template_as_boolean_rejects_objects() {
+		let error =
+			parse_template_as_boolean(&serde_json::json!({ "nested": true }), "{{ inputs }}")
+				.unwrap_err();
+		assert!(error.to_string().contains("is not a scalar boolean value"));
+	}
+
+	#[test]
+	fn normalize_when_expression_preserves_inequality_and_mid_token_bangs() {
+		assert_eq!(
+			normalize_when_expression("{{ flag != other }}"),
+			"{{ flag != other }}"
+		);
+		assert_eq!(normalize_when_expression("{{ foo!bar }}"), "{{ foo!bar }}");
+	}
+
+	#[test]
+	fn parse_string_as_boolean_rejects_invalid_values() {
+		let error = parse_string_as_boolean("maybe", "{{ inputs.run }}").unwrap_err();
+		assert_eq!(
+			error.to_string(),
+			"config error: `when` condition `{{ inputs.run }}` must be a boolean, got `maybe`"
+		);
+	}
+}

--- a/crates/monochange/src/monochange.init.toml
+++ b/crates/monochange/src/monochange.init.toml
@@ -689,13 +689,13 @@ default = "HEAD"
 name = "force"
 type = "boolean"
 help_text = "allow non-descendant retargets"
-default = "false"
+default = false
 
 [[cli.repair-release.inputs]]
 name = "sync_provider"
 type = "boolean"
 help_text = "sync hosted release state after tag movement (disable with --sync-provider=false)"
-default = "true"
+default = true
 
 [[cli.repair-release.inputs]]
 name = "format"

--- a/crates/monochange/src/monochange.init.toml
+++ b/crates/monochange/src/monochange.init.toml
@@ -519,6 +519,11 @@ comment_on_failure = true
 #   Command              — run an arbitrary shell command
 #
 # Common step fields:
+#   when            — optional condition controlling whether this step runs (e.g.
+#{% raw -%}
+#                     "{{ inputs.enabled }}", "{{ inputs.debug and not inputs.skip }}")
+#{% endraw -%}
+#                     If the expression resolves to false, the step is skipped.
 #   inputs          — optional map of step-local input overrides. Values can be
 #                     strings, booleans, or string arrays.
 {% raw -%}

--- a/crates/monochange/tests/cli_step_when.rs
+++ b/crates/monochange/tests/cli_step_when.rs
@@ -59,9 +59,11 @@ fn run_command(root: &Path, command: &str, args: &[&str]) -> Output {
 		.args(args)
 		.output()
 		.unwrap_or_else(|error| panic!("command output: {error}"));
-	if !output.status.success() {
-		panic!("command failed: {}", to_stderr(&output));
-	}
+	assert!(
+		output.status.success(),
+		"command failed: {}",
+		to_stderr(&output)
+	);
 	output
 }
 

--- a/crates/monochange/tests/cli_step_when.rs
+++ b/crates/monochange/tests/cli_step_when.rs
@@ -1,0 +1,70 @@
+use std::{fs, path::Path, process::Output};
+
+mod test_support;
+use test_support::{monochange_command, setup_scenario_workspace};
+
+#[test]
+fn cli_step_when_supports_logical_and_for_command_steps() {
+	let root = setup_scenario_workspace("cli-step-when");
+
+	let output = run_command(root.path(), "when-command", &["--run"]);
+	assert!(output.status.success(), "{}", to_stderr(&output));
+	assert!(
+		!root.path().join("when-command-output.txt").exists(),
+		"command should not run when extra=false"
+	);
+
+	let output = run_command(root.path(), "when-command", &["--run", "--extra"]);
+	assert!(output.status.success(), "{}", to_stderr(&output));
+	assert_eq!(
+		fs::read_to_string(root.path().join("when-command-output.txt"))
+			.unwrap_or_else(|error| panic!("read output: {error}")),
+		"hello"
+	);
+}
+
+#[test]
+fn cli_step_when_supports_not_operator_for_command_steps() {
+	let root = setup_scenario_workspace("cli-step-when");
+
+	let output = run_command(root.path(), "not-condition", &[]);
+	assert!(output.status.success(), "{}", to_stderr(&output));
+	assert!(
+		!root.path().join("not-output.txt").exists(),
+		"command should not run when skip=true"
+	);
+
+	let output = run_command(root.path(), "not-condition", &["--skip=false"]);
+	assert!(output.status.success(), "{}", to_stderr(&output));
+	assert_eq!(
+		fs::read_to_string(root.path().join("not-output.txt"))
+			.unwrap_or_else(|error| panic!("read output: {error}")),
+		"okay"
+	);
+}
+
+#[test]
+fn cli_step_when_skips_non_command_steps_when_false() {
+	let root = setup_scenario_workspace("cli-step-when");
+	let output = run_command(root.path(), "when-validate", &[]);
+	assert!(output.status.success(), "{}", to_stderr(&output));
+	let text = String::from_utf8_lossy(&output.stdout);
+	assert!(text.contains("command `when-validate` completed"));
+}
+
+fn run_command(root: &Path, command: &str, args: &[&str]) -> Output {
+	let output = monochange_command(None)
+		.current_dir(root)
+		.arg(command)
+		.args(args)
+		.output()
+		.unwrap_or_else(|error| panic!("command output: {error}"));
+	if !output.status.success() {
+		panic!("command failed: {}", to_stderr(&output));
+	}
+	output
+}
+
+fn to_stderr(output: &Output) -> String {
+	String::from_utf8_lossy(&output.stderr).into_owned()
+}

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -211,6 +211,30 @@ command = "echo should not run"
 }
 
 #[test]
+fn load_workspace_configuration_supports_boolean_input_default_values() {
+	let root = fixture_path("config/accepts-boolean-input-defaults");
+	let configuration = load_workspace_configuration(&root)
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+	let command = configuration
+		.cli
+		.iter()
+		.find(|command| command.name == "pr-check")
+		.unwrap_or_else(|| panic!("expected pr-check command"));
+	let dry_run = command
+		.inputs
+		.iter()
+		.find(|input| input.name == "dry_run")
+		.unwrap_or_else(|| panic!("missing dry_run input"));
+	let sync = command
+		.inputs
+		.iter()
+		.find(|input| input.name == "sync")
+		.unwrap_or_else(|| panic!("missing sync input"));
+	assert_eq!(dry_run.default.as_deref(), Some("true"));
+	assert_eq!(sync.default.as_deref(), Some("false"));
+}
+
+#[test]
 fn load_workspace_configuration_parses_package_group_and_cli_command_declarations() {
 	let root = fixture_path("config/package-group-and-cli");
 	let configuration = load_workspace_configuration(&root)
@@ -2665,16 +2689,16 @@ fn changeset_files_with_crlf_line_endings_parse_correctly() {
 	let configuration =
 		load_workspace_configuration(root).unwrap_or_else(|error| panic!("config: {error}"));
 
-	let packages = vec![monochange_core::PackageRecord::new(
-		monochange_core::Ecosystem::Cargo,
+	let packages = vec![PackageRecord::new(
+		Ecosystem::Cargo,
 		"core",
 		root.join("crates/core/Cargo.toml"),
 		root.to_path_buf(),
 		Some(Version::new(1, 0, 0)),
-		monochange_core::PublishState::Public,
+		PublishState::Public,
 	)];
 
-	let changeset = crate::load_changeset_file(
+	let changeset = load_changeset_file(
 		&root.join(".changeset/crlf-test.md"),
 		&configuration,
 		&packages,

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -190,6 +190,27 @@ type = "RetargetRelease"
 }
 
 #[test]
+fn load_workspace_configuration_rejects_empty_when_conditions() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	std::fs::write(
+		tempdir.path().join("monochange.toml"),
+		r#"
+[cli.announce]
+
+[[cli.announce.steps]]
+type = "Command"
+when = ""
+command = "echo should not run"
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write config: {error}"));
+	let error = load_workspace_configuration(tempdir.path())
+		.err()
+		.unwrap_or_else(|| panic!("expected empty-when error"));
+	assert!(error.to_string().contains("has an empty `when` condition"));
+}
+
+#[test]
 fn load_workspace_configuration_parses_package_group_and_cli_command_declarations() {
 	let root = fixture_path("config/package-group-and-cli");
 	let configuration = load_workspace_configuration(&root)

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -2683,6 +2683,15 @@ fn validate_cli(cli: &[CliCommandDefinition]) -> MonochangeResult<()> {
 
 		let mut seen_step_ids: BTreeSet<String> = BTreeSet::new();
 		for step in &cli_command.steps {
+			if let Some(condition) = step.when() {
+				if condition.trim().is_empty() {
+					return Err(MonochangeError::Config(format!(
+						"CLI command `{}` step `{}` has an empty `when` condition",
+						cli_command.name,
+						step.kind_name()
+					)));
+				}
+			}
 			for input_name in step.inputs().keys() {
 				if input_name.trim().is_empty() {
 					return Err(MonochangeError::Config(format!(
@@ -2815,7 +2824,7 @@ fn validate_cli_runtime_requirements(
 		}
 		for step in &cli_command.steps {
 			validate_step_input_overrides(cli_command, step)?;
-			if let CliStepDefinition::AffectedPackages { inputs } = step {
+			if let CliStepDefinition::AffectedPackages { inputs, .. } = step {
 				if !changesets.verify.enabled {
 					return Err(MonochangeError::Config(format!(
 						"CLI command `{}` uses `AffectedPackages` but `[changesets.verify].enabled` is false",

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -325,6 +325,7 @@ fn default_cli_commands_expose_validate_discover_change_release_and_affected() {
 	assert_eq!(
 		validate_cli_command.steps,
 		vec![CliStepDefinition::Validate {
+			when: None,
 			inputs: BTreeMap::new(),
 		}]
 	);
@@ -336,36 +337,42 @@ fn cli_step_definition_kind_name_covers_all_variants() {
 	let cases: Vec<(CliStepDefinition, &str)> = vec![
 		(
 			CliStepDefinition::Validate {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 			"Validate",
 		),
 		(
 			CliStepDefinition::Discover {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 			"Discover",
 		),
 		(
 			CliStepDefinition::CreateChangeFile {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 			"CreateChangeFile",
 		),
 		(
 			CliStepDefinition::PrepareRelease {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 			"PrepareRelease",
 		),
 		(
 			CliStepDefinition::CommitRelease {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 			"CommitRelease",
 		),
 		(
 			CliStepDefinition::RenderReleaseManifest {
+				when: None,
 				path: None,
 				inputs: BTreeMap::new(),
 			},
@@ -373,42 +380,49 @@ fn cli_step_definition_kind_name_covers_all_variants() {
 		),
 		(
 			CliStepDefinition::PublishRelease {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 			"PublishRelease",
 		),
 		(
 			CliStepDefinition::OpenReleaseRequest {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 			"OpenReleaseRequest",
 		),
 		(
 			CliStepDefinition::CommentReleasedIssues {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 			"CommentReleasedIssues",
 		),
 		(
 			CliStepDefinition::AffectedPackages {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 			"AffectedPackages",
 		),
 		(
 			CliStepDefinition::DiagnoseChangesets {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 			"DiagnoseChangesets",
 		),
 		(
 			CliStepDefinition::RetargetRelease {
+				when: None,
 				inputs: BTreeMap::new(),
 			},
 			"RetargetRelease",
 		),
 		(
 			CliStepDefinition::Command {
+				when: None,
 				command: "echo".into(),
 				dry_run_command: None,
 				shell: ShellConfig::None,
@@ -427,6 +441,7 @@ fn cli_step_definition_kind_name_covers_all_variants() {
 #[test]
 fn valid_input_names_returns_none_for_command_steps() {
 	let step = CliStepDefinition::Command {
+		when: None,
 		command: "echo hi".into(),
 		dry_run_command: None,
 		shell: ShellConfig::None,
@@ -440,6 +455,7 @@ fn valid_input_names_returns_none_for_command_steps() {
 #[test]
 fn valid_input_names_returns_empty_for_validate() {
 	let step = CliStepDefinition::Validate {
+		when: None,
 		inputs: BTreeMap::new(),
 	};
 	assert_eq!(step.valid_input_names(), Some([].as_slice()));
@@ -448,6 +464,7 @@ fn valid_input_names_returns_empty_for_validate() {
 #[test]
 fn valid_input_names_returns_empty_for_commit_release() {
 	let step = CliStepDefinition::CommitRelease {
+		when: None,
 		inputs: BTreeMap::new(),
 	};
 	assert_eq!(step.valid_input_names(), Some([].as_slice()));
@@ -456,6 +473,7 @@ fn valid_input_names_returns_empty_for_commit_release() {
 #[test]
 fn valid_input_names_returns_expected_names_for_affected_packages() {
 	let step = CliStepDefinition::AffectedPackages {
+		when: None,
 		inputs: BTreeMap::new(),
 	};
 	let names = step.valid_input_names().unwrap();
@@ -469,6 +487,7 @@ fn valid_input_names_returns_expected_names_for_affected_packages() {
 #[test]
 fn valid_input_names_returns_expected_names_for_retarget_release() {
 	let step = CliStepDefinition::RetargetRelease {
+		when: None,
 		inputs: BTreeMap::new(),
 	};
 	let names = step.valid_input_names().unwrap();
@@ -480,6 +499,7 @@ fn valid_input_names_returns_expected_names_for_retarget_release() {
 #[test]
 fn valid_input_names_returns_expected_names_for_create_change_file() {
 	let step = CliStepDefinition::CreateChangeFile {
+		when: None,
 		inputs: BTreeMap::new(),
 	};
 	let names = step.valid_input_names().unwrap();
@@ -524,6 +544,7 @@ fn default_change_command_supports_none_bump_and_omits_legacy_evidence_input() {
 fn expected_input_kind_returns_correct_types_for_affected_packages() {
 	use crate::CliInputKind;
 	let step = CliStepDefinition::AffectedPackages {
+		when: None,
 		inputs: BTreeMap::new(),
 	};
 	assert_eq!(
@@ -552,6 +573,7 @@ fn expected_input_kind_returns_correct_types_for_affected_packages() {
 #[test]
 fn expected_input_kind_returns_none_for_command_steps() {
 	let step = CliStepDefinition::Command {
+		when: None,
 		command: "echo".into(),
 		dry_run_command: None,
 		shell: ShellConfig::None,
@@ -565,6 +587,7 @@ fn expected_input_kind_returns_none_for_command_steps() {
 #[test]
 fn expected_input_kind_returns_none_for_commit_release() {
 	let step = CliStepDefinition::CommitRelease {
+		when: None,
 		inputs: BTreeMap::new(),
 	};
 	assert_eq!(step.expected_input_kind("format"), None);
@@ -574,6 +597,7 @@ fn expected_input_kind_returns_none_for_commit_release() {
 fn expected_input_kind_returns_correct_types_for_create_change_file() {
 	use crate::CliInputKind;
 	let step = CliStepDefinition::CreateChangeFile {
+		when: None,
 		inputs: BTreeMap::new(),
 	};
 	assert_eq!(
@@ -596,6 +620,7 @@ fn expected_input_kind_returns_correct_types_for_create_change_file() {
 fn expected_input_kind_returns_correct_types_for_diagnose_changesets() {
 	use crate::CliInputKind;
 	let step = CliStepDefinition::DiagnoseChangesets {
+		when: None,
 		inputs: BTreeMap::new(),
 	};
 	assert_eq!(
@@ -613,6 +638,7 @@ fn expected_input_kind_returns_correct_types_for_diagnose_changesets() {
 fn expected_input_kind_returns_correct_types_for_retarget_release() {
 	use crate::CliInputKind;
 	let step = CliStepDefinition::RetargetRelease {
+		when: None,
 		inputs: BTreeMap::new(),
 	};
 	assert_eq!(step.expected_input_kind("from"), Some(CliInputKind::String));
@@ -687,12 +713,14 @@ fn cli_step_definition_accepts_legacy_source_automation_step_aliases() {
 	assert_eq!(
 		publish_release,
 		CliStepDefinition::PublishRelease {
+			when: None,
 			inputs: BTreeMap::new(),
 		}
 	);
 	assert_eq!(
 		open_release_request,
 		CliStepDefinition::OpenReleaseRequest {
+			when: None,
 			inputs: BTreeMap::new(),
 		}
 	);

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -1099,10 +1099,14 @@ pub enum CliStepDefinition {
 	/// release.
 	Validate {
 		#[serde(default)]
+		when: Option<String>,
+		#[serde(default)]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Discover packages across supported ecosystems and render the result.
 	Discover {
+		#[serde(default)]
+		when: Option<String>,
 		#[serde(default)]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
@@ -1110,11 +1114,15 @@ pub enum CliStepDefinition {
 	/// prompts.
 	CreateChangeFile {
 		#[serde(default)]
+		when: Option<String>,
+		#[serde(default)]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Prepare a release and expose structured `release.*` context to later
 	/// steps.
 	PrepareRelease {
+		#[serde(default)]
+		when: Option<String>,
 		#[serde(default)]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
@@ -1123,6 +1131,8 @@ pub enum CliStepDefinition {
 	/// Requires a previous `PrepareRelease` step.
 	CommitRelease {
 		#[serde(default)]
+		when: Option<String>,
+		#[serde(default)]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Render the prepared release as a stable JSON manifest and optionally write
@@ -1130,6 +1140,8 @@ pub enum CliStepDefinition {
 	///
 	/// Requires a previous `PrepareRelease` step.
 	RenderReleaseManifest {
+		#[serde(default)]
+		when: Option<String>,
 		#[serde(default)]
 		path: Option<PathBuf>,
 		#[serde(default)]
@@ -1142,6 +1154,8 @@ pub enum CliStepDefinition {
 	/// configuration.
 	PublishRelease {
 		#[serde(default)]
+		when: Option<String>,
+		#[serde(default)]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	#[serde(alias = "OpenReleasePullRequest")]
@@ -1151,6 +1165,8 @@ pub enum CliStepDefinition {
 	/// configuration.
 	OpenReleaseRequest {
 		#[serde(default)]
+		when: Option<String>,
+		#[serde(default)]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Comment on linked released issues after a prepared release.
@@ -1158,6 +1174,8 @@ pub enum CliStepDefinition {
 	/// Requires a previous `PrepareRelease` step and currently expects
 	/// `[source].provider = "github"`.
 	CommentReleasedIssues {
+		#[serde(default)]
+		when: Option<String>,
 		#[serde(default)]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
@@ -1167,10 +1185,14 @@ pub enum CliStepDefinition {
 	/// Standalone CI-oriented step.
 	AffectedPackages {
 		#[serde(default)]
+		when: Option<String>,
+		#[serde(default)]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Inspect parsed changeset data, provenance, and linked metadata.
 	DiagnoseChangesets {
+		#[serde(default)]
+		when: Option<String>,
 		#[serde(default)]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
@@ -1180,12 +1202,16 @@ pub enum CliStepDefinition {
 	/// `retarget.*` state to later commands.
 	RetargetRelease {
 		#[serde(default)]
+		when: Option<String>,
+		#[serde(default)]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Run an arbitrary command with `monochange` template context.
 	///
 	/// Use this to bridge built-in `monochange` state into external tooling.
 	Command {
+		#[serde(default)]
+		when: Option<String>,
 		command: String,
 		#[serde(default, alias = "dry_run")]
 		dry_run_command: Option<String>,
@@ -1204,19 +1230,38 @@ impl CliStepDefinition {
 	#[must_use]
 	pub fn inputs(&self) -> &BTreeMap<String, CliStepInputValue> {
 		match self {
-			Self::Validate { inputs }
-			| Self::Discover { inputs }
-			| Self::CreateChangeFile { inputs }
-			| Self::PrepareRelease { inputs }
-			| Self::CommitRelease { inputs }
+			Self::Validate { inputs, .. }
+			| Self::Discover { inputs, .. }
+			| Self::CreateChangeFile { inputs, .. }
+			| Self::PrepareRelease { inputs, .. }
+			| Self::CommitRelease { inputs, .. }
 			| Self::RenderReleaseManifest { inputs, .. }
-			| Self::PublishRelease { inputs }
-			| Self::OpenReleaseRequest { inputs }
-			| Self::CommentReleasedIssues { inputs }
-			| Self::AffectedPackages { inputs }
-			| Self::DiagnoseChangesets { inputs }
-			| Self::RetargetRelease { inputs }
+			| Self::PublishRelease { inputs, .. }
+			| Self::OpenReleaseRequest { inputs, .. }
+			| Self::CommentReleasedIssues { inputs, .. }
+			| Self::AffectedPackages { inputs, .. }
+			| Self::DiagnoseChangesets { inputs, .. }
+			| Self::RetargetRelease { inputs, .. }
 			| Self::Command { inputs, .. } => inputs,
+		}
+	}
+
+	#[must_use]
+	pub fn when(&self) -> Option<&str> {
+		match self {
+			Self::Validate { when, .. }
+			| Self::Discover { when, .. }
+			| Self::CreateChangeFile { when, .. }
+			| Self::PrepareRelease { when, .. }
+			| Self::CommitRelease { when, .. }
+			| Self::RenderReleaseManifest { when, .. }
+			| Self::PublishRelease { when, .. }
+			| Self::OpenReleaseRequest { when, .. }
+			| Self::CommentReleasedIssues { when, .. }
+			| Self::AffectedPackages { when, .. }
+			| Self::DiagnoseChangesets { when, .. }
+			| Self::RetargetRelease { when, .. }
+			| Self::Command { when, .. } => when.as_deref(),
 		}
 	}
 
@@ -2464,6 +2509,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 			help_text: Some("Validate monochange configuration and changesets".to_string()),
 			inputs: Vec::new(),
 			steps: vec![CliStepDefinition::Validate {
+				when: None,
 				inputs: BTreeMap::new(),
 			}],
 		},
@@ -2480,6 +2526,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 				short: None,
 			}],
 			steps: vec![CliStepDefinition::Discover {
+				when: None,
 				inputs: BTreeMap::new(),
 			}],
 		},
@@ -2572,6 +2619,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 				},
 			],
 			steps: vec![CliStepDefinition::CreateChangeFile {
+				when: None,
 				inputs: BTreeMap::new(),
 			}],
 		},
@@ -2588,6 +2636,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 				short: None,
 			}],
 			steps: vec![CliStepDefinition::PrepareRelease {
+				when: None,
 				inputs: BTreeMap::new(),
 			}],
 		},
@@ -2652,6 +2701,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 				},
 			],
 			steps: vec![CliStepDefinition::AffectedPackages {
+				when: None,
 				inputs: BTreeMap::new(),
 			}],
 		},
@@ -2684,6 +2734,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 				},
 			],
 			steps: vec![CliStepDefinition::DiagnoseChangesets {
+				when: None,
 				inputs: BTreeMap::new(),
 			}],
 		},
@@ -2742,6 +2793,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 				},
 			],
 			steps: vec![CliStepDefinition::RetargetRelease {
+				when: None,
 				inputs: BTreeMap::new(),
 			}],
 		},

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -987,7 +987,7 @@ pub struct CliInputDefinition {
 	pub help_text: Option<String>,
 	#[serde(default)]
 	pub required: bool,
-	#[serde(default)]
+	#[serde(default, deserialize_with = "deserialize_cli_input_default")]
 	pub default: Option<String>,
 	#[serde(default)]
 	pub choices: Vec<String>,
@@ -997,12 +997,29 @@ pub struct CliInputDefinition {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
+enum CliInputDefault {
+	String(String),
+	Boolean(bool),
+}
+
+fn deserialize_cli_input_default<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+	D: serde::Deserializer<'de>,
+{
+	let value = Option::<CliInputDefault>::deserialize(deserializer)?;
+	Ok(value.map(|value| match value {
+		CliInputDefault::String(value) => value,
+		CliInputDefault::Boolean(value) => value.to_string(),
+	}))
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
 pub enum CliStepInputValue {
 	String(String),
 	Boolean(bool),
 	List(Vec<String>),
 }
-
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CommandVariable {

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -385,7 +385,6 @@ CLI command interpolation variables:
 
 - default command substitution when `variables` is omitted: `{{ version }}`, `$group_version`, `$released_packages`, `$changed_files`, and `$changesets`
 - command templates can read CLI inputs through `{{ inputs.name }}`; bare input names still work for backward compatibility
-- every step can define a `when` expression to control execution, e.g. `when = "{{ inputs.publish && !inputs.dry_run }}"`
 - every step can override the inputs it receives with `inputs = { ... }`; direct references like `"{{ inputs.labels }}"` preserve list and boolean values when rebinding to built-in steps
 - custom command substitution when `variables` is present: map your own replacement strings to variable names such as `version`, `group_version`, `released_packages`, `changed_files`, and `changesets`
 - `dry_run_command` on a `Command` step replaces `command` only when the CLI command is run with `--dry-run`

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -385,6 +385,7 @@ CLI command interpolation variables:
 
 - default command substitution when `variables` is omitted: `{{ version }}`, `$group_version`, `$released_packages`, `$changed_files`, and `$changesets`
 - command templates can read CLI inputs through `{{ inputs.name }}`; bare input names still work for backward compatibility
+- every step can define a `when` expression to control execution, e.g. `when = "{{ inputs.publish && !inputs.dry_run }}"`
 - every step can override the inputs it receives with `inputs = { ... }`; direct references like `"{{ inputs.labels }}"` preserve list and boolean values when rebinding to built-in steps
 - custom command substitution when `variables` is present: map your own replacement strings to variable names such as `version`, `group_version`, `released_packages`, `changed_files`, and `changesets`
 - `dry_run_command` on a `Command` step replaces `command` only when the CLI command is run with `--dry-run`

--- a/docs/src/reference/cli-steps/00-index.md
+++ b/docs/src/reference/cli-steps/00-index.md
@@ -79,12 +79,9 @@ In practice, most workflows fit one of four patterns:
 
 Every step can declare a `when = "..."` expression.
 
-It uses minijinja-style expression evaluation with template context and supports
-logical combinations like `and`, `or`, and `not` (for example:
-`"{{ inputs.publish && !inputs.dry_run }}"`).
+It uses minijinja-style expression evaluation with template context and supports logical combinations like `and`, `or`, and `not` (for example: `"{{ inputs.publish && !inputs.dry_run }}"`).
 
-If the expression resolves to false, monochange skips that step and continues
-with the next step.
+If the expression resolves to false, monochange skips that step and continues with the next step. Falsy values include `false`, `0`, and the empty string.
 
 ### Step-local `inputs`
 

--- a/docs/src/reference/cli-steps/00-index.md
+++ b/docs/src/reference/cli-steps/00-index.md
@@ -75,6 +75,17 @@ In practice, most workflows fit one of four patterns:
 
 ## Shared concepts
 
+### Step-local `when`
+
+Every step can declare a `when = "..."` expression.
+
+It uses minijinja-style expression evaluation with template context and supports
+logical combinations like `and`, `or`, and `not` (for example:
+`"{{ inputs.publish && !inputs.dry_run }}"`).
+
+If the expression resolves to false, monochange skips that step and continues
+with the next step.
+
 ### Step-local `inputs`
 
 Every step can define an `inputs = { ... }` override inside the step table.

--- a/docs/src/reference/cli-steps/01-validate.md
+++ b/docs/src/reference/cli-steps/01-validate.md
@@ -22,6 +22,16 @@ Compared with a shell-only `Command` step that runs `mc validate`, the built-in 
 
 `Validate` does not accept any built-in step inputs.
 
+## Step-level `when` condition
+
+All CLI steps support an optional `when = "..."` condition.
+
+If the expression resolves to false at runtime, monochange skips the step and continues with the next step.
+
+```toml
+when = "{{ inputs.enabled }}"
+```
+
 ## Prerequisites
 
 None. `Validate` is standalone.

--- a/docs/src/reference/cli-steps/02-discover.md
+++ b/docs/src/reference/cli-steps/02-discover.md
@@ -21,6 +21,16 @@ This is particularly valuable in mixed-ecosystem monorepos where discovery rules
 
 - `format` — `text` or `json`
 
+## Step-level `when` condition
+
+All CLI steps support an optional `when = "..."` condition.
+
+If the expression resolves to false at runtime, monochange skips the step and continues with the next step.
+
+```toml
+when = "{{ inputs.enabled }}"
+```
+
 ## Prerequisites
 
 None. `Discover` is standalone.

--- a/docs/src/reference/cli-steps/03-create-change-file.md
+++ b/docs/src/reference/cli-steps/03-create-change-file.md
@@ -31,6 +31,16 @@ That gives you a few advantages over rolling your own shell template generator:
 - `details` — optional long-form body
 - `output` — optional explicit file path
 
+## Step-level `when` condition
+
+All CLI steps support an optional `when = "..."` condition.
+
+If the expression resolves to false at runtime, monochange skips the step and continues with the next step.
+
+```toml
+when = "{{ inputs.enabled }}"
+```
+
 ## Prerequisites
 
 None. `CreateChangeFile` is standalone.

--- a/docs/src/reference/cli-steps/04-affected-packages.md
+++ b/docs/src/reference/cli-steps/04-affected-packages.md
@@ -29,6 +29,16 @@ It is the best fit for:
 - `verify` — whether to enforce non-zero failure on uncovered packages
 - `label` — skip labels supplied from CI
 
+## Step-level `when` condition
+
+All CLI steps support an optional `when = "..."` condition.
+
+If the expression resolves to false at runtime, monochange skips the step and continues with the next step.
+
+```toml
+when = "{{ inputs.enabled }}"
+```
+
 ## Prerequisites
 
 None. `AffectedPackages` is standalone.

--- a/docs/src/reference/cli-steps/05-diagnose-changesets.md
+++ b/docs/src/reference/cli-steps/05-diagnose-changesets.md
@@ -25,6 +25,16 @@ This makes it especially useful for debugging rich release-note context and CI p
 - `format` — `text` or `json`
 - `changeset` — one or more explicit changeset paths; omit to inspect all discovered changesets
 
+## Step-level `when` condition
+
+All CLI steps support an optional `when = "..."` condition.
+
+If the expression resolves to false at runtime, monochange skips the step and continues with the next step.
+
+```toml
+when = "{{ inputs.enabled }}"
+```
+
 ## Prerequisites
 
 None. `DiagnoseChangesets` is standalone.

--- a/docs/src/reference/cli-steps/06-retarget-release.md
+++ b/docs/src/reference/cli-steps/06-retarget-release.md
@@ -29,6 +29,16 @@ Typical use cases include:
 - `sync_provider` — whether hosted provider state should be synchronized
 - `format` — `text` or `json`
 
+## Step-level `when` condition
+
+All CLI steps support an optional `when = "..."` condition.
+
+If the expression resolves to false at runtime, monochange skips the step and continues with the next step.
+
+```toml
+when = "{{ inputs.enabled }}"
+```
+
 ## Prerequisites
 
 None.

--- a/docs/src/reference/cli-steps/07-prepare-release.md
+++ b/docs/src/reference/cli-steps/07-prepare-release.md
@@ -26,6 +26,16 @@ If your command eventually needs release metadata, start with `PrepareRelease` r
 
 - `format` — `text` or `json`
 
+## Step-level `when` condition
+
+All CLI steps support an optional `when = "..."` condition.
+
+If the expression resolves to false at runtime, monochange skips the step and continues with the next step.
+
+```toml
+when = "{{ inputs.enabled }}"
+```
+
 ## Prerequisites
 
 None. `PrepareRelease` is the producer step for the rest of the release workflow.

--- a/docs/src/reference/cli-steps/08-commit-release.md
+++ b/docs/src/reference/cli-steps/08-commit-release.md
@@ -26,6 +26,16 @@ This is especially useful when you want to:
 
 That is intentional: it consumes prepared release state instead of raw user input.
 
+## Step-level `when` condition
+
+All CLI steps support an optional `when = "..."` condition.
+
+If the expression resolves to false at runtime, monochange skips the step and continues with the next step.
+
+```toml
+when = "{{ inputs.enabled }}"
+```
+
 ## Prerequisites
 
 - a previous `PrepareRelease` step in the same command

--- a/docs/src/reference/cli-steps/09-render-release-manifest.md
+++ b/docs/src/reference/cli-steps/09-render-release-manifest.md
@@ -27,6 +27,16 @@ Step-specific config fields:
 
 - `path` — optional output path for the manifest file
 
+## Step-level `when` condition
+
+All CLI steps support an optional `when = "..."` condition.
+
+If the expression resolves to false at runtime, monochange skips the step and continues with the next step.
+
+```toml
+when = "{{ inputs.enabled }}"
+```
+
 ## Prerequisites
 
 - a previous `PrepareRelease` step in the same command

--- a/docs/src/reference/cli-steps/10-publish-release.md
+++ b/docs/src/reference/cli-steps/10-publish-release.md
@@ -21,6 +21,16 @@ That gives you:
 
 - `format` — `text` or `json`
 
+## Step-level `when` condition
+
+All CLI steps support an optional `when = "..."` condition.
+
+If the expression resolves to false at runtime, monochange skips the step and continues with the next step.
+
+```toml
+when = "{{ inputs.enabled }}"
+```
+
 ## Prerequisites
 
 - a previous `PrepareRelease` step in the same command

--- a/docs/src/reference/cli-steps/11-open-release-request.md
+++ b/docs/src/reference/cli-steps/11-open-release-request.md
@@ -20,6 +20,16 @@ This is a strong fit when your release process includes:
 
 - `format` — `text` or `json`
 
+## Step-level `when` condition
+
+All CLI steps support an optional `when = "..."` condition.
+
+If the expression resolves to false at runtime, monochange skips the step and continues with the next step.
+
+```toml
+when = "{{ inputs.enabled }}"
+```
+
 ## Prerequisites
 
 - a previous `PrepareRelease` step in the same command

--- a/docs/src/reference/cli-steps/12-comment-released-issues.md
+++ b/docs/src/reference/cli-steps/12-comment-released-issues.md
@@ -20,6 +20,16 @@ This is especially valuable when:
 
 - `format` — `text` or `json`
 
+## Step-level `when` condition
+
+All CLI steps support an optional `when = "..."` condition.
+
+If the expression resolves to false at runtime, monochange skips the step and continues with the next step.
+
+```toml
+when = "{{ inputs.enabled }}"
+```
+
 ## Prerequisites
 
 - a previous `PrepareRelease` step in the same command

--- a/docs/src/reference/cli-steps/13-command.md
+++ b/docs/src/reference/cli-steps/13-command.md
@@ -25,6 +25,7 @@ Use `Command` for what is truly custom.
 ## Core fields
 
 - `command` — the command to run in normal mode
+- `when` — optional boolean condition controlling whether the step runs
 - `dry_run_command` — optional replacement command used only when the command runs with `--dry-run`
 - `shell` — whether to run through a shell (`true`, `false`, or a custom shell binary name)
 - `id` — optional identifier that exposes `steps.<id>.stdout` and `steps.<id>.stderr` to later steps

--- a/fixtures/tests/cli-step-when/monochange.toml
+++ b/fixtures/tests/cli-step-when/monochange.toml
@@ -1,0 +1,44 @@
+[cli.when-command]
+help_text = "Conditionally run a command"
+
+[[cli.when-command.inputs]]
+name = "run"
+type = "boolean"
+default = "false"
+
+[[cli.when-command.inputs]]
+name = "extra"
+type = "boolean"
+default = "false"
+
+[[cli.when-command.steps]]
+type = "Command"
+when = "{{ inputs.run && inputs.extra }}"
+command = "printf '%s' hello > when-command-output.txt"
+shell = true
+
+[cli.not-condition]
+help_text = "Negation condition on command"
+
+[[cli.not-condition.inputs]]
+name = "skip"
+type = "boolean"
+default = "true"
+
+[[cli.not-condition.steps]]
+type = "Command"
+when = "{{ ! inputs.skip }}"
+command = "printf '%s' okay > not-output.txt"
+shell = true
+
+[cli.when-validate]
+help_text = "Conditionally run Validate"
+
+[[cli.when-validate.inputs]]
+name = "skip"
+type = "boolean"
+default = "true"
+
+[[cli.when-validate.steps]]
+type = "Validate"
+when = "{{ ! inputs.skip }}"

--- a/fixtures/tests/config/accepts-boolean-input-defaults/core/Cargo.toml
+++ b/fixtures/tests/config/accepts-boolean-input-defaults/core/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "core"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "lib.rs"

--- a/fixtures/tests/config/accepts-boolean-input-defaults/monochange.toml
+++ b/fixtures/tests/config/accepts-boolean-input-defaults/monochange.toml
@@ -1,0 +1,23 @@
+[defaults]
+package_type = "cargo"
+
+[package.core]
+path = "core"
+
+[changesets.verify]
+enabled = true
+
+[cli.pr-check]
+
+[[cli.pr-check.inputs]]
+name = "dry_run"
+type = "boolean"
+default = true
+
+[[cli.pr-check.inputs]]
+name = "sync"
+type = "boolean"
+default = false
+
+[[cli.pr-check.steps]]
+type = "Validate"


### PR DESCRIPTION
## Summary

- Add optional `when` condition support to **all** `CliStepDefinition` variants (not just `Command`) with backward-compatible default execution when omitted.
- Evaluate `when` at runtime before running each step and skip steps whose condition resolves to false.
- Support boolean composition in conditions with `&&`, `||`, and unary `!` (`when` expressions are normalized to Jinja `and`, `or`, `not`).
- Keep template-path behavior and value typing: direct template refs are looked up and coerced conservatively, with non-scalar values rejected.
- Add config-time validation for empty `when` strings.
- Add unit/integration test coverage:
  - unit tests in `crates/monochange/src/__tests.rs`
  - integration tests in `crates/monochange/tests/cli_step_when.rs`
  - config validation test in `crates/monochange_config/src/__tests.rs`
- Update CLI docs and init template guidance to document step-level `when` usage.

## Validation

- `cargo test -p monochange_config`
- `cargo test -p monochange`
- `cargo test -p monochange --test cli_step_when`
