### PR TITLE
fix: convert graph panics to errors and warn on missing group members

### DIFF
--- a/.changeset/056-graph-panic-to-error.md
+++ b/.changeset/056-graph-panic-to-error.md
@@ -1,0 +1,5 @@
+---
+monochange_graph: patch
+---
+
+Convert panics to proper errors when changesets reference packages or groups not found in the workspace. Warn instead of silently skipping unresolvable version group members during graph traversal.

--- a/crates/monochange_graph/src/__tests.rs
+++ b/crates/monochange_graph/src/__tests.rs
@@ -580,3 +580,48 @@ fn build_release_plan_returns_error_for_unknown_group_in_changeset() {
 	assert!(error.to_string().contains("nonexistent-group"));
 	assert!(error.to_string().contains("not found"));
 }
+
+#[test]
+fn build_release_plan_warns_on_missing_group_member_during_traversal() {
+	// Group has a member "ghost" that doesn't exist in packages.
+	// The BFS should warn but not crash, and the present member
+	// should still be synchronized.
+	let mut core = package("cargo:core", Version::new(1, 0, 0));
+	core.version_group_id = Some("sdk".to_string());
+	let version_group = VersionGroup {
+		group_id: "sdk".to_string(),
+		display_name: "sdk".to_string(),
+		members: vec![core.id.clone(), "ghost".to_string()],
+		mismatch_detected: false,
+	};
+
+	let plan = build_release_plan(
+		PathBuf::from("fixtures/mixed").as_path(),
+		&[core.clone()],
+		&[],
+		&[version_group],
+		&[ChangeSignal {
+			package_id: core.id.clone(),
+			requested_bump: Some(BumpSeverity::Minor),
+			explicit_version: None,
+			change_origin: "direct-change".to_string(),
+			evidence_refs: Vec::new(),
+			notes: Some("feature".to_string()),
+			details: None,
+			change_type: None,
+			source_path: PathBuf::from(".changeset/feature.md"),
+		}],
+		&[],
+		BumpSeverity::Patch,
+		false,
+	)
+	.unwrap_or_else(|error| panic!("release plan: {error}"));
+
+	// core should still get its bump despite the ghost member.
+	let core_decision = plan
+		.decisions
+		.iter()
+		.find(|decision| decision.package_id == core.id)
+		.unwrap_or_else(|| panic!("expected core decision"));
+	assert_eq!(core_decision.recommended_bump, BumpSeverity::Minor);
+}

--- a/crates/monochange_graph/src/__tests.rs
+++ b/crates/monochange_graph/src/__tests.rs
@@ -511,3 +511,72 @@ fn build_release_plan_rejects_explicit_versions_not_greater_than_current() {
 		.to_string()
 		.contains("must be greater than current version"));
 }
+
+#[test]
+fn build_release_plan_returns_error_for_unknown_package_in_changeset() {
+	let packages = vec![package("cargo:core", Version::new(1, 0, 0))];
+	let error = build_release_plan(
+		PathBuf::from("fixtures/cargo").as_path(),
+		&packages,
+		&[],
+		&[],
+		&[ChangeSignal {
+			package_id: "cargo:nonexistent".to_string(),
+			requested_bump: Some(BumpSeverity::Patch),
+			explicit_version: Some(Version::new(2, 0, 0)),
+			change_origin: "direct-change".to_string(),
+			evidence_refs: Vec::new(),
+			notes: None,
+			details: None,
+			change_type: None,
+			source_path: PathBuf::from(".changeset/ghost.md"),
+		}],
+		&[],
+		BumpSeverity::Patch,
+		false,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected error for unknown package"));
+	assert!(error.to_string().contains("cargo:nonexistent"));
+	assert!(error.to_string().contains("not found"));
+}
+
+#[test]
+fn build_release_plan_returns_error_for_unknown_group_in_changeset() {
+	let mut core = package("cargo:core", Version::new(1, 0, 0));
+	core.version_group_id = Some("sdk".to_string());
+	let version_group = VersionGroup {
+		group_id: "sdk".to_string(),
+		display_name: "sdk".to_string(),
+		members: vec![core.id.clone()],
+		mismatch_detected: false,
+	};
+	// Create a changeset that targets the group member, which maps to a group,
+	// but use a version_group_id that doesn't match any defined group.
+	let mut misrouted = package("cargo:orphan", Version::new(1, 0, 0));
+	misrouted.version_group_id = Some("nonexistent-group".to_string());
+	let error = build_release_plan(
+		PathBuf::from("fixtures/cargo").as_path(),
+		&[core, misrouted.clone()],
+		&[],
+		&[version_group],
+		&[ChangeSignal {
+			package_id: misrouted.id.clone(),
+			requested_bump: Some(BumpSeverity::Patch),
+			explicit_version: Some(Version::new(2, 0, 0)),
+			change_origin: "direct-change".to_string(),
+			evidence_refs: Vec::new(),
+			notes: None,
+			details: None,
+			change_type: None,
+			source_path: PathBuf::from(".changeset/orphan.md"),
+		}],
+		&[],
+		BumpSeverity::Patch,
+		false,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected error for unknown group"));
+	assert!(error.to_string().contains("nonexistent-group"));
+	assert!(error.to_string().contains("not found"));
+}

--- a/crates/monochange_graph/src/lib.rs
+++ b/crates/monochange_graph/src/lib.rs
@@ -232,8 +232,17 @@ pub fn build_release_plan(
 			let group_max = group
 				.members
 				.iter()
-				.filter_map(|member| states.get(member.as_str()))
-				.map(|state| state.severity)
+				.map(|member| {
+					states
+						.get(member.as_str())
+						.map(|state| state.severity)
+						.unwrap_or_else(|| {
+							eprintln!(
+								"warning: version group `{group_id}` member `{member}` was not found in discovered packages"
+							);
+							BumpSeverity::None
+						})
+				})
 				.max()
 				.unwrap_or(BumpSeverity::None);
 
@@ -351,9 +360,11 @@ fn resolve_explicit_versions(
 	let package_versions = package_inputs
 		.into_iter()
 		.map(|(package_id, inputs)| {
-			let package = package_by_id.get(package_id.as_str()).unwrap_or_else(|| {
-				panic!("package `{package_id}` missing while resolving explicit versions")
-			});
+			let package = package_by_id.get(package_id.as_str()).ok_or_else(|| {
+				MonochangeError::Config(format!(
+					"changeset references package `{package_id}` which was not found in the workspace"
+				))
+			})?;
 			let owner = format!("package `{package_id}`");
 			resolve_explicit_version_choice(
 				&owner,
@@ -369,9 +380,11 @@ fn resolve_explicit_versions(
 	let group_versions = group_inputs
 		.into_iter()
 		.map(|(group_id, inputs)| {
-			let group = group_by_id.get(group_id.as_str()).unwrap_or_else(|| {
-				panic!("group `{group_id}` missing while resolving explicit versions")
-			});
+			let group = group_by_id.get(group_id.as_str()).ok_or_else(|| {
+				MonochangeError::Config(format!(
+					"changeset references group `{group_id}` which was not found in the workspace configuration"
+				))
+			})?;
 			let current_version = group
 				.members
 				.iter()
@@ -407,7 +420,9 @@ fn resolve_explicit_version_choice(
 		.iter()
 		.map(|input| input.version.clone())
 		.max()
-		.unwrap_or_else(|| panic!("explicit version inputs cannot be empty"));
+		.ok_or_else(|| {
+			MonochangeError::Config(format!("no explicit version inputs found for {owner}"))
+		})?;
 	let distinct_versions = inputs
 		.iter()
 		.map(|input| input.version.clone())


### PR DESCRIPTION
## Summary

- Convert 3 `panic!()` calls to `MonochangeError::Config` returns in `resolve_explicit_versions()`
- Add warning output for version group members not found in discovered packages during BFS traversal
- Malformed changeset references now produce descriptive errors instead of crashing

Closes #139
Closes #140

## Test plan

- [x] All 12 graph tests pass
- [x] All 294 monochange tests pass
- [ ] CI passes