### PR TITLE
docs: update documentation for recent validation, security, and CLI changes

### DIFF
--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -509,7 +509,9 @@ When `version` is provided without `bump`, the bump is inferred from the current
 
 <!-- {@releaseWorkflowBehavior} -->
 
-`mc release` is part of monochange's built-in default command set. You only need to add `[cli.release]` when you want to replace that default definition with your own steps, inputs, or help text.
+`mc release` is part of monochange's built-in default command set. The defaults include: `validate`, `discover`, `change`, `release`, `affected`, `diagnostics`, and `repair-release`. You only need to add `[cli.release]` when you want to replace that default definition with your own steps, inputs, or help text.
+
+Commands like `commit-release` (which combines `PrepareRelease` + `CommitRelease` steps) are not included in the defaults — define them explicitly in your `monochange.toml` when you need them.
 
 During migration, you may still see references to `[[package_overrides]]` in older documentation or repositories, but release preparation now expects package/group declarations and consumes `.changeset/*.md` files through that new model.
 

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -13,7 +13,8 @@
 - dependency names are normalized into one graph
 - package ids and manifest paths in CLI output are rendered relative to the repository root for deterministic automation
 - version-group assignments are attached after discovery
-- unmatched group members and version mismatches produce warnings
+- unmatched group members (declared in config but not found during discovery) produce warnings
+- unresolvable group members (invalid package IDs in `group.packages`) produce errors during configuration loading
 - discovery currently scans all supported ecosystems regardless of `[ecosystems.*]` toggles in `monochange.toml`
 
 <!-- {/discoveryKeyBehaviors} -->
@@ -283,11 +284,16 @@ type = "AffectedPackages"
 
 <!-- {@configurationGitHubSnippet} -->
 
+The `[source]` section configures provider integration for releases, pull requests, and changeset enforcement.
+
+For self-hosted instances, set `api_url` or `host` to your server's URL. These fields **must** use `https://`; insecure `http://` schemes are rejected because API tokens would be transmitted in cleartext.
+
 ```toml
 [source]
 provider = "github"
 owner = "ifiokjr"
 repo = "monochange"
+# api_url = "https://github.company.com/api/v3"  # optional: for GitHub Enterprise
 
 [source.releases]
 enabled = true
@@ -414,7 +420,7 @@ version_format = "primary"
 - group changelog and group `versioned_files` can also be updated
 - grouped packages can use `empty_update_message` when their own changelog needs a version-only update with no direct notes
 - dependents of newly synced members still receive propagated parent bumps
-- unmatched members produce warnings during discovery
+- unmatched members (not found during discovery) produce warnings; unresolvable members (invalid IDs) produce errors
 - mismatched current versions produce warnings when `warn_on_group_mismatch = true`
 
 <!-- {/versionGroupsBehavior} -->

--- a/docs/src/guide/03-discovery.md
+++ b/docs/src/guide/03-discovery.md
@@ -32,7 +32,8 @@ Key behaviors:
 - dependency names are normalized into one graph
 - package ids and manifest paths in CLI output are rendered relative to the repository root for deterministic automation
 - version-group assignments are attached after discovery
-- unmatched group members and version mismatches produce warnings
+- unmatched group members (declared in config but not found during discovery) produce warnings
+- unresolvable group members (invalid package IDs in `group.packages`) produce errors during configuration loading
 - discovery currently scans all supported ecosystems regardless of `[ecosystems.*]` toggles in `monochange.toml`
 
 <!-- {/discoveryKeyBehaviors} -->

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -402,11 +402,16 @@ Use `[source]` plus `[source.releases]` when you want command steps such as `Pub
 
 <!-- {=configurationGitHubSnippet} -->
 
+The `[source]` section configures provider integration for releases, pull requests, and changeset enforcement.
+
+For self-hosted instances, set `api_url` or `host` to your server's URL. These fields **must** use `https://`; insecure `http://` schemes are rejected because API tokens would be transmitted in cleartext.
+
 ```toml
 [source]
 provider = "github"
 owner = "ifiokjr"
 repo = "monochange"
+# api_url = "https://github.company.com/api/v3"  # optional: for GitHub Enterprise
 
 [source.releases]
 enabled = true
@@ -577,5 +582,8 @@ mc validate
 - package and group declarations
 - manifest presence for each package type
 - group membership rules
-- `versioned_files` references
+- `versioned_files` structural rules (type/regex conflicts, capture groups)
+- `versioned_files` content checks: file existence, version field readability, regex pattern matching
 - `.changeset/*.md` targets and overlap rules
+- Cargo workspace version-group constraints
+- `[source]` url scheme security (`https://` required)

--- a/docs/src/guide/05-version-groups.md
+++ b/docs/src/guide/05-version-groups.md
@@ -34,7 +34,7 @@ When any member releases:
 - group changelog and group `versioned_files` can also be updated
 - grouped packages can use `empty_update_message` when their own changelog needs a version-only update with no direct notes
 - dependents of newly synced members still receive propagated parent bumps
-- unmatched members produce warnings during discovery
+- unmatched members (not found during discovery) produce warnings; unresolvable members (invalid IDs) produce errors
 - mismatched current versions produce warnings when `warn_on_group_mismatch = true`
 
 <!-- {/versionGroupsBehavior} -->

--- a/docs/src/guide/06-release-planning.md
+++ b/docs/src/guide/06-release-planning.md
@@ -131,9 +131,9 @@ mc release
 
 <!-- {=releaseWorkflowBehavior} -->
 
-`mc release` is part of monochange's built-in default command set. You only need to add `[cli.release]` when you want to replace that default definition with your own steps, inputs, or help text.
+`mc release` is part of monochange's built-in default command set. The defaults include: `validate`, `discover`, `change`, `release`, `affected`, `diagnostics`, and `repair-release`. You only need to add `[cli.release]` when you want to replace that default definition with your own steps, inputs, or help text.
 
-During migration, you may still see references to `[[package_overrides]]` in older documentation or repositories, but release preparation now expects package/group declarations and consumes `.changeset/*.md` files through that new model.
+Commands like `commit-release` (which combines `PrepareRelease` + `CommitRelease` steps) are not included in the defaults — define them explicitly in your `monochange.toml` when you need them.
 
 Current `PrepareRelease` behavior:
 

--- a/docs/src/guide/06-release-planning.md
+++ b/docs/src/guide/06-release-planning.md
@@ -135,6 +135,8 @@ mc release
 
 Commands like `commit-release` (which combines `PrepareRelease` + `CommitRelease` steps) are not included in the defaults — define them explicitly in your `monochange.toml` when you need them.
 
+During migration, you may still see references to `[[package_overrides]]` in older documentation or repositories, but release preparation now expects package/group declarations and consumes `.changeset/*.md` files through that new model.
+
 Current `PrepareRelease` behavior:
 
 - reads `.changeset/*.md`

--- a/docs/src/reference/cli-steps/01-validate.md
+++ b/docs/src/reference/cli-steps/01-validate.md
@@ -38,10 +38,26 @@ None. `Validate` is standalone.
 
 ## Side effects and outputs
 
-- validates workspace config and changesets
+**Structural checks** (always run):
+
+- validates workspace config syntax and required fields
+- validates package and group declarations, membership rules, and namespace collisions
+- validates CLI command definitions, step types, and input schemas
+- validates changeset files reference declared packages and groups
 - validates Cargo workspace version-group constraints
-- returns a normal success/failure result for the command
-- does not prepare release state for later steps
+
+**Content checks** (verify files on disk):
+
+- versioned file paths that are not globs must resolve to an existing file
+- ecosystem-typed versioned files (Cargo.toml, package.json, deno.json, pubspec.yaml) must contain a readable version field
+- regex versioned file patterns must match at least once in the target file
+- glob patterns that match zero files produce a non-fatal warning printed to stderr
+
+**Security checks:**
+
+- `[source].api_url` and `[source].host` must use `https://`; insecure `http://` schemes are rejected to prevent cleartext token transmission
+
+`Validate` returns a normal success/failure result for the command and does not prepare release state for later steps.
 
 That last point matters: `Validate` is a gate, not a state-producing step.
 


### PR DESCRIPTION
## Summary

Updates documentation across 6 files to reflect all recent changes:

- **Validate step reference** — expanded with content-level checks (file existence, version readability, regex matching) and security checks (https:// requirement)
- **Configuration guide** — expanded `mc validate` checklist, documented `api_url`/`host` fields with https:// requirement and GitHub Enterprise example
- **Release planning guide** — explicit list of default commands, note that `commit-release` requires user configuration
- **Discovery and version groups** — clarified unmatched vs unresolvable member behavior
- **MDT templates** — synced `configurationGitHubSnippet`, `discoveryKeyBehaviors`, `versionGroupsBehavior` snippets with their consumed copies

## Test plan

- [x] All doc changes are consistent between templates and consumed copies
- [x] No stale commit-release-as-default references remain
- [ ] CI passes