### PR TITLE
feat: add Ruby ecosystem support (monochange_ruby)

### DIFF
--- a/.changeset/feat-ruby-ecosystem.md
+++ b/.changeset/feat-ruby-ecosystem.md
@@ -1,0 +1,43 @@
+---
+monochange: minor
+monochange_core: minor
+monochange_config: minor
+---
+
+#### add Ruby ecosystem support
+
+monochange now discovers and manages Ruby gems from `.gemspec` files with version constants in `version.rb`.
+
+**Configuration:**
+
+```toml
+[defaults]
+package_type = "ruby"
+
+[package.core]
+path = "gems/core"
+versioned_files = [
+	{ path = "lib/core/version.rb", regex = 'VERSION\s*=\s*"(?<version>\d+\.\d+\.\d+)"' },
+]
+
+[ecosystems.ruby]
+enabled = true
+```
+
+**What it discovers:**
+
+- Gems by scanning for `.gemspec` files
+- Version constants from `lib/<gem_name>/version.rb` using `VERSION = "x.y.z"` pattern
+- Runtime dependencies from `add_dependency` and `add_runtime_dependency`
+- Development dependencies from `add_development_dependency`
+
+**Version management:**
+
+- Reads VERSION constants from `version.rb` files (supports both single and double quotes)
+- Updates VERSION constants with new version strings while preserving quote style
+- Falls back to `lib/version.rb` and recursive search when the standard path doesn't exist
+
+**Lockfile commands:**
+
+- Infers `bundle lock --update` when `Gemfile.lock` exists
+- Configurable via `[ecosystems.ruby].lockfile_commands`

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -4,6 +4,7 @@
 - npm workspaces, pnpm workspaces, Bun workspaces, and standalone `package.json` packages
 - Deno workspaces and standalone `deno.json` / `deno.jsonc` packages
 - Dart and Flutter workspaces plus standalone `pubspec.yaml` packages
+- Ruby gems from `.gemspec` files with `version.rb` version constants
 
 <!-- {/discoverySupportedSources} -->
 
@@ -357,6 +358,10 @@ enabled = true
 [ecosystems.dart]
 enabled = true
 lockfile_commands = [{ command = "flutter pub get", cwd = "packages/mobile" }]
+
+[ecosystems.ruby]
+enabled = true
+lockfile_commands = [{ command = "bundle lock --update" }]
 ```
 
 <!-- {/configurationEcosystemSettingsSnippet} -->

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -4,7 +4,7 @@
 
 It discovers packages, normalizes dependency data, applies group rules, turns explicit change files into release plans, and can run config-defined release preparation from those same inputs.
 
-Use it when your repository has outgrown one-ecosystem release tooling and you want one model for Cargo, npm/pnpm/Bun, Deno, and Dart/Flutter.
+Use it when your repository has outgrown one-ecosystem release tooling and you want one model for Cargo, npm/pnpm/Bun, Deno, Dart/Flutter, and Ruby.
 
 <!-- {/projectReadmeOverview} -->
 
@@ -40,12 +40,14 @@ Use it when your repository has outgrown one-ecosystem release tooling and you w
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__deno-orange?logo=rust)](https://crates.io/crates/monochange_deno) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__deno-1f425f?logo=docs.rs)](https://docs.rs/monochange_deno/)
 - `monochange_dart` — Dart and Flutter workspace discovery.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__dart-orange?logo=rust)](https://crates.io/crates/monochange_dart) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__dart-1f425f?logo=docs.rs)](https://docs.rs/monochange_dart/)
+- `monochange_ruby` — Ruby gem discovery from `.gemspec` files.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__ruby-orange?logo=rust)](https://crates.io/crates/monochange_ruby) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__ruby-1f425f?logo=docs.rs)](https://docs.rs/monochange_ruby/)
 
 <!-- {/projectCrateCatalog} -->
 
 <!-- {@projectMilestoneCapabilities} -->
 
-- discover Cargo, npm/pnpm/Bun, Deno, Dart, and Flutter packages
+- discover Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, and Ruby packages
 - normalize dependency edges across ecosystems
 - coordinate shared package groups from `monochange.toml`
 - compute release plans from explicit change input

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2094,6 +2094,7 @@ dependencies = [
  "semver",
  "similar-asserts",
  "tempfile",
+ "tracing",
  "walkdir",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,6 +1852,7 @@ dependencies = [
  "monochange_gitlab",
  "monochange_graph",
  "monochange_npm",
+ "monochange_ruby",
  "monochange_semver",
  "monochange_test_helpers",
  "rayon",
@@ -1930,6 +1931,7 @@ dependencies = [
  "monochange_github",
  "monochange_gitlab",
  "monochange_npm",
+ "monochange_ruby",
  "monochange_test_helpers",
  "regex",
  "rstest",
@@ -2076,6 +2078,22 @@ dependencies = [
  "similar-asserts",
  "thiserror 2.0.18",
  "tracing",
+ "walkdir",
+]
+
+[[package]]
+name = "monochange_ruby"
+version = "0.0.0"
+dependencies = [
+ "glob",
+ "insta",
+ "monochange_core",
+ "monochange_test_helpers",
+ "regex",
+ "rstest",
+ "semver",
+ "similar-asserts",
+ "tempfile",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
 	"crates/monochange_gitlab",
 	"crates/monochange_graph",
 	"crates/monochange_npm",
+	"crates/monochange_ruby",
 	"crates/monochange_semver",
 	"docs",
 ]
@@ -27,6 +28,7 @@ default-members = [
 	"crates/monochange_gitea",
 	"crates/monochange_gitlab",
 	"crates/monochange_npm",
+	"crates/monochange_ruby",
 	"crates/monochange_semver",
 	"docs",
 ]
@@ -96,6 +98,7 @@ monochange_github = { version = "0.0.0", path = "./crates/monochange_github" }
 monochange_gitlab = { version = "0.0.0", path = "./crates/monochange_gitlab" }
 monochange_graph = { version = "0.0.0", path = "./crates/monochange_graph" }
 monochange_npm = { version = "0.0.0", path = "./crates/monochange_npm" }
+monochange_ruby = { version = "0.0.0", path = "./crates/monochange_ruby" }
 monochange_semver = { version = "0.0.0", path = "./crates/monochange_semver" }
 
 [workspace.metadata.bin]

--- a/crates/monochange/Cargo.toml
+++ b/crates/monochange/Cargo.toml
@@ -32,6 +32,7 @@ monochange_github = { workspace = true }
 monochange_gitlab = { workspace = true }
 monochange_graph = { workspace = true }
 monochange_npm = { workspace = true }
+monochange_ruby = { workspace = true }
 monochange_semver = { workspace = true }
 rayon = { workspace = true, default-features = true }
 regex = { workspace = true, default-features = true }

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -6872,6 +6872,7 @@ fn build_command_and_configured_change_type_choices_include_runtime_metadata() {
 		npm: monochange_core::EcosystemSettings::default(),
 		deno: monochange_core::EcosystemSettings::default(),
 		dart: monochange_core::EcosystemSettings::default(),
+		ruby: monochange_core::EcosystemSettings::default(),
 	};
 	assert_eq!(
 		crate::configured_change_type_choices(&configuration),
@@ -6918,6 +6919,7 @@ fn apply_runtime_change_type_choices_updates_only_unconfigured_change_inputs() {
 		npm: monochange_core::EcosystemSettings::default(),
 		deno: monochange_core::EcosystemSettings::default(),
 		dart: monochange_core::EcosystemSettings::default(),
+		ruby: monochange_core::EcosystemSettings::default(),
 	};
 	let mut cli = vec![
 		monochange_core::CliCommandDefinition {
@@ -6972,6 +6974,7 @@ fn apply_runtime_change_type_choices_preserves_existing_choice_inputs_and_empty_
 		npm: monochange_core::EcosystemSettings::default(),
 		deno: monochange_core::EcosystemSettings::default(),
 		dart: monochange_core::EcosystemSettings::default(),
+		ruby: monochange_core::EcosystemSettings::default(),
 	};
 	let mut cli = vec![monochange_core::CliCommandDefinition {
 		name: "change".to_string(),

--- a/crates/monochange/src/interactive.rs
+++ b/crates/monochange/src/interactive.rs
@@ -396,6 +396,7 @@ mod __tests {
 			npm: EcosystemSettings::default(),
 			deno: EcosystemSettings::default(),
 			dart: EcosystemSettings::default(),
+			ruby: EcosystemSettings::default(),
 		}
 	}
 
@@ -608,6 +609,7 @@ mod __tests {
 			npm: EcosystemSettings::default(),
 			deno: EcosystemSettings::default(),
 			dart: EcosystemSettings::default(),
+			ruby: EcosystemSettings::default(),
 		};
 		let displays = build_selectable_targets(&configuration)
 			.into_iter()
@@ -666,6 +668,7 @@ mod __tests {
 			npm: EcosystemSettings::default(),
 			deno: EcosystemSettings::default(),
 			dart: EcosystemSettings::default(),
+			ruby: EcosystemSettings::default(),
 		};
 		let target = build_selectable_targets(&configuration)
 			.into_iter()

--- a/crates/monochange/src/monochange.init.toml
+++ b/crates/monochange/src/monochange.init.toml
@@ -9,7 +9,7 @@
     packages         -- list of { id, path, type, changelog? }
     has_group        -- true when more than one package was discovered
     package_ids_toml -- pre-formatted TOML array contents
-    has_cargo / has_npm / has_deno / has_dart -- ecosystem detected flags
+    has_cargo / has_npm / has_deno / has_dart / has_ruby -- ecosystem detected flags
 #}
 # =============================================================================
 # monochange.toml — repository configuration for monochange
@@ -51,7 +51,7 @@ warn_on_group_mismatch = true
 # Default package type for all packages that don't declare their own `type`.
 # Setting this avoids repeating `type = "cargo"` on every [package.*] entry.
 #
-# Options: "cargo", "npm", "deno", "dart", "flutter"
+# Options: "cargo", "npm", "deno", "dart", "flutter", "ruby"
 # Default: none (each package must declare its own type)
 # package_type = "cargo"
 
@@ -191,7 +191,7 @@ warn_on_group_mismatch = true
 #   path  — relative path from repo root to the package directory
 #
 # Optional fields:
-#   type                    — "cargo", "npm", "deno", "dart", "flutter"
+#   type                    — "cargo", "npm", "deno", "dart", "flutter", "ruby"
 #                             (not needed when defaults.package_type is set)
 #   changelog               — true, false, "path/to/changelog.md", or a table
 #                             with { path, format }; overrides [defaults.changelog]
@@ -360,6 +360,14 @@ enabled = true
 enabled = true
 {% else %}
 # [ecosystems.dart]
+# enabled = true
+{% endif %}
+
+{% if has_ruby %}
+[ecosystems.ruby]
+enabled = true
+{% else %}
+# [ecosystems.ruby]
 # enabled = true
 {% endif %}
 

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -22,6 +22,7 @@ pub(crate) enum VersionedFileKind {
 	Npm(monochange_npm::NpmVersionedFileKind),
 	Deno(monochange_deno::DenoVersionedFileKind),
 	Dart(monochange_dart::DartVersionedFileKind),
+	Ruby(monochange_ruby::RubyVersionedFileKind),
 }
 
 pub(crate) fn versioned_file_kind(
@@ -40,6 +41,9 @@ pub(crate) fn versioned_file_kind(
 		}
 		monochange_core::EcosystemType::Dart => {
 			monochange_dart::supported_versioned_file_kind(path).map(VersionedFileKind::Dart)
+		}
+		monochange_core::EcosystemType::Ruby => {
+			monochange_ruby::supported_versioned_file_kind(path).map(VersionedFileKind::Ruby)
 		}
 	}
 }
@@ -255,6 +259,7 @@ pub(crate) fn read_cached_document(
 				monochange_core::EcosystemType::Npm => "npm",
 				monochange_core::EcosystemType::Deno => "deno",
 				monochange_core::EcosystemType::Dart => "dart",
+				monochange_core::EcosystemType::Ruby => "ruby",
 			},
 		)));
 	};
@@ -358,6 +363,15 @@ pub(crate) fn read_cached_document(
 			}
 			Ok(CachedDocument::Text(contents))
 		}
+		VersionedFileKind::Ruby(_) => {
+			let Some(contents) = text_contents else {
+				return Err(MonochangeError::Config(format!(
+					"failed to parse {} as text",
+					path.display()
+				)));
+			};
+			Ok(CachedDocument::Text(contents))
+		}
 		VersionedFileKind::Npm(_) | VersionedFileKind::Deno(_) => {
 			let Some(contents) = text_contents.as_ref() else {
 				return Err(MonochangeError::Config(format!(
@@ -397,6 +411,9 @@ pub(crate) fn resolve_versioned_prefix(
 		}
 		monochange_core::EcosystemType::Dart => {
 			context.configuration.dart.dependency_version_prefix.clone()
+		}
+		monochange_core::EcosystemType::Ruby => {
+			context.configuration.ruby.dependency_version_prefix.clone()
 		}
 	};
 	ecosystem_prefix.unwrap_or_else(|| ecosystem_type.default_prefix().to_string())
@@ -557,6 +574,7 @@ pub(crate) fn apply_versioned_file_definition(
 					monochange_core::EcosystemType::Npm => "npm",
 					monochange_core::EcosystemType::Deno => "deno",
 					monochange_core::EcosystemType::Dart => "dart",
+					monochange_core::EcosystemType::Ruby => "ruby",
 				},
 			)));
 		};
@@ -703,6 +721,11 @@ pub(crate) fn apply_versioned_file_definition(
 			(CachedDocument::Yaml(mapping), VersionedFileKind::Dart(kind)) => {
 				if kind == monochange_dart::DartVersionedFileKind::Lock {
 					monochange_dart::update_pubspec_lock(mapping, &raw_versions);
+				}
+			}
+			(CachedDocument::Text(contents), VersionedFileKind::Ruby(kind)) => {
+				if kind == monochange_ruby::RubyVersionedFileKind::VersionFile {
+					*contents = monochange_ruby::update_version_file_text(contents, owner_version);
 				}
 			}
 			_ => {}

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -28,6 +28,7 @@ use monochange_dart::discover_dart_packages;
 use monochange_deno::discover_deno_packages;
 use monochange_github as github_provider;
 use monochange_npm::discover_npm_packages;
+use monochange_ruby::discover_ruby_gems;
 use serde_json::json;
 use typed_builder::TypedBuilder;
 
@@ -374,6 +375,7 @@ fn render_annotated_init_config(root: &Path) -> MonochangeResult<String> {
 			PackageType::Deno => "deno",
 			PackageType::Dart => "dart",
 			PackageType::Flutter => "flutter",
+			PackageType::Ruby => "ruby",
 		};
 		let mut entry = BTreeMap::new();
 		entry.insert("id", json!(id));
@@ -391,6 +393,7 @@ fn render_annotated_init_config(root: &Path) -> MonochangeResult<String> {
 	let has_dart = packages
 		.iter()
 		.any(|p| p.ecosystem == Ecosystem::Dart || p.ecosystem == Ecosystem::Flutter);
+	let has_ruby = packages.iter().any(|p| p.ecosystem == Ecosystem::Ruby);
 
 	let package_ids_toml = package_ids
 		.iter()
@@ -406,6 +409,7 @@ fn render_annotated_init_config(root: &Path) -> MonochangeResult<String> {
 		"has_npm": has_npm,
 		"has_deno": has_deno,
 		"has_dart": has_dart,
+		"has_ruby": has_ruby,
 	});
 
 	let jinja_context = minijinja::Value::from_serialize(&context);
@@ -437,6 +441,7 @@ fn discover_packages(root: &Path) -> MonochangeResult<Vec<PackageRecord>> {
 		discover_npm_packages(root)?,
 		discover_deno_packages(root)?,
 		discover_dart_packages(root)?,
+		discover_ruby_gems(root)?,
 	] {
 		packages.extend(discovery.packages);
 	}
@@ -477,6 +482,7 @@ fn package_type_for_ecosystem(ecosystem: Ecosystem) -> PackageType {
 		Ecosystem::Deno => PackageType::Deno,
 		Ecosystem::Dart => PackageType::Dart,
 		Ecosystem::Flutter => PackageType::Flutter,
+		Ecosystem::Ruby => PackageType::Ruby,
 	}
 }
 
@@ -495,10 +501,13 @@ pub(crate) fn build_lockfile_command_executions(
 	let deno_executions = resolve_lockfile_command_executions(root, &configuration.deno.lockfile_commands, packages.iter().filter(|package| package.ecosystem == Ecosystem::Deno && released_versions.contains_key(&package.id)).collect(), monochange_deno::default_lockfile_commands)?;
 	#[rustfmt::skip]
 	let dart_executions = resolve_lockfile_command_executions(root, &configuration.dart.lockfile_commands, packages.iter().filter(|package| matches!(package.ecosystem, Ecosystem::Dart | Ecosystem::Flutter) && released_versions.contains_key(&package.id)).collect(), monochange_dart::default_lockfile_commands)?;
+	#[rustfmt::skip]
+	let ruby_executions = resolve_lockfile_command_executions(root, &configuration.ruby.lockfile_commands, packages.iter().filter(|package| package.ecosystem == Ecosystem::Ruby && released_versions.contains_key(&package.id)).collect(), monochange_ruby::default_lockfile_commands)?;
 	let mut executions = cargo_executions;
 	executions.extend(npm_executions);
 	executions.extend(deno_executions);
 	executions.extend(dart_executions);
+	executions.extend(ruby_executions);
 	Ok(dedup_lockfile_command_executions(executions))
 }
 
@@ -578,6 +587,7 @@ pub fn discover_workspace(root: &Path) -> MonochangeResult<DiscoveryReport> {
 		discover_npm_packages(root)?,
 		discover_deno_packages(root)?,
 		discover_dart_packages(root)?,
+		discover_ruby_gems(root)?,
 	] {
 		warnings.extend(discovery.warnings);
 		packages.extend(discovery.packages);

--- a/crates/monochange_config/Cargo.toml
+++ b/crates/monochange_config/Cargo.toml
@@ -25,6 +25,7 @@ monochange_gitea = { workspace = true }
 monochange_github = { workspace = true }
 monochange_gitlab = { workspace = true }
 monochange_npm = { workspace = true }
+monochange_ruby = { workspace = true }
 regex = { workspace = true, default-features = true }
 semver = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -337,6 +337,8 @@ struct RawEcosystems {
 	deno: RawEcosystemSettings,
 	#[serde(default)]
 	dart: RawEcosystemSettings,
+	#[serde(default)]
+	ruby: RawEcosystemSettings,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -827,6 +829,7 @@ fn package_type_to_ecosystem_type(package_type: PackageType) -> EcosystemType {
 		PackageType::Npm => EcosystemType::Npm,
 		PackageType::Deno => EcosystemType::Deno,
 		PackageType::Dart | PackageType::Flutter => EcosystemType::Dart,
+		PackageType::Ruby => EcosystemType::Ruby,
 	}
 }
 
@@ -942,6 +945,8 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		normalize_ecosystem_settings(&contents, "deno", EcosystemType::Deno, ecosystems.deno)?;
 	let dart_ecosystem =
 		normalize_ecosystem_settings(&contents, "dart", EcosystemType::Dart, ecosystems.dart)?;
+	let ruby_ecosystem =
+		normalize_ecosystem_settings(&contents, "ruby", EcosystemType::Ruby, ecosystems.ruby)?;
 	let defaults_changelog_policy = defaults
 		.changelog
 		.as_ref()
@@ -998,6 +1003,7 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 					EcosystemType::Npm => npm_ecosystem.versioned_files.clone(),
 					EcosystemType::Deno => deno_ecosystem.versioned_files.clone(),
 					EcosystemType::Dart => dart_ecosystem.versioned_files.clone(),
+					EcosystemType::Ruby => ruby_ecosystem.versioned_files.clone(),
 				}
 			};
 			let mut versioned_files = inherited_versioned_files;
@@ -1207,6 +1213,7 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		("npm", &npm_ecosystem),
 		("deno", &deno_ecosystem),
 		("dart", &dart_ecosystem),
+		("ruby", &ruby_ecosystem),
 	] {
 		let declared_packages = packages
 			.iter()
@@ -1252,6 +1259,7 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		npm: npm_ecosystem,
 		deno: deno_ecosystem,
 		dart: dart_ecosystem,
+		ruby: ruby_ecosystem,
 	})
 }
 
@@ -2073,6 +2081,7 @@ fn path_is_supported_for_ecosystem(path: &Path, ecosystem_type: EcosystemType) -
 		EcosystemType::Npm => monochange_npm::supported_versioned_file_kind(path).is_some(),
 		EcosystemType::Deno => monochange_deno::supported_versioned_file_kind(path).is_some(),
 		EcosystemType::Dart => monochange_dart::supported_versioned_file_kind(path).is_some(),
+		EcosystemType::Ruby => monochange_ruby::supported_versioned_file_kind(path).is_some(),
 	}
 }
 
@@ -2223,6 +2232,7 @@ fn validate_versioned_files(
 							EcosystemType::Npm => "npm",
 							EcosystemType::Deno => "deno",
 							EcosystemType::Dart => "dart",
+							EcosystemType::Ruby => "ruby",
 						}
 					),
 					vec![config_section_label(
@@ -2286,6 +2296,7 @@ fn expected_manifest_name(package_type: PackageType) -> &'static str {
 		PackageType::Npm => "package.json",
 		PackageType::Deno => "deno.json",
 		PackageType::Dart | PackageType::Flutter => "pubspec.yaml",
+		PackageType::Ruby => ".gemspec",
 	}
 }
 
@@ -3460,6 +3471,7 @@ pub fn validate_versioned_files_content(root: &Path) -> MonochangeResult<Vec<Str
 		("npm", &configuration.npm),
 		("deno", &configuration.deno),
 		("dart", &configuration.dart),
+		("ruby", &configuration.ruby),
 	];
 	for &(eco_name, settings) in ecosystem_entries {
 		if !settings.versioned_files.is_empty() {
@@ -3630,6 +3642,13 @@ fn validate_ecosystem_version_readable(
 			if yaml.get("version").and_then(|v| v.as_str()).is_none() {
 				return Err(MonochangeError::Config(format!(
 					"{owner_kind} `{owner_id}` versioned file `{display_path}` does not contain a `version` string field"
+				)));
+			}
+		}
+		EcosystemType::Ruby => {
+			if !contents.contains("spec.name") {
+				return Err(MonochangeError::Config(format!(
+					"{owner_kind} `{owner_id}` versioned file `{display_path}` does not appear to be a valid gemspec (missing `spec.name`)"
 				)));
 			}
 		}

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -882,6 +882,7 @@ fn sample_workspace_configuration() -> WorkspaceConfiguration {
 		npm: EcosystemSettings::default(),
 		deno: EcosystemSettings::default(),
 		dart: EcosystemSettings::default(),
+		ruby: EcosystemSettings::default(),
 	}
 }
 

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -187,6 +187,7 @@ pub enum Ecosystem {
 	Deno,
 	Dart,
 	Flutter,
+	Ruby,
 }
 
 impl Ecosystem {
@@ -198,6 +199,7 @@ impl Ecosystem {
 			Self::Deno => "deno",
 			Self::Dart => "dart",
 			Self::Flutter => "flutter",
+			Self::Ruby => "ruby",
 		}
 	}
 }
@@ -348,6 +350,7 @@ pub enum PackageType {
 	Deno,
 	Dart,
 	Flutter,
+	Ruby,
 }
 
 impl PackageType {
@@ -359,6 +362,7 @@ impl PackageType {
 			Self::Deno => "deno",
 			Self::Dart => "dart",
 			Self::Flutter => "flutter",
+			Self::Ruby => "ruby",
 		}
 	}
 }
@@ -378,6 +382,7 @@ pub enum EcosystemType {
 	Npm,
 	Deno,
 	Dart,
+	Ruby,
 }
 
 impl EcosystemType {
@@ -386,6 +391,7 @@ impl EcosystemType {
 		match self {
 			Self::Cargo => "",
 			Self::Npm | Self::Deno | Self::Dart => "^",
+			Self::Ruby => "~> ",
 		}
 	}
 
@@ -396,6 +402,7 @@ impl EcosystemType {
 			Self::Npm => &["dependencies", "devDependencies", "peerDependencies"],
 			Self::Deno => &["imports"],
 			Self::Dart => &["dependencies", "dev_dependencies"],
+			Self::Ruby => &["runtime_dependencies"],
 		}
 	}
 }
@@ -2484,6 +2491,7 @@ pub struct WorkspaceConfiguration {
 	pub npm: EcosystemSettings,
 	pub deno: EcosystemSettings,
 	pub dart: EcosystemSettings,
+	pub ruby: EcosystemSettings,
 }
 
 impl WorkspaceConfiguration {

--- a/crates/monochange_ruby/Cargo.toml
+++ b/crates/monochange_ruby/Cargo.toml
@@ -17,6 +17,7 @@ glob = { workspace = true, default-features = true }
 monochange_core = { workspace = true }
 regex = { workspace = true, default-features = true }
 semver = { workspace = true, default-features = true }
+tracing = { workspace = true, default-features = true }
 walkdir = { workspace = true, default-features = true }
 
 [dev-dependencies]

--- a/crates/monochange_ruby/Cargo.toml
+++ b/crates/monochange_ruby/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "monochange_ruby"
+version = { workspace = true }
+categories = { workspace = true }
+documentation = "https://docs.rs/monochange_ruby"
+edition = { workspace = true }
+include = { workspace = true }
+keywords = ["cli", "changelog", "releases", "versioning", "monorepo"]
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+description = "Ruby ecosystem adapter for monochange — discovers gems from .gemspec files and version.rb constants"
+
+[dependencies]
+glob = { workspace = true, default-features = true }
+monochange_core = { workspace = true }
+regex = { workspace = true, default-features = true }
+semver = { workspace = true, default-features = true }
+walkdir = { workspace = true, default-features = true }
+
+[dev-dependencies]
+insta = { workspace = true, default-features = true }
+monochange_test_helpers = { version = "0.0.0", path = "../../testing/monochange_test_helpers" }
+rstest = { workspace = true, default-features = true }
+similar-asserts = { workspace = true, default-features = true }
+tempfile = { workspace = true, default-features = true }
+
+[lints]
+workspace = true

--- a/crates/monochange_ruby/src/__tests.rs
+++ b/crates/monochange_ruby/src/__tests.rs
@@ -407,3 +407,37 @@ fn discover_ruby_gems_skips_vendor_and_bundle_directories() {
 	);
 	assert_eq!(discovery.packages.first().unwrap().name, "root");
 }
+
+#[test]
+fn discover_ruby_gems_finds_version_in_deeply_nested_path() {
+	let root = fixture_path("ruby/nested-version");
+	let discovery = discover_ruby_gems(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+
+	assert_eq!(discovery.packages.len(), 1);
+	let pkg = discovery.packages.first().unwrap();
+	assert_eq!(pkg.name, "nested_version");
+	assert_eq!(
+		pkg.current_version,
+		Some(Version::new(3, 0, 0)),
+		"should find version.rb via recursive search"
+	);
+}
+
+#[test]
+fn parse_gemspec_dependencies_with_single_quotes() {
+	let contents = "Gem::Specification.new do |s|\n  s.add_dependency 'rack', '~> 2.0'\n  s.add_development_dependency 'minitest', '~> 5.0'\nend";
+	let deps = parse_gemspec_dependencies(contents);
+	let runtime: Vec<&str> = deps
+		.iter()
+		.filter(|d| d.kind == DependencyKind::Runtime)
+		.map(|d| d.name.as_str())
+		.collect();
+	assert!(runtime.contains(&"rack"));
+
+	let dev: Vec<&str> = deps
+		.iter()
+		.filter(|d| d.kind == DependencyKind::Development)
+		.map(|d| d.name.as_str())
+		.collect();
+	assert!(dev.contains(&"minitest"));
+}

--- a/crates/monochange_ruby/src/__tests.rs
+++ b/crates/monochange_ruby/src/__tests.rs
@@ -1,0 +1,409 @@
+use std::path::PathBuf;
+
+use monochange_core::DependencyKind;
+use monochange_core::Ecosystem;
+use monochange_core::EcosystemAdapter;
+use monochange_core::PackageRecord;
+use monochange_core::PublishState;
+use semver::Version;
+
+use crate::discover_ruby_gems;
+use crate::parse_gem_name;
+use crate::parse_gemspec_dependencies;
+use crate::parse_version_constant;
+use crate::update_version_file_text;
+use crate::RubyAdapter;
+use crate::RubyVersionedFileKind;
+
+fn fixture_path(relative: &str) -> PathBuf {
+	monochange_test_helpers::fs::fixture_path_from(env!("CARGO_MANIFEST_DIR"), relative)
+}
+
+// -- adapter --
+
+#[test]
+fn adapter_reports_ruby_ecosystem() {
+	assert_eq!(RubyAdapter.ecosystem(), Ecosystem::Ruby);
+}
+
+#[test]
+fn adapter_discover_delegates_to_discover_ruby_gems() {
+	let root = fixture_path("ruby/single-gem");
+	let discovery = RubyAdapter
+		.discover(&root)
+		.unwrap_or_else(|error| panic!("discover: {error}"));
+	assert_eq!(discovery.packages.len(), 1);
+	assert_eq!(discovery.packages.first().unwrap().name, "my_gem");
+}
+
+// -- supported_versioned_file_kind --
+
+#[test]
+fn supported_versioned_file_kind_recognizes_ruby_files() {
+	use crate::supported_versioned_file_kind;
+	assert_eq!(
+		supported_versioned_file_kind("my_gem.gemspec".as_ref()),
+		Some(RubyVersionedFileKind::Gemspec)
+	);
+	assert_eq!(
+		supported_versioned_file_kind("version.rb".as_ref()),
+		Some(RubyVersionedFileKind::VersionFile)
+	);
+	assert_eq!(
+		supported_versioned_file_kind("Gemfile.lock".as_ref()),
+		Some(RubyVersionedFileKind::Lock)
+	);
+	assert_eq!(supported_versioned_file_kind("Cargo.toml".as_ref()), None);
+	assert_eq!(supported_versioned_file_kind("other.rb".as_ref()), None);
+}
+
+// -- parse_gem_name --
+
+#[test]
+fn parse_gem_name_extracts_name_from_gemspec() {
+	let contents = r#"Gem::Specification.new do |spec|
+  spec.name = "my_gem"
+  spec.version = MyGem::VERSION
+end"#;
+	assert_eq!(parse_gem_name(contents), Some("my_gem".to_string()));
+}
+
+#[test]
+fn parse_gem_name_handles_single_quotes() {
+	let contents = "Gem::Specification.new do |s|\n  s.name = 'cool-gem'\nend";
+	assert_eq!(parse_gem_name(contents), Some("cool-gem".to_string()));
+}
+
+#[test]
+fn parse_gem_name_handles_short_block_variable() {
+	let contents = "Gem::Specification.new do |s|\n  s.name    = \"short\"\nend";
+	assert_eq!(parse_gem_name(contents), Some("short".to_string()));
+}
+
+#[test]
+fn parse_gem_name_returns_none_without_name() {
+	let contents = "Gem::Specification.new do |spec|\n  spec.summary = \"no name\"\nend";
+	assert_eq!(parse_gem_name(contents), None);
+}
+
+// -- parse_version_constant --
+
+#[test]
+fn parse_version_constant_extracts_semver() {
+	assert_eq!(
+		parse_version_constant("  VERSION = \"1.2.3\"\n"),
+		Some(Version::new(1, 2, 3))
+	);
+	assert_eq!(
+		parse_version_constant("  VERSION = '0.1.0'\n"),
+		Some(Version::new(0, 1, 0))
+	);
+	assert_eq!(
+		parse_version_constant("module Foo\n  VERSION = \"10.20.30\"\nend\n"),
+		Some(Version::new(10, 20, 30))
+	);
+}
+
+#[test]
+fn parse_version_constant_returns_none_for_non_semver() {
+	assert_eq!(parse_version_constant("VERSION = 'not-a-version'"), None);
+	assert_eq!(parse_version_constant("no version here"), None);
+	assert_eq!(parse_version_constant(""), None);
+}
+
+// -- parse_gemspec_dependencies --
+
+#[test]
+fn parse_gemspec_dependencies_extracts_runtime_and_dev_deps() {
+	let contents = r#"Gem::Specification.new do |spec|
+  spec.name = "test"
+  spec.add_dependency "rails", "~> 7.0"
+  spec.add_runtime_dependency "redis", ">= 4.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+end"#;
+	let deps = parse_gemspec_dependencies(contents);
+
+	let runtime: Vec<&str> = deps
+		.iter()
+		.filter(|d| d.kind == DependencyKind::Runtime)
+		.map(|d| d.name.as_str())
+		.collect();
+	assert!(runtime.contains(&"rails"), "missing rails: {runtime:?}");
+	assert!(runtime.contains(&"redis"), "missing redis: {runtime:?}");
+
+	let dev: Vec<&str> = deps
+		.iter()
+		.filter(|d| d.kind == DependencyKind::Development)
+		.map(|d| d.name.as_str())
+		.collect();
+	assert!(dev.contains(&"rspec"), "missing rspec: {dev:?}");
+}
+
+#[test]
+fn parse_gemspec_dependencies_extracts_version_constraints() {
+	let contents = "Gem::Specification.new do |s|\n  s.add_dependency \"rails\", \"~> 7.0\"\nend";
+	let deps = parse_gemspec_dependencies(contents);
+	assert_eq!(deps.len(), 1);
+	assert_eq!(
+		deps.first().unwrap().version_constraint.as_deref(),
+		Some("~> 7.0")
+	);
+}
+
+#[test]
+fn parse_gemspec_dependencies_handles_no_deps() {
+	let contents = "Gem::Specification.new do |spec|\n  spec.name = \"bare\"\nend";
+	let deps = parse_gemspec_dependencies(contents);
+	assert!(deps.is_empty());
+}
+
+// -- discover_ruby_gems --
+
+#[test]
+fn discover_ruby_gems_finds_single_gem() {
+	let root = fixture_path("ruby/single-gem");
+	let discovery = discover_ruby_gems(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+
+	assert_eq!(discovery.packages.len(), 1);
+	let pkg = discovery.packages.first().unwrap();
+	assert_eq!(pkg.name, "my_gem");
+	assert_eq!(pkg.ecosystem, Ecosystem::Ruby);
+	assert_eq!(pkg.current_version, Some(Version::new(1, 2, 3)));
+}
+
+#[test]
+fn discover_ruby_gems_finds_monorepo_gems() {
+	let root = fixture_path("ruby/monorepo");
+	let discovery = discover_ruby_gems(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+
+	assert_eq!(discovery.packages.len(), 2);
+	let names: Vec<&str> = discovery.packages.iter().map(|p| p.name.as_str()).collect();
+	assert!(names.contains(&"core"), "missing core: {names:?}");
+	assert!(names.contains(&"api"), "missing api: {names:?}");
+
+	let core = discovery
+		.packages
+		.iter()
+		.find(|p| p.name == "core")
+		.unwrap();
+	assert_eq!(core.current_version, Some(Version::new(2, 0, 0)));
+
+	let api = discovery.packages.iter().find(|p| p.name == "api").unwrap();
+	assert_eq!(api.current_version, Some(Version::new(1, 5, 0)));
+}
+
+#[test]
+fn discover_ruby_gems_extracts_dependencies() {
+	let root = fixture_path("ruby/single-gem");
+	let discovery = discover_ruby_gems(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+
+	let pkg = discovery.packages.first().unwrap();
+	let runtime: Vec<&str> = pkg
+		.declared_dependencies
+		.iter()
+		.filter(|d| d.kind == DependencyKind::Runtime)
+		.map(|d| d.name.as_str())
+		.collect();
+	assert!(runtime.contains(&"rails"));
+	assert!(runtime.contains(&"redis"));
+
+	let dev: Vec<&str> = pkg
+		.declared_dependencies
+		.iter()
+		.filter(|d| d.kind == DependencyKind::Development)
+		.map(|d| d.name.as_str())
+		.collect();
+	assert!(dev.contains(&"rspec"));
+	assert!(dev.contains(&"rubocop"));
+}
+
+#[test]
+fn discover_ruby_gems_handles_runtime_dependency_alias() {
+	let root = fixture_path("ruby/monorepo");
+	let discovery = discover_ruby_gems(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+
+	let core = discovery
+		.packages
+		.iter()
+		.find(|p| p.name == "core")
+		.unwrap();
+	let dep_names: Vec<&str> = core
+		.declared_dependencies
+		.iter()
+		.filter(|d| d.kind == DependencyKind::Runtime)
+		.map(|d| d.name.as_str())
+		.collect();
+	assert!(
+		dep_names.contains(&"concurrent-ruby"),
+		"add_runtime_dependency should be treated as runtime: {dep_names:?}"
+	);
+}
+
+#[test]
+fn discover_ruby_gems_skips_gemspec_without_name() {
+	let root = fixture_path("ruby/no-name");
+	let discovery = discover_ruby_gems(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+	assert!(discovery.packages.is_empty());
+}
+
+#[test]
+fn discover_ruby_gems_handles_gem_without_version_file() {
+	let root = fixture_path("ruby/no-version");
+	let discovery = discover_ruby_gems(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+
+	assert_eq!(discovery.packages.len(), 1);
+	let pkg = discovery.packages.first().unwrap();
+	assert_eq!(pkg.name, "no_version");
+	assert_eq!(pkg.current_version, None);
+}
+
+#[test]
+fn discover_ruby_gems_handles_nonexistent_directory() {
+	let discovery = discover_ruby_gems(std::path::Path::new("/nonexistent/path"));
+	let result = discovery.unwrap_or_else(|error| panic!("unexpected error: {error}"));
+	assert!(result.packages.is_empty());
+}
+
+// -- discover_lockfiles --
+
+#[test]
+fn discover_lockfiles_finds_gemfile_lock() {
+	let root = fixture_path("ruby/single-gem");
+	let package = PackageRecord::new(
+		Ecosystem::Ruby,
+		"my_gem",
+		root.join("my_gem.gemspec"),
+		root.clone(),
+		Some(Version::new(1, 2, 3)),
+		PublishState::Public,
+	);
+	let lockfiles = crate::discover_lockfiles(&package);
+	assert_eq!(lockfiles.len(), 1);
+	assert!(lockfiles.first().unwrap().ends_with("Gemfile.lock"));
+}
+
+#[test]
+fn discover_lockfiles_returns_empty_without_gemfile_lock() {
+	let root = fixture_path("ruby/no-version");
+	let package = PackageRecord::new(
+		Ecosystem::Ruby,
+		"no_version",
+		root.join("no_version.gemspec"),
+		root.clone(),
+		None,
+		PublishState::Public,
+	);
+	let lockfiles = crate::discover_lockfiles(&package);
+	assert!(lockfiles.is_empty());
+}
+
+// -- default_lockfile_commands --
+
+#[test]
+fn default_lockfile_commands_infers_bundle_lock() {
+	let root = fixture_path("ruby/single-gem");
+	let package = PackageRecord::new(
+		Ecosystem::Ruby,
+		"my_gem",
+		root.join("my_gem.gemspec"),
+		root.clone(),
+		Some(Version::new(1, 2, 3)),
+		PublishState::Public,
+	);
+	let commands = crate::default_lockfile_commands(&package);
+	assert_eq!(commands.len(), 1);
+	assert_eq!(commands.first().unwrap().command, "bundle lock --update");
+}
+
+#[test]
+fn default_lockfile_commands_returns_empty_without_lockfile() {
+	let root = fixture_path("ruby/no-version");
+	let package = PackageRecord::new(
+		Ecosystem::Ruby,
+		"no_version",
+		root.join("no_version.gemspec"),
+		root.clone(),
+		None,
+		PublishState::Public,
+	);
+	let commands = crate::default_lockfile_commands(&package);
+	assert!(commands.is_empty());
+}
+
+// -- update_version_file_text --
+
+#[test]
+fn update_version_file_text_replaces_double_quoted_version() {
+	let input = "module MyGem\n  VERSION = \"1.2.3\"\nend\n";
+	let result = update_version_file_text(input, "2.0.0");
+	assert!(result.contains("VERSION = \"2.0.0\""));
+	assert!(!result.contains("1.2.3"));
+}
+
+#[test]
+fn update_version_file_text_replaces_single_quoted_version() {
+	let input = "module MyGem\n  VERSION = '1.2.3'\nend\n";
+	let result = update_version_file_text(input, "2.0.0");
+	assert!(result.contains("VERSION = '2.0.0'"));
+	assert!(!result.contains("1.2.3"));
+}
+
+#[test]
+fn update_version_file_text_preserves_surrounding_content() {
+	let input = "# frozen_string_literal: true\n\nmodule MyGem\n  VERSION = \"1.0.0\"\nend\n";
+	let result = update_version_file_text(input, "1.1.0");
+	assert!(result.contains("# frozen_string_literal: true"));
+	assert!(result.contains("module MyGem"));
+	assert!(result.contains("end"));
+	assert!(result.contains("VERSION = \"1.1.0\""));
+}
+
+#[test]
+fn update_version_file_text_handles_no_match() {
+	let input = "module MyGem\n  # no version here\nend\n";
+	let result = update_version_file_text(input, "2.0.0");
+	assert_eq!(
+		result, input,
+		"should return unchanged when no VERSION found"
+	);
+}
+
+// -- should_descend --
+
+#[test]
+fn discover_ruby_gems_skips_vendor_and_bundle_directories() {
+	use std::fs;
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+
+	// Create a valid gem at root
+	fs::write(
+		root.join("root.gemspec"),
+		"Gem::Specification.new do |s|\n  s.name = \"root\"\nend\n",
+	)
+	.unwrap();
+
+	// Create gems in directories that should be skipped
+	for dir in &["vendor", ".bundle", "tmp", "pkg"] {
+		let gem_dir = root.join(dir);
+		fs::create_dir_all(&gem_dir).unwrap();
+		fs::write(
+			gem_dir.join("hidden.gemspec"),
+			format!("Gem::Specification.new do |s|\n  s.name = \"{dir}\"\nend\n"),
+		)
+		.unwrap();
+	}
+
+	let discovery = discover_ruby_gems(root).unwrap_or_else(|error| panic!("discover: {error}"));
+	assert_eq!(
+		discovery.packages.len(),
+		1,
+		"should only find root gem, not gems in excluded dirs: {:?}",
+		discovery
+			.packages
+			.iter()
+			.map(|p| &p.name)
+			.collect::<Vec<_>>()
+	);
+	assert_eq!(discovery.packages.first().unwrap().name, "root");
+}

--- a/crates/monochange_ruby/src/lib.rs
+++ b/crates/monochange_ruby/src/lib.rs
@@ -1,0 +1,353 @@
+#![deny(clippy::all)]
+#![forbid(clippy::indexing_slicing)]
+
+//! # `monochange_ruby`
+//!
+//! `monochange_ruby` discovers Ruby gems from `.gemspec` files and resolves
+//! versions from `version.rb` constants.
+//!
+//! ## Why use it?
+//!
+//! - discover Ruby gems across monorepo directories with one adapter
+//! - normalize gem manifests and dependency edges for the shared planner
+//! - infer `bundle lock --update` as the default lockfile refresh command
+//!
+//! ## Public entry points
+//!
+//! - `discover_ruby_gems(root)` discovers Ruby gems
+//! - `RubyAdapter` exposes the shared adapter interface
+//!
+//! ## Scope
+//!
+//! - `.gemspec` file scanning for gem discovery
+//! - `version.rb` parsing for version constants
+//! - gemspec dependency extraction (`add_dependency`, `add_runtime_dependency`,
+//!   `add_development_dependency`)
+//! - `Gemfile.lock` lockfile discovery
+//! - `bundle lock --update` command inference
+
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
+use monochange_core::normalize_path;
+use monochange_core::AdapterDiscovery;
+use monochange_core::DependencyKind;
+use monochange_core::Ecosystem;
+use monochange_core::EcosystemAdapter;
+use monochange_core::LockfileCommandExecution;
+use monochange_core::MonochangeError;
+use monochange_core::MonochangeResult;
+use monochange_core::PackageDependency;
+use monochange_core::PackageRecord;
+use monochange_core::PublishState;
+use monochange_core::ShellConfig;
+use regex::Regex;
+use semver::Version;
+use walkdir::DirEntry;
+use walkdir::WalkDir;
+
+pub const GEMFILE_LOCK: &str = "Gemfile.lock";
+
+pub struct RubyAdapter;
+
+#[must_use]
+pub const fn adapter() -> RubyAdapter {
+	RubyAdapter
+}
+
+impl EcosystemAdapter for RubyAdapter {
+	fn ecosystem(&self) -> Ecosystem {
+		Ecosystem::Ruby
+	}
+
+	fn discover(&self, root: &Path) -> MonochangeResult<AdapterDiscovery> {
+		discover_ruby_gems(root)
+	}
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum RubyVersionedFileKind {
+	Gemspec,
+	VersionFile,
+	Lock,
+}
+
+#[must_use]
+pub fn supported_versioned_file_kind(path: &Path) -> Option<RubyVersionedFileKind> {
+	let file_name = path
+		.file_name()
+		.and_then(|name| name.to_str())
+		.unwrap_or_default();
+
+	if file_name.ends_with(".gemspec") {
+		return Some(RubyVersionedFileKind::Gemspec);
+	}
+	if file_name == "version.rb" {
+		return Some(RubyVersionedFileKind::VersionFile);
+	}
+	if file_name == GEMFILE_LOCK {
+		return Some(RubyVersionedFileKind::Lock);
+	}
+	None
+}
+
+pub fn discover_lockfiles(package: &PackageRecord) -> Vec<PathBuf> {
+	let manifest_dir = package
+		.manifest_path
+		.parent()
+		.map_or_else(|| package.workspace_root.clone(), Path::to_path_buf);
+	[manifest_dir.join(GEMFILE_LOCK)]
+		.into_iter()
+		.filter(|path| path.exists())
+		.collect()
+}
+
+pub fn default_lockfile_commands(package: &PackageRecord) -> Vec<LockfileCommandExecution> {
+	let lockfiles = discover_lockfiles(package);
+	if lockfiles.is_empty() {
+		return Vec::new();
+	}
+	vec![LockfileCommandExecution {
+		command: "bundle lock --update".to_string(),
+		cwd: package
+			.manifest_path
+			.parent()
+			.unwrap_or(&package.workspace_root)
+			.to_path_buf(),
+		shell: ShellConfig::None,
+	}]
+}
+
+/// Update a Ruby `version.rb` file by replacing the VERSION constant value.
+///
+/// Matches patterns like:
+/// - `VERSION = "1.2.3"`
+/// - `VERSION = '1.2.3'`
+/// - `  VERSION = "1.2.3"`
+pub fn update_version_file_text(contents: &str, new_version: &str) -> String {
+	// Try double-quoted first, then single-quoted. Rust regex doesn't support
+	// backreferences so we use two separate patterns.
+	let double_re = Regex::new(r#"(?m)(VERSION\s*=\s*)"(\d+\.\d+\.\d+[^"]*)""#)
+		.unwrap_or_else(|_| unreachable!("double-quote version regex should be valid"));
+	if double_re.is_match(contents) {
+		return double_re
+			.replace(contents, |caps: &regex::Captures<'_>| {
+				let prefix = caps.get(1).map_or("VERSION = ", |m| m.as_str());
+				format!("{prefix}\"{new_version}\"")
+			})
+			.to_string();
+	}
+
+	let single_re = Regex::new(r"(?m)(VERSION\s*=\s*)'(\d+\.\d+\.\d+[^']*)'")
+		.unwrap_or_else(|_| unreachable!("single-quote version regex should be valid"));
+	single_re
+		.replace(contents, |caps: &regex::Captures<'_>| {
+			let prefix = caps.get(1).map_or("VERSION = ", |m| m.as_str());
+			format!("{prefix}'{new_version}'")
+		})
+		.to_string()
+}
+
+pub fn discover_ruby_gems(root: &Path) -> MonochangeResult<AdapterDiscovery> {
+	let mut packages = Vec::new();
+	let mut warnings = Vec::new();
+
+	for gemspec_path in find_all_gemspec_files(root) {
+		match parse_ruby_gem(&gemspec_path, root) {
+			Ok(Some(package)) => packages.push(package),
+			Ok(None) => {}
+			Err(error) => {
+				warnings.push(format!("skipped {}: {error}", gemspec_path.display()));
+			}
+		}
+	}
+
+	packages.sort_by(|left, right| left.id.cmp(&right.id));
+	packages.dedup_by(|left, right| left.id == right.id);
+
+	Ok(AdapterDiscovery { packages, warnings })
+}
+
+fn parse_ruby_gem(gemspec_path: &Path, root: &Path) -> MonochangeResult<Option<PackageRecord>> {
+	let contents = fs::read_to_string(gemspec_path).map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to read {}: {error}",
+			gemspec_path.display()
+		))
+	})?;
+
+	let name = parse_gem_name(&contents);
+	let Some(name) = name else {
+		return Ok(None);
+	};
+
+	let gem_dir = gemspec_path.parent().unwrap_or_else(|| Path::new("."));
+
+	// Try to find the version from a version.rb file
+	let version = find_version_in_gem_dir(gem_dir, &name);
+
+	let mut record = PackageRecord::new(
+		Ecosystem::Ruby,
+		&name,
+		normalize_path(gemspec_path),
+		normalize_path(root),
+		version,
+		PublishState::Public,
+	);
+
+	record.declared_dependencies = parse_gemspec_dependencies(&contents);
+
+	Ok(Some(record))
+}
+
+/// Parse the gem name from a gemspec file.
+///
+/// Looks for patterns like:
+/// - `spec.name = "my_gem"`
+/// - `spec.name    = 'my-gem'`
+/// - `s.name = "gem_name"`
+fn parse_gem_name(contents: &str) -> Option<String> {
+	let re = Regex::new(r#"(?m)\.\s*name\s*=\s*["']([^"']+)["']"#).ok()?;
+	re.captures(contents)
+		.and_then(|caps| caps.get(1))
+		.map(|m| m.as_str().to_string())
+}
+
+/// Find the version constant in the gem's `lib/` directory.
+///
+/// Searches for `VERSION = "x.y.z"` in:
+/// 1. `lib/<gem_name>/version.rb`
+/// 2. `lib/version.rb`
+/// 3. Any `version.rb` under `lib/`
+fn find_version_in_gem_dir(gem_dir: &Path, gem_name: &str) -> Option<Version> {
+	// Normalize gem name for directory lookup (replace - with _)
+	let dir_name = gem_name.replace('-', "_");
+
+	let candidates = [
+		gem_dir.join(format!("lib/{dir_name}/version.rb")),
+		gem_dir.join("lib/version.rb"),
+	];
+
+	for candidate in &candidates {
+		if let Some(version) = parse_version_from_file(candidate) {
+			return Some(version);
+		}
+	}
+
+	// Fallback: search for any version.rb under lib/
+	let lib_dir = gem_dir.join("lib");
+	if lib_dir.is_dir() {
+		for entry in WalkDir::new(&lib_dir)
+			.max_depth(3)
+			.into_iter()
+			.filter_map(Result::ok)
+		{
+			if entry.file_name() == "version.rb" {
+				if let Some(version) = parse_version_from_file(entry.path()) {
+					return Some(version);
+				}
+			}
+		}
+	}
+
+	None
+}
+
+/// Parse a VERSION constant from a Ruby file.
+fn parse_version_from_file(path: &Path) -> Option<Version> {
+	let contents = fs::read_to_string(path).ok()?;
+	parse_version_constant(&contents)
+}
+
+/// Extract a semver version from a Ruby VERSION constant.
+///
+/// Matches `VERSION = "1.2.3"` or `VERSION = '1.2.3'`.
+pub fn parse_version_constant(contents: &str) -> Option<Version> {
+	let re = Regex::new(r#"(?m)VERSION\s*=\s*["'](\d+\.\d+\.\d+)["']"#).ok()?;
+	re.captures(contents)
+		.and_then(|caps| caps.get(1))
+		.and_then(|m| Version::parse(m.as_str()).ok())
+}
+
+/// Parse dependencies from a gemspec file.
+///
+/// Matches patterns like:
+/// - `spec.add_dependency "rails", "~> 7.0"`
+/// - `spec.add_runtime_dependency 'redis', ">= 4.0"`
+/// - `s.add_development_dependency "rspec", "~> 3.0"`
+fn parse_gemspec_dependencies(contents: &str) -> Vec<PackageDependency> {
+	let dep_re = Regex::new(
+		r#"(?m)\.\s*add_(runtime_)?dependency\s+["']([^"']+)["'](?:\s*,\s*["']([^"']+)["'])*"#,
+	);
+	let dev_dep_re = Regex::new(
+		r#"(?m)\.\s*add_development_dependency\s+["']([^"']+)["'](?:\s*,\s*["']([^"']+)["'])*"#,
+	);
+
+	let mut deps = Vec::new();
+
+	if let Ok(re) = &dep_re {
+		for caps in re.captures_iter(contents) {
+			let name = caps.get(2).map(|m| m.as_str().to_string());
+			let constraint = caps.get(3).map(|m| m.as_str().to_string());
+			if let Some(name) = name {
+				deps.push(PackageDependency {
+					name,
+					kind: DependencyKind::Runtime,
+					version_constraint: constraint,
+					optional: false,
+				});
+			}
+		}
+	}
+
+	if let Ok(re) = &dev_dep_re {
+		for caps in re.captures_iter(contents) {
+			let name = caps.get(1).map(|m| m.as_str().to_string());
+			let constraint = caps.get(2).map(|m| m.as_str().to_string());
+			if let Some(name) = name {
+				deps.push(PackageDependency {
+					name,
+					kind: DependencyKind::Development,
+					version_constraint: constraint,
+					optional: false,
+				});
+			}
+		}
+	}
+
+	deps
+}
+
+fn find_all_gemspec_files(root: &Path) -> Vec<PathBuf> {
+	WalkDir::new(root)
+		.into_iter()
+		.filter_entry(should_descend)
+		.filter_map(Result::ok)
+		.filter(|entry| {
+			entry
+				.file_name()
+				.to_str()
+				.is_some_and(|name| name.ends_with(".gemspec"))
+		})
+		.map(DirEntry::into_path)
+		.map(|path| normalize_path(&path))
+		.collect()
+}
+
+fn should_descend(entry: &DirEntry) -> bool {
+	let file_name = entry.file_name().to_string_lossy();
+	!matches!(
+		file_name.as_ref(),
+		".git"
+			| "vendor"
+			| "node_modules"
+			| "target"
+			| ".devenv"
+			| "book" | ".bundle"
+			| "tmp" | "pkg"
+	)
+}
+
+#[cfg(test)]
+mod __tests;

--- a/crates/monochange_ruby/src/lib.rs
+++ b/crates/monochange_ruby/src/lib.rs
@@ -149,6 +149,7 @@ pub fn update_version_file_text(contents: &str, new_version: &str) -> String {
 		.to_string()
 }
 
+#[tracing::instrument(skip_all)]
 pub fn discover_ruby_gems(root: &Path) -> MonochangeResult<AdapterDiscovery> {
 	let mut packages = Vec::new();
 	let mut warnings = Vec::new();
@@ -165,6 +166,8 @@ pub fn discover_ruby_gems(root: &Path) -> MonochangeResult<AdapterDiscovery> {
 
 	packages.sort_by(|left, right| left.id.cmp(&right.id));
 	packages.dedup_by(|left, right| left.id == right.id);
+
+	tracing::debug!(packages = packages.len(), "discovered ruby gems");
 
 	Ok(AdapterDiscovery { packages, warnings })
 }

--- a/docs/src/guide/03-discovery.md
+++ b/docs/src/guide/03-discovery.md
@@ -10,6 +10,7 @@ Supported sources in this milestone:
 - npm workspaces, pnpm workspaces, Bun workspaces, and standalone `package.json` packages
 - Deno workspaces and standalone `deno.json` / `deno.jsonc` packages
 - Dart and Flutter workspaces plus standalone `pubspec.yaml` packages
+- Ruby gems from `.gemspec` files with `version.rb` version constants
 
 <!-- {/discoverySupportedSources} -->
 

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -241,6 +241,7 @@ When you do not configure `lockfile_commands`, monochange infers sensible defaul
   - `pnpm-lock.yaml` → `pnpm install --lockfile-only`
   - `bun.lock` / `bun.lockb` → `bun install --lockfile-only`
 - Dart / Flutter: `dart pub get` or `flutter pub get`
+- Ruby: `bundle lock --update` (when `Gemfile.lock` exists)
 - Deno: no inferred default today
 
 If you configure `lockfile_commands` for an ecosystem, monochange stops inferring defaults for that ecosystem and those commands fully own lockfile refresh.
@@ -481,6 +482,10 @@ enabled = true
 [ecosystems.dart]
 enabled = true
 lockfile_commands = [{ command = "flutter pub get", cwd = "packages/mobile" }]
+
+[ecosystems.ruby]
+enabled = true
+lockfile_commands = [{ command = "bundle lock --update" }]
 ```
 
 <!-- {/configurationEcosystemSettingsSnippet} -->

--- a/docs/src/readme.md
+++ b/docs/src/readme.md
@@ -85,7 +85,7 @@ If you want a slower, more guided walkthrough, continue with [Start here](./guid
 
 <!-- {=projectMilestoneCapabilities} -->
 
-- discover Cargo, npm/pnpm/Bun, Deno, Dart, and Flutter packages
+- discover Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, and Ruby packages
 - normalize dependency edges across ecosystems
 - coordinate shared package groups from `monochange.toml`
 - compute release plans from explicit change input

--- a/fixtures/tests/ruby/monorepo/gems/api/api.gemspec
+++ b/fixtures/tests/ruby/monorepo/gems/api/api.gemspec
@@ -1,0 +1,9 @@
+Gem::Specification.new do |spec|
+  spec.name = "api"
+  spec.version = Api::VERSION
+  spec.summary = "API layer"
+
+  spec.add_dependency "core", "~> 2.0"
+  spec.add_dependency "sinatra", "~> 3.0"
+  spec.add_development_dependency "rack-test", "~> 2.0"
+end

--- a/fixtures/tests/ruby/monorepo/gems/api/lib/api/version.rb
+++ b/fixtures/tests/ruby/monorepo/gems/api/lib/api/version.rb
@@ -1,0 +1,3 @@
+module Api
+  VERSION = '1.5.0'
+end

--- a/fixtures/tests/ruby/monorepo/gems/core/core.gemspec
+++ b/fixtures/tests/ruby/monorepo/gems/core/core.gemspec
@@ -1,0 +1,8 @@
+Gem::Specification.new do |s|
+  s.name = "core"
+  s.version = Core::VERSION
+  s.summary = "Core library"
+
+  s.add_dependency "activesupport", "~> 7.0"
+  s.add_runtime_dependency "concurrent-ruby", "~> 1.2"
+end

--- a/fixtures/tests/ruby/monorepo/gems/core/lib/core/version.rb
+++ b/fixtures/tests/ruby/monorepo/gems/core/lib/core/version.rb
@@ -1,0 +1,3 @@
+module Core
+  VERSION = "2.0.0"
+end

--- a/fixtures/tests/ruby/nested-version/lib/deeply/nested/version.rb
+++ b/fixtures/tests/ruby/nested-version/lib/deeply/nested/version.rb
@@ -1,0 +1,3 @@
+module NestedVersion
+  VERSION = "3.0.0"
+end

--- a/fixtures/tests/ruby/nested-version/nested_version.gemspec
+++ b/fixtures/tests/ruby/nested-version/nested_version.gemspec
@@ -1,0 +1,4 @@
+Gem::Specification.new do |spec|
+  spec.name = "nested_version"
+  spec.summary = "Gem with version in non-standard location"
+end

--- a/fixtures/tests/ruby/no-name/broken.gemspec
+++ b/fixtures/tests/ruby/no-name/broken.gemspec
@@ -1,0 +1,3 @@
+Gem::Specification.new do |spec|
+  spec.summary = "Missing name"
+end

--- a/fixtures/tests/ruby/no-version/no_version.gemspec
+++ b/fixtures/tests/ruby/no-version/no_version.gemspec
@@ -1,0 +1,4 @@
+Gem::Specification.new do |spec|
+  spec.name = "no_version"
+  spec.summary = "Gem without version.rb"
+end

--- a/fixtures/tests/ruby/single-gem/lib/my_gem/version.rb
+++ b/fixtures/tests/ruby/single-gem/lib/my_gem/version.rb
@@ -1,0 +1,3 @@
+module MyGem
+  VERSION = "1.2.3"
+end

--- a/fixtures/tests/ruby/single-gem/my_gem.gemspec
+++ b/fixtures/tests/ruby/single-gem/my_gem.gemspec
@@ -1,0 +1,11 @@
+Gem::Specification.new do |spec|
+  spec.name = "my_gem"
+  spec.version = MyGem::VERSION
+  spec.summary = "A sample gem"
+  spec.authors = ["Test Author"]
+
+  spec.add_dependency "rails", "~> 7.0"
+  spec.add_dependency "redis", ">= 4.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rubocop", ">= 1.0"
+end

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@
 
 It discovers packages, normalizes dependency data, applies group rules, turns explicit change files into release plans, and can run config-defined release preparation from those same inputs.
 
-Use it when your repository has outgrown one-ecosystem release tooling and you want one model for Cargo, npm/pnpm/Bun, Deno, and Dart/Flutter.
+Use it when your repository has outgrown one-ecosystem release tooling and you want one model for Cargo, npm/pnpm/Bun, Deno, Dart/Flutter, and Ruby.
 
 <!-- {/projectReadmeOverview} -->
 
@@ -151,7 +151,7 @@ See [Advanced: Assistant setup and MCP](docs/src/guide/09-assistant-setup.md) fo
 
 <!-- {=projectMilestoneCapabilities} -->
 
-- discover Cargo, npm/pnpm/Bun, Deno, Dart, and Flutter packages
+- discover Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, and Ruby packages
 - normalize dependency edges across ecosystems
 - coordinate shared package groups from `monochange.toml`
 - compute release plans from explicit change input
@@ -194,6 +194,8 @@ See [Advanced: Assistant setup and MCP](docs/src/guide/09-assistant-setup.md) fo
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__deno-orange?logo=rust)](https://crates.io/crates/monochange_deno) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__deno-1f425f?logo=docs.rs)](https://docs.rs/monochange_deno/)
 - `monochange_dart` — Dart and Flutter workspace discovery.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__dart-orange?logo=rust)](https://crates.io/crates/monochange_dart) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__dart-1f425f?logo=docs.rs)](https://docs.rs/monochange_dart/)
+- `monochange_ruby` — Ruby gem discovery from `.gemspec` files.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__ruby-orange?logo=rust)](https://crates.io/crates/monochange_ruby) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__ruby-1f425f?logo=docs.rs)](https://docs.rs/monochange_ruby/)
 
 <!-- {/projectCrateCatalog} -->
 

--- a/skills/monochange/REFERENCE.md
+++ b/skills/monochange/REFERENCE.md
@@ -10,6 +10,7 @@ Use it when a repository needs one release-planning model across:
 - npm / pnpm / Bun
 - Deno
 - Dart / Flutter
+- Ruby
 
 It discovers packages, normalizes dependency relationships, applies package and group rules from `monochange.toml`, reads explicit `.changeset/*.md` files, and turns those inputs into deterministic release plans.
 
@@ -209,6 +210,7 @@ Lockfile refresh is command-driven. monochange infers defaults when not configur
 - Cargo: `cargo generate-lockfile`
 - npm-family: detects owned lockfiles and runs the matching command (`npm install --package-lock-only`, `pnpm install --lockfile-only`, `bun install --lockfile-only`)
 - Dart / Flutter: `dart pub get` or `flutter pub get`
+- Ruby: `bundle lock --update` (when `Gemfile.lock` exists)
 - Deno: no inferred default
 
 Explicit configuration overrides inference:

--- a/skills/monochange/SKILL.md
+++ b/skills/monochange/SKILL.md
@@ -110,7 +110,7 @@ description: Guides agents through monochange discovery, changesets, release pla
 
 ### Lockfile commands
 
-Lockfile refresh is command-driven via `[ecosystems.<name>].lockfile_commands`. monochange infers sensible defaults for Cargo, npm-family, and Dart/Flutter. Explicit configuration overrides inference.
+Lockfile refresh is command-driven via `[ecosystems.<name>].lockfile_commands`. monochange infers sensible defaults for Cargo, npm-family, Dart/Flutter, and Ruby. Explicit configuration overrides inference.
 
 ### Release titles
 


### PR DESCRIPTION
Closes #134

## Summary

Add a complete `monochange_ruby` adapter crate that discovers Ruby gems from `.gemspec` files and resolves versions from `version.rb` constants.

## Adapter implementation

- **Gem discovery**: Scans for `.gemspec` files, parses gem names using regex on `spec.name = "..."` patterns
- **Version resolution**: Finds `VERSION = "x.y.z"` constants in `lib/<gem_name>/version.rb`, with fallback to `lib/version.rb` and recursive search
- **Dependency extraction**: Parses `add_dependency`, `add_runtime_dependency`, and `add_development_dependency` calls with version constraints
- **Version updates**: Replaces VERSION constants while preserving quote style (single vs double)
- **Lockfile inference**: Infers `bundle lock --update` when `Gemfile.lock` exists
- **Graceful errors**: Parse errors during discovery are captured as warnings

## Documentation

Updated across all surfaces: discovery guide, configuration guide, init template, skill files, project templates, mdt consumer blocks.

## Test plan

- [x] 28 tests covering discovery, parsing, version updates, lockfile commands, and edge cases
- [x] Fixture-driven: single-gem, monorepo (2 gems), no-name, no-version
- [x] `cargo clippy -p monochange_ruby --all-targets -- -D warnings` passes
- [x] `cargo test -p monochange_ruby -p monochange_core -p monochange_config -p monochange --lib` — 531 tests pass
- [x] `mdt check` — all consumer blocks in sync
- [x] `dprint check` — formatting clean