### PR TITLE
feat(cli): add mc populate for default commands

### DIFF
--- a/.changeset/mc-populate-cli-defaults.md
+++ b/.changeset/mc-populate-cli-defaults.md
@@ -1,0 +1,21 @@
+---
+monochange: patch
+---
+
+# add mc populate for materializing default CLI commands into config
+
+Before:
+
+```bash
+mc populate
+```
+
+The command did not exist, so users had to copy built-in `[cli.*]` definitions by hand when they wanted editable defaults in `monochange.toml`.
+
+After:
+
+```bash
+mc populate
+```
+
+monochange appends only the missing built-in CLI command definitions to `monochange.toml`, leaving existing command overrides unchanged.

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -436,7 +436,7 @@ Generate a starter config from the packages monochange detects:
 mc init
 ```
 
-`mc init` writes an annotated `monochange.toml`, so most first-time users can start with the generated file instead of hand-authoring config.
+`mc init` writes an annotated `monochange.toml`, so most first-time users can start with the generated file instead of hand-authoring config. If you later want editable copies of the built-in CLI commands, run `mc populate` to append any missing default command definitions to `monochange.toml`.
 
 Validate the workspace:
 

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -424,7 +424,15 @@ fn render_cli_commands_toml_handles_manifest_and_command_step_variants() {
 	let rendered = crate::render_cli_commands_toml(&[monochange_core::CliCommandDefinition {
 		name: "custom".to_string(),
 		help_text: None,
-		inputs: Vec::new(),
+		inputs: vec![CliInputDefinition {
+			name: "mode".to_string(),
+			kind: CliInputKind::Choice,
+			help_text: Some("Select the command mode".to_string()),
+			required: true,
+			default: Some("safe".to_string()),
+			choices: vec!["safe".to_string(), "fast".to_string()],
+			short: Some('m'),
+		}],
 		steps: vec![
 			monochange_core::CliStepDefinition::RenderReleaseManifest {
 				when: Some("{{ inputs.enabled }}".to_string()),
@@ -452,10 +460,28 @@ fn render_cli_commands_toml_handles_manifest_and_command_step_variants() {
 				dry_run_command: None,
 				shell: monochange_core::ShellConfig::Default,
 				id: Some("default-shell".to_string()),
-				variables: Some(BTreeMap::from([(
-					"version_value".to_string(),
-					monochange_core::CommandVariable::Version,
-				)])),
+				variables: Some(BTreeMap::from([
+					(
+						"version_value".to_string(),
+						monochange_core::CommandVariable::Version,
+					),
+					(
+						"group_version_value".to_string(),
+						monochange_core::CommandVariable::GroupVersion,
+					),
+					(
+						"released_packages_value".to_string(),
+						monochange_core::CommandVariable::ReleasedPackages,
+					),
+					(
+						"changed_files_value".to_string(),
+						monochange_core::CommandVariable::ChangedFiles,
+					),
+					(
+						"changesets_value".to_string(),
+						monochange_core::CommandVariable::Changesets,
+					),
+				])),
 				inputs: BTreeMap::from([(
 					"changed_paths".to_string(),
 					monochange_core::CliStepInputValue::List(vec!["src/lib.rs".to_string()]),
@@ -470,10 +496,46 @@ fn render_cli_commands_toml_handles_manifest_and_command_step_variants() {
 				variables: None,
 				inputs: BTreeMap::new(),
 			},
+			monochange_core::CliStepDefinition::CommitRelease {
+				when: None,
+				inputs: BTreeMap::from([(
+					"format".to_string(),
+					monochange_core::CliStepInputValue::String("json".to_string()),
+				)]),
+			},
+			monochange_core::CliStepDefinition::PublishRelease {
+				when: None,
+				inputs: BTreeMap::from([(
+					"format".to_string(),
+					monochange_core::CliStepInputValue::String("text".to_string()),
+				)]),
+			},
+			monochange_core::CliStepDefinition::OpenReleaseRequest {
+				when: None,
+				inputs: BTreeMap::from([(
+					"format".to_string(),
+					monochange_core::CliStepInputValue::String("json".to_string()),
+				)]),
+			},
+			monochange_core::CliStepDefinition::CommentReleasedIssues {
+				when: None,
+				inputs: BTreeMap::from([(
+					"format".to_string(),
+					monochange_core::CliStepInputValue::String("text".to_string()),
+				)]),
+			},
 		],
 	}]);
 
 	assert!(rendered.contains("[cli.custom]"));
+	assert!(rendered.contains("[[cli.custom.inputs]]"));
+	assert!(rendered.contains("name = \"mode\""));
+	assert!(rendered.contains("type = \"choice\""));
+	assert!(rendered.contains("help_text = \"Select the command mode\""));
+	assert!(rendered.contains("required = true"));
+	assert!(rendered.contains("default = \"safe\""));
+	assert!(rendered.contains("choices = [\"safe\", \"fast\"]"));
+	assert!(rendered.contains("short = \"m\""));
 	assert!(rendered.contains("[[cli.custom.steps]]"));
 	assert!(rendered.contains("type = \"RenderReleaseManifest\""));
 	assert!(rendered.contains("when = \"{{ inputs.enabled }}\""));
@@ -482,9 +544,17 @@ fn render_cli_commands_toml_handles_manifest_and_command_step_variants() {
 	assert!(rendered.contains("dry_run_command = \"echo dry-run\""));
 	assert!(rendered.contains("inputs = { enabled = true }"));
 	assert!(rendered.contains("shell = true"));
-	assert!(rendered.contains("variables = { version_value = \"version\" }"));
+	assert!(rendered.contains("group_version_value = \"group_version\""));
+	assert!(rendered.contains("released_packages_value = \"released_packages\""));
+	assert!(rendered.contains("changed_files_value = \"changed_files\""));
+	assert!(rendered.contains("changesets_value = \"changesets\""));
+	assert!(rendered.contains("version_value = \"version\""));
 	assert!(rendered.contains("inputs = { changed_paths = [\"src/lib.rs\"] }"));
 	assert!(rendered.contains("shell = \"bash\""));
+	assert!(rendered.contains("type = \"CommitRelease\""));
+	assert!(rendered.contains("type = \"PublishRelease\""));
+	assert!(rendered.contains("type = \"OpenReleaseRequest\""));
+	assert!(rendered.contains("type = \"CommentReleasedIssues\""));
 	assert!(!rendered.contains("name = \"custom\""));
 }
 

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -13,11 +13,16 @@ use httpmock::MockServer;
 use monochange_config::load_workspace_configuration;
 use monochange_core::BumpSeverity;
 use monochange_core::ChangesetTargetKind;
+use monochange_core::CliCommandDefinition;
 use monochange_core::CliInputDefinition;
 use monochange_core::CliInputKind;
+use monochange_core::CliStepDefinition;
+use monochange_core::CliStepInputValue;
+use monochange_core::CommandVariable;
 use monochange_core::Ecosystem;
 use monochange_core::GroupChangelogInclude;
 use monochange_core::PreparedChangesetTarget;
+use monochange_core::ShellConfig;
 use monochange_core::VersionFormat;
 use monochange_test_helpers::copy_directory;
 use monochange_test_helpers::current_test_name;
@@ -259,6 +264,223 @@ fn init_requires_force_to_overwrite_existing_configuration() {
 	.err()
 	.unwrap_or_else(|| panic!("expected init failure"));
 	assert!(error.to_string().contains("--force"));
+}
+
+#[test]
+fn populate_adds_all_missing_default_cli_commands_to_an_existing_configuration() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_fixture("monochange/populate-no-cli", tempdir.path());
+
+	let output = run_cli(
+		tempdir.path(),
+		[OsString::from("mc"), OsString::from("populate")],
+	)
+	.unwrap_or_else(|error| panic!("populate output: {error}"));
+	let config = fs::read_to_string(tempdir.path().join("monochange.toml"))
+		.unwrap_or_else(|error| panic!("config: {error}"));
+
+	assert!(output.contains("added 7 default CLI commands"));
+	for table in [
+		"[cli.validate]",
+		"[cli.discover]",
+		"[cli.change]",
+		"[cli.release]",
+		"[cli.affected]",
+		"[cli.diagnostics]",
+		"[cli.repair-release]",
+	] {
+		assert!(config.contains(table), "missing populated table `{table}`");
+	}
+}
+
+#[test]
+fn populate_preserves_existing_cli_commands_and_only_adds_missing_defaults() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_fixture("monochange/populate-partial-cli", tempdir.path());
+
+	let output = run_cli(
+		tempdir.path(),
+		[OsString::from("mc"), OsString::from("populate")],
+	)
+	.unwrap_or_else(|error| panic!("populate output: {error}"));
+	let config = fs::read_to_string(tempdir.path().join("monochange.toml"))
+		.unwrap_or_else(|error| panic!("config: {error}"));
+
+	assert!(output.contains("added 6 default CLI commands"));
+	assert!(config.contains("help_text = \"Custom release pipeline\""));
+	assert_eq!(config.matches("[cli.release]").count(), 1);
+	for table in [
+		"[cli.validate]",
+		"[cli.discover]",
+		"[cli.change]",
+		"[cli.affected]",
+		"[cli.diagnostics]",
+		"[cli.repair-release]",
+	] {
+		assert!(config.contains(table), "missing populated table `{table}`");
+	}
+}
+
+#[test]
+fn populate_reports_when_all_default_cli_commands_are_already_present() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_fixture("monochange/populate-all-defaults", tempdir.path());
+	let before = fs::read_to_string(tempdir.path().join("monochange.toml"))
+		.unwrap_or_else(|error| panic!("config before: {error}"));
+
+	let output = run_cli(
+		tempdir.path(),
+		[OsString::from("mc"), OsString::from("populate")],
+	)
+	.unwrap_or_else(|error| panic!("populate output: {error}"));
+	let after = fs::read_to_string(tempdir.path().join("monochange.toml"))
+		.unwrap_or_else(|error| panic!("config after: {error}"));
+
+	assert!(output.contains("already defines all default CLI commands"));
+	assert_eq!(after, before);
+}
+
+#[test]
+fn populate_requires_an_existing_monochange_configuration_file() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_fixture("monochange/populate-missing-config", tempdir.path());
+
+	let error = run_cli(
+		tempdir.path(),
+		[OsString::from("mc"), OsString::from("populate")],
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected populate failure"));
+	assert!(error.to_string().contains("monochange.toml does not exist"));
+}
+
+#[cfg(unix)]
+#[test]
+fn populate_reports_write_failures_when_configuration_is_read_only() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_fixture("monochange/populate-no-cli", tempdir.path());
+	let path = tempdir.path().join("monochange.toml");
+	let mut permissions = fs::metadata(&path)
+		.unwrap_or_else(|error| panic!("metadata: {error}"))
+		.permissions();
+	permissions.set_mode(0o444);
+	fs::set_permissions(&path, permissions).unwrap_or_else(|error| panic!("chmod: {error}"));
+
+	let error = run_cli(
+		tempdir.path(),
+		[OsString::from("mc"), OsString::from("populate")],
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected populate failure"));
+	assert!(error.to_string().contains("failed to write"));
+}
+
+#[test]
+fn populate_rejects_invalid_monochange_toml() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_fixture("monochange/populate-invalid-config", tempdir.path());
+
+	let error = run_cli(
+		tempdir.path(),
+		[OsString::from("mc"), OsString::from("populate")],
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected populate failure"));
+	assert!(error.to_string().contains("failed to parse"));
+}
+
+#[test]
+fn populate_rejects_non_file_configuration_paths() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_fixture(
+		"monochange/populate-config-path-is-directory",
+		tempdir.path(),
+	);
+
+	let error = run_cli(
+		tempdir.path(),
+		[OsString::from("mc"), OsString::from("populate")],
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected populate failure"));
+	assert!(error.to_string().contains("failed to read"));
+}
+
+#[test]
+fn populate_adds_default_cli_commands_to_an_empty_configuration_file() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_fixture("monochange/populate-empty-config", tempdir.path());
+
+	let output = run_cli(
+		tempdir.path(),
+		[OsString::from("mc"), OsString::from("populate")],
+	)
+	.unwrap_or_else(|error| panic!("populate output: {error}"));
+	let config = fs::read_to_string(tempdir.path().join("monochange.toml"))
+		.unwrap_or_else(|error| panic!("config: {error}"));
+
+	assert!(output.contains("added 7 default CLI commands"));
+	assert!(config.starts_with("[cli.validate]"));
+}
+
+#[test]
+fn render_cli_commands_toml_handles_manifest_and_command_step_variants() {
+	let rendered = crate::render_cli_commands_toml(&[CliCommandDefinition {
+		name: "custom".to_string(),
+		help_text: None,
+		inputs: Vec::new(),
+		steps: vec![
+			CliStepDefinition::RenderReleaseManifest {
+				path: Some(PathBuf::from("target/release-manifest.json")),
+				inputs: BTreeMap::from([(
+					"format".to_string(),
+					CliStepInputValue::String("json".to_string()),
+				)]),
+			},
+			CliStepDefinition::Command {
+				command: "echo hello".to_string(),
+				dry_run_command: Some("echo dry-run".to_string()),
+				shell: ShellConfig::None,
+				id: Some("none-shell".to_string()),
+				variables: None,
+				inputs: BTreeMap::from([("enabled".to_string(), CliStepInputValue::Boolean(true))]),
+			},
+			CliStepDefinition::Command {
+				command: "echo through-shell".to_string(),
+				dry_run_command: None,
+				shell: ShellConfig::Default,
+				id: Some("default-shell".to_string()),
+				variables: Some(BTreeMap::from([(
+					"version_value".to_string(),
+					CommandVariable::Version,
+				)])),
+				inputs: BTreeMap::from([(
+					"changed_paths".to_string(),
+					CliStepInputValue::List(vec!["src/lib.rs".to_string()]),
+				)]),
+			},
+			CliStepDefinition::Command {
+				command: "echo custom-shell".to_string(),
+				dry_run_command: None,
+				shell: ShellConfig::Custom("bash".to_string()),
+				id: Some("custom-shell".to_string()),
+				variables: None,
+				inputs: BTreeMap::new(),
+			},
+		],
+	}]);
+
+	assert!(rendered.contains("[[cli.custom.steps]]"));
+	assert!(rendered.contains("type = \"RenderReleaseManifest\""));
+	assert!(rendered.contains("path = \"target/release-manifest.json\""));
+	assert!(rendered.contains("inputs = { format = \"json\" }"));
+	assert!(rendered.contains("dry_run_command = \"echo dry-run\""));
+	assert!(rendered.contains("inputs = { enabled = true }"));
+	assert!(rendered.contains("shell = true"));
+	assert!(rendered.contains("variables = { version_value = \"version\" }"));
+	assert!(rendered.contains("inputs = { changed_paths = [\"src/lib.rs\"] }"));
+	assert!(rendered.contains("shell = \"bash\""));
+	assert!(!rendered.contains("name = \"custom\""));
 }
 
 #[test]
@@ -1482,14 +1704,14 @@ fn command_step_without_dry_run_override_reports_skipped_command() {
 	write_blank_monochange_config(tempdir.path());
 	let configuration = load_workspace_configuration(tempdir.path())
 		.unwrap_or_else(|error| panic!("configuration: {error}"));
-	let cli_command = monochange_core::CliCommandDefinition {
+	let cli_command = CliCommandDefinition {
 		name: "announce".to_string(),
 		help_text: None,
 		inputs: Vec::new(),
-		steps: vec![monochange_core::CliStepDefinition::Command {
+		steps: vec![CliStepDefinition::Command {
 			command: "echo hello".to_string(),
 			dry_run_command: None,
-			shell: monochange_core::ShellConfig::default(),
+			shell: ShellConfig::default(),
 			id: None,
 			variables: None,
 			inputs: BTreeMap::new(),
@@ -1512,14 +1734,14 @@ fn command_step_rejects_unparseable_commands() {
 	write_blank_monochange_config(tempdir.path());
 	let configuration = load_workspace_configuration(tempdir.path())
 		.unwrap_or_else(|error| panic!("configuration: {error}"));
-	let cli_command = monochange_core::CliCommandDefinition {
+	let cli_command = CliCommandDefinition {
 		name: "announce".to_string(),
 		help_text: None,
 		inputs: Vec::new(),
-		steps: vec![monochange_core::CliStepDefinition::Command {
+		steps: vec![CliStepDefinition::Command {
 			command: "\"unterminated".to_string(),
 			dry_run_command: None,
-			shell: monochange_core::ShellConfig::default(),
+			shell: ShellConfig::default(),
 			id: None,
 			variables: None,
 			inputs: BTreeMap::new(),
@@ -1545,14 +1767,14 @@ fn command_step_rejects_empty_commands() {
 	write_blank_monochange_config(tempdir.path());
 	let configuration = load_workspace_configuration(tempdir.path())
 		.unwrap_or_else(|error| panic!("configuration: {error}"));
-	let cli_command = monochange_core::CliCommandDefinition {
+	let cli_command = CliCommandDefinition {
 		name: "announce".to_string(),
 		help_text: None,
 		inputs: Vec::new(),
-		steps: vec![monochange_core::CliStepDefinition::Command {
+		steps: vec![CliStepDefinition::Command {
 			command: String::new(),
 			dry_run_command: None,
-			shell: monochange_core::ShellConfig::default(),
+			shell: ShellConfig::default(),
 			id: None,
 			variables: None,
 			inputs: BTreeMap::new(),
@@ -1576,14 +1798,14 @@ fn command_step_reports_process_spawn_failures() {
 	write_blank_monochange_config(tempdir.path());
 	let configuration = load_workspace_configuration(tempdir.path())
 		.unwrap_or_else(|error| panic!("configuration: {error}"));
-	let cli_command = monochange_core::CliCommandDefinition {
+	let cli_command = CliCommandDefinition {
 		name: "announce".to_string(),
 		help_text: None,
 		inputs: Vec::new(),
-		steps: vec![monochange_core::CliStepDefinition::Command {
+		steps: vec![CliStepDefinition::Command {
 			command: "definitely-not-a-real-command-12345".to_string(),
 			dry_run_command: None,
-			shell: monochange_core::ShellConfig::default(),
+			shell: ShellConfig::default(),
 			id: None,
 			variables: None,
 			inputs: BTreeMap::new(),
@@ -1609,14 +1831,14 @@ fn command_step_reports_nonzero_exit_status_without_stderr() {
 	write_blank_monochange_config(tempdir.path());
 	let configuration = load_workspace_configuration(tempdir.path())
 		.unwrap_or_else(|error| panic!("configuration: {error}"));
-	let cli_command = monochange_core::CliCommandDefinition {
+	let cli_command = CliCommandDefinition {
 		name: "announce".to_string(),
 		help_text: None,
 		inputs: Vec::new(),
-		steps: vec![monochange_core::CliStepDefinition::Command {
+		steps: vec![CliStepDefinition::Command {
 			command: "sh -c 'exit 7'".to_string(),
 			dry_run_command: None,
-			shell: monochange_core::ShellConfig::default(),
+			shell: ShellConfig::default(),
 			id: None,
 			variables: None,
 			inputs: BTreeMap::new(),
@@ -1643,14 +1865,14 @@ fn command_step_reports_stderr_text_for_nonzero_exit_status() {
 	write_blank_monochange_config(tempdir.path());
 	let configuration = load_workspace_configuration(tempdir.path())
 		.unwrap_or_else(|error| panic!("configuration: {error}"));
-	let cli_command = monochange_core::CliCommandDefinition {
+	let cli_command = CliCommandDefinition {
 		name: "announce".to_string(),
 		help_text: None,
 		inputs: Vec::new(),
-		steps: vec![monochange_core::CliStepDefinition::Command {
+		steps: vec![CliStepDefinition::Command {
 			command: "sh -c 'echo boom 1>&2; exit 1'".to_string(),
 			dry_run_command: None,
-			shell: monochange_core::ShellConfig::default(),
+			shell: ShellConfig::default(),
 			id: None,
 			variables: None,
 			inputs: BTreeMap::new(),
@@ -1674,7 +1896,7 @@ fn execute_cli_command_without_steps_reports_completion_status() {
 	write_blank_monochange_config(tempdir.path());
 	let configuration = load_workspace_configuration(tempdir.path())
 		.unwrap_or_else(|error| panic!("configuration: {error}"));
-	let cli_command = monochange_core::CliCommandDefinition {
+	let cli_command = CliCommandDefinition {
 		name: "noop".to_string(),
 		help_text: None,
 		inputs: Vec::new(),
@@ -3011,14 +3233,8 @@ fn template_context_exposes_manifest_affected_steps_and_custom_variables() {
 	};
 	let inputs = BTreeMap::from([("format".to_string(), vec!["json".to_string()])]);
 	let variables = BTreeMap::from([
-		(
-			"custom_version".to_string(),
-			monochange_core::CommandVariable::Version,
-		),
-		(
-			"custom_changesets".to_string(),
-			monochange_core::CommandVariable::Changesets,
-		),
+		("custom_version".to_string(), CommandVariable::Version),
+		("custom_changesets".to_string(), CommandVariable::Changesets),
 	]);
 	let template_context = crate::build_cli_template_context(&context, &inputs, Some(&variables));
 	assert_eq!(
@@ -3065,7 +3281,7 @@ fn template_context_exposes_manifest_affected_steps_and_custom_variables() {
 
 #[test]
 fn render_cli_command_result_prefers_retarget_report() {
-	let cli_command = monochange_core::CliCommandDefinition {
+	let cli_command = CliCommandDefinition {
 		name: "repair-release".to_string(),
 		help_text: None,
 		inputs: Vec::new(),
@@ -3100,7 +3316,7 @@ fn render_cli_command_result_prefers_retarget_report() {
 
 #[test]
 fn render_cli_command_result_renders_release_follow_up_sections() {
-	let cli_command = monochange_core::CliCommandDefinition {
+	let cli_command = CliCommandDefinition {
 		name: "release".to_string(),
 		help_text: None,
 		inputs: Vec::new(),
@@ -3144,11 +3360,11 @@ fn execute_cli_command_retarget_release_requires_from_input() {
 	write_blank_monochange_config(tempdir.path());
 	let configuration = load_workspace_configuration(tempdir.path())
 		.unwrap_or_else(|error| panic!("configuration: {error}"));
-	let cli_command = monochange_core::CliCommandDefinition {
+	let cli_command = CliCommandDefinition {
 		name: "repair-release".to_string(),
 		help_text: None,
 		inputs: Vec::new(),
-		steps: vec![monochange_core::CliStepDefinition::RetargetRelease {
+		steps: vec![CliStepDefinition::RetargetRelease {
 			inputs: BTreeMap::new(),
 		}],
 	};
@@ -3175,7 +3391,7 @@ fn execute_cli_command_release_follow_up_steps_require_prepare_release() {
 	let cases = [
 		(
 			"release-manifest",
-			monochange_core::CliStepDefinition::RenderReleaseManifest {
+			CliStepDefinition::RenderReleaseManifest {
 				path: None,
 				inputs: BTreeMap::new(),
 			},
@@ -3183,28 +3399,28 @@ fn execute_cli_command_release_follow_up_steps_require_prepare_release() {
 		),
 		(
 			"publish-release",
-			monochange_core::CliStepDefinition::PublishRelease {
+			CliStepDefinition::PublishRelease {
 				inputs: BTreeMap::new(),
 			},
 			"`PublishRelease` requires a previous `PrepareRelease` step",
 		),
 		(
 			"release-pr",
-			monochange_core::CliStepDefinition::OpenReleaseRequest {
+			CliStepDefinition::OpenReleaseRequest {
 				inputs: BTreeMap::new(),
 			},
 			"`OpenReleaseRequest` requires a previous `PrepareRelease` step",
 		),
 		(
 			"release-comments",
-			monochange_core::CliStepDefinition::CommentReleasedIssues {
+			CliStepDefinition::CommentReleasedIssues {
 				inputs: BTreeMap::new(),
 			},
 			"`CommentReleasedIssues` requires a previous `PrepareRelease` step",
 		),
 	];
 	for (name, step, expected) in cases {
-		let cli_command = monochange_core::CliCommandDefinition {
+		let cli_command = CliCommandDefinition {
 			name: name.to_string(),
 			help_text: None,
 			inputs: Vec::new(),
@@ -3238,15 +3454,15 @@ fn execute_cli_command_source_follow_up_steps_require_source_configuration() {
 		pull_requests: monochange_core::ChangeRequestSettings::default(),
 		bot: monochange_core::BotSettings::default(),
 	});
-	let prepare_and_publish = monochange_core::CliCommandDefinition {
+	let prepare_and_publish = CliCommandDefinition {
 		name: "publish-release".to_string(),
 		help_text: None,
 		inputs: Vec::new(),
 		steps: vec![
-			monochange_core::CliStepDefinition::PrepareRelease {
+			CliStepDefinition::PrepareRelease {
 				inputs: BTreeMap::new(),
 			},
-			monochange_core::CliStepDefinition::CommentReleasedIssues {
+			CliStepDefinition::CommentReleasedIssues {
 				inputs: BTreeMap::new(),
 			},
 		],
@@ -3275,14 +3491,14 @@ fn execute_cli_command_publish_and_request_steps_require_source_configuration() 
 	let cases = [
 		(
 			"publish-release",
-			monochange_core::CliStepDefinition::PublishRelease {
+			CliStepDefinition::PublishRelease {
 				inputs: BTreeMap::new(),
 			},
 			"`PublishRelease` requires `[source]` configuration",
 		),
 		(
 			"release-pr",
-			monochange_core::CliStepDefinition::OpenReleaseRequest {
+			CliStepDefinition::OpenReleaseRequest {
 				inputs: BTreeMap::new(),
 			},
 			"`OpenReleaseRequest` requires `[source]` configuration",
@@ -3290,12 +3506,12 @@ fn execute_cli_command_publish_and_request_steps_require_source_configuration() 
 	];
 
 	for (name, step, expected) in cases {
-		let cli_command = monochange_core::CliCommandDefinition {
+		let cli_command = CliCommandDefinition {
 			name: name.to_string(),
 			help_text: None,
 			inputs: Vec::new(),
 			steps: vec![
-				monochange_core::CliStepDefinition::PrepareRelease {
+				CliStepDefinition::PrepareRelease {
 					inputs: BTreeMap::new(),
 				},
 				step,
@@ -3314,11 +3530,11 @@ fn execute_cli_command_change_step_requires_reason_input() {
 	let root = fixture_path("monochange/release-base");
 	let configuration = load_workspace_configuration(&root)
 		.unwrap_or_else(|error| panic!("configuration: {error}"));
-	let cli_command = monochange_core::CliCommandDefinition {
+	let cli_command = CliCommandDefinition {
 		name: "change".to_string(),
 		help_text: None,
 		inputs: Vec::new(),
-		steps: vec![monochange_core::CliStepDefinition::CreateChangeFile {
+		steps: vec![CliStepDefinition::CreateChangeFile {
 			inputs: BTreeMap::new(),
 		}],
 	};
@@ -3356,15 +3572,15 @@ fn execute_cli_command_release_follow_up_steps_render_dry_run_outputs() {
 		load_workspace_configuration(root).unwrap_or_else(|error| panic!("configuration: {error}"));
 
 	let manifest_path = root.join("target/release-manifest.json");
-	let render_manifest = monochange_core::CliCommandDefinition {
+	let render_manifest = CliCommandDefinition {
 		name: "release-manifest".to_string(),
 		help_text: None,
 		inputs: Vec::new(),
 		steps: vec![
-			monochange_core::CliStepDefinition::PrepareRelease {
+			CliStepDefinition::PrepareRelease {
 				inputs: BTreeMap::new(),
 			},
-			monochange_core::CliStepDefinition::RenderReleaseManifest {
+			CliStepDefinition::RenderReleaseManifest {
 				path: Some(PathBuf::from("target/release-manifest.json")),
 				inputs: BTreeMap::new(),
 			},
@@ -3383,15 +3599,15 @@ fn execute_cli_command_release_follow_up_steps_render_dry_run_outputs() {
 		fs::read_to_string(&manifest_path).unwrap_or_else(|error| panic!("read manifest: {error}"));
 	assert!(manifest_contents.contains("\"releaseTargets\""));
 
-	let publish_release = monochange_core::CliCommandDefinition {
+	let publish_release = CliCommandDefinition {
 		name: "publish-release".to_string(),
 		help_text: None,
 		inputs: Vec::new(),
 		steps: vec![
-			monochange_core::CliStepDefinition::PrepareRelease {
+			CliStepDefinition::PrepareRelease {
 				inputs: BTreeMap::new(),
 			},
-			monochange_core::CliStepDefinition::PublishRelease {
+			CliStepDefinition::PublishRelease {
 				inputs: BTreeMap::new(),
 			},
 		],
@@ -3407,15 +3623,15 @@ fn execute_cli_command_release_follow_up_steps_render_dry_run_outputs() {
 	assert!(publish_output.contains("releases:"));
 	assert!(publish_output.contains("dry-run"));
 
-	let release_request = monochange_core::CliCommandDefinition {
+	let release_request = CliCommandDefinition {
 		name: "release-pr".to_string(),
 		help_text: None,
 		inputs: Vec::new(),
 		steps: vec![
-			monochange_core::CliStepDefinition::PrepareRelease {
+			CliStepDefinition::PrepareRelease {
 				inputs: BTreeMap::new(),
 			},
-			monochange_core::CliStepDefinition::OpenReleaseRequest {
+			CliStepDefinition::OpenReleaseRequest {
 				inputs: BTreeMap::new(),
 			},
 		],
@@ -3431,15 +3647,15 @@ fn execute_cli_command_release_follow_up_steps_render_dry_run_outputs() {
 	assert!(request_output.contains("release request:"));
 	assert!(request_output.contains("dry-run"));
 
-	let issue_comments = monochange_core::CliCommandDefinition {
+	let issue_comments = CliCommandDefinition {
 		name: "release-comments".to_string(),
 		help_text: None,
 		inputs: Vec::new(),
 		steps: vec![
-			monochange_core::CliStepDefinition::PrepareRelease {
+			CliStepDefinition::PrepareRelease {
 				inputs: BTreeMap::new(),
 			},
-			monochange_core::CliStepDefinition::CommentReleasedIssues {
+			CliStepDefinition::CommentReleasedIssues {
 				inputs: BTreeMap::new(),
 			},
 		],
@@ -4290,11 +4506,11 @@ fn execute_cli_command_commit_release_requires_prepare_release() {
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	let configuration = load_workspace_configuration(tempdir.path())
 		.unwrap_or_else(|error| panic!("configuration: {error}"));
-	let cli_command = monochange_core::CliCommandDefinition {
+	let cli_command = CliCommandDefinition {
 		name: "commit-release".to_string(),
 		help_text: None,
 		inputs: Vec::new(),
-		steps: vec![monochange_core::CliStepDefinition::CommitRelease {
+		steps: vec![CliStepDefinition::CommitRelease {
 			inputs: BTreeMap::new(),
 		}],
 	};
@@ -6428,7 +6644,7 @@ fn apply_runtime_change_type_choices_updates_only_unconfigured_change_inputs() {
 		dart: monochange_core::EcosystemSettings::default(),
 	};
 	let mut cli = vec![
-		monochange_core::CliCommandDefinition {
+		CliCommandDefinition {
 			name: "change".to_string(),
 			help_text: Some("Create a change".to_string()),
 			inputs: vec![CliInputDefinition {
@@ -6442,7 +6658,7 @@ fn apply_runtime_change_type_choices_updates_only_unconfigured_change_inputs() {
 			}],
 			steps: Vec::new(),
 		},
-		monochange_core::CliCommandDefinition {
+		CliCommandDefinition {
 			name: "change-with-existing-choices".to_string(),
 			help_text: None,
 			inputs: vec![CliInputDefinition {
@@ -6481,7 +6697,7 @@ fn apply_runtime_change_type_choices_preserves_existing_choice_inputs_and_empty_
 		deno: monochange_core::EcosystemSettings::default(),
 		dart: monochange_core::EcosystemSettings::default(),
 	};
-	let mut cli = vec![monochange_core::CliCommandDefinition {
+	let mut cli = vec![CliCommandDefinition {
 		name: "change".to_string(),
 		help_text: None,
 		inputs: vec![CliInputDefinition {
@@ -6599,7 +6815,7 @@ fn build_release_record_subcommand_requires_from_and_supports_json_output() {
 
 #[test]
 fn build_command_with_cli_registers_custom_subcommands_and_default_help_text() {
-	let cli = vec![monochange_core::CliCommandDefinition {
+	let cli = vec![CliCommandDefinition {
 		name: "custom".to_string(),
 		help_text: None,
 		inputs: Vec::new(),
@@ -6630,7 +6846,7 @@ fn cli_command_after_help_covers_supported_commands_and_custom_commands() {
 		("repair-release", "Defaults to descendant-only retargets"),
 	];
 	for (name, expected) in cases {
-		let after_help = crate::cli_command_after_help(&monochange_core::CliCommandDefinition {
+		let after_help = crate::cli_command_after_help(&CliCommandDefinition {
 			name: name.to_string(),
 			help_text: None,
 			inputs: Vec::new(),
@@ -6639,20 +6855,18 @@ fn cli_command_after_help_covers_supported_commands_and_custom_commands() {
 		.unwrap_or_else(|| panic!("expected after_help for {name}"));
 		assert!(after_help.contains(expected));
 	}
-	assert!(
-		crate::cli_command_after_help(&monochange_core::CliCommandDefinition {
-			name: "custom".to_string(),
-			help_text: None,
-			inputs: Vec::new(),
-			steps: Vec::new(),
-		})
-		.is_none()
-	);
+	assert!(crate::cli_command_after_help(&CliCommandDefinition {
+		name: "custom".to_string(),
+		help_text: None,
+		inputs: Vec::new(),
+		steps: Vec::new(),
+	})
+	.is_none());
 }
 
 #[test]
 fn build_cli_command_subcommand_parses_supported_input_kinds() {
-	let cli_command = monochange_core::CliCommandDefinition {
+	let cli_command = CliCommandDefinition {
 		name: "custom".to_string(),
 		help_text: Some("Run a custom command".to_string()),
 		inputs: vec![

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -103,6 +103,10 @@ pub(crate) fn build_command_with_cli(
 						.action(ArgAction::SetTrue),
 				),
 		)
+		.subcommand(
+			Command::new("populate")
+				.about("Add any missing built-in CLI commands to monochange.toml so you can customize them"),
+		)
 		.subcommand(build_assist_subcommand())
 		.subcommand(build_release_record_subcommand())
 		.subcommand(

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -150,6 +150,7 @@ use git_support::git_head_commit;
 use git_support::git_stage_paths;
 use release_record::render_release_record_discovery;
 use workspace_ops::init_workspace;
+use workspace_ops::populate_workspace;
 
 pub use changeset_policy::affected_packages;
 pub use changeset_policy::evaluate_changeset_policy;
@@ -235,6 +236,8 @@ pub(crate) use git_support::run_git_status;
 pub(crate) use workspace_ops::build_lockfile_command_executions;
 #[cfg(test)]
 pub(crate) use workspace_ops::change_type_default_bump;
+#[cfg(test)]
+pub(crate) use workspace_ops::render_cli_commands_toml;
 #[cfg(test)]
 pub(crate) use workspace_ops::render_interactive_changeset_markdown;
 
@@ -542,6 +545,22 @@ where
 		Some(("init", init_matches)) => {
 			let path = init_workspace(root, init_matches.get_flag("force"))?;
 			Ok(format!("wrote {}", path.display()))
+		}
+		Some(("populate", _)) => {
+			let result = populate_workspace(root)?;
+			if result.added_commands.is_empty() {
+				Ok(format!(
+					"{} already defines all default CLI commands",
+					result.path.display()
+				))
+			} else {
+				Ok(format!(
+					"updated {} and added {} default CLI commands: {}",
+					result.path.display(),
+					result.added_commands.len(),
+					result.added_commands.join(", ")
+				))
+			}
 		}
 		Some(("assist", assist_matches)) => {
 			let assistant = match assist_matches

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -135,8 +135,7 @@ fn render_cli_command_toml(rendered: &mut String, command: &CliCommandDefinition
 	writeln!(rendered, "[cli.{}]", command.name)
 		.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
 	if let Some(help_text) = &command.help_text {
-		writeln!(rendered, "help_text = {}", render_toml_string(help_text))
-			.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+		write_toml_key_value(rendered, "help_text", render_toml_string(help_text));
 	}
 	for input in &command.inputs {
 		rendered.push('\n');
@@ -152,44 +151,38 @@ fn render_cli_command_toml(rendered: &mut String, command: &CliCommandDefinition
 	}
 }
 
-fn render_cli_input_toml(rendered: &mut String, input: &monochange_core::CliInputDefinition) {
-	writeln!(rendered, "name = {}", render_toml_string(&input.name))
+fn write_toml_key_value(rendered: &mut String, key: &str, value: String) {
+	writeln!(rendered, "{key} = {value}")
 		.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
-	writeln!(
+}
+
+fn render_cli_input_toml(rendered: &mut String, input: &monochange_core::CliInputDefinition) {
+	write_toml_key_value(rendered, "name", render_toml_string(&input.name));
+	write_toml_key_value(
 		rendered,
-		"type = {}",
+		"type",
 		render_toml_string(match input.kind {
 			monochange_core::CliInputKind::String => "string",
 			monochange_core::CliInputKind::StringList => "string_list",
 			monochange_core::CliInputKind::Path => "path",
 			monochange_core::CliInputKind::Choice => "choice",
 			monochange_core::CliInputKind::Boolean => "boolean",
-		})
-	)
-	.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
-	if let Some(help_text) = &input.help_text {
-		writeln!(rendered, "help_text = {}", render_toml_string(help_text))
-			.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
-	}
+		}),
+	);
+	input.help_text.iter().for_each(|help_text| {
+		write_toml_key_value(rendered, "help_text", render_toml_string(help_text))
+	});
 	if input.required {
-		writeln!(rendered, "required = true")
-			.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+		write_toml_key_value(rendered, "required", "true".to_string());
 	}
 	if let Some(default) = &input.default {
-		writeln!(rendered, "default = {}", render_toml_string(default))
-			.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+		write_toml_key_value(rendered, "default", render_toml_string(default));
 	}
 	if !input.choices.is_empty() {
-		writeln!(rendered, "choices = {}", render_toml_array(&input.choices))
-			.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+		write_toml_key_value(rendered, "choices", render_toml_array(&input.choices));
 	}
 	if let Some(short) = input.short {
-		writeln!(
-			rendered,
-			"short = {}",
-			render_toml_string(&short.to_string())
-		)
-		.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+		write_toml_key_value(rendered, "short", render_toml_string(&short.to_string()));
 	}
 }
 
@@ -203,14 +196,13 @@ fn render_cli_step_toml(rendered: &mut String, step: &monochange_core::CliStepDe
 	}
 	match step {
 		monochange_core::CliStepDefinition::RenderReleaseManifest { path, inputs, .. } => {
-			if let Some(path) = path {
-				writeln!(
+			path.iter().for_each(|path| {
+				write_toml_key_value(
 					rendered,
-					"path = {}",
-					render_toml_string(&path.display().to_string())
-				)
-				.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
-			}
+					"path",
+					render_toml_string(&path.display().to_string()),
+				);
+			});
 			render_step_inputs_toml(rendered, inputs);
 		}
 		monochange_core::CliStepDefinition::Command {
@@ -243,10 +235,8 @@ fn render_cli_step_toml(rendered: &mut String, step: &monochange_core::CliStepDe
 						.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
 				}
 			}
-			if let Some(id) = id {
-				writeln!(rendered, "id = {}", render_toml_string(id))
-					.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
-			}
+			id.iter()
+				.for_each(|id| write_toml_key_value(rendered, "id", render_toml_string(id)));
 			if let Some(variables) = variables {
 				writeln!(
 					rendered,

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use std::fmt::Write as _;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
@@ -10,7 +11,9 @@ use monochange_config::apply_version_groups;
 use monochange_config::load_change_signals;
 use monochange_config::load_changeset_file;
 use monochange_config::load_workspace_configuration;
+use monochange_core::default_cli_commands;
 use monochange_core::BumpSeverity;
+use monochange_core::CliCommandDefinition;
 use monochange_core::DiscoveryReport;
 use monochange_core::Ecosystem;
 use monochange_core::LockfileCommandDefinition;
@@ -45,6 +48,299 @@ pub(crate) fn init_workspace(root: &Path, force: bool) -> MonochangeResult<PathB
 		MonochangeError::Io(format!("failed to write {}: {error}", path.display()))
 	})?;
 	Ok(path)
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct PopulateWorkspaceResult {
+	pub path: PathBuf,
+	pub added_commands: Vec<String>,
+}
+
+pub(crate) fn populate_workspace(root: &Path) -> MonochangeResult<PopulateWorkspaceResult> {
+	let path = monochange_config::config_path(root);
+	if !path.exists() {
+		return Err(MonochangeError::Config(format!(
+			"{} does not exist; run `mc init` first or create a monochange.toml before running `mc populate`",
+			path.display()
+		)));
+	}
+
+	let contents = match fs::read_to_string(&path) {
+		Ok(contents) => contents,
+		Err(error) => {
+			return Err(MonochangeError::Io(format!(
+				"failed to read {}: {error}",
+				path.display()
+			)));
+		}
+	};
+	let existing = existing_cli_command_names(&contents, &path)?;
+	let missing = default_cli_commands()
+		.into_iter()
+		.filter(|command| !existing.contains(&command.name))
+		.collect::<Vec<_>>();
+
+	if missing.is_empty() {
+		return Ok(PopulateWorkspaceResult {
+			path,
+			added_commands: Vec::new(),
+		});
+	}
+
+	let mut updated = contents.trim_end().to_string();
+	if !updated.is_empty() {
+		updated.push_str("\n\n");
+	}
+	updated.push_str(&render_cli_commands_toml(&missing));
+	updated.push('\n');
+	if let Err(error) = fs::write(&path, updated) {
+		return Err(MonochangeError::Io(format!(
+			"failed to write {}: {error}",
+			path.display()
+		)));
+	}
+
+	Ok(PopulateWorkspaceResult {
+		path,
+		added_commands: missing.into_iter().map(|command| command.name).collect(),
+	})
+}
+
+fn existing_cli_command_names(contents: &str, path: &Path) -> MonochangeResult<BTreeSet<String>> {
+	if contents.trim().is_empty() {
+		return Ok(BTreeSet::new());
+	}
+	let document = toml::from_str::<toml::Value>(contents).map_err(|error| {
+		MonochangeError::Config(format!("failed to parse {}: {error}", path.display()))
+	})?;
+	Ok(document
+		.get("cli")
+		.and_then(toml::Value::as_table)
+		.map(|table| table.keys().cloned().collect())
+		.unwrap_or_default())
+}
+
+pub(crate) fn render_cli_commands_toml(commands: &[CliCommandDefinition]) -> String {
+	let mut rendered = String::new();
+	for (index, command) in commands.iter().enumerate() {
+		if index > 0 {
+			rendered.push_str("\n\n");
+		}
+		render_cli_command_toml(&mut rendered, command);
+	}
+	rendered
+}
+
+fn render_cli_command_toml(rendered: &mut String, command: &CliCommandDefinition) {
+	writeln!(rendered, "[cli.{}]", command.name)
+		.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+	if let Some(help_text) = &command.help_text {
+		writeln!(rendered, "help_text = {}", render_toml_string(help_text))
+			.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+	}
+	for input in &command.inputs {
+		rendered.push('\n');
+		writeln!(rendered, "[[cli.{}.inputs]]", command.name)
+			.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+		render_cli_input_toml(rendered, input);
+	}
+	for step in &command.steps {
+		rendered.push('\n');
+		writeln!(rendered, "[[cli.{}.steps]]", command.name)
+			.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+		render_cli_step_toml(rendered, step);
+	}
+}
+
+fn render_cli_input_toml(rendered: &mut String, input: &monochange_core::CliInputDefinition) {
+	writeln!(rendered, "name = {}", render_toml_string(&input.name))
+		.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+	writeln!(
+		rendered,
+		"type = {}",
+		render_toml_string(match input.kind {
+			monochange_core::CliInputKind::String => "string",
+			monochange_core::CliInputKind::StringList => "string_list",
+			monochange_core::CliInputKind::Path => "path",
+			monochange_core::CliInputKind::Choice => "choice",
+			monochange_core::CliInputKind::Boolean => "boolean",
+		})
+	)
+	.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+	if let Some(help_text) = &input.help_text {
+		writeln!(rendered, "help_text = {}", render_toml_string(help_text))
+			.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+	}
+	if input.required {
+		writeln!(rendered, "required = true")
+			.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+	}
+	if let Some(default) = &input.default {
+		writeln!(rendered, "default = {}", render_toml_string(default))
+			.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+	}
+	if !input.choices.is_empty() {
+		writeln!(rendered, "choices = {}", render_toml_array(&input.choices))
+			.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+	}
+	if let Some(short) = input.short {
+		writeln!(
+			rendered,
+			"short = {}",
+			render_toml_string(&short.to_string())
+		)
+		.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+	}
+}
+
+fn render_cli_step_toml(rendered: &mut String, step: &monochange_core::CliStepDefinition) {
+	let step_type = step.kind_name();
+	writeln!(rendered, "type = {}", render_toml_string(step_type))
+		.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+	match step {
+		monochange_core::CliStepDefinition::RenderReleaseManifest { path, inputs } => {
+			if let Some(path) = path {
+				writeln!(
+					rendered,
+					"path = {}",
+					render_toml_string(&path.display().to_string())
+				)
+				.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+			}
+			render_step_inputs_toml(rendered, inputs);
+		}
+		monochange_core::CliStepDefinition::Command {
+			command,
+			dry_run_command,
+			shell,
+			id,
+			variables,
+			inputs,
+		} => {
+			writeln!(rendered, "command = {}", render_toml_string(command))
+				.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+			if let Some(dry_run_command) = dry_run_command {
+				writeln!(
+					rendered,
+					"dry_run_command = {}",
+					render_toml_string(dry_run_command)
+				)
+				.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+			}
+			match shell {
+				monochange_core::ShellConfig::None => {}
+				monochange_core::ShellConfig::Default => {
+					writeln!(rendered, "shell = true")
+						.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+				}
+				monochange_core::ShellConfig::Custom(shell) => {
+					writeln!(rendered, "shell = {}", render_toml_string(shell))
+						.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+				}
+			}
+			if let Some(id) = id {
+				writeln!(rendered, "id = {}", render_toml_string(id))
+					.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+			}
+			if let Some(variables) = variables {
+				writeln!(
+					rendered,
+					"variables = {}",
+					render_command_variables_inline_table(variables)
+				)
+				.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+			}
+			render_step_inputs_toml(rendered, inputs);
+		}
+		monochange_core::CliStepDefinition::Validate { inputs }
+		| monochange_core::CliStepDefinition::Discover { inputs }
+		| monochange_core::CliStepDefinition::CreateChangeFile { inputs }
+		| monochange_core::CliStepDefinition::PrepareRelease { inputs }
+		| monochange_core::CliStepDefinition::CommitRelease { inputs }
+		| monochange_core::CliStepDefinition::PublishRelease { inputs }
+		| monochange_core::CliStepDefinition::OpenReleaseRequest { inputs }
+		| monochange_core::CliStepDefinition::CommentReleasedIssues { inputs }
+		| monochange_core::CliStepDefinition::AffectedPackages { inputs }
+		| monochange_core::CliStepDefinition::DiagnoseChangesets { inputs }
+		| monochange_core::CliStepDefinition::RetargetRelease { inputs } => {
+			render_step_inputs_toml(rendered, inputs);
+		}
+	}
+}
+
+fn render_step_inputs_toml(
+	rendered: &mut String,
+	inputs: &BTreeMap<String, monochange_core::CliStepInputValue>,
+) {
+	if inputs.is_empty() {
+		return;
+	}
+	writeln!(
+		rendered,
+		"inputs = {}",
+		render_step_inputs_inline_table(inputs)
+	)
+	.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+}
+
+fn render_step_inputs_inline_table(
+	inputs: &BTreeMap<String, monochange_core::CliStepInputValue>,
+) -> String {
+	format!(
+		"{{ {} }}",
+		inputs
+			.iter()
+			.map(|(name, value)| format!("{name} = {}", render_step_input_value(value)))
+			.collect::<Vec<_>>()
+			.join(", ")
+	)
+}
+
+fn render_step_input_value(value: &monochange_core::CliStepInputValue) -> String {
+	match value {
+		monochange_core::CliStepInputValue::String(value) => render_toml_string(value),
+		monochange_core::CliStepInputValue::Boolean(value) => value.to_string(),
+		monochange_core::CliStepInputValue::List(values) => render_toml_array(values),
+	}
+}
+
+fn render_command_variables_inline_table(
+	variables: &BTreeMap<String, monochange_core::CommandVariable>,
+) -> String {
+	format!(
+		"{{ {} }}",
+		variables
+			.iter()
+			.map(|(name, value)| {
+				format!(
+					"{name} = {}",
+					render_toml_string(match value {
+						monochange_core::CommandVariable::Version => "version",
+						monochange_core::CommandVariable::GroupVersion => "group_version",
+						monochange_core::CommandVariable::ReleasedPackages => "released_packages",
+						monochange_core::CommandVariable::ChangedFiles => "changed_files",
+						monochange_core::CommandVariable::Changesets => "changesets",
+					})
+				)
+			})
+			.collect::<Vec<_>>()
+			.join(", ")
+	)
+}
+
+fn render_toml_array(values: &[String]) -> String {
+	format!(
+		"[{}]",
+		values
+			.iter()
+			.map(|value| render_toml_string(value))
+			.collect::<Vec<_>>()
+			.join(", ")
+	)
+}
+
+fn render_toml_string(value: &str) -> String {
+	toml::Value::String(value.to_string()).to_string()
 }
 
 /// The minijinja template for `mc init`, loaded at compile time.

--- a/crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_prints_help.snap
+++ b/crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_prints_help.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/monochange/tests/cli_main_binary.rs
-assertion_line: 12
 info:
   program: monochange
   args:
@@ -17,6 +16,7 @@ Usage: monochange <COMMAND>
 
 Commands:
   init            Generate monochange.toml with detected packages, groups, and default CLI commands
+  populate        Add any missing built-in CLI commands to monochange.toml so you can customize them
   assist          Print assistant setup guidance, install steps, and MCP configuration
   release-record  Inspect the monochange release record associated with a tag or commit
   mcp             Start the monochange MCP (Model Context Protocol) server over stdin/stdout

--- a/docs/src/guide/02-setup.md
+++ b/docs/src/guide/02-setup.md
@@ -14,7 +14,13 @@ mc init
 
 `mc init` detects packages, writes an annotated `monochange.toml`, and gives you a better starting point than hand-authoring a first config from scratch.
 
-The generated file becomes the source of truth for commands like `mc validate`, `mc discover`, `mc change`, and `mc release`.
+The generated file becomes the source of truth for commands like `mc validate`, `mc discover`, `mc change`, and `mc release`. If you later want editable copies of the built-in CLI commands, run:
+
+```bash
+mc populate
+```
+
+That appends any missing default command definitions to `monochange.toml` without overwriting commands you already defined.
 
 ## 2. Validate the generated workspace
 

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -259,6 +259,8 @@ lockfile_commands = [
 
 CLI commands are user-defined top-level commands. monochange starts from its built-in default command set, then applies each `[cli.<command>]` entry as a full command override when the name matches or as an additional command when it does not. Each resulting command becomes invocable as `mc <command>`, and legacy `[[workflows]]` tables are no longer supported.
 
+If you want editable copies of the built-in commands in your config file, run `mc populate`. It appends only the missing default command definitions to `monochange.toml` and leaves existing `[cli.<command>]` entries unchanged.
+
 <!-- {=configurationWorkflowsSnippet} -->
 
 ```toml

--- a/docs/src/readme.md
+++ b/docs/src/readme.md
@@ -30,7 +30,7 @@ Generate a starter config from the packages monochange detects:
 mc init
 ```
 
-`mc init` writes an annotated `monochange.toml`, so most first-time users can start with the generated file instead of hand-authoring config.
+`mc init` writes an annotated `monochange.toml`, so most first-time users can start with the generated file instead of hand-authoring config. If you later want editable copies of the built-in CLI commands, run `mc populate` to append any missing default command definitions to `monochange.toml`.
 
 Validate the workspace:
 

--- a/fixtures/tests/monochange/populate-all-defaults/monochange.toml
+++ b/fixtures/tests/monochange/populate-all-defaults/monochange.toml
@@ -1,0 +1,13 @@
+[cli.validate]
+
+[cli.discover]
+
+[cli.change]
+
+[cli.release]
+
+[cli.affected]
+
+[cli.diagnostics]
+
+[cli.repair-release]

--- a/fixtures/tests/monochange/populate-config-path-is-directory/monochange.toml/README.md
+++ b/fixtures/tests/monochange/populate-config-path-is-directory/monochange.toml/README.md
@@ -1,0 +1,1 @@
+directory placeholder so monochange.toml is not a file

--- a/fixtures/tests/monochange/populate-invalid-config/monochange.toml
+++ b/fixtures/tests/monochange/populate-invalid-config/monochange.toml
@@ -1,0 +1,2 @@
+[defaults
+parent_bump = "patch"

--- a/fixtures/tests/monochange/populate-missing-config/README.md
+++ b/fixtures/tests/monochange/populate-missing-config/README.md
@@ -1,0 +1,1 @@
+workspace fixture without a monochange.toml file

--- a/fixtures/tests/monochange/populate-no-cli/monochange.toml
+++ b/fixtures/tests/monochange/populate-no-cli/monochange.toml
@@ -1,0 +1,2 @@
+[defaults]
+parent_bump = "patch"

--- a/fixtures/tests/monochange/populate-partial-cli/monochange.toml
+++ b/fixtures/tests/monochange/populate-partial-cli/monochange.toml
@@ -1,0 +1,12 @@
+[defaults]
+parent_bump = "patch"
+
+[cli.release]
+help_text = "Custom release pipeline"
+
+[[cli.release.steps]]
+type = "PrepareRelease"
+
+[[cli.release.steps]]
+type = "RenderReleaseManifest"
+path = ".monochange/release-manifest.json"

--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ Generate a starter config from the packages monochange detects:
 mc init
 ```
 
-`mc init` writes an annotated `monochange.toml`, so most first-time users can start with the generated file instead of hand-authoring config.
+`mc init` writes an annotated `monochange.toml`, so most first-time users can start with the generated file instead of hand-authoring config. If you later want editable copies of the built-in CLI commands, run `mc populate` to append any missing default command definitions to `monochange.toml`.
 
 Validate the workspace:
 

--- a/skills/monochange/SKILL.md
+++ b/skills/monochange/SKILL.md
@@ -42,6 +42,7 @@ description: Guides agents through monochange discovery, changesets, release pla
 | Command               | Purpose                                                     |
 | --------------------- | ----------------------------------------------------------- |
 | `mc init`             | Generate a starter `monochange.toml` from detected packages |
+| `mc populate`         | Append missing built-in CLI command definitions to config   |
 | `mc validate`         | Validate config and changeset targets                       |
 | `mc discover`         | Discover packages across ecosystems                         |
 | `mc change`           | Create a `.changeset/*.md` file                             |


### PR DESCRIPTION
## Summary
- add a new `mc populate` command that appends any missing built-in CLI command definitions to `monochange.toml`
- preserve existing `[cli.<command>]` entries so custom overrides are never replaced
- document the new workflow and add fixture coverage for success, no-op, parse, read, write, and renderer branches

## User-facing behavior
Before:
```bash
mc populate
```
This command did not exist, so users had to copy built-in `[cli.*]` definitions by hand when they wanted editable defaults in `monochange.toml`.

After:
```bash
mc populate
```
monochange appends only the missing built-in CLI command definitions to `monochange.toml` and leaves existing command overrides unchanged.

## Testing
- `devenv shell build:all`
- `devenv shell lint:all`
- `devenv shell test:all` *(with `commit.gpgsign=false` in the local environment to avoid a machine-specific GPG signing failure inside git-backed tests)*
- `devenv shell mc validate`
- `cargo run -p monochange --bin mc -- affected --changed-paths ...`

## Coverage
I added explicit tests for the new populate flow covering:
- missing config
- empty config
- partial config with existing overrides
- no-op when all defaults already exist
- invalid TOML
- non-file config path read failure
- read-only file write failure
- TOML rendering for manifest and command step variants
