### PR TITLE
perf: scope workspace tree walk to modified directories only

### DIFF
--- a/.changeset/054-scoped-workspace-walk.md
+++ b/.changeset/054-scoped-workspace-walk.md
@@ -1,0 +1,5 @@
+---
+monochange: patch
+---
+
+Scope workspace tree walk during release to only directories containing modified files, avoiding a full traversal of the entire workspace.

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -526,7 +526,7 @@ fn materialize_lockfile_command_updates(
 	for command in lockfile_commands {
 		run_lockfile_command(root, temp_root, command)?;
 	}
-	collect_workspace_file_updates(root, temp_root)
+	collect_workspace_file_updates(root, temp_root, base_updates, lockfile_commands)
 }
 
 fn remap_workspace_path(root: &Path, temp_root: &Path, path: &Path) -> MonochangeResult<PathBuf> {
@@ -596,10 +596,45 @@ fn run_lockfile_command(
 fn collect_workspace_file_updates(
 	root: &Path,
 	temp_root: &Path,
+	base_updates: &[FileUpdate],
+	lockfile_commands: &[LockfileCommandExecution],
 ) -> MonochangeResult<Vec<FileUpdate>> {
+	// Instead of walking the entire workspace tree, only scan directories
+	// that could have been modified: directories containing explicitly
+	// updated files and lockfile command working directories.
+	let normalized_root = monochange_core::normalize_path(root);
+	let mut dirs_to_scan = BTreeSet::new();
+	for update in base_updates {
+		if let Some(parent) = update.path.parent() {
+			let normalized = monochange_core::normalize_path(parent);
+			if let Ok(relative) = normalized.strip_prefix(&normalized_root) {
+				dirs_to_scan.insert(relative.to_path_buf());
+			}
+		}
+	}
+	for command in lockfile_commands {
+		let normalized = monochange_core::normalize_path(&command.cwd);
+		if let Ok(relative) = normalized.strip_prefix(&normalized_root) {
+			dirs_to_scan.insert(relative.to_path_buf());
+		} else {
+			dirs_to_scan.insert(command.cwd.clone());
+		}
+	}
+	// Always scan the changeset directory (files are deleted during release).
+	dirs_to_scan.insert(PathBuf::from(".changeset"));
+
 	let mut relative_paths = BTreeSet::new();
-	collect_workspace_files(root, root, &mut relative_paths)?;
-	collect_workspace_files(temp_root, temp_root, &mut relative_paths)?;
+	for dir in &dirs_to_scan {
+		let original_dir = root.join(dir);
+		let temp_dir = temp_root.join(dir);
+		if original_dir.is_dir() {
+			collect_workspace_files(root, &original_dir, &mut relative_paths)?;
+		}
+		if temp_dir.is_dir() {
+			collect_workspace_files(temp_root, &temp_dir, &mut relative_paths)?;
+		}
+	}
+
 	let mut updates = Vec::new();
 	for relative in relative_paths {
 		let before = read_optional_file(&root.join(&relative))?;
@@ -979,8 +1014,14 @@ mod workspace_ops_tests {
 		)
 		.unwrap_or_else(|error| panic!("write generated file: {error}"));
 
-		let updates = collect_workspace_file_updates(fixture.path(), temp_root.path())
-			.unwrap_or_else(|error| panic!("collect updates: {error}"));
+		let lockfile_cmd = LockfileCommandExecution {
+			command: String::new(),
+			cwd: fixture.path().to_path_buf(),
+			shell: monochange_core::ShellConfig::None,
+		};
+		let updates =
+			collect_workspace_file_updates(fixture.path(), temp_root.path(), &[], &[lockfile_cmd])
+				.unwrap_or_else(|error| panic!("collect updates: {error}"));
 		assert!(updates
 			.iter()
 			.any(|update| update.path.ends_with("generated.txt")));


### PR DESCRIPTION
## Summary

- Replace full workspace tree walk with scoped directory scanning
- Only traverse directories that contain versioned file updates, lockfile command cwd paths, and the .changeset directory
- Handle macOS /private symlink paths via normalize_path before prefix stripping
- For large monorepos with thousands of files, this eliminates most unnecessary filesystem I/O during release

Closes #103

## Test plan

- [x] All 285 monochange lib tests pass (including 4 lockfile command tests)
- [x] Workspace copy/diff test passes with scoped walk
- [ ] CI passes