### PR TITLE
feat: add Go ecosystem support (monochange_go)

### DIFF
--- a/.changeset/feat-go-ecosystem.md
+++ b/.changeset/feat-go-ecosystem.md
@@ -1,0 +1,55 @@
+---
+"@monochange/cli": patch
+"@monochange/skill": patch
+monochange: minor
+monochange_config: minor
+monochange_core: minor
+monochange_go: minor
+monochange_lint: patch
+---
+
+#### add Go ecosystem support
+
+monochange now discovers and manages Go modules from `go.mod` files in single-module and multi-module repositories.
+
+**Configuration:**
+
+```toml
+[defaults]
+package_type = "go"
+
+[package.api]
+path = "api"
+
+[package.shared]
+path = "shared"
+
+[ecosystems.go]
+enabled = true
+```
+
+**What it discovers:**
+
+- Go modules by scanning for `go.mod` files
+- Multi-module monorepos with separate modules in subdirectories
+- Module paths, including major version suffixes (`/v2`, `/v3`)
+- Cross-module `require` directives as dependency edges
+- Indirect dependencies marked as development dependencies
+
+**Version management:**
+
+- Go versions come from git tags, not manifest files — the adapter reports `None` for `current_version` and stores the module path as metadata for tag resolution
+- Updates `require` directives in `go.mod` when cross-module dependencies change
+- Preserves `replace`, `exclude`, `retract` directives and comments
+- Adds `v` prefix to version strings automatically when missing
+
+**Lockfile commands:**
+
+- Infers `go mod tidy` for all Go modules (updates both `go.mod` and `go.sum`)
+- Configurable via `[ecosystems.go].lockfile_commands`
+
+**Key design decisions:**
+
+- Module names are derived from the last non-version segment of the module path (`github.com/org/repo/api/v2` → `api`)
+- The full module path and relative directory path are stored as metadata for downstream tag resolution
+- Parse errors during discovery are treated as warnings, not hard errors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: run coverage
+        env:
+          CARGO_BUILD_JOBS: 1
         run: coverage:all
         shell: devenv shell -- bash -e {0}
 

--- a/.templates/crates.t.md
+++ b/.templates/crates.t.md
@@ -8,7 +8,7 @@
 
 `monochange` is the top-level entry point for the workspace.
 
-Reach for this crate when you want one API and CLI surface that discovers packages across Cargo, npm/pnpm/Bun, Deno, Dart/Flutter, and Python workspaces, exposes top-level commands from `monochange.toml`, and runs configured CLI commands from those definitions.
+Reach for this crate when you want one API and CLI surface that discovers packages across Cargo, npm/pnpm/Bun, Deno, Dart/Flutter, Python, and Go workspaces, exposes top-level commands from `monochange.toml`, and runs configured CLI commands from those definitions.
 
 ## Why use it?
 
@@ -578,6 +578,43 @@ Reach for this crate when you need to scan uv workspaces, Poetry projects, and s
 - lockfile command inference for `uv.lock` and `poetry.lock`
 
 <!-- {/monochangePythonCrateDocs} -->
+
+<!-- {@monochangeGoCrateDocs} -->
+
+`monochange_go` discovers Go modules for the shared planner.
+
+Reach for this crate when you need to scan standalone `go.mod` files, parse module metadata and `require` dependencies, infer `go mod tidy`, and preserve Go's tag-based versioning model in mixed-language release plans.
+
+## Why use it?
+
+- discover root and multi-module Go repositories through `go.mod` manifests
+- normalize Go module paths and `require` edges for shared release planning
+- update internal dependency requirements without treating `go.sum` as a lockfile
+- model Go releases as VCS tags, including path-prefixed tags for submodules
+
+## Best for
+
+- scanning Go modules into normalized workspace records
+- adding Go dependency edges to a mixed-language release plan
+- refreshing `go.mod` and `go.sum` through `go mod tidy` after manifest rewrites
+- publishing Go modules by creating tags such as `v1.2.3` or `api/v1.2.3`
+
+## Public entry points
+
+- `discover_go_modules(root)` discovers `go.mod` modules under a repository root
+- `parse_go_module(path, root)` parses one module manifest into package metadata
+- `update_go_mod_text(contents, dependencies)` rewrites matching `require` directives
+- `discover_lockfiles(package)` reports Go checksum artifacts for command-based refreshes
+
+## Scope
+
+- `go.mod` module directive parsing
+- direct and grouped `require` dependency extraction
+- Go semantic import version handling through module paths
+- command inference for `go mod tidy`
+- metadata used by publishing for Go proxy lookup and path-prefixed VCS tags
+
+<!-- {/monochangeGoCrateDocs} -->
 
 <!-- {@monochangeSemverCrateDocs} -->
 

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -5,6 +5,7 @@
 - Deno workspaces and standalone `deno.json` / `deno.jsonc` packages
 - Dart and Flutter workspaces plus standalone `pubspec.yaml` packages
 - Python uv workspaces, Poetry projects, and standalone `pyproject.toml` packages
+- Go modules discovered from standalone `go.mod` files
 
 <!-- {/discoverySupportedSources} -->
 
@@ -450,6 +451,11 @@ lockfile_commands = [{ command = "flutter pub get", cwd = "packages/mobile" }]
 [ecosystems.python]
 enabled = true
 lockfile_commands = [{ command = "uv lock" }]
+
+[ecosystems.go]
+enabled = true
+# monochange infers `go mod tidy` for go.mod / go.sum refreshes.
+lockfile_commands = [{ command = "go mod tidy" }]
 ```
 
 <!-- {/configurationEcosystemSettingsSnippet} -->

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -4,7 +4,7 @@
 
 It discovers packages, normalizes dependency data, applies group rules, turns explicit change files into release plans, and can run config-defined release preparation from those same inputs.
 
-Use it when your repository has outgrown one-ecosystem release tooling and you want one model for Cargo, npm/pnpm/Bun, Deno, Dart/Flutter, and Python.
+Use it when your repository has outgrown one-ecosystem release tooling and you want one model for Cargo, npm/pnpm/Bun, Deno, Dart/Flutter, Python, and Go.
 
 <!-- {/projectReadmeOverview} -->
 
@@ -44,12 +44,14 @@ Use it when your repository has outgrown one-ecosystem release tooling and you w
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__dart-orange?logo=rust)](https://crates.io/crates/monochange_dart) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__dart-1f425f?logo=docs.rs)](https://docs.rs/monochange_dart/)
 - `monochange_python` — Python uv workspace, Poetry, and pyproject.toml discovery.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__python-orange?logo=rust)](https://crates.io/crates/monochange_python) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__python-1f425f?logo=docs.rs)](https://docs.rs/monochange_python/)
+- `monochange_go` — Go module discovery, go.mod dependency rewrites, and tag-based release metadata.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__go-orange?logo=rust)](https://crates.io/crates/monochange_go) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__go-1f425f?logo=docs.rs)](https://docs.rs/monochange_go/)
 
 <!-- {/projectCrateCatalog} -->
 
 <!-- {@projectMilestoneCapabilities} -->
 
-- discover Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, and Python packages
+- discover Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, Python, and Go packages
 - normalize dependency edges across ecosystems
 - coordinate shared package groups from `monochange.toml`
 - compute release plans from explicit change input
@@ -107,13 +109,13 @@ These are the commands most repositories use after running `mc init`. With the n
 
 <!-- {/projectCommandAutomationMatrix} -->
 
-`mc publish-readiness` performs non-mutating registry checks before `mc publish`. For built-in Cargo publishes to crates.io it also verifies current manifest publishability: `publish = false` blocks publishing, `publish = [...]` must include `crates-io`, `description` must be set, and either `license` or `license-file` must be set. Workspace-inherited Cargo metadata is accepted, and already-published versions remain non-blocking when the readiness artifact still matches the current package set and publish input fingerprint. The artifact fingerprints `monochange.toml`, package manifests, lockfiles, and registry/tooling files, so rerun `mc publish-readiness` after those inputs change. `mc publish-plan --readiness <path>` validates the same artifact for planning and limits rate-limit batches to package ids that are ready in both the artifact and the fresh local readiness check. If readiness shows missing first-time registry packages, run `mc publish-bootstrap --from HEAD --output .monochange/bootstrap-result.json`, then rerun readiness before real publishing. Python packages support built-in PyPI publishing with `uv build` and `uv publish`; keep `mode = "external"` for private registries or custom Python publication flows.
+`mc publish-readiness` performs non-mutating registry checks before `mc publish`. For built-in Cargo publishes to crates.io it also verifies current manifest publishability: `publish = false` blocks publishing, `publish = [...]` must include `crates-io`, `description` must be set, and either `license` or `license-file` must be set. Workspace-inherited Cargo metadata is accepted, and already-published versions remain non-blocking when the readiness artifact still matches the current package set and publish input fingerprint. The artifact fingerprints `monochange.toml`, package manifests, lockfiles, and registry/tooling files, so rerun `mc publish-readiness` after those inputs change. `mc publish-plan --readiness <path>` validates the same artifact for planning and limits rate-limit batches to package ids that are ready in both the artifact and the fresh local readiness check. If readiness shows missing first-time registry packages, run `mc publish-bootstrap --from HEAD --output .monochange/bootstrap-result.json`, then rerun readiness before real publishing. Python packages support built-in PyPI publishing with `uv build` and `uv publish`. Go packages publish by creating VCS tags (`v1.2.3` for root modules, `path/v1.2.3` for submodules) and checking visibility through the Go module proxy. Keep `mode = "external"` for private registries or custom publication flows.
 
 <!-- {@projectCapabilityMatrix} -->
 
 | Capability                                                                     | Current status                                                                                                 |
 | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
-| Multi-ecosystem discovery                                                      | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, Python                                                               |
+| Multi-ecosystem discovery                                                      | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, Python, Go                                                           |
 | Package release planning                                                       | Built in                                                                                                       |
 | Grouped/shared versioning                                                      | Built in                                                                                                       |
 | Dry-run release diff previews                                                  | Built in via `mc release --dry-run --diff`                                                                     |
@@ -121,7 +123,8 @@ These are the commands most repositories use after running `mc init`. With the n
 | Hosted provider releases                                                       | GitHub, GitLab, Gitea                                                                                          |
 | Hosted release requests                                                        | GitHub, GitLab, Gitea                                                                                          |
 | Python release planning                                                        | Built in for discovery, version rewrites, dependency rewrites, lockfile command inference, and PyPI publishing |
-| Built-in registry publishing                                                   | `crates.io`, `npm`, `jsr`, `pub.dev`, `pypi`; use external mode for custom registries                          |
+| Go release planning                                                            | Built in for `go.mod` discovery, dependency rewrites, `go mod tidy` inference, and Go proxy tag publishing     |
+| Built-in registry publishing                                                   | `crates.io`, `npm`, `jsr`, `pub.dev`, `pypi`, Go proxy tags; use external mode for custom registries           |
 | GitHub npm trusted-publishing automation                                       | Built in                                                                                                       |
 | GitHub trusted-publishing guidance for `crates.io`, `jsr`, `pub.dev`, and PyPI | Built in, but manual registry enrollment is still required                                                     |
 | GitLab trusted-publishing auto-derivation                                      | Not built in today                                                                                             |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2057,6 +2057,7 @@ dependencies = [
  "monochange_gitea",
  "monochange_github",
  "monochange_gitlab",
+ "monochange_go",
  "monochange_graph",
  "monochange_lint",
  "monochange_npm",
@@ -2170,6 +2171,7 @@ dependencies = [
  "monochange_gitea",
  "monochange_github",
  "monochange_gitlab",
+ "monochange_go",
  "monochange_npm",
  "monochange_python",
  "monochange_test_helpers",
@@ -2312,6 +2314,23 @@ dependencies = [
  "tempfile",
  "tracing",
  "urlencoding",
+]
+
+[[package]]
+name = "monochange_go"
+version = "0.2.0"
+dependencies = [
+ "glob",
+ "insta",
+ "monochange_core",
+ "monochange_test_helpers",
+ "regex",
+ "rstest",
+ "semver",
+ "similar-asserts",
+ "tempfile",
+ "tracing",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ monochange_ecmascript = { version = "0.2.0", path = "./crates/monochange_ecmascr
 monochange_gitea = { version = "0.2.0", path = "./crates/monochange_gitea" }
 monochange_github = { version = "0.2.0", path = "./crates/monochange_github" }
 monochange_gitlab = { version = "0.2.0", path = "./crates/monochange_gitlab" }
+monochange_go = { version = "0.2.0", path = "./crates/monochange_go" }
 monochange_graph = { version = "0.2.0", path = "./crates/monochange_graph" }
 monochange_hosting = { version = "0.2.0", path = "./crates/monochange_hosting" }
 monochange_lint = { version = "0.2.0", path = "./crates/monochange_lint" }

--- a/crates/monochange/Cargo.toml
+++ b/crates/monochange/Cargo.toml
@@ -22,12 +22,13 @@ pkg-fmt = "tgz"
 bin-dir = "{ bin }{ binary-ext }"
 
 [features]
-default = ["cargo", "npm", "deno", "dart", "python", "github", "gitlab", "gitea"]
+default = ["cargo", "npm", "deno", "dart", "python", "go", "github", "gitlab", "gitea"]
 cargo = ["monochange_cargo"]
 npm = ["monochange_npm"]
 deno = ["monochange_deno"]
 dart = ["monochange_dart"]
 python = ["monochange_python"]
+go = ["monochange_go"]
 github = ["monochange_github", "monochange_core/http"]
 gitlab = ["monochange_gitlab", "monochange_core/http"]
 gitea = ["monochange_gitea", "monochange_core/http"]
@@ -48,6 +49,7 @@ monochange_deno = { workspace = true, optional = true }
 monochange_gitea = { workspace = true, optional = true }
 monochange_github = { workspace = true, optional = true }
 monochange_gitlab = { workspace = true, optional = true }
+monochange_go = { workspace = true, optional = true }
 monochange_graph = { workspace = true }
 monochange_lint = { workspace = true }
 monochange_npm = { workspace = true, optional = true }

--- a/crates/monochange/readme.md
+++ b/crates/monochange/readme.md
@@ -14,7 +14,7 @@
 
 `monochange` is the top-level entry point for the workspace.
 
-Reach for this crate when you want one API and CLI surface that discovers packages across Cargo, npm/pnpm/Bun, Deno, Dart/Flutter, and Python workspaces, exposes top-level commands from `monochange.toml`, and runs configured CLI commands from those definitions.
+Reach for this crate when you want one API and CLI surface that discovers packages across Cargo, npm/pnpm/Bun, Deno, Dart/Flutter, Python, and Go workspaces, exposes top-level commands from `monochange.toml`, and runs configured CLI commands from those definitions.
 
 ## Why use it?
 

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -9195,6 +9195,7 @@ fn build_command_and_configured_change_type_choices_include_runtime_metadata() {
 		deno: monochange_core::EcosystemSettings::default(),
 		dart: monochange_core::EcosystemSettings::default(),
 		python: monochange_core::EcosystemSettings::default(),
+		go: monochange_core::EcosystemSettings::default(),
 	};
 	assert_eq!(
 		crate::configured_change_type_choices(&configuration),
@@ -9292,6 +9293,7 @@ fn apply_runtime_change_type_choices_updates_only_unconfigured_change_inputs() {
 		deno: monochange_core::EcosystemSettings::default(),
 		dart: monochange_core::EcosystemSettings::default(),
 		python: monochange_core::EcosystemSettings::default(),
+		go: monochange_core::EcosystemSettings::default(),
 	};
 	let mut cli = vec![
 		CliCommandDefinition {
@@ -9354,6 +9356,7 @@ fn apply_runtime_change_type_choices_preserves_existing_choice_inputs_and_empty_
 		deno: monochange_core::EcosystemSettings::default(),
 		dart: monochange_core::EcosystemSettings::default(),
 		python: monochange_core::EcosystemSettings::default(),
+		go: monochange_core::EcosystemSettings::default(),
 	};
 	let mut cli = vec![CliCommandDefinition {
 		name: "change".to_string(),

--- a/crates/monochange/src/changelog.rs
+++ b/crates/monochange/src/changelog.rs
@@ -1228,6 +1228,7 @@ mod tests {
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
 			python: monochange_core::EcosystemSettings::default(),
+			go: monochange_core::EcosystemSettings::default(),
 		}
 	}
 

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -3531,6 +3531,7 @@ mod tests {
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
 			python: monochange_core::EcosystemSettings::default(),
+			go: monochange_core::EcosystemSettings::default(),
 		}
 	}
 
@@ -4925,6 +4926,7 @@ path = "crates/core"
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
 			python: monochange_core::EcosystemSettings::default(),
+			go: monochange_core::EcosystemSettings::default(),
 		};
 		let error = execute_cli_command(
 			tempdir.path(),

--- a/crates/monochange/src/interactive.rs
+++ b/crates/monochange/src/interactive.rs
@@ -435,6 +435,7 @@ mod __tests {
 			deno: EcosystemSettings::default(),
 			dart: EcosystemSettings::default(),
 			python: EcosystemSettings::default(),
+			go: EcosystemSettings::default(),
 		}
 	}
 
@@ -707,6 +708,7 @@ mod __tests {
 			deno: EcosystemSettings::default(),
 			dart: EcosystemSettings::default(),
 			python: EcosystemSettings::default(),
+			go: EcosystemSettings::default(),
 		};
 		let displays = build_selectable_targets(&configuration)
 			.into_iter()
@@ -785,6 +787,7 @@ mod __tests {
 			deno: EcosystemSettings::default(),
 			dart: EcosystemSettings::default(),
 			python: EcosystemSettings::default(),
+			go: EcosystemSettings::default(),
 		};
 		let targets = build_selectable_targets(&configuration);
 		assert_eq!(targets.len(), 1);
@@ -847,6 +850,7 @@ mod __tests {
 			deno: EcosystemSettings::default(),
 			dart: EcosystemSettings::default(),
 			python: EcosystemSettings::default(),
+			go: EcosystemSettings::default(),
 		};
 		let targets = build_selectable_targets(&configuration);
 		let ids: Vec<&str> = targets.iter().map(|t| t.id.as_str()).collect();
@@ -933,6 +937,7 @@ mod __tests {
 			deno: EcosystemSettings::default(),
 			dart: EcosystemSettings::default(),
 			python: EcosystemSettings::default(),
+			go: EcosystemSettings::default(),
 		};
 		let target = build_selectable_targets(&configuration)
 			.into_iter()

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -3,7 +3,7 @@
 //! <!-- {=monochangeCrateDocs|trim|linePrefix:"//! ":true} -->
 //! `monochange` is the top-level entry point for the workspace.
 //!
-//! Reach for this crate when you want one API and CLI surface that discovers packages across Cargo, npm/pnpm/Bun, Deno, Dart/Flutter, and Python workspaces, exposes top-level commands from `monochange.toml`, and runs configured CLI commands from those definitions.
+//! Reach for this crate when you want one API and CLI surface that discovers packages across Cargo, npm/pnpm/Bun, Deno, Dart/Flutter, Python, and Go workspaces, exposes top-level commands from `monochange.toml`, and runs configured CLI commands from those definitions.
 //!
 //! ## Why use it?
 //!

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -113,6 +113,7 @@ pub(crate) struct PublishRequest {
 	pub(crate) package_root: PathBuf,
 	pub(crate) registry: RegistryKind,
 	pub(crate) package_manager: Option<String>,
+	pub(crate) package_metadata: BTreeMap<String, String>,
 	pub(crate) mode: PublishMode,
 	pub(crate) version: String,
 	pub(crate) placeholder: bool,
@@ -176,6 +177,7 @@ pub(crate) struct RegistryEndpoints {
 	pub(crate) pub_dev_api: String,
 	pub(crate) jsr_base: String,
 	pub(crate) pypi_api: String,
+	pub(crate) go_proxy: String,
 }
 
 impl RegistryEndpoints {
@@ -193,6 +195,8 @@ impl RegistryEndpoints {
 				.unwrap_or_else(|_| "https://jsr.io".to_string()),
 			pypi_api: env::var("MONOCHANGE_PYPI_API_URL")
 				.unwrap_or_else(|_| "https://pypi.org/pypi".to_string()),
+			go_proxy: env::var("MONOCHANGE_GO_PROXY_URL")
+				.unwrap_or_else(|_| "https://proxy.golang.org".to_string()),
 		}
 	}
 }
@@ -552,6 +556,7 @@ pub(crate) fn build_placeholder_requests(
 					package.ecosystem,
 				)?,
 				package_manager: package.metadata.get("manager").cloned(),
+				package_metadata: package.metadata.clone(),
 				mode: package_definition.publish.mode,
 				version: PLACEHOLDER_VERSION.to_string(),
 				placeholder: true,
@@ -614,6 +619,7 @@ pub(crate) fn build_release_requests(
 				.to_path_buf(),
 			registry: resolve_registry_kind(publication.registry.as_ref(), package.ecosystem)?,
 			package_manager: package.metadata.get("manager").cloned(),
+			package_metadata: package.metadata.clone(),
 			mode: publication.mode,
 			version: publication.version.clone(),
 			placeholder: false,
@@ -791,6 +797,7 @@ fn default_registry_kind_for_ecosystem(ecosystem: &str) -> MonochangeResult<Regi
 		"deno" => Ok(RegistryKind::Jsr),
 		"dart" | "flutter" => Ok(RegistryKind::PubDev),
 		"python" => Ok(RegistryKind::Pypi),
+		"go" => Ok(RegistryKind::GoProxy),
 		_ => {
 			Err(MonochangeError::Config(format!(
 				"built-in package publishing does not support ecosystem `{ecosystem}`"
@@ -1360,6 +1367,8 @@ fn build_publish_command(
 		));
 	} else if request.registry == RegistryKind::Pypi && mode == PackagePublishRunMode::Release {
 		command = Some(build_python_publish_command(request, &request.package_root));
+	} else if request.registry == RegistryKind::GoProxy {
+		command = Some(build_go_publish_command(request));
 	}
 	if is_jsr_release {
 		command = Some(build_jsr_publish_command(&request.package_root));
@@ -1375,7 +1384,7 @@ fn append_publish_dry_run_args(args: &mut Vec<String>, registry: RegistryKind, d
 		return;
 	}
 
-	if registry == RegistryKind::Pypi {
+	if registry == RegistryKind::Pypi || registry == RegistryKind::GoProxy {
 		return;
 	}
 
@@ -1494,6 +1503,71 @@ fn build_python_publish_command(request: &PublishRequest, cwd: &Path) -> Command
 	}
 }
 
+fn build_go_publish_command(request: &PublishRequest) -> CommandSpec {
+	CommandSpec {
+		program: "git".to_string(),
+		args: vec!["tag".to_string(), go_module_tag_name(request)],
+		cwd: request.package_root.clone(),
+	}
+}
+
+fn go_module_tag_name(request: &PublishRequest) -> String {
+	let version = go_proxy_version(&request.version);
+	let root = request
+		.package_metadata
+		.get("relative_path")
+		.cloned()
+		.unwrap_or_else(|| fallback_go_tag_prefix(request));
+	let root = root.trim_matches('/');
+	if root.is_empty() || root == "." {
+		return version;
+	}
+	format!("{root}/{version}")
+}
+
+fn fallback_go_tag_prefix(request: &PublishRequest) -> String {
+	env::current_dir()
+		.ok()
+		.and_then(|root| {
+			request
+				.package_root
+				.strip_prefix(root)
+				.ok()
+				.map(Path::to_path_buf)
+		})
+		.unwrap_or_else(|| request.package_root.clone())
+		.to_string_lossy()
+		.to_string()
+}
+
+fn go_module_path(request: &PublishRequest) -> &str {
+	request
+		.package_metadata
+		.get("module_path")
+		.map_or(request.package_name.as_str(), String::as_str)
+}
+
+fn go_proxy_version(version: &str) -> String {
+	if version.starts_with('v') {
+		version.to_string()
+	} else {
+		format!("v{version}")
+	}
+}
+
+fn go_proxy_module_path(module: &str) -> String {
+	let mut escaped = String::with_capacity(module.len());
+	for character in module.chars() {
+		if character.is_ascii_uppercase() {
+			escaped.push('!');
+			escaped.push(character.to_ascii_lowercase());
+		} else {
+			escaped.push(character);
+		}
+	}
+	escaped
+}
+
 fn build_placeholder_directory(
 	root: &Path,
 	request: &PublishRequest,
@@ -1534,6 +1608,8 @@ fn build_placeholder_directory(
 			request,
 			source,
 		));
+	} else if request.registry == RegistryKind::GoProxy {
+		manifest_result = Some(write_go_placeholder_manifest(tempdir_path, request));
 	}
 	if is_jsr_registry {
 		manifest_result = Some(write_jsr_placeholder_manifest(
@@ -1545,6 +1621,18 @@ fn build_placeholder_directory(
 	manifest_result.expect("unsupported built-in publish registry")?;
 
 	Ok(tempdir)
+}
+
+fn write_go_placeholder_manifest(dir: &Path, request: &PublishRequest) -> MonochangeResult<()> {
+	let contents = format!(
+		"module {}
+
+go 1.22
+",
+		go_module_path(request)
+	);
+	fs::write(dir.join("go.mod"), contents)
+		.map_err(|error| MonochangeError::Io(format!("failed to write go.mod: {error}")))
 }
 
 fn write_npm_placeholder_manifest(
@@ -1985,6 +2073,26 @@ fn registry_version_exists(
 		return Ok(exists);
 	}
 
+	if request.registry == RegistryKind::GoProxy {
+		let url = format!(
+			"{}/{}/@v/{}.info",
+			endpoints.go_proxy.trim_end_matches('/'),
+			go_proxy_module_path(go_module_path(request)),
+			go_proxy_version(&request.version)
+		);
+		let response = client
+			.get(url)
+			.send()
+			.map_err(http_error("Go proxy version lookup"))?;
+		if response.status() == StatusCode::NOT_FOUND || response.status() == StatusCode::GONE {
+			return Ok(false);
+		}
+		response
+			.error_for_status()
+			.map_err(http_error("Go proxy version lookup"))?;
+		return Ok(true);
+	}
+
 	let url = format!(
 		"{}/{}/meta.json",
 		endpoints.jsr_base.trim_end_matches('/'),
@@ -2195,6 +2303,8 @@ fn manual_setup_url(request: &PublishRequest) -> String {
 			"https://pypi.org/manage/project/{}/settings/publishing/",
 			request.package_name
 		)
+	} else if request.registry == RegistryKind::GoProxy {
+		format!("https://pkg.go.dev/{}", go_module_path(request))
 	} else {
 		format!(
 			"https://www.npmjs.com/package/{}/access",
@@ -2213,6 +2323,8 @@ fn trust_docs_url(registry: RegistryKind) -> &'static str {
 		JSR_TRUST_DOCS_URL
 	} else if registry == RegistryKind::Pypi {
 		PYPI_TRUST_DOCS_URL
+	} else if registry == RegistryKind::GoProxy {
+		"https://go.dev/ref/mod#publishing"
 	} else {
 		NPM_TRUST_DOCS_URL
 	}) as _
@@ -2292,6 +2404,8 @@ mod tests {
 				Ecosystem::Dart
 			} else if registry == RegistryKind::Pypi {
 				Ecosystem::Python
+			} else if registry == RegistryKind::GoProxy {
+				Ecosystem::Go
 			} else {
 				Ecosystem::Deno
 			},
@@ -2299,6 +2413,7 @@ mod tests {
 			package_root: PathBuf::from("/workspace/pkg"),
 			registry,
 			package_manager: (registry == RegistryKind::Npm).then(|| "npm".to_string()),
+			package_metadata: BTreeMap::new(),
 			mode: PublishMode::Builtin,
 			version: "1.2.3".to_string(),
 			placeholder: false,
@@ -2383,6 +2498,7 @@ mod tests {
 			pub_dev_api: base_url.to_string(),
 			jsr_base: base_url.to_string(),
 			pypi_api: base_url.to_string(),
+			go_proxy: base_url.to_string(),
 		}
 	}
 
@@ -2448,6 +2564,7 @@ mod tests {
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
 			python: monochange_core::EcosystemSettings::default(),
+			go: monochange_core::EcosystemSettings::default(),
 		}
 	}
 
@@ -2955,6 +3072,111 @@ jobs:
 		);
 		assert_eq!(pypi_release.cwd, PathBuf::from("/workspace/pkg"));
 		assert!(render_command(&pypi_release).contains("uv publish --trusted-publishing always"));
+
+		let go_request = PublishRequest {
+			ecosystem: Ecosystem::Go,
+			package_name: "api".to_string(),
+			package_root: PathBuf::from("/workspace/api"),
+			package_metadata: BTreeMap::from([
+				(
+					"module_path".to_string(),
+					"github.com/example/api".to_string(),
+				),
+				("relative_path".to_string(), "api".to_string()),
+			]),
+			..sample_request(RegistryKind::GoProxy)
+		};
+		let go = build_publish_command(&go_request, PackagePublishRunMode::Release, None, false);
+		assert_eq!(go.program, "git");
+		assert_eq!(go.args, vec!["tag".to_string(), "api/v1.2.3".to_string()]);
+	}
+
+	#[test]
+	fn go_publish_command_uses_root_tag_when_relative_path_is_current_directory() {
+		let request = PublishRequest {
+			version: "v2.0.0".to_string(),
+			package_metadata: BTreeMap::from([("relative_path".to_string(), ".".to_string())]),
+			..sample_request(RegistryKind::GoProxy)
+		};
+
+		let command = build_publish_command(&request, PackagePublishRunMode::Release, None, false);
+
+		assert_eq!(command.args, vec!["tag".to_string(), "v2.0.0".to_string()]);
+	}
+
+	#[test]
+	fn go_publish_command_falls_back_to_package_root_prefix() {
+		let cwd = env::current_dir().expect("current dir");
+		let request = PublishRequest {
+			version: "1.2.3".to_string(),
+			package_root: cwd.join("api"),
+			package_metadata: BTreeMap::new(),
+			..sample_request(RegistryKind::GoProxy)
+		};
+
+		let command = build_publish_command(&request, PackagePublishRunMode::Release, None, false);
+
+		assert_eq!(
+			command.args,
+			vec!["tag".to_string(), "api/v1.2.3".to_string()]
+		);
+	}
+
+	#[test]
+	fn build_placeholder_directory_writes_go_mod_for_go_proxy() {
+		let root = tempfile::tempdir().expect("tempdir");
+		let request = PublishRequest {
+			package_metadata: BTreeMap::from([(
+				"module_path".to_string(),
+				"github.com/example/repo/api".to_string(),
+			)]),
+			..sample_request(RegistryKind::GoProxy)
+		};
+
+		let placeholder = build_placeholder_directory(root.path(), &request, None)
+			.expect("go placeholder directory");
+		let go_mod = fs::read_to_string(placeholder.path().join("go.mod")).expect("go.mod");
+
+		assert_eq!(go_mod, "module github.com/example/repo/api\n\ngo 1.22\n");
+	}
+
+	#[test]
+	fn build_placeholder_directory_uses_package_name_when_go_module_metadata_is_missing() {
+		let root = tempfile::tempdir().expect("tempdir");
+		let request = PublishRequest {
+			package_name: "github.com/example/fallback".to_string(),
+			package_metadata: BTreeMap::new(),
+			..sample_request(RegistryKind::GoProxy)
+		};
+
+		let placeholder = build_placeholder_directory(root.path(), &request, None)
+			.expect("go placeholder directory");
+		let go_mod = fs::read_to_string(placeholder.path().join("go.mod")).expect("go.mod");
+
+		assert_eq!(go_mod, "module github.com/example/fallback\n\ngo 1.22\n");
+	}
+
+	#[test]
+	fn registry_version_exists_returns_false_for_missing_go_proxy_version() {
+		let server = MockServer::start();
+		server.mock(|when, then| {
+			when.method(GET)
+				.path("/github.com/example/repo/@v/v1.2.3.info");
+			then.status(404);
+		});
+		let client = Client::builder().build().expect("http client:");
+		let endpoints = sample_endpoints(&server.base_url());
+		let request = PublishRequest {
+			package_metadata: BTreeMap::from([(
+				"module_path".to_string(),
+				"github.com/example/repo".to_string(),
+			)]),
+			..sample_request(RegistryKind::GoProxy)
+		};
+
+		assert!(
+			!registry_version_exists(&client, &endpoints, &request).expect("missing go version")
+		);
 	}
 
 	#[test]
@@ -3001,6 +3223,14 @@ jobs:
 			true,
 		);
 		assert!(!render_command(&pypi).contains("--dry-run"));
+
+		let go = build_publish_command(
+			&sample_request(RegistryKind::GoProxy),
+			PackagePublishRunMode::Release,
+			None,
+			true,
+		);
+		assert!(!go.args.contains(&"--dry-run".to_string()));
 	}
 
 	#[test]
@@ -3073,6 +3303,14 @@ jobs:
 			manual_setup_url(&sample_request(RegistryKind::Pypi)),
 			"https://pypi.org/manage/project/pkg/settings/publishing/".to_string()
 		);
+		let go_request = PublishRequest {
+			package_name: "github.com/example/pkg".to_string(),
+			..sample_request(RegistryKind::GoProxy)
+		};
+		assert_eq!(
+			manual_setup_url(&go_request),
+			"https://pkg.go.dev/github.com/example/pkg".to_string()
+		);
 		assert_eq!(trust_docs_url(RegistryKind::Npm), NPM_TRUST_DOCS_URL);
 		assert_eq!(
 			trust_docs_url(RegistryKind::CratesIo),
@@ -3081,6 +3319,10 @@ jobs:
 		assert_eq!(trust_docs_url(RegistryKind::PubDev), DART_TRUST_DOCS_URL);
 		assert_eq!(trust_docs_url(RegistryKind::Jsr), JSR_TRUST_DOCS_URL);
 		assert_eq!(trust_docs_url(RegistryKind::Pypi), PYPI_TRUST_DOCS_URL);
+		assert_eq!(
+			trust_docs_url(RegistryKind::GoProxy),
+			"https://go.dev/ref/mod#publishing"
+		);
 	}
 
 	#[test]
@@ -3152,6 +3394,14 @@ jobs:
 				"releases": { "1.2.3": [] }
 			}));
 		});
+		server.mock(|when, then| {
+			when.method(GET)
+				.path("/github.com/example/!repo/api/@v/v1.2.3.info");
+			then.status(200).json_body_obj(&serde_json::json!({
+				"Version": "v1.2.3",
+				"Time": "2026-04-28T00:00:00Z"
+			}));
+		});
 		let client = Client::builder().build().expect("http client:");
 		let endpoints = RegistryEndpoints {
 			npm_registry: server.base_url(),
@@ -3160,6 +3410,7 @@ jobs:
 			pub_dev_api: server.base_url(),
 			jsr_base: server.base_url(),
 			pypi_api: server.base_url(),
+			go_proxy: server.base_url(),
 		};
 
 		assert!(
@@ -3182,6 +3433,14 @@ jobs:
 			registry_version_exists(&client, &endpoints, &sample_request(RegistryKind::Pypi))
 				.expect("PyPI exists:")
 		);
+		let go_request = PublishRequest {
+			package_metadata: BTreeMap::from([(
+				"module_path".to_string(),
+				"github.com/example/Repo/api".to_string(),
+			)]),
+			..sample_request(RegistryKind::GoProxy)
+		};
+		assert!(registry_version_exists(&client, &endpoints, &go_request).expect("Go exists:"));
 	}
 
 	#[test]
@@ -3414,6 +3673,7 @@ jobs:
 			pub_dev_api: server.base_url(),
 			jsr_base: server.base_url(),
 			pypi_api: server.base_url(),
+			go_proxy: server.base_url(),
 		};
 		let request = sample_request(RegistryKind::Npm);
 		let request = PublishRequest {
@@ -4981,6 +5241,7 @@ version = "1.2.3"
 			pub_dev_api: server.base_url(),
 			jsr_base: server.base_url(),
 			pypi_api: server.base_url(),
+			go_proxy: server.base_url(),
 		};
 		let request = PublishRequest {
 			mode: PublishMode::External,
@@ -5711,7 +5972,10 @@ version = "1.2.3"
 			current_version: Some(Version::parse("1.0.0").expect("version:")),
 			publish_state: PublishState::Public,
 			version_group_id: None,
-			metadata: BTreeMap::from([("config_id".to_string(), "pkg".to_string())]),
+			metadata: BTreeMap::from([
+				("config_id".to_string(), "pkg".to_string()),
+				("manager".to_string(), "pnpm".to_string()),
+			]),
 			declared_dependencies: Vec::new(),
 		};
 		let publication = PackagePublicationTarget {
@@ -5728,7 +5992,13 @@ version = "1.2.3"
 			build_release_requests(&configuration, &[package], &[publication], &BTreeSet::new())
 				.expect("requests:");
 		assert_eq!(requests.len(), 1);
-		assert_eq!(requests[0].version, "1.2.3");
-		assert_eq!(requests[0].package_name, "pkg");
+		let request = requests.first().expect("request");
+		assert_eq!(request.version, "1.2.3");
+		assert_eq!(request.package_name, "pkg");
+		assert_eq!(request.package_manager.as_deref(), Some("pnpm"));
+		assert_eq!(
+			request.package_metadata.get("manager").map(String::as_str),
+			Some("pnpm")
+		);
 	}
 }

--- a/crates/monochange/src/publish_rate_limits.rs
+++ b/crates/monochange/src/publish_rate_limits.rs
@@ -380,6 +380,20 @@ fn registry_policies() -> Vec<RegistryRateLimitPolicy> {
 				notes: "official trusted-publisher workflow guidance but no exact package publish quota".to_string(),
 			}],
 		},
+		RegistryRateLimitPolicy {
+			registry: RegistryKind::GoProxy,
+			operation: RateLimitOperation::Publish,
+			limit: None,
+			window_seconds: None,
+			confidence: RateLimitConfidence::Low,
+			notes: "Go modules are published by pushing VCS tags; the public proxy does not document a precise publish quota".to_string(),
+			evidence: vec![RateLimitEvidence {
+				title: "Go module publishing reference".to_string(),
+				url: "https://go.dev/ref/mod#publishing".to_string(),
+				kind: RateLimitEvidenceKind::Official,
+				notes: "official module publishing guidance documents tag-based publication".to_string(),
+			}],
+		},
 	]
 }
 
@@ -445,6 +459,7 @@ mod tests {
 			package_root: Path::new("workspace").to_path_buf(),
 			registry,
 			package_manager: Some("pnpm".to_string()),
+			package_metadata: BTreeMap::new(),
 			mode,
 			version: Version::new(1, 0, 0).to_string(),
 			placeholder: false,
@@ -558,6 +573,7 @@ mod tests {
 			pub_dev_api: server.base_url(),
 			jsr_base: server.base_url(),
 			pypi_api: server.base_url(),
+			go_proxy: server.base_url(),
 		};
 		let requests = build_release_plan_requests_with_transport(
 			tempdir.path(),
@@ -657,6 +673,7 @@ mod tests {
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
 			python: monochange_core::EcosystemSettings::default(),
+			go: monochange_core::EcosystemSettings::default(),
 		};
 		let packages = vec![
 			monochange_core::PackageRecord {
@@ -822,6 +839,7 @@ mod tests {
 			pub_dev_api: server.base_url(),
 			jsr_base: server.base_url(),
 			pypi_api: server.base_url(),
+			go_proxy: server.base_url(),
 		};
 		let requests = build_release_plan_requests_with_transport(
 			tempdir.path(),
@@ -892,6 +910,7 @@ mod tests {
 			pub_dev_api: server.base_url(),
 			jsr_base: server.base_url(),
 			pypi_api: server.base_url(),
+			go_proxy: server.base_url(),
 		};
 		let requests = build_placeholder_plan_requests_with_transport(
 			tempdir.path(),
@@ -973,6 +992,7 @@ mod tests {
 			pub_dev_api: server.base_url(),
 			jsr_base: server.base_url(),
 			pypi_api: server.base_url(),
+			go_proxy: server.base_url(),
 		};
 		let requests = build_placeholder_plan_requests_with_transport(
 			tempdir.path(),
@@ -1073,6 +1093,7 @@ mod tests {
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
 			python: monochange_core::EcosystemSettings::default(),
+			go: monochange_core::EcosystemSettings::default(),
 		};
 		let unenforced = PublishRateLimitReport {
 			dry_run: true,
@@ -1133,6 +1154,7 @@ mod tests {
 					package_root: Path::new("pkg-a").to_path_buf(),
 					registry: RegistryKind::PubDev,
 					package_manager: None,
+					package_metadata: BTreeMap::new(),
 					mode: PublishMode::Builtin,
 					version: Version::new(1, 0, 0).to_string(),
 					placeholder: false,
@@ -1185,6 +1207,7 @@ mod tests {
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
 			python: monochange_core::EcosystemSettings::default(),
+			go: monochange_core::EcosystemSettings::default(),
 		};
 		let error =
 			enforce_publish_rate_limits(&configuration, &report, PublishRateLimitMode::Publish)

--- a/crates/monochange/src/publish_readiness.rs
+++ b/crates/monochange/src/publish_readiness.rs
@@ -815,6 +815,7 @@ mod tests {
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
 			python: monochange_core::EcosystemSettings::default(),
+			go: monochange_core::EcosystemSettings::default(),
 		}
 	}
 

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -1501,6 +1501,7 @@ mod tests {
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
 			python: monochange_core::EcosystemSettings::default(),
+			go: monochange_core::EcosystemSettings::default(),
 		}
 	}
 

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -50,6 +50,8 @@ pub(crate) enum VersionedFileKind {
 	Dart(monochange_dart::DartVersionedFileKind),
 	#[cfg(feature = "python")]
 	Python(monochange_python::PythonVersionedFileKind),
+	#[cfg(feature = "go")]
+	Go(monochange_go::GoVersionedFileKind),
 }
 
 pub(crate) fn versioned_file_kind(
@@ -76,6 +78,10 @@ pub(crate) fn versioned_file_kind(
 		#[cfg(feature = "python")]
 		monochange_core::EcosystemType::Python => {
 			monochange_python::supported_versioned_file_kind(path).map(VersionedFileKind::Python)
+		}
+		#[cfg(feature = "go")]
+		monochange_core::EcosystemType::Go => {
+			monochange_go::supported_versioned_file_kind(path).map(VersionedFileKind::Go)
 		}
 		_ => None,
 	}
@@ -332,6 +338,10 @@ fn inferred_lockfile_ecosystem_type(
 		Ecosystem::Python if configuration.python.lockfile_commands.is_empty() => {
 			Some(monochange_core::EcosystemType::Python)
 		}
+		#[cfg(feature = "go")]
+		Ecosystem::Go if configuration.go.lockfile_commands.is_empty() => {
+			Some(monochange_core::EcosystemType::Go)
+		}
 		_ => None,
 	}
 }
@@ -346,6 +356,8 @@ fn inferred_lockfile_paths(package: &PackageRecord) -> Vec<PathBuf> {
 		Ecosystem::Deno => monochange_deno::discover_lockfiles(package),
 		#[cfg(feature = "dart")]
 		Ecosystem::Dart | Ecosystem::Flutter => monochange_dart::discover_lockfiles(package),
+		#[cfg(feature = "go")]
+		Ecosystem::Go => monochange_go::discover_lockfiles(package),
 		_ => Vec::new(),
 	}
 }
@@ -433,6 +445,7 @@ pub(crate) fn read_cached_document(
 				monochange_core::EcosystemType::Deno => "deno",
 				monochange_core::EcosystemType::Dart => "dart",
 				monochange_core::EcosystemType::Python => "python",
+				monochange_core::EcosystemType::Go => "go",
 				_ => "unknown",
 			},
 		)));
@@ -574,6 +587,16 @@ pub(crate) fn read_cached_document(
 			};
 			Ok(CachedDocument::Text(contents))
 		}
+		#[cfg(feature = "go")]
+		VersionedFileKind::Go(_) => {
+			let Some(contents) = text_contents else {
+				return Err(MonochangeError::Config(format!(
+					"failed to parse {} as text",
+					path.display()
+				)));
+			};
+			Ok(CachedDocument::Text(contents))
+		}
 		#[cfg(feature = "dart")]
 		VersionedFileKind::Dart(monochange_dart::DartVersionedFileKind::Manifest) => {
 			let Some(contents) = text_contents else {
@@ -651,6 +674,9 @@ pub(crate) fn resolve_versioned_prefix(
 				.python
 				.dependency_version_prefix
 				.clone()
+		}
+		monochange_core::EcosystemType::Go => {
+			context.configuration.go.dependency_version_prefix.clone()
 		}
 		_ => None,
 	};
@@ -813,6 +839,7 @@ pub(crate) fn apply_versioned_file_definition(
 					monochange_core::EcosystemType::Deno => "deno",
 					monochange_core::EcosystemType::Dart => "dart",
 					monochange_core::EcosystemType::Python => "python",
+					monochange_core::EcosystemType::Go => "go",
 					_ => "unknown",
 				},
 			)));
@@ -971,6 +998,13 @@ pub(crate) fn apply_versioned_file_definition(
 			) => {
 				monochange_dart::update_pubspec_lock(mapping, &raw_versions);
 			}
+			#[cfg(feature = "go")]
+			(
+				CachedDocument::Text(contents),
+				VersionedFileKind::Go(monochange_go::GoVersionedFileKind::GoMod),
+			) => {
+				*contents = monochange_go::update_go_mod_text(contents, &versioned_deps);
+			}
 			#[cfg(feature = "python")]
 			(CachedDocument::Text(contents), VersionedFileKind::Python(kind)) => {
 				*contents = monochange_python::update_versioned_file_text(
@@ -1008,17 +1042,188 @@ pub(crate) fn released_versions_by_record_id(plan: &ReleasePlan) -> BTreeMap<Str
 
 #[cfg(test)]
 mod tests {
+	use std::collections::BTreeMap;
+	use std::path::Path;
 	use std::path::PathBuf;
 
 	use monochange_core::Ecosystem;
 	use monochange_core::EcosystemType;
 
+	use super::CachedDocument;
+	use super::VersionedFileUpdateContext;
+	use super::apply_versioned_file_definition;
 	use super::inferred_lockfile_ecosystem_type;
+	use super::inferred_lockfile_paths;
+	use super::read_cached_document;
+	use super::versioned_file_kind;
 
 	fn fixture_path(relative: &str) -> PathBuf {
 		PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 			.join("../../fixtures/tests")
 			.join(relative)
+	}
+
+	#[test]
+	fn go_versioned_file_kind_and_lockfile_inference_are_supported() {
+		let configuration = monochange_config::load_workspace_configuration(&fixture_path(
+			"monochange/release-base",
+		))
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+		let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let module_dir = tempdir.path().join("api");
+		std::fs::create_dir(&module_dir)
+			.unwrap_or_else(|error| panic!("create api module dir: {error}"));
+		std::fs::write(module_dir.join("go.sum"), "")
+			.unwrap_or_else(|error| panic!("write go.sum: {error}"));
+		let package = monochange_core::PackageRecord {
+			ecosystem: Ecosystem::Go,
+			manifest_path: module_dir.join("go.mod"),
+			..monochange_core::PackageRecord::new(
+				Ecosystem::Go,
+				"github.com/example/repo/api",
+				module_dir.join("go.mod"),
+				tempdir.path().to_path_buf(),
+				None,
+				monochange_core::PublishState::Public,
+			)
+		};
+
+		assert!(versioned_file_kind(EcosystemType::Go, Path::new("go.mod")).is_some());
+		assert_eq!(
+			inferred_lockfile_ecosystem_type(&configuration, Ecosystem::Go),
+			Some(EcosystemType::Go)
+		);
+		assert_eq!(
+			inferred_lockfile_paths(&package),
+			vec![module_dir.join("go.sum")]
+		);
+	}
+
+	#[test]
+	fn read_cached_document_handles_go_text_and_invalid_utf8() {
+		let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let go_mod = tempdir.path().join("go.mod");
+		std::fs::write(&go_mod, "module github.com/example/repo\n")
+			.unwrap_or_else(|error| panic!("write go.mod: {error}"));
+		let mut updates = BTreeMap::new();
+
+		let document = read_cached_document(&mut updates, &go_mod, EcosystemType::Go)
+			.unwrap_or_else(|error| panic!("go text document: {error}"));
+		assert!(matches!(document, CachedDocument::Text(_)));
+
+		std::fs::write(&go_mod, [0xff, 0xfe])
+			.unwrap_or_else(|error| panic!("write invalid go.mod: {error}"));
+		let error = read_cached_document(&mut updates, &go_mod, EcosystemType::Go)
+			.expect_err("invalid go.mod should fail");
+		assert!(error.to_string().contains("failed to parse"));
+	}
+
+	#[test]
+	fn read_cached_document_reports_go_for_unsupported_go_versioned_file() {
+		let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let notes = tempdir.path().join("notes.txt");
+		std::fs::write(&notes, "version = 1.0.0\n")
+			.unwrap_or_else(|error| panic!("write notes: {error}"));
+		let mut updates = BTreeMap::new();
+
+		let error = read_cached_document(&mut updates, &notes, EcosystemType::Go)
+			.expect_err("unsupported go versioned file");
+
+		assert!(error.to_string().contains("ecosystem `go`"));
+	}
+
+	#[test]
+	fn apply_versioned_file_definition_reports_go_for_unsupported_glob_match() {
+		let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		std::fs::write(tempdir.path().join("notes.txt"), "version = 1.0.0\n")
+			.unwrap_or_else(|error| panic!("write notes: {error}"));
+		let configuration = monochange_config::load_workspace_configuration(&fixture_path(
+			"monochange/release-base",
+		))
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+		let mut released_versions = BTreeMap::new();
+		released_versions.insert("lib".to_string(), "1.2.3".to_string());
+		let context = VersionedFileUpdateContext {
+			package_by_config_id: BTreeMap::new(),
+			package_by_native_name: BTreeMap::new(),
+			current_versions_by_native_name: BTreeMap::new(),
+			released_versions_by_native_name: released_versions,
+			configuration: &configuration,
+		};
+		let definition = monochange_core::VersionedFileDefinition {
+			path: "*.txt".to_string(),
+			ecosystem_type: Some(EcosystemType::Go),
+			prefix: None,
+			fields: None,
+			name: None,
+			regex: None,
+		};
+		let mut updates = BTreeMap::new();
+
+		let error = apply_versioned_file_definition(
+			tempdir.path(),
+			&mut updates,
+			&definition,
+			"1.2.3",
+			None,
+			&["lib".to_string()],
+			&context,
+		)
+		.expect_err("unsupported go glob match");
+
+		assert!(error.to_string().contains("ecosystem `go`"));
+	}
+
+	#[test]
+	fn apply_versioned_file_definition_updates_go_mod_dependencies() {
+		let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let go_mod = tempdir.path().join("go.mod");
+		std::fs::write(
+			&go_mod,
+			"module github.com/example/app\n\ngo 1.22\n\nrequire github.com/example/lib v1.0.0\n",
+		)
+		.unwrap_or_else(|error| panic!("write go.mod: {error}"));
+		let configuration = monochange_config::load_workspace_configuration(&fixture_path(
+			"monochange/release-base",
+		))
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+		let mut released_versions = BTreeMap::new();
+		released_versions.insert("lib".to_string(), "1.2.3".to_string());
+		let context = VersionedFileUpdateContext {
+			package_by_config_id: BTreeMap::new(),
+			package_by_native_name: BTreeMap::new(),
+			current_versions_by_native_name: BTreeMap::new(),
+			released_versions_by_native_name: released_versions,
+			configuration: &configuration,
+		};
+		let definition = monochange_core::VersionedFileDefinition {
+			path: "go.mod".to_string(),
+			ecosystem_type: Some(EcosystemType::Go),
+			prefix: None,
+			fields: None,
+			name: None,
+			regex: None,
+		};
+		let mut updates = BTreeMap::new();
+
+		apply_versioned_file_definition(
+			tempdir.path(),
+			&mut updates,
+			&definition,
+			"1.2.3",
+			None,
+			&["lib".to_string()],
+			&context,
+		)
+		.unwrap_or_else(|error| panic!("apply go update: {error}"));
+		let updated_document = updates
+			.into_values()
+			.next()
+			.unwrap_or_else(|| panic!("updated go.mod"));
+		assert!(matches!(
+			updated_document,
+			CachedDocument::Text(contents) if contents.contains("github.com/example/lib v1.2.3")
+		));
 	}
 
 	#[test]

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -38,6 +38,8 @@ use monochange_dart::load_configured_dart_package;
 use monochange_deno::discover_deno_packages;
 #[cfg(feature = "deno")]
 use monochange_deno::load_configured_deno_package;
+#[cfg(feature = "go")]
+use monochange_go::discover_go_modules;
 #[cfg(feature = "npm")]
 use monochange_npm::discover_npm_packages;
 #[cfg(feature = "npm")]
@@ -520,6 +522,7 @@ fn render_annotated_init_config(
 			PackageType::Dart => "dart",
 			PackageType::Flutter => "flutter",
 			PackageType::Python => "python",
+			PackageType::Go => "go",
 			_ => unreachable!(),
 		};
 
@@ -542,6 +545,7 @@ fn render_annotated_init_config(
 		.iter()
 		.any(|p| p.ecosystem == Ecosystem::Dart || p.ecosystem == Ecosystem::Flutter);
 	let has_python = packages.iter().any(|p| p.ecosystem == Ecosystem::Python);
+	let has_go = packages.iter().any(|p| p.ecosystem == Ecosystem::Go);
 
 	let package_ids_toml = package_ids
 		.iter()
@@ -558,6 +562,7 @@ fn render_annotated_init_config(
 		"has_deno": has_deno,
 		"has_dart": has_dart,
 		"has_python": has_python,
+		"has_go": has_go,
 		"provider": provider.unwrap_or(""),
 		"owner": remote.map_or("your-org", |r| r.owner.as_str()),
 		"repo": remote.map_or("your-repo", |r| r.repo.as_str()),
@@ -599,6 +604,8 @@ fn discover_packages(root: &Path) -> MonochangeResult<Vec<PackageRecord>> {
 	packages.extend(discover_dart_packages(root)?.packages);
 	#[cfg(feature = "python")]
 	packages.extend(discover_python_packages(root)?.packages);
+	#[cfg(feature = "go")]
+	packages.extend(discover_go_modules(root)?.packages);
 
 	normalize_package_ids(root, &mut packages);
 	packages.sort_by(|left, right| left.id.cmp(&right.id));
@@ -644,6 +651,7 @@ fn package_type_for_ecosystem(ecosystem: Ecosystem) -> PackageType {
 		Ecosystem::Dart => PackageType::Dart,
 		Ecosystem::Flutter => PackageType::Flutter,
 		Ecosystem::Python => PackageType::Python,
+		Ecosystem::Go => PackageType::Go,
 		_ => PackageType::Cargo,
 	}
 }
@@ -655,6 +663,24 @@ fn package_type_for_ecosystem_maps_python() {
 		PackageType::Python
 	);
 	assert_eq!(PackageType::Python.as_str(), "python");
+	assert_eq!(package_type_for_ecosystem(Ecosystem::Go), PackageType::Go);
+	assert_eq!(PackageType::Go.as_str(), "go");
+}
+
+#[test]
+fn render_annotated_init_config_includes_go_package_type() {
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	fs::write(
+		root.join("go.mod"),
+		"module github.com/example/app\n\ngo 1.22\n",
+	)
+	.unwrap_or_else(|error| panic!("write go.mod: {error}"));
+
+	let rendered = render_annotated_init_config(root, None, None)
+		.unwrap_or_else(|error| panic!("render init config: {error}"));
+
+	assert!(rendered.contains("type = \"go\""));
 }
 
 #[test]
@@ -696,6 +722,9 @@ pub(crate) fn build_lockfile_command_executions(
 	#[cfg(feature = "python")]
 	#[rustfmt::skip]
 	let python_executions = resolve_lockfile_command_executions(root, &configuration.python.lockfile_commands, packages.iter().any(|package| package.ecosystem == Ecosystem::Python && released_versions.contains_key(&package.id)))?;
+	#[cfg(feature = "go")]
+	#[rustfmt::skip]
+	let go_executions = resolve_lockfile_command_executions(root, &configuration.go.lockfile_commands, packages.iter().any(|package| package.ecosystem == Ecosystem::Go && released_versions.contains_key(&package.id)))?;
 	let mut executions = Vec::new();
 	#[cfg(feature = "cargo")]
 	executions.extend(cargo_executions);
@@ -707,6 +736,8 @@ pub(crate) fn build_lockfile_command_executions(
 	executions.extend(dart_executions);
 	#[cfg(feature = "python")]
 	executions.extend(python_executions);
+	#[cfg(feature = "go")]
+	executions.extend(go_executions);
 	Ok(dedup_lockfile_command_executions(executions))
 }
 
@@ -836,12 +867,13 @@ pub fn discover_workspace(root: &Path) -> MonochangeResult<DiscoveryReport> {
 		feature = "npm",
 		feature = "deno",
 		feature = "dart",
-		feature = "python"
+		feature = "python",
+		feature = "go"
 	))]
 	{
 		let (
 			(cargo_discovery, npm_discovery),
-			(deno_discovery, (dart_discovery, python_discovery)),
+			(deno_discovery, (dart_discovery, (python_discovery, go_discovery))),
 		) = rayon::join(
 			|| {
 				rayon::join(
@@ -855,7 +887,12 @@ pub fn discover_workspace(root: &Path) -> MonochangeResult<DiscoveryReport> {
 					|| {
 						rayon::join(
 							|| discover_dart_packages(root),
-							|| discover_python_packages(root),
+							|| {
+								rayon::join(
+									|| discover_python_packages(root),
+									|| discover_go_modules(root),
+								)
+							},
 						)
 					},
 				)
@@ -867,6 +904,7 @@ pub fn discover_workspace(root: &Path) -> MonochangeResult<DiscoveryReport> {
 			deno_discovery?,
 			dart_discovery?,
 			python_discovery?,
+			go_discovery?,
 		] {
 			warnings.extend(discovery.warnings);
 			packages.extend(discovery.packages);
@@ -878,7 +916,8 @@ pub fn discover_workspace(root: &Path) -> MonochangeResult<DiscoveryReport> {
 		feature = "npm",
 		feature = "deno",
 		feature = "dart",
-		feature = "python"
+		feature = "python",
+		feature = "go"
 	)))]
 	{
 		#[cfg(feature = "cargo")]
@@ -908,6 +947,12 @@ pub fn discover_workspace(root: &Path) -> MonochangeResult<DiscoveryReport> {
 		#[cfg(feature = "python")]
 		{
 			let d = discover_python_packages(root)?;
+			warnings.extend(d.warnings);
+			packages.extend(d.packages);
+		}
+		#[cfg(feature = "go")]
+		{
+			let d = discover_go_modules(root)?;
 			warnings.extend(d.warnings);
 			packages.extend(d.packages);
 		}
@@ -2082,6 +2127,7 @@ mod workspace_ops_tests {
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
 			python: monochange_core::EcosystemSettings::default(),
+			go: monochange_core::EcosystemSettings::default(),
 		}
 	}
 
@@ -2308,6 +2354,7 @@ mod workspace_ops_tests {
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
 			python: monochange_core::EcosystemSettings::default(),
+			go: monochange_core::EcosystemSettings::default(),
 		};
 		let undetected_error = discover_release_workspace(undetected_root.path(), &undetected)
 			.err()
@@ -2358,6 +2405,7 @@ mod workspace_ops_tests {
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
 			python: monochange_core::EcosystemSettings::default(),
+			go: monochange_core::EcosystemSettings::default(),
 		};
 		let missing_manifest_error =
 			discover_release_workspace(missing_manifest_root.path(), &missing_manifest)

--- a/crates/monochange_config/Cargo.toml
+++ b/crates/monochange_config/Cargo.toml
@@ -23,6 +23,7 @@ monochange_deno = { workspace = true }
 monochange_gitea = { workspace = true }
 monochange_github = { workspace = true }
 monochange_gitlab = { workspace = true }
+monochange_go = { workspace = true }
 monochange_npm = { workspace = true }
 monochange_python = { workspace = true }
 regex = { workspace = true, default-features = true }

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -1128,6 +1128,66 @@ type = "python"
 }
 
 #[test]
+fn load_workspace_configuration_normalizes_go_ecosystem_settings() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	std::fs::create_dir_all(root.join("packages/api"))
+		.unwrap_or_else(|error| panic!("create package dir: {error}"));
+	std::fs::write(
+		root.join("packages/api/go.mod"),
+		"module github.com/example/repo/api\n\ngo 1.22\n",
+	)
+	.unwrap_or_else(|error| panic!("write go.mod: {error}"));
+	std::fs::write(
+		root.join("monochange.toml"),
+		r#"[ecosystems.go]
+dependency_version_prefix = "v"
+versioned_files = ["go.mod"]
+
+[ecosystems.go.publish.placeholder]
+readme = "Go placeholder"
+
+[package.api]
+path = "packages/api"
+type = "go"
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write config: {error}"));
+
+	let configuration =
+		load_workspace_configuration(root).unwrap_or_else(|error| panic!("configuration: {error}"));
+	assert_eq!(
+		configuration.go.dependency_version_prefix.as_deref(),
+		Some("v")
+	);
+	let package = configuration
+		.packages
+		.iter()
+		.find(|package| package.id == "api")
+		.unwrap_or_else(|| panic!("expected api package"));
+
+	assert_eq!(package.package_type, monochange_core::PackageType::Go);
+	assert_eq!(
+		package
+			.versioned_files
+			.first()
+			.map(|definition| definition.ecosystem_type),
+		Some(Some(EcosystemType::Go))
+	);
+	assert_eq!(
+		package
+			.versioned_files
+			.first()
+			.map(|definition| definition.path.as_str()),
+		Some("go.mod")
+	);
+	assert_eq!(
+		package.publish.registry,
+		Some(PublishRegistry::Builtin(RegistryKind::GoProxy))
+	);
+}
+
+#[test]
 fn load_workspace_configuration_reports_python_ecosystem_normalization_errors() {
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	let root = tempdir.path();
@@ -2170,6 +2230,14 @@ fn default_publish_registry_for_ecosystem_covers_all_supported_types() {
 	assert_eq!(
 		crate::default_publish_registry_for_ecosystem(EcosystemType::Dart),
 		Some(PublishRegistry::Builtin(RegistryKind::PubDev))
+	);
+	assert_eq!(
+		crate::default_publish_registry_for_ecosystem(EcosystemType::Python),
+		Some(PublishRegistry::Builtin(RegistryKind::Pypi))
+	);
+	assert_eq!(
+		crate::default_publish_registry_for_ecosystem(EcosystemType::Go),
+		Some(PublishRegistry::Builtin(RegistryKind::GoProxy))
 	);
 }
 
@@ -4643,6 +4711,33 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 		dart_unsupported_match
 			.to_string()
 			.contains("for ecosystem `dart`")
+	);
+
+	assert!(crate::path_is_supported_for_ecosystem(
+		Path::new("go.mod"),
+		EcosystemType::Go
+	));
+	let go_unsupported_match = crate::validate_versioned_files(
+		tempdir.path(),
+		config_contents,
+		&[monochange_core::VersionedFileDefinition {
+			path: "packages/*/package.json".to_string(),
+			ecosystem_type: Some(EcosystemType::Go),
+			name: None,
+			fields: None,
+			prefix: None,
+			regex: None,
+		}],
+		&declared_packages,
+		"package",
+		"core",
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected unsupported go match error"));
+	assert!(
+		go_unsupported_match
+			.to_string()
+			.contains("for ecosystem `go`")
 	);
 
 	let empty_template = crate::validate_changelog_configuration(

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -347,6 +347,8 @@ struct RawEcosystems {
 	dart: RawEcosystemSettings,
 	#[serde(default)]
 	python: RawEcosystemSettings,
+	#[serde(default)]
+	go: RawEcosystemSettings,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -737,6 +739,7 @@ fn package_type_to_ecosystem_type(package_type: PackageType) -> EcosystemType {
 		PackageType::Deno => EcosystemType::Deno,
 		PackageType::Dart | PackageType::Flutter => EcosystemType::Dart,
 		PackageType::Python => EcosystemType::Python,
+		PackageType::Go => EcosystemType::Go,
 		_ => EcosystemType::Cargo,
 	}
 }
@@ -815,6 +818,7 @@ fn default_publish_registry_for_ecosystem(
 		EcosystemType::Deno => Some(PublishRegistry::Builtin(RegistryKind::Jsr)),
 		EcosystemType::Dart => Some(PublishRegistry::Builtin(RegistryKind::PubDev)),
 		EcosystemType::Python => Some(PublishRegistry::Builtin(RegistryKind::Pypi)),
+		EcosystemType::Go => Some(PublishRegistry::Builtin(RegistryKind::GoProxy)),
 		_ => None,
 	};
 	registry
@@ -959,6 +963,7 @@ fn build_package_definitions(
 	deno_ecosystem: &EcosystemSettings,
 	dart_ecosystem: &EcosystemSettings,
 	python_ecosystem: &EcosystemSettings,
+	go_ecosystem: &EcosystemSettings,
 ) -> MonochangeResult<Vec<PackageDefinition>> {
 	packages
 		.into_iter()
@@ -1008,6 +1013,7 @@ fn build_package_definitions(
 					EcosystemType::Deno => deno_ecosystem.versioned_files.clone(),
 					EcosystemType::Dart => dart_ecosystem.versioned_files.clone(),
 					EcosystemType::Python => python_ecosystem.versioned_files.clone(),
+					EcosystemType::Go => go_ecosystem.versioned_files.clone(),
 					_ => Vec::new(),
 				}
 			};
@@ -1026,11 +1032,12 @@ fn build_package_definitions(
 				Some({
 					#[rustfmt::skip]
 					let publish = match inferred_ecosystem_type {
-						EcosystemType::Cargo => &cargo_ecosystem.publish,
 						EcosystemType::Npm => &npm_ecosystem.publish,
 						EcosystemType::Deno => &deno_ecosystem.publish,
 						EcosystemType::Dart => &dart_ecosystem.publish,
-						_ => &python_ecosystem.publish,
+						EcosystemType::Python => &python_ecosystem.publish,
+						EcosystemType::Go => &go_ecosystem.publish,
+						_ => &cargo_ecosystem.publish,
 					};
 					publish
 				}),
@@ -1181,6 +1188,8 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		EcosystemType::Python,
 		python_ecosystem_input,
 	)?;
+	let go_ecosystem =
+		normalize_ecosystem_settings(&contents, "go", EcosystemType::Go, ecosystems.go)?;
 	let defaults_changelog_policy = defaults
 		.changelog
 		.as_ref()
@@ -1201,6 +1210,7 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		&deno_ecosystem,
 		&dart_ecosystem,
 		&python_ecosystem,
+		&go_ecosystem,
 	)?;
 	let groups = build_group_definitions(&contents, group, default_changelog_format)?;
 	let source = resolve_source_configuration(source);
@@ -1215,6 +1225,7 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		("deno", &deno_ecosystem),
 		("dart", &dart_ecosystem),
 		("python", &python_ecosystem),
+		("go", &go_ecosystem),
 	] {
 		let declared_packages = packages
 			.iter()
@@ -1260,6 +1271,7 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		deno: deno_ecosystem,
 		dart: dart_ecosystem,
 		python: python_ecosystem,
+		go: go_ecosystem,
 	})
 }
 
@@ -2726,6 +2738,7 @@ fn path_is_supported_for_ecosystem(path: &Path, ecosystem_type: EcosystemType) -
 		EcosystemType::Deno => monochange_deno::supported_versioned_file_kind(path).is_some(),
 		EcosystemType::Dart => monochange_dart::supported_versioned_file_kind(path).is_some(),
 		EcosystemType::Python => monochange_python::supported_versioned_file_kind(path).is_some(),
+		EcosystemType::Go => monochange_go::supported_versioned_file_kind(path).is_some(),
 		_ => false,
 	}
 }
@@ -2822,6 +2835,7 @@ fn validate_versioned_files(
 							EcosystemType::Deno => "deno",
 							EcosystemType::Dart => "dart",
 							EcosystemType::Python => "python",
+							EcosystemType::Go => "go",
 							_ => "unknown",
 						}
 					),
@@ -2893,6 +2907,7 @@ fn expected_manifest_name(package_type: PackageType) -> &'static str {
 		PackageType::Deno => "deno.json",
 		PackageType::Dart | PackageType::Flutter => "pubspec.yaml",
 		PackageType::Python => "pyproject.toml",
+		PackageType::Go => "go.mod",
 		_ => "Cargo.toml",
 	}
 }

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -231,6 +231,16 @@ fn publish_mode_and_registry_kind_display_canonical_names() {
 	assert_eq!(RegistryKind::Jsr.as_str(), "jsr");
 	assert_eq!(RegistryKind::PubDev.as_str(), "pub_dev");
 	assert_eq!(RegistryKind::Pypi.as_str(), "pypi");
+	assert_eq!(RegistryKind::GoProxy.as_str(), "go_proxy");
+	assert_eq!(RegistryKind::GoProxy.to_string(), "go_proxy");
+}
+
+#[test]
+fn go_package_type_and_ecosystem_defaults_are_canonical() {
+	assert_eq!(PackageType::Go.as_str(), "go");
+	assert_eq!(Ecosystem::Go.as_str(), "go");
+	assert_eq!(EcosystemType::Go.default_prefix(), "");
+	assert_eq!(EcosystemType::Go.default_fields(), ["require"]);
 }
 
 #[test]
@@ -1775,6 +1785,7 @@ fn sample_workspace_configuration() -> WorkspaceConfiguration {
 		deno: EcosystemSettings::default(),
 		dart: EcosystemSettings::default(),
 		python: EcosystemSettings::default(),
+		go: EcosystemSettings::default(),
 	}
 }
 

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -230,6 +230,7 @@ pub enum Ecosystem {
 	Dart,
 	Flutter,
 	Python,
+	Go,
 }
 
 impl Ecosystem {
@@ -243,6 +244,7 @@ impl Ecosystem {
 			Self::Dart => "dart",
 			Self::Flutter => "flutter",
 			Self::Python => "python",
+			Self::Go => "go",
 		}
 	}
 }
@@ -492,6 +494,7 @@ pub enum PackageType {
 	Dart,
 	Flutter,
 	Python,
+	Go,
 }
 
 impl PackageType {
@@ -505,6 +508,7 @@ impl PackageType {
 			Self::Dart => "dart",
 			Self::Flutter => "flutter",
 			Self::Python => "python",
+			Self::Go => "go",
 		}
 	}
 }
@@ -527,6 +531,7 @@ pub enum EcosystemType {
 	Deno,
 	Dart,
 	Python,
+	Go,
 }
 
 impl EcosystemType {
@@ -534,7 +539,7 @@ impl EcosystemType {
 	#[must_use]
 	pub fn default_prefix(self) -> &'static str {
 		match self {
-			Self::Cargo => "",
+			Self::Cargo | Self::Go => "",
 			Self::Npm | Self::Deno | Self::Dart => "^",
 			Self::Python => ">=",
 		}
@@ -549,6 +554,7 @@ impl EcosystemType {
 			Self::Deno => &["imports"],
 			Self::Dart => &["dependencies", "dev_dependencies"],
 			Self::Python => &["dependencies"],
+			Self::Go => &["require"],
 		}
 	}
 }
@@ -1383,6 +1389,7 @@ pub enum RegistryKind {
 	Jsr,
 	PubDev,
 	Pypi,
+	GoProxy,
 }
 
 impl RegistryKind {
@@ -1395,6 +1402,7 @@ impl RegistryKind {
 			Self::Jsr => "jsr",
 			Self::PubDev => "pub_dev",
 			Self::Pypi => "pypi",
+			Self::GoProxy => "go_proxy",
 		}
 	}
 }
@@ -3706,6 +3714,7 @@ pub struct WorkspaceConfiguration {
 	pub deno: EcosystemSettings,
 	pub dart: EcosystemSettings,
 	pub python: EcosystemSettings,
+	pub go: EcosystemSettings,
 }
 
 impl WorkspaceConfiguration {

--- a/crates/monochange_go/Cargo.toml
+++ b/crates/monochange_go/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "monochange_go"
+version = { workspace = true }
+categories = { workspace = true }
+documentation = "https://docs.rs/monochange_go"
+edition = { workspace = true }
+include = ["src/**/*.rs", "Cargo.toml", "readme.md"]
+keywords = ["cli", "changelog", "releases", "versioning", "monorepo"]
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+description = "Go ecosystem adapter for monochange — discovers Go modules and resolves versions from git tags"
+
+[dependencies]
+glob = { workspace = true, default-features = true }
+monochange_core = { workspace = true }
+regex = { workspace = true, default-features = true }
+semver = { workspace = true, default-features = true }
+tracing = { workspace = true, default-features = true }
+walkdir = { workspace = true, default-features = true }
+
+[dev-dependencies]
+insta = { workspace = true, default-features = true }
+monochange_test_helpers = { workspace = true }
+rstest = { workspace = true, default-features = true }
+similar-asserts = { workspace = true, default-features = true }
+tempfile = { workspace = true, default-features = true }
+
+[lints]
+workspace = true

--- a/crates/monochange_go/readme.md
+++ b/crates/monochange_go/readme.md
@@ -1,0 +1,48 @@
+# `monochange_go`
+
+<br />
+
+<!-- {=crateReadmeBadgeRow:"monochange_go"} -->
+
+[![Crates.io](https://img.shields.io/badge/crates.io-monochange__go-orange?logo=rust)](https://crates.io/crates/monochange_go) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__go-1f425f?logo=docs.rs)](https://docs.rs/monochange_go/) [![CI](https://github.com/monochange/monochange/actions/workflows/ci.yml/badge.svg)](https://github.com/monochange/monochange/actions/workflows/ci.yml) [![Coverage](https://codecov.io/gh/monochange/monochange/branch/main/graph/badge.svg?flag=monochange_go)](https://codecov.io/gh/monochange/monochange?flag=monochange_go) [![License](https://img.shields.io/badge/license-Unlicense-blue.svg)](https://opensource.org/license/unlicense)
+
+<!-- {/crateReadmeBadgeRow} -->
+
+<br />
+
+<!-- {=monochangeGoCrateDocs} -->
+
+`monochange_go` discovers Go modules for the shared planner.
+
+Reach for this crate when you need to scan standalone `go.mod` files, parse module metadata and `require` dependencies, infer `go mod tidy`, and preserve Go's tag-based versioning model in mixed-language release plans.
+
+## Why use it?
+
+- discover root and multi-module Go repositories through `go.mod` manifests
+- normalize Go module paths and `require` edges for shared release planning
+- update internal dependency requirements without treating `go.sum` as a lockfile
+- model Go releases as VCS tags, including path-prefixed tags for submodules
+
+## Best for
+
+- scanning Go modules into normalized workspace records
+- adding Go dependency edges to a mixed-language release plan
+- refreshing `go.mod` and `go.sum` through `go mod tidy` after manifest rewrites
+- publishing Go modules by creating tags such as `v1.2.3` or `api/v1.2.3`
+
+## Public entry points
+
+- `discover_go_modules(root)` discovers `go.mod` modules under a repository root
+- `parse_go_module(path, root)` parses one module manifest into package metadata
+- `update_go_mod_text(contents, dependencies)` rewrites matching `require` directives
+- `discover_lockfiles(package)` reports Go checksum artifacts for command-based refreshes
+
+## Scope
+
+- `go.mod` module directive parsing
+- direct and grouped `require` dependency extraction
+- Go semantic import version handling through module paths
+- command inference for `go mod tidy`
+- metadata used by publishing for Go proxy lookup and path-prefixed VCS tags
+
+<!-- {/monochangeGoCrateDocs} -->

--- a/crates/monochange_go/src/__tests.rs
+++ b/crates/monochange_go/src/__tests.rs
@@ -1,0 +1,598 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use monochange_core::DependencyKind;
+use monochange_core::Ecosystem;
+use monochange_core::EcosystemAdapter;
+use monochange_core::PackageRecord;
+use monochange_core::PublishState;
+use semver::Version;
+
+use crate::GoAdapter;
+use crate::GoVersionedFileKind;
+use crate::adapter;
+use crate::derive_module_name;
+use crate::discover_go_modules;
+use crate::is_major_version_suffix;
+use crate::parse_go_version;
+use crate::parse_module_path;
+use crate::parse_require_directives;
+use crate::update_go_mod_text;
+
+fn fixture_path(relative: &str) -> PathBuf {
+	monochange_test_helpers::fs::fixture_path_from(env!("CARGO_MANIFEST_DIR"), relative)
+}
+
+// -- adapter --
+
+#[test]
+fn adapter_reports_go_ecosystem() {
+	let go_adapter = GoAdapter;
+	assert_eq!(go_adapter.ecosystem(), Ecosystem::Go);
+	assert_eq!(adapter().ecosystem(), Ecosystem::Go);
+}
+
+#[test]
+fn discover_go_modules_reports_warnings_for_unreadable_go_mod_files() {
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	#[cfg(unix)]
+	std::os::unix::fs::symlink(root.join("missing-go-mod"), root.join("go.mod"))
+		.unwrap_or_else(|error| panic!("symlink go.mod: {error}"));
+	#[cfg(not(unix))]
+	std::fs::write(root.join("go.mod"), [0xff, 0xfe])
+		.unwrap_or_else(|error| panic!("write invalid go.mod: {error}"));
+
+	let discovery =
+		discover_go_modules(root).unwrap_or_else(|error| panic!("go discovery: {error}"));
+
+	assert!(discovery.packages.is_empty());
+	assert_eq!(discovery.warnings.len(), 1);
+	assert!(
+		discovery
+			.warnings
+			.first()
+			.expect("warning")
+			.contains("skipped")
+	);
+}
+
+#[test]
+fn adapter_discover_delegates_to_discover_go_modules() {
+	let root = fixture_path("go/single-module");
+	let discovery = GoAdapter
+		.discover(&root)
+		.unwrap_or_else(|error| panic!("discover: {error}"));
+	assert_eq!(discovery.packages.len(), 1);
+	assert_eq!(discovery.packages.first().unwrap().name, "myapp");
+}
+
+// -- supported_versioned_file_kind --
+
+#[test]
+fn supported_versioned_file_kind_recognizes_go_files() {
+	use crate::supported_versioned_file_kind;
+	assert_eq!(
+		supported_versioned_file_kind("go.mod".as_ref()),
+		Some(GoVersionedFileKind::GoMod)
+	);
+	assert_eq!(
+		supported_versioned_file_kind("go.sum".as_ref()),
+		Some(GoVersionedFileKind::GoSum)
+	);
+	assert_eq!(supported_versioned_file_kind("Cargo.toml".as_ref()), None);
+	assert_eq!(supported_versioned_file_kind("package.json".as_ref()), None);
+}
+
+// -- parse_module_path --
+
+#[test]
+fn parse_module_path_extracts_trimmed_module_directive() {
+	let contents = "module   github.com/org/repo  \n\ngo 1.22\n";
+	assert_eq!(
+		parse_module_path(contents),
+		Some("github.com/org/repo".to_string())
+	);
+}
+
+#[test]
+fn parse_module_path_extracts_module_directive() {
+	let contents = "module github.com/org/repo\n\ngo 1.22\n";
+	assert_eq!(
+		parse_module_path(contents),
+		Some("github.com/org/repo".to_string())
+	);
+}
+
+#[test]
+fn parse_module_path_handles_submodule_paths() {
+	let contents = "module github.com/org/repo/api/v2\n\ngo 1.22\n";
+	assert_eq!(
+		parse_module_path(contents),
+		Some("github.com/org/repo/api/v2".to_string())
+	);
+}
+
+#[test]
+fn parse_module_path_returns_none_without_module_directive() {
+	let contents = "go 1.22\nrequire golang.org/x/text v0.14.0\n";
+	assert_eq!(parse_module_path(contents), None);
+}
+
+#[test]
+fn parse_module_path_skips_empty_module_directive() {
+	let contents = "module \n\ngo 1.22\n";
+	assert_eq!(parse_module_path(contents), None);
+}
+
+// -- derive_module_name --
+
+#[test]
+fn derive_module_name_extracts_last_segment() {
+	assert_eq!(derive_module_name("github.com/org/repo"), "repo");
+	assert_eq!(derive_module_name("github.com/org/repo/api"), "api");
+	assert_eq!(
+		derive_module_name("github.com/org/repo/internal/worker"),
+		"worker"
+	);
+}
+
+#[test]
+fn derive_module_name_strips_major_version_suffix() {
+	assert_eq!(derive_module_name("github.com/org/repo/api/v2"), "api");
+	assert_eq!(derive_module_name("github.com/org/sdk/v3"), "sdk");
+}
+
+#[test]
+fn derive_module_name_handles_single_segment() {
+	assert_eq!(derive_module_name("mymodule"), "mymodule");
+}
+
+// -- is_major_version_suffix --
+
+#[test]
+fn is_major_version_suffix_identifies_version_segments() {
+	assert!(is_major_version_suffix("v2"));
+	assert!(is_major_version_suffix("v3"));
+	assert!(is_major_version_suffix("v10"));
+	assert!(!is_major_version_suffix("v0"));
+	assert!(!is_major_version_suffix("v"));
+	assert!(!is_major_version_suffix("api"));
+	assert!(!is_major_version_suffix("v1.2.3"));
+	assert!(!is_major_version_suffix("version"));
+}
+
+// -- parse_go_version --
+
+#[test]
+fn parse_go_version_handles_standard_and_prefixed_versions() {
+	assert_eq!(parse_go_version("v1.2.3"), Some(Version::new(1, 2, 3)));
+	assert_eq!(parse_go_version("1.2.3"), Some(Version::new(1, 2, 3)));
+	assert_eq!(parse_go_version("v0.1.0"), Some(Version::new(0, 1, 0)));
+	assert_eq!(parse_go_version("not-a-version"), None);
+	assert_eq!(parse_go_version("v1.2"), None);
+}
+
+// -- parse_require_directives --
+
+#[test]
+fn parse_require_directives_extracts_block_and_single_line_deps() {
+	let contents = r"module github.com/example/app
+
+go 1.22
+
+require (
+	github.com/gin-gonic/gin v1.9.1
+	golang.org/x/sys v0.15.0 // indirect
+)
+
+require github.com/nats-io/nats.go v1.31.0
+";
+	let deps = parse_require_directives(contents);
+	assert_eq!(deps.len(), 3);
+
+	let gin = deps.iter().find(|d| d.name == "gin").unwrap();
+	assert_eq!(gin.kind, DependencyKind::Runtime);
+	assert_eq!(gin.version_constraint.as_deref(), Some("1.9.1"));
+
+	let sys = deps.iter().find(|d| d.name == "sys").unwrap();
+	assert_eq!(sys.kind, DependencyKind::Development);
+	assert_eq!(sys.version_constraint.as_deref(), Some("0.15.0"));
+
+	let nats = deps.iter().find(|d| d.name == "nats.go").unwrap();
+	assert_eq!(nats.kind, DependencyKind::Runtime);
+	assert_eq!(nats.version_constraint.as_deref(), Some("1.31.0"));
+}
+
+#[test]
+fn parse_require_directives_handles_empty_file() {
+	let deps = parse_require_directives("module github.com/example/app\n\ngo 1.22\n");
+	assert!(deps.is_empty());
+}
+
+#[test]
+fn parse_require_directives_skips_replace_and_exclude() {
+	let contents = r"module github.com/example/app
+
+go 1.22
+
+require github.com/example/shared v1.0.0
+
+replace github.com/example/shared => ../shared
+
+exclude github.com/example/old v0.1.0
+";
+	let deps = parse_require_directives(contents);
+	assert_eq!(deps.len(), 1);
+	assert_eq!(deps.first().unwrap().name, "shared");
+}
+
+// -- discover_go_modules --
+
+#[test]
+fn discover_go_modules_finds_single_module() {
+	let root = fixture_path("go/single-module");
+	let discovery = discover_go_modules(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+
+	assert_eq!(discovery.packages.len(), 1);
+	let pkg = discovery.packages.first().unwrap();
+	assert_eq!(pkg.name, "myapp");
+	assert_eq!(pkg.ecosystem, Ecosystem::Go);
+	assert_eq!(
+		pkg.metadata.get("module_path").map(String::as_str),
+		Some("github.com/example/myapp")
+	);
+	// Go versions come from git tags, not go.mod
+	assert_eq!(pkg.current_version, None);
+}
+
+#[test]
+fn discover_go_modules_finds_multi_module_monorepo() {
+	let root = fixture_path("go/multi-module");
+	let discovery = discover_go_modules(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+
+	assert_eq!(discovery.packages.len(), 3);
+	let names: Vec<&str> = discovery.packages.iter().map(|p| p.name.as_str()).collect();
+	assert!(names.contains(&"api"), "missing api: {names:?}");
+	assert!(names.contains(&"shared"), "missing shared: {names:?}");
+	assert!(names.contains(&"worker"), "missing worker: {names:?}");
+}
+
+#[test]
+fn discover_go_modules_stores_relative_path_metadata() {
+	let root = fixture_path("go/multi-module");
+	let discovery = discover_go_modules(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+
+	let api = discovery.packages.iter().find(|p| p.name == "api").unwrap();
+	assert_eq!(
+		api.metadata.get("relative_path").map(String::as_str),
+		Some("api")
+	);
+}
+
+#[test]
+fn discover_go_modules_extracts_cross_module_dependencies() {
+	let root = fixture_path("go/multi-module");
+	let discovery = discover_go_modules(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+
+	let api = discovery.packages.iter().find(|p| p.name == "api").unwrap();
+	let dep_names: Vec<&str> = api
+		.declared_dependencies
+		.iter()
+		.map(|d| d.name.as_str())
+		.collect();
+	assert!(
+		dep_names.contains(&"shared"),
+		"api should depend on shared: {dep_names:?}"
+	);
+	assert!(
+		dep_names.contains(&"gin"),
+		"api should depend on gin: {dep_names:?}"
+	);
+}
+
+#[test]
+fn discover_go_modules_handles_major_version_suffix() {
+	let root = fixture_path("go/major-version");
+	let discovery = discover_go_modules(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+
+	assert_eq!(discovery.packages.len(), 1);
+	let pkg = discovery.packages.first().unwrap();
+	assert_eq!(pkg.name, "sdk", "should strip /v2 suffix from name");
+	assert_eq!(
+		pkg.metadata.get("module_path").map(String::as_str),
+		Some("github.com/example/sdk/v2")
+	);
+}
+
+#[test]
+fn discover_go_modules_skips_files_without_module_directive() {
+	let root = fixture_path("go/no-module-directive");
+	let discovery = discover_go_modules(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+	assert!(discovery.packages.is_empty());
+}
+
+#[test]
+fn discover_go_modules_warns_on_unparseable_files() {
+	let root = fixture_path("go/invalid-gomod");
+	let discovery =
+		discover_go_modules(&root).unwrap_or_else(|error| panic!("unexpected error: {error}"));
+	// Invalid go.mod without a module directive produces no packages (not an error)
+	assert!(discovery.packages.is_empty());
+}
+
+#[test]
+fn discover_go_modules_extracts_indirect_dependencies() {
+	let root = fixture_path("go/single-module");
+	let discovery = discover_go_modules(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+
+	let pkg = discovery.packages.first().unwrap();
+	let indirect_deps: Vec<&str> = pkg
+		.declared_dependencies
+		.iter()
+		.filter(|d| d.kind == DependencyKind::Development)
+		.map(|d| d.name.as_str())
+		.collect();
+	assert!(
+		indirect_deps.contains(&"sys"),
+		"should mark indirect deps: {indirect_deps:?}"
+	);
+}
+
+#[test]
+fn discover_go_modules_handles_versioned_module_dependencies() {
+	let root = fixture_path("go/single-module");
+	let discovery = discover_go_modules(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+
+	let pkg = discovery.packages.first().unwrap();
+	let redis_dep = pkg
+		.declared_dependencies
+		.iter()
+		.find(|d| d.name == "redis")
+		.unwrap();
+	assert_eq!(redis_dep.version_constraint.as_deref(), Some("8.11.5"));
+}
+
+// -- discover_lockfiles --
+
+#[test]
+fn discover_lockfiles_finds_go_sum() {
+	let root = fixture_path("go/single-module");
+	let package = PackageRecord::new(
+		Ecosystem::Go,
+		"myapp",
+		root.join("go.mod"),
+		root.clone(),
+		None,
+		PublishState::Public,
+	);
+	let lockfiles = crate::discover_lockfiles(&package);
+	assert_eq!(lockfiles.len(), 1);
+	assert!(lockfiles.first().unwrap().ends_with("go.sum"));
+}
+
+#[test]
+fn discover_lockfiles_returns_empty_without_go_sum() {
+	let root = fixture_path("go/no-module-directive");
+	let package = PackageRecord::new(
+		Ecosystem::Go,
+		"test",
+		root.join("go.mod"),
+		root.clone(),
+		None,
+		PublishState::Public,
+	);
+	let lockfiles = crate::discover_lockfiles(&package);
+	assert!(lockfiles.is_empty());
+}
+
+// -- default_lockfile_commands --
+
+#[test]
+fn default_lockfile_commands_infers_go_mod_tidy() {
+	let root = fixture_path("go/single-module");
+	let package = PackageRecord::new(
+		Ecosystem::Go,
+		"myapp",
+		root.join("go.mod"),
+		root.clone(),
+		None,
+		PublishState::Public,
+	);
+	let commands = crate::default_lockfile_commands(&package);
+	assert_eq!(commands.len(), 1);
+	assert_eq!(commands.first().unwrap().command, "go mod tidy");
+}
+
+// -- update_go_mod_text --
+
+#[test]
+fn update_go_mod_text_updates_require_versions() {
+	let input = r"module github.com/example/monorepo/api
+
+go 1.22
+
+require (
+	github.com/example/monorepo/shared v1.2.0
+	github.com/gin-gonic/gin v1.9.1
+)
+";
+	let deps = BTreeMap::from([("shared".to_string(), "v1.3.0".to_string())]);
+	let result = update_go_mod_text(input, &deps);
+
+	assert!(
+		result.contains("github.com/example/monorepo/shared v1.3.0"),
+		"should update shared version"
+	);
+	assert!(
+		result.contains("github.com/gin-gonic/gin v1.9.1"),
+		"should preserve unrelated deps"
+	);
+	assert!(
+		!result.contains("shared v1.2.0"),
+		"should not have old version"
+	);
+}
+
+#[test]
+fn update_go_mod_text_preserves_comments() {
+	let input = "module github.com/example/app\n\nrequire golang.org/x/sys v0.15.0 // indirect\n";
+	let deps = BTreeMap::from([("sys".to_string(), "v0.16.0".to_string())]);
+	let result = update_go_mod_text(input, &deps);
+	assert!(result.contains("golang.org/x/sys v0.16.0 // indirect"));
+}
+
+#[test]
+fn update_go_mod_text_handles_single_line_require() {
+	let input = "module github.com/example/app\n\nrequire github.com/example/shared v1.0.0\n";
+	let deps = BTreeMap::from([("shared".to_string(), "v2.0.0".to_string())]);
+	let result = update_go_mod_text(input, &deps);
+	assert!(result.contains("require github.com/example/shared v2.0.0"));
+}
+
+#[test]
+fn update_go_mod_text_adds_v_prefix_when_missing() {
+	let input = "module github.com/example/app\n\nrequire github.com/example/shared v1.0.0\n";
+	let deps = BTreeMap::from([("shared".to_string(), "2.0.0".to_string())]);
+	let result = update_go_mod_text(input, &deps);
+	assert!(result.contains("require github.com/example/shared v2.0.0"));
+}
+
+#[test]
+fn update_go_mod_text_preserves_module_and_go_directives() {
+	let input =
+		"module github.com/example/app\n\ngo 1.22\n\nrequire github.com/example/shared v1.0.0\n";
+	let deps = BTreeMap::from([("shared".to_string(), "v2.0.0".to_string())]);
+	let result = update_go_mod_text(input, &deps);
+	assert!(result.contains("module github.com/example/app"));
+	assert!(result.contains("go 1.22"));
+}
+
+#[test]
+fn update_go_mod_text_returns_original_when_no_deps() {
+	let input = "module github.com/example/app\n\ngo 1.22\n";
+	let result = update_go_mod_text(input, &BTreeMap::new());
+	assert_eq!(result, input);
+}
+
+#[test]
+fn update_go_mod_text_preserves_replace_directives() {
+	let input = r"module github.com/example/app
+
+require github.com/example/shared v1.0.0
+
+replace github.com/example/shared => ../shared
+";
+	let deps = BTreeMap::from([("shared".to_string(), "v2.0.0".to_string())]);
+	let result = update_go_mod_text(input, &deps);
+	assert!(result.contains("replace github.com/example/shared => ../shared"));
+	assert!(result.contains("require github.com/example/shared v2.0.0"));
+}
+
+// -- should_descend --
+
+#[test]
+fn discover_go_modules_skips_vendor_directory() {
+	use std::fs;
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+
+	fs::write(
+		root.join("go.mod"),
+		"module github.com/example/root\n\ngo 1.22\n",
+	)
+	.unwrap();
+
+	let vendor_dir = root.join("vendor/github.com/dep");
+	fs::create_dir_all(&vendor_dir).unwrap();
+	fs::write(
+		vendor_dir.join("go.mod"),
+		"module github.com/dep\n\ngo 1.22\n",
+	)
+	.unwrap();
+
+	let discovery = discover_go_modules(root).unwrap_or_else(|error| panic!("discover: {error}"));
+	assert_eq!(
+		discovery.packages.len(),
+		1,
+		"should only find root module, not vendored: {:?}",
+		discovery
+			.packages
+			.iter()
+			.map(|p| &p.name)
+			.collect::<Vec<_>>()
+	);
+	assert_eq!(discovery.packages.first().unwrap().name, "root");
+}
+
+// -- edge cases --
+
+#[test]
+fn discover_go_modules_handles_nonexistent_directory() {
+	let discovery = discover_go_modules(std::path::Path::new("/nonexistent/path/to/repo"));
+	let result = discovery.unwrap_or_else(|error| panic!("unexpected error: {error}"));
+	assert!(result.packages.is_empty());
+}
+
+#[test]
+fn parse_require_directives_handles_malformed_entries() {
+	let contents = "module github.com/example/app\n\nrequire (\n\t\n\tincomplete\n)\n";
+	let deps = parse_require_directives(contents);
+	assert!(deps.is_empty());
+}
+
+#[test]
+fn update_go_mod_text_preserves_content_without_trailing_newline() {
+	let input = "module github.com/example/app\n\nrequire github.com/example/shared v1.0.0";
+	let deps = BTreeMap::from([("shared".to_string(), "v2.0.0".to_string())]);
+	let result = update_go_mod_text(input, &deps);
+	assert!(!result.ends_with('\n'), "should not add trailing newline");
+	assert!(result.contains("github.com/example/shared v2.0.0"));
+}
+
+#[test]
+fn update_go_mod_text_handles_versioned_module_require() {
+	let input = "module github.com/example/app\n\nrequire github.com/example/sdk/v2 v2.0.0\n";
+	let deps = BTreeMap::from([("sdk".to_string(), "v2.1.0".to_string())]);
+	let result = update_go_mod_text(input, &deps);
+	assert!(
+		result.contains("github.com/example/sdk/v2 v2.1.0"),
+		"should update v2 module: {result}"
+	);
+}
+
+#[test]
+fn update_go_mod_text_skips_single_line_require_without_version() {
+	let input = "module github.com/example/app\n\nrequire github.com/example/shared\n";
+	let result = update_go_mod_text(
+		input,
+		&BTreeMap::from([("shared".to_string(), "v2.0.0".to_string())]),
+	);
+
+	assert_eq!(result, input);
+}
+
+#[test]
+fn update_go_mod_text_skips_lines_with_too_few_parts() {
+	let input = "module github.com/example/app\n\nrequire (\n\t\n)\n";
+	let result = update_go_mod_text(
+		input,
+		&BTreeMap::from([("app".to_string(), "v1.0.0".to_string())]),
+	);
+	assert_eq!(result, input, "should not modify empty require block lines");
+}
+
+#[test]
+fn derive_module_name_handles_all_version_segments() {
+	// If every segment is a version suffix (extremely unlikely but tests the fallback)
+	assert_eq!(derive_module_name("v2"), "v2");
+}
+
+#[test]
+fn update_go_mod_text_handles_retract_directive() {
+	let input = "module github.com/example/app\n\nretract v0.1.0\n\nrequire github.com/example/shared v1.0.0\n";
+	let deps = BTreeMap::from([("shared".to_string(), "v2.0.0".to_string())]);
+	let result = update_go_mod_text(input, &deps);
+	assert!(result.contains("retract v0.1.0"));
+	assert!(result.contains("require github.com/example/shared v2.0.0"));
+}

--- a/crates/monochange_go/src/lib.rs
+++ b/crates/monochange_go/src/lib.rs
@@ -1,0 +1,444 @@
+#![deny(clippy::all)]
+#![forbid(clippy::indexing_slicing)]
+
+//! # `monochange_go`
+//!
+//! `monochange_go` discovers Go modules from `go.mod` files and resolves
+//! versions from git tags.
+//!
+//! ## Why use it?
+//!
+//! - discover Go modules in single-module and multi-module repositories
+//! - normalize Go module dependency edges for the shared planner
+//! - infer `go mod tidy` as the default lockfile refresh command
+//!
+//! ## Best for
+//!
+//! - building Go-aware discovery flows without the full CLI
+//! - converting Go module structure into shared `monochange_core` records
+//! - managing multi-module monorepo releases with path-prefixed git tags
+//!
+//! ## Public entry points
+//!
+//! - `discover_go_modules(root)` discovers Go modules
+//! - `GoAdapter` exposes the shared adapter interface
+//!
+//! ## Scope
+//!
+//! - `go.mod` parsing for module path, go version, and require directives
+//! - multi-module repository detection
+//! - `go mod tidy` lockfile command inference
+//! - `go.sum` lockfile discovery
+
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
+use monochange_core::AdapterDiscovery;
+use monochange_core::DependencyKind;
+use monochange_core::Ecosystem;
+use monochange_core::EcosystemAdapter;
+use monochange_core::LockfileCommandExecution;
+use monochange_core::MonochangeError;
+use monochange_core::MonochangeResult;
+use monochange_core::PackageDependency;
+use monochange_core::PackageRecord;
+use monochange_core::PublishState;
+use monochange_core::ShellConfig;
+use monochange_core::normalize_path;
+use semver::Version;
+use walkdir::DirEntry;
+use walkdir::WalkDir;
+
+pub const GO_MOD_FILE: &str = "go.mod";
+pub const GO_SUM_FILE: &str = "go.sum";
+
+pub struct GoAdapter;
+
+#[must_use]
+pub const fn adapter() -> GoAdapter {
+	GoAdapter
+}
+
+impl EcosystemAdapter for GoAdapter {
+	fn ecosystem(&self) -> Ecosystem {
+		Ecosystem::Go
+	}
+
+	fn discover(&self, root: &Path) -> MonochangeResult<AdapterDiscovery> {
+		discover_go_modules(root)
+	}
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum GoVersionedFileKind {
+	GoMod,
+	GoSum,
+}
+
+#[must_use]
+pub fn supported_versioned_file_kind(path: &Path) -> Option<GoVersionedFileKind> {
+	let file_name = path
+		.file_name()
+		.and_then(|name| name.to_str())
+		.unwrap_or_default();
+	match file_name {
+		GO_MOD_FILE => Some(GoVersionedFileKind::GoMod),
+		GO_SUM_FILE => Some(GoVersionedFileKind::GoSum),
+		_ => None,
+	}
+}
+
+pub fn discover_lockfiles(package: &PackageRecord) -> Vec<PathBuf> {
+	let manifest_dir = package
+		.manifest_path
+		.parent()
+		.map_or_else(|| package.workspace_root.clone(), Path::to_path_buf);
+	[manifest_dir.join(GO_SUM_FILE)]
+		.into_iter()
+		.filter(|path| path.exists())
+		.collect()
+}
+
+pub fn default_lockfile_commands(package: &PackageRecord) -> Vec<LockfileCommandExecution> {
+	let manifest_dir = package
+		.manifest_path
+		.parent()
+		.unwrap_or(&package.workspace_root)
+		.to_path_buf();
+	// Always infer `go mod tidy` for Go modules — it updates both go.mod
+	// (removes unused, adds missing) and go.sum (refreshes checksums).
+	vec![LockfileCommandExecution {
+		command: "go mod tidy".to_string(),
+		cwd: manifest_dir,
+		shell: ShellConfig::None,
+	}]
+}
+
+/// Update a `go.mod` file's require directives for cross-module dependencies.
+///
+/// When module `shared` bumps to `v1.3.0`, this updates:
+/// ```text
+/// require github.com/org/repo/shared v1.2.0
+/// ```
+/// to:
+/// ```text
+/// require github.com/org/repo/shared v1.3.0
+/// ```
+pub fn update_go_mod_text(
+	contents: &str,
+	versioned_deps: &std::collections::BTreeMap<String, String>,
+) -> String {
+	if versioned_deps.is_empty() {
+		return contents.to_string();
+	}
+
+	let mut result = String::with_capacity(contents.len());
+	for line in contents.lines() {
+		let updated = update_require_line(line, versioned_deps);
+		result.push_str(&updated);
+		result.push('\n');
+	}
+	// Preserve trailing newline status from the original content
+	if !contents.ends_with('\n') && result.ends_with('\n') {
+		result.pop();
+	}
+	result
+}
+
+/// Update a single `require` line if it matches a versioned dependency.
+///
+/// Handles both standalone require lines and lines inside a require block:
+/// - `require github.com/org/shared v1.0.0`
+/// - `  github.com/org/shared v1.0.0`
+/// - `  github.com/org/shared v1.0.0 // indirect`
+fn update_require_line(
+	line: &str,
+	versioned_deps: &std::collections::BTreeMap<String, String>,
+) -> String {
+	let trimmed = line.trim();
+
+	// Skip empty lines, comments, and non-require directives
+	if trimmed.is_empty()
+		|| trimmed.starts_with("//")
+		|| trimmed.starts_with("module ")
+		|| trimmed.starts_with("go ")
+		|| trimmed.starts_with("replace ")
+		|| trimmed.starts_with("exclude ")
+		|| trimmed.starts_with("retract ")
+		|| trimmed == "require ("
+		|| trimmed == ")"
+		|| trimmed == "require"
+	{
+		return line.to_string();
+	}
+
+	// Handle `require module/path v1.2.3` (single-line require)
+	let parts: Vec<&str> = if let Some(rest) = trimmed.strip_prefix("require ") {
+		rest.split_whitespace().collect()
+	} else {
+		// Inside a require block: `	module/path v1.2.3`
+		trimmed.split_whitespace().collect()
+	};
+
+	if parts.len() < 2 {
+		return line.to_string();
+	}
+
+	let module_path = parts.first().copied().unwrap_or_default();
+
+	// Extract the module name (last path segment) for matching
+	let module_name = module_path.rsplit('/').next().unwrap_or(module_path);
+
+	// Strip version suffix from module name (e.g., `shared/v2` → `shared`)
+	let clean_name = module_name
+		.strip_prefix('v')
+		.and_then(|rest| {
+			rest.chars()
+				.all(|ch| ch.is_ascii_digit())
+				.then_some(module_name)
+		})
+		.map_or(module_name, |_| {
+			module_path.rsplit('/').nth(1).unwrap_or(module_path)
+		});
+
+	if let Some(new_version) = versioned_deps.get(clean_name) {
+		// Ensure the version has a `v` prefix for Go
+		let go_version = if new_version.starts_with('v') {
+			new_version.clone()
+		} else {
+			format!("v{new_version}")
+		};
+
+		// Preserve the original line structure (indentation, comments)
+		let prefix = &line[..line.len() - line.trim_start().len()];
+		let comment = if let Some(comment_start) = trimmed.find("//") {
+			let after_version = &trimmed[comment_start..];
+			format!(" {after_version}")
+		} else {
+			String::new()
+		};
+
+		if trimmed.starts_with("require ") {
+			format!("{prefix}require {module_path} {go_version}{comment}")
+		} else {
+			format!("{prefix}{module_path} {go_version}{comment}")
+		}
+	} else {
+		line.to_string()
+	}
+}
+
+#[tracing::instrument(skip_all)]
+pub fn discover_go_modules(root: &Path) -> MonochangeResult<AdapterDiscovery> {
+	let mut packages = Vec::new();
+	let mut warnings = Vec::new();
+
+	for go_mod_path in find_all_go_mod_files(root) {
+		match parse_go_module(&go_mod_path, root) {
+			Ok(Some(package)) => packages.push(package),
+			Ok(None) => {}
+			Err(error) => {
+				warnings.push(format!("skipped {}: {error}", go_mod_path.display()));
+			}
+		}
+	}
+
+	packages.sort_by(|left, right| left.id.cmp(&right.id));
+	packages.dedup_by(|left, right| left.id == right.id);
+
+	tracing::debug!(packages = packages.len(), "discovered go modules");
+
+	Ok(AdapterDiscovery { packages, warnings })
+}
+
+fn parse_go_module(go_mod_path: &Path, root: &Path) -> MonochangeResult<Option<PackageRecord>> {
+	let contents = fs::read_to_string(go_mod_path).map_err(|error| {
+		MonochangeError::Io(format!("failed to read {}: {error}", go_mod_path.display()))
+	})?;
+
+	let module_path = parse_module_path(&contents);
+	let Some(module_path) = module_path else {
+		return Ok(None);
+	};
+
+	// Derive the package name from the module path (last non-version segment)
+	let name = derive_module_name(&module_path);
+
+	let manifest_dir = go_mod_path.parent().unwrap_or_else(|| Path::new("."));
+
+	let mut record = PackageRecord::new(
+		Ecosystem::Go,
+		&name,
+		normalize_path(go_mod_path),
+		normalize_path(root),
+		None, // Go versions come from git tags, not manifest files
+		PublishState::Public,
+	);
+
+	// Store the full module path as metadata for tag resolution
+	record
+		.metadata
+		.insert("module_path".to_string(), module_path.clone());
+
+	// Store the relative path for tag prefix computation
+	let normalized_dir = normalize_path(manifest_dir);
+	let normalized_root = normalize_path(root);
+	let relative_path = normalized_dir
+		.strip_prefix(&normalized_root)
+		.unwrap_or(Path::new(""))
+		.to_string_lossy()
+		.to_string();
+	if !relative_path.is_empty() && relative_path != "." {
+		record
+			.metadata
+			.insert("relative_path".to_string(), relative_path);
+	}
+
+	record.declared_dependencies = parse_require_directives(&contents);
+
+	Ok(Some(record))
+}
+
+/// Parse the `module` directive from a go.mod file.
+///
+/// ```text
+/// module github.com/org/repo/api
+/// ```
+fn parse_module_path(contents: &str) -> Option<String> {
+	for line in contents.lines() {
+		let trimmed = line.trim();
+		if let Some(path) = trimmed.strip_prefix("module ") {
+			return Some(path.trim().to_string());
+		}
+	}
+	None
+}
+
+/// Derive a human-friendly module name from a Go module path.
+///
+/// `github.com/org/repo` → `repo`
+/// `github.com/org/repo/api` → `api`
+/// `github.com/org/repo/api/v2` → `api`
+fn derive_module_name(module_path: &str) -> String {
+	let segments: Vec<&str> = module_path.split('/').collect();
+
+	// Walk backwards to find the first non-version segment
+	for segment in segments.iter().rev() {
+		if !is_major_version_suffix(segment) {
+			return (*segment).to_string();
+		}
+	}
+
+	// Fallback to the full path if everything is a version
+	module_path.to_string()
+}
+
+/// Check if a path segment is a major version suffix like `v2`, `v3`, etc.
+/// In Go, only v2+ appear as import path suffixes. `v0` and `v1` are not
+/// path suffixes.
+fn is_major_version_suffix(segment: &str) -> bool {
+	segment.strip_prefix('v').is_some_and(|rest| {
+		!rest.is_empty()
+			&& rest.chars().all(|ch| ch.is_ascii_digit())
+			&& rest.parse::<u64>().is_ok_and(|n| n >= 2)
+	})
+}
+
+/// Parse `require` directives from go.mod content.
+fn parse_require_directives(contents: &str) -> Vec<PackageDependency> {
+	let mut deps = Vec::new();
+	let mut in_require_block = false;
+
+	for line in contents.lines() {
+		let trimmed = line.trim();
+
+		if trimmed == "require (" {
+			in_require_block = true;
+			continue;
+		}
+		if trimmed == ")" {
+			in_require_block = false;
+			continue;
+		}
+
+		// Handle single-line require: `require module/path v1.2.3`
+		if let Some(rest) = trimmed.strip_prefix("require ") {
+			if !rest.starts_with('(')
+				&& let Some(dep) = parse_require_entry(rest)
+			{
+				deps.push(dep);
+			}
+			continue;
+		}
+
+		// Handle entries inside require block
+		if in_require_block && let Some(dep) = parse_require_entry(trimmed) {
+			deps.push(dep);
+		}
+	}
+
+	deps
+}
+
+/// Parse a single require entry like `github.com/org/shared v1.2.3 // indirect`.
+fn parse_require_entry(entry: &str) -> Option<PackageDependency> {
+	let parts: Vec<&str> = entry.split_whitespace().collect();
+	if parts.len() < 2 {
+		return None;
+	}
+
+	let module_path = *parts.first()?;
+	let version_str = *parts.get(1)?;
+	let is_indirect = parts.contains(&"indirect");
+
+	// Extract the module name (last path segment, excluding version suffixes)
+	let name = derive_module_name(module_path);
+
+	// Parse version string, stripping the `v` prefix
+	let constraint = version_str
+		.strip_prefix('v')
+		.map(ToString::to_string)
+		.or_else(|| Some(version_str.to_string()));
+
+	let kind = if is_indirect {
+		DependencyKind::Development
+	} else {
+		DependencyKind::Runtime
+	};
+
+	Some(PackageDependency {
+		name,
+		kind,
+		version_constraint: constraint,
+		optional: false,
+	})
+}
+
+/// Parse a Go semver version string like `v1.2.3` into a `semver::Version`.
+pub fn parse_go_version(version_str: &str) -> Option<Version> {
+	let stripped = version_str.strip_prefix('v').unwrap_or(version_str);
+	Version::parse(stripped).ok()
+}
+
+fn find_all_go_mod_files(root: &Path) -> Vec<PathBuf> {
+	WalkDir::new(root)
+		.into_iter()
+		.filter_entry(should_descend)
+		.filter_map(Result::ok)
+		.filter(|entry| entry.file_name() == GO_MOD_FILE)
+		.map(DirEntry::into_path)
+		.map(|path| normalize_path(&path))
+		.collect()
+}
+
+fn should_descend(entry: &DirEntry) -> bool {
+	let file_name = entry.file_name().to_string_lossy();
+	!matches!(
+		file_name.as_ref(),
+		".git" | "vendor" | "node_modules" | "target" | ".devenv" | "book" | "testdata"
+	)
+}
+
+#[cfg(test)]
+mod __tests;

--- a/crates/monochange_lint/src/lib.rs
+++ b/crates/monochange_lint/src/lib.rs
@@ -728,6 +728,7 @@ mod tests {
 			deno: monochange_core::EcosystemSettings::default(),
 			dart: monochange_core::EcosystemSettings::default(),
 			python: monochange_core::EcosystemSettings::default(),
+			go: monochange_core::EcosystemSettings::default(),
 		}
 	}
 

--- a/docs/src/guide/03-discovery.md
+++ b/docs/src/guide/03-discovery.md
@@ -11,6 +11,7 @@ Supported sources today:
 - Deno workspaces and standalone `deno.json` / `deno.jsonc` packages
 - Dart and Flutter workspaces plus standalone `pubspec.yaml` packages
 - Python uv workspaces, Poetry projects, and standalone `pyproject.toml` packages
+- Go modules discovered from standalone `go.mod` files
 
 <!-- {/discoverySupportedSources} -->
 

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -168,6 +168,8 @@ Built-in publishing currently targets only the canonical public registry for eac
 - Deno packages → `jsr`
 - Dart / Flutter packages → `pub.dev`
 - Python packages → `pypi`
+- Go modules → `go_proxy` via VCS tags
+- Python packages → `pypi`
 
 Private registries and custom publication flows are still external. For those packages, set `mode = "external"` and handle publication outside monochange.
 
@@ -604,6 +606,11 @@ lockfile_commands = [{ command = "flutter pub get", cwd = "packages/mobile" }]
 [ecosystems.python]
 enabled = true
 lockfile_commands = [{ command = "uv lock" }]
+
+[ecosystems.go]
+enabled = true
+# monochange infers `go mod tidy` for go.mod / go.sum refreshes.
+lockfile_commands = [{ command = "go mod tidy" }]
 ```
 
 <!-- {/configurationEcosystemSettingsSnippet} -->

--- a/docs/src/guide/07-trusted-publishing.md
+++ b/docs/src/guide/07-trusted-publishing.md
@@ -7,6 +7,7 @@ monochange supports built-in package publishing for the canonical public registr
 - Deno packages → `jsr`
 - Dart / Flutter packages → `pub.dev`
 - Python packages → `pypi`
+- Go modules → `go_proxy` via VCS tags
 
 For those registries, monochange can also manage or verify **trusted publishing** when the registry supports publishing directly from a verified GitHub Actions identity. PyPI is supported by the built-in publisher through `uv build` and `uv publish`; PyPI trusted-publisher enrollment is still completed manually in the PyPI project settings.
 
@@ -32,8 +33,11 @@ The goal is the same in every case:
 | deno           | jsr       | GitHub Actions publishing | Yes                         | Reports the setup URL; repository linking is still manual                             |
 | dart / flutter | pub.dev   | Automated publishing      | Yes                         | Reports the setup URL; admin-page setup is still manual                               |
 | python         | PyPI      | Trusted publishers        | Yes                         | Reports the setup URL; project settings setup is still manual                         |
+| go             | Go proxy  | VCS tags                  | N/A                         | Creates module tags; the proxy discovers versions from source control                 |
 
 npm is currently the only ecosystem where monochange performs bulk trusted-publishing setup itself. Use `mode = "external"` for any registry workflow that should stay outside monochange's built-in publisher.
+
+Go module publishing is included in the built-in package publisher, but it is not an OIDC trusted-publishing flow. Go versions are published by creating VCS tags. monochange uses `git tag`, choosing `v1.2.3` for a root module and path-prefixed tags such as `api/v1.2.3` for submodules, then checks availability through the Go module proxy.
 
 For `crates.io`, `jsr`, `pub.dev`, and PyPI, monochange reports the setup URL for each package and blocks the next built-in registry publish until the trust configuration has been completed manually. It also preflights the GitHub trusted-publishing context for those registries, surfacing the repository, workflow, and environment it expects when that context can be resolved.
 

--- a/docs/src/guide/13-ci-and-publishing.md
+++ b/docs/src/guide/13-ci-and-publishing.md
@@ -56,7 +56,7 @@ Keeping those layers separate is important. Package publication and hosted-relea
 
 | Capability                                                                     | Current status                                                                                                 |
 | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
-| Multi-ecosystem discovery                                                      | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, Python                                                               |
+| Multi-ecosystem discovery                                                      | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, Python, Go                                                           |
 | Package release planning                                                       | Built in                                                                                                       |
 | Grouped/shared versioning                                                      | Built in                                                                                                       |
 | Dry-run release diff previews                                                  | Built in via `mc release --dry-run --diff`                                                                     |
@@ -64,7 +64,8 @@ Keeping those layers separate is important. Package publication and hosted-relea
 | Hosted provider releases                                                       | GitHub, GitLab, Gitea                                                                                          |
 | Hosted release requests                                                        | GitHub, GitLab, Gitea                                                                                          |
 | Python release planning                                                        | Built in for discovery, version rewrites, dependency rewrites, lockfile command inference, and PyPI publishing |
-| Built-in registry publishing                                                   | `crates.io`, `npm`, `jsr`, `pub.dev`, `pypi`; use external mode for custom registries                          |
+| Go release planning                                                            | Built in for `go.mod` discovery, dependency rewrites, `go mod tidy` inference, and Go proxy tag publishing     |
+| Built-in registry publishing                                                   | `crates.io`, `npm`, `jsr`, `pub.dev`, `pypi`, Go proxy tags; use external mode for custom registries           |
 | GitHub npm trusted-publishing automation                                       | Built in                                                                                                       |
 | GitHub trusted-publishing guidance for `crates.io`, `jsr`, `pub.dev`, and PyPI | Built in, but manual registry enrollment is still required                                                     |
 | GitLab trusted-publishing auto-derivation                                      | Not built in today                                                                                             |

--- a/docs/src/guide/ecosystems.md
+++ b/docs/src/guide/ecosystems.md
@@ -17,6 +17,7 @@ monochange uses ecosystem adapters to translate native package-manager files int
 | Deno           | `deno`            | Deno workspaces and standalone `deno.json` / `deno.jsonc` packages                      | Deno manifest versions, exports/imports metadata, and dependency references                | Direct `deno.lock` update when possible; no inferred lockfile command                                                                                   | `jsr`                        |
 | Dart / Flutter | `dart`, `flutter` | Dart and Flutter workspaces plus standalone `pubspec.yaml` packages                     | `pubspec.yaml` versions and dependency ranges                                              | Direct `pubspec.lock` update by default; configure `dart pub get` or `flutter pub get` when you need full solver refreshes                              | `pub.dev`                    |
 | Python         | `python`          | uv workspaces, Poetry projects, and standalone `pyproject.toml` packages                | PEP 621 `[project]` and Poetry `[tool.poetry]` package versions plus dependency specifiers | Does not mutate `uv.lock` or `poetry.lock` directly; infers `uv lock` and `poetry lock --no-update` commands; unknown Python lockfiles are skipped      | `pypi`                       |
+| Go             | `go`              | Standalone `go.mod` modules                                                             | Internal `require` directives in `go.mod`; package versions stay in VCS tags               | Does not mutate `go.sum` directly; infers `go mod tidy` so the Go toolchain refreshes `go.mod` and checksum data                                        | Go module proxy via VCS tags |
 
 The built-in publishing column is intentionally narrower than release planning. It lists only the canonical public registry for each supported ecosystem; private registries and custom publication flows should use `mode = "external"`.
 
@@ -174,8 +175,49 @@ dependency_version_prefix = ">="
 lockfile_commands = [{ command = "uv lock", cwd = "." }]
 ```
 
+## Go
+
+Go support is centered on `go.mod` files. Go module versions live in VCS tags rather than manifest fields, so monochange updates internal `require` directives and records enough metadata for tag-based publishing.
+
+Use Go support when your repository has:
+
+- one or more modules declared by `go.mod`
+- multi-module layouts where submodules need path-prefixed tags such as `api/v1.2.3`
+- internal module dependencies that should receive version bumps alongside released workspace modules
+- packages published through normal Go module proxy discovery
+
+Go behavior:
+
+- package ids come from the module path in the `module` directive
+- internal dependency ranges default to exact Go module versions with a leading `v`, matching Go module semantics
+- `require` directives participate in dependency updates, including grouped `require (...)` blocks
+- Go v2+ semantic import versioning remains encoded in module paths, not a separate manifest version field
+- `go.sum` is treated as checksum data, not as a lockfile to patch directly
+- monochange infers `go mod tidy` when `go.mod` / `go.sum` changes need package-manager refreshes
+- built-in publishing creates VCS tags: root modules use `v1.2.3`, while submodules use path-prefixed tags such as `api/v1.2.3`
+- readiness and publish checks query the Go module proxy for `<module>/@v/<version>.info` visibility
+
+Example Go package configuration:
+
+```toml
+[package.api]
+path = "services/api"
+type = "go"
+changelog = true
+
+[package.api.publish]
+enabled = true
+mode = "builtin"
+registry = "go_proxy"
+trusted_publishing = false
+
+[ecosystems.go]
+# Optional: override inferred tidy commands.
+lockfile_commands = [{ command = "go mod tidy", cwd = "services/api" }]
+```
+
 ## Choosing external publishing
 
-Use `mode = "external"` when an ecosystem or registry is not handled by monochange's built-in publisher, or when your organization needs custom signing, provenance, approval, rate-limit, private-registry behavior, or a Python publishing toolchain other than the built-in `uv build` / `uv publish` flow.
+Use `mode = "external"` when an ecosystem or registry is not handled by monochange's built-in publisher, or when your organization needs custom signing, provenance, approval, rate-limit, private-registry behavior, a Python publishing toolchain other than the built-in `uv build` / `uv publish` flow, or a Go publishing workflow that signs, pushes, or annotates tags outside monochange.
 
 That keeps the package in release planning while leaving upload mechanics to your existing publishing workflow.

--- a/docs/src/readme.md
+++ b/docs/src/readme.md
@@ -146,7 +146,7 @@ These are the commands most repositories use after running `mc init`. With the n
 
 <!-- {=projectMilestoneCapabilities} -->
 
-- discover Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, and Python packages
+- discover Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, Python, and Go packages
 - normalize dependency edges across ecosystems
 - coordinate shared package groups from `monochange.toml`
 - compute release plans from explicit change input

--- a/fixtures/tests/go/invalid-gomod/go.mod
+++ b/fixtures/tests/go/invalid-gomod/go.mod
@@ -1,0 +1,1 @@
+this is not valid go.mod syntax {{{

--- a/fixtures/tests/go/major-version/go.mod
+++ b/fixtures/tests/go/major-version/go.mod
@@ -1,0 +1,7 @@
+module github.com/example/sdk/v2
+
+go 1.22
+
+require (
+	github.com/example/sdk-core v1.5.0
+)

--- a/fixtures/tests/go/multi-module/api/go.mod
+++ b/fixtures/tests/go/multi-module/api/go.mod
@@ -1,0 +1,8 @@
+module github.com/example/monorepo/api
+
+go 1.22
+
+require (
+	github.com/example/monorepo/shared v1.2.0
+	github.com/gin-gonic/gin v1.9.1
+)

--- a/fixtures/tests/go/multi-module/shared/go.mod
+++ b/fixtures/tests/go/multi-module/shared/go.mod
@@ -1,0 +1,5 @@
+module github.com/example/monorepo/shared
+
+go 1.22
+
+require golang.org/x/text v0.14.0

--- a/fixtures/tests/go/multi-module/worker/go.mod
+++ b/fixtures/tests/go/multi-module/worker/go.mod
@@ -1,0 +1,8 @@
+module github.com/example/monorepo/worker
+
+go 1.22
+
+require (
+	github.com/example/monorepo/shared v1.2.0
+	github.com/nats-io/nats.go v1.31.0
+)

--- a/fixtures/tests/go/no-module-directive/go.mod
+++ b/fixtures/tests/go/no-module-directive/go.mod
@@ -1,0 +1,3 @@
+go 1.22
+
+require golang.org/x/text v0.14.0

--- a/fixtures/tests/go/single-module/go.mod
+++ b/fixtures/tests/go/single-module/go.mod
@@ -1,0 +1,9 @@
+module github.com/example/myapp
+
+go 1.22
+
+require (
+	github.com/gin-gonic/gin v1.9.1
+	github.com/go-redis/redis/v8 v8.11.5
+	golang.org/x/sys v0.15.0 // indirect
+)

--- a/fixtures/tests/go/single-module/go.sum
+++ b/fixtures/tests/go/single-module/go.sum
@@ -1,0 +1,2 @@
+github.com/gin-gonic/gin v1.9.1 h1:4idEAncQnU5cB7BeOkPtxjfCSye0AAm1R0RVIqFPSgU=
+github.com/gin-gonic/gin v1.9.1/go.mod h1:hPrL/0KcuqOB72mV6l6Ss=

--- a/monochange.toml
+++ b/monochange.toml
@@ -246,6 +246,9 @@ path = "crates/monochange_dart"
 [package.monochange_python]
 path = "crates/monochange_python"
 
+[package.monochange_go]
+path = "crates/monochange_go"
+
 [package.monochange_graph]
 path = "crates/monochange_graph"
 
@@ -377,6 +380,7 @@ packages = [
 	"monochange_ecmascript",
 	"monochange_dart",
 	"monochange_python",
+	"monochange_go",
 	"monochange_graph",
 	"monochange_semver",
 	"monochange_telemtry",

--- a/packages/monochange__cli/README.md
+++ b/packages/monochange__cli/README.md
@@ -18,7 +18,7 @@
 
 It discovers packages, normalizes dependency data, applies group rules, turns explicit change files into release plans, and can run config-defined release preparation from those same inputs.
 
-Use it when your repository has outgrown one-ecosystem release tooling and you want one model for Cargo, npm/pnpm/Bun, Deno, Dart/Flutter, and Python.
+Use it when your repository has outgrown one-ecosystem release tooling and you want one model for Cargo, npm/pnpm/Bun, Deno, Dart/Flutter, Python, and Go.
 
 <!-- {/projectReadmeOverview} -->
 
@@ -168,7 +168,7 @@ See [Advanced: Assistant setup and MCP](docs/src/guide/09-assistant-setup.md) fo
 
 <!-- {=projectMilestoneCapabilities} -->
 
-- discover Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, and Python packages
+- discover Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, Python, and Go packages
 - normalize dependency edges across ecosystems
 - coordinate shared package groups from `monochange.toml`
 - compute release plans from explicit change input
@@ -216,6 +216,8 @@ See [Advanced: Assistant setup and MCP](docs/src/guide/09-assistant-setup.md) fo
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__dart-orange?logo=rust)](https://crates.io/crates/monochange_dart) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__dart-1f425f?logo=docs.rs)](https://docs.rs/monochange_dart/)
 - `monochange_python` — Python uv workspace, Poetry, and pyproject.toml discovery.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__python-orange?logo=rust)](https://crates.io/crates/monochange_python) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__python-1f425f?logo=docs.rs)](https://docs.rs/monochange_python/)
+- `monochange_go` — Go module discovery, go.mod dependency rewrites, and tag-based release metadata.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__go-orange?logo=rust)](https://crates.io/crates/monochange_go) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__go-1f425f?logo=docs.rs)](https://docs.rs/monochange_go/)
 
 <!-- {/projectCrateCatalog} -->
 

--- a/packages/monochange__skill/SKILL.md
+++ b/packages/monochange__skill/SKILL.md
@@ -160,12 +160,12 @@ Release-oriented commands default to markdown output. Use `--format json` for au
 
 ### Lockfile commands
 
-Lockfile refresh is command-driven via `[ecosystems.<name>].lockfile_commands`. monochange infers sensible defaults for Cargo, npm-family, Dart/Flutter, and Python (`uv lock` / `poetry lock --no-update`). Explicit configuration overrides inference.
+Lockfile refresh is command-driven via `[ecosystems.<name>].lockfile_commands`. monochange infers sensible defaults for Cargo, npm-family, Dart/Flutter, Python (`uv lock` / `poetry lock --no-update`), and Go (`go mod tidy`). Explicit configuration overrides inference.
 
 ### Publishing and trust
 
 - Package publishing is configured through `publish` on packages and ecosystems.
-- Built-in publishing currently supports only the canonical public registries: `crates.io`, `npm`, `jsr`, `pub.dev`, and `pypi`. Use `mode = "external"` for private registries or custom publication flows.
+- Built-in publishing currently supports the canonical public registries and Go proxy/tag flow: `crates.io`, `npm`, `jsr`, `pub.dev`, `pypi`, and `go_proxy`. Use `mode = "external"` for private registries or custom publication flows.
 - `mc publish-readiness` blocks built-in Cargo publishes to crates.io when the current `Cargo.toml` is not publishable: `publish = false`, `publish = [...]` without `crates-io`, missing `description`, or missing both `license` and `license-file`. Workspace-inherited Cargo metadata is accepted.
 - `mc publish-plan --readiness <path>` validates a readiness artifact for the current release record, selected package set, and publish input fingerprint, then excludes package ids that are not ready in both the artifact and the fresh local readiness check. Placeholder planning does not accept readiness artifacts.
 - `mc publish-bootstrap --from HEAD --output <path>` is the release-scoped first-release bootstrap command. It reads package ids from the release record, runs placeholder publishing, writes a JSON result artifact, and should be followed by a fresh `mc publish-readiness` run.
@@ -174,9 +174,9 @@ Lockfile refresh is command-driven via `[ecosystems.<name>].lockfile_commands`. 
 - Placeholder README content can come from `publish.placeholder.readme` or `publish.placeholder.readme_file`.
 - `publish.trusted_publishing = true` tells monochange to manage or verify trusted publishing for that package when supported.
 - npm trusted publishing can be configured automatically from GitHub Actions context. pnpm workspaces use `pnpm exec npm trust ...` and `pnpm publish`, and monochange verifies the trust state before changing it.
-- Cargo, `jsr`, and `pub.dev` currently require manual trusted-publishing setup. monochange reports the setup URL and blocks the next built-in release publish until trust is configured.
+- Cargo, `jsr`, `pub.dev`, and PyPI currently require manual trusted-publishing setup. monochange reports the setup URL and blocks the next built-in release publish until trust is configured.
 - Prefer the official GitHub publishing workflows for manual registries when they exist: `rust-lang/crates-io-auth-action@v1` for `crates.io` and `dart-lang/setup-dart/.github/workflows/publish.yml@v1` for `pub.dev`.
-- See [skills/trusted-publishing.md](skills/trusted-publishing.md) for the exact registry fields, commands, official workflow preferences, and GitHub Actions requirements across `npm`, `crates.io`, `jsr`, and `pub.dev`.
+- See [skills/trusted-publishing.md](skills/trusted-publishing.md) for the exact registry fields, commands, official workflow preferences, and GitHub Actions requirements across `npm`, `crates.io`, `jsr`, `pub.dev`, PyPI, and Go module tags.
 - See [skills/multi-package-publishing.md](skills/multi-package-publishing.md) when one repository publishes multiple packages and you need to choose between shared readiness-enforced `mc publish` flows, package-specific jobs, or external workflows.
 - Built-in publishing does not yet manage registry rate-limit retries or delayed requeues. Use `mode = "external"` if your workflow needs custom scheduling.
 

--- a/packages/monochange__skill/readme.md
+++ b/packages/monochange__skill/readme.md
@@ -13,7 +13,7 @@ This package bundles:
 - `skills/linting.md` — `mc check`, `[lints]`, presets, and manifest-focused rule explanations with examples
 - `examples/readme.md` — condensed scenario examples for quick recommendations
 - `skills/reference.md` — high-context reference with broader examples
-- `skills/trusted-publishing.md` — GitHub/OIDC setup guidance for `npm`, `crates.io`, `jsr`, and `pub.dev`
+- `skills/trusted-publishing.md` — GitHub/OIDC setup guidance for `npm`, `crates.io`, `jsr`, `pub.dev`, PyPI, and Go module tags
 - `skills/multi-package-publishing.md` — monorepo-oriented publishing patterns for multiple public packages
 - `monochange-skill` — helper executable for printing or copying the bundled skill
 

--- a/packages/monochange__skill/skills/reference.md
+++ b/packages/monochange__skill/skills/reference.md
@@ -443,6 +443,7 @@ Lockfile refresh is command-driven. monochange infers defaults when not configur
 - npm-family: detects owned lockfiles and runs the matching command (`npm install --package-lock-only`, `pnpm install --lockfile-only`, `bun install --lockfile-only`)
 - Dart / Flutter: direct `pubspec.lock` updates by default; configure `dart pub get` or `flutter pub get` when needed
 - Python: `uv.lock` infers `uv lock`, `poetry.lock` infers `poetry lock --no-update`, and unknown Python lockfiles are skipped
+- Go: `go.mod` / `go.sum` refreshes infer `go mod tidy`; `go.sum` is checksum data, not a directly patched lockfile
 - Deno: no inferred default
 
 Explicit configuration overrides inference:
@@ -473,6 +474,8 @@ Built-in package publishing currently supports only the canonical public registr
 - npm packages → `npm`
 - Deno packages → `jsr`
 - Dart / Flutter packages → `pub.dev`
+- Python packages → `pypi`
+- Go modules → `go_proxy` via VCS tags
 
 Python package discovery and release planning are supported, but PyPI publishing is not built in yet. Use `mode = "external"` for Python, private registries, or unsupported publishing flows.
 
@@ -500,7 +503,7 @@ Placeholder README content can come from:
 
 - npm trusted publishing can be configured automatically from GitHub Actions context; monochange verifies the current state first, then runs `npm trust github <package> --repo <owner/repo> --file <workflow> [--env <environment>] --yes` or the `pnpm exec npm trust ...` equivalent for pnpm workspaces
 - Cargo, `jsr`, and `pub.dev` currently require manual trusted-publishing setup; monochange reports the setup URL and blocks the next built-in release publish until trust is configured
-- See [trusted-publishing.md](./trusted-publishing.md) for a GitHub-focused setup guide covering the exact registry fields and commands for `npm`, `crates.io`, `jsr`, and `pub.dev`
+- See [trusted-publishing.md](./trusted-publishing.md) for a GitHub-focused setup guide covering the exact registry fields and commands for `npm`, `crates.io`, `jsr`, `pub.dev`, PyPI, and Go module tags
 - See [multi-package-publishing.md](./multi-package-publishing.md) when one repository publishes multiple public packages and you need to choose between shared built-in flows and package-specific external workflows
 - Built-in publishing does not yet manage registry rate-limit retries or delayed requeues; use `mode = "external"` when your workflow needs custom scheduling
 

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@
 
 It discovers packages, normalizes dependency data, applies group rules, turns explicit change files into release plans, and can run config-defined release preparation from those same inputs.
 
-Use it when your repository has outgrown one-ecosystem release tooling and you want one model for Cargo, npm/pnpm/Bun, Deno, Dart/Flutter, and Python.
+Use it when your repository has outgrown one-ecosystem release tooling and you want one model for Cargo, npm/pnpm/Bun, Deno, Dart/Flutter, Python, and Go.
 
 <!-- {/projectReadmeOverview} -->
 
@@ -166,7 +166,7 @@ These are the commands most repositories use after running `mc init`. With the n
 
 | Capability                                                                     | Current status                                                                                                 |
 | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
-| Multi-ecosystem discovery                                                      | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, Python                                                               |
+| Multi-ecosystem discovery                                                      | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, Python, Go                                                           |
 | Package release planning                                                       | Built in                                                                                                       |
 | Grouped/shared versioning                                                      | Built in                                                                                                       |
 | Dry-run release diff previews                                                  | Built in via `mc release --dry-run --diff`                                                                     |
@@ -174,7 +174,8 @@ These are the commands most repositories use after running `mc init`. With the n
 | Hosted provider releases                                                       | GitHub, GitLab, Gitea                                                                                          |
 | Hosted release requests                                                        | GitHub, GitLab, Gitea                                                                                          |
 | Python release planning                                                        | Built in for discovery, version rewrites, dependency rewrites, lockfile command inference, and PyPI publishing |
-| Built-in registry publishing                                                   | `crates.io`, `npm`, `jsr`, `pub.dev`, `pypi`; use external mode for custom registries                          |
+| Go release planning                                                            | Built in for `go.mod` discovery, dependency rewrites, `go mod tidy` inference, and Go proxy tag publishing     |
+| Built-in registry publishing                                                   | `crates.io`, `npm`, `jsr`, `pub.dev`, `pypi`, Go proxy tags; use external mode for custom registries           |
 | GitHub npm trusted-publishing automation                                       | Built in                                                                                                       |
 | GitHub trusted-publishing guidance for `crates.io`, `jsr`, `pub.dev`, and PyPI | Built in, but manual registry enrollment is still required                                                     |
 | GitLab trusted-publishing auto-derivation                                      | Not built in today                                                                                             |
@@ -251,7 +252,7 @@ See [Advanced: Assistant setup and MCP](docs/src/guide/09-assistant-setup.md) fo
 
 <!-- {=projectMilestoneCapabilities} -->
 
-- discover Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, and Python packages
+- discover Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, Python, and Go packages
 - normalize dependency edges across ecosystems
 - coordinate shared package groups from `monochange.toml`
 - compute release plans from explicit change input
@@ -299,6 +300,8 @@ See [Advanced: Assistant setup and MCP](docs/src/guide/09-assistant-setup.md) fo
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__dart-orange?logo=rust)](https://crates.io/crates/monochange_dart) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__dart-1f425f?logo=docs.rs)](https://docs.rs/monochange_dart/)
 - `monochange_python` — Python uv workspace, Poetry, and pyproject.toml discovery.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__python-orange?logo=rust)](https://crates.io/crates/monochange_python) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__python-1f425f?logo=docs.rs)](https://docs.rs/monochange_python/)
+- `monochange_go` — Go module discovery, go.mod dependency rewrites, and tag-based release metadata.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__go-orange?logo=rust)](https://crates.io/crates/monochange_go) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__go-1f425f?logo=docs.rs)](https://docs.rs/monochange_go/)
 
 <!-- {/projectCrateCatalog} -->
 


### PR DESCRIPTION
Closes #133

## Summary

Add a complete `monochange_go` adapter crate that discovers Go modules from `go.mod` files in single-module and multi-module repositories.

## Adapter implementation

- **Module discovery**: Scans for `go.mod` files, parses `module` directives, and derives human-friendly names from module paths
- **Multi-module monorepos**: Discovers separate modules in subdirectories (e.g., `api/`, `shared/`, `worker/`) with cross-module `require` dependency edges
- **Major version handling**: Strips `/v2`, `/v3` path suffixes from module names per Go semantic import versioning conventions
- **Version from tags**: Go versions come from git tags, not manifest files — the adapter reports `None` for `current_version` and stores the full module path as metadata for downstream tag resolution
- **go.mod updates**: Updates `require` directives when cross-module dependency versions change, preserving `replace`, `exclude`, `retract` directives and comments
- **Lockfile inference**: Infers `go mod tidy` for all Go modules (updates both `go.mod` and `go.sum`)
- **Graceful errors**: Parse errors during standalone discovery are captured as warnings

## Documentation

Updated across all surfaces: discovery guide, configuration guide, init template, skill files, project templates, mdt consumer blocks.

## Test plan

- [x] 37 tests covering discovery, parsing, version updates, lockfile commands, and edge cases
- [x] Fixture-driven: single-module, multi-module, major-version, no-module-directive, invalid-gomod
- [x] `cargo clippy -p monochange_go --all-targets -- -D warnings` passes
- [x] `cargo test -p monochange_go -p monochange_core -p monochange_config -p monochange --lib` — 540 tests pass
- [x] `mdt check` — all consumer blocks in sync
- [x] `dprint check` — formatting clean