### PR TITLE
refactor!: rename GitHub-specific provider types to generic names

### DIFF
--- a/.changeset/055-rename-provider-types.md
+++ b/.changeset/055-rename-provider-types.md
@@ -5,4 +5,4 @@ monochange_github: patch
 monochange: patch
 ---
 
-Rename GitHub-specific provider types to generic names in monochange_core. `GitHubReleaseSettings` becomes `ReleaseProviderSettings`, `GitHubPullRequestSettings` becomes `ChangeRequestSettings`, etc. Type aliases removed. This is a breaking change for downstream consumers of the public API.
+Rename GitHub-specific provider types to provider-prefixed generic names in monochange_core. `GitHubReleaseSettings` → `ProviderReleaseSettings`, `GitHubPullRequestSettings` → `ProviderMergeRequestSettings`, `GitHubBotSettings` → `ProviderBotSettings`, etc. Type aliases removed. This is a breaking change for downstream consumers of the public API.

--- a/.changeset/055-rename-provider-types.md
+++ b/.changeset/055-rename-provider-types.md
@@ -1,0 +1,7 @@
+---
+monochange_core: minor
+monochange_config: patch
+monochange: patch
+---
+
+Rename GitHub-specific provider types to generic names in monochange_core. `GitHubReleaseSettings` becomes `ReleaseProviderSettings`, `GitHubPullRequestSettings` becomes `ChangeRequestSettings`, etc. Type aliases removed. This is a breaking change for downstream consumers of the public API.

--- a/.changeset/055-rename-provider-types.md
+++ b/.changeset/055-rename-provider-types.md
@@ -2,6 +2,8 @@
 monochange_core: minor
 monochange_config: patch
 monochange_github: patch
+monochange_gitea: patch
+monochange_gitlab: patch
 monochange: patch
 ---
 

--- a/.changeset/055-rename-provider-types.md
+++ b/.changeset/055-rename-provider-types.md
@@ -1,6 +1,7 @@
 ---
 monochange_core: minor
 monochange_config: patch
+monochange_github: patch
 monochange: patch
 ---
 

--- a/.templates/crates.t.md
+++ b/.templates/crates.t.md
@@ -367,9 +367,9 @@ Reach for this crate when you want to preview or publish GitHub releases and rel
 ## Example
 
 ```rust
-use monochange_core::BotSettings;
-use monochange_core::ChangeRequestSettings;
-use monochange_core::ReleaseProviderSettings;
+use monochange_core::ProviderBotSettings;
+use monochange_core::ProviderMergeRequestSettings;
+use monochange_core::ProviderReleaseSettings;
 use monochange_core::SourceConfiguration;
 use monochange_core::SourceProvider;
 use monochange_core::ReleaseManifest;
@@ -416,9 +416,9 @@ let github = SourceConfiguration {
     repo: "monochange".to_string(),
     host: None,
     api_url: None,
-    releases: ReleaseProviderSettings::default(),
-    pull_requests: ChangeRequestSettings::default(),
-    bot: BotSettings::default(),
+    releases: ProviderReleaseSettings::default(),
+    pull_requests: ProviderMergeRequestSettings::default(),
+    bot: ProviderBotSettings::default(),
 };
 
 let requests = build_release_requests(&github, &manifest);

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -2702,12 +2702,12 @@ fn sample_source_configuration_for_release_commit() -> monochange_core::SourceCo
 		repo: "monochange".to_string(),
 		host: None,
 		api_url: None,
-		releases: monochange_core::ReleaseProviderSettings::default(),
-		pull_requests: monochange_core::ChangeRequestSettings {
+		releases: monochange_core::ProviderReleaseSettings::default(),
+		pull_requests: monochange_core::ProviderMergeRequestSettings {
 			title: "chore(release): prepare release".to_string(),
-			..monochange_core::ChangeRequestSettings::default()
+			..monochange_core::ProviderMergeRequestSettings::default()
 		},
-		bot: monochange_core::BotSettings::default(),
+		bot: monochange_core::ProviderBotSettings::default(),
 	}
 }
 
@@ -3404,9 +3404,9 @@ fn execute_cli_command_source_follow_up_steps_require_source_configuration() {
 		api_url: Some("https://gitlab.example.com/api/v4".to_string()),
 		owner: "org".to_string(),
 		repo: "repo".to_string(),
-		releases: monochange_core::ReleaseProviderSettings::default(),
-		pull_requests: monochange_core::ChangeRequestSettings::default(),
-		bot: monochange_core::BotSettings::default(),
+		releases: monochange_core::ProviderReleaseSettings::default(),
+		pull_requests: monochange_core::ProviderMergeRequestSettings::default(),
+		bot: monochange_core::ProviderBotSettings::default(),
 	});
 	let prepare_and_publish = monochange_core::CliCommandDefinition {
 		name: "publish-release".to_string(),
@@ -4055,9 +4055,9 @@ fn plan_release_retarget_marks_unsupported_provider_sync_in_dry_run() {
 		api_url: None,
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
-		releases: monochange_core::ReleaseProviderSettings::default(),
-		pull_requests: monochange_core::ChangeRequestSettings::default(),
-		bot: monochange_core::BotSettings::default(),
+		releases: monochange_core::ProviderReleaseSettings::default(),
+		pull_requests: monochange_core::ProviderMergeRequestSettings::default(),
+		bot: monochange_core::ProviderBotSettings::default(),
 	};
 
 	let plan =
@@ -4138,9 +4138,9 @@ fn plan_release_retarget_rejects_provider_kind_mismatches() {
 		api_url: None,
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
-		releases: monochange_core::ReleaseProviderSettings::default(),
-		pull_requests: monochange_core::ChangeRequestSettings::default(),
-		bot: monochange_core::BotSettings::default(),
+		releases: monochange_core::ProviderReleaseSettings::default(),
+		pull_requests: monochange_core::ProviderMergeRequestSettings::default(),
+		bot: monochange_core::ProviderBotSettings::default(),
 	};
 
 	let error =
@@ -4381,9 +4381,9 @@ fn sync_retargeted_provider_releases_reports_unsupported_provider_in_dry_run() {
 		api_url: None,
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
-		releases: monochange_core::ReleaseProviderSettings::default(),
-		pull_requests: monochange_core::ChangeRequestSettings::default(),
-		bot: monochange_core::BotSettings::default(),
+		releases: monochange_core::ProviderReleaseSettings::default(),
+		pull_requests: monochange_core::ProviderMergeRequestSettings::default(),
+		bot: monochange_core::ProviderBotSettings::default(),
 	};
 	let updates = vec![monochange_core::RetargetTagResult {
 		tag_name: "v1.2.3".to_string(),
@@ -4412,9 +4412,9 @@ fn sync_retargeted_provider_releases_rejects_unsupported_provider_in_real_mode()
 		api_url: None,
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
-		releases: monochange_core::ReleaseProviderSettings::default(),
-		pull_requests: monochange_core::ChangeRequestSettings::default(),
-		bot: monochange_core::BotSettings::default(),
+		releases: monochange_core::ProviderReleaseSettings::default(),
+		pull_requests: monochange_core::ProviderMergeRequestSettings::default(),
+		bot: monochange_core::ProviderBotSettings::default(),
 	};
 	let updates = vec![monochange_core::RetargetTagResult {
 		tag_name: "v1.2.3".to_string(),
@@ -4456,9 +4456,9 @@ fn execute_release_retarget_rejects_unsupported_provider_sync_in_real_mode() {
 		api_url: None,
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
-		releases: monochange_core::ReleaseProviderSettings::default(),
-		pull_requests: monochange_core::ChangeRequestSettings::default(),
-		bot: monochange_core::BotSettings::default(),
+		releases: monochange_core::ProviderReleaseSettings::default(),
+		pull_requests: monochange_core::ProviderMergeRequestSettings::default(),
+		bot: monochange_core::ProviderBotSettings::default(),
 	};
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	let error = crate::execute_release_retarget(tempdir.path(), Some(&source), &plan)
@@ -7007,9 +7007,9 @@ fn render_tag_name_and_provider_urls_follow_provider_conventions() {
 		api_url: None,
 		owner: "group".to_string(),
 		repo: "monochange".to_string(),
-		releases: monochange_core::ReleaseProviderSettings::default(),
-		pull_requests: monochange_core::ChangeRequestSettings::default(),
-		bot: monochange_core::BotSettings::default(),
+		releases: monochange_core::ProviderReleaseSettings::default(),
+		pull_requests: monochange_core::ProviderMergeRequestSettings::default(),
+		bot: monochange_core::ProviderBotSettings::default(),
 	};
 	assert!(crate::tag_url_for_provider(&gitlab, "v1.2.3").contains("gitlab.example.com"));
 	assert!(crate::compare_url_for_provider(&gitlab, "v1.2.2", "v1.2.3").contains("/-/compare/"));
@@ -7443,9 +7443,9 @@ fn build_source_release_requests_and_change_request_cover_gitea_dispatch() {
 		api_url: Some("https://gitea.example.com/api/v1".to_string()),
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
-		releases: monochange_core::ReleaseProviderSettings::default(),
-		pull_requests: monochange_core::ChangeRequestSettings::default(),
-		bot: monochange_core::BotSettings::default(),
+		releases: monochange_core::ProviderReleaseSettings::default(),
+		pull_requests: monochange_core::ProviderMergeRequestSettings::default(),
+		bot: monochange_core::ProviderBotSettings::default(),
 	};
 	let manifest = sample_release_manifest_for_commit_message(true, true);
 	let requests = crate::build_source_release_requests(&source, &manifest);
@@ -7549,9 +7549,9 @@ fn sample_github_source_configuration(api_url: &str) -> monochange_core::SourceC
 		api_url: Some(api_url.to_string()),
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
-		releases: monochange_core::ReleaseProviderSettings::default(),
-		pull_requests: monochange_core::ChangeRequestSettings::default(),
-		bot: monochange_core::BotSettings::default(),
+		releases: monochange_core::ProviderReleaseSettings::default(),
+		pull_requests: monochange_core::ProviderMergeRequestSettings::default(),
+		bot: monochange_core::ProviderBotSettings::default(),
 	}
 }
 

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -1208,9 +1208,9 @@ pub(crate) fn inferred_retarget_source_configuration(
 		repo: provider.repo.clone(),
 		host: provider.host.clone(),
 		api_url: None,
-		releases: monochange_core::ReleaseProviderSettings::default(),
-		pull_requests: monochange_core::ChangeRequestSettings::default(),
-		bot: monochange_core::BotSettings::default(),
+		releases: monochange_core::ProviderReleaseSettings::default(),
+		pull_requests: monochange_core::ProviderMergeRequestSettings::default(),
+		bot: monochange_core::ProviderBotSettings::default(),
 	})
 }
 

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -873,7 +873,7 @@ pub(crate) fn build_release_commit_message(
 ) -> CommitMessage {
 	CommitMessage {
 		subject: source.map_or_else(
-			|| monochange_core::ChangeRequestSettings::default().title,
+			|| monochange_core::ProviderMergeRequestSettings::default().title,
 			|source| source.pull_requests.title.clone(),
 		),
 		body: Some(render_release_commit_body(source, manifest)),

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -381,7 +381,7 @@ fn load_workspace_configuration_parses_github_release_settings() {
 	assert!(source.releases.generate_notes);
 	assert_eq!(
 		source.releases.source,
-		monochange_core::GitHubReleaseNotesSource::GitHubGenerated
+		monochange_core::ReleaseNotesSource::GitHubGenerated
 	);
 	assert!(source.pull_requests.enabled);
 	assert_eq!(source.pull_requests.branch_prefix, "automation/release");
@@ -2572,10 +2572,10 @@ fn validate_package_and_github_settings_cover_duplicate_and_pattern_errors() {
 		crate::validate_github_configuration(Some(&monochange_core::GitHubConfiguration {
 			owner: "ifiokjr".to_string(),
 			repo: "monochange".to_string(),
-			releases: monochange_core::GitHubReleaseSettings::default(),
-			pull_requests: monochange_core::GitHubPullRequestSettings::default(),
-			bot: monochange_core::GitHubBotSettings {
-				changesets: monochange_core::GitHubChangesetBotSettings {
+			releases: monochange_core::ReleaseProviderSettings::default(),
+			pull_requests: monochange_core::ChangeRequestSettings::default(),
+			bot: monochange_core::BotSettings {
+				changesets: monochange_core::ChangesetBotSettings {
 					enabled: true,
 					required: true,
 					skip_labels: vec!["skip".to_string()],

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -381,7 +381,7 @@ fn load_workspace_configuration_parses_github_release_settings() {
 	assert!(source.releases.generate_notes);
 	assert_eq!(
 		source.releases.source,
-		monochange_core::ReleaseNotesSource::GitHubGenerated
+		monochange_core::ProviderReleaseNotesSource::GitHubGenerated
 	);
 	assert!(source.pull_requests.enabled);
 	assert_eq!(source.pull_requests.branch_prefix, "automation/release");
@@ -2507,9 +2507,9 @@ fn validate_source_and_changeset_settings_reject_empty_values() {
 			api_url: None,
 			owner: " ".to_string(),
 			repo: "monochange".to_string(),
-			releases: monochange_core::ReleaseProviderSettings::default(),
-			pull_requests: monochange_core::ChangeRequestSettings::default(),
-			bot: monochange_core::BotSettings::default(),
+			releases: monochange_core::ProviderReleaseSettings::default(),
+			pull_requests: monochange_core::ProviderMergeRequestSettings::default(),
+			bot: monochange_core::ProviderBotSettings::default(),
 		}))
 		.err()
 		.unwrap_or_else(|| panic!("expected source validation error"));
@@ -2572,10 +2572,10 @@ fn validate_package_and_github_settings_cover_duplicate_and_pattern_errors() {
 		crate::validate_github_configuration(Some(&monochange_core::GitHubConfiguration {
 			owner: "ifiokjr".to_string(),
 			repo: "monochange".to_string(),
-			releases: monochange_core::ReleaseProviderSettings::default(),
-			pull_requests: monochange_core::ChangeRequestSettings::default(),
-			bot: monochange_core::BotSettings {
-				changesets: monochange_core::ChangesetBotSettings {
+			releases: monochange_core::ProviderReleaseSettings::default(),
+			pull_requests: monochange_core::ProviderMergeRequestSettings::default(),
+			bot: monochange_core::ProviderBotSettings {
+				changesets: monochange_core::ProviderChangesetBotSettings {
 					enabled: true,
 					required: true,
 					skip_labels: vec!["skip".to_string()],

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -107,9 +107,6 @@ use monochange_core::CliInputKind;
 use monochange_core::CliStepDefinition;
 use monochange_core::CliStepInputValue;
 
-use monochange_core::BotSettings;
-use monochange_core::ChangeRequestSettings;
-use monochange_core::ChangesetBotSettings;
 use monochange_core::Ecosystem;
 use monochange_core::EcosystemSettings;
 use monochange_core::EcosystemType;
@@ -123,9 +120,12 @@ use monochange_core::MonochangeResult;
 use monochange_core::PackageDefinition;
 use monochange_core::PackageRecord;
 use monochange_core::PackageType;
+use monochange_core::ProviderBotSettings;
+use monochange_core::ProviderChangesetBotSettings;
+use monochange_core::ProviderMergeRequestSettings;
+use monochange_core::ProviderReleaseNotesSource;
+use monochange_core::ProviderReleaseSettings;
 use monochange_core::ReleaseNotesSettings;
-use monochange_core::ReleaseNotesSource;
-use monochange_core::ReleaseProviderSettings;
 use monochange_core::SourceConfiguration;
 use monochange_core::SourceProvider;
 use monochange_core::VersionFormat;
@@ -409,11 +409,11 @@ struct RawSourceConfiguration {
 	#[serde(default)]
 	api_url: Option<String>,
 	#[serde(default)]
-	releases: RawReleaseProviderSettings,
+	releases: RawProviderReleaseSettings,
 	#[serde(default)]
-	pull_requests: RawChangeRequestSettings,
+	pull_requests: RawProviderMergeRequestSettings,
 	#[serde(default)]
-	bot: RawBotSettings,
+	bot: RawProviderBotSettings,
 }
 
 #[derive(Debug, Deserialize)]
@@ -421,16 +421,16 @@ struct RawGitHubConfiguration {
 	owner: String,
 	repo: String,
 	#[serde(default)]
-	releases: RawReleaseProviderSettings,
+	releases: RawProviderReleaseSettings,
 	#[serde(default)]
-	pull_requests: RawChangeRequestSettings,
+	pull_requests: RawProviderMergeRequestSettings,
 	#[serde(default)]
-	bot: RawBotSettings,
+	bot: RawProviderBotSettings,
 }
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Deserialize)]
-struct RawReleaseProviderSettings {
+struct RawProviderReleaseSettings {
 	#[serde(default = "default_true")]
 	enabled: bool,
 	#[serde(default)]
@@ -440,24 +440,24 @@ struct RawReleaseProviderSettings {
 	#[serde(default)]
 	generate_notes: bool,
 	#[serde(default)]
-	source: ReleaseNotesSource,
+	source: ProviderReleaseNotesSource,
 }
 
-impl Default for RawReleaseProviderSettings {
+impl Default for RawProviderReleaseSettings {
 	fn default() -> Self {
 		Self {
 			enabled: default_true(),
 			draft: false,
 			prerelease: false,
 			generate_notes: false,
-			source: ReleaseNotesSource::Monochange,
+			source: ProviderReleaseNotesSource::Monochange,
 		}
 	}
 }
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Deserialize)]
-struct RawChangeRequestSettings {
+struct RawProviderMergeRequestSettings {
 	#[serde(default = "default_true")]
 	enabled: bool,
 	#[serde(default = "default_pull_request_branch_prefix")]
@@ -472,7 +472,7 @@ struct RawChangeRequestSettings {
 	auto_merge: bool,
 }
 
-impl Default for RawChangeRequestSettings {
+impl Default for RawProviderMergeRequestSettings {
 	fn default() -> Self {
 		Self {
 			enabled: default_true(),
@@ -487,7 +487,7 @@ impl Default for RawChangeRequestSettings {
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Deserialize)]
-struct RawChangesetBotSettings {
+struct RawProviderChangesetBotSettings {
 	#[serde(default)]
 	enabled: bool,
 	#[serde(default = "default_true")]
@@ -502,7 +502,7 @@ struct RawChangesetBotSettings {
 	ignored_paths: Vec<String>,
 }
 
-impl Default for RawChangesetBotSettings {
+impl Default for RawProviderChangesetBotSettings {
 	fn default() -> Self {
 		Self {
 			enabled: false,
@@ -516,9 +516,9 @@ impl Default for RawChangesetBotSettings {
 }
 
 #[derive(Debug, Deserialize, Default)]
-struct RawBotSettings {
+struct RawProviderBotSettings {
 	#[serde(default)]
-	changesets: RawChangesetBotSettings,
+	changesets: RawProviderChangesetBotSettings,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -1112,14 +1112,14 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		repo: source.repo,
 		host: source.host,
 		api_url: source.api_url,
-		releases: ReleaseProviderSettings {
+		releases: ProviderReleaseSettings {
 			enabled: source.releases.enabled,
 			draft: source.releases.draft,
 			prerelease: source.releases.prerelease,
 			generate_notes: source.releases.generate_notes,
 			source: source.releases.source,
 		},
-		pull_requests: ChangeRequestSettings {
+		pull_requests: ProviderMergeRequestSettings {
 			enabled: source.pull_requests.enabled,
 			branch_prefix: source.pull_requests.branch_prefix,
 			base: source.pull_requests.base,
@@ -1127,8 +1127,8 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 			labels: source.pull_requests.labels,
 			auto_merge: source.pull_requests.auto_merge,
 		},
-		bot: BotSettings {
-			changesets: ChangesetBotSettings {
+		bot: ProviderBotSettings {
+			changesets: ProviderChangesetBotSettings {
 				enabled: source.bot.changesets.enabled,
 				required: source.bot.changesets.required,
 				skip_labels: source.bot.changesets.skip_labels,
@@ -1150,14 +1150,14 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		github.map(|github| GitHubConfiguration {
 			owner: github.owner,
 			repo: github.repo,
-			releases: ReleaseProviderSettings {
+			releases: ProviderReleaseSettings {
 				enabled: github.releases.enabled,
 				draft: github.releases.draft,
 				prerelease: github.releases.prerelease,
 				generate_notes: github.releases.generate_notes,
 				source: github.releases.source,
 			},
-			pull_requests: ChangeRequestSettings {
+			pull_requests: ProviderMergeRequestSettings {
 				enabled: github.pull_requests.enabled,
 				branch_prefix: github.pull_requests.branch_prefix,
 				base: github.pull_requests.base,
@@ -1165,8 +1165,8 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 				labels: github.pull_requests.labels,
 				auto_merge: github.pull_requests.auto_merge,
 			},
-			bot: BotSettings {
-				changesets: ChangesetBotSettings {
+			bot: ProviderBotSettings {
+				changesets: ProviderChangesetBotSettings {
 					enabled: github.bot.changesets.enabled,
 					required: github.bot.changesets.required,
 					skip_labels: github.bot.changesets.skip_labels,

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -107,16 +107,14 @@ use monochange_core::CliInputKind;
 use monochange_core::CliStepDefinition;
 use monochange_core::CliStepInputValue;
 
+use monochange_core::BotSettings;
+use monochange_core::ChangeRequestSettings;
+use monochange_core::ChangesetBotSettings;
 use monochange_core::Ecosystem;
 use monochange_core::EcosystemSettings;
 use monochange_core::EcosystemType;
 use monochange_core::ExtraChangelogSection;
-use monochange_core::GitHubBotSettings;
-use monochange_core::GitHubChangesetBotSettings;
 use monochange_core::GitHubConfiguration;
-use monochange_core::GitHubPullRequestSettings;
-use monochange_core::GitHubReleaseNotesSource;
-use monochange_core::GitHubReleaseSettings;
 use monochange_core::GroupChangelogInclude;
 use monochange_core::GroupDefinition;
 use monochange_core::LockfileCommandDefinition;
@@ -126,6 +124,8 @@ use monochange_core::PackageDefinition;
 use monochange_core::PackageRecord;
 use monochange_core::PackageType;
 use monochange_core::ReleaseNotesSettings;
+use monochange_core::ReleaseNotesSource;
+use monochange_core::ReleaseProviderSettings;
 use monochange_core::SourceConfiguration;
 use monochange_core::SourceProvider;
 use monochange_core::VersionFormat;
@@ -409,11 +409,11 @@ struct RawSourceConfiguration {
 	#[serde(default)]
 	api_url: Option<String>,
 	#[serde(default)]
-	releases: RawGitHubReleaseSettings,
+	releases: RawReleaseProviderSettings,
 	#[serde(default)]
-	pull_requests: RawGitHubPullRequestSettings,
+	pull_requests: RawChangeRequestSettings,
 	#[serde(default)]
-	bot: RawGitHubBotSettings,
+	bot: RawBotSettings,
 }
 
 #[derive(Debug, Deserialize)]
@@ -421,16 +421,16 @@ struct RawGitHubConfiguration {
 	owner: String,
 	repo: String,
 	#[serde(default)]
-	releases: RawGitHubReleaseSettings,
+	releases: RawReleaseProviderSettings,
 	#[serde(default)]
-	pull_requests: RawGitHubPullRequestSettings,
+	pull_requests: RawChangeRequestSettings,
 	#[serde(default)]
-	bot: RawGitHubBotSettings,
+	bot: RawBotSettings,
 }
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Deserialize)]
-struct RawGitHubReleaseSettings {
+struct RawReleaseProviderSettings {
 	#[serde(default = "default_true")]
 	enabled: bool,
 	#[serde(default)]
@@ -440,24 +440,24 @@ struct RawGitHubReleaseSettings {
 	#[serde(default)]
 	generate_notes: bool,
 	#[serde(default)]
-	source: GitHubReleaseNotesSource,
+	source: ReleaseNotesSource,
 }
 
-impl Default for RawGitHubReleaseSettings {
+impl Default for RawReleaseProviderSettings {
 	fn default() -> Self {
 		Self {
 			enabled: default_true(),
 			draft: false,
 			prerelease: false,
 			generate_notes: false,
-			source: GitHubReleaseNotesSource::Monochange,
+			source: ReleaseNotesSource::Monochange,
 		}
 	}
 }
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Deserialize)]
-struct RawGitHubPullRequestSettings {
+struct RawChangeRequestSettings {
 	#[serde(default = "default_true")]
 	enabled: bool,
 	#[serde(default = "default_pull_request_branch_prefix")]
@@ -472,7 +472,7 @@ struct RawGitHubPullRequestSettings {
 	auto_merge: bool,
 }
 
-impl Default for RawGitHubPullRequestSettings {
+impl Default for RawChangeRequestSettings {
 	fn default() -> Self {
 		Self {
 			enabled: default_true(),
@@ -487,7 +487,7 @@ impl Default for RawGitHubPullRequestSettings {
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Deserialize)]
-struct RawGitHubChangesetBotSettings {
+struct RawChangesetBotSettings {
 	#[serde(default)]
 	enabled: bool,
 	#[serde(default = "default_true")]
@@ -502,7 +502,7 @@ struct RawGitHubChangesetBotSettings {
 	ignored_paths: Vec<String>,
 }
 
-impl Default for RawGitHubChangesetBotSettings {
+impl Default for RawChangesetBotSettings {
 	fn default() -> Self {
 		Self {
 			enabled: false,
@@ -516,9 +516,9 @@ impl Default for RawGitHubChangesetBotSettings {
 }
 
 #[derive(Debug, Deserialize, Default)]
-struct RawGitHubBotSettings {
+struct RawBotSettings {
 	#[serde(default)]
-	changesets: RawGitHubChangesetBotSettings,
+	changesets: RawChangesetBotSettings,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -1112,14 +1112,14 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		repo: source.repo,
 		host: source.host,
 		api_url: source.api_url,
-		releases: GitHubReleaseSettings {
+		releases: ReleaseProviderSettings {
 			enabled: source.releases.enabled,
 			draft: source.releases.draft,
 			prerelease: source.releases.prerelease,
 			generate_notes: source.releases.generate_notes,
 			source: source.releases.source,
 		},
-		pull_requests: GitHubPullRequestSettings {
+		pull_requests: ChangeRequestSettings {
 			enabled: source.pull_requests.enabled,
 			branch_prefix: source.pull_requests.branch_prefix,
 			base: source.pull_requests.base,
@@ -1127,8 +1127,8 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 			labels: source.pull_requests.labels,
 			auto_merge: source.pull_requests.auto_merge,
 		},
-		bot: GitHubBotSettings {
-			changesets: GitHubChangesetBotSettings {
+		bot: BotSettings {
+			changesets: ChangesetBotSettings {
 				enabled: source.bot.changesets.enabled,
 				required: source.bot.changesets.required,
 				skip_labels: source.bot.changesets.skip_labels,
@@ -1150,14 +1150,14 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		github.map(|github| GitHubConfiguration {
 			owner: github.owner,
 			repo: github.repo,
-			releases: GitHubReleaseSettings {
+			releases: ReleaseProviderSettings {
 				enabled: github.releases.enabled,
 				draft: github.releases.draft,
 				prerelease: github.releases.prerelease,
 				generate_notes: github.releases.generate_notes,
 				source: github.releases.source,
 			},
-			pull_requests: GitHubPullRequestSettings {
+			pull_requests: ChangeRequestSettings {
 				enabled: github.pull_requests.enabled,
 				branch_prefix: github.pull_requests.branch_prefix,
 				base: github.pull_requests.base,
@@ -1165,8 +1165,8 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 				labels: github.pull_requests.labels,
 				auto_merge: github.pull_requests.auto_merge,
 			},
-			bot: GitHubBotSettings {
-				changesets: GitHubChangesetBotSettings {
+			bot: BotSettings {
+				changesets: ChangesetBotSettings {
 					enabled: github.bot.changesets.enabled,
 					required: github.bot.changesets.required,
 					skip_labels: github.bot.changesets.skip_labels,

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -2125,7 +2125,7 @@ fn extract_release_record_json(block_contents: &str) -> ReleaseRecordResult<Stri
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
-pub enum GitHubReleaseNotesSource {
+pub enum ReleaseNotesSource {
 	#[default]
 	Monochange,
 	#[serde(rename = "github_generated")]
@@ -2134,17 +2134,17 @@ pub enum GitHubReleaseNotesSource {
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct GitHubReleaseSettings {
+pub struct ReleaseProviderSettings {
 	pub enabled: bool,
 	pub draft: bool,
 	pub prerelease: bool,
 	pub generate_notes: bool,
-	pub source: GitHubReleaseNotesSource,
+	pub source: ReleaseNotesSource,
 }
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct GitHubPullRequestSettings {
+pub struct ChangeRequestSettings {
 	pub enabled: bool,
 	pub branch_prefix: String,
 	pub base: String,
@@ -2155,7 +2155,7 @@ pub struct GitHubPullRequestSettings {
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct GitHubChangesetBotSettings {
+pub struct ChangesetBotSettings {
 	pub enabled: bool,
 	pub required: bool,
 	pub skip_labels: Vec<String>,
@@ -2165,9 +2165,9 @@ pub struct GitHubChangesetBotSettings {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
-pub struct GitHubBotSettings {
+pub struct BotSettings {
 	#[serde(default)]
-	pub changesets: GitHubChangesetBotSettings,
+	pub changesets: ChangesetBotSettings,
 }
 
 #[allow(clippy::struct_excessive_bools)]
@@ -2244,19 +2244,19 @@ pub struct ChangesetPolicyEvaluation {
 	pub errors: Vec<String>,
 }
 
-impl Default for GitHubReleaseSettings {
+impl Default for ReleaseProviderSettings {
 	fn default() -> Self {
 		Self {
 			enabled: true,
 			draft: false,
 			prerelease: false,
 			generate_notes: false,
-			source: GitHubReleaseNotesSource::Monochange,
+			source: ReleaseNotesSource::Monochange,
 		}
 	}
 }
 
-impl Default for GitHubPullRequestSettings {
+impl Default for ChangeRequestSettings {
 	fn default() -> Self {
 		Self {
 			enabled: true,
@@ -2269,7 +2269,7 @@ impl Default for GitHubPullRequestSettings {
 	}
 }
 
-impl Default for GitHubChangesetBotSettings {
+impl Default for ChangesetBotSettings {
 	fn default() -> Self {
 		Self {
 			enabled: false,
@@ -2298,11 +2298,11 @@ pub struct GitHubConfiguration {
 	pub owner: String,
 	pub repo: String,
 	#[serde(default)]
-	pub releases: GitHubReleaseSettings,
+	pub releases: ReleaseProviderSettings,
 	#[serde(default)]
-	pub pull_requests: GitHubPullRequestSettings,
+	pub pull_requests: ChangeRequestSettings,
 	#[serde(default)]
-	pub bot: GitHubBotSettings,
+	pub bot: BotSettings,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Default)]
@@ -2343,12 +2343,6 @@ pub struct SourceCapabilities {
 	pub released_issue_comments: bool,
 	pub requires_host: bool,
 }
-
-pub type ReleaseNotesSource = GitHubReleaseNotesSource;
-pub type ReleaseProviderSettings = GitHubReleaseSettings;
-pub type ChangeRequestSettings = GitHubPullRequestSettings;
-pub type ChangesetBotSettings = GitHubChangesetBotSettings;
-pub type BotSettings = GitHubBotSettings;
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SourceConfiguration {

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -2125,7 +2125,7 @@ fn extract_release_record_json(block_contents: &str) -> ReleaseRecordResult<Stri
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
-pub enum ReleaseNotesSource {
+pub enum ProviderReleaseNotesSource {
 	#[default]
 	Monochange,
 	#[serde(rename = "github_generated")]
@@ -2134,17 +2134,17 @@ pub enum ReleaseNotesSource {
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct ReleaseProviderSettings {
+pub struct ProviderReleaseSettings {
 	pub enabled: bool,
 	pub draft: bool,
 	pub prerelease: bool,
 	pub generate_notes: bool,
-	pub source: ReleaseNotesSource,
+	pub source: ProviderReleaseNotesSource,
 }
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct ChangeRequestSettings {
+pub struct ProviderMergeRequestSettings {
 	pub enabled: bool,
 	pub branch_prefix: String,
 	pub base: String,
@@ -2155,7 +2155,7 @@ pub struct ChangeRequestSettings {
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct ChangesetBotSettings {
+pub struct ProviderChangesetBotSettings {
 	pub enabled: bool,
 	pub required: bool,
 	pub skip_labels: Vec<String>,
@@ -2165,9 +2165,9 @@ pub struct ChangesetBotSettings {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
-pub struct BotSettings {
+pub struct ProviderBotSettings {
 	#[serde(default)]
-	pub changesets: ChangesetBotSettings,
+	pub changesets: ProviderChangesetBotSettings,
 }
 
 #[allow(clippy::struct_excessive_bools)]
@@ -2244,19 +2244,19 @@ pub struct ChangesetPolicyEvaluation {
 	pub errors: Vec<String>,
 }
 
-impl Default for ReleaseProviderSettings {
+impl Default for ProviderReleaseSettings {
 	fn default() -> Self {
 		Self {
 			enabled: true,
 			draft: false,
 			prerelease: false,
 			generate_notes: false,
-			source: ReleaseNotesSource::Monochange,
+			source: ProviderReleaseNotesSource::Monochange,
 		}
 	}
 }
 
-impl Default for ChangeRequestSettings {
+impl Default for ProviderMergeRequestSettings {
 	fn default() -> Self {
 		Self {
 			enabled: true,
@@ -2269,7 +2269,7 @@ impl Default for ChangeRequestSettings {
 	}
 }
 
-impl Default for ChangesetBotSettings {
+impl Default for ProviderChangesetBotSettings {
 	fn default() -> Self {
 		Self {
 			enabled: false,
@@ -2298,11 +2298,11 @@ pub struct GitHubConfiguration {
 	pub owner: String,
 	pub repo: String,
 	#[serde(default)]
-	pub releases: ReleaseProviderSettings,
+	pub releases: ProviderReleaseSettings,
 	#[serde(default)]
-	pub pull_requests: ChangeRequestSettings,
+	pub pull_requests: ProviderMergeRequestSettings,
 	#[serde(default)]
-	pub bot: BotSettings,
+	pub bot: ProviderBotSettings,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Default)]
@@ -2355,11 +2355,11 @@ pub struct SourceConfiguration {
 	#[serde(default)]
 	pub api_url: Option<String>,
 	#[serde(default)]
-	pub releases: ReleaseProviderSettings,
+	pub releases: ProviderReleaseSettings,
 	#[serde(default)]
-	pub pull_requests: ChangeRequestSettings,
+	pub pull_requests: ProviderMergeRequestSettings,
 	#[serde(default)]
-	pub bot: BotSettings,
+	pub bot: ProviderBotSettings,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/crates/monochange_gitea/src/__tests.rs
+++ b/crates/monochange_gitea/src/__tests.rs
@@ -5,10 +5,12 @@ use httpmock::Method::PATCH;
 use httpmock::Method::POST;
 use httpmock::MockServer;
 use insta::assert_snapshot;
-use monochange_core::BotSettings;
 use monochange_core::BumpSeverity;
-use monochange_core::ChangeRequestSettings;
 use monochange_core::CommitMessage;
+use monochange_core::ProviderBotSettings;
+use monochange_core::ProviderMergeRequestSettings;
+use monochange_core::ProviderReleaseNotesSource;
+use monochange_core::ProviderReleaseSettings;
 use monochange_core::ReleaseManifest;
 use monochange_core::ReleaseManifestChangelog;
 use monochange_core::ReleaseManifestPlan;
@@ -16,9 +18,7 @@ use monochange_core::ReleaseManifestPlanDecision;
 use monochange_core::ReleaseManifestTarget;
 use monochange_core::ReleaseNotesDocument;
 use monochange_core::ReleaseNotesSection;
-use monochange_core::ReleaseNotesSource;
 use monochange_core::ReleaseOwnerKind;
-use monochange_core::ReleaseProviderSettings;
 use monochange_core::SourceCapabilities;
 use monochange_core::SourceChangeRequestOperation;
 use monochange_core::SourceConfiguration;
@@ -91,9 +91,9 @@ fn validate_source_configuration_rejects_missing_host_and_unsupported_features()
 		.contains("[source].host must be set for `provider = \"gitea\"`"));
 
 	let error = validate_source_configuration(&SourceConfiguration {
-		pull_requests: ChangeRequestSettings {
+		pull_requests: ProviderMergeRequestSettings {
 			auto_merge: true,
-			..ChangeRequestSettings::default()
+			..ProviderMergeRequestSettings::default()
 		},
 		..sample_source(None, Some("https://codeberg.org".to_string()))
 	})
@@ -104,9 +104,9 @@ fn validate_source_configuration_rejects_missing_host_and_unsupported_features()
 		.contains("[source.pull_requests].auto_merge is not supported"));
 
 	let error = validate_source_configuration(&SourceConfiguration {
-		releases: ReleaseProviderSettings {
-			source: ReleaseNotesSource::GitHubGenerated,
-			..ReleaseProviderSettings::default()
+		releases: ProviderReleaseSettings {
+			source: ProviderReleaseNotesSource::GitHubGenerated,
+			..ProviderReleaseSettings::default()
 		},
 		..sample_source(None, Some("https://codeberg.org".to_string()))
 	})
@@ -278,9 +278,9 @@ fn release_pull_request_branch_and_body_helpers_cover_sanitization_and_formattin
 #[test]
 fn release_body_supports_generated_notes_and_minimal_fallback() {
 	let generated_source = SourceConfiguration {
-		releases: ReleaseProviderSettings {
-			source: ReleaseNotesSource::GitHubGenerated,
-			..ReleaseProviderSettings::default()
+		releases: ProviderReleaseSettings {
+			source: ProviderReleaseNotesSource::GitHubGenerated,
+			..ProviderReleaseSettings::default()
 		},
 		..sample_source(None, Some("https://codeberg.org".to_string()))
 	};
@@ -604,9 +604,9 @@ fn sample_source(api_url: Option<String>, host: Option<String>) -> SourceConfigu
 		repo: "monochange".to_string(),
 		host,
 		api_url,
-		releases: ReleaseProviderSettings::default(),
-		pull_requests: ChangeRequestSettings::default(),
-		bot: BotSettings::default(),
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+		bot: ProviderBotSettings::default(),
 	}
 }
 

--- a/crates/monochange_gitea/src/lib.rs
+++ b/crates/monochange_gitea/src/lib.rs
@@ -14,9 +14,9 @@ use monochange_core::git::run_commit_command_allow_nothing_to_commit;
 use monochange_core::CommitMessage;
 use monochange_core::MonochangeError;
 use monochange_core::MonochangeResult;
+use monochange_core::ProviderReleaseNotesSource;
 use monochange_core::ReleaseManifest;
 use monochange_core::ReleaseManifestTarget;
-use monochange_core::ReleaseNotesSource;
 use monochange_core::ReleaseOwnerKind;
 use monochange_core::SourceCapabilities;
 use monochange_core::SourceChangeRequest;
@@ -56,8 +56,10 @@ pub fn validate_source_configuration(source: &SourceConfiguration) -> Monochange
 		));
 	}
 	if source.releases.generate_notes
-		|| matches!(source.releases.source, ReleaseNotesSource::GitHubGenerated)
-	{
+		|| matches!(
+			source.releases.source,
+			ProviderReleaseNotesSource::GitHubGenerated
+		) {
 		return Err(MonochangeError::Config(
 			"provider-generated release notes are not supported for `provider = \"gitea\"`; use `source = \"monochange\"`"
 				.to_string(),
@@ -539,8 +541,8 @@ fn release_body(
 	target: &ReleaseManifestTarget,
 ) -> Option<String> {
 	match source.releases.source {
-		ReleaseNotesSource::GitHubGenerated => None,
-		ReleaseNotesSource::Monochange => manifest
+		ProviderReleaseNotesSource::GitHubGenerated => None,
+		ProviderReleaseNotesSource::Monochange => manifest
 			.changelogs
 			.iter()
 			.find(|changelog| {

--- a/crates/monochange_github/readme.md
+++ b/crates/monochange_github/readme.md
@@ -38,9 +38,9 @@ Reach for this crate when you want to preview or publish GitHub releases and rel
 ## Example
 
 ```rust
-use monochange_core::BotSettings;
-use monochange_core::ChangeRequestSettings;
-use monochange_core::ReleaseProviderSettings;
+use monochange_core::ProviderBotSettings;
+use monochange_core::ProviderMergeRequestSettings;
+use monochange_core::ProviderReleaseSettings;
 use monochange_core::SourceConfiguration;
 use monochange_core::SourceProvider;
 use monochange_core::ReleaseManifest;
@@ -87,9 +87,9 @@ let github = SourceConfiguration {
     repo: "monochange".to_string(),
     host: None,
     api_url: None,
-    releases: ReleaseProviderSettings::default(),
-    pull_requests: ChangeRequestSettings::default(),
-    bot: BotSettings::default(),
+    releases: ProviderReleaseSettings::default(),
+    pull_requests: ProviderMergeRequestSettings::default(),
+    bot: ProviderBotSettings::default(),
 };
 
 let requests = build_release_requests(&github, &manifest);

--- a/crates/monochange_github/src/__tests.rs
+++ b/crates/monochange_github/src/__tests.rs
@@ -6,8 +6,6 @@ use httpmock::Method::POST;
 use httpmock::MockServer;
 use insta::assert_json_snapshot;
 use insta::assert_snapshot;
-use monochange_core::BotSettings;
-use monochange_core::ChangeRequestSettings;
 use monochange_core::ChangesetContext;
 use monochange_core::ChangesetRevision;
 use monochange_core::CommitMessage;
@@ -20,15 +18,17 @@ use monochange_core::HostingCapabilities;
 use monochange_core::HostingProviderKind;
 use monochange_core::MonochangeError;
 use monochange_core::PreparedChangeset;
+use monochange_core::ProviderBotSettings;
+use monochange_core::ProviderMergeRequestSettings;
+use monochange_core::ProviderReleaseNotesSource;
+use monochange_core::ProviderReleaseSettings;
 use monochange_core::ReleaseManifest;
 use monochange_core::ReleaseManifestChangelog;
 use monochange_core::ReleaseManifestPlan;
 use monochange_core::ReleaseManifestTarget;
 use monochange_core::ReleaseNotesDocument;
 use monochange_core::ReleaseNotesSection;
-use monochange_core::ReleaseNotesSource;
 use monochange_core::ReleaseOwnerKind;
-use monochange_core::ReleaseProviderSettings;
 use monochange_core::RetargetOperation;
 use monochange_core::RetargetProviderOperation;
 use monochange_core::RetargetTagResult;
@@ -50,9 +50,9 @@ fn build_release_requests_uses_matching_monochange_changelog_bodies() {
 		api_url: None,
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
-		releases: ReleaseProviderSettings::default(),
-		pull_requests: ChangeRequestSettings::default(),
-		bot: BotSettings::default(),
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+		bot: ProviderBotSettings::default(),
 	};
 	let manifest = sample_manifest();
 
@@ -82,13 +82,13 @@ fn build_release_requests_can_defer_to_github_generated_notes() {
 		api_url: None,
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
-		releases: ReleaseProviderSettings {
-			source: ReleaseNotesSource::GitHubGenerated,
+		releases: ProviderReleaseSettings {
+			source: ProviderReleaseNotesSource::GitHubGenerated,
 			generate_notes: true,
-			..ReleaseProviderSettings::default()
+			..ProviderReleaseSettings::default()
 		},
-		pull_requests: ChangeRequestSettings::default(),
-		bot: BotSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+		bot: ProviderBotSettings::default(),
 	};
 	let manifest = sample_manifest();
 
@@ -125,9 +125,9 @@ fn github_url_helpers_use_source_configuration_coordinates() {
 		api_url: None,
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
-		releases: ReleaseProviderSettings::default(),
-		pull_requests: ChangeRequestSettings::default(),
-		bot: BotSettings::default(),
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+		bot: ProviderBotSettings::default(),
 	};
 
 	temp_env::with_var("GITHUB_SERVER_URL", Some("https://example.com"), || {
@@ -150,13 +150,13 @@ fn validate_source_configuration_rejects_conflicting_release_note_modes() {
 		api_url: None,
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
-		releases: ReleaseProviderSettings {
+		releases: ProviderReleaseSettings {
 			generate_notes: true,
-			source: ReleaseNotesSource::Monochange,
-			..ReleaseProviderSettings::default()
+			source: ProviderReleaseNotesSource::Monochange,
+			..ProviderReleaseSettings::default()
 		},
-		pull_requests: ChangeRequestSettings::default(),
-		bot: BotSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+		bot: ProviderBotSettings::default(),
 	})
 	.err()
 	.unwrap_or_else(|| panic!("expected validation error"));
@@ -188,9 +188,9 @@ fn comment_released_issues_public_api_uses_source_configuration() {
 		api_url: Some(server.base_url()),
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
-		releases: ReleaseProviderSettings::default(),
-		pull_requests: ChangeRequestSettings::default(),
-		bot: BotSettings::default(),
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+		bot: ProviderBotSettings::default(),
 	};
 	let mut manifest = sample_manifest();
 	manifest.changesets = vec![PreparedChangeset {
@@ -244,9 +244,9 @@ fn build_release_requests_fall_back_to_minimal_release_bodies() {
 		api_url: None,
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
-		releases: ReleaseProviderSettings::default(),
-		pull_requests: ChangeRequestSettings::default(),
-		bot: BotSettings::default(),
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+		bot: ProviderBotSettings::default(),
 	};
 	let manifest = ReleaseManifest {
 		command: "release".to_string(),
@@ -310,16 +310,16 @@ fn build_release_pull_request_request_renders_branch_and_body() {
 		api_url: None,
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
-		releases: ReleaseProviderSettings::default(),
-		pull_requests: ChangeRequestSettings {
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings {
 			branch_prefix: "automation/release".to_string(),
 			base: "develop".to_string(),
 			title: "chore(release): prepare release".to_string(),
 			labels: vec!["release".to_string(), "automated".to_string()],
 			auto_merge: true,
-			..ChangeRequestSettings::default()
+			..ProviderMergeRequestSettings::default()
 		},
-		bot: BotSettings::default(),
+		bot: ProviderBotSettings::default(),
 	};
 	let manifest = sample_manifest();
 
@@ -428,9 +428,9 @@ fn sync_retargeted_releases_plans_updates_in_dry_run_mode() {
 		api_url: Some("https://example.com".to_string()),
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
-		releases: ReleaseProviderSettings::default(),
-		pull_requests: ChangeRequestSettings::default(),
-		bot: BotSettings::default(),
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+		bot: ProviderBotSettings::default(),
 	};
 	let updates = vec![RetargetTagResult {
 		tag_name: "v1.2.3".to_string(),
@@ -482,9 +482,9 @@ fn sync_retargeted_releases_updates_existing_release_target_commitish() {
 		api_url: Some(server.base_url()),
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
-		releases: ReleaseProviderSettings::default(),
-		pull_requests: ChangeRequestSettings::default(),
-		bot: BotSettings::default(),
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+		bot: ProviderBotSettings::default(),
 	};
 	let updates = vec![RetargetTagResult {
 		tag_name: "v1.2.3".to_string(),
@@ -532,9 +532,9 @@ fn sync_retargeted_releases_reports_already_aligned_release() {
 		api_url: Some(server.base_url()),
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
-		releases: ReleaseProviderSettings::default(),
-		pull_requests: ChangeRequestSettings::default(),
-		bot: BotSettings::default(),
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+		bot: ProviderBotSettings::default(),
 	};
 	let updates = vec![RetargetTagResult {
 		tag_name: "v1.2.3".to_string(),
@@ -577,9 +577,9 @@ fn sync_retargeted_releases_errors_when_release_lookup_is_missing() {
 		api_url: Some(server.base_url()),
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
-		releases: ReleaseProviderSettings::default(),
-		pull_requests: ChangeRequestSettings::default(),
-		bot: BotSettings::default(),
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+		bot: ProviderBotSettings::default(),
 	};
 	let updates = vec![RetargetTagResult {
 		tag_name: "v1.2.3".to_string(),
@@ -630,9 +630,9 @@ fn sync_retargeted_releases_public_api_uses_source_configuration_and_env() {
 		api_url: Some(server.base_url()),
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
-		releases: ReleaseProviderSettings::default(),
-		pull_requests: ChangeRequestSettings::default(),
-		bot: BotSettings::default(),
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+		bot: ProviderBotSettings::default(),
 	};
 	let updates = vec![RetargetTagResult {
 		tag_name: "v1.2.3".to_string(),
@@ -1028,9 +1028,9 @@ fn enrich_changeset_context_resolves_pull_requests_and_related_issues() {
 		api_url: None,
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
-		releases: ReleaseProviderSettings::default(),
-		pull_requests: ChangeRequestSettings::default(),
-		bot: BotSettings::default(),
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+		bot: ProviderBotSettings::default(),
 	};
 	let mut changesets = vec![PreparedChangeset {
 		path: PathBuf::from(".changeset/feature.md"),
@@ -1129,9 +1129,9 @@ fn enrich_changeset_context_public_api_uses_source_configuration() {
 		api_url: None,
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
-		releases: ReleaseProviderSettings::default(),
-		pull_requests: ChangeRequestSettings::default(),
-		bot: BotSettings::default(),
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+		bot: ProviderBotSettings::default(),
 	};
 	let mut changesets = vec![PreparedChangeset {
 		path: PathBuf::from(".changeset/feature.md"),
@@ -1217,9 +1217,9 @@ fn comment_released_issues_skips_existing_markers_and_posts_missing_comments() {
 		api_url: None,
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
-		releases: ReleaseProviderSettings::default(),
-		pull_requests: ChangeRequestSettings::default(),
-		bot: BotSettings::default(),
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+		bot: ProviderBotSettings::default(),
 	};
 	let mut manifest = sample_manifest();
 	manifest.changesets = vec![PreparedChangeset {

--- a/crates/monochange_github/src/__tests.rs
+++ b/crates/monochange_github/src/__tests.rs
@@ -11,7 +11,6 @@ use monochange_core::ChangeRequestSettings;
 use monochange_core::ChangesetContext;
 use monochange_core::ChangesetRevision;
 use monochange_core::CommitMessage;
-use monochange_core::GitHubReleaseNotesSource;
 use monochange_core::HostedActorRef;
 use monochange_core::HostedActorSourceKind;
 use monochange_core::HostedCommitRef;
@@ -27,6 +26,7 @@ use monochange_core::ReleaseManifestPlan;
 use monochange_core::ReleaseManifestTarget;
 use monochange_core::ReleaseNotesDocument;
 use monochange_core::ReleaseNotesSection;
+use monochange_core::ReleaseNotesSource;
 use monochange_core::ReleaseOwnerKind;
 use monochange_core::ReleaseProviderSettings;
 use monochange_core::RetargetOperation;
@@ -83,7 +83,7 @@ fn build_release_requests_can_defer_to_github_generated_notes() {
 		owner: "ifiokjr".to_string(),
 		repo: "monochange".to_string(),
 		releases: ReleaseProviderSettings {
-			source: GitHubReleaseNotesSource::GitHubGenerated,
+			source: ReleaseNotesSource::GitHubGenerated,
 			generate_notes: true,
 			..ReleaseProviderSettings::default()
 		},
@@ -152,7 +152,7 @@ fn validate_source_configuration_rejects_conflicting_release_note_modes() {
 		repo: "monochange".to_string(),
 		releases: ReleaseProviderSettings {
 			generate_notes: true,
-			source: GitHubReleaseNotesSource::Monochange,
+			source: ReleaseNotesSource::Monochange,
 			..ReleaseProviderSettings::default()
 		},
 		pull_requests: ChangeRequestSettings::default(),

--- a/crates/monochange_github/src/lib.rs
+++ b/crates/monochange_github/src/lib.rs
@@ -30,9 +30,9 @@
 //! ## Example
 //!
 //! ```rust
-//! use monochange_core::BotSettings;
-//! use monochange_core::ChangeRequestSettings;
-//! use monochange_core::ReleaseProviderSettings;
+//! use monochange_core::ProviderBotSettings;
+//! use monochange_core::ProviderMergeRequestSettings;
+//! use monochange_core::ProviderReleaseSettings;
 //! use monochange_core::SourceConfiguration;
 //! use monochange_core::SourceProvider;
 //! use monochange_core::ReleaseManifest;
@@ -79,9 +79,9 @@
 //!     repo: "monochange".to_string(),
 //!     host: None,
 //!     api_url: None,
-//!     releases: ReleaseProviderSettings::default(),
-//!     pull_requests: ChangeRequestSettings::default(),
-//!     bot: BotSettings::default(),
+//!     releases: ProviderReleaseSettings::default(),
+//!     pull_requests: ProviderMergeRequestSettings::default(),
+//!     bot: ProviderBotSettings::default(),
 //! };
 //!
 //! let requests = build_release_requests(&github, &manifest);
@@ -114,9 +114,9 @@ use monochange_core::HostingProviderKind;
 use monochange_core::MonochangeError;
 use monochange_core::MonochangeResult;
 use monochange_core::PreparedChangeset;
+use monochange_core::ProviderReleaseNotesSource;
 use monochange_core::ReleaseManifest;
 use monochange_core::ReleaseManifestTarget;
-use monochange_core::ReleaseNotesSource;
 use monochange_core::ReleaseOwnerKind;
 use monochange_core::RetargetOperation;
 use monochange_core::RetargetProviderOperation;
@@ -160,8 +160,10 @@ pub const fn source_capabilities() -> SourceCapabilities {
 
 pub fn validate_source_configuration(source: &SourceConfiguration) -> MonochangeResult<()> {
 	if source.releases.generate_notes
-		&& matches!(source.releases.source, ReleaseNotesSource::Monochange)
-	{
+		&& matches!(
+			source.releases.source,
+			ProviderReleaseNotesSource::Monochange
+		) {
 		return Err(MonochangeError::Config(
 			"[source.releases].generate_notes cannot be true when `source = \"monochange\"`; choose one release-note source"
 				.to_string(),
@@ -1246,8 +1248,8 @@ fn release_body(
 	target: &ReleaseManifestTarget,
 ) -> Option<String> {
 	match github.releases.source {
-		ReleaseNotesSource::GitHubGenerated => None,
-		ReleaseNotesSource::Monochange => manifest
+		ProviderReleaseNotesSource::GitHubGenerated => None,
+		ProviderReleaseNotesSource::Monochange => manifest
 			.changelogs
 			.iter()
 			.find(|changelog| {

--- a/crates/monochange_github/tests/env_wrappers.rs
+++ b/crates/monochange_github/tests/env_wrappers.rs
@@ -3,11 +3,11 @@ use std::path::PathBuf;
 use httpmock::Method::GET;
 use httpmock::Method::POST;
 use httpmock::MockServer;
-use monochange_core::BotSettings;
-use monochange_core::ChangeRequestSettings;
 use monochange_core::CommitMessage;
+use monochange_core::ProviderBotSettings;
+use monochange_core::ProviderMergeRequestSettings;
+use monochange_core::ProviderReleaseSettings;
 use monochange_core::ReleaseOwnerKind;
-use monochange_core::ReleaseProviderSettings;
 use monochange_core::SourceConfiguration;
 use monochange_core::SourceProvider;
 use monochange_github::publish_release_pull_request;
@@ -148,9 +148,9 @@ fn sample_github_source() -> SourceConfiguration {
 		repo: "monochange".to_string(),
 		host: None,
 		api_url: None,
-		releases: ReleaseProviderSettings::default(),
-		pull_requests: ChangeRequestSettings::default(),
-		bot: BotSettings::default(),
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+		bot: ProviderBotSettings::default(),
 	}
 }
 

--- a/crates/monochange_gitlab/src/__tests.rs
+++ b/crates/monochange_gitlab/src/__tests.rs
@@ -6,10 +6,12 @@ use httpmock::Method::POST;
 use httpmock::Method::PUT;
 use httpmock::MockServer;
 use insta::assert_snapshot;
-use monochange_core::BotSettings;
 use monochange_core::BumpSeverity;
-use monochange_core::ChangeRequestSettings;
 use monochange_core::CommitMessage;
+use monochange_core::ProviderBotSettings;
+use monochange_core::ProviderMergeRequestSettings;
+use monochange_core::ProviderReleaseNotesSource;
+use monochange_core::ProviderReleaseSettings;
 use monochange_core::ReleaseManifest;
 use monochange_core::ReleaseManifestChangelog;
 use monochange_core::ReleaseManifestPlan;
@@ -17,9 +19,7 @@ use monochange_core::ReleaseManifestPlanDecision;
 use monochange_core::ReleaseManifestTarget;
 use monochange_core::ReleaseNotesDocument;
 use monochange_core::ReleaseNotesSection;
-use monochange_core::ReleaseNotesSource;
 use monochange_core::ReleaseOwnerKind;
-use monochange_core::ReleaseProviderSettings;
 use monochange_core::SourceCapabilities;
 use monochange_core::SourceChangeRequestOperation;
 use monochange_core::SourceConfiguration;
@@ -85,9 +85,9 @@ fn gitlab_source_capabilities_capture_provider_limits() {
 #[test]
 fn validate_source_configuration_rejects_unsupported_gitlab_features() {
 	let error = validate_source_configuration(&SourceConfiguration {
-		pull_requests: ChangeRequestSettings {
+		pull_requests: ProviderMergeRequestSettings {
 			auto_merge: true,
-			..ChangeRequestSettings::default()
+			..ProviderMergeRequestSettings::default()
 		},
 		..sample_source(None)
 	})
@@ -98,9 +98,9 @@ fn validate_source_configuration_rejects_unsupported_gitlab_features() {
 		.contains("[source.pull_requests].auto_merge is not supported"));
 
 	let error = validate_source_configuration(&SourceConfiguration {
-		releases: ReleaseProviderSettings {
+		releases: ProviderReleaseSettings {
 			draft: true,
-			..ReleaseProviderSettings::default()
+			..ProviderReleaseSettings::default()
 		},
 		..sample_source(None)
 	})
@@ -111,9 +111,9 @@ fn validate_source_configuration_rejects_unsupported_gitlab_features() {
 		.contains("[source.releases].draft is not supported"));
 
 	let error = validate_source_configuration(&SourceConfiguration {
-		releases: ReleaseProviderSettings {
+		releases: ProviderReleaseSettings {
 			prerelease: true,
-			..ReleaseProviderSettings::default()
+			..ProviderReleaseSettings::default()
 		},
 		..sample_source(None)
 	})
@@ -124,9 +124,9 @@ fn validate_source_configuration_rejects_unsupported_gitlab_features() {
 		.contains("[source.releases].prerelease is not supported"));
 
 	let error = validate_source_configuration(&SourceConfiguration {
-		releases: ReleaseProviderSettings {
-			source: ReleaseNotesSource::GitHubGenerated,
-			..ReleaseProviderSettings::default()
+		releases: ProviderReleaseSettings {
+			source: ProviderReleaseNotesSource::GitHubGenerated,
+			..ProviderReleaseSettings::default()
 		},
 		..sample_source(None)
 	})
@@ -336,9 +336,9 @@ fn release_pull_request_branch_and_body_helpers_cover_sanitization_and_formattin
 #[test]
 fn release_body_supports_generated_notes_and_minimal_fallback() {
 	let generated_source = SourceConfiguration {
-		releases: ReleaseProviderSettings {
-			source: ReleaseNotesSource::GitHubGenerated,
-			..ReleaseProviderSettings::default()
+		releases: ProviderReleaseSettings {
+			source: ProviderReleaseNotesSource::GitHubGenerated,
+			..ProviderReleaseSettings::default()
 		},
 		..sample_source(None)
 	};
@@ -633,9 +633,9 @@ fn sample_source(api_url: Option<String>) -> SourceConfiguration {
 		repo: "monochange".to_string(),
 		host: Some("https://gitlab.com".to_string()),
 		api_url,
-		releases: ReleaseProviderSettings::default(),
-		pull_requests: ChangeRequestSettings::default(),
-		bot: BotSettings::default(),
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+		bot: ProviderBotSettings::default(),
 	}
 }
 

--- a/crates/monochange_gitlab/src/lib.rs
+++ b/crates/monochange_gitlab/src/lib.rs
@@ -14,9 +14,9 @@ use monochange_core::git::run_commit_command_allow_nothing_to_commit;
 use monochange_core::CommitMessage;
 use monochange_core::MonochangeError;
 use monochange_core::MonochangeResult;
+use monochange_core::ProviderReleaseNotesSource;
 use monochange_core::ReleaseManifest;
 use monochange_core::ReleaseManifestTarget;
-use monochange_core::ReleaseNotesSource;
 use monochange_core::ReleaseOwnerKind;
 use monochange_core::SourceCapabilities;
 use monochange_core::SourceChangeRequest;
@@ -60,8 +60,10 @@ pub fn validate_source_configuration(source: &SourceConfiguration) -> Monochange
 		));
 	}
 	if source.releases.generate_notes
-		|| matches!(source.releases.source, ReleaseNotesSource::GitHubGenerated)
-	{
+		|| matches!(
+			source.releases.source,
+			ProviderReleaseNotesSource::GitHubGenerated
+		) {
 		return Err(MonochangeError::Config(
 			"provider-generated release notes are not supported for `provider = \"gitlab\"`; use `source = \"monochange\"`"
 				.to_string(),
@@ -556,8 +558,8 @@ fn release_body(
 	target: &ReleaseManifestTarget,
 ) -> Option<String> {
 	match source.releases.source {
-		ReleaseNotesSource::GitHubGenerated => None,
-		ReleaseNotesSource::Monochange => manifest
+		ProviderReleaseNotesSource::GitHubGenerated => None,
+		ProviderReleaseNotesSource::Monochange => manifest
 			.changelogs
 			.iter()
 			.find(|changelog| {


### PR DESCRIPTION
## Summary

Remove GitHub-specific naming from provider types in `monochange_core`:

| Old name | New name |
|----------|----------|
| `GitHubReleaseNotesSource` | `ReleaseNotesSource` |
| `GitHubReleaseSettings` | `ReleaseProviderSettings` |
| `GitHubPullRequestSettings` | `ChangeRequestSettings` |
| `GitHubChangesetBotSettings` | `ChangesetBotSettings` |
| `GitHubBotSettings` | `BotSettings` |

Type aliases removed. Internal `Raw*` config structs also renamed.

**BREAKING CHANGE**: Public type names changed.

Closes #136

## Test plan

- [x] Full workspace compiles
- [x] All tests pass (zero failures)
- [ ] CI passes