### PR TITLE
fix: remove lint and fix warnings

### DIFF
--- a/.changeset/fix-lint-all-warnings.md
+++ b/.changeset/fix-lint-all-warnings.md
@@ -1,0 +1,8 @@
+---
+monochange: patch
+monochange_graph: patch
+monochange_gitea: patch
+monochange_gitlab: patch
+---
+
+Keep `lint:all` and `fix:all` warning-free by tightening generated TOML rendering helpers, simplifying version-group severity fallback logic, refreshing Gitea and GitLab crate README provider blocks, and updating deny configuration for the current lockfile.

--- a/.templates/crates.t.md
+++ b/.templates/crates.t.md
@@ -69,6 +69,24 @@
 
 <!-- {/monochangeGithubBadgeLinks} -->
 
+<!-- {@monochangeGiteaBadgeLinks} -->
+
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__gitea-orange?logo=rust
+[crate-link]: https://crates.io/crates/monochange_gitea
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange__gitea-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange_gitea/
+
+<!-- {/monochangeGiteaBadgeLinks} -->
+
+<!-- {@monochangeGitlabBadgeLinks} -->
+
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__gitlab-orange?logo=rust
+[crate-link]: https://crates.io/crates/monochange_gitlab
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange__gitlab-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange_gitlab/
+
+<!-- {/monochangeGitlabBadgeLinks} -->
+
 <!-- {@monochangeNpmBadgeLinks} -->
 
 [crate-image]: https://img.shields.io/badge/crates.io-monochange__npm-orange?logo=rust
@@ -429,6 +447,60 @@ assert_eq!(requests[0].repository, "ifiokjr/monochange");
 ```
 
 <!-- {/monochangeGithubCrateDocs} -->
+
+<!-- {@monochangeGiteaCrateDocs} -->
+
+`monochange_gitea` turns `monochange` release manifests into Gitea automation requests.
+
+Reach for this crate when you want to preview or publish Gitea releases and release pull requests using the same structured release data that powers changelog files and release manifests.
+
+## Why use it?
+
+- derive Gitea release payloads and release-PR bodies from `monochange`'s structured release manifest
+- keep Gitea automation aligned with changelog rendering and release targets
+- reuse one publishing path for dry-run previews and real repository updates
+
+## Best for
+
+- building Gitea release automation on top of `mc release`
+- previewing would-be Gitea releases and release PRs in CI before publishing
+- self-hosted Gitea instances that need the same release workflow as GitHub or GitLab
+
+## Public entry points
+
+- `build_release_requests(manifest, source)` builds release payloads from prepared release state
+- `build_change_request(manifest, source)` builds a pull-request payload for the release
+- `validate_source_configuration(source)` validates Gitea-specific source config
+- `source_capabilities()` returns provider feature flags
+
+<!-- {/monochangeGiteaCrateDocs} -->
+
+<!-- {@monochangeGitlabCrateDocs} -->
+
+`monochange_gitlab` turns `monochange` release manifests into GitLab automation requests.
+
+Reach for this crate when you want to preview or publish GitLab releases and merge requests using the same structured release data that powers changelog files and release manifests.
+
+## Why use it?
+
+- derive GitLab release payloads and merge-request bodies from `monochange`'s structured release manifest
+- keep GitLab automation aligned with changelog rendering and release targets
+- reuse one publishing path for dry-run previews and real repository updates
+
+## Best for
+
+- building GitLab release automation on top of `mc release`
+- previewing would-be GitLab releases and merge requests in CI before publishing
+- self-hosted GitLab instances that need the same release workflow as GitHub
+
+## Public entry points
+
+- `build_release_requests(manifest, source)` builds release payloads from prepared release state
+- `build_change_request(manifest, source)` builds a merge-request payload for the release
+- `validate_source_configuration(source)` validates GitLab-specific source config
+- `source_capabilities()` returns provider feature flags
+
+<!-- {/monochangeGitlabCrateDocs} -->
 
 <!-- {@monochangeNpmCrateDocs} -->
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -135,7 +135,7 @@ fn render_cli_command_toml(rendered: &mut String, command: &CliCommandDefinition
 	writeln!(rendered, "[cli.{}]", command.name)
 		.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
 	if let Some(help_text) = &command.help_text {
-		write_toml_key_value(rendered, "help_text", render_toml_string(help_text));
+		write_toml_key_value(rendered, "help_text", &render_toml_string(help_text));
 	}
 	for input in &command.inputs {
 		rendered.push('\n');
@@ -151,17 +151,17 @@ fn render_cli_command_toml(rendered: &mut String, command: &CliCommandDefinition
 	}
 }
 
-fn write_toml_key_value(rendered: &mut String, key: &str, value: String) {
+fn write_toml_key_value(rendered: &mut String, key: &str, value: &str) {
 	writeln!(rendered, "{key} = {value}")
 		.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
 }
 
 fn render_cli_input_toml(rendered: &mut String, input: &monochange_core::CliInputDefinition) {
-	write_toml_key_value(rendered, "name", render_toml_string(&input.name));
+	write_toml_key_value(rendered, "name", &render_toml_string(&input.name));
 	write_toml_key_value(
 		rendered,
 		"type",
-		render_toml_string(match input.kind {
+		&render_toml_string(match input.kind {
 			monochange_core::CliInputKind::String => "string",
 			monochange_core::CliInputKind::StringList => "string_list",
 			monochange_core::CliInputKind::Path => "path",
@@ -170,19 +170,19 @@ fn render_cli_input_toml(rendered: &mut String, input: &monochange_core::CliInpu
 		}),
 	);
 	input.help_text.iter().for_each(|help_text| {
-		write_toml_key_value(rendered, "help_text", render_toml_string(help_text));
+		write_toml_key_value(rendered, "help_text", &render_toml_string(help_text));
 	});
 	if input.required {
-		write_toml_key_value(rendered, "required", "true".to_string());
+		write_toml_key_value(rendered, "required", "true");
 	}
 	if let Some(default) = &input.default {
-		write_toml_key_value(rendered, "default", render_toml_string(default));
+		write_toml_key_value(rendered, "default", &render_toml_string(default));
 	}
 	if !input.choices.is_empty() {
-		write_toml_key_value(rendered, "choices", render_toml_array(&input.choices));
+		write_toml_key_value(rendered, "choices", &render_toml_array(&input.choices));
 	}
 	if let Some(short) = input.short {
-		write_toml_key_value(rendered, "short", render_toml_string(&short.to_string()));
+		write_toml_key_value(rendered, "short", &render_toml_string(&short.to_string()));
 	}
 }
 
@@ -196,13 +196,13 @@ fn render_cli_step_toml(rendered: &mut String, step: &monochange_core::CliStepDe
 	}
 	match step {
 		monochange_core::CliStepDefinition::RenderReleaseManifest { path, inputs, .. } => {
-			path.iter().for_each(|path| {
+			if let Some(path) = path {
 				write_toml_key_value(
 					rendered,
 					"path",
-					render_toml_string(&path.display().to_string()),
+					&render_toml_string(&path.display().to_string()),
 				);
-			});
+			}
 			render_step_inputs_toml(rendered, inputs);
 		}
 		monochange_core::CliStepDefinition::Command {
@@ -235,8 +235,9 @@ fn render_cli_step_toml(rendered: &mut String, step: &monochange_core::CliStepDe
 						.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
 				}
 			}
-			id.iter()
-				.for_each(|id| write_toml_key_value(rendered, "id", render_toml_string(id)));
+			if let Some(id) = id {
+				write_toml_key_value(rendered, "id", &render_toml_string(id));
+			}
 			if let Some(variables) = variables {
 				writeln!(
 					rendered,
@@ -919,6 +920,7 @@ fn run_lockfile_command_in_place(
 	)))
 }
 
+#[cfg(test)]
 fn remap_workspace_path(root: &Path, temp_root: &Path, path: &Path) -> MonochangeResult<PathBuf> {
 	let normalized_root = monochange_core::normalize_path(root);
 	let normalized_path = monochange_core::normalize_path(path);
@@ -934,6 +936,7 @@ fn remap_workspace_path(root: &Path, temp_root: &Path, path: &Path) -> Monochang
 	Ok(temp_root.join(relative))
 }
 
+#[cfg(test)]
 fn run_lockfile_command(
 	root: &Path,
 	temp_root: &Path,
@@ -983,6 +986,7 @@ fn run_lockfile_command(
 	)))
 }
 
+#[cfg(test)]
 fn collect_workspace_file_updates(
 	root: &Path,
 	temp_root: &Path,
@@ -1040,6 +1044,7 @@ fn collect_workspace_file_updates(
 	Ok(updates)
 }
 
+#[cfg(test)]
 fn read_optional_file(path: &Path) -> MonochangeResult<Option<Vec<u8>>> {
 	match fs::read(path) {
 		Ok(contents) => Ok(Some(contents)),
@@ -1058,12 +1063,14 @@ fn read_optional_file(path: &Path) -> MonochangeResult<Option<Vec<u8>>> {
 	}
 }
 
+#[cfg(test)]
 fn entry_file_type(entry: &fs::DirEntry, path: &Path) -> MonochangeResult<fs::FileType> {
 	entry
 		.file_type()
 		.map_err(|error| MonochangeError::Io(format!("failed to stat {}: {error}", path.display())))
 }
 
+#[cfg(test)]
 fn strip_workspace_prefix<'a>(path: &'a Path, root: &Path) -> MonochangeResult<&'a Path> {
 	path.strip_prefix(root).map_err(|error| {
 		MonochangeError::Config(format!(
@@ -1074,12 +1081,14 @@ fn strip_workspace_prefix<'a>(path: &'a Path, root: &Path) -> MonochangeResult<&
 	})
 }
 
+#[cfg(test)]
 #[rustfmt::skip]
 fn ensure_parent_directory(path: &Path) -> MonochangeResult<()> {
 	if let Some(parent) = path.parent() { fs::create_dir_all(parent).map_err(|error| MonochangeError::Io(format!("failed to create {}: {error}", parent.display())))?; }
 	Ok(())
 }
 
+#[cfg(test)]
 fn copy_workspace_file(source: &Path, destination: &Path) -> MonochangeResult<()> {
 	fs::copy(source, destination).map_err(|error| {
 		MonochangeError::Io(format!(
@@ -1091,6 +1100,7 @@ fn copy_workspace_file(source: &Path, destination: &Path) -> MonochangeResult<()
 	Ok(())
 }
 
+#[cfg(test)]
 #[rustfmt::skip]
 fn collect_workspace_files(root: &Path, current: &Path, relative_paths: &mut BTreeSet<PathBuf>) -> MonochangeResult<()> {
 	for entry in fs::read_dir(current).map_err(|error| MonochangeError::Io(format!("failed to read {}: {error}", current.display())))? {
@@ -1104,6 +1114,7 @@ fn collect_workspace_files(root: &Path, current: &Path, relative_paths: &mut BTr
 	Ok(())
 }
 
+#[cfg(test)]
 #[rustfmt::skip]
 fn copy_workspace_tree(source: &Path, destination: &Path) -> MonochangeResult<()> {
 	fs::create_dir_all(destination).map_err(|error| MonochangeError::Io(format!("failed to create {}: {error}", destination.display())))?;
@@ -1317,7 +1328,7 @@ mod workspace_ops_tests {
 			&LockfileCommandExecution {
 				command: "'".to_string(),
 				cwd: fixture.path().to_path_buf(),
-				shell: monochange_core::ShellConfig::None,
+				shell: ShellConfig::None,
 			},
 		)
 		.err()
@@ -1330,7 +1341,7 @@ mod workspace_ops_tests {
 			&LockfileCommandExecution {
 				command: "   ".to_string(),
 				cwd: fixture.path().to_path_buf(),
-				shell: monochange_core::ShellConfig::None,
+				shell: ShellConfig::None,
 			},
 		)
 		.err()
@@ -1345,7 +1356,7 @@ mod workspace_ops_tests {
 			&LockfileCommandExecution {
 				command: "definitely-not-a-real-command".to_string(),
 				cwd: fixture.path().to_path_buf(),
-				shell: monochange_core::ShellConfig::None,
+				shell: ShellConfig::None,
 			},
 		)
 		.err()
@@ -1364,7 +1375,7 @@ mod workspace_ops_tests {
 					.display()
 					.to_string(),
 				cwd: fixture.path().to_path_buf(),
-				shell: monochange_core::ShellConfig::None,
+				shell: ShellConfig::None,
 			},
 		)
 		.err()
@@ -1381,7 +1392,7 @@ mod workspace_ops_tests {
 					.display()
 					.to_string(),
 				cwd: fixture.path().to_path_buf(),
-				shell: monochange_core::ShellConfig::None,
+				shell: ShellConfig::None,
 			},
 		)
 		.err()
@@ -1410,7 +1421,7 @@ mod workspace_ops_tests {
 					.display()
 					.to_string(),
 				cwd: fixture.path().to_path_buf(),
-				shell: monochange_core::ShellConfig::None,
+				shell: ShellConfig::None,
 			},
 		)
 		.unwrap_or_else(|error| panic!("write generated file: {error}"));
@@ -1418,7 +1429,7 @@ mod workspace_ops_tests {
 		let lockfile_cmd = LockfileCommandExecution {
 			command: String::new(),
 			cwd: fixture.path().to_path_buf(),
-			shell: monochange_core::ShellConfig::None,
+			shell: ShellConfig::None,
 		};
 		let updates =
 			collect_workspace_file_updates(fixture.path(), temp_root.path(), &[], &[lockfile_cmd])

--- a/crates/monochange_gitea/readme.md
+++ b/crates/monochange_gitea/readme.md
@@ -37,17 +37,22 @@ Reach for this crate when you want to preview or publish Gitea releases and rele
 
 <!-- {/monochangeGiteaCrateDocs} -->
 
-<!-- {=crateReadmeFooterLinks} -->
+<!-- {=monochangeGiteaBadgeLinks} -->
 
-[crate-image]: https://img.shields.io/crates/v/monochange_gitea.svg
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__gitea-orange?logo=rust
 [crate-link]: https://crates.io/crates/monochange_gitea
-[docs-image]: https://docs.rs/monochange_gitea/badge.svg
-[docs-link]: https://docs.rs/monochange_gitea
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange__gitea-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange_gitea/
+
+<!-- {/monochangeGiteaBadgeLinks} -->
+
+<!-- {=repoStatusBadgeLinks} -->
+
 [ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
 [ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
 [coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
 [coverage-link]: https://codecov.io/gh/ifiokjr/monochange
-[license-image]: https://img.shields.io/crates/l/monochange_gitea.svg
-[license-link]: https://unlicense.org
+[license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
+[license-link]: https://opensource.org/license/unlicense
 
-<!-- {/crateReadmeFooterLinks} -->
+<!-- {/repoStatusBadgeLinks} -->

--- a/crates/monochange_gitlab/readme.md
+++ b/crates/monochange_gitlab/readme.md
@@ -37,17 +37,22 @@ Reach for this crate when you want to preview or publish GitLab releases and mer
 
 <!-- {/monochangeGitlabCrateDocs} -->
 
-<!-- {=crateReadmeFooterLinks} -->
+<!-- {=monochangeGitlabBadgeLinks} -->
 
-[crate-image]: https://img.shields.io/crates/v/monochange_gitlab.svg
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__gitlab-orange?logo=rust
 [crate-link]: https://crates.io/crates/monochange_gitlab
-[docs-image]: https://docs.rs/monochange_gitlab/badge.svg
-[docs-link]: https://docs.rs/monochange_gitlab
+[docs-image]: https://img.shields.io/badge/docs.rs-monochange__gitlab-1f425f?logo=docs.rs
+[docs-link]: https://docs.rs/monochange_gitlab/
+
+<!-- {/monochangeGitlabBadgeLinks} -->
+
+<!-- {=repoStatusBadgeLinks} -->
+
 [ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
 [ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
 [coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
 [coverage-link]: https://codecov.io/gh/ifiokjr/monochange
-[license-image]: https://img.shields.io/crates/l/monochange_gitlab.svg
-[license-link]: https://unlicense.org
+[license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
+[license-link]: https://opensource.org/license/unlicense
 
-<!-- {/crateReadmeFooterLinks} -->
+<!-- {/repoStatusBadgeLinks} -->

--- a/crates/monochange_graph/src/lib.rs
+++ b/crates/monochange_graph/src/lib.rs
@@ -241,13 +241,15 @@ pub fn build_release_plan(
 				.map(|member| {
 					states
 						.get(member.as_str())
-						.map(|state| state.severity)
-						.unwrap_or_else(|| {
-							eprintln!(
-								"warning: version group `{group_id}` member `{member}` was not found in discovered packages"
-							);
-							BumpSeverity::None
-						})
+						.map_or_else(
+							|| {
+								eprintln!(
+									"warning: version group `{group_id}` member `{member}` was not found in discovered packages"
+								);
+								BumpSeverity::None
+							},
+							|state| state.severity,
+						)
 				})
 				.max()
 				.unwrap_or(BumpSeverity::None);

--- a/deny.toml
+++ b/deny.toml
@@ -32,6 +32,19 @@ confidence-threshold = 0.8
 multiple-versions = "warn"
 wildcards = "deny"
 highlight = "all"
+skip = [
+	# These remain duplicated through transitive dependencies outside the workspace's
+	# direct control. Track them explicitly so cargo-deny stays focused on new
+	# duplicate introductions.
+	"core-foundation@0.9.4",
+	"getrandom@0.2.17",
+	"getrandom@0.4.2",
+	"r-efi@5.3.0",
+	"thiserror@1.0.69",
+	"thiserror-impl@1.0.69",
+	"unicode-width@0.1.14",
+	"windows-sys@0.45.0",
+]
 
 [sources]
 unknown-registry = "deny"


### PR DESCRIPTION
## Summary
- remove the pedantic lint warnings in workspace TOML rendering and version-group fallback code
- restore missing mdt provider blocks for the Gitea and GitLab crate READMEs
- update deny configuration and lockfile entries so `lint:all` and `fix:all` run cleanly again

## Validation
- `devenv shell fix:all`
- `devenv shell lint:all`
- `mc affected --verify --changed-paths ...`
- `devenv test`
