### PR TITLE
feat: add Python ecosystem support (monochange_python)

### DIFF
--- a/.changeset/feat-python-ecosystem.md
+++ b/.changeset/feat-python-ecosystem.md
@@ -1,7 +1,10 @@
 ---
+"@monochange/cli": minor
 monochange: minor
 monochange_core: minor
 monochange_config: minor
+monochange_lint: minor
+monochange_python: minor
 ---
 
 #### add Python ecosystem support

--- a/.changeset/feat-python-ecosystem.md
+++ b/.changeset/feat-python-ecosystem.md
@@ -1,0 +1,49 @@
+---
+monochange: minor
+monochange_core: minor
+monochange_config: minor
+---
+
+#### add Python ecosystem support
+
+monochange now discovers and manages Python packages from uv workspaces, Poetry projects, and standalone `pyproject.toml` files.
+
+**Configuration:**
+
+```toml
+[defaults]
+package_type = "python"
+
+[package.core]
+path = "packages/core"
+
+[ecosystems.python]
+enabled = true
+lockfile_commands = [{ command = "uv lock" }]
+```
+
+**What it discovers:**
+
+- uv workspaces via `[tool.uv.workspace].members` glob patterns
+- Poetry projects via `[tool.poetry]` sections
+- Standalone `pyproject.toml` files with PEP 621 `[project]` metadata
+
+**Version management:**
+
+- Reads and updates `[project].version` in `pyproject.toml`
+- Parses PEP 440 versions and maps to semver (e.g., `1.2` → `1.2.0`)
+- Updates dependency version constraints in `[project].dependencies`
+- Handles `dynamic = ["version"]` gracefully (reports `None` for dynamic versions)
+
+**Lockfile commands:**
+
+- Infers `uv lock` for uv projects (detected by `uv.lock`)
+- Infers `poetry lock --no-update` for Poetry projects (detected by `poetry.lock`)
+- Configurable via `[ecosystems.python].lockfile_commands`
+
+**Dependency extraction:**
+
+- PEP 621 `[project].dependencies` and `[project.optional-dependencies]`
+- Poetry `[tool.poetry.dependencies]` and `[tool.poetry.group.*.dependencies]`
+- PEP 503 name normalization for cross-package dependency matching
+- PEP 508 version specifier parsing with extras support

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -4,6 +4,7 @@
 - npm workspaces, pnpm workspaces, Bun workspaces, and standalone `package.json` packages
 - Deno workspaces and standalone `deno.json` / `deno.jsonc` packages
 - Dart and Flutter workspaces plus standalone `pubspec.yaml` packages
+- Python uv workspaces, Poetry projects, and standalone `pyproject.toml` packages
 
 <!-- {/discoverySupportedSources} -->
 
@@ -433,6 +434,10 @@ enabled = true
 [ecosystems.dart]
 enabled = true
 lockfile_commands = [{ command = "flutter pub get", cwd = "packages/mobile" }]
+
+[ecosystems.python]
+enabled = true
+lockfile_commands = [{ command = "uv lock" }]
 ```
 
 <!-- {/configurationEcosystemSettingsSnippet} -->

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -4,7 +4,7 @@
 
 It discovers packages, normalizes dependency data, applies group rules, turns explicit change files into release plans, and can run config-defined release preparation from those same inputs.
 
-Use it when your repository has outgrown one-ecosystem release tooling and you want one model for Cargo, npm/pnpm/Bun, Deno, and Dart/Flutter.
+Use it when your repository has outgrown one-ecosystem release tooling and you want one model for Cargo, npm/pnpm/Bun, Deno, Dart/Flutter, and Python.
 
 <!-- {/projectReadmeOverview} -->
 
@@ -40,12 +40,14 @@ Use it when your repository has outgrown one-ecosystem release tooling and you w
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__deno-orange?logo=rust)](https://crates.io/crates/monochange_deno) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__deno-1f425f?logo=docs.rs)](https://docs.rs/monochange_deno/)
 - `monochange_dart` — Dart and Flutter workspace discovery.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__dart-orange?logo=rust)](https://crates.io/crates/monochange_dart) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__dart-1f425f?logo=docs.rs)](https://docs.rs/monochange_dart/)
+- `monochange_python` — Python uv workspace, Poetry, and pyproject.toml discovery.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__python-orange?logo=rust)](https://crates.io/crates/monochange_python) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__python-1f425f?logo=docs.rs)](https://docs.rs/monochange_python/)
 
 <!-- {/projectCrateCatalog} -->
 
 <!-- {@projectMilestoneCapabilities} -->
 
-- discover Cargo, npm/pnpm/Bun, Deno, Dart, and Flutter packages
+- discover Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, and Python packages
 - normalize dependency edges across ecosystems
 - coordinate shared package groups from `monochange.toml`
 - compute release plans from explicit change input

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2404,6 +2404,7 @@ dependencies = [
  "tempfile",
  "toml",
  "toml_edit",
+ "tracing",
  "walkdir",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,6 +2060,7 @@ dependencies = [
  "monochange_graph",
  "monochange_lint",
  "monochange_npm",
+ "monochange_python",
  "monochange_semver",
  "monochange_test_helpers",
  "portable-pty",
@@ -2169,6 +2170,7 @@ dependencies = [
  "monochange_github",
  "monochange_gitlab",
  "monochange_npm",
+ "monochange_python",
  "monochange_test_helpers",
  "proptest",
  "regex",
@@ -2384,6 +2386,24 @@ dependencies = [
  "similar-asserts",
  "thiserror 2.0.18",
  "tracing",
+ "walkdir",
+]
+
+[[package]]
+name = "monochange_python"
+version = "0.2.0"
+dependencies = [
+ "glob",
+ "insta",
+ "monochange_core",
+ "monochange_test_helpers",
+ "rstest",
+ "semver",
+ "serde",
+ "similar-asserts",
+ "tempfile",
+ "toml",
+ "toml_edit",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ monochange_lint = { version = "0.2.0", path = "./crates/monochange_lint" }
 monochange_lint_testing = { version = "0.2.0", path = "./crates/monochange_lint_testing" }
 monochange_linting = { version = "0.2.0", path = "./crates/monochange_linting" }
 monochange_npm = { version = "0.2.0", path = "./crates/monochange_npm" }
+monochange_python = { version = "0.2.0", path = "./crates/monochange_python" }
 monochange_semver = { version = "0.2.0", path = "./crates/monochange_semver" }
 monochange_test_helpers = { version = "0.0.2", path = "./crates/monochange_test_helpers" }
 

--- a/crates/monochange/Cargo.toml
+++ b/crates/monochange/Cargo.toml
@@ -22,11 +22,12 @@ pkg-fmt = "tgz"
 bin-dir = "{ bin }{ binary-ext }"
 
 [features]
-default = ["cargo", "npm", "deno", "dart", "github", "gitlab", "gitea"]
+default = ["cargo", "npm", "deno", "dart", "python", "github", "gitlab", "gitea"]
 cargo = ["monochange_cargo"]
 npm = ["monochange_npm"]
 deno = ["monochange_deno"]
 dart = ["monochange_dart"]
+python = ["monochange_python"]
 github = ["monochange_github", "monochange_core/http"]
 gitlab = ["monochange_gitlab", "monochange_core/http"]
 gitea = ["monochange_gitea", "monochange_core/http"]
@@ -50,6 +51,7 @@ monochange_gitlab = { workspace = true, optional = true }
 monochange_graph = { workspace = true }
 monochange_lint = { workspace = true }
 monochange_npm = { workspace = true, optional = true }
+monochange_python = { workspace = true, optional = true }
 monochange_semver = { workspace = true }
 rayon = { workspace = true, default-features = true }
 regex = { workspace = true, default-features = true }

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -8731,6 +8731,7 @@ fn build_command_and_configured_change_type_choices_include_runtime_metadata() {
 		npm: monochange_core::EcosystemSettings::default(),
 		deno: monochange_core::EcosystemSettings::default(),
 		dart: monochange_core::EcosystemSettings::default(),
+		python: monochange_core::EcosystemSettings::default(),
 	};
 	assert_eq!(
 		crate::configured_change_type_choices(&configuration),
@@ -8827,6 +8828,7 @@ fn apply_runtime_change_type_choices_updates_only_unconfigured_change_inputs() {
 		npm: monochange_core::EcosystemSettings::default(),
 		deno: monochange_core::EcosystemSettings::default(),
 		dart: monochange_core::EcosystemSettings::default(),
+		python: monochange_core::EcosystemSettings::default(),
 	};
 	let mut cli = vec![
 		CliCommandDefinition {
@@ -8888,6 +8890,7 @@ fn apply_runtime_change_type_choices_preserves_existing_choice_inputs_and_empty_
 		npm: monochange_core::EcosystemSettings::default(),
 		deno: monochange_core::EcosystemSettings::default(),
 		dart: monochange_core::EcosystemSettings::default(),
+		python: monochange_core::EcosystemSettings::default(),
 	};
 	let mut cli = vec![CliCommandDefinition {
 		name: "change".to_string(),

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -6653,6 +6653,20 @@ fn versioned_file_kind_detects_supported_paths_across_ecosystems() {
 		),
 		Some(crate::VersionedFileKind::Dart(_))
 	));
+	assert!(matches!(
+		crate::versioned_file_kind(
+			monochange_core::EcosystemType::Python,
+			&fixture_path("python/standalone/pyproject.toml"),
+		),
+		Some(crate::VersionedFileKind::Python(_))
+	));
+	assert!(matches!(
+		crate::versioned_file_kind(
+			monochange_core::EcosystemType::Python,
+			&fixture_path("python/uv-workspace/uv.lock"),
+		),
+		Some(crate::VersionedFileKind::Python(_))
+	));
 }
 
 #[test]
@@ -6763,6 +6777,25 @@ fn read_cached_document_parses_supported_document_formats() {
 	)
 	.unwrap_or_else(|error| panic!("dart lock: {error}"));
 	assert!(matches!(dart_yaml, crate::CachedDocument::Yaml(_)));
+
+	let python_manifest = crate::read_cached_document(
+		&mut BTreeMap::new(),
+		&fixture_path("python/standalone/pyproject.toml"),
+		monochange_core::EcosystemType::Python,
+	)
+	.unwrap_or_else(|error| panic!("python manifest: {error}"));
+	assert!(matches!(
+		python_manifest,
+		crate::CachedDocument::Text(contents) if contents.contains("[project]")
+	));
+
+	let python_lock = crate::read_cached_document(
+		&mut BTreeMap::new(),
+		&fixture_path("python/uv-workspace/uv.lock"),
+		monochange_core::EcosystemType::Python,
+	)
+	.unwrap_or_else(|error| panic!("python lock: {error}"));
+	assert!(matches!(python_lock, crate::CachedDocument::Text(_)));
 }
 
 #[test]
@@ -6770,6 +6803,7 @@ fn resolve_versioned_prefix_prefers_explicit_then_ecosystem_then_default() {
 	let mut configuration = load_workspace_configuration(&fixture_path("monochange/release-base"))
 		.unwrap_or_else(|error| panic!("configuration: {error}"));
 	configuration.npm.dependency_version_prefix = Some("workspace:".to_string());
+	configuration.python.dependency_version_prefix = Some("~=".to_string());
 	configuration.deno.dependency_version_prefix = None;
 	let context = crate::VersionedFileUpdateContext {
 		package_by_config_id: BTreeMap::new(),
@@ -6813,6 +6847,24 @@ fn resolve_versioned_prefix_prefers_explicit_then_ecosystem_then_default() {
 	assert_eq!(
 		crate::resolve_versioned_prefix(&fallback, &context),
 		monochange_core::EcosystemType::Deno.default_prefix()
+	);
+
+	let python = monochange_core::VersionedFileDefinition {
+		path: "packages/app/pyproject.toml".to_string(),
+		ecosystem_type: Some(monochange_core::EcosystemType::Python),
+		prefix: None,
+		fields: None,
+		name: None,
+		regex: None,
+	};
+	assert_eq!(crate::resolve_versioned_prefix(&python, &context), "~=");
+	assert_eq!(
+		monochange_core::EcosystemType::Python.default_prefix(),
+		">="
+	);
+	assert_eq!(
+		monochange_core::EcosystemType::Python.default_fields(),
+		["dependencies"]
 	);
 }
 
@@ -8206,6 +8258,85 @@ fn apply_versioned_file_definition_updates_npm_manifest_and_lock_variants() {
 	assert!(matches!(
 		bun_document,
 		crate::CachedDocument::Text(contents) if contents.contains("\"left-pad\": \"2.0.0\"")
+	));
+}
+
+#[test]
+fn apply_versioned_file_definition_updates_python_manifest_and_lock_variants() {
+	let configuration = versioned_test_configuration();
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let manifest_path = tempdir.path().join("pyproject.toml");
+	fs::write(
+		&manifest_path,
+		r#"[project]
+name = "python-app"
+version = "1.0.0"
+dependencies = ["python-core>=1.0.0"]
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write pyproject: {error}"));
+	let lock_path = tempdir.path().join("uv.lock");
+	fs::write(&lock_path, "version = 1\n").unwrap_or_else(|error| panic!("write lock: {error}"));
+
+	let context = versioned_test_context(
+		&configuration,
+		BTreeMap::from([("python-core".to_string(), "2.0.0".to_string())]),
+		&[],
+	);
+	let manifest_definition = monochange_core::VersionedFileDefinition {
+		path: "pyproject.toml".to_string(),
+		ecosystem_type: Some(monochange_core::EcosystemType::Python),
+		prefix: None,
+		fields: None,
+		name: None,
+		regex: None,
+	};
+	let dep_names = vec!["python-core".to_string()];
+	let mut updates = BTreeMap::new();
+	crate::apply_versioned_file_definition(
+		tempdir.path(),
+		&mut updates,
+		&manifest_definition,
+		"2.0.0",
+		None,
+		&dep_names,
+		&context,
+	)
+	.unwrap_or_else(|error| panic!("python manifest update: {error}"));
+	let manifest_document = updates
+		.remove(&manifest_path)
+		.unwrap_or_else(|| panic!("expected python manifest update"));
+	assert!(matches!(
+		manifest_document,
+		crate::CachedDocument::Text(contents)
+			if contents.contains("version = \"2.0.0\"")
+				&& contents.contains("python-core>=2.0.0")
+	));
+
+	let lock_definition = monochange_core::VersionedFileDefinition {
+		path: "uv.lock".to_string(),
+		ecosystem_type: Some(monochange_core::EcosystemType::Python),
+		prefix: None,
+		fields: None,
+		name: None,
+		regex: None,
+	};
+	crate::apply_versioned_file_definition(
+		tempdir.path(),
+		&mut updates,
+		&lock_definition,
+		"2.0.0",
+		None,
+		&dep_names,
+		&context,
+	)
+	.unwrap_or_else(|error| panic!("python lock update: {error}"));
+	let lock_document = updates
+		.remove(&lock_path)
+		.unwrap_or_else(|| panic!("expected python lock update"));
+	assert!(matches!(
+		lock_document,
+		crate::CachedDocument::Text(contents) if contents == "version = 1\n"
 	));
 }
 

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -8426,8 +8426,12 @@ fn apply_versioned_file_definition_reports_python_error_paths() {
 	.unwrap_or_else(|| panic!("expected unsupported python path error"));
 	assert!(error.to_string().contains("python"));
 
-	fs::write(tempdir.path().join("pyproject.toml"), "[project\n")
-		.unwrap_or_else(|error| panic!("write invalid manifest: {error}"));
+	let manifest_path = tempdir.path().join("pyproject.toml");
+	fs::write(
+		&manifest_path,
+		"[project]\nname = \"python-core\"\nversion = \"1.0.0\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write manifest: {error}"));
 	let manifest_definition = monochange_core::VersionedFileDefinition {
 		path: "pyproject.toml".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Python),
@@ -8436,6 +8440,10 @@ fn apply_versioned_file_definition_reports_python_error_paths() {
 		name: None,
 		regex: None,
 	};
+	updates.insert(
+		manifest_path,
+		crate::CachedDocument::Text("[project\n".to_string()),
+	);
 	let error = crate::apply_versioned_file_definition(
 		tempdir.path(),
 		&mut updates,

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -6799,6 +6799,57 @@ fn read_cached_document_parses_supported_document_formats() {
 }
 
 #[test]
+fn read_cached_document_reports_python_error_paths() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let manifest_path = tempdir.path().join("pyproject.toml");
+	let lock_path = tempdir.path().join("uv.lock");
+	let unsupported_path = tempdir.path().join("unknown.txt");
+
+	fs::write(&manifest_path, [0xff, 0xfe])
+		.unwrap_or_else(|error| panic!("write manifest: {error}"));
+	let error = crate::read_cached_document(
+		&mut BTreeMap::new(),
+		&manifest_path,
+		monochange_core::EcosystemType::Python,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected invalid UTF-8 manifest error"));
+	assert!(error.to_string().contains("is not valid UTF-8"));
+
+	fs::write(&lock_path, [0xff, 0xfe]).unwrap_or_else(|error| panic!("write lock: {error}"));
+	let error = crate::read_cached_document(
+		&mut BTreeMap::new(),
+		&lock_path,
+		monochange_core::EcosystemType::Python,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected invalid UTF-8 lock error"));
+	assert!(error.to_string().contains("is not valid UTF-8"));
+
+	fs::write(&manifest_path, "[project\n")
+		.unwrap_or_else(|error| panic!("write invalid manifest: {error}"));
+	let error = crate::read_cached_document(
+		&mut BTreeMap::new(),
+		&manifest_path,
+		monochange_core::EcosystemType::Python,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected invalid TOML manifest error"));
+	assert!(error.to_string().contains("failed to parse"));
+
+	fs::write(&unsupported_path, "text")
+		.unwrap_or_else(|error| panic!("write unsupported: {error}"));
+	let error = crate::read_cached_document(
+		&mut BTreeMap::new(),
+		&unsupported_path,
+		monochange_core::EcosystemType::Python,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected unsupported Python versioned file error"));
+	assert!(error.to_string().contains("python"));
+}
+
+#[test]
 fn resolve_versioned_prefix_prefers_explicit_then_ecosystem_then_default() {
 	let mut configuration = load_workspace_configuration(&fixture_path("monochange/release-base"))
 		.unwrap_or_else(|error| panic!("configuration: {error}"));
@@ -8338,6 +8389,65 @@ dependencies = ["python-core>=1.0.0"]
 		lock_document,
 		crate::CachedDocument::Text(contents) if contents == "version = 1\n"
 	));
+}
+
+#[test]
+fn apply_versioned_file_definition_reports_python_error_paths() {
+	let configuration = versioned_test_configuration();
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let context = versioned_test_context(
+		&configuration,
+		BTreeMap::from([("python-core".to_string(), "2.0.0".to_string())]),
+		&[],
+	);
+	let dep_names = vec!["python-core".to_string()];
+	let mut updates = BTreeMap::new();
+
+	fs::write(tempdir.path().join("unknown.txt"), "text")
+		.unwrap_or_else(|error| panic!("write unsupported: {error}"));
+	let unsupported_definition = monochange_core::VersionedFileDefinition {
+		path: "unknown.txt".to_string(),
+		ecosystem_type: Some(monochange_core::EcosystemType::Python),
+		prefix: None,
+		fields: None,
+		name: None,
+		regex: None,
+	};
+	let error = crate::apply_versioned_file_definition(
+		tempdir.path(),
+		&mut updates,
+		&unsupported_definition,
+		"2.0.0",
+		None,
+		&dep_names,
+		&context,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected unsupported python path error"));
+	assert!(error.to_string().contains("python"));
+
+	fs::write(tempdir.path().join("pyproject.toml"), "[project\n")
+		.unwrap_or_else(|error| panic!("write invalid manifest: {error}"));
+	let manifest_definition = monochange_core::VersionedFileDefinition {
+		path: "pyproject.toml".to_string(),
+		ecosystem_type: Some(monochange_core::EcosystemType::Python),
+		prefix: None,
+		fields: None,
+		name: None,
+		regex: None,
+	};
+	let error = crate::apply_versioned_file_definition(
+		tempdir.path(),
+		&mut updates,
+		&manifest_definition,
+		"2.0.0",
+		None,
+		&dep_names,
+		&context,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected invalid python manifest error"));
+	assert!(error.to_string().contains("failed to parse"));
 }
 
 #[test]

--- a/crates/monochange/src/changelog.rs
+++ b/crates/monochange/src/changelog.rs
@@ -1227,6 +1227,7 @@ mod tests {
 			npm: monochange_core::EcosystemSettings::default(),
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
+			python: monochange_core::EcosystemSettings::default(),
 		}
 	}
 

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -3283,6 +3283,7 @@ mod tests {
 			npm: monochange_core::EcosystemSettings::default(),
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
+			python: monochange_core::EcosystemSettings::default(),
 		}
 	}
 
@@ -4551,6 +4552,7 @@ path = "crates/core"
 			npm: monochange_core::EcosystemSettings::default(),
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
+			python: monochange_core::EcosystemSettings::default(),
 		};
 		let error = execute_cli_command(
 			tempdir.path(),

--- a/crates/monochange/src/interactive.rs
+++ b/crates/monochange/src/interactive.rs
@@ -434,6 +434,7 @@ mod __tests {
 			npm: EcosystemSettings::default(),
 			deno: EcosystemSettings::default(),
 			dart: EcosystemSettings::default(),
+			python: EcosystemSettings::default(),
 		}
 	}
 
@@ -705,6 +706,7 @@ mod __tests {
 			npm: EcosystemSettings::default(),
 			deno: EcosystemSettings::default(),
 			dart: EcosystemSettings::default(),
+			python: EcosystemSettings::default(),
 		};
 		let displays = build_selectable_targets(&configuration)
 			.into_iter()
@@ -928,6 +930,7 @@ mod __tests {
 			npm: EcosystemSettings::default(),
 			deno: EcosystemSettings::default(),
 			dart: EcosystemSettings::default(),
+			python: EcosystemSettings::default(),
 		};
 		let target = build_selectable_targets(&configuration)
 			.into_iter()

--- a/crates/monochange/src/interactive.rs
+++ b/crates/monochange/src/interactive.rs
@@ -784,6 +784,7 @@ mod __tests {
 			npm: EcosystemSettings::default(),
 			deno: EcosystemSettings::default(),
 			dart: EcosystemSettings::default(),
+			python: EcosystemSettings::default(),
 		};
 		let targets = build_selectable_targets(&configuration);
 		assert_eq!(targets.len(), 1);
@@ -845,6 +846,7 @@ mod __tests {
 			npm: EcosystemSettings::default(),
 			deno: EcosystemSettings::default(),
 			dart: EcosystemSettings::default(),
+			python: EcosystemSettings::default(),
 		};
 		let targets = build_selectable_targets(&configuration);
 		let ids: Vec<&str> = targets.iter().map(|t| t.id.as_str()).collect();

--- a/crates/monochange/src/monochange.init.toml
+++ b/crates/monochange/src/monochange.init.toml
@@ -9,7 +9,7 @@
     packages         -- list of { id, path, type, changelog? }
     has_group        -- true when more than one package was discovered
     package_ids_toml -- pre-formatted TOML array contents
-    has_cargo / has_npm / has_deno / has_dart -- ecosystem detected flags
+    has_cargo / has_npm / has_deno / has_dart / has_python -- ecosystem detected flags
 #}
 # =============================================================================
 # monochange.toml — repository configuration for monochange
@@ -51,7 +51,7 @@ warn_on_group_mismatch = true
 # Default package type for all packages that don't declare their own `type`.
 # Setting this avoids repeating `type = "cargo"` on every [package.*] entry.
 #
-# Options: "cargo", "npm", "deno", "dart", "flutter"
+# Options: "cargo", "npm", "deno", "dart", "flutter", "python"
 # Default: none (each package must declare its own type)
 # package_type = "cargo"
 
@@ -246,7 +246,7 @@ warn_on_group_mismatch = true
 #   path  — relative path from repo root to the package directory
 #
 # Optional fields:
-#   type                    — "cargo", "npm", "deno", "dart", "flutter"
+#   type                    — "cargo", "npm", "deno", "dart", "flutter", "python"
 #                             (not needed when defaults.package_type is set)
 #   changelog               — true, false, "path/to/changelog.md", or a table
 #                             with { path, format }; overrides [defaults.changelog]
@@ -565,6 +565,14 @@ enabled = true
 # enabled = true
 # workflow = "publish.yml"
 # registry = "pub_dev"
+
+{% if has_python %}
+[ecosystems.python]
+enabled = true
+{% else %}
+# [ecosystems.python]
+# enabled = true
+{% endif %}
 
 # =============================================================================
 # [source] — source-control provider configuration

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -2054,6 +2054,7 @@ mod tests {
 			npm: monochange_core::EcosystemSettings::default(),
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
+			python: monochange_core::EcosystemSettings::default(),
 		}
 	}
 

--- a/crates/monochange/src/publish_rate_limits.rs
+++ b/crates/monochange/src/publish_rate_limits.rs
@@ -625,6 +625,7 @@ mod tests {
 			npm: monochange_core::EcosystemSettings::default(),
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
+			python: monochange_core::EcosystemSettings::default(),
 		};
 		let packages = vec![
 			monochange_core::PackageRecord {
@@ -1037,6 +1038,7 @@ mod tests {
 			npm: monochange_core::EcosystemSettings::default(),
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
+			python: monochange_core::EcosystemSettings::default(),
 		};
 		let unenforced = PublishRateLimitReport {
 			dry_run: true,
@@ -1148,6 +1150,7 @@ mod tests {
 			npm: monochange_core::EcosystemSettings::default(),
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
+			python: monochange_core::EcosystemSettings::default(),
 		};
 		let error =
 			enforce_publish_rate_limits(&configuration, &report, PublishRateLimitMode::Publish)

--- a/crates/monochange/src/publish_readiness.rs
+++ b/crates/monochange/src/publish_readiness.rs
@@ -558,6 +558,7 @@ mod tests {
 			npm: monochange_core::EcosystemSettings::default(),
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
+			python: monochange_core::EcosystemSettings::default(),
 		}
 	}
 

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -1500,6 +1500,7 @@ mod tests {
 			npm: monochange_core::EcosystemSettings::default(),
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
+			python: monochange_core::EcosystemSettings::default(),
 		}
 	}
 

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -645,11 +645,13 @@ pub(crate) fn resolve_versioned_prefix(
 		monochange_core::EcosystemType::Dart => {
 			context.configuration.dart.dependency_version_prefix.clone()
 		}
-		monochange_core::EcosystemType::Python => context
-			.configuration
-			.python
-			.dependency_version_prefix
-			.clone(),
+		monochange_core::EcosystemType::Python => {
+			context
+				.configuration
+				.python
+				.dependency_version_prefix
+				.clone()
+		}
 		_ => None,
 	};
 	ecosystem_prefix.unwrap_or_else(|| ecosystem_type.default_prefix().to_string())

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -645,9 +645,11 @@ pub(crate) fn resolve_versioned_prefix(
 		monochange_core::EcosystemType::Dart => {
 			context.configuration.dart.dependency_version_prefix.clone()
 		}
-		monochange_core::EcosystemType::Python => {
-			context.configuration.python.dependency_version_prefix.clone()
-		}
+		monochange_core::EcosystemType::Python => context
+			.configuration
+			.python
+			.dependency_version_prefix
+			.clone(),
 		_ => None,
 	};
 	ecosystem_prefix.unwrap_or_else(|| ecosystem_type.default_prefix().to_string())

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -48,6 +48,8 @@ pub(crate) enum VersionedFileKind {
 	Deno(monochange_deno::DenoVersionedFileKind),
 	#[cfg(feature = "dart")]
 	Dart(monochange_dart::DartVersionedFileKind),
+	#[cfg(feature = "python")]
+	Python(monochange_python::PythonVersionedFileKind),
 }
 
 pub(crate) fn versioned_file_kind(
@@ -70,6 +72,10 @@ pub(crate) fn versioned_file_kind(
 		#[cfg(feature = "dart")]
 		monochange_core::EcosystemType::Dart => {
 			monochange_dart::supported_versioned_file_kind(path).map(VersionedFileKind::Dart)
+		}
+		#[cfg(feature = "python")]
+		monochange_core::EcosystemType::Python => {
+			monochange_python::supported_versioned_file_kind(path).map(VersionedFileKind::Python)
 		}
 		_ => None,
 	}
@@ -322,6 +328,10 @@ fn inferred_lockfile_ecosystem_type(
 		Ecosystem::Dart | Ecosystem::Flutter if configuration.dart.lockfile_commands.is_empty() => {
 			Some(monochange_core::EcosystemType::Dart)
 		}
+		#[cfg(feature = "python")]
+		Ecosystem::Python if configuration.python.lockfile_commands.is_empty() => {
+			Some(monochange_core::EcosystemType::Python)
+		}
 		_ => None,
 	}
 }
@@ -422,6 +432,7 @@ pub(crate) fn read_cached_document(
 				monochange_core::EcosystemType::Npm => "npm",
 				monochange_core::EcosystemType::Deno => "deno",
 				monochange_core::EcosystemType::Dart => "dart",
+				monochange_core::EcosystemType::Python => "python",
 				_ => "unknown",
 			},
 		)));
@@ -534,6 +545,35 @@ pub(crate) fn read_cached_document(
 				})?;
 			Ok(CachedDocument::Text(contents))
 		}
+		#[cfg(feature = "python")]
+		VersionedFileKind::Python(monochange_python::PythonVersionedFileKind::Manifest) => {
+			let Some(contents) = text_contents else {
+				return Err(MonochangeError::Config(format!(
+					"{} is not valid UTF-8",
+					path.display()
+				)));
+			};
+			let contents = monochange_python::update_versioned_file_text(
+				&contents,
+				monochange_python::PythonVersionedFileKind::Manifest,
+				None,
+				&BTreeMap::new(),
+			)
+			.map_err(|error| {
+				MonochangeError::Config(format!("failed to parse {}: {error}", path.display()))
+			})?;
+			Ok(CachedDocument::Text(contents))
+		}
+		#[cfg(feature = "python")]
+		VersionedFileKind::Python(monochange_python::PythonVersionedFileKind::Lock) => {
+			let Some(contents) = text_contents else {
+				return Err(MonochangeError::Config(format!(
+					"{} is not valid UTF-8",
+					path.display()
+				)));
+			};
+			Ok(CachedDocument::Text(contents))
+		}
 		#[cfg(feature = "dart")]
 		VersionedFileKind::Dart(monochange_dart::DartVersionedFileKind::Manifest) => {
 			let Some(contents) = text_contents else {
@@ -604,6 +644,9 @@ pub(crate) fn resolve_versioned_prefix(
 		}
 		monochange_core::EcosystemType::Dart => {
 			context.configuration.dart.dependency_version_prefix.clone()
+		}
+		monochange_core::EcosystemType::Python => {
+			context.configuration.python.dependency_version_prefix.clone()
 		}
 		_ => None,
 	};
@@ -765,6 +808,7 @@ pub(crate) fn apply_versioned_file_definition(
 					monochange_core::EcosystemType::Npm => "npm",
 					monochange_core::EcosystemType::Deno => "deno",
 					monochange_core::EcosystemType::Dart => "dart",
+					monochange_core::EcosystemType::Python => "python",
 					_ => "unknown",
 				},
 			)));
@@ -922,6 +966,21 @@ pub(crate) fn apply_versioned_file_definition(
 				VersionedFileKind::Dart(monochange_dart::DartVersionedFileKind::Lock),
 			) => {
 				monochange_dart::update_pubspec_lock(mapping, &raw_versions);
+			}
+			#[cfg(feature = "python")]
+			(CachedDocument::Text(contents), VersionedFileKind::Python(kind)) => {
+				*contents = monochange_python::update_versioned_file_text(
+					contents,
+					kind,
+					Some(owner_version),
+					&versioned_deps,
+				)
+				.map_err(|error| {
+					MonochangeError::Config(format!(
+						"failed to parse {}: {error}",
+						resolved_path.display()
+					))
+				})?;
 			}
 			_ => {}
 		}

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -1005,3 +1005,32 @@ pub(crate) fn released_versions_by_record_id(plan: &ReleasePlan) -> BTreeMap<Str
 		})
 		.collect()
 }
+
+#[cfg(test)]
+mod tests {
+	use std::path::PathBuf;
+
+	use monochange_core::Ecosystem;
+	use monochange_core::EcosystemType;
+
+	use super::inferred_lockfile_ecosystem_type;
+
+	fn fixture_path(relative: &str) -> PathBuf {
+		PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+			.join("../../fixtures/tests")
+			.join(relative)
+	}
+
+	#[test]
+	fn inferred_lockfile_ecosystem_type_maps_python_when_commands_are_not_configured() {
+		let configuration = monochange_config::load_workspace_configuration(&fixture_path(
+			"monochange/release-base",
+		))
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+
+		assert_eq!(
+			inferred_lockfile_ecosystem_type(&configuration, Ecosystem::Python),
+			Some(EcosystemType::Python)
+		);
+	}
+}

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -42,6 +42,8 @@ use monochange_deno::load_configured_deno_package;
 use monochange_npm::discover_npm_packages;
 #[cfg(feature = "npm")]
 use monochange_npm::load_configured_npm_package;
+#[cfg(feature = "python")]
+use monochange_python::discover_python_packages;
 use serde_json::json;
 use typed_builder::TypedBuilder;
 
@@ -517,6 +519,7 @@ fn render_annotated_init_config(
 			PackageType::Deno => "deno",
 			PackageType::Dart => "dart",
 			PackageType::Flutter => "flutter",
+			PackageType::Python => "python",
 			_ => unreachable!(),
 		};
 
@@ -538,6 +541,7 @@ fn render_annotated_init_config(
 	let has_dart = packages
 		.iter()
 		.any(|p| p.ecosystem == Ecosystem::Dart || p.ecosystem == Ecosystem::Flutter);
+	let has_python = packages.iter().any(|p| p.ecosystem == Ecosystem::Python);
 
 	let package_ids_toml = package_ids
 		.iter()
@@ -553,6 +557,7 @@ fn render_annotated_init_config(
 		"has_npm": has_npm,
 		"has_deno": has_deno,
 		"has_dart": has_dart,
+		"has_python": has_python,
 		"provider": provider.unwrap_or(""),
 		"owner": remote.map_or("your-org", |r| r.owner.as_str()),
 		"repo": remote.map_or("your-repo", |r| r.repo.as_str()),
@@ -592,6 +597,8 @@ fn discover_packages(root: &Path) -> MonochangeResult<Vec<PackageRecord>> {
 	packages.extend(discover_deno_packages(root)?.packages);
 	#[cfg(feature = "dart")]
 	packages.extend(discover_dart_packages(root)?.packages);
+	#[cfg(feature = "python")]
+	packages.extend(discover_python_packages(root)?.packages);
 
 	normalize_package_ids(root, &mut packages);
 	packages.sort_by(|left, right| left.id.cmp(&right.id));
@@ -636,6 +643,7 @@ fn package_type_for_ecosystem(ecosystem: Ecosystem) -> PackageType {
 		Ecosystem::Deno => PackageType::Deno,
 		Ecosystem::Dart => PackageType::Dart,
 		Ecosystem::Flutter => PackageType::Flutter,
+		Ecosystem::Python => PackageType::Python,
 		_ => PackageType::Cargo,
 	}
 }
@@ -661,6 +669,9 @@ pub(crate) fn build_lockfile_command_executions(
 	#[cfg(feature = "dart")]
 	#[rustfmt::skip]
 	let dart_executions = resolve_lockfile_command_executions(root, &configuration.dart.lockfile_commands, packages.iter().any(|package| matches!(package.ecosystem, Ecosystem::Dart | Ecosystem::Flutter) && released_versions.contains_key(&package.id)))?;
+	#[cfg(feature = "python")]
+	#[rustfmt::skip]
+	let python_executions = resolve_lockfile_command_executions(root, &configuration.python.lockfile_commands, packages.iter().any(|package| package.ecosystem == Ecosystem::Python && released_versions.contains_key(&package.id)))?;
 	let mut executions = Vec::new();
 	#[cfg(feature = "cargo")]
 	executions.extend(cargo_executions);
@@ -670,6 +681,8 @@ pub(crate) fn build_lockfile_command_executions(
 	executions.extend(deno_executions);
 	#[cfg(feature = "dart")]
 	executions.extend(dart_executions);
+	#[cfg(feature = "python")]
+	executions.extend(python_executions);
 	Ok(dedup_lockfile_command_executions(executions))
 }
 
@@ -794,9 +807,9 @@ pub fn discover_workspace(root: &Path) -> MonochangeResult<DiscoveryReport> {
 	let mut warnings = Vec::new();
 	let mut packages = Vec::new();
 
-	#[cfg(all(feature = "cargo", feature = "npm", feature = "deno", feature = "dart"))]
+	#[cfg(all(feature = "cargo", feature = "npm", feature = "deno", feature = "dart", feature = "python"))]
 	{
-		let ((cargo_discovery, npm_discovery), (deno_discovery, dart_discovery)) = rayon::join(
+		let ((cargo_discovery, npm_discovery), (deno_discovery, (dart_discovery, python_discovery))) = rayon::join(
 			|| {
 				rayon::join(
 					|| discover_cargo_packages(root),
@@ -806,7 +819,10 @@ pub fn discover_workspace(root: &Path) -> MonochangeResult<DiscoveryReport> {
 			|| {
 				rayon::join(
 					|| discover_deno_packages(root),
-					|| discover_dart_packages(root),
+					|| rayon::join(
+						|| discover_dart_packages(root),
+						|| discover_python_packages(root),
+					),
 				)
 			},
 		);
@@ -815,13 +831,14 @@ pub fn discover_workspace(root: &Path) -> MonochangeResult<DiscoveryReport> {
 			npm_discovery?,
 			deno_discovery?,
 			dart_discovery?,
+			python_discovery?,
 		] {
 			warnings.extend(discovery.warnings);
 			packages.extend(discovery.packages);
 		}
 	}
 
-	#[cfg(not(all(feature = "cargo", feature = "npm", feature = "deno", feature = "dart")))]
+	#[cfg(not(all(feature = "cargo", feature = "npm", feature = "deno", feature = "dart", feature = "python")))]
 	{
 		#[cfg(feature = "cargo")]
 		{
@@ -844,6 +861,12 @@ pub fn discover_workspace(root: &Path) -> MonochangeResult<DiscoveryReport> {
 		#[cfg(feature = "dart")]
 		{
 			let d = discover_dart_packages(root)?;
+			warnings.extend(d.warnings);
+			packages.extend(d.packages);
+		}
+		#[cfg(feature = "python")]
+		{
+			let d = discover_python_packages(root)?;
 			warnings.extend(d.warnings);
 			packages.extend(d.packages);
 		}

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -657,6 +657,21 @@ fn package_type_for_ecosystem_maps_python() {
 	assert_eq!(PackageType::Python.as_str(), "python");
 }
 
+#[test]
+fn render_annotated_init_config_includes_python_package_type() {
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	fs::write(
+		root.join("pyproject.toml"),
+		"[project]\nname = \"python-app\"\nversion = \"1.0.0\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write pyproject: {error}"));
+
+	let rendered = render_annotated_init_config(root, None, None)
+		.unwrap_or_else(|error| panic!("render init config: {error}"));
+	assert!(rendered.contains("type = \"python\""), "{rendered}");
+}
+
 pub(crate) fn build_lockfile_command_executions(
 	root: &Path,
 	configuration: &monochange_core::WorkspaceConfiguration,

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -807,9 +807,18 @@ pub fn discover_workspace(root: &Path) -> MonochangeResult<DiscoveryReport> {
 	let mut warnings = Vec::new();
 	let mut packages = Vec::new();
 
-	#[cfg(all(feature = "cargo", feature = "npm", feature = "deno", feature = "dart", feature = "python"))]
+	#[cfg(all(
+		feature = "cargo",
+		feature = "npm",
+		feature = "deno",
+		feature = "dart",
+		feature = "python"
+	))]
 	{
-		let ((cargo_discovery, npm_discovery), (deno_discovery, (dart_discovery, python_discovery))) = rayon::join(
+		let (
+			(cargo_discovery, npm_discovery),
+			(deno_discovery, (dart_discovery, python_discovery)),
+		) = rayon::join(
 			|| {
 				rayon::join(
 					|| discover_cargo_packages(root),
@@ -819,10 +828,12 @@ pub fn discover_workspace(root: &Path) -> MonochangeResult<DiscoveryReport> {
 			|| {
 				rayon::join(
 					|| discover_deno_packages(root),
-					|| rayon::join(
-						|| discover_dart_packages(root),
-						|| discover_python_packages(root),
-					),
+					|| {
+						rayon::join(
+							|| discover_dart_packages(root),
+							|| discover_python_packages(root),
+						)
+					},
 				)
 			},
 		);
@@ -838,7 +849,13 @@ pub fn discover_workspace(root: &Path) -> MonochangeResult<DiscoveryReport> {
 		}
 	}
 
-	#[cfg(not(all(feature = "cargo", feature = "npm", feature = "deno", feature = "dart", feature = "python")))]
+	#[cfg(not(all(
+		feature = "cargo",
+		feature = "npm",
+		feature = "deno",
+		feature = "dart",
+		feature = "python"
+	)))]
 	{
 		#[cfg(feature = "cargo")]
 		{

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -648,6 +648,15 @@ fn package_type_for_ecosystem(ecosystem: Ecosystem) -> PackageType {
 	}
 }
 
+#[test]
+fn package_type_for_ecosystem_maps_python() {
+	assert_eq!(
+		package_type_for_ecosystem(Ecosystem::Python),
+		PackageType::Python
+	);
+	assert_eq!(PackageType::Python.as_str(), "python");
+}
+
 pub(crate) fn build_lockfile_command_executions(
 	root: &Path,
 	configuration: &monochange_core::WorkspaceConfiguration,

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -2057,6 +2057,7 @@ mod workspace_ops_tests {
 			npm: monochange_core::EcosystemSettings::default(),
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
+			python: monochange_core::EcosystemSettings::default(),
 		}
 	}
 
@@ -2282,6 +2283,7 @@ mod workspace_ops_tests {
 			npm: monochange_core::EcosystemSettings::default(),
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
+			python: monochange_core::EcosystemSettings::default(),
 		};
 		let undetected_error = discover_release_workspace(undetected_root.path(), &undetected)
 			.err()
@@ -2331,6 +2333,7 @@ mod workspace_ops_tests {
 			npm: monochange_core::EcosystemSettings::default(),
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
+			python: monochange_core::EcosystemSettings::default(),
 		};
 		let missing_manifest_error =
 			discover_release_workspace(missing_manifest_root.path(), &missing_manifest)

--- a/crates/monochange_config/Cargo.toml
+++ b/crates/monochange_config/Cargo.toml
@@ -24,6 +24,7 @@ monochange_gitea = { workspace = true }
 monochange_github = { workspace = true }
 monochange_gitlab = { workspace = true }
 monochange_npm = { workspace = true }
+monochange_python = { workspace = true }
 regex = { workspace = true, default-features = true }
 semver = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -1037,6 +1037,27 @@ type = "python"
 }
 
 #[test]
+fn load_workspace_configuration_reports_python_ecosystem_normalization_errors() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	std::fs::write(
+		root.join("monochange.toml"),
+		r#"[ecosystems.python.publish]
+registry = "https://example.com/simple"
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write config: {error}"));
+
+	let error = load_workspace_configuration(root)
+		.expect_err("unsupported Python registry override should be rejected");
+	let message = error.to_string();
+	assert!(
+		message.contains("ecosystems `python` uses built-in publishing"),
+		"unexpected error: {message}"
+	);
+}
+
+#[test]
 fn load_workspace_configuration_rejects_python_versioned_file_glob_unsupported_files() {
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	let root = tempdir.path();

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -984,6 +984,93 @@ fn load_workspace_configuration_inherits_ecosystem_versioned_files_for_cargo_den
 }
 
 #[test]
+fn load_workspace_configuration_inherits_python_ecosystem_defaults() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	std::fs::create_dir_all(root.join("packages/app"))
+		.unwrap_or_else(|error| panic!("create package dir: {error}"));
+	std::fs::write(
+		root.join("packages/app/pyproject.toml"),
+		"[project]\nname = \"python-app\"\nversion = \"1.0.0\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write pyproject: {error}"));
+	std::fs::write(
+		root.join("monochange.toml"),
+		r#"[ecosystems.python]
+dependency_version_prefix = "~="
+versioned_files = ["pyproject.toml"]
+
+[package.app]
+path = "packages/app"
+type = "python"
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write config: {error}"));
+
+	let configuration =
+		load_workspace_configuration(root).unwrap_or_else(|error| panic!("configuration: {error}"));
+	assert_eq!(
+		configuration.python.dependency_version_prefix.as_deref(),
+		Some("~=")
+	);
+	let package = configuration
+		.packages
+		.iter()
+		.find(|package| package.id == "app")
+		.unwrap_or_else(|| panic!("expected app package"));
+	assert_eq!(package.package_type, monochange_core::PackageType::Python);
+	assert_eq!(
+		package
+			.versioned_files
+			.first()
+			.map(|definition| definition.ecosystem_type),
+		Some(Some(EcosystemType::Python))
+	);
+	assert_eq!(
+		package
+			.versioned_files
+			.first()
+			.map(|definition| definition.path.as_str()),
+		Some("pyproject.toml")
+	);
+	assert!(package.publish.registry.is_none());
+}
+
+#[test]
+fn load_workspace_configuration_rejects_python_versioned_file_glob_unsupported_files() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	std::fs::create_dir_all(root.join("packages/app"))
+		.unwrap_or_else(|error| panic!("create package dir: {error}"));
+	std::fs::write(
+		root.join("packages/app/pyproject.toml"),
+		"[project]\nname = \"python-app\"\nversion = \"1.0.0\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write pyproject: {error}"));
+	std::fs::write(root.join("packages/app/unsupported.json"), "{}")
+		.unwrap_or_else(|error| panic!("write unsupported: {error}"));
+	std::fs::write(
+		root.join("monochange.toml"),
+		r#"[package.app]
+path = "packages/app"
+type = "python"
+versioned_files = ["packages/app/*.json"]
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write config: {error}"));
+
+	let error = match load_workspace_configuration(root) {
+		Ok(configuration) => panic!("expected error: {configuration:?}"),
+		Err(error) => error,
+	};
+	let message = error.to_string();
+	assert!(
+		message.contains("ecosystem `python`"),
+		"unexpected error: {message}"
+	);
+}
+
+#[test]
 fn load_workspace_configuration_parses_ecosystem_lockfile_commands() {
 	let root = fixture_path("config/lockfile-commands");
 	let configuration = load_workspace_configuration(&root)

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -4506,6 +4506,33 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 			.contains("for ecosystem `cargo`")
 	);
 
+	assert!(crate::path_is_supported_for_ecosystem(
+		Path::new("pubspec.yaml"),
+		EcosystemType::Dart
+	));
+	let dart_unsupported_match = crate::validate_versioned_files(
+		tempdir.path(),
+		config_contents,
+		&[monochange_core::VersionedFileDefinition {
+			path: "packages/*/package.json".to_string(),
+			ecosystem_type: Some(EcosystemType::Dart),
+			name: None,
+			fields: None,
+			prefix: None,
+			regex: None,
+		}],
+		&declared_packages,
+		"package",
+		"core",
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected unsupported dart match error"));
+	assert!(
+		dart_unsupported_match
+			.to_string()
+			.contains("for ecosystem `dart`")
+	);
+
 	let empty_template = crate::validate_changelog_configuration(
 		"",
 		&crate::RawChangelogSettings {

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -2891,6 +2891,7 @@ fn expected_manifest_name(package_type: PackageType) -> &'static str {
 		PackageType::Npm => "package.json",
 		PackageType::Deno => "deno.json",
 		PackageType::Dart | PackageType::Flutter => "pubspec.yaml",
+		PackageType::Python => "pyproject.toml",
 		_ => "Cargo.toml",
 	}
 }

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -1173,11 +1173,12 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		normalize_ecosystem_settings(&contents, "deno", EcosystemType::Deno, ecosystems.deno)?;
 	let dart_ecosystem =
 		normalize_ecosystem_settings(&contents, "dart", EcosystemType::Dart, ecosystems.dart)?;
+	let python_ecosystem_input = ecosystems.python;
 	let python_ecosystem = normalize_ecosystem_settings(
 		&contents,
 		"python",
 		EcosystemType::Python,
-		ecosystems.python,
+		python_ecosystem_input,
 	)?;
 	let defaults_changelog_policy = defaults
 		.changelog

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -1029,8 +1029,7 @@ fn build_package_definitions(
 						EcosystemType::Npm => &npm_ecosystem.publish,
 						EcosystemType::Deno => &deno_ecosystem.publish,
 						EcosystemType::Dart => &dart_ecosystem.publish,
-						EcosystemType::Python => &python_ecosystem.publish,
-						_ => unreachable!("unsupported ecosystem type for package publish"),
+						_ => &python_ecosystem.publish,
 					};
 					publish
 				}),

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -814,7 +814,6 @@ fn default_publish_registry_for_ecosystem(
 		EcosystemType::Npm => Some(PublishRegistry::Builtin(RegistryKind::Npm)),
 		EcosystemType::Deno => Some(PublishRegistry::Builtin(RegistryKind::Jsr)),
 		EcosystemType::Dart => Some(PublishRegistry::Builtin(RegistryKind::PubDev)),
-		EcosystemType::Python => None,
 		_ => None,
 	};
 	registry

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -1175,8 +1175,12 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		normalize_ecosystem_settings(&contents, "deno", EcosystemType::Deno, ecosystems.deno)?;
 	let dart_ecosystem =
 		normalize_ecosystem_settings(&contents, "dart", EcosystemType::Dart, ecosystems.dart)?;
-	let python_ecosystem =
-		normalize_ecosystem_settings(&contents, "python", EcosystemType::Python, ecosystems.python)?;
+	let python_ecosystem = normalize_ecosystem_settings(
+		&contents,
+		"python",
+		EcosystemType::Python,
+		ecosystems.python,
+	)?;
 	let defaults_changelog_policy = defaults
 		.changelog
 		.as_ref()

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -345,6 +345,8 @@ struct RawEcosystems {
 	deno: RawEcosystemSettings,
 	#[serde(default)]
 	dart: RawEcosystemSettings,
+	#[serde(default)]
+	python: RawEcosystemSettings,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -734,6 +736,7 @@ fn package_type_to_ecosystem_type(package_type: PackageType) -> EcosystemType {
 		PackageType::Npm => EcosystemType::Npm,
 		PackageType::Deno => EcosystemType::Deno,
 		PackageType::Dart | PackageType::Flutter => EcosystemType::Dart,
+		PackageType::Python => EcosystemType::Python,
 		_ => EcosystemType::Cargo,
 	}
 }
@@ -810,7 +813,9 @@ fn default_publish_registry_for_ecosystem(
 		EcosystemType::Cargo => Some(PublishRegistry::Builtin(RegistryKind::CratesIo)),
 		EcosystemType::Npm => Some(PublishRegistry::Builtin(RegistryKind::Npm)),
 		EcosystemType::Deno => Some(PublishRegistry::Builtin(RegistryKind::Jsr)),
-		EcosystemType::Dart => Some(PublishRegistry::Builtin(RegistryKind::PubDev)), _ => None,
+		EcosystemType::Dart => Some(PublishRegistry::Builtin(RegistryKind::PubDev)),
+		EcosystemType::Python => None,
+		_ => None,
 	};
 	registry
 }
@@ -953,6 +958,7 @@ fn build_package_definitions(
 	npm_ecosystem: &EcosystemSettings,
 	deno_ecosystem: &EcosystemSettings,
 	dart_ecosystem: &EcosystemSettings,
+	python_ecosystem: &EcosystemSettings,
 ) -> MonochangeResult<Vec<PackageDefinition>> {
 	packages
 		.into_iter()
@@ -1001,6 +1007,7 @@ fn build_package_definitions(
 					EcosystemType::Npm => npm_ecosystem.versioned_files.clone(),
 					EcosystemType::Deno => deno_ecosystem.versioned_files.clone(),
 					EcosystemType::Dart => dart_ecosystem.versioned_files.clone(),
+					EcosystemType::Python => python_ecosystem.versioned_files.clone(),
 					_ => Vec::new(),
 				}
 			};
@@ -1022,7 +1029,9 @@ fn build_package_definitions(
 						EcosystemType::Cargo => &cargo_ecosystem.publish,
 						EcosystemType::Npm => &npm_ecosystem.publish,
 						EcosystemType::Deno => &deno_ecosystem.publish,
-						EcosystemType::Dart => &dart_ecosystem.publish, _ => unreachable!("unsupported ecosystem type for package publish"),
+						EcosystemType::Dart => &dart_ecosystem.publish,
+						EcosystemType::Python => &python_ecosystem.publish,
+						_ => unreachable!("unsupported ecosystem type for package publish"),
 					};
 					publish
 				}),
@@ -1166,6 +1175,8 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		normalize_ecosystem_settings(&contents, "deno", EcosystemType::Deno, ecosystems.deno)?;
 	let dart_ecosystem =
 		normalize_ecosystem_settings(&contents, "dart", EcosystemType::Dart, ecosystems.dart)?;
+	let python_ecosystem =
+		normalize_ecosystem_settings(&contents, "python", EcosystemType::Python, ecosystems.python)?;
 	let defaults_changelog_policy = defaults
 		.changelog
 		.as_ref()
@@ -1185,6 +1196,7 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		&npm_ecosystem,
 		&deno_ecosystem,
 		&dart_ecosystem,
+		&python_ecosystem,
 	)?;
 	let groups = build_group_definitions(&contents, group, default_changelog_format)?;
 	let source = resolve_source_configuration(source);
@@ -1198,6 +1210,7 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		("npm", &npm_ecosystem),
 		("deno", &deno_ecosystem),
 		("dart", &dart_ecosystem),
+		("python", &python_ecosystem),
 	] {
 		let declared_packages = packages
 			.iter()
@@ -1242,6 +1255,7 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		npm: npm_ecosystem,
 		deno: deno_ecosystem,
 		dart: dart_ecosystem,
+		python: python_ecosystem,
 	})
 }
 
@@ -2707,6 +2721,7 @@ fn path_is_supported_for_ecosystem(path: &Path, ecosystem_type: EcosystemType) -
 		EcosystemType::Npm => monochange_npm::supported_versioned_file_kind(path).is_some(),
 		EcosystemType::Deno => monochange_deno::supported_versioned_file_kind(path).is_some(),
 		EcosystemType::Dart => monochange_dart::supported_versioned_file_kind(path).is_some(),
+		EcosystemType::Python => monochange_python::supported_versioned_file_kind(path).is_some(),
 		_ => false,
 	}
 }
@@ -2802,6 +2817,7 @@ fn validate_versioned_files(
 							EcosystemType::Npm => "npm",
 							EcosystemType::Deno => "deno",
 							EcosystemType::Dart => "dart",
+							EcosystemType::Python => "python",
 							_ => "unknown",
 						}
 					),
@@ -4223,6 +4239,7 @@ pub fn validate_versioned_files_content(root: &Path) -> MonochangeResult<Vec<Str
 		("npm", &configuration.npm),
 		("deno", &configuration.deno),
 		("dart", &configuration.dart),
+		("python", &configuration.python),
 	];
 	for &(eco_name, settings) in ecosystem_entries {
 		if !settings.versioned_files.is_empty() {

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -20,6 +20,7 @@ use crate::CliStepDefinition;
 use crate::DependencyKind;
 use crate::Ecosystem;
 use crate::EcosystemSettings;
+use crate::EcosystemType;
 use crate::GroupChangelogInclude;
 use crate::GroupDefinition;
 use crate::HostedIssueCommentPlan;
@@ -228,6 +229,14 @@ fn publish_mode_and_registry_kind_display_canonical_names() {
 	assert_eq!(RegistryKind::Npm.as_str(), "npm");
 	assert_eq!(RegistryKind::Jsr.as_str(), "jsr");
 	assert_eq!(RegistryKind::PubDev.as_str(), "pub_dev");
+}
+
+#[test]
+fn python_package_type_and_ecosystem_defaults_are_canonical() {
+	assert_eq!(PackageType::Python.as_str(), "python");
+	assert_eq!(Ecosystem::Python.as_str(), "python");
+	assert_eq!(EcosystemType::Python.default_prefix(), ">=");
+	assert_eq!(EcosystemType::Python.default_fields(), ["dependencies"]);
 }
 
 #[test]
@@ -554,7 +563,7 @@ fn versioned_file_definition_uses_regex_returns_true_when_set() {
 fn versioned_file_definition_uses_regex_returns_false_when_unset() {
 	let definition = VersionedFileDefinition {
 		path: "Cargo.toml".to_string(),
-		ecosystem_type: Some(crate::EcosystemType::Cargo),
+		ecosystem_type: Some(EcosystemType::Cargo),
 		prefix: None,
 		fields: None,
 		name: None,

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -1739,6 +1739,7 @@ fn sample_workspace_configuration() -> WorkspaceConfiguration {
 		npm: EcosystemSettings::default(),
 		deno: EcosystemSettings::default(),
 		dart: EcosystemSettings::default(),
+		python: EcosystemSettings::default(),
 	}
 }
 

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -229,6 +229,7 @@ pub enum Ecosystem {
 	Deno,
 	Dart,
 	Flutter,
+	Python,
 }
 
 impl Ecosystem {
@@ -241,6 +242,7 @@ impl Ecosystem {
 			Self::Deno => "deno",
 			Self::Dart => "dart",
 			Self::Flutter => "flutter",
+			Self::Python => "python",
 		}
 	}
 }
@@ -489,6 +491,7 @@ pub enum PackageType {
 	Deno,
 	Dart,
 	Flutter,
+	Python,
 }
 
 impl PackageType {
@@ -501,6 +504,7 @@ impl PackageType {
 			Self::Deno => "deno",
 			Self::Dart => "dart",
 			Self::Flutter => "flutter",
+			Self::Python => "python",
 		}
 	}
 }
@@ -522,6 +526,7 @@ pub enum EcosystemType {
 	Npm,
 	Deno,
 	Dart,
+	Python,
 }
 
 impl EcosystemType {
@@ -531,6 +536,7 @@ impl EcosystemType {
 		match self {
 			Self::Cargo => "",
 			Self::Npm | Self::Deno | Self::Dart => "^",
+			Self::Python => ">=",
 		}
 	}
 
@@ -542,6 +548,7 @@ impl EcosystemType {
 			Self::Npm => &["dependencies", "devDependencies", "peerDependencies"],
 			Self::Deno => &["imports"],
 			Self::Dart => &["dependencies", "dev_dependencies"],
+			Self::Python => &["dependencies"],
 		}
 	}
 }
@@ -3652,6 +3659,7 @@ pub struct WorkspaceConfiguration {
 	pub npm: EcosystemSettings,
 	pub deno: EcosystemSettings,
 	pub dart: EcosystemSettings,
+	pub python: EcosystemSettings,
 }
 
 impl WorkspaceConfiguration {

--- a/crates/monochange_lint/src/lib.rs
+++ b/crates/monochange_lint/src/lib.rs
@@ -727,6 +727,7 @@ mod tests {
 			npm: monochange_core::EcosystemSettings::default(),
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
+			python: monochange_core::EcosystemSettings::default(),
 		}
 	}
 

--- a/crates/monochange_python/Cargo.toml
+++ b/crates/monochange_python/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "monochange_python"
+version = { workspace = true }
+categories = { workspace = true }
+documentation = "https://docs.rs/monochange_python"
+edition = { workspace = true }
+include = ["src/**/*.rs", "Cargo.toml", "readme.md"]
+keywords = ["cli", "changelog", "releases", "versioning", "monorepo"]
+license = { workspace = true }
+readme = "readme.md"
+repository = { workspace = true }
+rust-version = { workspace = true }
+description = "Python ecosystem adapter for monochange — discovers uv workspaces, Poetry, and setuptools projects"
+
+[dependencies]
+glob = { workspace = true, default-features = true }
+monochange_core = { workspace = true }
+semver = { workspace = true, default-features = true }
+serde = { workspace = true, default-features = true }
+toml = { workspace = true, default-features = true }
+toml_edit = { workspace = true, default-features = true }
+walkdir = { workspace = true, default-features = true }
+
+[dev-dependencies]
+insta = { workspace = true, default-features = true }
+monochange_test_helpers = { workspace = true }
+rstest = { workspace = true, default-features = true }
+similar-asserts = { workspace = true, default-features = true }
+tempfile = { workspace = true, default-features = true }
+
+[lints]
+workspace = true

--- a/crates/monochange_python/Cargo.toml
+++ b/crates/monochange_python/Cargo.toml
@@ -19,6 +19,7 @@ semver = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }
 toml = { workspace = true, default-features = true }
 toml_edit = { workspace = true, default-features = true }
+tracing = { workspace = true, default-features = true }
 walkdir = { workspace = true, default-features = true }
 
 [dev-dependencies]

--- a/crates/monochange_python/src/__tests.rs
+++ b/crates/monochange_python/src/__tests.rs
@@ -7,6 +7,8 @@ use monochange_core::PackageRecord;
 use monochange_core::PublishState;
 use semver::Version;
 
+use crate::PythonAdapter;
+use crate::PythonVersionedFileKind;
 use crate::discover_python_packages;
 use crate::extract_version_constraint;
 use crate::normalize_python_package_name;
@@ -14,8 +16,6 @@ use crate::parse_dependency_name;
 use crate::parse_pep440_as_semver;
 use crate::update_dependency_specifier;
 use crate::update_versioned_file_text;
-use crate::PythonAdapter;
-use crate::PythonVersionedFileKind;
 
 fn fixture_path(relative: &str) -> PathBuf {
 	monochange_test_helpers::fs::fixture_path_from(env!("CARGO_MANIFEST_DIR"), relative)

--- a/crates/monochange_python/src/__tests.rs
+++ b/crates/monochange_python/src/__tests.rs
@@ -617,12 +617,19 @@ fn discover_python_packages_warns_on_empty_workspace_patterns() {
 // -- parse error paths --
 
 #[test]
-fn discover_python_packages_reports_parse_errors_for_invalid_toml() {
+fn discover_python_packages_warns_on_invalid_toml_in_standalone_scan() {
 	let root = fixture_path("python/invalid-toml");
-	let error = discover_python_packages(&root)
-		.err()
-		.unwrap_or_else(|| panic!("expected parse error"));
-	assert!(error.to_string().contains("failed to parse"));
+	let discovery =
+		discover_python_packages(&root).unwrap_or_else(|error| panic!("unexpected error: {error}"));
+	assert!(discovery.packages.is_empty());
+	assert!(
+		discovery
+			.warnings
+			.iter()
+			.any(|w| w.contains("failed to parse")),
+		"expected warning about parse failure: {:?}",
+		discovery.warnings
+	);
 }
 
 // -- Poetry complex dependency parsing --
@@ -821,20 +828,8 @@ fn expand_workspace_members_handles_glob_matching_pyproject_files() {
 	assert_eq!(discovery.packages.first().unwrap().name, "core");
 }
 
-// -- parse_python_package with invalid TOML --
-
-#[test]
-fn parse_python_package_reports_error_for_invalid_toml() {
-	let root = fixture_path("python/invalid-toml");
-	let error = discover_python_packages(&root)
-		.err()
-		.unwrap_or_else(|| panic!("expected parse error"));
-	let message = error.to_string();
-	assert!(
-		message.contains("failed to parse"),
-		"expected parse error message, got: {message}"
-	);
-}
+// parse_python_package invalid TOML is tested by
+// discover_python_packages_warns_on_invalid_toml_in_standalone_scan above
 
 // -- update_versioned_file with both version and deps --
 

--- a/crates/monochange_python/src/__tests.rs
+++ b/crates/monochange_python/src/__tests.rs
@@ -859,6 +859,7 @@ fn default_lockfile_commands_handles_uv_poetry_and_unknown_lockfiles() {
 		.collect::<Vec<_>>();
 
 	assert_eq!(command_names, vec!["uv lock", "poetry lock --no-update"]);
+	assert_eq!(crate::lockfile_command("requirements.lock"), None);
 	let root_name = root.file_name().unwrap_or_else(|| panic!("temp root name"));
 	assert!(
 		commands
@@ -956,6 +957,32 @@ fn private_package_parser_covers_error_and_dependency_value_branches() {
 		.unwrap_or_else(|| panic!("expected parse package error"));
 	assert!(parse_error.to_string().contains("failed to parse"));
 
+	let project = toml::from_str::<toml::Value>(
+		r#"
+[project]
+dependencies = ["requests>=2", 1]
+
+[project.optional-dependencies]
+dev = ["pytest>=8", 1]
+empty = "not-an-array"
+"#,
+	)
+	.unwrap_or_else(|error| panic!("parse project fixture: {error}"));
+	let project_table = project
+		.get("project")
+		.unwrap_or_else(|| panic!("expected project table"));
+	let pep621_deps = crate::parse_pep621_dependencies(project_table);
+	assert!(
+		pep621_deps
+			.iter()
+			.any(|dep| dep.name == "requests" && !dep.optional)
+	);
+	assert!(
+		pep621_deps
+			.iter()
+			.any(|dep| dep.name == "pytest" && dep.optional)
+	);
+
 	let poetry = toml::from_str::<toml::Value>(
 		r#"
 [dependencies]
@@ -965,6 +992,12 @@ celery = { version = "^5.3" }
 local = { path = "../local" }
 unknown = 1
 
+[group]
+metadata = "not-a-group-table"
+
+[group.empty]
+dependencies = "not-a-dependency-table"
+
 [group.dev.dependencies]
 pytest = "^8.0"
 ruff = { version = "^0.4" }
@@ -973,6 +1006,9 @@ numbered = 1
 "#,
 	)
 	.unwrap_or_else(|error| panic!("parse poetry fixture: {error}"));
+	let empty_poetry = toml::Value::Table(toml::map::Map::new());
+	assert!(crate::parse_poetry_dependencies(&empty_poetry).is_empty());
+
 	let deps = crate::parse_poetry_dependencies(&poetry);
 	assert!(
 		deps.iter()

--- a/crates/monochange_python/src/__tests.rs
+++ b/crates/monochange_python/src/__tests.rs
@@ -1,0 +1,589 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use monochange_core::DependencyKind;
+use monochange_core::Ecosystem;
+use monochange_core::PackageRecord;
+use monochange_core::PublishState;
+use semver::Version;
+
+use crate::PythonAdapter;
+use crate::PythonVersionedFileKind;
+use crate::discover_python_packages;
+use crate::extract_version_constraint;
+use crate::normalize_python_package_name;
+use crate::parse_dependency_name;
+use crate::parse_pep440_as_semver;
+use crate::update_dependency_specifier;
+use crate::update_versioned_file_text;
+
+fn fixture_path(relative: &str) -> PathBuf {
+	monochange_test_helpers::fs::fixture_path_from(env!("CARGO_MANIFEST_DIR"), relative)
+}
+
+// -- adapter --
+
+#[test]
+fn adapter_reports_python_ecosystem() {
+	use monochange_core::EcosystemAdapter;
+	let adapter = crate::adapter();
+	assert_eq!(adapter.ecosystem(), Ecosystem::Python);
+}
+
+// -- supported_versioned_file_kind --
+
+#[test]
+fn supported_versioned_file_kind_recognizes_manifest_and_lockfiles() {
+	use crate::supported_versioned_file_kind;
+	assert_eq!(
+		supported_versioned_file_kind("pyproject.toml".as_ref()),
+		Some(PythonVersionedFileKind::Manifest)
+	);
+	assert_eq!(
+		supported_versioned_file_kind("uv.lock".as_ref()),
+		Some(PythonVersionedFileKind::Lock)
+	);
+	assert_eq!(
+		supported_versioned_file_kind("poetry.lock".as_ref()),
+		Some(PythonVersionedFileKind::Lock)
+	);
+	assert_eq!(
+		supported_versioned_file_kind("unknown.txt".as_ref()),
+		None
+	);
+	assert_eq!(
+		supported_versioned_file_kind("Cargo.toml".as_ref()),
+		None
+	);
+}
+
+// -- normalize_python_package_name --
+
+#[test]
+fn normalize_python_package_name_lowercases_and_replaces_separators() {
+	assert_eq!(normalize_python_package_name("My-Package"), "my-package");
+	assert_eq!(normalize_python_package_name("my_package"), "my-package");
+	assert_eq!(normalize_python_package_name("My.Package"), "my-package");
+	assert_eq!(
+		normalize_python_package_name("UPPER__CASE"),
+		"upper-case"
+	);
+	assert_eq!(normalize_python_package_name("simple"), "simple");
+	assert_eq!(normalize_python_package_name(""), "");
+	assert_eq!(normalize_python_package_name("a-_-b"), "a-b");
+}
+
+// -- parse_dependency_name --
+
+#[test]
+fn parse_dependency_name_extracts_name_from_pep508_specifiers() {
+	assert_eq!(
+		parse_dependency_name("httpx>=0.20.0"),
+		Some("httpx".to_string())
+	);
+	assert_eq!(
+		parse_dependency_name("Django>2.1; os_name != 'nt'"),
+		Some("Django".to_string())
+	);
+	assert_eq!(
+		parse_dependency_name("my-package>=1.0"),
+		Some("my-package".to_string())
+	);
+	assert_eq!(
+		parse_dependency_name("my_package>=1.0"),
+		Some("my_package".to_string())
+	);
+	assert_eq!(
+		parse_dependency_name("pkg.name>=1.0"),
+		Some("pkg.name".to_string())
+	);
+	assert_eq!(parse_dependency_name(""), None);
+	assert_eq!(
+		parse_dependency_name(">=1.0"),
+		None
+	);
+}
+
+// -- parse_pep440_as_semver --
+
+#[test]
+fn parse_pep440_as_semver_handles_standard_and_two_part_versions() {
+	assert_eq!(
+		parse_pep440_as_semver("1.2.3"),
+		Some(Version::new(1, 2, 3))
+	);
+	assert_eq!(
+		parse_pep440_as_semver("0.1.0"),
+		Some(Version::new(0, 1, 0))
+	);
+	assert_eq!(
+		parse_pep440_as_semver("1.2"),
+		Some(Version::new(1, 2, 0))
+	);
+	assert_eq!(parse_pep440_as_semver("1.2.3a1"), None);
+	assert_eq!(parse_pep440_as_semver("not-a-version"), None);
+	assert_eq!(parse_pep440_as_semver("1"), None);
+}
+
+// -- update_dependency_specifier --
+
+#[test]
+fn update_dependency_specifier_replaces_matching_version_constraints() {
+	let deps = BTreeMap::from([("my-core".to_string(), ">=2.0.0".to_string())]);
+
+	assert_eq!(
+		update_dependency_specifier("my-core>=1.0.0", &deps),
+		Some("my-core>=2.0.0".to_string())
+	);
+	assert_eq!(
+		update_dependency_specifier("my_core>=1.0.0", &deps),
+		Some("my_core>=2.0.0".to_string())
+	);
+	assert_eq!(
+		update_dependency_specifier("other-package>=1.0", &deps),
+		None
+	);
+}
+
+#[test]
+fn update_dependency_specifier_preserves_extras() {
+	let deps = BTreeMap::from([("httpx".to_string(), ">=2.0.0".to_string())]);
+
+	assert_eq!(
+		update_dependency_specifier("httpx[cli]>=1.0.0", &deps),
+		Some("httpx[cli]>=2.0.0".to_string())
+	);
+}
+
+// -- discover_python_packages --
+
+#[test]
+fn discover_python_packages_finds_uv_workspace_members() {
+	let root = fixture_path("python/uv-workspace");
+	let discovery = discover_python_packages(&root)
+		.unwrap_or_else(|error| panic!("discover: {error}"));
+
+	assert_eq!(discovery.packages.len(), 2);
+	let names: Vec<&str> = discovery
+		.packages
+		.iter()
+		.map(|p| p.name.as_str())
+		.collect();
+	assert!(names.contains(&"my-core"), "missing my-core: {names:?}");
+	assert!(names.contains(&"my-cli"), "missing my-cli: {names:?}");
+
+	let core = discovery
+		.packages
+		.iter()
+		.find(|p| p.name == "my-core")
+		.unwrap();
+	assert_eq!(core.ecosystem, Ecosystem::Python);
+	assert_eq!(core.current_version, Some(Version::new(1, 0, 0)));
+	assert!(core.declared_dependencies.len() >= 2);
+}
+
+#[test]
+fn discover_python_packages_finds_standalone_package() {
+	let root = fixture_path("python/standalone");
+	let discovery = discover_python_packages(&root)
+		.unwrap_or_else(|error| panic!("discover: {error}"));
+
+	assert_eq!(discovery.packages.len(), 1);
+	let pkg = &discovery.packages.first().unwrap();
+	assert_eq!(pkg.name, "standalone-tool");
+	assert_eq!(pkg.current_version, Some(Version::new(2, 5, 0)));
+	assert_eq!(pkg.ecosystem, Ecosystem::Python);
+}
+
+#[test]
+fn discover_python_packages_finds_poetry_project() {
+	let root = fixture_path("python/poetry-project");
+	let discovery = discover_python_packages(&root)
+		.unwrap_or_else(|error| panic!("discover: {error}"));
+
+	assert_eq!(discovery.packages.len(), 1);
+	let pkg = discovery.packages.first().unwrap();
+	assert_eq!(pkg.name, "poetry-app");
+	assert_eq!(pkg.current_version, Some(Version::new(3, 1, 0)));
+
+	let runtime_deps: Vec<&str> = pkg
+		.declared_dependencies
+		.iter()
+		.filter(|d| d.kind == DependencyKind::Runtime)
+		.map(|d| d.name.as_str())
+		.collect();
+	assert!(runtime_deps.contains(&"django"));
+	assert!(runtime_deps.contains(&"celery"));
+	assert!(
+		!runtime_deps.contains(&"python"),
+		"python itself should be excluded"
+	);
+
+	let dev_deps: Vec<&str> = pkg
+		.declared_dependencies
+		.iter()
+		.filter(|d| d.kind == DependencyKind::Development)
+		.map(|d| d.name.as_str())
+		.collect();
+	assert!(dev_deps.contains(&"pytest"));
+	assert!(dev_deps.contains(&"black"));
+}
+
+#[test]
+fn discover_python_packages_handles_dynamic_version() {
+	let root = fixture_path("python/dynamic-version");
+	let discovery = discover_python_packages(&root)
+		.unwrap_or_else(|error| panic!("discover: {error}"));
+
+	assert_eq!(discovery.packages.len(), 1);
+	let pkg = discovery.packages.first().unwrap();
+	assert_eq!(pkg.name, "dynamic-pkg");
+	assert_eq!(pkg.current_version, None, "dynamic version should be None");
+}
+
+#[test]
+fn discover_python_packages_handles_two_part_version() {
+	let root = fixture_path("python/two-part-version");
+	let discovery = discover_python_packages(&root)
+		.unwrap_or_else(|error| panic!("discover: {error}"));
+
+	assert_eq!(discovery.packages.len(), 1);
+	let pkg = discovery.packages.first().unwrap();
+	assert_eq!(pkg.current_version, Some(Version::new(1, 2, 0)));
+}
+
+#[test]
+fn discover_python_packages_skips_files_without_project_section() {
+	let root = fixture_path("python/no-project-section");
+	let discovery = discover_python_packages(&root)
+		.unwrap_or_else(|error| panic!("discover: {error}"));
+
+	assert!(discovery.packages.is_empty());
+}
+
+#[test]
+fn discover_python_packages_extracts_dependency_edges_from_uv_workspace() {
+	let root = fixture_path("python/uv-workspace");
+	let discovery = discover_python_packages(&root)
+		.unwrap_or_else(|error| panic!("discover: {error}"));
+
+	let cli = discovery
+		.packages
+		.iter()
+		.find(|p| p.name == "my-cli")
+		.unwrap();
+	let dep_names: Vec<&str> = cli
+		.declared_dependencies
+		.iter()
+		.map(|d| d.name.as_str())
+		.collect();
+	assert!(dep_names.contains(&"my-core"));
+	assert!(dep_names.contains(&"click"));
+}
+
+#[test]
+fn discover_python_packages_extracts_optional_dependency_edges() {
+	let root = fixture_path("python/uv-workspace");
+	let discovery = discover_python_packages(&root)
+		.unwrap_or_else(|error| panic!("discover: {error}"));
+
+	let core = discovery
+		.packages
+		.iter()
+		.find(|p| p.name == "my-core")
+		.unwrap();
+	let optional_deps: Vec<&str> = core
+		.declared_dependencies
+		.iter()
+		.filter(|d| d.optional)
+		.map(|d| d.name.as_str())
+		.collect();
+	assert!(optional_deps.contains(&"pytest"));
+	assert!(optional_deps.contains(&"ruff"));
+}
+
+// -- discover_lockfiles --
+
+#[test]
+fn discover_lockfiles_returns_empty_when_no_lockfile_exists() {
+	let root = fixture_path("python/standalone");
+	let package = PackageRecord::new(
+		Ecosystem::Python,
+		"standalone-tool",
+		root.join("pyproject.toml"),
+		root.clone(),
+		Some(Version::new(2, 5, 0)),
+		PublishState::Public,
+	);
+	let lockfiles = crate::discover_lockfiles(&package);
+	assert!(lockfiles.is_empty());
+}
+
+// -- default_lockfile_commands --
+
+#[test]
+fn default_lockfile_commands_return_empty_when_no_lockfile_exists() {
+	let root = fixture_path("python/standalone");
+	let package = PackageRecord::new(
+		Ecosystem::Python,
+		"standalone-tool",
+		root.join("pyproject.toml"),
+		root.clone(),
+		Some(Version::new(2, 5, 0)),
+		PublishState::Public,
+	);
+	let commands = crate::default_lockfile_commands(&package);
+	assert!(commands.is_empty());
+}
+
+// -- update_versioned_file_text --
+
+#[test]
+fn update_versioned_file_text_updates_project_version() {
+	let input = r#"[project]
+name = "my-core"
+version = "1.0.0"
+dependencies = []
+"#;
+	let result = update_versioned_file_text(
+		input,
+		PythonVersionedFileKind::Manifest,
+		Some("2.0.0"),
+		&BTreeMap::new(),
+	)
+	.unwrap_or_else(|error| panic!("update: {error}"));
+
+	assert!(result.contains(r#"version = "2.0.0""#));
+	assert!(!result.contains(r#"version = "1.0.0""#));
+}
+
+#[test]
+fn update_versioned_file_text_updates_dependency_versions() {
+	let input = r#"[project]
+name = "my-cli"
+version = "1.0.0"
+dependencies = [
+    "my-core>=1.0.0",
+    "click>=8.0",
+]
+"#;
+	let deps = BTreeMap::from([("my-core".to_string(), ">=2.0.0".to_string())]);
+	let result = update_versioned_file_text(
+		input,
+		PythonVersionedFileKind::Manifest,
+		None,
+		&deps,
+	)
+	.unwrap_or_else(|error| panic!("update: {error}"));
+
+	assert!(result.contains("my-core>=2.0.0"));
+	assert!(!result.contains("my-core>=1.0.0"));
+	assert!(result.contains("click>=8.0"), "unrelated deps should be preserved");
+}
+
+#[test]
+fn update_versioned_file_text_preserves_lock_files_unchanged() {
+	let input = "# uv.lock contents\n[[package]]\nname = \"test\"\n";
+	let result = update_versioned_file_text(
+		input,
+		PythonVersionedFileKind::Lock,
+		Some("2.0.0"),
+		&BTreeMap::new(),
+	)
+	.unwrap_or_else(|error| panic!("update: {error}"));
+
+	assert_eq!(result, input, "lock files should not be mutated directly");
+}
+
+#[test]
+fn update_versioned_file_text_handles_missing_project_section() {
+	let input = "[build-system]\nrequires = [\"setuptools\"]\n";
+	let result = update_versioned_file_text(
+		input,
+		PythonVersionedFileKind::Manifest,
+		Some("2.0.0"),
+		&BTreeMap::new(),
+	)
+	.unwrap_or_else(|error| panic!("update: {error}"));
+
+	assert_eq!(result, input, "no project section means no changes");
+}
+
+#[test]
+fn update_versioned_file_text_handles_no_version_to_update() {
+	let input = r#"[project]
+name = "my-core"
+version = "1.0.0"
+dependencies = []
+"#;
+	let result = update_versioned_file_text(
+		input,
+		PythonVersionedFileKind::Manifest,
+		None,
+		&BTreeMap::new(),
+	)
+	.unwrap_or_else(|error| panic!("update: {error}"));
+
+	assert!(
+		result.contains(r#"version = "1.0.0""#),
+		"version should be unchanged when no new version is provided"
+	);
+}
+
+#[test]
+fn update_versioned_file_text_handles_empty_dependency_array() {
+	let input = r#"[project]
+name = "my-core"
+version = "1.0.0"
+dependencies = []
+"#;
+	let deps = BTreeMap::from([("nonexistent".to_string(), ">=2.0.0".to_string())]);
+	let result = update_versioned_file_text(
+		input,
+		PythonVersionedFileKind::Manifest,
+		None,
+		&deps,
+	)
+	.unwrap_or_else(|error| panic!("update: {error}"));
+
+	assert_eq!(result, input, "no matching deps means no changes");
+}
+
+// -- adapter trait dispatch --
+
+#[test]
+fn adapter_discover_delegates_to_discover_python_packages() {
+	use monochange_core::EcosystemAdapter;
+	let root = fixture_path("python/standalone");
+	let discovery = PythonAdapter
+		.discover(&root)
+		.unwrap_or_else(|error| panic!("discover: {error}"));
+	assert_eq!(discovery.packages.len(), 1);
+	assert_eq!(discovery.packages.first().unwrap().name, "standalone-tool");
+}
+
+// -- discover_lockfiles with real lockfiles --
+
+#[test]
+fn discover_lockfiles_finds_uv_lock_at_workspace_root() {
+	let root = fixture_path("python/uv-workspace");
+	let package = PackageRecord::new(
+		Ecosystem::Python,
+		"my-core",
+		root.join("packages/core/pyproject.toml"),
+		root.clone(),
+		Some(Version::new(1, 0, 0)),
+		PublishState::Public,
+	);
+	let lockfiles = crate::discover_lockfiles(&package);
+	assert_eq!(lockfiles.len(), 1);
+	assert!(lockfiles.first().unwrap().ends_with("uv.lock"));
+}
+
+#[test]
+fn discover_lockfiles_finds_poetry_lock() {
+	let root = fixture_path("python/poetry-project");
+	let package = PackageRecord::new(
+		Ecosystem::Python,
+		"poetry-app",
+		root.join("pyproject.toml"),
+		root.clone(),
+		Some(Version::new(3, 1, 0)),
+		PublishState::Public,
+	);
+	let lockfiles = crate::discover_lockfiles(&package);
+	assert_eq!(lockfiles.len(), 1);
+	assert!(lockfiles.first().unwrap().ends_with("poetry.lock"));
+}
+
+// -- default_lockfile_commands with real lockfiles --
+
+#[test]
+fn default_lockfile_commands_infers_uv_lock_for_uv_workspace() {
+	let root = fixture_path("python/uv-workspace");
+	let package = PackageRecord::new(
+		Ecosystem::Python,
+		"my-core",
+		root.join("packages/core/pyproject.toml"),
+		root.clone(),
+		Some(Version::new(1, 0, 0)),
+		PublishState::Public,
+	);
+	let commands = crate::default_lockfile_commands(&package);
+	assert_eq!(commands.len(), 1);
+	assert_eq!(commands.first().unwrap().command, "uv lock");
+}
+
+#[test]
+fn default_lockfile_commands_infers_poetry_lock_for_poetry_project() {
+	let root = fixture_path("python/poetry-project");
+	let package = PackageRecord::new(
+		Ecosystem::Python,
+		"poetry-app",
+		root.join("pyproject.toml"),
+		root.clone(),
+		Some(Version::new(3, 1, 0)),
+		PublishState::Public,
+	);
+	let commands = crate::default_lockfile_commands(&package);
+	assert_eq!(commands.len(), 1);
+	assert_eq!(commands.first().unwrap().command, "poetry lock --no-update");
+}
+
+// -- extract_version_constraint --
+
+#[test]
+fn extract_version_constraint_handles_simple_and_complex_specifiers() {
+	assert_eq!(
+		extract_version_constraint("httpx>=0.20.0", "httpx"),
+		Some(">=0.20.0".to_string())
+	);
+	assert_eq!(
+		extract_version_constraint("httpx[cli]>=0.20.0", "httpx"),
+		Some(">=0.20.0".to_string())
+	);
+	assert_eq!(
+		extract_version_constraint("numpy>=1.20.0; python_version < '3.9'", "numpy"),
+		Some(">=1.20.0".to_string())
+	);
+	assert_eq!(
+		extract_version_constraint("requests", "requests"),
+		None
+	);
+}
+
+// -- update with missing dependencies array --
+
+#[test]
+fn update_versioned_file_text_handles_project_without_dependencies_key() {
+	let input = r#"[project]
+name = "minimal"
+version = "1.0.0"
+"#;
+	let deps = BTreeMap::from([("my-core".to_string(), ">=2.0.0".to_string())]);
+	let result = update_versioned_file_text(
+		input,
+		PythonVersionedFileKind::Manifest,
+		Some("2.0.0"),
+		&deps,
+	)
+	.unwrap_or_else(|error| panic!("update: {error}"));
+	assert!(result.contains(r#"version = "2.0.0""#));
+}
+
+// -- update_dependency_specifier edge cases --
+
+#[test]
+fn update_dependency_specifier_returns_none_for_empty_spec() {
+	let deps = BTreeMap::from([("pkg".to_string(), ">=1.0".to_string())]);
+	assert_eq!(update_dependency_specifier("", &deps), None);
+}
+
+#[test]
+fn update_dependency_specifier_handles_name_only_spec() {
+	let deps = BTreeMap::from([("requests".to_string(), ">=2.0".to_string())]);
+	assert_eq!(
+		update_dependency_specifier("requests", &deps),
+		Some("requests>=2.0".to_string())
+	);
+}

--- a/crates/monochange_python/src/__tests.rs
+++ b/crates/monochange_python/src/__tests.rs
@@ -882,3 +882,38 @@ fn normalize_python_package_name_handles_leading_and_trailing_separators() {
 	assert_eq!(normalize_python_package_name("trailing-"), "trailing-");
 	assert_eq!(normalize_python_package_name("a"), "a");
 }
+
+#[test]
+fn discover_python_packages_skips_project_without_name() {
+	let root = fixture_path("python/project-no-name");
+	let discovery =
+		discover_python_packages(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+	assert!(
+		discovery.packages.is_empty(),
+		"should skip packages without a name"
+	);
+}
+
+#[test]
+fn update_versioned_file_text_handles_version_and_deps_with_env_markers() {
+	let input = r#"[project]
+name = "cli"
+version = "1.0.0"
+dependencies = [
+    "numpy>=1.20.0; python_version < '3.9'",
+    "my-core>=1.0.0",
+]
+"#;
+	let deps = BTreeMap::from([("my-core".to_string(), ">=2.0.0".to_string())]);
+	let result = update_versioned_file_text(
+		input,
+		PythonVersionedFileKind::Manifest,
+		Some("2.0.0"),
+		&deps,
+	)
+	.unwrap_or_else(|error| panic!("update: {error}"));
+	assert!(result.contains(r#"version = "2.0.0""#));
+	assert!(result.contains("my-core>=2.0.0"));
+	// Environment markers should be stripped from the constraint
+	assert!(result.contains("numpy"));
+}

--- a/crates/monochange_python/src/__tests.rs
+++ b/crates/monochange_python/src/__tests.rs
@@ -7,8 +7,6 @@ use monochange_core::PackageRecord;
 use monochange_core::PublishState;
 use semver::Version;
 
-use crate::PythonAdapter;
-use crate::PythonVersionedFileKind;
 use crate::discover_python_packages;
 use crate::extract_version_constraint;
 use crate::normalize_python_package_name;
@@ -16,6 +14,8 @@ use crate::parse_dependency_name;
 use crate::parse_pep440_as_semver;
 use crate::update_dependency_specifier;
 use crate::update_versioned_file_text;
+use crate::PythonAdapter;
+use crate::PythonVersionedFileKind;
 
 fn fixture_path(relative: &str) -> PathBuf {
 	monochange_test_helpers::fs::fixture_path_from(env!("CARGO_MANIFEST_DIR"), relative)
@@ -47,14 +47,8 @@ fn supported_versioned_file_kind_recognizes_manifest_and_lockfiles() {
 		supported_versioned_file_kind("poetry.lock".as_ref()),
 		Some(PythonVersionedFileKind::Lock)
 	);
-	assert_eq!(
-		supported_versioned_file_kind("unknown.txt".as_ref()),
-		None
-	);
-	assert_eq!(
-		supported_versioned_file_kind("Cargo.toml".as_ref()),
-		None
-	);
+	assert_eq!(supported_versioned_file_kind("unknown.txt".as_ref()), None);
+	assert_eq!(supported_versioned_file_kind("Cargo.toml".as_ref()), None);
 }
 
 // -- normalize_python_package_name --
@@ -64,10 +58,7 @@ fn normalize_python_package_name_lowercases_and_replaces_separators() {
 	assert_eq!(normalize_python_package_name("My-Package"), "my-package");
 	assert_eq!(normalize_python_package_name("my_package"), "my-package");
 	assert_eq!(normalize_python_package_name("My.Package"), "my-package");
-	assert_eq!(
-		normalize_python_package_name("UPPER__CASE"),
-		"upper-case"
-	);
+	assert_eq!(normalize_python_package_name("UPPER__CASE"), "upper-case");
 	assert_eq!(normalize_python_package_name("simple"), "simple");
 	assert_eq!(normalize_python_package_name(""), "");
 	assert_eq!(normalize_python_package_name("a-_-b"), "a-b");
@@ -98,28 +89,16 @@ fn parse_dependency_name_extracts_name_from_pep508_specifiers() {
 		Some("pkg.name".to_string())
 	);
 	assert_eq!(parse_dependency_name(""), None);
-	assert_eq!(
-		parse_dependency_name(">=1.0"),
-		None
-	);
+	assert_eq!(parse_dependency_name(">=1.0"), None);
 }
 
 // -- parse_pep440_as_semver --
 
 #[test]
 fn parse_pep440_as_semver_handles_standard_and_two_part_versions() {
-	assert_eq!(
-		parse_pep440_as_semver("1.2.3"),
-		Some(Version::new(1, 2, 3))
-	);
-	assert_eq!(
-		parse_pep440_as_semver("0.1.0"),
-		Some(Version::new(0, 1, 0))
-	);
-	assert_eq!(
-		parse_pep440_as_semver("1.2"),
-		Some(Version::new(1, 2, 0))
-	);
+	assert_eq!(parse_pep440_as_semver("1.2.3"), Some(Version::new(1, 2, 3)));
+	assert_eq!(parse_pep440_as_semver("0.1.0"), Some(Version::new(0, 1, 0)));
+	assert_eq!(parse_pep440_as_semver("1.2"), Some(Version::new(1, 2, 0)));
 	assert_eq!(parse_pep440_as_semver("1.2.3a1"), None);
 	assert_eq!(parse_pep440_as_semver("not-a-version"), None);
 	assert_eq!(parse_pep440_as_semver("1"), None);
@@ -160,15 +139,11 @@ fn update_dependency_specifier_preserves_extras() {
 #[test]
 fn discover_python_packages_finds_uv_workspace_members() {
 	let root = fixture_path("python/uv-workspace");
-	let discovery = discover_python_packages(&root)
-		.unwrap_or_else(|error| panic!("discover: {error}"));
+	let discovery =
+		discover_python_packages(&root).unwrap_or_else(|error| panic!("discover: {error}"));
 
 	assert_eq!(discovery.packages.len(), 2);
-	let names: Vec<&str> = discovery
-		.packages
-		.iter()
-		.map(|p| p.name.as_str())
-		.collect();
+	let names: Vec<&str> = discovery.packages.iter().map(|p| p.name.as_str()).collect();
 	assert!(names.contains(&"my-core"), "missing my-core: {names:?}");
 	assert!(names.contains(&"my-cli"), "missing my-cli: {names:?}");
 
@@ -185,8 +160,8 @@ fn discover_python_packages_finds_uv_workspace_members() {
 #[test]
 fn discover_python_packages_finds_standalone_package() {
 	let root = fixture_path("python/standalone");
-	let discovery = discover_python_packages(&root)
-		.unwrap_or_else(|error| panic!("discover: {error}"));
+	let discovery =
+		discover_python_packages(&root).unwrap_or_else(|error| panic!("discover: {error}"));
 
 	assert_eq!(discovery.packages.len(), 1);
 	let pkg = &discovery.packages.first().unwrap();
@@ -198,8 +173,8 @@ fn discover_python_packages_finds_standalone_package() {
 #[test]
 fn discover_python_packages_finds_poetry_project() {
 	let root = fixture_path("python/poetry-project");
-	let discovery = discover_python_packages(&root)
-		.unwrap_or_else(|error| panic!("discover: {error}"));
+	let discovery =
+		discover_python_packages(&root).unwrap_or_else(|error| panic!("discover: {error}"));
 
 	assert_eq!(discovery.packages.len(), 1);
 	let pkg = discovery.packages.first().unwrap();
@@ -232,8 +207,8 @@ fn discover_python_packages_finds_poetry_project() {
 #[test]
 fn discover_python_packages_handles_dynamic_version() {
 	let root = fixture_path("python/dynamic-version");
-	let discovery = discover_python_packages(&root)
-		.unwrap_or_else(|error| panic!("discover: {error}"));
+	let discovery =
+		discover_python_packages(&root).unwrap_or_else(|error| panic!("discover: {error}"));
 
 	assert_eq!(discovery.packages.len(), 1);
 	let pkg = discovery.packages.first().unwrap();
@@ -244,8 +219,8 @@ fn discover_python_packages_handles_dynamic_version() {
 #[test]
 fn discover_python_packages_handles_two_part_version() {
 	let root = fixture_path("python/two-part-version");
-	let discovery = discover_python_packages(&root)
-		.unwrap_or_else(|error| panic!("discover: {error}"));
+	let discovery =
+		discover_python_packages(&root).unwrap_or_else(|error| panic!("discover: {error}"));
 
 	assert_eq!(discovery.packages.len(), 1);
 	let pkg = discovery.packages.first().unwrap();
@@ -255,8 +230,8 @@ fn discover_python_packages_handles_two_part_version() {
 #[test]
 fn discover_python_packages_skips_files_without_project_section() {
 	let root = fixture_path("python/no-project-section");
-	let discovery = discover_python_packages(&root)
-		.unwrap_or_else(|error| panic!("discover: {error}"));
+	let discovery =
+		discover_python_packages(&root).unwrap_or_else(|error| panic!("discover: {error}"));
 
 	assert!(discovery.packages.is_empty());
 }
@@ -264,8 +239,8 @@ fn discover_python_packages_skips_files_without_project_section() {
 #[test]
 fn discover_python_packages_extracts_dependency_edges_from_uv_workspace() {
 	let root = fixture_path("python/uv-workspace");
-	let discovery = discover_python_packages(&root)
-		.unwrap_or_else(|error| panic!("discover: {error}"));
+	let discovery =
+		discover_python_packages(&root).unwrap_or_else(|error| panic!("discover: {error}"));
 
 	let cli = discovery
 		.packages
@@ -284,8 +259,8 @@ fn discover_python_packages_extracts_dependency_edges_from_uv_workspace() {
 #[test]
 fn discover_python_packages_extracts_optional_dependency_edges() {
 	let root = fixture_path("python/uv-workspace");
-	let discovery = discover_python_packages(&root)
-		.unwrap_or_else(|error| panic!("discover: {error}"));
+	let discovery =
+		discover_python_packages(&root).unwrap_or_else(|error| panic!("discover: {error}"));
 
 	let core = discovery
 		.packages
@@ -368,17 +343,15 @@ dependencies = [
 ]
 "#;
 	let deps = BTreeMap::from([("my-core".to_string(), ">=2.0.0".to_string())]);
-	let result = update_versioned_file_text(
-		input,
-		PythonVersionedFileKind::Manifest,
-		None,
-		&deps,
-	)
-	.unwrap_or_else(|error| panic!("update: {error}"));
+	let result = update_versioned_file_text(input, PythonVersionedFileKind::Manifest, None, &deps)
+		.unwrap_or_else(|error| panic!("update: {error}"));
 
 	assert!(result.contains("my-core>=2.0.0"));
 	assert!(!result.contains("my-core>=1.0.0"));
-	assert!(result.contains("click>=8.0"), "unrelated deps should be preserved");
+	assert!(
+		result.contains("click>=8.0"),
+		"unrelated deps should be preserved"
+	);
 }
 
 #[test]
@@ -438,13 +411,8 @@ version = "1.0.0"
 dependencies = []
 "#;
 	let deps = BTreeMap::from([("nonexistent".to_string(), ">=2.0.0".to_string())]);
-	let result = update_versioned_file_text(
-		input,
-		PythonVersionedFileKind::Manifest,
-		None,
-		&deps,
-	)
-	.unwrap_or_else(|error| panic!("update: {error}"));
+	let result = update_versioned_file_text(input, PythonVersionedFileKind::Manifest, None, &deps)
+		.unwrap_or_else(|error| panic!("update: {error}"));
 
 	assert_eq!(result, input, "no matching deps means no changes");
 }
@@ -546,10 +514,7 @@ fn extract_version_constraint_handles_simple_and_complex_specifiers() {
 		extract_version_constraint("numpy>=1.20.0; python_version < '3.9'", "numpy"),
 		Some(">=1.20.0".to_string())
 	);
-	assert_eq!(
-		extract_version_constraint("requests", "requests"),
-		None
-	);
+	assert_eq!(extract_version_constraint("requests", "requests"), None);
 }
 
 // -- update with missing dependencies array --
@@ -586,4 +551,339 @@ fn update_dependency_specifier_handles_name_only_spec() {
 		update_dependency_specifier("requests", &deps),
 		Some("requests>=2.0".to_string())
 	);
+}
+
+// -- discover_lockfiles fallback to manifest dir --
+
+#[test]
+fn discover_lockfiles_falls_back_to_manifest_directory() {
+	use std::fs;
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let workspace_root = tempdir.path().to_path_buf();
+	let pkg_dir = workspace_root.join("packages/mylib");
+	fs::create_dir_all(&pkg_dir).unwrap();
+	fs::write(
+		pkg_dir.join("pyproject.toml"),
+		"[project]\nname = \"mylib\"\nversion = \"1.0.0\"\n",
+	)
+	.unwrap();
+	// Put lockfile in package dir, NOT workspace root
+	fs::write(pkg_dir.join("uv.lock"), "").unwrap();
+
+	let package = PackageRecord::new(
+		Ecosystem::Python,
+		"mylib",
+		pkg_dir.join("pyproject.toml"),
+		workspace_root,
+		Some(Version::new(1, 0, 0)),
+		PublishState::Public,
+	);
+	let lockfiles = crate::discover_lockfiles(&package);
+	assert_eq!(lockfiles.len(), 1);
+	assert!(lockfiles.first().unwrap().ends_with("uv.lock"));
+}
+
+#[test]
+fn discover_lockfiles_prefers_workspace_root_then_manifest_directory() {
+	let root = fixture_path("python/uv-workspace");
+	// Simulate a member package whose workspace root has a lockfile
+	let package = PackageRecord::new(
+		Ecosystem::Python,
+		"my-core",
+		root.join("packages/core/pyproject.toml"),
+		root.clone(),
+		Some(Version::new(1, 0, 0)),
+		PublishState::Public,
+	);
+	let lockfiles = crate::discover_lockfiles(&package);
+	assert!(!lockfiles.is_empty());
+	assert!(lockfiles.first().unwrap().ends_with("uv.lock"));
+}
+
+// -- workspace pattern warnings --
+
+#[test]
+fn discover_python_packages_warns_on_empty_workspace_patterns() {
+	let root = fixture_path("python/uv-workspace-empty-pattern");
+	let discovery =
+		discover_python_packages(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+	assert!(
+		discovery.warnings.iter().any(|w| w.contains("nonexistent")),
+		"expected warning about unmatched pattern: {:?}",
+		discovery.warnings
+	);
+}
+
+// -- parse error paths --
+
+#[test]
+fn discover_python_packages_reports_parse_errors_for_invalid_toml() {
+	let root = fixture_path("python/invalid-toml");
+	let error = discover_python_packages(&root)
+		.err()
+		.unwrap_or_else(|| panic!("expected parse error"));
+	assert!(error.to_string().contains("failed to parse"));
+}
+
+// -- Poetry complex dependency parsing --
+
+#[test]
+fn discover_python_packages_parses_complex_poetry_dependencies() {
+	let root = fixture_path("python/poetry-complex");
+	let discovery =
+		discover_python_packages(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+
+	assert_eq!(discovery.packages.len(), 1);
+	let pkg = discovery.packages.first().unwrap();
+	assert_eq!(pkg.name, "complex-poetry");
+	assert_eq!(pkg.current_version, Some(Version::new(2, 0, 0)));
+
+	let runtime_deps: Vec<&str> = pkg
+		.declared_dependencies
+		.iter()
+		.filter(|d| d.kind == DependencyKind::Runtime)
+		.map(|d| d.name.as_str())
+		.collect();
+	assert!(
+		runtime_deps.contains(&"django"),
+		"missing django: {runtime_deps:?}"
+	);
+	assert!(
+		runtime_deps.contains(&"celery"),
+		"missing celery: {runtime_deps:?}"
+	);
+	assert!(
+		runtime_deps.contains(&"local-pkg"),
+		"missing local-pkg: {runtime_deps:?}"
+	);
+	assert!(
+		!runtime_deps.contains(&"python"),
+		"python should be excluded"
+	);
+
+	// Check Poetry has table-style constraints
+	let celery_dep = pkg
+		.declared_dependencies
+		.iter()
+		.find(|d| d.name == "celery")
+		.unwrap();
+	assert_eq!(celery_dep.version_constraint.as_deref(), Some("^5.3"));
+
+	// Path dependencies have no version constraint
+	let local_dep = pkg
+		.declared_dependencies
+		.iter()
+		.find(|d| d.name == "local-pkg")
+		.unwrap();
+	assert_eq!(local_dep.version_constraint, None);
+
+	let dev_deps: Vec<&str> = pkg
+		.declared_dependencies
+		.iter()
+		.filter(|d| d.kind == DependencyKind::Development)
+		.map(|d| d.name.as_str())
+		.collect();
+	assert!(
+		dev_deps.contains(&"pytest"),
+		"missing pytest from test group: {dev_deps:?}"
+	);
+	assert!(
+		dev_deps.contains(&"coverage"),
+		"missing coverage from test group: {dev_deps:?}"
+	);
+	assert!(
+		dev_deps.contains(&"ruff"),
+		"missing ruff from lint group: {dev_deps:?}"
+	);
+}
+
+// -- update with non-string items in dependency array --
+
+#[test]
+fn update_versioned_file_text_skips_non_string_dependency_items() {
+	let input = r#"[project]
+name = "test"
+version = "1.0.0"
+dependencies = [
+    "my-core>=1.0.0",
+    {include-group = "shared"},
+]
+"#;
+	let deps = BTreeMap::from([("my-core".to_string(), ">=2.0.0".to_string())]);
+	let result = update_versioned_file_text(input, PythonVersionedFileKind::Manifest, None, &deps)
+		.unwrap_or_else(|error| panic!("update: {error}"));
+	assert!(result.contains("my-core>=2.0.0"));
+}
+
+// -- extract_version_constraint extras --
+
+#[test]
+fn extract_version_constraint_handles_extras_in_specifier() {
+	assert_eq!(
+		extract_version_constraint("httpx[cli,http2]>=0.20.0", "httpx"),
+		Some(">=0.20.0".to_string())
+	);
+}
+
+#[test]
+fn extract_version_constraint_returns_none_for_no_constraint() {
+	assert_eq!(
+		extract_version_constraint("simple-package", "simple-package"),
+		None
+	);
+}
+
+// -- should_descend coverage --
+
+#[test]
+fn discover_python_packages_skips_venv_and_pycache_directories() {
+	use std::fs;
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+
+	// Create a valid package at root
+	fs::write(
+		root.join("pyproject.toml"),
+		"[project]\nname = \"root\"\nversion = \"1.0.0\"\ndependencies = []\n",
+	)
+	.unwrap();
+
+	// Create packages in directories that should be skipped
+	for dir in &[
+		".venv",
+		"venv",
+		"__pycache__",
+		".mypy_cache",
+		".tox",
+		"dist",
+		"build",
+	] {
+		let pkg_dir = root.join(dir);
+		fs::create_dir_all(&pkg_dir).unwrap();
+		fs::write(
+			pkg_dir.join("pyproject.toml"),
+			format!("[project]\nname = \"{dir}\"\nversion = \"0.0.1\"\ndependencies = []\n"),
+		)
+		.unwrap();
+	}
+
+	let discovery =
+		discover_python_packages(root).unwrap_or_else(|error| panic!("discover: {error}"));
+	assert_eq!(
+		discovery.packages.len(),
+		1,
+		"should only find root package, not packages in excluded dirs: {:?}",
+		discovery
+			.packages
+			.iter()
+			.map(|p| &p.name)
+			.collect::<Vec<_>>()
+	);
+	assert_eq!(discovery.packages.first().unwrap().name, "root");
+}
+
+// -- IO error paths --
+
+#[test]
+fn discover_python_packages_reports_io_error_for_unreadable_workspace_root() {
+	let error = discover_python_packages(std::path::Path::new("/nonexistent/path/to/repo"));
+	// Should not error since the root pyproject.toml simply doesn't exist
+	// and the walker finds no files either
+	let discovery = error.unwrap_or_else(|error| panic!("unexpected error: {error}"));
+	assert!(discovery.packages.is_empty());
+}
+
+// -- workspace member expansion with direct pyproject.toml files --
+
+#[test]
+fn expand_workspace_members_handles_glob_matching_pyproject_files() {
+	use std::fs;
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+
+	// Create workspace root with glob pattern that matches pyproject.toml directly
+	let pkg_dir = root.join("packages/core");
+	fs::create_dir_all(&pkg_dir).unwrap();
+	fs::write(
+		pkg_dir.join("pyproject.toml"),
+		"[project]\nname = \"core\"\nversion = \"1.0.0\"\ndependencies = []\n",
+	)
+	.unwrap();
+	fs::write(
+		root.join("pyproject.toml"),
+		"[project]\nname = \"root\"\nversion = \"0.1.0\"\n\n[tool.uv.workspace]\nmembers = [\"packages/*\"]\n",
+	)
+	.unwrap();
+
+	let discovery =
+		discover_python_packages(root).unwrap_or_else(|error| panic!("discover: {error}"));
+	assert_eq!(discovery.packages.len(), 1);
+	assert_eq!(discovery.packages.first().unwrap().name, "core");
+}
+
+// -- parse_python_package with invalid TOML --
+
+#[test]
+fn parse_python_package_reports_error_for_invalid_toml() {
+	let root = fixture_path("python/invalid-toml");
+	let error = discover_python_packages(&root)
+		.err()
+		.unwrap_or_else(|| panic!("expected parse error"));
+	let message = error.to_string();
+	assert!(
+		message.contains("failed to parse"),
+		"expected parse error message, got: {message}"
+	);
+}
+
+// -- update_versioned_file with both version and deps --
+
+#[test]
+fn update_versioned_file_text_updates_version_and_deps_simultaneously() {
+	let input = r#"[project]
+name = "my-cli"
+version = "1.0.0"
+dependencies = [
+    "my-core>=1.0.0",
+    "httpx[cli]>=0.20.0",
+]
+"#;
+	let deps = BTreeMap::from([
+		("my-core".to_string(), ">=2.0.0".to_string()),
+		("httpx".to_string(), ">=1.0.0".to_string()),
+	]);
+	let result = update_versioned_file_text(
+		input,
+		PythonVersionedFileKind::Manifest,
+		Some("2.0.0"),
+		&deps,
+	)
+	.unwrap_or_else(|error| panic!("update: {error}"));
+
+	assert!(result.contains(r#"version = "2.0.0""#));
+	assert!(result.contains("my-core>=2.0.0"));
+	assert!(result.contains("httpx[cli]>=1.0.0"));
+}
+
+// -- PEP 440 edge cases --
+
+#[test]
+fn parse_pep440_as_semver_handles_pre_release_and_invalid_formats() {
+	// Pre-release suffixes are not supported
+	assert_eq!(parse_pep440_as_semver("1.0.0rc1"), None);
+	assert_eq!(parse_pep440_as_semver("1.0.0.post1"), None);
+	assert_eq!(parse_pep440_as_semver("1.0.0.dev0"), None);
+	// Four-part versions are not semver
+	assert_eq!(parse_pep440_as_semver("1.2.3.4"), None);
+	// Valid two-part
+	assert_eq!(parse_pep440_as_semver("0.1"), Some(Version::new(0, 1, 0)));
+}
+
+// -- normalize edge cases --
+
+#[test]
+fn normalize_python_package_name_handles_leading_and_trailing_separators() {
+	assert_eq!(normalize_python_package_name("-leading"), "leading");
+	assert_eq!(normalize_python_package_name("trailing-"), "trailing-");
+	assert_eq!(normalize_python_package_name("a"), "a");
 }

--- a/crates/monochange_python/src/__tests.rs
+++ b/crates/monochange_python/src/__tests.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::fs;
 use std::path::PathBuf;
 
 use monochange_core::DependencyKind;
@@ -828,8 +829,173 @@ fn expand_workspace_members_handles_glob_matching_pyproject_files() {
 	assert_eq!(discovery.packages.first().unwrap().name, "core");
 }
 
-// parse_python_package invalid TOML is tested by
-// discover_python_packages_warns_on_invalid_toml_in_standalone_scan above
+#[test]
+fn default_lockfile_commands_handles_uv_poetry_and_unknown_lockfiles() {
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	fs::write(
+		root.join("pyproject.toml"),
+		"[project]\nname = \"app\"\nversion = \"1.0.0\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write pyproject: {error}"));
+	fs::write(root.join("uv.lock"), "").unwrap_or_else(|error| panic!("write uv.lock: {error}"));
+	fs::write(root.join("poetry.lock"), "")
+		.unwrap_or_else(|error| panic!("write poetry.lock: {error}"));
+	fs::write(root.join("requirements.lock"), "")
+		.unwrap_or_else(|error| panic!("write requirements.lock: {error}"));
+	let package = PackageRecord::new(
+		Ecosystem::Python,
+		"app",
+		root.join("pyproject.toml"),
+		root.to_path_buf(),
+		Some(Version::new(1, 0, 0)),
+		PublishState::Unpublished,
+	);
+
+	let commands = crate::default_lockfile_commands(&package);
+	let command_names = commands
+		.iter()
+		.map(|command| command.command.as_str())
+		.collect::<Vec<_>>();
+
+	assert_eq!(command_names, vec!["uv lock", "poetry lock --no-update"]);
+	let root_name = root.file_name().unwrap_or_else(|| panic!("temp root name"));
+	assert!(
+		commands
+			.iter()
+			.all(|command| command.cwd.ends_with(root_name))
+	);
+}
+
+#[test]
+fn update_versioned_file_text_returns_early_without_project_dependencies() {
+	let deps = BTreeMap::from([("core".to_string(), ">=2.0.0".to_string())]);
+
+	let without_project = update_versioned_file_text(
+		"[tool.custom]\nname = \"app\"\n",
+		PythonVersionedFileKind::Manifest,
+		Some("2.0.0"),
+		&deps,
+	)
+	.unwrap_or_else(|error| panic!("update without project: {error}"));
+	assert!(!without_project.contains("2.0.0"));
+
+	let without_dependencies = update_versioned_file_text(
+		"[project]\nname = \"app\"\nversion = \"1.0.0\"\n",
+		PythonVersionedFileKind::Manifest,
+		Some("2.0.0"),
+		&deps,
+	)
+	.unwrap_or_else(|error| panic!("update without dependencies: {error}"));
+	assert!(without_dependencies.contains("version = \"2.0.0\""));
+	assert!(!without_dependencies.contains("core>=2.0.0"));
+}
+
+#[test]
+fn private_workspace_helpers_cover_error_and_match_branches() {
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	let manifest_path = root.join("pyproject.toml");
+	let packages = root.join("packages");
+	let package_dir = packages.join("core");
+	fs::create_dir_all(&package_dir).unwrap_or_else(|error| panic!("create package dir: {error}"));
+	fs::write(
+		&manifest_path,
+		"[project]\nname = \"root\"\nversion = \"1.0.0\"\n\n[tool.uv.workspace]\nmembers = [\"packages/*\", \"packages/core/pyproject.toml\", \"README.md\", \"missing/*\"]\n",
+	)
+	.unwrap_or_else(|error| panic!("write root pyproject: {error}"));
+	fs::write(
+		package_dir.join("pyproject.toml"),
+		"[project]\nname = \"core\"\nversion = \"1.0.0\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write core pyproject: {error}"));
+	fs::write(root.join("README.md"), "# docs\n")
+		.unwrap_or_else(|error| panic!("write readme: {error}"));
+
+	let members = crate::parse_uv_workspace_members(&manifest_path)
+		.unwrap_or_else(|error| panic!("parse uv members: {error}"))
+		.unwrap_or_else(|| panic!("expected uv workspace members"));
+	assert!(members.contains(&"packages/*".to_string()));
+
+	let missing_error = crate::parse_uv_workspace_members(&root.join("missing-pyproject.toml"))
+		.err()
+		.unwrap_or_else(|| panic!("expected missing pyproject error"));
+	assert!(missing_error.to_string().contains("failed to read"));
+
+	fs::write(root.join("invalid.toml"), "[project\n")
+		.unwrap_or_else(|error| panic!("write invalid toml: {error}"));
+	let parse_error = crate::parse_uv_workspace_members(&root.join("invalid.toml"))
+		.err()
+		.unwrap_or_else(|| panic!("expected invalid toml error"));
+	assert!(parse_error.to_string().contains("failed to parse"));
+
+	let mut warnings = Vec::new();
+	let manifests = crate::expand_workspace_members(root, &members, &mut warnings);
+	assert!(
+		manifests
+			.iter()
+			.any(|manifest| manifest.ends_with("packages/core/pyproject.toml")),
+		"missing core manifest in {manifests:?}"
+	);
+	assert!(warnings.iter().any(|warning| warning.contains("missing/*")));
+}
+
+#[test]
+fn private_package_parser_covers_error_and_dependency_value_branches() {
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	let missing_error = crate::parse_python_package(&root.join("missing.toml"), root)
+		.err()
+		.unwrap_or_else(|| panic!("expected missing package error"));
+	assert!(missing_error.to_string().contains("failed to read"));
+
+	let invalid_path = root.join("invalid.toml");
+	fs::write(&invalid_path, "[project\n").unwrap_or_else(|error| panic!("write invalid: {error}"));
+	let parse_error = crate::parse_python_package(&invalid_path, root)
+		.err()
+		.unwrap_or_else(|| panic!("expected parse package error"));
+	assert!(parse_error.to_string().contains("failed to parse"));
+
+	let poetry = toml::from_str::<toml::Value>(
+		r#"
+[dependencies]
+python = ">=3.11"
+django = "^4.2"
+celery = { version = "^5.3" }
+local = { path = "../local" }
+unknown = 1
+
+[group.dev.dependencies]
+pytest = "^8.0"
+ruff = { version = "^0.4" }
+tooling = { path = "../tooling" }
+numbered = 1
+"#,
+	)
+	.unwrap_or_else(|error| panic!("parse poetry fixture: {error}"));
+	let deps = crate::parse_poetry_dependencies(&poetry);
+	assert!(
+		deps.iter()
+			.any(|dep| dep.name == "django" && dep.version_constraint.as_deref() == Some("^4.2"))
+	);
+	assert!(
+		deps.iter()
+			.any(|dep| dep.name == "celery" && dep.version_constraint.as_deref() == Some("^5.3"))
+	);
+	assert!(
+		deps.iter()
+			.any(|dep| dep.name == "local" && dep.version_constraint.is_none())
+	);
+	assert!(
+		deps.iter()
+			.any(|dep| dep.name == "ruff" && dep.version_constraint.as_deref() == Some("^0.4"))
+	);
+	assert!(
+		deps.iter()
+			.any(|dep| dep.name == "tooling" && dep.version_constraint.is_none())
+	);
+	assert!(!deps.iter().any(|dep| dep.name == "python"));
+}
 
 // -- update_versioned_file with both version and deps --
 

--- a/crates/monochange_python/src/lib.rs
+++ b/crates/monochange_python/src/lib.rs
@@ -185,12 +185,12 @@ fn update_project_version(document: &mut DocumentMut, owner_version: Option<&str
 	else {
 		return;
 	};
-	if let Some(existing) = project.get_mut("version") {
-		if let Some(existing_value) = existing.as_value() {
-			let mut new_value = toml_edit::Value::from(version);
-			*new_value.decor_mut() = existing_value.decor().clone();
-			*existing = Item::Value(new_value);
-		}
+	if let Some(existing) = project.get_mut("version")
+		&& let Some(existing_value) = existing.as_value()
+	{
+		let mut new_value = toml_edit::Value::from(version);
+		*new_value.decor_mut() = existing_value.decor().clone();
+		*existing = Item::Value(new_value);
 	}
 }
 
@@ -472,15 +472,15 @@ fn parse_pep621_dependencies(project: &Value) -> Vec<PackageDependency> {
 
 	if let Some(dep_array) = project.get("dependencies").and_then(Value::as_array) {
 		for dep in dep_array {
-			if let Some(spec) = dep.as_str() {
-				if let Some(name) = parse_dependency_name(spec) {
-					deps.push(PackageDependency {
-						name: normalize_python_package_name(&name),
-						kind: DependencyKind::Runtime,
-						version_constraint: extract_version_constraint(spec, &name),
-						optional: false,
-					});
-				}
+			if let Some(spec) = dep.as_str()
+				&& let Some(name) = parse_dependency_name(spec)
+			{
+				deps.push(PackageDependency {
+					name: normalize_python_package_name(&name),
+					kind: DependencyKind::Runtime,
+					version_constraint: extract_version_constraint(spec, &name),
+					optional: false,
+				});
 			}
 		}
 	}
@@ -492,15 +492,15 @@ fn parse_pep621_dependencies(project: &Value) -> Vec<PackageDependency> {
 		for (_group, group_deps) in optional_deps {
 			if let Some(dep_array) = group_deps.as_array() {
 				for dep in dep_array {
-					if let Some(spec) = dep.as_str() {
-						if let Some(name) = parse_dependency_name(spec) {
-							deps.push(PackageDependency {
-								name: normalize_python_package_name(&name),
-								kind: DependencyKind::Development,
-								version_constraint: extract_version_constraint(spec, &name),
-								optional: true,
-							});
-						}
+					if let Some(spec) = dep.as_str()
+						&& let Some(name) = parse_dependency_name(spec)
+					{
+						deps.push(PackageDependency {
+							name: normalize_python_package_name(&name),
+							kind: DependencyKind::Development,
+							version_constraint: extract_version_constraint(spec, &name),
+							optional: true,
+						});
 					}
 				}
 			}

--- a/crates/monochange_python/src/lib.rs
+++ b/crates/monochange_python/src/lib.rs
@@ -280,6 +280,7 @@ fn normalize_python_package_name(name: &str) -> String {
 	result
 }
 
+#[tracing::instrument(skip_all)]
 pub fn discover_python_packages(root: &Path) -> MonochangeResult<AdapterDiscovery> {
 	let mut packages = Vec::new();
 	let mut warnings = Vec::new();
@@ -332,6 +333,8 @@ pub fn discover_python_packages(root: &Path) -> MonochangeResult<AdapterDiscover
 
 	packages.sort_by(|left, right| left.id.cmp(&right.id));
 	packages.dedup_by(|left, right| left.id == right.id);
+
+	tracing::debug!(packages = packages.len(), "discovered python packages");
 
 	Ok(AdapterDiscovery { packages, warnings })
 }

--- a/crates/monochange_python/src/lib.rs
+++ b/crates/monochange_python/src/lib.rs
@@ -127,11 +127,7 @@ pub fn default_lockfile_commands(package: &PackageRecord) -> Vec<LockfileCommand
 		.into_iter()
 		.filter_map(|lockfile| {
 			let file_name = lockfile.file_name()?.to_str()?;
-			let command = match file_name {
-				UV_LOCK_FILE => "uv lock",
-				POETRY_LOCK_FILE => "poetry lock --no-update",
-				_ => return None,
-			};
+			let command = lockfile_command(file_name)?;
 			Some(LockfileCommandExecution {
 				command: command.to_string(),
 				cwd: lockfile
@@ -142,6 +138,14 @@ pub fn default_lockfile_commands(package: &PackageRecord) -> Vec<LockfileCommand
 			})
 		})
 		.collect()
+}
+
+fn lockfile_command(file_name: &str) -> Option<&'static str> {
+	match file_name {
+		UV_LOCK_FILE => Some("uv lock"),
+		POETRY_LOCK_FILE => Some("poetry lock --no-update"),
+		_ => None,
+	}
 }
 
 pub fn update_versioned_file_text(

--- a/crates/monochange_python/src/lib.rs
+++ b/crates/monochange_python/src/lib.rs
@@ -207,10 +207,7 @@ fn update_project_dependencies(
 	else {
 		return;
 	};
-	let Some(deps) = project
-		.get_mut("dependencies")
-		.and_then(Item::as_array_mut)
-	else {
+	let Some(deps) = project.get_mut("dependencies").and_then(Item::as_array_mut) else {
 		return;
 	};
 	for item in deps.iter_mut() {
@@ -382,9 +379,7 @@ fn expand_workspace_members(
 		for matched_path in matches {
 			let manifest_path = if matched_path.is_dir() {
 				matched_path.join(PYPROJECT_FILE)
-			} else if matched_path
-				.file_name()
-				.and_then(|name| name.to_str())
+			} else if matched_path.file_name().and_then(|name| name.to_str())
 				== Some(PYPROJECT_FILE)
 			{
 				matched_path
@@ -432,10 +427,7 @@ fn parse_python_package(
 		let version = if dynamic { None } else { version };
 		let deps = parse_pep621_dependencies(project);
 		(name, version, deps)
-	} else if let Some(poetry) = parsed
-		.get("tool")
-		.and_then(|tool| tool.get("poetry"))
-	{
+	} else if let Some(poetry) = parsed.get("tool").and_then(|tool| tool.get("poetry")) {
 		let name = poetry.get("name").and_then(Value::as_str);
 		let version = poetry
 			.get("version")
@@ -570,11 +562,7 @@ fn extract_version_constraint(spec: &str, name: &str) -> Option<String> {
 	} else {
 		rest
 	};
-	let constraint = after_extras
-		.split(';')
-		.next()
-		.unwrap_or("")
-		.trim();
+	let constraint = after_extras.split(';').next().unwrap_or("").trim();
 	if constraint.is_empty() {
 		None
 	} else {
@@ -625,7 +613,8 @@ fn should_descend(entry: &DirEntry) -> bool {
 			| ".ruff_cache"
 			| ".pytest_cache"
 			| "node_modules"
-			| "target" | ".devenv"
+			| "target"
+			| ".devenv"
 			| "book" | ".tox"
 			| "dist" | "build"
 			| ".eggs" | "*.egg-info"

--- a/crates/monochange_python/src/lib.rs
+++ b/crates/monochange_python/src/lib.rs
@@ -32,7 +32,6 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use glob::glob;
-use monochange_core::normalize_path;
 use monochange_core::AdapterDiscovery;
 use monochange_core::DependencyKind;
 use monochange_core::Ecosystem;
@@ -44,6 +43,7 @@ use monochange_core::PackageDependency;
 use monochange_core::PackageRecord;
 use monochange_core::PublishState;
 use monochange_core::ShellConfig;
+use monochange_core::normalize_path;
 use semver::Version;
 use toml::Value;
 use toml_edit::DocumentMut;
@@ -254,11 +254,7 @@ fn parse_dependency_name(spec: &str) -> Option<String> {
 		.chars()
 		.take_while(|ch| ch.is_alphanumeric() || *ch == '-' || *ch == '_' || *ch == '.')
 		.collect();
-	if name.is_empty() {
-		None
-	} else {
-		Some(name)
-	}
+	if name.is_empty() { None } else { Some(name) }
 }
 
 /// Normalize a Python package name per PEP 503: lowercase, replace [-_.]+
@@ -524,10 +520,12 @@ fn parse_poetry_dependencies(poetry: &Value) -> Vec<PackageDependency> {
 			}
 			let constraint = match value {
 				Value::String(version) => Some(version.clone()),
-				Value::Table(table) => table
-					.get("version")
-					.and_then(Value::as_str)
-					.map(ToString::to_string),
+				Value::Table(table) => {
+					table
+						.get("version")
+						.and_then(Value::as_str)
+						.map(ToString::to_string)
+				}
 				_ => None,
 			};
 			deps.push(PackageDependency {
@@ -550,10 +548,12 @@ fn parse_poetry_dependencies(poetry: &Value) -> Vec<PackageDependency> {
 				for (name, value) in group_deps {
 					let constraint = match value {
 						Value::String(version) => Some(version.clone()),
-						Value::Table(table) => table
-							.get("version")
-							.and_then(Value::as_str)
-							.map(ToString::to_string),
+						Value::Table(table) => {
+							table
+								.get("version")
+								.and_then(Value::as_str)
+								.map(ToString::to_string)
+						}
 						_ => None,
 					};
 					deps.push(PackageDependency {

--- a/crates/monochange_python/src/lib.rs
+++ b/crates/monochange_python/src/lib.rs
@@ -1,0 +1,636 @@
+#![deny(clippy::all)]
+#![forbid(clippy::indexing_slicing)]
+
+//! # `monochange_python`
+//!
+//! `monochange_python` discovers Python packages from uv workspaces, Poetry
+//! projects, and standalone `pyproject.toml` files.
+//!
+//! ## Why use it?
+//!
+//! - discover uv workspaces and standalone Python packages with one adapter
+//! - normalize Python package manifests and dependency edges for the shared
+//!   planner
+//! - infer lockfile refresh commands for uv and Poetry
+//!
+//! ## Public entry points
+//!
+//! - `discover_python_packages(root)` discovers Python packages
+//! - `PythonAdapter` exposes the shared adapter interface
+//!
+//! ## Scope
+//!
+//! - uv workspace member expansion
+//! - `pyproject.toml` parsing (`[project]` and `[tool.poetry]`)
+//! - normalized dependency extraction from PEP 621 metadata
+//! - lockfile command inference for uv and Poetry
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
+use glob::glob;
+use monochange_core::normalize_path;
+use monochange_core::AdapterDiscovery;
+use monochange_core::DependencyKind;
+use monochange_core::Ecosystem;
+use monochange_core::EcosystemAdapter;
+use monochange_core::LockfileCommandExecution;
+use monochange_core::MonochangeError;
+use monochange_core::MonochangeResult;
+use monochange_core::PackageDependency;
+use monochange_core::PackageRecord;
+use monochange_core::PublishState;
+use monochange_core::ShellConfig;
+use semver::Version;
+use toml::Value;
+use toml_edit::DocumentMut;
+use toml_edit::Item;
+use walkdir::DirEntry;
+use walkdir::WalkDir;
+
+pub const PYPROJECT_FILE: &str = "pyproject.toml";
+pub const UV_LOCK_FILE: &str = "uv.lock";
+pub const POETRY_LOCK_FILE: &str = "poetry.lock";
+
+pub struct PythonAdapter;
+
+#[must_use]
+pub const fn adapter() -> PythonAdapter {
+	PythonAdapter
+}
+
+impl EcosystemAdapter for PythonAdapter {
+	fn ecosystem(&self) -> Ecosystem {
+		Ecosystem::Python
+	}
+
+	fn discover(&self, root: &Path) -> MonochangeResult<AdapterDiscovery> {
+		discover_python_packages(root)
+	}
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum PythonVersionedFileKind {
+	Manifest,
+	Lock,
+}
+
+#[must_use]
+pub fn supported_versioned_file_kind(path: &Path) -> Option<PythonVersionedFileKind> {
+	let file_name = path
+		.file_name()
+		.and_then(|name| name.to_str())
+		.unwrap_or_default();
+	match file_name {
+		PYPROJECT_FILE => Some(PythonVersionedFileKind::Manifest),
+		UV_LOCK_FILE | POETRY_LOCK_FILE => Some(PythonVersionedFileKind::Lock),
+		_ => None,
+	}
+}
+
+pub fn discover_lockfiles(package: &PackageRecord) -> Vec<PathBuf> {
+	let manifest_dir = package
+		.manifest_path
+		.parent()
+		.map_or_else(|| package.workspace_root.clone(), Path::to_path_buf);
+	let scope = if manifest_dir == package.workspace_root {
+		manifest_dir.clone()
+	} else {
+		package.workspace_root.clone()
+	};
+
+	let mut discovered: Vec<PathBuf> = [scope.join(UV_LOCK_FILE), scope.join(POETRY_LOCK_FILE)]
+		.into_iter()
+		.filter(|path| path.exists())
+		.collect();
+
+	if discovered.is_empty() && scope != manifest_dir {
+		discovered.extend(
+			[
+				manifest_dir.join(UV_LOCK_FILE),
+				manifest_dir.join(POETRY_LOCK_FILE),
+			]
+			.into_iter()
+			.filter(|path| path.exists()),
+		);
+	}
+
+	discovered
+}
+
+pub fn default_lockfile_commands(package: &PackageRecord) -> Vec<LockfileCommandExecution> {
+	let lockfiles = discover_lockfiles(package);
+	lockfiles
+		.into_iter()
+		.filter_map(|lockfile| {
+			let file_name = lockfile.file_name()?.to_str()?;
+			let command = match file_name {
+				UV_LOCK_FILE => "uv lock",
+				POETRY_LOCK_FILE => "poetry lock --no-update",
+				_ => return None,
+			};
+			Some(LockfileCommandExecution {
+				command: command.to_string(),
+				cwd: lockfile
+					.parent()
+					.unwrap_or(&package.workspace_root)
+					.to_path_buf(),
+				shell: ShellConfig::None,
+			})
+		})
+		.collect()
+}
+
+pub fn update_versioned_file_text(
+	contents: &str,
+	kind: PythonVersionedFileKind,
+	owner_version: Option<&str>,
+	versioned_deps: &BTreeMap<String, String>,
+) -> Result<String, toml_edit::TomlError> {
+	let mut document = contents.parse::<DocumentMut>()?;
+	update_versioned_file(&mut document, kind, owner_version, versioned_deps);
+	Ok(document.to_string())
+}
+
+pub fn update_versioned_file(
+	document: &mut DocumentMut,
+	kind: PythonVersionedFileKind,
+	owner_version: Option<&str>,
+	versioned_deps: &BTreeMap<String, String>,
+) {
+	match kind {
+		PythonVersionedFileKind::Manifest => {
+			update_project_version(document, owner_version);
+			update_project_dependencies(document, versioned_deps);
+		}
+		PythonVersionedFileKind::Lock => {
+			// Lock files (uv.lock, poetry.lock) are complex and fragile to
+			// mutate directly. Prefer running lockfile commands (`uv lock` or
+			// `poetry lock --no-update`) which re-resolve the full dependency
+			// graph after manifest versions are updated.
+		}
+	}
+}
+
+fn update_project_version(document: &mut DocumentMut, owner_version: Option<&str>) {
+	let Some(version) = owner_version else {
+		return;
+	};
+	let Some(project) = document
+		.get_mut("project")
+		.and_then(Item::as_table_like_mut)
+	else {
+		return;
+	};
+	if let Some(existing) = project.get_mut("version") {
+		if let Some(existing_value) = existing.as_value() {
+			let mut new_value = toml_edit::Value::from(version);
+			*new_value.decor_mut() = existing_value.decor().clone();
+			*existing = Item::Value(new_value);
+		}
+	}
+}
+
+fn update_project_dependencies(
+	document: &mut DocumentMut,
+	versioned_deps: &BTreeMap<String, String>,
+) {
+	if versioned_deps.is_empty() {
+		return;
+	}
+	let Some(project) = document
+		.get_mut("project")
+		.and_then(Item::as_table_like_mut)
+	else {
+		return;
+	};
+	let Some(deps) = project
+		.get_mut("dependencies")
+		.and_then(Item::as_array_mut)
+	else {
+		return;
+	};
+	for item in deps.iter_mut() {
+		let Some(spec) = item.as_str() else {
+			continue;
+		};
+		if let Some(updated) = update_dependency_specifier(spec, versioned_deps) {
+			let mut new_value = toml_edit::Value::from(updated);
+			*new_value.decor_mut() = item.decor().clone();
+			*item = new_value;
+		}
+	}
+}
+
+/// Update a PEP 508 dependency specifier if the package name matches a
+/// versioned dependency.
+///
+/// Input:  `"my-core>=1.0.0"`, deps = `{"my-core": ">=2.0.0"}`
+/// Output: `Some("my-core>=2.0.0")`
+fn update_dependency_specifier(
+	spec: &str,
+	versioned_deps: &BTreeMap<String, String>,
+) -> Option<String> {
+	let name = parse_dependency_name(spec)?;
+	let normalized = normalize_python_package_name(&name);
+	let version = versioned_deps.get(&normalized)?;
+	// Replace everything after the package name with the new version constraint.
+	// Preserve extras (e.g., `httpx[cli]>=1.0` → `httpx[cli]>=2.0`).
+	let after_name = &spec[name.len()..];
+	let extras_end = after_name
+		.find(|ch: char| ch != '[' && ch != ']' && !ch.is_alphanumeric() && ch != ',')
+		.unwrap_or(0);
+	let extras = &after_name[..extras_end];
+	Some(format!("{name}{extras}{version}"))
+}
+
+/// Parse the package name from a PEP 508 dependency specifier.
+///
+/// `"httpx>=0.20.0"` → `"httpx"`
+/// `"httpx[cli]>=0.20.0"` → `"httpx"`
+/// `"Django>2.1; os_name != 'nt'"` → `"Django"`
+fn parse_dependency_name(spec: &str) -> Option<String> {
+	let name: String = spec
+		.chars()
+		.take_while(|ch| ch.is_alphanumeric() || *ch == '-' || *ch == '_' || *ch == '.')
+		.collect();
+	if name.is_empty() {
+		None
+	} else {
+		Some(name)
+	}
+}
+
+/// Normalize a Python package name per PEP 503: lowercase, replace [-_.]+
+/// with a single hyphen.
+fn normalize_python_package_name(name: &str) -> String {
+	let mut result = String::with_capacity(name.len());
+	let mut prev_was_separator = false;
+	for ch in name.chars() {
+		if ch == '-' || ch == '_' || ch == '.' {
+			if !prev_was_separator && !result.is_empty() {
+				result.push('-');
+			}
+			prev_was_separator = true;
+		} else {
+			result.push(ch.to_ascii_lowercase());
+			prev_was_separator = false;
+		}
+	}
+	result
+}
+
+pub fn discover_python_packages(root: &Path) -> MonochangeResult<AdapterDiscovery> {
+	let mut packages = Vec::new();
+	let mut warnings = Vec::new();
+	let mut included_manifests = BTreeSet::new();
+
+	// Phase 1: uv workspace discovery
+	let root_manifest = root.join(PYPROJECT_FILE);
+	if root_manifest.exists() {
+		if let Some(workspace_members) = parse_uv_workspace_members(&root_manifest)? {
+			// Exclude the workspace root manifest from standalone discovery
+			included_manifests.insert(normalize_path(&root_manifest));
+			let member_manifests =
+				expand_workspace_members(root, &workspace_members, &mut warnings);
+			for manifest_path in member_manifests {
+				if let Some(package) = parse_python_package(&manifest_path, root)? {
+					included_manifests.insert(normalize_path(&manifest_path));
+					packages.push(package);
+				}
+			}
+		}
+	}
+
+	// Phase 2: scan for standalone pyproject.toml files not already discovered
+	for manifest_path in find_all_pyproject_files(root) {
+		let normalized = normalize_path(&manifest_path);
+		if included_manifests.contains(&normalized) {
+			continue;
+		}
+		let manifest_dir = manifest_path
+			.parent()
+			.unwrap_or_else(|| Path::new("."))
+			.to_path_buf();
+		if let Some(package) = parse_python_package(&manifest_path, &manifest_dir)? {
+			packages.push(package);
+		}
+	}
+
+	packages.sort_by(|left, right| left.id.cmp(&right.id));
+	packages.dedup_by(|left, right| left.id == right.id);
+
+	Ok(AdapterDiscovery { packages, warnings })
+}
+
+fn parse_uv_workspace_members(manifest_path: &Path) -> MonochangeResult<Option<Vec<String>>> {
+	let contents = fs::read_to_string(manifest_path).map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to read {}: {error}",
+			manifest_path.display()
+		))
+	})?;
+	let parsed = toml::from_str::<Value>(&contents).map_err(|error| {
+		MonochangeError::Discovery(format!(
+			"failed to parse {}: {error}",
+			manifest_path.display()
+		))
+	})?;
+
+	let members = parsed
+		.get("tool")
+		.and_then(|tool| tool.get("uv"))
+		.and_then(|uv| uv.get("workspace"))
+		.and_then(|workspace| workspace.get("members"))
+		.and_then(Value::as_array)
+		.map(|members| {
+			members
+				.iter()
+				.filter_map(Value::as_str)
+				.map(ToString::to_string)
+				.collect()
+		});
+
+	Ok(members)
+}
+
+fn expand_workspace_members(
+	root: &Path,
+	patterns: &[String],
+	warnings: &mut Vec<String>,
+) -> BTreeSet<PathBuf> {
+	let mut manifests = BTreeSet::new();
+
+	for pattern in patterns {
+		let joined = root.join(pattern).to_string_lossy().to_string();
+		let matches: Vec<PathBuf> = glob(&joined)
+			.into_iter()
+			.flat_map(|paths| paths.filter_map(Result::ok))
+			.map(|path| normalize_path(&path))
+			.collect();
+
+		if matches.is_empty() {
+			warnings.push(format!(
+				"uv workspace pattern `{pattern}` under {} matched no packages",
+				root.display()
+			));
+		}
+
+		for matched_path in matches {
+			let manifest_path = if matched_path.is_dir() {
+				matched_path.join(PYPROJECT_FILE)
+			} else if matched_path
+				.file_name()
+				.and_then(|name| name.to_str())
+				== Some(PYPROJECT_FILE)
+			{
+				matched_path
+			} else {
+				continue;
+			};
+
+			if manifest_path.exists() {
+				manifests.insert(manifest_path);
+			}
+		}
+	}
+
+	manifests
+}
+
+fn parse_python_package(
+	manifest_path: &Path,
+	workspace_root: &Path,
+) -> MonochangeResult<Option<PackageRecord>> {
+	let contents = fs::read_to_string(manifest_path).map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to read {}: {error}",
+			manifest_path.display()
+		))
+	})?;
+	let parsed = toml::from_str::<Value>(&contents).map_err(|error| {
+		MonochangeError::Discovery(format!(
+			"failed to parse {}: {error}",
+			manifest_path.display()
+		))
+	})?;
+
+	// Prefer [project] (PEP 621) over [tool.poetry]
+	let (name, version, dependencies) = if let Some(project) = parsed.get("project") {
+		let name = project.get("name").and_then(Value::as_str);
+		let version = project
+			.get("version")
+			.and_then(Value::as_str)
+			.and_then(parse_pep440_as_semver);
+		let dynamic = project
+			.get("dynamic")
+			.and_then(Value::as_array)
+			.is_some_and(|arr| arr.iter().any(|v| v.as_str() == Some("version")));
+		let version = if dynamic { None } else { version };
+		let deps = parse_pep621_dependencies(project);
+		(name, version, deps)
+	} else if let Some(poetry) = parsed
+		.get("tool")
+		.and_then(|tool| tool.get("poetry"))
+	{
+		let name = poetry.get("name").and_then(Value::as_str);
+		let version = poetry
+			.get("version")
+			.and_then(Value::as_str)
+			.and_then(parse_pep440_as_semver);
+		let deps = parse_poetry_dependencies(poetry);
+		(name, version, deps)
+	} else {
+		return Ok(None);
+	};
+
+	let Some(name) = name else {
+		return Ok(None);
+	};
+
+	let mut record = PackageRecord::new(
+		Ecosystem::Python,
+		name,
+		normalize_path(manifest_path),
+		normalize_path(workspace_root),
+		version,
+		PublishState::Public,
+	);
+	record.declared_dependencies = dependencies;
+	Ok(Some(record))
+}
+
+fn parse_pep621_dependencies(project: &Value) -> Vec<PackageDependency> {
+	let mut deps = Vec::new();
+
+	if let Some(dep_array) = project.get("dependencies").and_then(Value::as_array) {
+		for dep in dep_array {
+			if let Some(spec) = dep.as_str() {
+				if let Some(name) = parse_dependency_name(spec) {
+					deps.push(PackageDependency {
+						name: normalize_python_package_name(&name),
+						kind: DependencyKind::Runtime,
+						version_constraint: extract_version_constraint(spec, &name),
+						optional: false,
+					});
+				}
+			}
+		}
+	}
+
+	if let Some(optional_deps) = project
+		.get("optional-dependencies")
+		.and_then(Value::as_table)
+	{
+		for (_group, group_deps) in optional_deps {
+			if let Some(dep_array) = group_deps.as_array() {
+				for dep in dep_array {
+					if let Some(spec) = dep.as_str() {
+						if let Some(name) = parse_dependency_name(spec) {
+							deps.push(PackageDependency {
+								name: normalize_python_package_name(&name),
+								kind: DependencyKind::Development,
+								version_constraint: extract_version_constraint(spec, &name),
+								optional: true,
+							});
+						}
+					}
+				}
+			}
+		}
+	}
+
+	deps
+}
+
+fn parse_poetry_dependencies(poetry: &Value) -> Vec<PackageDependency> {
+	let mut deps = Vec::new();
+
+	if let Some(dep_table) = poetry.get("dependencies").and_then(Value::as_table) {
+		for (name, value) in dep_table {
+			if name == "python" {
+				continue;
+			}
+			let constraint = match value {
+				Value::String(version) => Some(version.clone()),
+				Value::Table(table) => table
+					.get("version")
+					.and_then(Value::as_str)
+					.map(ToString::to_string),
+				_ => None,
+			};
+			deps.push(PackageDependency {
+				name: normalize_python_package_name(name),
+				kind: DependencyKind::Runtime,
+				version_constraint: constraint,
+				optional: false,
+			});
+		}
+	}
+
+	// Parse grouped dev dependencies
+	if let Some(groups) = poetry.get("group").and_then(Value::as_table) {
+		for (_group_name, group) in groups {
+			if let Some(group_deps) = group
+				.as_table()
+				.and_then(|table| table.get("dependencies"))
+				.and_then(Value::as_table)
+			{
+				for (name, value) in group_deps {
+					let constraint = match value {
+						Value::String(version) => Some(version.clone()),
+						Value::Table(table) => table
+							.get("version")
+							.and_then(Value::as_str)
+							.map(ToString::to_string),
+						_ => None,
+					};
+					deps.push(PackageDependency {
+						name: normalize_python_package_name(name),
+						kind: DependencyKind::Development,
+						version_constraint: constraint,
+						optional: false,
+					});
+				}
+			}
+		}
+	}
+
+	deps
+}
+
+fn extract_version_constraint(spec: &str, name: &str) -> Option<String> {
+	let rest = spec.get(name.len()..)?;
+	// Skip extras like [cli]
+	let after_extras = if rest.starts_with('[') {
+		rest.find(']').map_or(rest, |end| &rest[end + 1..])
+	} else {
+		rest
+	};
+	let constraint = after_extras
+		.split(';')
+		.next()
+		.unwrap_or("")
+		.trim();
+	if constraint.is_empty() {
+		None
+	} else {
+		Some(constraint.to_string())
+	}
+}
+
+/// Parse a PEP 440 version string as semver where possible.
+///
+/// Handles common cases like `1.2.3`, `1.2`, `0.1.0`. Ignores PEP 440
+/// pre-release suffixes (`a1`, `b2`, `rc1`, `.post1`, `.dev0`) that don't
+/// map cleanly to semver.
+fn parse_pep440_as_semver(version: &str) -> Option<Version> {
+	// Try direct semver parse first
+	if let Ok(version) = Version::parse(version) {
+		return Some(version);
+	}
+	// Try adding .0 for two-part versions like "1.2"
+	let parts: Vec<&str> = version.split('.').collect();
+	match parts.len() {
+		2 => {
+			let extended = format!("{version}.0");
+			Version::parse(&extended).ok()
+		}
+		_ => None,
+	}
+}
+
+fn find_all_pyproject_files(root: &Path) -> Vec<PathBuf> {
+	WalkDir::new(root)
+		.into_iter()
+		.filter_entry(should_descend)
+		.filter_map(Result::ok)
+		.filter(|entry| entry.file_name() == PYPROJECT_FILE)
+		.map(DirEntry::into_path)
+		.map(|path| normalize_path(&path))
+		.collect()
+}
+
+fn should_descend(entry: &DirEntry) -> bool {
+	let file_name = entry.file_name().to_string_lossy();
+	!matches!(
+		file_name.as_ref(),
+		".git"
+			| ".venv" | "venv"
+			| "__pycache__"
+			| ".mypy_cache"
+			| ".ruff_cache"
+			| ".pytest_cache"
+			| "node_modules"
+			| "target" | ".devenv"
+			| "book" | ".tox"
+			| "dist" | "build"
+			| ".eggs" | "*.egg-info"
+	)
+}
+
+#[cfg(test)]
+mod __tests;

--- a/crates/monochange_python/src/lib.rs
+++ b/crates/monochange_python/src/lib.rs
@@ -288,7 +288,14 @@ pub fn discover_python_packages(root: &Path) -> MonochangeResult<AdapterDiscover
 	// Phase 1: uv workspace discovery
 	let root_manifest = root.join(PYPROJECT_FILE);
 	if root_manifest.exists() {
-		if let Some(workspace_members) = parse_uv_workspace_members(&root_manifest)? {
+		let workspace_members = match parse_uv_workspace_members(&root_manifest) {
+			Ok(members) => members,
+			Err(error) => {
+				warnings.push(format!("skipped {}: {error}", root_manifest.display()));
+				None
+			}
+		};
+		if let Some(workspace_members) = workspace_members {
 			// Exclude the workspace root manifest from standalone discovery
 			included_manifests.insert(normalize_path(&root_manifest));
 			let member_manifests =
@@ -302,7 +309,9 @@ pub fn discover_python_packages(root: &Path) -> MonochangeResult<AdapterDiscover
 		}
 	}
 
-	// Phase 2: scan for standalone pyproject.toml files not already discovered
+	// Phase 2: scan for standalone pyproject.toml files not already discovered.
+	// Parse errors are treated as warnings since the walker picks up all
+	// pyproject.toml files including test fixtures and generated files.
 	for manifest_path in find_all_pyproject_files(root) {
 		let normalized = normalize_path(&manifest_path);
 		if included_manifests.contains(&normalized) {
@@ -312,8 +321,12 @@ pub fn discover_python_packages(root: &Path) -> MonochangeResult<AdapterDiscover
 			.parent()
 			.unwrap_or_else(|| Path::new("."))
 			.to_path_buf();
-		if let Some(package) = parse_python_package(&manifest_path, &manifest_dir)? {
-			packages.push(package);
+		match parse_python_package(&manifest_path, &manifest_dir) {
+			Ok(Some(package)) => packages.push(package),
+			Ok(None) => {}
+			Err(error) => {
+				warnings.push(format!("skipped {}: {error}", manifest_path.display()));
+			}
 		}
 	}
 

--- a/docs/plans/active/python-ecosystem-refresh.md
+++ b/docs/plans/active/python-ecosystem-refresh.md
@@ -45,6 +45,8 @@ PR #152 added Python ecosystem support, but it was created against an older mono
 - [x] monitor GitHub checks
 - [x] fix changeset coverage for packages reported by CI check
 - [x] add targeted patch-coverage tests for Python/versioned-file/config/core/workspace integration
+- [x] rebase refreshed PR branch over the latest `origin/main` publish-readiness changes
+- [x] fix latest CI compile/lint/test/coverage failures after the base branch advanced
 
 ## Validation
 
@@ -53,7 +55,7 @@ PR #152 added Python ecosystem support, but it was created against an older mono
 - [x] `cargo test -p monochange_config`
 - [x] `cargo test -p monochange --features python --lib`
 - [x] `cargo fmt --all`
-- [x] `devenv shell lint:all` phases through docs/lint/deny/validation completed before publish dry-run timeout in the interactive run
+- [x] `devenv shell lint:all` completed; publish dry-run reported expected unpublished internal dependency warnings plus the Python crate readme warning without lint failures
 - [x] pre-push `lint and test` hook completed successfully before force-push
 - [x] `mc validate`
 - [x] `cargo fmt --all --check`
@@ -62,6 +64,7 @@ PR #152 added Python ecosystem support, but it was created against an older mono
 - [x] `cargo test -p monochange_core python_package_type_and_ecosystem_defaults_are_canonical`
 - [x] `cargo test -p monochange --features python apply_versioned_file_definition_updates_python_manifest_and_lock_variants`
 - [x] `cargo check -p monochange --all-features --tests`
+- [x] `cargo check --workspace --all-features --all-targets`
 - [x] `cargo test -p monochange_python` after additional patch-coverage tests
 - [x] `cargo test -p monochange --features python read_cached_document_reports_python_error_paths --lib`
 - [x] `cargo test -p monochange --features python apply_versioned_file_definition_reports_python_error_paths --lib`
@@ -69,8 +72,9 @@ PR #152 added Python ecosystem support, but it was created against an older mono
 - [x] `cargo test -p monochange --features python render_annotated_init_config_includes_python_package_type --lib`
 - [x] `cargo test -p monochange_python private_package_parser_covers_error_and_dependency_value_branches --lib`
 - [x] `cargo test -p monochange_config validate_versioned_files_and_release_notes_cover_remaining_validation_paths --lib`
+- [x] `cargo test -p monochange_config load_workspace_configuration_reports_python_ecosystem_normalization_errors --lib`
 - [x] `devenv shell coverage:all`
-- [x] `MONOCHANGE_PATCH_COVERAGE_BASE=$(git merge-base origin/main HEAD) MONOCHANGE_PATCH_COVERAGE_HEAD=HEAD devenv shell coverage:patch` (`PATCH_COVERAGE 573/573 (100.00%)`)
+- [x] `MONOCHANGE_PATCH_COVERAGE_BASE=$(git merge-base origin/main HEAD) MONOCHANGE_PATCH_COVERAGE_HEAD=HEAD devenv shell coverage:patch` (`PATCH_COVERAGE 575/575 (100.00%)`)
 
 ## Notes
 

--- a/docs/plans/active/python-ecosystem-refresh.md
+++ b/docs/plans/active/python-ecosystem-refresh.md
@@ -1,0 +1,57 @@
+# Python ecosystem refresh
+
+## Problem statement
+
+PR #152 added Python ecosystem support, but it was created against an older monochange architecture and no longer applied cleanly to `main`.
+
+## Scope
+
+- rebase the PR #152 work onto current `main` in an isolated worktree
+- preserve Python package discovery for uv workspaces, Poetry projects, and standalone `pyproject.toml` projects
+- integrate Python ecosystem configuration into current core/config/CLI/release-update paths
+- refresh documentation so Python appears alongside Cargo, npm, Deno, and Dart / Flutter
+- validate the rebased branch with targeted tests and repository quality checks
+
+## Non-goals
+
+- redesigning Python packaging semantics beyond the original PR scope
+- adding registry publishing to PyPI in this refresh
+- changing unrelated ecosystem behavior except where required by current architecture
+
+## Affected files
+
+- `crates/monochange_python/**`
+- `crates/monochange_core/src/lib.rs`
+- `crates/monochange_config/src/lib.rs`
+- `crates/monochange/src/versioned_files.rs`
+- `crates/monochange/src/workspace_ops.rs`
+- `crates/monochange/src/monochange.init.toml`
+- `.templates/**`
+- `docs/src/**`
+- `fixtures/tests/python/**`
+
+## Plan
+
+- [x] create isolated worktree on `feat/python-ecosystem-refresh`
+- [x] inspect PR #152 and identify stale integration points
+- [x] rebase original PR branch onto current `main`
+- [x] resolve architecture conflicts for workspace discovery, versioned files, config normalization, and docs
+- [x] run targeted compile check for `monochange` with Python enabled
+- [x] run formatter (`cargo fmt --all`)
+- [x] run targeted Python adapter tests
+- [ ] run repository lint/quality validation (`devenv shell lint:all`)
+- [ ] update PR branch or open replacement PR after validation
+
+## Validation
+
+- [x] `cargo check -p monochange --features python`
+- [x] `cargo test -p monochange_python`
+- [x] `cargo fmt --all`
+- [ ] `devenv shell lint:all`
+
+## Notes
+
+- Worktree: `/Users/ifiokjr/.pi/agent/worktrees/root/root/Users/ifiokjr/Developer/projects/monochange/monochange/worktrees/feat-python-ecosystem-refresh`
+- Source PR: #152 (`worktree-feat-python-ecosystem`)
+- Refresh branch: `feat/python-ecosystem-refresh`
+- Python lockfiles are handled through inferred commands (`uv lock`, `poetry lock --no-update`) instead of direct lockfile mutation.

--- a/docs/plans/active/python-ecosystem-refresh.md
+++ b/docs/plans/active/python-ecosystem-refresh.md
@@ -40,6 +40,7 @@ PR #152 added Python ecosystem support, but it was created against an older mono
 - [x] run formatter (`cargo fmt --all`)
 - [x] run targeted Python adapter tests
 - [ ] run repository lint/quality validation (`devenv shell lint:all`)
+- [x] run workspace config validation (`mc validate`)
 - [ ] update PR branch or open replacement PR after validation
 
 ## Validation
@@ -47,7 +48,8 @@ PR #152 added Python ecosystem support, but it was created against an older mono
 - [x] `cargo check -p monochange --features python`
 - [x] `cargo test -p monochange_python`
 - [x] `cargo fmt --all`
-- [ ] `devenv shell lint:all`
+- [ ] `devenv shell lint:all` (Rust, architecture, docs, JS lint, deny, and validation phases passed; timed out during publish dry-run packaging)
+- [x] `mc validate`
 
 ## Notes
 

--- a/docs/plans/active/python-ecosystem-refresh.md
+++ b/docs/plans/active/python-ecosystem-refresh.md
@@ -42,16 +42,26 @@ PR #152 added Python ecosystem support, but it was created against an older mono
 - [x] run repository lint/test validation through the pre-push hook
 - [x] run workspace config validation (`mc validate`)
 - [x] update PR #152 branch
-- [ ] monitor GitHub checks
+- [x] monitor GitHub checks
+- [x] fix changeset coverage for packages reported by CI check
+- [x] add targeted patch-coverage tests for Python/versioned-file/config/core/workspace integration
 
 ## Validation
 
 - [x] `cargo check -p monochange --features python`
 - [x] `cargo test -p monochange_python`
+- [x] `cargo test -p monochange_config`
+- [x] `cargo test -p monochange --features python --lib`
 - [x] `cargo fmt --all`
 - [x] `devenv shell lint:all` phases through docs/lint/deny/validation completed before publish dry-run timeout in the interactive run
 - [x] pre-push `lint and test` hook completed successfully before force-push
 - [x] `mc validate`
+- [x] `cargo fmt --all --check`
+- [x] `cargo test -p monochange_config load_workspace_configuration_inherits_python_ecosystem_defaults`
+- [x] `cargo test -p monochange_config load_workspace_configuration_rejects_python_versioned_file_glob_unsupported_files`
+- [x] `cargo test -p monochange_core python_package_type_and_ecosystem_defaults_are_canonical`
+- [x] `cargo test -p monochange --features python apply_versioned_file_definition_updates_python_manifest_and_lock_variants`
+- [x] `cargo check -p monochange --all-features --tests`
 
 ## Notes
 
@@ -60,3 +70,4 @@ PR #152 added Python ecosystem support, but it was created against an older mono
 - Refresh branch: `feat/python-ecosystem-refresh`
 - PR branch updated: `worktree-feat-python-ecosystem`
 - Python lockfiles are handled through inferred commands (`uv lock`, `poetry lock --no-update`) instead of direct lockfile mutation.
+- CI follow-up found missing changeset package entries and patch coverage gaps; this pass adds targeted tests plus Python manifest-name validation for configured Python packages.

--- a/docs/plans/active/python-ecosystem-refresh.md
+++ b/docs/plans/active/python-ecosystem-refresh.md
@@ -39,16 +39,18 @@ PR #152 added Python ecosystem support, but it was created against an older mono
 - [x] run targeted compile check for `monochange` with Python enabled
 - [x] run formatter (`cargo fmt --all`)
 - [x] run targeted Python adapter tests
-- [ ] run repository lint/quality validation (`devenv shell lint:all`)
+- [x] run repository lint/test validation through the pre-push hook
 - [x] run workspace config validation (`mc validate`)
-- [ ] update PR branch or open replacement PR after validation
+- [x] update PR #152 branch
+- [ ] monitor GitHub checks
 
 ## Validation
 
 - [x] `cargo check -p monochange --features python`
 - [x] `cargo test -p monochange_python`
 - [x] `cargo fmt --all`
-- [ ] `devenv shell lint:all` (Rust, architecture, docs, JS lint, deny, and validation phases passed; timed out during publish dry-run packaging)
+- [x] `devenv shell lint:all` phases through docs/lint/deny/validation completed before publish dry-run timeout in the interactive run
+- [x] pre-push `lint and test` hook completed successfully before force-push
 - [x] `mc validate`
 
 ## Notes
@@ -56,4 +58,5 @@ PR #152 added Python ecosystem support, but it was created against an older mono
 - Worktree: `/Users/ifiokjr/.pi/agent/worktrees/root/root/Users/ifiokjr/Developer/projects/monochange/monochange/worktrees/feat-python-ecosystem-refresh`
 - Source PR: #152 (`worktree-feat-python-ecosystem`)
 - Refresh branch: `feat/python-ecosystem-refresh`
+- PR branch updated: `worktree-feat-python-ecosystem`
 - Python lockfiles are handled through inferred commands (`uv lock`, `poetry lock --no-update`) instead of direct lockfile mutation.

--- a/docs/plans/active/python-ecosystem-refresh.md
+++ b/docs/plans/active/python-ecosystem-refresh.md
@@ -67,6 +67,10 @@ PR #152 added Python ecosystem support, but it was created against an older mono
 - [x] `cargo test -p monochange --features python apply_versioned_file_definition_reports_python_error_paths --lib`
 - [x] `cargo test -p monochange --features python inferred_lockfile_ecosystem_type_maps_python_when_commands_are_not_configured --lib`
 - [x] `cargo test -p monochange --features python render_annotated_init_config_includes_python_package_type --lib`
+- [x] `cargo test -p monochange_python private_package_parser_covers_error_and_dependency_value_branches --lib`
+- [x] `cargo test -p monochange_config validate_versioned_files_and_release_notes_cover_remaining_validation_paths --lib`
+- [x] `devenv shell coverage:all`
+- [x] `MONOCHANGE_PATCH_COVERAGE_BASE=$(git merge-base origin/main HEAD) MONOCHANGE_PATCH_COVERAGE_HEAD=HEAD devenv shell coverage:patch` (`PATCH_COVERAGE 573/573 (100.00%)`)
 
 ## Notes
 

--- a/docs/plans/active/python-ecosystem-refresh.md
+++ b/docs/plans/active/python-ecosystem-refresh.md
@@ -62,6 +62,11 @@ PR #152 added Python ecosystem support, but it was created against an older mono
 - [x] `cargo test -p monochange_core python_package_type_and_ecosystem_defaults_are_canonical`
 - [x] `cargo test -p monochange --features python apply_versioned_file_definition_updates_python_manifest_and_lock_variants`
 - [x] `cargo check -p monochange --all-features --tests`
+- [x] `cargo test -p monochange_python` after additional patch-coverage tests
+- [x] `cargo test -p monochange --features python read_cached_document_reports_python_error_paths --lib`
+- [x] `cargo test -p monochange --features python apply_versioned_file_definition_reports_python_error_paths --lib`
+- [x] `cargo test -p monochange --features python inferred_lockfile_ecosystem_type_maps_python_when_commands_are_not_configured --lib`
+- [x] `cargo test -p monochange --features python render_annotated_init_config_includes_python_package_type --lib`
 
 ## Notes
 

--- a/docs/src/guide/03-discovery.md
+++ b/docs/src/guide/03-discovery.md
@@ -10,6 +10,7 @@ Supported sources today:
 - npm workspaces, pnpm workspaces, Bun workspaces, and standalone `package.json` packages
 - Deno workspaces and standalone `deno.json` / `deno.jsonc` packages
 - Dart and Flutter workspaces plus standalone `pubspec.yaml` packages
+- Python uv workspaces, Poetry projects, and standalone `pyproject.toml` packages
 
 <!-- {/discoverySupportedSources} -->
 

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -343,6 +343,8 @@ Built-in direct lockfile updates cover:
 - Deno: `deno.lock`
 - Dart / Flutter: `pubspec.lock`
 
+For Python projects, monochange infers package-manager lockfile commands instead of mutating lockfiles directly: `uv.lock` uses `uv lock`, and `poetry.lock` uses `poetry lock --no-update`.
+
 If you configure `lockfile_commands` for an ecosystem, monochange stops using the built-in direct updater for that ecosystem and those commands fully own lockfile refresh. Use that escape hatch only when your workspace needs package-manager-side regeneration beyond version rewrites.
 
 For Cargo specifically, monochange no longer falls back to `cargo generate-lockfile` automatically when a lockfile looks incomplete. That keeps `mc release` on the fast path and leaves the final dependency-resolution refresh under your control: either configure `[ecosystems.cargo].lockfile_commands` explicitly or run `cargo generate-lockfile` / `cargo check` yourself afterwards.
@@ -590,6 +592,10 @@ enabled = true
 [ecosystems.dart]
 enabled = true
 lockfile_commands = [{ command = "flutter pub get", cwd = "packages/mobile" }]
+
+[ecosystems.python]
+enabled = true
+lockfile_commands = [{ command = "uv lock" }]
 ```
 
 <!-- {/configurationEcosystemSettingsSnippet} -->

--- a/docs/src/readme.md
+++ b/docs/src/readme.md
@@ -145,7 +145,7 @@ These are the commands most repositories use after running `mc init`. With the n
 
 <!-- {=projectMilestoneCapabilities} -->
 
-- discover Cargo, npm/pnpm/Bun, Deno, Dart, and Flutter packages
+- discover Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, and Python packages
 - normalize dependency edges across ecosystems
 - coordinate shared package groups from `monochange.toml`
 - compute release plans from explicit change input

--- a/fixtures/tests/python/dynamic-version/pyproject.toml
+++ b/fixtures/tests/python/dynamic-version/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "dynamic-pkg"
+dynamic = ["version"]
+dependencies = []

--- a/fixtures/tests/python/invalid-toml/pyproject.toml
+++ b/fixtures/tests/python/invalid-toml/pyproject.toml
@@ -1,0 +1,2 @@
+[project
+name = broken syntax here

--- a/fixtures/tests/python/lockfile-in-package-dir/pyproject.toml
+++ b/fixtures/tests/python/lockfile-in-package-dir/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "local-lock"
+version = "1.0.0"
+dependencies = []

--- a/fixtures/tests/python/no-project-section/pyproject.toml
+++ b/fixtures/tests/python/no-project-section/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/fixtures/tests/python/poetry-complex/pyproject.toml
+++ b/fixtures/tests/python/poetry-complex/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "complex-poetry"
+version = "2.0.0"
+
+[tool.poetry.dependencies]
+python = "^3.10"
+django = "^4.2"
+celery = {version = "^5.3", optional = true}
+local-pkg = {path = "../shared", develop = true}
+
+[tool.poetry.group.test.dependencies]
+pytest = "^7.0"
+coverage = {version = "^7.0", extras = ["toml"]}
+
+[tool.poetry.group.lint.dependencies]
+ruff = "*"

--- a/fixtures/tests/python/poetry-project/pyproject.toml
+++ b/fixtures/tests/python/poetry-project/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.poetry]
+name = "poetry-app"
+version = "3.1.0"
+description = "A Poetry-managed package"
+
+[tool.poetry.dependencies]
+python = "^3.10"
+django = "^4.2"
+celery = "^5.3"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.0"
+black = "^23.0"

--- a/fixtures/tests/python/project-no-name/pyproject.toml
+++ b/fixtures/tests/python/project-no-name/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+version = "1.0.0"
+dependencies = []

--- a/fixtures/tests/python/standalone/pyproject.toml
+++ b/fixtures/tests/python/standalone/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "standalone-tool"
+version = "2.5.0"
+requires-python = ">=3.8"
+dependencies = [
+	"requests>=2.28.0",
+	"numpy>=1.20.0; python_version < '3.9'",
+]

--- a/fixtures/tests/python/two-part-version/pyproject.toml
+++ b/fixtures/tests/python/two-part-version/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "two-part"
+version = "1.2"
+dependencies = []

--- a/fixtures/tests/python/uv-workspace-empty-pattern/pyproject.toml
+++ b/fixtures/tests/python/uv-workspace-empty-pattern/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "empty-pattern"
+version = "1.0.0"
+
+[tool.uv.workspace]
+members = [
+	"nonexistent/*",
+]

--- a/fixtures/tests/python/uv-workspace/packages/cli/pyproject.toml
+++ b/fixtures/tests/python/uv-workspace/packages/cli/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "my-cli"
+version = "1.0.0"
+requires-python = ">=3.12"
+dependencies = [
+	"my-core>=1.0.0",
+	"click>=8.0",
+]

--- a/fixtures/tests/python/uv-workspace/packages/core/pyproject.toml
+++ b/fixtures/tests/python/uv-workspace/packages/core/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "my-core"
+version = "1.0.0"
+requires-python = ">=3.12"
+dependencies = [
+	"httpx>=0.20.0",
+	"pydantic>=2.0",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0", "ruff>=0.1.0"]

--- a/fixtures/tests/python/uv-workspace/pyproject.toml
+++ b/fixtures/tests/python/uv-workspace/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "my-monorepo"
+version = "0.1.0"
+
+[tool.uv.workspace]
+members = [
+	"packages/core",
+	"packages/cli",
+]

--- a/monochange.toml
+++ b/monochange.toml
@@ -38,7 +38,7 @@ warn_on_group_mismatch = true
 # Default package type for all packages that don't declare their own `type`.
 # Setting this avoids repeating `type = "cargo"` on every [package.*] entry.
 #
-# Options: "cargo", "npm", "deno", "dart", "flutter"
+# Options: "cargo", "npm", "deno", "dart", "flutter", "python"
 # Default: none (each package must declare its own type)
 package_type = "cargo"
 
@@ -243,6 +243,9 @@ path = "crates/monochange_ecmascript"
 [package.monochange_dart]
 path = "crates/monochange_dart"
 
+[package.monochange_python]
+path = "crates/monochange_python"
+
 [package.monochange_graph]
 path = "crates/monochange_graph"
 
@@ -370,6 +373,7 @@ packages = [
 	"monochange_deno",
 	"monochange_ecmascript",
 	"monochange_dart",
+	"monochange_python",
 	"monochange_graph",
 	"monochange_semver",
 	"monochange_github",

--- a/packages/monochange__cli/README.md
+++ b/packages/monochange__cli/README.md
@@ -18,7 +18,7 @@
 
 It discovers packages, normalizes dependency data, applies group rules, turns explicit change files into release plans, and can run config-defined release preparation from those same inputs.
 
-Use it when your repository has outgrown one-ecosystem release tooling and you want one model for Cargo, npm/pnpm/Bun, Deno, and Dart/Flutter.
+Use it when your repository has outgrown one-ecosystem release tooling and you want one model for Cargo, npm/pnpm/Bun, Deno, Dart/Flutter, and Python.
 
 <!-- {/projectReadmeOverview} -->
 
@@ -167,7 +167,7 @@ See [Advanced: Assistant setup and MCP](docs/src/guide/09-assistant-setup.md) fo
 
 <!-- {=projectMilestoneCapabilities} -->
 
-- discover Cargo, npm/pnpm/Bun, Deno, Dart, and Flutter packages
+- discover Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, and Python packages
 - normalize dependency edges across ecosystems
 - coordinate shared package groups from `monochange.toml`
 - compute release plans from explicit change input
@@ -211,6 +211,8 @@ See [Advanced: Assistant setup and MCP](docs/src/guide/09-assistant-setup.md) fo
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__deno-orange?logo=rust)](https://crates.io/crates/monochange_deno) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__deno-1f425f?logo=docs.rs)](https://docs.rs/monochange_deno/)
 - `monochange_dart` — Dart and Flutter workspace discovery.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__dart-orange?logo=rust)](https://crates.io/crates/monochange_dart) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__dart-1f425f?logo=docs.rs)](https://docs.rs/monochange_dart/)
+- `monochange_python` — Python uv workspace, Poetry, and pyproject.toml discovery.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__python-orange?logo=rust)](https://crates.io/crates/monochange_python) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__python-1f425f?logo=docs.rs)](https://docs.rs/monochange_python/)
 
 <!-- {/projectCrateCatalog} -->
 

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@
 
 It discovers packages, normalizes dependency data, applies group rules, turns explicit change files into release plans, and can run config-defined release preparation from those same inputs.
 
-Use it when your repository has outgrown one-ecosystem release tooling and you want one model for Cargo, npm/pnpm/Bun, Deno, and Dart/Flutter.
+Use it when your repository has outgrown one-ecosystem release tooling and you want one model for Cargo, npm/pnpm/Bun, Deno, Dart/Flutter, and Python.
 
 <!-- {/projectReadmeOverview} -->
 
@@ -248,7 +248,7 @@ See [Advanced: Assistant setup and MCP](docs/src/guide/09-assistant-setup.md) fo
 
 <!-- {=projectMilestoneCapabilities} -->
 
-- discover Cargo, npm/pnpm/Bun, Deno, Dart, and Flutter packages
+- discover Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, and Python packages
 - normalize dependency edges across ecosystems
 - coordinate shared package groups from `monochange.toml`
 - compute release plans from explicit change input
@@ -292,6 +292,8 @@ See [Advanced: Assistant setup and MCP](docs/src/guide/09-assistant-setup.md) fo
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__deno-orange?logo=rust)](https://crates.io/crates/monochange_deno) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__deno-1f425f?logo=docs.rs)](https://docs.rs/monochange_deno/)
 - `monochange_dart` — Dart and Flutter workspace discovery.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__dart-orange?logo=rust)](https://crates.io/crates/monochange_dart) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__dart-1f425f?logo=docs.rs)](https://docs.rs/monochange_dart/)
+- `monochange_python` — Python uv workspace, Poetry, and pyproject.toml discovery.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__python-orange?logo=rust)](https://crates.io/crates/monochange_python) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__python-1f425f?logo=docs.rs)](https://docs.rs/monochange_python/)
 
 <!-- {/projectCrateCatalog} -->
 


### PR DESCRIPTION
Closes #132

## Summary

Add a complete `monochange_python` adapter crate that discovers, versions, and manages releases for Python packages across uv workspaces, Poetry projects, and standalone `pyproject.toml` files.

## Adapter implementation

- **uv workspace discovery**: Expands `[tool.uv.workspace].members` globs and discovers member packages, excluding the workspace root from standalone scanning
- **PEP 621 parsing**: Reads `[project].name`, `[project].version`, `[project].dependencies`, and `[project.optional-dependencies]`
- **Poetry fallback**: Discovers packages from `[tool.poetry]` sections with support for grouped dev dependencies (`[tool.poetry.group.*.dependencies]`), table-style version constraints, and path dependencies
- **Version updates**: Updates `[project].version` and dependency version constraints in `pyproject.toml` using format-preserving TOML editing
- **Lockfile inference**: Infers `uv lock` for uv projects (detected by `uv.lock`) and `poetry lock --no-update` for Poetry projects (detected by `poetry.lock`)
- **PEP 503 name normalization**: Normalizes package names (lowercases, replaces `[-_.]` runs with single hyphens) for cross-package dependency matching
- **PEP 440 version mapping**: Parses Python version strings and maps to semver (handles two-part versions like `1.2` → `1.2.0`)
- **Graceful error handling**: Parse errors in standalone discovery are captured as warnings, not hard errors

## Core wiring

- Add `Python` variant to `Ecosystem`, `EcosystemType`, `PackageType` enums in `monochange_core`
- Add `python` field to `WorkspaceConfiguration` and `RawEcosystems` structs
- Register Python adapter in discovery loop, versioned file dispatch, lockfile command resolution, and config validation
- Add `[ecosystems.python]` config section with full `EcosystemSettings` support
- Add `has_python` template context flag for `mc init`

## Documentation

- **Discovery guide**: Add Python to supported sources list
- **Configuration guide**: Add Python lockfile commands, ecosystem settings example with `[ecosystems.python]`
- **Init template**: Add `has_python` flag, conditional `[ecosystems.python]` block, update package type comments
- **Skill files**: Add Python to ecosystem lists, lockfile command documentation
- **Project templates**: Add `monochange_python` to crate catalog and milestone capabilities
- **mdt sync**: All consumer blocks updated (readme.md, docs/src/readme.md)

## Test plan

- [x] 46 tests covering discovery, parsing, updates, lockfile commands, and edge cases
- [x] Fixture-driven: uv-workspace, standalone, poetry-project, poetry-complex, dynamic-version, two-part-version, no-project-section, invalid-toml, lockfile-in-package-dir, uv-workspace-empty-pattern
- [x] `cargo clippy -p monochange_python --all-targets -- -D warnings` passes
- [x] `cargo test -p monochange_python -p monochange_core -p monochange_config -p monochange --lib` — 543 tests pass
- [x] `mdt check` — all consumer blocks in sync
- [x] `dprint check` — formatting clean
- [x] All 5 CI checks passing (build, check, coverage, lint, test)