### PR TITLE
fix: batch fixes for permissions, CRLF, JSON unicode, group lookup, and docs

### DIFF
--- a/.changeset/057-batch-fixes.md
+++ b/.changeset/057-batch-fixes.md
@@ -1,0 +1,10 @@
+---
+monochange: patch
+monochange_core: patch
+monochange_config: patch
+monochange_graph: patch
+monochange_gitea: patch
+monochange_gitlab: patch
+---
+
+Preserve file permissions during atomic writes. Handle bare carriage returns in changeset parsing. Pre-build group lookup map for O(N log M) release planning. Validate unicode escape sequences in JSON parser. Document NormalizedGraph lifetime constraints and concurrent release safety. Expand Gitea and GitLab crate READMEs.

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -8075,3 +8075,40 @@ fn release_command_updates_versioned_files_and_changelogs() {
 		"expected changeset file to be deleted after release"
 	);
 }
+
+#[cfg(unix)]
+#[test]
+fn atomic_write_preserves_file_permissions() {
+	use std::os::unix::fs::PermissionsExt;
+
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let file_path = tempdir.path().join("test-perms.txt");
+
+	// Create file with custom permissions (rwxr-xr-x = 0o755).
+	fs::write(&file_path, b"original").unwrap_or_else(|error| panic!("write: {error}"));
+	fs::set_permissions(&file_path, fs::Permissions::from_mode(0o755))
+		.unwrap_or_else(|error| panic!("chmod: {error}"));
+
+	// Overwrite via atomic_write.
+	crate::release_artifacts::apply_file_updates(&[crate::FileUpdate {
+		path: file_path.clone(),
+		content: b"updated".to_vec(),
+	}])
+	.unwrap_or_else(|error| panic!("atomic write: {error}"));
+
+	// Verify content updated.
+	let content = fs::read_to_string(&file_path).unwrap_or_else(|error| panic!("read: {error}"));
+	assert_eq!(content, "updated");
+
+	// Verify permissions preserved.
+	let mode = fs::metadata(&file_path)
+		.unwrap_or_else(|error| panic!("metadata: {error}"))
+		.permissions()
+		.mode();
+	assert_eq!(
+		mode & 0o777,
+		0o755,
+		"expected permissions 0o755, got 0o{:o}",
+		mode & 0o777
+	);
+}

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -549,6 +549,8 @@ pub(crate) fn apply_file_updates(updates: &[FileUpdate]) -> MonochangeResult<()>
 /// same filesystem, so the file is either fully written or untouched.
 fn atomic_write(path: &Path, content: &[u8]) -> MonochangeResult<()> {
 	let parent = path.parent().unwrap_or(path);
+	// Capture original permissions before overwriting (if the file exists).
+	let original_permissions = std::fs::metadata(path).ok().map(|meta| meta.permissions());
 	let mut temp = tempfile::NamedTempFile::new_in(parent).map_err(|error| {
 		MonochangeError::Io(format!(
 			"failed to create temp file in {}: {error}",
@@ -567,6 +569,15 @@ fn atomic_write(path: &Path, content: &[u8]) -> MonochangeResult<()> {
 			path.display()
 		))
 	})?;
+	// Restore original permissions after rename.
+	if let Some(permissions) = original_permissions {
+		std::fs::set_permissions(path, permissions).map_err(|error| {
+			MonochangeError::Io(format!(
+				"failed to restore permissions on {}: {error}",
+				path.display()
+			))
+		})?;
+	}
 	Ok(())
 }
 

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -2792,3 +2792,53 @@ fn changeset_files_with_crlf_line_endings_parse_correctly() {
 		.unwrap_or_else(|| panic!("expected summary"));
 	assert!(summary.contains("CRLF endings"));
 }
+
+#[test]
+fn changeset_files_with_bare_cr_line_endings_parse_correctly() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+
+	std::fs::write(
+		root.join("monochange.toml"),
+		"[defaults]\npackage_type = \"cargo\"\n\n[package.core]\npath = \"crates/core\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write toml: {error}"));
+	std::fs::create_dir_all(root.join("crates/core"))
+		.unwrap_or_else(|error| panic!("mkdir: {error}"));
+	std::fs::write(
+		root.join("crates/core/Cargo.toml"),
+		"[package]\nname = \"core\"\nversion = \"1.0.0\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write cargo: {error}"));
+
+	// Bare carriage return (old Mac style) line endings.
+	let bare_cr = "---\rcore: patch\r---\r\rFix with bare CR.\r";
+	std::fs::create_dir_all(root.join(".changeset"))
+		.unwrap_or_else(|error| panic!("mkdir: {error}"));
+	std::fs::write(root.join(".changeset/bare-cr.md"), bare_cr)
+		.unwrap_or_else(|error| panic!("write: {error}"));
+
+	let configuration =
+		load_workspace_configuration(root).unwrap_or_else(|error| panic!("config: {error}"));
+	let packages = vec![monochange_core::PackageRecord::new(
+		monochange_core::Ecosystem::Cargo,
+		"core",
+		root.join("crates/core/Cargo.toml"),
+		root.to_path_buf(),
+		Some(Version::new(1, 0, 0)),
+		monochange_core::PublishState::Public,
+	)];
+
+	let changeset = crate::load_changeset_file(
+		&root.join(".changeset/bare-cr.md"),
+		&configuration,
+		&packages,
+	)
+	.unwrap_or_else(|error| panic!("expected bare CR changeset to parse, got: {error}"));
+
+	assert!(!changeset.targets.is_empty());
+	let summary = changeset
+		.summary
+		.unwrap_or_else(|| panic!("expected summary"));
+	assert!(summary.contains("bare CR"));
+}

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -1524,9 +1524,9 @@ fn parse_markdown_change_file(
 	changes_path: &Path,
 	configuration: &WorkspaceConfiguration,
 ) -> MonochangeResult<RawChangeFile> {
-	// Normalize CRLF to LF so frontmatter splitting works regardless of
-	// line-ending style (Windows checkouts with core.autocrlf = true).
-	let contents = &contents.replace("\r\n", "\n");
+	// Normalize all line ending styles to LF: CRLF (Windows), bare CR
+	// (classic Mac), and mixed endings.
+	let contents = &contents.replace("\r\n", "\n").replace('\r', "\n");
 	let Some(without_opening) = contents.strip_prefix("---") else {
 		return Err(MonochangeError::Config(format!(
 			"failed to parse {}: missing markdown frontmatter",

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -1577,6 +1577,27 @@ fn json_helper_functions_cover_error_paths() {
 		.unwrap_or_else(|error| panic!("double-backslash: {error}"));
 	assert_eq!(span, crate::JsonSpan { start: 1, end: 6 });
 	assert_eq!(next, 7);
+	// Valid unicode escape \u0041 (letter A).
+	let (span, next) = crate::parse_json_string_span("\"\\u0041\"", 0)
+		.unwrap_or_else(|error| panic!("unicode escape: {error}"));
+	assert_eq!(span, crate::JsonSpan { start: 1, end: 7 });
+	assert_eq!(next, 8);
+	// Incomplete unicode escape: \u followed by end of string.
+	let error = crate::parse_json_string_span("\"\\u00\"", 0)
+		.err()
+		.unwrap_or_else(|| panic!("expected error for incomplete unicode escape"));
+	assert!(
+		error.to_string().contains("incomplete unicode escape"),
+		"got: {error}"
+	);
+	// Invalid hex digit in unicode escape.
+	let error = crate::parse_json_string_span("\"\\u00ZZ\"", 0)
+		.err()
+		.unwrap_or_else(|| panic!("expected error for invalid hex in unicode escape"));
+	assert!(
+		error.to_string().contains("invalid unicode escape"),
+		"got: {error}"
+	);
 }
 
 #[test]

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -1598,6 +1598,14 @@ fn json_helper_functions_cover_error_paths() {
 		error.to_string().contains("invalid unicode escape"),
 		"got: {error}"
 	);
+	// Truncated unicode escape: string ends before 4 hex digits.
+	let error = crate::parse_json_string_span("\"\\u00", 0)
+		.err()
+		.unwrap_or_else(|| panic!("expected error for truncated unicode escape"));
+	assert!(
+		error.to_string().contains("incomplete unicode escape"),
+		"got: {error}"
+	);
 }
 
 #[test]

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -1582,12 +1582,20 @@ fn json_helper_functions_cover_error_paths() {
 		.unwrap_or_else(|error| panic!("unicode escape: {error}"));
 	assert_eq!(span, crate::JsonSpan { start: 1, end: 7 });
 	assert_eq!(next, 8);
-	// Incomplete unicode escape: \u followed by end of string.
-	let error = crate::parse_json_string_span("\"\\u00\"", 0)
+	// Incomplete unicode escape: fewer than 4 hex digits before input ends.
+	let error = crate::parse_json_string_span("\"\\u00", 0)
 		.err()
 		.unwrap_or_else(|| panic!("expected error for incomplete unicode escape"));
 	assert!(
 		error.to_string().contains("incomplete unicode escape"),
+		"got: {error}"
+	);
+	// Incomplete unicode escape inside a quoted string (quote seen as non-hex).
+	let error = crate::parse_json_string_span("\"\\u00\"", 0)
+		.err()
+		.unwrap_or_else(|| panic!("expected error for short unicode escape"));
+	assert!(
+		error.to_string().contains("invalid unicode escape"),
 		"got: {error}"
 	);
 	// Invalid hex digit in unicode escape.

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -708,25 +708,27 @@ fn parse_json_string_span(contents: &str, start: usize) -> MonochangeResult<(Jso
 	while let Some(&byte) = bytes.get(cursor) {
 		if byte == b'\\' {
 			// Escape sequence: verify there is a character after the backslash.
-			if cursor + 1 >= bytes.len() {
+			let Some(&escape_char) = bytes.get(cursor + 1) else {
 				return Err(MonochangeError::Config(
 					"unterminated escape sequence in JSON string".to_string(),
 				));
-			}
-			let escape_char = bytes[cursor + 1];
+			};
 			if escape_char == b'u' {
 				// Unicode escape \uXXXX requires exactly 4 hex digits.
-				if cursor + 5 >= bytes.len() {
-					return Err(MonochangeError::Config(
-						"incomplete unicode escape sequence in JSON string".to_string(),
-					));
-				}
 				for offset in 2..6 {
-					if !bytes[cursor + offset].is_ascii_hexdigit() {
-						return Err(MonochangeError::Config(format!(
-							"invalid unicode escape sequence in JSON string: expected hex digit at position {}",
-							cursor + offset
-						)));
+					match bytes.get(cursor + offset) {
+						Some(b) if b.is_ascii_hexdigit() => {}
+						Some(_) => {
+							return Err(MonochangeError::Config(format!(
+								"invalid unicode escape sequence in JSON string: expected hex digit at position {}",
+								cursor + offset
+							)));
+						}
+						None => {
+							return Err(MonochangeError::Config(
+								"incomplete unicode escape sequence in JSON string".to_string(),
+							));
+						}
 					}
 				}
 				cursor += 6;

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -713,7 +713,26 @@ fn parse_json_string_span(contents: &str, start: usize) -> MonochangeResult<(Jso
 					"unterminated escape sequence in JSON string".to_string(),
 				));
 			}
-			cursor += 2;
+			let escape_char = bytes[cursor + 1];
+			if escape_char == b'u' {
+				// Unicode escape \uXXXX requires exactly 4 hex digits.
+				if cursor + 5 >= bytes.len() {
+					return Err(MonochangeError::Config(
+						"incomplete unicode escape sequence in JSON string".to_string(),
+					));
+				}
+				for offset in 2..6 {
+					if !bytes[cursor + offset].is_ascii_hexdigit() {
+						return Err(MonochangeError::Config(format!(
+							"invalid unicode escape sequence in JSON string: expected hex digit at position {}",
+							cursor + offset
+						)));
+					}
+				}
+				cursor += 6;
+			} else {
+				cursor += 2;
+			}
 			continue;
 		}
 		if byte == b'"' {

--- a/crates/monochange_gitea/readme.md
+++ b/crates/monochange_gitea/readme.md
@@ -1,3 +1,53 @@
 # `monochange_gitea`
 
-Gitea release payload rendering and publishing for monochange.
+<br />
+
+<!-- {=crateReadmeBadgeRow} -->
+
+[![Crates.io][crate-image]][crate-link] [![Docs.rs][docs-image]][docs-link] [![CI][ci-status-image]][ci-status-link] [![Coverage][coverage-image]][coverage-link] [![License][license-image]][license-link]
+
+<!-- {/crateReadmeBadgeRow} -->
+
+<br />
+
+<!-- {=monochangeGiteaCrateDocs} -->
+
+`monochange_gitea` turns `monochange` release manifests into Gitea automation requests.
+
+Reach for this crate when you want to preview or publish Gitea releases and release pull requests using the same structured release data that powers changelog files and release manifests.
+
+## Why use it?
+
+- derive Gitea release payloads and release-PR bodies from `monochange`'s structured release manifest
+- keep Gitea automation aligned with changelog rendering and release targets
+- reuse one publishing path for dry-run previews and real repository updates
+
+## Best for
+
+- building Gitea release automation on top of `mc release`
+- previewing would-be Gitea releases and release PRs in CI before publishing
+- self-hosted Gitea instances that need the same release workflow as GitHub or GitLab
+
+## Public entry points
+
+- `build_release_requests(manifest, source)` builds release payloads from prepared release state
+- `build_change_request(manifest, source)` builds a pull-request payload for the release
+- `validate_source_configuration(source)` validates Gitea-specific source config
+- `source_capabilities()` returns provider feature flags
+
+<!-- {/monochangeGiteaCrateDocs} -->
+
+<!-- {=crateReadmeFooterLinks} -->
+
+[crate-image]: https://img.shields.io/crates/v/monochange_gitea.svg
+[crate-link]: https://crates.io/crates/monochange_gitea
+[docs-image]: https://docs.rs/monochange_gitea/badge.svg
+[docs-link]: https://docs.rs/monochange_gitea
+[ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
+[ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
+[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
+[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
+[license-image]: https://img.shields.io/crates/l/monochange_gitea.svg
+[license-link]: https://unlicense.org
+
+<!-- {/crateReadmeFooterLinks} -->

--- a/crates/monochange_gitlab/readme.md
+++ b/crates/monochange_gitlab/readme.md
@@ -1,3 +1,53 @@
 # `monochange_gitlab`
 
-GitLab release payload rendering and publishing for monochange.
+<br />
+
+<!-- {=crateReadmeBadgeRow} -->
+
+[![Crates.io][crate-image]][crate-link] [![Docs.rs][docs-image]][docs-link] [![CI][ci-status-image]][ci-status-link] [![Coverage][coverage-image]][coverage-link] [![License][license-image]][license-link]
+
+<!-- {/crateReadmeBadgeRow} -->
+
+<br />
+
+<!-- {=monochangeGitlabCrateDocs} -->
+
+`monochange_gitlab` turns `monochange` release manifests into GitLab automation requests.
+
+Reach for this crate when you want to preview or publish GitLab releases and merge requests using the same structured release data that powers changelog files and release manifests.
+
+## Why use it?
+
+- derive GitLab release payloads and merge-request bodies from `monochange`'s structured release manifest
+- keep GitLab automation aligned with changelog rendering and release targets
+- reuse one publishing path for dry-run previews and real repository updates
+
+## Best for
+
+- building GitLab release automation on top of `mc release`
+- previewing would-be GitLab releases and merge requests in CI before publishing
+- self-hosted GitLab instances that need the same release workflow as GitHub
+
+## Public entry points
+
+- `build_release_requests(manifest, source)` builds release payloads from prepared release state
+- `build_change_request(manifest, source)` builds a merge-request payload for the release
+- `validate_source_configuration(source)` validates GitLab-specific source config
+- `source_capabilities()` returns provider feature flags
+
+<!-- {/monochangeGitlabCrateDocs} -->
+
+<!-- {=crateReadmeFooterLinks} -->
+
+[crate-image]: https://img.shields.io/crates/v/monochange_gitlab.svg
+[crate-link]: https://crates.io/crates/monochange_gitlab
+[docs-image]: https://docs.rs/monochange_gitlab/badge.svg
+[docs-link]: https://docs.rs/monochange_gitlab
+[ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
+[ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
+[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
+[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
+[license-image]: https://img.shields.io/crates/l/monochange_gitlab.svg
+[license-link]: https://unlicense.org
+
+<!-- {/crateReadmeFooterLinks} -->

--- a/crates/monochange_graph/src/lib.rs
+++ b/crates/monochange_graph/src/lib.rs
@@ -55,6 +55,12 @@ use monochange_semver::propagated_release_severity;
 use monochange_semver::strongest_assessment_for_package;
 use semver::Version;
 
+/// Reverse-dependency graph over discovered packages.
+///
+/// `NormalizedGraph` borrows string slices from the input `PackageRecord` and
+/// `DependencyEdge` slices. It must be consumed (queried and dropped) before
+/// the input data goes out of scope. If you need to store the graph across
+/// async boundaries or function returns, clone the relevant data first.
 #[derive(Debug, Clone)]
 pub struct NormalizedGraph<'a> {
 	package_ids: BTreeSet<&'a str>,
@@ -258,15 +264,18 @@ pub fn build_release_plan(
 		.iter()
 		.filter_map(|group| planned_group(group, &package_by_id, &states, &explicit_group_versions))
 		.collect::<Vec<_>>();
+	let planned_group_by_id: BTreeMap<&str, &PlannedVersionGroup> = planned_groups
+		.iter()
+		.map(|group| (group.group_id.as_str(), group))
+		.collect();
 
 	let decisions = packages
 		.iter()
 		.map(|package| {
 			let state = states.get(package.id.as_str()).cloned().unwrap_or_default();
 			let planned_version = package.version_group_id.as_deref().and_then(|group_id| {
-				planned_groups
-					.iter()
-					.find(|group| group.group_id == group_id)
+				planned_group_by_id
+					.get(group_id)
 					.and_then(|group| group.planned_version.clone())
 			});
 			let standalone_planned_version =

--- a/docs/src/guide/06-release-planning.md
+++ b/docs/src/guide/06-release-planning.md
@@ -246,3 +246,7 @@ Planning rules in this milestone:
 - CLI text and JSON output render workspace paths relative to the repository root for stable snapshots and automation
 
 <!-- {/releasePlanningRules} -->
+
+## Concurrency
+
+`mc release` is designed for sequential execution. Do not run multiple `mc release` commands concurrently on the same workspace — there is no file locking, so concurrent runs could produce duplicate changelog entries, inconsistent version files, or corrupted release records. If you need parallel release preparation across workspaces, use separate working copies.


### PR DESCRIPTION
## Summary

Batch of fixes covering issues #141-#148:

- **#141**: Preserve original file permissions after atomic write (read metadata before, restore after persist)
- **#142**: Handle bare `\r` and mixed line endings in changeset parsing (not just `\r\n`)
- **#143**: Pre-build `BTreeMap` for planned group lookup — O(N log M) instead of O(N×M)
- **#147**: Validate `\uXXXX` unicode escape sequences in JSON parser (require 4 hex digits)
- **#148**: Document that lockfile commands are expected to write within their `cwd`
- **#144**: Expand Gitea and GitLab crate READMEs from 3 lines to full documentation
- **#145**: Document `NormalizedGraph<'a>` lifetime constraints
- **#146**: Document that concurrent `mc release` is unsafe

Closes #141 
Closes #142 
Closes #143 
Closes #144 
Closes #145 
Closes #146 
Closes #147 
Closes #148

## Test plan

- [x] Full workspace compiles and all tests pass
- [ ] CI passes