### PR TITLE
fix(cli): preserve built-in commands across config overrides

### DIFF
--- a/.changeset/cli-default-command-overrides.md
+++ b/.changeset/cli-default-command-overrides.md
@@ -1,0 +1,24 @@
+---
+monochange: patch
+monochange_config: patch
+---
+
+# allow per-command CLI overrides without redefining every built-in command
+
+Before:
+
+```toml
+[cli.release]
+# custom release steps
+```
+
+Defining one CLI command replaced the entire built-in command set, so users had to copy every default command they still wanted.
+
+After:
+
+```toml
+[cli.release]
+# custom release steps
+```
+
+Only the built-in `release` command is replaced. Other built-in commands stay available automatically, and additional custom commands are still appended.

--- a/.templates/crates.t.md
+++ b/.templates/crates.t.md
@@ -138,7 +138,7 @@ mc mcp
 
 - aggregate all supported ecosystem adapters
 - load `monochange.toml`
-- synthesize default CLI commands when config does not declare any
+- start from the built-in default CLI commands and let matching config entries replace them
 - resolve change input files
 - render discovery and release command output in text or JSON
 - execute configured CLI commands plus built-in assistant setup and MCP commands

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -503,7 +503,7 @@ When `version` is provided without `bump`, the bump is inferred from the current
 
 <!-- {@releaseWorkflowBehavior} -->
 
-`mc release` is a config-defined top-level command. When your config omits `[cli.<command>]` entries, monochange synthesizes the default `release` command automatically.
+`mc release` is part of monochange's built-in default command set. You only need to add `[cli.release]` when you want to replace that default definition with your own steps, inputs, or help text.
 
 During migration, you may still see references to `[[package_overrides]]` in older documentation or repositories, but release preparation now expects package/group declarations and consumes `.changeset/*.md` files through that new model.
 

--- a/crates/monochange/readme.md
+++ b/crates/monochange/readme.md
@@ -43,7 +43,7 @@ mc mcp
 
 - aggregate all supported ecosystem adapters
 - load `monochange.toml`
-- synthesize default CLI commands when config does not declare any
+- start from the built-in default CLI commands and let matching config entries replace them
 - resolve change input files
 - render discovery and release command output in text or JSON
 - execute configured CLI commands plus built-in assistant setup and MCP commands

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -1949,7 +1949,7 @@ fn release_planning_guide_describes_release_cli_command_requirements() {
 		fs::read_to_string(release_guide).unwrap_or_else(|error| panic!("release guide: {error}"));
 
 	for expected in [
-		"`mc release` is a config-defined top-level command.",
+		"`mc release` is part of monochange's built-in default command set.",
 		"`[[package_overrides]]`",
 		"`.changeset/*.md`",
 		"`--dry-run`",
@@ -6503,11 +6503,20 @@ fn apply_runtime_change_type_choices_preserves_existing_choice_inputs_and_empty_
 #[test]
 fn cli_commands_for_root_uses_workspace_cli_when_configuration_load_succeeds() {
 	let cli = crate::cli_commands_for_root(&fixture_path("config/package-group-and-cli"));
+	let command_names = cli
+		.iter()
+		.map(|command| command.name.as_str())
+		.collect::<Vec<_>>();
+	assert!(command_names.contains(&"validate"));
+	assert!(command_names.contains(&"discover"));
+	assert!(command_names.contains(&"release"));
 	assert_eq!(
 		cli.iter()
-			.map(|command| command.name.as_str())
-			.collect::<Vec<_>>(),
-		vec!["release"]
+			.find(|command| command.name == "release")
+			.unwrap_or_else(|| panic!("expected release command"))
+			.steps
+			.len(),
+		2
 	);
 }
 

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -34,7 +34,7 @@
 //!
 //! - aggregate all supported ecosystem adapters
 //! - load `monochange.toml`
-//! - synthesize default CLI commands when config does not declare any
+//! - start from the built-in default CLI commands and let matching config entries replace them
 //! - resolve change input files
 //! - render discovery and release command output in text or JSON
 //! - execute configured CLI commands plus built-in assistant setup and MCP commands

--- a/crates/monochange/src/monochange.init.toml
+++ b/crates/monochange/src/monochange.init.toml
@@ -490,6 +490,11 @@ comment_on_failure = true
 # Each [cli.<name>] table becomes a top-level `mc <name>` command.
 # Legacy [[workflows]] tables are no longer supported.
 #
+# monochange starts from its built-in default command set. If you redefine a
+# built-in command like [cli.release], your definition fully replaces the
+# default for that command. You can delete unchanged built-in command tables
+# from your real monochange.toml and keep only the overrides you care about.
+#
 # Reserved names that cannot be used: "init", "help", "version"
 #
 # Fields:

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -126,6 +126,78 @@ fn load_workspace_configuration_supports_diagnostics_cli_command_definition() {
 }
 
 #[test]
+fn load_workspace_configuration_merges_default_cli_commands_with_overrides_and_custom_commands() {
+	let root = fixture_path("config/merge-default-cli-overrides");
+	let configuration = load_workspace_configuration(&root)
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+	let cli_command_names = configuration
+		.cli
+		.iter()
+		.map(|cli_command| cli_command.name.as_str())
+		.collect::<Vec<_>>();
+	assert_eq!(
+		cli_command_names,
+		vec![
+			"validate",
+			"discover",
+			"change",
+			"release",
+			"affected",
+			"diagnostics",
+			"repair-release",
+			"release-manifest"
+		]
+	);
+
+	let discover = configuration
+		.cli
+		.iter()
+		.find(|command| command.name == "discover")
+		.unwrap_or_else(|| panic!("expected discover command"));
+	assert_eq!(
+		discover.help_text.as_deref(),
+		Some("Discover packages across supported ecosystems")
+	);
+	assert_eq!(discover.inputs.len(), 1);
+
+	let release = configuration
+		.cli
+		.iter()
+		.find(|command| command.name == "release")
+		.unwrap_or_else(|| panic!("expected release command"));
+	assert_eq!(
+		release.help_text.as_deref(),
+		Some("Prepare a release and write a stable JSON manifest")
+	);
+	assert!(release.inputs.is_empty());
+	assert!(matches!(
+		release.steps.first(),
+		Some(CliStepDefinition::PrepareRelease { .. })
+	));
+	assert!(matches!(
+		release.steps.get(1),
+		Some(CliStepDefinition::RenderReleaseManifest {
+			path: Some(path),
+			..
+		}) if path == &PathBuf::from(".monochange/release-manifest.json")
+	));
+
+	let release_manifest = configuration
+		.cli
+		.iter()
+		.find(|command| command.name == "release-manifest")
+		.unwrap_or_else(|| panic!("expected release-manifest command"));
+	assert!(matches!(
+		release_manifest.steps.first(),
+		Some(CliStepDefinition::PrepareRelease { .. })
+	));
+	assert!(matches!(
+		release_manifest.steps.get(1),
+		Some(CliStepDefinition::RenderReleaseManifest { .. })
+	));
+}
+
+#[test]
 fn load_workspace_configuration_supports_commit_release_cli_command_definition() {
 	let root = fixture_path("config/commit-release-cli");
 	let configuration = load_workspace_configuration(&root)
@@ -213,12 +285,12 @@ fn load_workspace_configuration_parses_package_group_and_cli_command_declaration
 	);
 	assert_eq!(configuration.packages.len(), 2);
 	assert_eq!(configuration.groups.len(), 1);
-	assert_eq!(configuration.cli.len(), 1);
 	assert_eq!(
 		configuration
 			.cli
-			.first()
-			.unwrap_or_else(|| panic!("expected CLI command"))
+			.iter()
+			.find(|command| command.name == "release")
+			.unwrap_or_else(|| panic!("expected release CLI command"))
 			.steps
 			.len(),
 		2
@@ -1750,7 +1822,10 @@ fn load_workspace_configuration_accepts_comment_released_issues_for_github() {
 	let root = fixture_path("config/accepts-comment-github");
 	let configuration = load_workspace_configuration(&root)
 		.unwrap_or_else(|error| panic!("configuration: {error}"));
-	assert_eq!(configuration.cli.len(), 1);
+	assert!(configuration
+		.cli
+		.iter()
+		.any(|command| command.name == "comment"));
 }
 
 #[test]
@@ -1780,7 +1855,10 @@ fn load_workspace_configuration_accepts_affected_packages_step_input_overrides()
 	let root = fixture_path("config/affected-step-overrides");
 	let configuration = load_workspace_configuration(&root)
 		.unwrap_or_else(|error| panic!("configuration: {error}"));
-	assert_eq!(configuration.cli.len(), 1);
+	assert!(configuration
+		.cli
+		.iter()
+		.any(|command| command.name == "pr-check"));
 }
 
 #[test]
@@ -1788,7 +1866,10 @@ fn load_workspace_configuration_accepts_affected_packages_with_since_in_step_ove
 	let root = fixture_path("config/affected-step-since");
 	let configuration = load_workspace_configuration(&root)
 		.unwrap_or_else(|error| panic!("configuration: {error}"));
-	assert_eq!(configuration.cli.len(), 1);
+	assert!(configuration
+		.cli
+		.iter()
+		.any(|command| command.name == "pr-check"));
 }
 
 #[test]
@@ -2644,16 +2725,16 @@ fn changeset_files_with_crlf_line_endings_parse_correctly() {
 	let configuration =
 		load_workspace_configuration(root).unwrap_or_else(|error| panic!("config: {error}"));
 
-	let packages = vec![monochange_core::PackageRecord::new(
-		monochange_core::Ecosystem::Cargo,
+	let packages = vec![PackageRecord::new(
+		Ecosystem::Cargo,
 		"core",
 		root.join("crates/core/Cargo.toml"),
 		root.to_path_buf(),
 		Some(Version::new(1, 0, 0)),
-		monochange_core::PublishState::Public,
+		PublishState::Public,
 	)];
 
-	let changeset = crate::load_changeset_file(
+	let changeset = load_changeset_file(
 		&root.join(".changeset/crlf-test.md"),
 		&configuration,
 		&packages,

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -583,6 +583,27 @@ fn default_warn_on_group_mismatch() -> bool {
 	true
 }
 
+fn merge_cli_commands(cli: BTreeMap<String, RawCliCommandDefinition>) -> Vec<CliCommandDefinition> {
+	let mut merged = default_cli_commands();
+	for (name, definition) in cli {
+		let command = CliCommandDefinition {
+			name: name.clone(),
+			help_text: definition.help_text,
+			inputs: definition.inputs,
+			steps: definition.steps,
+		};
+		if let Some(existing) = merged
+			.iter_mut()
+			.find(|cli_command| cli_command.name == name)
+		{
+			*existing = command;
+		} else {
+			merged.push(command);
+		}
+	}
+	merged
+}
+
 fn default_true() -> bool {
 	true
 }
@@ -908,18 +929,7 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 			"legacy `[[workflows]]` configuration is no longer supported; use `[cli.<command>]` with `[[cli.<command>.steps]]` instead".to_string(),
 		));
 	}
-	let cli = if cli.is_empty() {
-		default_cli_commands()
-	} else {
-		cli.into_iter()
-			.map(|(name, definition)| CliCommandDefinition {
-				name,
-				help_text: definition.help_text,
-				inputs: definition.inputs,
-				steps: definition.steps,
-			})
-			.collect::<Vec<_>>()
-	};
+	let cli = merge_cli_commands(cli);
 	let default_package_type = defaults.package_type;
 	let default_package_changelog = defaults.changelog.clone();
 	let default_extra_changelog_sections = defaults.extra_changelog_sections.clone();

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -257,7 +257,7 @@ lockfile_commands = [
 
 ## CLI commands
 
-CLI commands are user-defined top-level commands. Each `[cli.<command>]` entry becomes invocable as `mc <command>`, and legacy `[[workflows]]` tables are no longer supported.
+CLI commands are user-defined top-level commands. monochange starts from its built-in default command set, then applies each `[cli.<command>]` entry as a full command override when the name matches or as an additional command when it does not. Each resulting command becomes invocable as `mc <command>`, and legacy `[[workflows]]` tables are no longer supported.
 
 <!-- {=configurationWorkflowsSnippet} -->
 

--- a/docs/src/guide/06-release-planning.md
+++ b/docs/src/guide/06-release-planning.md
@@ -131,7 +131,7 @@ mc release
 
 <!-- {=releaseWorkflowBehavior} -->
 
-`mc release` is a config-defined top-level command. When your config omits `[cli.<command>]` entries, monochange synthesizes the default `release` command automatically.
+`mc release` is part of monochange's built-in default command set. You only need to add `[cli.release]` when you want to replace that default definition with your own steps, inputs, or help text.
 
 During migration, you may still see references to `[[package_overrides]]` in older documentation or repositories, but release preparation now expects package/group declarations and consumes `.changeset/*.md` files through that new model.
 

--- a/fixtures/tests/config/merge-default-cli-overrides/monochange.toml
+++ b/fixtures/tests/config/merge-default-cli-overrides/monochange.toml
@@ -1,0 +1,19 @@
+[cli.release]
+help_text = "Prepare a release and write a stable JSON manifest"
+
+[[cli.release.steps]]
+type = "PrepareRelease"
+
+[[cli.release.steps]]
+type = "RenderReleaseManifest"
+path = ".monochange/release-manifest.json"
+
+[cli.release-manifest]
+help_text = "Prepare a release and write a stable JSON manifest"
+
+[[cli.release-manifest.steps]]
+type = "PrepareRelease"
+
+[[cli.release-manifest.steps]]
+type = "RenderReleaseManifest"
+path = ".monochange/release-manifest.json"

--- a/specs/001-first-step-port/contracts/cli.md
+++ b/specs/001-first-step-port/contracts/cli.md
@@ -64,7 +64,7 @@ monochange release [--dry-run] [--format <text|json>]
 ## CLI Surface Rules
 
 - repositories may define custom top-level commands through `[cli.<command>]`
-- when `[cli.<command>]` is omitted, monochange synthesizes `validate`, `discover`, `change`, and `release`
+- monochange starts from its built-in default command set; a configured `[cli.<command>]` entry with the same name replaces that command, and a new name adds an extra top-level command
 - command-declared inputs become CLI flags
 - all configured commands implicitly support `--help` and `--dry-run`
 - `init`, `help`, and `version` remain reserved built-ins

--- a/specs/cli-commands-api-design.md
+++ b/specs/cli-commands-api-design.md
@@ -85,7 +85,7 @@ Future non-command automation can live under separate namespaces such as:
 
 ## Behavioral rules
 
-- if no `[cli.<command>]` entries are declared, monochange synthesizes `validate`, `discover`, `change`, and `release`
+- monochange starts from its built-in default command set; any configured `[cli.<command>]` entry with the same name replaces that built-in definition, and new names are added alongside the defaults
 - built-in reserved names remain `init`, `help`, and `version`
 - command inputs become CLI flags
 - all configured commands implicitly support `--help` and `--dry-run`

--- a/specs/cli-commands-api-implementation-plan.md
+++ b/specs/cli-commands-api-implementation-plan.md
@@ -22,7 +22,7 @@
 3. **CLI runtime update**
    - build clap subcommands from configured CLI commands
    - keep implicit `--dry-run` support
-   - preserve default synthesized commands when config omits `cli`
+   - preserve the built-in default command set and let same-name config entries replace individual commands
 
 4. **Init output update**
    - emit `[cli.<command>]` definitions from `mc init`


### PR DESCRIPTION
## Summary
- preserve the built-in CLI command set when loading `monochange.toml`
- let a configured `[cli.<command>]` entry fully replace only the matching built-in command while leaving the rest available
- add fixture coverage and update docs/init guidance to describe command-level overrides

## User-facing behavior
Before, defining one CLI command in `monochange.toml` replaced the whole built-in command set.

After, defining `[cli.release]` replaces only `release`; the other built-in commands still exist unless you explicitly override them too.

## Testing
- `devenv shell build:all`
- `devenv shell lint:all`
- `devenv shell test:all`
- `devenv shell mc validate`
- `cargo bin cargo-llvm-cov test -p monochange_config --all-features --no-report`
- `cargo bin cargo-llvm-cov --text -p monochange_config`

## Coverage
The changed production code paths in `crates/monochange_config/src/lib.rs` are line-covered:
- `merge_cli_commands(...)` override path covered
- `merge_cli_commands(...)` append path covered
- `merge_cli_commands(...)` empty-input/default path covered through config-loading tests
- `load_workspace_configuration(...)` call site for `merge_cli_commands(cli)` covered
