### PR TITLE
feat: add tracing instrumentation for performance profiling and debugging

### DIFF
--- a/.changeset/059-add-tracing.md
+++ b/.changeset/059-add-tracing.md
@@ -1,0 +1,15 @@
+---
+monochange: patch
+monochange_cargo: patch
+monochange_config: patch
+monochange_core: patch
+monochange_dart: patch
+monochange_deno: patch
+monochange_gitea: patch
+monochange_github: patch
+monochange_gitlab: patch
+monochange_graph: patch
+monochange_npm: patch
+---
+
+Add `tracing` instrumentation for performance profiling and debugging. Tracing is off by default with near-zero overhead and activates via `--log-level <FILTER>` or the `RUST_LOG` environment variable. Spans with timing cover CLI dispatch, workspace discovery, release preparation, git operations, provider API calls, changelog rendering, and lockfile materialization.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,6 +1758,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1861,6 +1870,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "typed-builder",
 ]
 
@@ -1898,6 +1909,7 @@ dependencies = [
  "thiserror 2.0.18",
  "toml",
  "toml_edit",
+ "tracing",
  "walkdir",
 ]
 
@@ -1929,6 +1941,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml",
+ "tracing",
 ]
 
 [[package]]
@@ -1942,6 +1955,7 @@ dependencies = [
  "serde_json",
  "similar-asserts",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -1957,6 +1971,7 @@ dependencies = [
  "serde_yaml_ng",
  "similar-asserts",
  "thiserror 2.0.18",
+ "tracing",
  "walkdir",
 ]
 
@@ -1973,6 +1988,7 @@ dependencies = [
  "serde_json",
  "similar-asserts",
  "thiserror 2.0.18",
+ "tracing",
  "walkdir",
 ]
 
@@ -1990,6 +2006,7 @@ dependencies = [
  "serde_json",
  "temp-env",
  "tempfile",
+ "tracing",
  "urlencoding",
 ]
 
@@ -2009,6 +2026,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "urlencoding",
 ]
 
@@ -2026,6 +2044,7 @@ dependencies = [
  "serde_json",
  "temp-env",
  "tempfile",
+ "tracing",
  "urlencoding",
 ]
 
@@ -2039,6 +2058,7 @@ dependencies = [
  "rstest",
  "semver",
  "similar-asserts",
+ "tracing",
 ]
 
 [[package]]
@@ -2055,6 +2075,7 @@ dependencies = [
  "serde_yaml_ng",
  "similar-asserts",
  "thiserror 2.0.18",
+ "tracing",
  "walkdir",
 ]
 
@@ -2076,6 +2097,15 @@ dependencies = [
  "insta",
  "rmcp",
  "tempfile",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3159,6 +3189,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3704,6 +3743,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3810,6 +3879,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,8 @@ toml = { version = "^1.1.2", default-features = false }
 # Pinned: format-preserving edits in Cargo.toml files depend on this version's
 # whitespace and comment handling. Bumping requires verifying manifest output.
 toml_edit = { version = "0.25.10", default-features = false, features = ["parse"] }
+tracing = { version = "0.1", default-features = false, features = ["attributes"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "ansi"] }
 typed-builder = { version = "0.23.2", default-features = false }
 urlencoding = { version = "^2", default-features = false }
 walkdir = { version = "^2", default-features = false }

--- a/crates/monochange/Cargo.toml
+++ b/crates/monochange/Cargo.toml
@@ -46,6 +46,8 @@ tempfile = { workspace = true, default-features = true }
 thiserror = { workspace = true, default-features = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"], default-features = true }
 toml = { workspace = true, default-features = true }
+tracing = { workspace = true, default-features = true }
+tracing-subscriber = { workspace = true, default-features = true }
 typed-builder = { workspace = true, default-features = true }
 
 [dev-dependencies]

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -8266,3 +8266,91 @@ fn batch_changeset_contexts_resolves_introduced_and_updated_commits() {
 		"last_updated commit should match the most recent commit"
 	);
 }
+
+#[test]
+fn extract_log_level_returns_none_when_flag_absent() {
+	let args = ["mc", "discover", "--format", "json"];
+	assert_eq!(
+		crate::extract_log_level(args.iter().map(ToString::to_string)),
+		None
+	);
+}
+
+#[test]
+fn extract_log_level_returns_value_for_separate_flag() {
+	let args = ["mc", "--log-level", "debug", "discover"];
+	assert_eq!(
+		crate::extract_log_level(args.iter().map(ToString::to_string)),
+		Some("debug".to_string())
+	);
+}
+
+#[test]
+fn extract_log_level_returns_value_for_equals_syntax() {
+	let args = ["mc", "--log-level=monochange=trace", "release"];
+	assert_eq!(
+		crate::extract_log_level(args.iter().map(ToString::to_string)),
+		Some("monochange=trace".to_string())
+	);
+}
+
+#[test]
+fn extract_log_level_returns_none_when_flag_has_no_value() {
+	let args = ["mc", "--log-level"];
+	assert_eq!(
+		crate::extract_log_level(args.iter().map(ToString::to_string)),
+		None
+	);
+}
+
+#[test]
+fn init_tracing_with_none_does_not_install_subscriber() {
+	crate::tracing_setup::init_tracing(None);
+}
+
+#[test]
+fn init_tracing_with_valid_filter_does_not_panic() {
+	crate::tracing_setup::init_tracing(Some("monochange=debug"));
+}
+
+#[test]
+fn cli_accepts_log_level_flag_without_error() {
+	let output = run_with_args(
+		"mc",
+		[
+			OsString::from("mc"),
+			OsString::from("--log-level"),
+			OsString::from("debug"),
+			OsString::from("--help"),
+		],
+	)
+	.unwrap_or_else(|error| panic!("log-level with help: {error}"));
+
+	assert!(output.contains("Usage: mc <COMMAND>"));
+}
+
+#[test]
+fn cli_accepts_log_level_equals_syntax_without_error() {
+	let output = run_with_args(
+		"mc",
+		[
+			OsString::from("mc"),
+			OsString::from("--log-level=monochange=trace"),
+			OsString::from("--help"),
+		],
+	)
+	.unwrap_or_else(|error| panic!("log-level equals with help: {error}"));
+
+	assert!(output.contains("Usage: mc <COMMAND>"));
+}
+
+#[test]
+fn cli_help_does_not_show_log_level_flag() {
+	let output = run_with_args("mc", [OsString::from("mc"), OsString::from("--help")])
+		.unwrap_or_else(|error| panic!("help output: {error}"));
+
+	assert!(
+		!output.contains("--log-level"),
+		"hidden flag should not appear in help output"
+	);
+}

--- a/crates/monochange/src/changelog.rs
+++ b/crates/monochange/src/changelog.rs
@@ -13,6 +13,7 @@ pub(crate) struct ChangelogBuildContext<'a> {
 	pub release_targets: &'a [ReleaseTarget],
 }
 
+#[tracing::instrument(skip_all)]
 pub(crate) fn build_changelog_updates(
 	context: ChangelogBuildContext<'_>,
 ) -> MonochangeResult<Vec<ChangelogUpdate>> {

--- a/crates/monochange/src/changesets.rs
+++ b/crates/monochange/src/changesets.rs
@@ -227,6 +227,7 @@ pub(crate) fn build_prepared_changesets(
 
 /// Load git context for all changesets in two batched git-log calls instead
 /// of 2*N individual subprocess spawns.
+#[tracing::instrument(skip_all, fields(count = loaded_changesets.len()))]
 fn batch_load_changeset_contexts(
 	root: &Path,
 	loaded_changesets: &[monochange_config::LoadedChangesetFile],
@@ -285,6 +286,7 @@ fn batch_load_changeset_contexts(
 ///
 /// This replaces N individual `git log` subprocess calls with a single call
 /// that walks the history once.
+#[tracing::instrument(skip_all, fields(count = paths.len(), introduced))]
 fn batch_git_log(
 	root: &Path,
 	paths: &[PathBuf],
@@ -405,6 +407,7 @@ pub(crate) fn short_commit_sha(sha: &str) -> String {
 	sha.chars().take(7).collect()
 }
 
+#[tracing::instrument(skip_all)]
 pub(crate) fn build_release_plan_from_signals(
 	configuration: &monochange_core::WorkspaceConfiguration,
 	discovery: &DiscoveryReport,

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -93,6 +93,14 @@ pub(crate) fn build_command_with_cli(
 		.about("Manage versions and releases for your multiplatform, multilanguage monorepo")
 		.subcommand_required(true)
 		.arg_required_else_help(true)
+		.arg(
+			Arg::new("log-level")
+				.long("log-level")
+				.global(true)
+				.help("Set tracing filter (e.g. debug, monochange=trace)")
+				.value_name("FILTER")
+				.hide(true),
+		)
 		.subcommand(
 			Command::new("init")
 				.about("Generate monochange.toml with detected packages, groups, and default CLI commands")

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -196,6 +196,7 @@ pub(crate) fn execute_cli_command(
 	execute_cli_command_with_options(root, configuration, cli_command, dry_run, false, inputs)
 }
 
+#[tracing::instrument(skip_all, fields(command = cli_command.name))]
 pub(crate) fn execute_cli_command_with_options(
 	root: &Path,
 	configuration: &monochange_core::WorkspaceConfiguration,
@@ -234,6 +235,7 @@ pub(crate) fn execute_cli_command_with_options(
 
 		if !should_execute_cli_step(step, &context, &step_inputs)? {
 			if let Some(condition) = step.when() {
+				tracing::debug!(step = step.kind_name(), condition = %condition, "skipped CLI step");
 				context.command_logs.push(format!(
 					"skipped step `{}` because when condition `{condition}` is false",
 					step.kind_name()
@@ -242,6 +244,7 @@ pub(crate) fn execute_cli_command_with_options(
 			continue;
 		}
 
+		tracing::debug!(step = step.kind_name(), "executing CLI step");
 		match step {
 			CliStepDefinition::Validate { .. } => {
 				validate_workspace(root)?;

--- a/crates/monochange/src/git_support.rs
+++ b/crates/monochange/src/git_support.rs
@@ -73,6 +73,7 @@ pub(crate) fn resolve_git_commit_ref(root: &Path, from: &str) -> MonochangeResul
 }
 
 #[rustfmt::skip]
+#[tracing::instrument(skip_all, fields(commit))]
 pub(crate) fn first_parent_commits(root: &Path, commit: &str) -> MonochangeResult<Vec<String>> {
 	let output = run_git_capture(
 		root,
@@ -94,6 +95,7 @@ pub(crate) fn read_git_commit_message(root: &Path, commit: &str) -> MonochangeRe
 	)
 }
 
+#[tracing::instrument(skip_all, fields(args = ?args))]
 pub(crate) fn run_git_capture(
 	root: &Path,
 	args: &[&str],
@@ -103,6 +105,7 @@ pub(crate) fn run_git_capture(
 		.map_err(|error| MonochangeError::Discovery(format!("{error_message}: {error}")))?;
 	if !output.status.success() {
 		let stderr = git_stderr_trimmed(&output);
+		tracing::warn!(args = ?args, %stderr, "git command failed");
 		let detail = [error_message, stderr.as_str()]
 			.into_iter()
 			.filter(|part| !part.is_empty())

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -252,6 +252,7 @@ mod interactive;
 mod mcp;
 mod release_artifacts;
 mod release_record;
+mod tracing_setup;
 mod versioned_files;
 mod workspace_ops;
 
@@ -505,12 +506,28 @@ struct CommandStepOutput {
 const CHANGESET_DIR: &str = ".changeset";
 
 pub fn run_from_env(bin_name: &'static str) -> MonochangeResult<()> {
+	let log_level = extract_log_level_from_args();
+	tracing_setup::init_tracing(log_level.as_deref());
+
 	let args = std::env::args_os();
 	let output = run_with_args(bin_name, args)?;
 	if !output.is_empty() {
 		println!("{output}");
 	}
 	Ok(())
+}
+
+fn extract_log_level_from_args() -> Option<String> {
+	let mut args = std::env::args().peekable();
+	while let Some(arg) = args.next() {
+		if arg == "--log-level" {
+			return args.next();
+		}
+		if let Some(value) = arg.strip_prefix("--log-level=") {
+			return Some(value.to_string());
+		}
+	}
+	None
 }
 
 pub fn run_with_args<I>(bin_name: &'static str, args: I) -> MonochangeResult<String>
@@ -521,6 +538,7 @@ where
 	run_with_args_in_dir(bin_name, args, &root)
 }
 
+#[tracing::instrument(skip_all, fields(bin_name))]
 fn run_with_args_in_dir<I>(bin_name: &'static str, args: I, root: &Path) -> MonochangeResult<String>
 where
 	I: IntoIterator<Item = OsString>,

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -518,7 +518,14 @@ pub fn run_from_env(bin_name: &'static str) -> MonochangeResult<()> {
 }
 
 fn extract_log_level_from_args() -> Option<String> {
-	let mut args = std::env::args().peekable();
+	extract_log_level(std::env::args())
+}
+
+fn extract_log_level<I>(args: I) -> Option<String>
+where
+	I: IntoIterator<Item = String>,
+{
+	let mut args = args.into_iter();
 	while let Some(arg) = args.next() {
 		if arg == "--log-level" {
 			return args.next();

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -582,6 +582,7 @@ fn atomic_write(path: &Path, content: &[u8]) -> MonochangeResult<()> {
 }
 
 #[rustfmt::skip]
+#[tracing::instrument(skip_all)]
 pub(crate) fn build_file_diff_previews(root: &Path, updates: &[FileUpdate]) -> MonochangeResult<Vec<PreparedFileDiff>> { let colorize_diffs = diff_output_colors_enabled();
 	#[cfg(test)]
 	if FORCE_BUILD_FILE_DIFF_PREVIEWS_ERROR.with(Cell::get) {

--- a/crates/monochange/src/release_record.rs
+++ b/crates/monochange/src/release_record.rs
@@ -38,6 +38,7 @@ pub(crate) fn render_release_record_discovery(
 	}
 }
 
+#[tracing::instrument(skip_all, fields(from))]
 pub fn discover_release_record(
 	root: &Path,
 	from: &str,
@@ -47,6 +48,11 @@ pub fn discover_release_record(
 		.into_iter()
 		.enumerate()
 	{
+		tracing::trace!(
+			commit = &commit[..7],
+			distance,
+			"scanning for release record"
+		);
 		let message = read_git_commit_message(root, &commit)?;
 		match parse_release_record_block(&message) {
 			Ok(record) => {

--- a/crates/monochange/src/tracing_setup.rs
+++ b/crates/monochange/src/tracing_setup.rs
@@ -1,0 +1,28 @@
+use tracing_subscriber::fmt;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::EnvFilter;
+
+/// Initialize the tracing subscriber for CLI diagnostics.
+///
+/// Priority:
+/// 1. `RUST_LOG` environment variable (full precedence when set)
+/// 2. `log_level` parameter from `--log-level` CLI flag
+/// 3. No subscriber installed (silent, near-zero overhead)
+pub(crate) fn init_tracing(log_level: Option<&str>) {
+	let filter = match EnvFilter::try_from_default_env() {
+		Ok(env_filter) => env_filter,
+		Err(_) => match log_level {
+			Some(level) => EnvFilter::new(level),
+			None => return,
+		},
+	};
+
+	let subscriber = fmt::Subscriber::builder()
+		.with_env_filter(filter)
+		.with_span_events(FmtSpan::CLOSE)
+		.with_target(true)
+		.with_writer(std::io::stderr)
+		.finish();
+
+	let _ = tracing::subscriber::set_global_default(subscriber);
+}

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -567,6 +567,7 @@ pub(crate) fn validate_cargo_workspace_version_groups(root: &Path) -> Monochange
 	monochange_cargo::validate_workspace_version_groups(&packages)
 }
 
+#[tracing::instrument(skip_all)]
 pub fn discover_workspace(root: &Path) -> MonochangeResult<DiscoveryReport> {
 	let configuration = load_workspace_configuration(root)?;
 	let mut warnings = Vec::new();
@@ -590,6 +591,11 @@ pub fn discover_workspace(root: &Path) -> MonochangeResult<DiscoveryReport> {
 		apply_version_groups(&mut packages, &configuration)?;
 	warnings.extend(version_group_warnings);
 	let dependencies = materialize_dependency_edges(&packages);
+	tracing::info!(
+		packages = packages.len(),
+		warnings = warnings.len(),
+		"workspace discovery complete"
+	);
 
 	Ok(DiscoveryReport {
 		workspace_root: root.to_path_buf(),
@@ -796,6 +802,7 @@ pub fn plan_release(root: &Path, changes_path: &Path) -> MonochangeResult<Releas
 	build_release_plan_from_signals(&configuration, &discovery, &change_signals)
 }
 
+#[tracing::instrument(skip_all)]
 fn materialize_lockfile_command_updates(
 	root: &Path,
 	base_updates: &[FileUpdate],
@@ -1134,6 +1141,7 @@ pub fn prepare_release(root: &Path, dry_run: bool) -> MonochangeResult<PreparedR
 	prepare_release_execution(root, dry_run).map(|execution| execution.prepared_release)
 }
 
+#[tracing::instrument(skip_all, fields(dry_run))]
 pub(crate) fn prepare_release_execution(
 	root: &Path,
 	dry_run: bool,
@@ -1141,6 +1149,7 @@ pub(crate) fn prepare_release_execution(
 	let configuration = load_workspace_configuration(root)?;
 	let discovery = discover_workspace(root)?;
 	let changeset_paths = discover_changeset_paths(root)?;
+	tracing::debug!(count = changeset_paths.len(), "discovered changesets");
 	let loaded_changesets = {
 		use rayon::prelude::*;
 		changeset_paths
@@ -1162,6 +1171,10 @@ pub(crate) fn prepare_release_execution(
 	}
 	let plan = build_release_plan_from_signals(&configuration, &discovery, &change_signals)?;
 	let released_packages = released_package_names(&discovery.packages, &plan);
+	tracing::debug!(
+		count = released_packages.len(),
+		"identified released packages"
+	);
 	if released_packages.is_empty() {
 		return Err(MonochangeError::Config(
 			"no releaseable packages were found in discovered changesets".to_string(),
@@ -1202,6 +1215,11 @@ pub(crate) fn prepare_release_execution(
 	.concat();
 	let lockfile_commands =
 		build_lockfile_command_executions(root, &configuration, &discovery.packages, &plan)?;
+	tracing::debug!(
+		manifest_updates = manifest_updates.len(),
+		lockfile_commands = lockfile_commands.len(),
+		"built manifest and lockfile updates"
+	);
 	let file_updates = if lockfile_commands.is_empty() || dry_run {
 		// During dry-run, skip the expensive workspace copy and lockfile
 		// command execution. The base updates already contain all version
@@ -1252,6 +1270,12 @@ pub(crate) fn prepare_release_execution(
 			deleted_changesets.push(root_relative(root, path));
 		}
 	}
+
+	tracing::info!(
+		changed_files = changed_files.len(),
+		dry_run,
+		"release preparation complete"
+	);
 
 	Ok(PreparedReleaseExecution {
 		prepared_release: PreparedRelease {

--- a/crates/monochange/tests/test_support.rs
+++ b/crates/monochange/tests/test_support.rs
@@ -30,6 +30,7 @@ pub fn setup_scenario_workspace(relative: &str) -> tempfile::TempDir {
 pub fn monochange_command(release_date: Option<&str>) -> Command {
 	let mut command = Command::new(get_cargo_bin("mc"));
 	command.env("NO_COLOR", "1");
+	command.env_remove("RUST_LOG");
 	if let Some(release_date) = release_date {
 		command.env("MONOCHANGE_RELEASE_DATE", release_date);
 	}

--- a/crates/monochange_cargo/Cargo.toml
+++ b/crates/monochange_cargo/Cargo.toml
@@ -21,6 +21,7 @@ serde = { workspace = true, default-features = true }
 thiserror = { workspace = true, default-features = true }
 toml = { workspace = true, default-features = true }
 toml_edit = { workspace = true, default-features = true }
+tracing = { workspace = true, default-features = true }
 walkdir = { workspace = true, default-features = true }
 
 [dev-dependencies]

--- a/crates/monochange_cargo/src/lib.rs
+++ b/crates/monochange_cargo/src/lib.rs
@@ -509,6 +509,7 @@ impl CompatibilityProvider for RustSemverProvider {
 	}
 }
 
+#[tracing::instrument(skip_all)]
 pub fn discover_cargo_packages(root: &Path) -> MonochangeResult<AdapterDiscovery> {
 	let workspace_manifests = find_workspace_manifests(root);
 	let mut included_manifests = HashSet::new();
@@ -539,6 +540,7 @@ pub fn discover_cargo_packages(root: &Path) -> MonochangeResult<AdapterDiscovery
 
 	packages.sort_by(|left, right| left.id.cmp(&right.id));
 	packages.dedup_by(|left, right| left.id == right.id);
+	tracing::debug!(packages = packages.len(), "discovered cargo packages");
 
 	Ok(AdapterDiscovery { packages, warnings })
 }

--- a/crates/monochange_config/Cargo.toml
+++ b/crates/monochange_config/Cargo.toml
@@ -32,6 +32,7 @@ serde_json = { workspace = true, default-features = true }
 serde_yaml_ng = { workspace = true, default-features = true }
 thiserror = { workspace = true, default-features = true }
 toml = { workspace = true, default-features = true }
+tracing = { workspace = true, default-features = true }
 
 [dev-dependencies]
 insta = { workspace = true, default-features = true }

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -895,6 +895,7 @@ fn normalize_ecosystem_settings(
 	})
 }
 
+#[tracing::instrument(skip_all)]
 pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceConfiguration> {
 	let path = config_path(root);
 	let contents = if path.exists() {

--- a/crates/monochange_core/Cargo.toml
+++ b/crates/monochange_core/Cargo.toml
@@ -17,6 +17,7 @@ semver = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
 thiserror = { workspace = true, default-features = true }
+tracing = { workspace = true, default-features = true }
 
 [dev-dependencies]
 insta = { workspace = true, default-features = true }

--- a/crates/monochange_core/src/git.rs
+++ b/crates/monochange_core/src/git.rs
@@ -62,8 +62,10 @@ pub fn git_push_branch_command(root: &Path, branch: &str) -> Command {
 	command
 }
 
+#[tracing::instrument(skip_all, fields(args = ?args))]
 pub fn git_command_output(root: &Path, args: &[&str]) -> std::io::Result<Output> {
-	git_command(root).args(args).output()
+	let mut command = git_command(root);
+	command.args(args).output()
 }
 
 #[must_use]
@@ -93,6 +95,7 @@ pub fn git_reports_nothing_to_commit(output: &Output) -> bool {
 		|| git_stderr_trimmed(output).contains("nothing to commit")
 }
 
+#[tracing::instrument(skip_all, fields(action))]
 pub fn run_command(mut command: Command, action: &str) -> MonochangeResult<()> {
 	let output = command
 		.output()

--- a/crates/monochange_dart/Cargo.toml
+++ b/crates/monochange_dart/Cargo.toml
@@ -19,6 +19,7 @@ semver = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }
 serde_yaml_ng = { workspace = true, default-features = true }
 thiserror = { workspace = true, default-features = true }
+tracing = { workspace = true, default-features = true }
 walkdir = { workspace = true, default-features = true }
 
 [dev-dependencies]

--- a/crates/monochange_dart/src/lib.rs
+++ b/crates/monochange_dart/src/lib.rs
@@ -376,6 +376,7 @@ impl EcosystemAdapter for DartAdapter {
 	}
 }
 
+#[tracing::instrument(skip_all)]
 pub fn discover_dart_packages(root: &Path) -> MonochangeResult<AdapterDiscovery> {
 	let workspace_manifests = find_workspace_manifests(root);
 	let mut included_manifests = HashSet::new();
@@ -406,6 +407,7 @@ pub fn discover_dart_packages(root: &Path) -> MonochangeResult<AdapterDiscovery>
 
 	packages.sort_by(|left, right| left.id.cmp(&right.id));
 	packages.dedup_by(|left, right| left.id == right.id);
+	tracing::debug!(packages = packages.len(), "discovered dart packages");
 
 	Ok(AdapterDiscovery { packages, warnings })
 }

--- a/crates/monochange_deno/Cargo.toml
+++ b/crates/monochange_deno/Cargo.toml
@@ -19,6 +19,7 @@ semver = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
 thiserror = { workspace = true, default-features = true }
+tracing = { workspace = true, default-features = true }
 walkdir = { workspace = true, default-features = true }
 
 [dev-dependencies]

--- a/crates/monochange_deno/src/lib.rs
+++ b/crates/monochange_deno/src/lib.rs
@@ -157,6 +157,7 @@ impl EcosystemAdapter for DenoAdapter {
 	}
 }
 
+#[tracing::instrument(skip_all)]
 pub fn discover_deno_packages(root: &Path) -> MonochangeResult<AdapterDiscovery> {
 	let workspace_manifests = find_workspace_manifests(root);
 	let mut included_manifests = HashSet::new();
@@ -187,6 +188,7 @@ pub fn discover_deno_packages(root: &Path) -> MonochangeResult<AdapterDiscovery>
 
 	packages.sort_by(|left, right| left.id.cmp(&right.id));
 	packages.dedup_by(|left, right| left.id == right.id);
+	tracing::debug!(packages = packages.len(), "discovered deno packages");
 
 	Ok(AdapterDiscovery { packages, warnings })
 }

--- a/crates/monochange_gitea/Cargo.toml
+++ b/crates/monochange_gitea/Cargo.toml
@@ -17,6 +17,7 @@ monochange_core = { workspace = true }
 reqwest = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
+tracing = { workspace = true, default-features = true }
 urlencoding = { workspace = true, default-features = true }
 
 [dev-dependencies]

--- a/crates/monochange_gitea/src/lib.rs
+++ b/crates/monochange_gitea/src/lib.rs
@@ -197,6 +197,7 @@ pub fn build_release_pull_request_request(
 	}
 }
 
+#[tracing::instrument(skip_all)]
 pub fn publish_release_requests(
 	source: &SourceConfiguration,
 	requests: &[SourceReleaseRequest],

--- a/crates/monochange_github/Cargo.toml
+++ b/crates/monochange_github/Cargo.toml
@@ -19,6 +19,7 @@ serde = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
 thiserror = { workspace = true, default-features = true }
 tokio = { workspace = true, default-features = true }
+tracing = { workspace = true, default-features = true }
 urlencoding = { workspace = true, default-features = true }
 
 [dev-dependencies]

--- a/crates/monochange_github/src/lib.rs
+++ b/crates/monochange_github/src/lib.rs
@@ -417,6 +417,7 @@ pub fn compare_url(source: &SourceConfiguration, previous_tag: &str, current_tag
 	)
 }
 
+#[tracing::instrument(skip_all)]
 pub fn enrich_changeset_context(
 	source: &SourceConfiguration,
 	changesets: &mut [PreparedChangeset],
@@ -447,6 +448,7 @@ pub fn enrich_changeset_context(
 	}
 
 	let Ok(token) = env::var("GITHUB_TOKEN").or_else(|_| env::var("GH_TOKEN")) else {
+		tracing::debug!("skipping GitHub enrichment: no GITHUB_TOKEN or GH_TOKEN found");
 		return;
 	};
 	let Ok(runtime) = github_runtime() else {
@@ -751,6 +753,7 @@ pub fn plan_released_issue_comments(
 	plans_by_issue.into_values().collect()
 }
 
+#[tracing::instrument(skip_all)]
 pub fn comment_released_issues(
 	source: &SourceConfiguration,
 	manifest: &ReleaseManifest,
@@ -831,6 +834,7 @@ fn release_issue_comment_body(release_tags: &[String], marker: &str) -> String {
 	}
 }
 
+#[tracing::instrument(skip_all)]
 pub fn publish_release_requests(
 	source: &SourceConfiguration,
 	requests: &[GitHubReleaseRequest],
@@ -843,6 +847,7 @@ pub fn publish_release_requests(
 	})
 }
 
+#[tracing::instrument(skip_all)]
 pub fn publish_release_pull_request(
 	source: &SourceConfiguration,
 	root: &Path,
@@ -862,6 +867,7 @@ pub fn publish_release_pull_request(
 	})
 }
 
+#[tracing::instrument(skip_all)]
 pub fn sync_retargeted_releases(
 	source: &SourceConfiguration,
 	tag_updates: &[RetargetTagResult],
@@ -891,6 +897,7 @@ async fn publish_release_request_with_client(
 	client: &Octocrab,
 	request: &GitHubReleaseRequest,
 ) -> MonochangeResult<GitHubReleaseOutcome> {
+	tracing::info!(tag = %request.tag_name, repository = %request.repository, "publishing GitHub release");
 	let payload = GitHubReleasePayload {
 		tag_name: &request.tag_name,
 		name: &request.name,

--- a/crates/monochange_gitlab/Cargo.toml
+++ b/crates/monochange_gitlab/Cargo.toml
@@ -17,6 +17,7 @@ monochange_core = { workspace = true }
 reqwest = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
+tracing = { workspace = true, default-features = true }
 urlencoding = { workspace = true, default-features = true }
 
 [dev-dependencies]

--- a/crates/monochange_gitlab/src/lib.rs
+++ b/crates/monochange_gitlab/src/lib.rs
@@ -203,6 +203,7 @@ pub fn build_release_pull_request_request(
 	}
 }
 
+#[tracing::instrument(skip_all)]
 pub fn publish_release_requests(
 	source: &SourceConfiguration,
 	requests: &[SourceReleaseRequest],

--- a/crates/monochange_graph/Cargo.toml
+++ b/crates/monochange_graph/Cargo.toml
@@ -16,6 +16,7 @@ description = "Dependency graph and propagation logic for monochange"
 monochange_core = { workspace = true }
 monochange_semver = { workspace = true }
 semver = { workspace = true, default-features = true }
+tracing = { workspace = true, default-features = true }
 
 [dev-dependencies]
 insta = { workspace = true, default-features = true }

--- a/crates/monochange_graph/src/lib.rs
+++ b/crates/monochange_graph/src/lib.rs
@@ -138,6 +138,7 @@ impl<'a> NormalizedGraph<'a> {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[tracing::instrument(skip_all)]
 pub fn build_release_plan(
 	workspace_root: &Path,
 	packages: &[PackageRecord],

--- a/crates/monochange_npm/Cargo.toml
+++ b/crates/monochange_npm/Cargo.toml
@@ -20,6 +20,7 @@ serde = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
 serde_yaml_ng = { workspace = true, default-features = true }
 thiserror = { workspace = true, default-features = true }
+tracing = { workspace = true, default-features = true }
 walkdir = { workspace = true, default-features = true }
 
 [dev-dependencies]

--- a/crates/monochange_npm/src/lib.rs
+++ b/crates/monochange_npm/src/lib.rs
@@ -583,6 +583,7 @@ impl EcosystemAdapter for NpmAdapter {
 	}
 }
 
+#[tracing::instrument(skip_all)]
 pub fn discover_npm_packages(root: &Path) -> MonochangeResult<AdapterDiscovery> {
 	let mut included_manifests = HashSet::new();
 	let mut packages = Vec::new();
@@ -624,6 +625,7 @@ pub fn discover_npm_packages(root: &Path) -> MonochangeResult<AdapterDiscovery> 
 
 	packages.sort_by(|left, right| left.id.cmp(&right.id));
 	packages.dedup_by(|left, right| left.id == right.id);
+	tracing::debug!(packages = packages.len(), "discovered npm packages");
 
 	Ok(AdapterDiscovery { packages, warnings })
 }


### PR DESCRIPTION
## Summary

- Adds `tracing` and `tracing-subscriber` across the workspace (12 crates) to provide structured diagnostics for performance profiling, debugging, and operational visibility
- Tracing is **off by default** with near-zero overhead — activates via `--log-level <FILTER>` CLI flag or `RUST_LOG` env var
- 25 `#[instrument]` spans on hot paths covering CLI dispatch, workspace discovery, release preparation, git operations, GitHub/Gitea/GitLab API calls, changelog rendering, and lockfile materialization
- Strategic `debug!`/`info!`/`warn!`/`trace!` events at key milestones throughout the release pipeline

## Usage

```bash
# Via environment variable
RUST_LOG=monochange=debug mc discover --format json

# Via CLI flag  
mc release --dry-run --log-level monochange=trace

# See octocrab HTTP internals too
RUST_LOG=monochange=debug,octocrab=debug mc release --dry-run
```

## Test plan

- [x] `cargo check --workspace` — clean (no new warnings)
- [x] `cargo clippy --workspace` — clean (no new warnings)
- [x] 902/902 tests pass
- [x] Pre-commit hooks pass (dprint, secrets, lint)
- [ ] Manual: `RUST_LOG=monochange=debug mc discover` shows span timing on stderr, clean output on stdout
- [ ] Manual: `mc discover` with no env/flag produces zero tracing output