### PR TITLE
feat: add JVM ecosystem support (monochange_jvm)

### DIFF
--- a/.changeset/feat-jvm-ecosystem.md
+++ b/.changeset/feat-jvm-ecosystem.md
@@ -1,0 +1,47 @@
+---
+monochange: minor
+monochange_core: minor
+monochange_config: minor
+---
+
+#### add JVM ecosystem support (Gradle and Maven)
+
+monochange now discovers and manages JVM projects from Gradle multi-project builds and Maven multi-module projects.
+
+**Configuration:**
+
+```toml
+[defaults]
+package_type = "jvm"
+
+[package.core]
+path = "core"
+
+[package.api]
+path = "api"
+
+[ecosystems.jvm]
+enabled = true
+lockfile_commands = [{ command = "./gradlew dependencies --write-locks" }]
+```
+
+**What it discovers:**
+
+- Gradle multi-project builds via `settings.gradle.kts` / `settings.gradle` with `include(...)` directives
+- Maven multi-module projects via `pom.xml` with `<modules>` declarations
+- Both Kotlin DSL (`build.gradle.kts`) and Groovy DSL (`build.gradle`) build files
+- Project versions from `version = "x.y.z"` in Gradle or `<version>` in Maven
+- Dependencies from Gradle configurations (`implementation`, `api`, `compileOnly`, `testImplementation`) and Maven scopes (`compile`, `test`, `provided`)
+
+**Version management:**
+
+- Updates `version = "x.y.z"` in `build.gradle.kts` / `build.gradle`
+- Updates `<version>` in Maven `pom.xml`
+- Updates version entries in Gradle Version Catalogs (`gradle/libs.versions.toml`)
+- Skips Maven property references (`${revision}`, `${project.version}`)
+
+**Lockfile commands:**
+
+- Gradle: infers `./gradlew dependencies --write-locks` (prefers wrapper, falls back to bare `gradle`)
+- Maven: no inferred default (Maven has no native lockfile)
+- Configurable via `[ecosystems.jvm].lockfile_commands`

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -4,6 +4,7 @@
 - npm workspaces, pnpm workspaces, Bun workspaces, and standalone `package.json` packages
 - Deno workspaces and standalone `deno.json` / `deno.jsonc` packages
 - Dart and Flutter workspaces plus standalone `pubspec.yaml` packages
+- Gradle multi-project builds and Maven multi-module projects
 
 <!-- {/discoverySupportedSources} -->
 
@@ -357,6 +358,10 @@ enabled = true
 [ecosystems.dart]
 enabled = true
 lockfile_commands = [{ command = "flutter pub get", cwd = "packages/mobile" }]
+
+[ecosystems.jvm]
+enabled = true
+lockfile_commands = [{ command = "./gradlew dependencies --write-locks" }]
 ```
 
 <!-- {/configurationEcosystemSettingsSnippet} -->

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -4,7 +4,7 @@
 
 It discovers packages, normalizes dependency data, applies group rules, turns explicit change files into release plans, and can run config-defined release preparation from those same inputs.
 
-Use it when your repository has outgrown one-ecosystem release tooling and you want one model for Cargo, npm/pnpm/Bun, Deno, and Dart/Flutter.
+Use it when your repository has outgrown one-ecosystem release tooling and you want one model for Cargo, npm/pnpm/Bun, Deno, Dart/Flutter, and JVM (Gradle/Maven).
 
 <!-- {/projectReadmeOverview} -->
 
@@ -40,12 +40,14 @@ Use it when your repository has outgrown one-ecosystem release tooling and you w
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__deno-orange?logo=rust)](https://crates.io/crates/monochange_deno) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__deno-1f425f?logo=docs.rs)](https://docs.rs/monochange_deno/)
 - `monochange_dart` — Dart and Flutter workspace discovery.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__dart-orange?logo=rust)](https://crates.io/crates/monochange_dart) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__dart-1f425f?logo=docs.rs)](https://docs.rs/monochange_dart/)
+- `monochange_jvm` — Gradle and Maven project discovery.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__jvm-orange?logo=rust)](https://crates.io/crates/monochange_jvm) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__jvm-1f425f?logo=docs.rs)](https://docs.rs/monochange_jvm/)
 
 <!-- {/projectCrateCatalog} -->
 
 <!-- {@projectMilestoneCapabilities} -->
 
-- discover Cargo, npm/pnpm/Bun, Deno, Dart, and Flutter packages
+- discover Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, and JVM (Gradle/Maven) packages
 - normalize dependency edges across ecosystems
 - coordinate shared package groups from `monochange.toml`
 - compute release plans from explicit change input

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2078,6 +2078,7 @@ dependencies = [
  "tempfile",
  "toml",
  "toml_edit",
+ "tracing",
  "walkdir",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1851,6 +1851,7 @@ dependencies = [
  "monochange_github",
  "monochange_gitlab",
  "monochange_graph",
+ "monochange_jvm",
  "monochange_npm",
  "monochange_semver",
  "monochange_test_helpers",
@@ -1929,6 +1930,7 @@ dependencies = [
  "monochange_gitea",
  "monochange_github",
  "monochange_gitlab",
+ "monochange_jvm",
  "monochange_npm",
  "monochange_test_helpers",
  "regex",
@@ -2059,6 +2061,24 @@ dependencies = [
  "semver",
  "similar-asserts",
  "tracing",
+]
+
+[[package]]
+name = "monochange_jvm"
+version = "0.0.0"
+dependencies = [
+ "glob",
+ "insta",
+ "monochange_core",
+ "monochange_test_helpers",
+ "regex",
+ "rstest",
+ "semver",
+ "similar-asserts",
+ "tempfile",
+ "toml",
+ "toml_edit",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 	"crates/monochange_github",
 	"crates/monochange_gitlab",
 	"crates/monochange_graph",
+	"crates/monochange_jvm",
 	"crates/monochange_npm",
 	"crates/monochange_semver",
 	"docs",
@@ -23,6 +24,7 @@ default-members = [
 	"crates/monochange_dart",
 	"crates/monochange_deno",
 	"crates/monochange_graph",
+	"crates/monochange_jvm",
 	"crates/monochange_github",
 	"crates/monochange_gitea",
 	"crates/monochange_gitlab",
@@ -95,6 +97,7 @@ monochange_gitea = { version = "0.0.0", path = "./crates/monochange_gitea" }
 monochange_github = { version = "0.0.0", path = "./crates/monochange_github" }
 monochange_gitlab = { version = "0.0.0", path = "./crates/monochange_gitlab" }
 monochange_graph = { version = "0.0.0", path = "./crates/monochange_graph" }
+monochange_jvm = { version = "0.0.0", path = "./crates/monochange_jvm" }
 monochange_npm = { version = "0.0.0", path = "./crates/monochange_npm" }
 monochange_semver = { version = "0.0.0", path = "./crates/monochange_semver" }
 

--- a/crates/monochange/Cargo.toml
+++ b/crates/monochange/Cargo.toml
@@ -31,6 +31,7 @@ monochange_gitea = { workspace = true }
 monochange_github = { workspace = true }
 monochange_gitlab = { workspace = true }
 monochange_graph = { workspace = true }
+monochange_jvm = { workspace = true }
 monochange_npm = { workspace = true }
 monochange_semver = { workspace = true }
 rayon = { workspace = true, default-features = true }

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -6872,6 +6872,7 @@ fn build_command_and_configured_change_type_choices_include_runtime_metadata() {
 		npm: monochange_core::EcosystemSettings::default(),
 		deno: monochange_core::EcosystemSettings::default(),
 		dart: monochange_core::EcosystemSettings::default(),
+		jvm: monochange_core::EcosystemSettings::default(),
 	};
 	assert_eq!(
 		crate::configured_change_type_choices(&configuration),
@@ -6918,6 +6919,7 @@ fn apply_runtime_change_type_choices_updates_only_unconfigured_change_inputs() {
 		npm: monochange_core::EcosystemSettings::default(),
 		deno: monochange_core::EcosystemSettings::default(),
 		dart: monochange_core::EcosystemSettings::default(),
+		jvm: monochange_core::EcosystemSettings::default(),
 	};
 	let mut cli = vec![
 		monochange_core::CliCommandDefinition {
@@ -6972,6 +6974,7 @@ fn apply_runtime_change_type_choices_preserves_existing_choice_inputs_and_empty_
 		npm: monochange_core::EcosystemSettings::default(),
 		deno: monochange_core::EcosystemSettings::default(),
 		dart: monochange_core::EcosystemSettings::default(),
+		jvm: monochange_core::EcosystemSettings::default(),
 	};
 	let mut cli = vec![monochange_core::CliCommandDefinition {
 		name: "change".to_string(),

--- a/crates/monochange/src/interactive.rs
+++ b/crates/monochange/src/interactive.rs
@@ -396,6 +396,7 @@ mod __tests {
 			npm: EcosystemSettings::default(),
 			deno: EcosystemSettings::default(),
 			dart: EcosystemSettings::default(),
+			jvm: EcosystemSettings::default(),
 		}
 	}
 
@@ -608,6 +609,7 @@ mod __tests {
 			npm: EcosystemSettings::default(),
 			deno: EcosystemSettings::default(),
 			dart: EcosystemSettings::default(),
+			jvm: EcosystemSettings::default(),
 		};
 		let displays = build_selectable_targets(&configuration)
 			.into_iter()
@@ -666,6 +668,7 @@ mod __tests {
 			npm: EcosystemSettings::default(),
 			deno: EcosystemSettings::default(),
 			dart: EcosystemSettings::default(),
+			jvm: EcosystemSettings::default(),
 		};
 		let target = build_selectable_targets(&configuration)
 			.into_iter()

--- a/crates/monochange/src/monochange.init.toml
+++ b/crates/monochange/src/monochange.init.toml
@@ -9,7 +9,7 @@
     packages         -- list of { id, path, type, changelog? }
     has_group        -- true when more than one package was discovered
     package_ids_toml -- pre-formatted TOML array contents
-    has_cargo / has_npm / has_deno / has_dart -- ecosystem detected flags
+    has_cargo / has_npm / has_deno / has_dart / has_jvm -- ecosystem detected flags
 #}
 # =============================================================================
 # monochange.toml — repository configuration for monochange
@@ -51,7 +51,7 @@ warn_on_group_mismatch = true
 # Default package type for all packages that don't declare their own `type`.
 # Setting this avoids repeating `type = "cargo"` on every [package.*] entry.
 #
-# Options: "cargo", "npm", "deno", "dart", "flutter"
+# Options: "cargo", "npm", "deno", "dart", "flutter", "jvm"
 # Default: none (each package must declare its own type)
 # package_type = "cargo"
 
@@ -191,7 +191,7 @@ warn_on_group_mismatch = true
 #   path  — relative path from repo root to the package directory
 #
 # Optional fields:
-#   type                    — "cargo", "npm", "deno", "dart", "flutter"
+#   type                    — "cargo", "npm", "deno", "dart", "flutter", "jvm"
 #                             (not needed when defaults.package_type is set)
 #   changelog               — true, false, "path/to/changelog.md", or a table
 #                             with { path, format }; overrides [defaults.changelog]
@@ -360,6 +360,14 @@ enabled = true
 enabled = true
 {% else %}
 # [ecosystems.dart]
+# enabled = true
+{% endif %}
+
+{% if has_jvm %}
+[ecosystems.jvm]
+enabled = true
+{% else %}
+# [ecosystems.jvm]
 # enabled = true
 {% endif %}
 

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -532,6 +532,34 @@ pub(crate) fn build_dart_manifest_updates(
 	Ok(updates)
 }
 
+pub(crate) fn build_jvm_manifest_updates(
+	packages: &[PackageRecord],
+	plan: &ReleasePlan,
+) -> MonochangeResult<Vec<FileUpdate>> {
+	let released_versions = released_versions_by_record_id(plan);
+	let mut updates = Vec::new();
+	for package in packages
+		.iter()
+		.filter(|package| package.ecosystem == Ecosystem::Jvm)
+	{
+		let Some(version) = released_versions.get(&package.id) else {
+			continue;
+		};
+		let contents = fs::read_to_string(&package.manifest_path).map_err(|error| {
+			MonochangeError::Io(format!(
+				"failed to read {}: {error}",
+				package.manifest_path.display()
+			))
+		})?;
+		let rendered = monochange_jvm::update_gradle_build_version(&contents, version);
+		updates.push(FileUpdate {
+			path: package.manifest_path.clone(),
+			content: rendered.into_bytes(),
+		});
+	}
+	Ok(updates)
+}
+
 pub(crate) fn apply_file_updates(updates: &[FileUpdate]) -> MonochangeResult<()> {
 	for update in updates {
 		if let Some(parent) = update.path.parent() {

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -22,6 +22,7 @@ pub(crate) enum VersionedFileKind {
 	Npm(monochange_npm::NpmVersionedFileKind),
 	Deno(monochange_deno::DenoVersionedFileKind),
 	Dart(monochange_dart::DartVersionedFileKind),
+	Jvm(monochange_jvm::JvmVersionedFileKind),
 }
 
 pub(crate) fn versioned_file_kind(
@@ -40,6 +41,9 @@ pub(crate) fn versioned_file_kind(
 		}
 		monochange_core::EcosystemType::Dart => {
 			monochange_dart::supported_versioned_file_kind(path).map(VersionedFileKind::Dart)
+		}
+		monochange_core::EcosystemType::Jvm => {
+			monochange_jvm::supported_versioned_file_kind(path).map(VersionedFileKind::Jvm)
 		}
 	}
 }
@@ -255,6 +259,7 @@ pub(crate) fn read_cached_document(
 				monochange_core::EcosystemType::Npm => "npm",
 				monochange_core::EcosystemType::Deno => "deno",
 				monochange_core::EcosystemType::Dart => "dart",
+				monochange_core::EcosystemType::Jvm => "jvm",
 			},
 		)));
 	};
@@ -358,6 +363,15 @@ pub(crate) fn read_cached_document(
 			}
 			Ok(CachedDocument::Text(contents))
 		}
+		VersionedFileKind::Jvm(_) => {
+			let Some(contents) = text_contents else {
+				return Err(MonochangeError::Config(format!(
+					"failed to parse {} as text",
+					path.display()
+				)));
+			};
+			Ok(CachedDocument::Text(contents))
+		}
 		VersionedFileKind::Npm(_) | VersionedFileKind::Deno(_) => {
 			let Some(contents) = text_contents.as_ref() else {
 				return Err(MonochangeError::Config(format!(
@@ -397,6 +411,9 @@ pub(crate) fn resolve_versioned_prefix(
 		}
 		monochange_core::EcosystemType::Dart => {
 			context.configuration.dart.dependency_version_prefix.clone()
+		}
+		monochange_core::EcosystemType::Jvm => {
+			context.configuration.jvm.dependency_version_prefix.clone()
 		}
 	};
 	ecosystem_prefix.unwrap_or_else(|| ecosystem_type.default_prefix().to_string())
@@ -557,6 +574,7 @@ pub(crate) fn apply_versioned_file_definition(
 					monochange_core::EcosystemType::Npm => "npm",
 					monochange_core::EcosystemType::Deno => "deno",
 					monochange_core::EcosystemType::Dart => "dart",
+					monochange_core::EcosystemType::Jvm => "jvm",
 				},
 			)));
 		};
@@ -703,6 +721,23 @@ pub(crate) fn apply_versioned_file_definition(
 			(CachedDocument::Yaml(mapping), VersionedFileKind::Dart(kind)) => {
 				if kind == monochange_dart::DartVersionedFileKind::Lock {
 					monochange_dart::update_pubspec_lock(mapping, &raw_versions);
+				}
+			}
+			(CachedDocument::Text(contents), VersionedFileKind::Jvm(kind)) => {
+				if kind == monochange_jvm::JvmVersionedFileKind::GradleBuild {
+					*contents =
+						monochange_jvm::update_gradle_build_version(contents, owner_version);
+				} else if kind == monochange_jvm::JvmVersionedFileKind::VersionCatalog {
+					*contents =
+						monochange_jvm::update_version_catalog_text(contents, &versioned_deps)
+							.map_err(|error| {
+								MonochangeError::Config(format!(
+									"failed to parse {}: {error}",
+									resolved_path.display()
+								))
+							})?;
+				} else if kind == monochange_jvm::JvmVersionedFileKind::MavenPom {
+					*contents = monochange_jvm::update_pom_version(contents, owner_version);
 				}
 			}
 			_ => {}

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -27,6 +27,7 @@ use monochange_core::SourceProvider;
 use monochange_dart::discover_dart_packages;
 use monochange_deno::discover_deno_packages;
 use monochange_github as github_provider;
+use monochange_jvm::discover_jvm_projects;
 use monochange_npm::discover_npm_packages;
 use serde_json::json;
 use typed_builder::TypedBuilder;
@@ -374,6 +375,7 @@ fn render_annotated_init_config(root: &Path) -> MonochangeResult<String> {
 			PackageType::Deno => "deno",
 			PackageType::Dart => "dart",
 			PackageType::Flutter => "flutter",
+			PackageType::Jvm => "jvm",
 		};
 		let mut entry = BTreeMap::new();
 		entry.insert("id", json!(id));
@@ -391,6 +393,7 @@ fn render_annotated_init_config(root: &Path) -> MonochangeResult<String> {
 	let has_dart = packages
 		.iter()
 		.any(|p| p.ecosystem == Ecosystem::Dart || p.ecosystem == Ecosystem::Flutter);
+	let has_jvm = packages.iter().any(|p| p.ecosystem == Ecosystem::Jvm);
 
 	let package_ids_toml = package_ids
 		.iter()
@@ -406,6 +409,7 @@ fn render_annotated_init_config(root: &Path) -> MonochangeResult<String> {
 		"has_npm": has_npm,
 		"has_deno": has_deno,
 		"has_dart": has_dart,
+		"has_jvm": has_jvm,
 	});
 
 	let jinja_context = minijinja::Value::from_serialize(&context);
@@ -437,6 +441,7 @@ fn discover_packages(root: &Path) -> MonochangeResult<Vec<PackageRecord>> {
 		discover_npm_packages(root)?,
 		discover_deno_packages(root)?,
 		discover_dart_packages(root)?,
+		discover_jvm_projects(root)?,
 	] {
 		packages.extend(discovery.packages);
 	}
@@ -477,6 +482,7 @@ fn package_type_for_ecosystem(ecosystem: Ecosystem) -> PackageType {
 		Ecosystem::Deno => PackageType::Deno,
 		Ecosystem::Dart => PackageType::Dart,
 		Ecosystem::Flutter => PackageType::Flutter,
+		Ecosystem::Jvm => PackageType::Jvm,
 	}
 }
 
@@ -495,10 +501,13 @@ pub(crate) fn build_lockfile_command_executions(
 	let deno_executions = resolve_lockfile_command_executions(root, &configuration.deno.lockfile_commands, packages.iter().filter(|package| package.ecosystem == Ecosystem::Deno && released_versions.contains_key(&package.id)).collect(), monochange_deno::default_lockfile_commands)?;
 	#[rustfmt::skip]
 	let dart_executions = resolve_lockfile_command_executions(root, &configuration.dart.lockfile_commands, packages.iter().filter(|package| matches!(package.ecosystem, Ecosystem::Dart | Ecosystem::Flutter) && released_versions.contains_key(&package.id)).collect(), monochange_dart::default_lockfile_commands)?;
+	#[rustfmt::skip]
+	let jvm_executions = resolve_lockfile_command_executions(root, &configuration.jvm.lockfile_commands, packages.iter().filter(|package| package.ecosystem == Ecosystem::Jvm && released_versions.contains_key(&package.id)).collect(), monochange_jvm::default_lockfile_commands)?;
 	let mut executions = cargo_executions;
 	executions.extend(npm_executions);
 	executions.extend(deno_executions);
 	executions.extend(dart_executions);
+	executions.extend(jvm_executions);
 	Ok(dedup_lockfile_command_executions(executions))
 }
 
@@ -578,6 +587,7 @@ pub fn discover_workspace(root: &Path) -> MonochangeResult<DiscoveryReport> {
 		discover_npm_packages(root)?,
 		discover_deno_packages(root)?,
 		discover_dart_packages(root)?,
+		discover_jvm_projects(root)?,
 	] {
 		warnings.extend(discovery.warnings);
 		packages.extend(discovery.packages);
@@ -1186,7 +1196,15 @@ pub(crate) fn prepare_release_execution(
 	let npm_updates = build_npm_manifest_updates(&discovery.packages, &plan)?;
 	let deno_updates = build_deno_manifest_updates(&discovery.packages, &plan)?;
 	let dart_updates = build_dart_manifest_updates(&discovery.packages, &plan)?;
-	let manifest_updates = [cargo_updates, npm_updates, deno_updates, dart_updates].concat();
+	let jvm_updates = build_jvm_manifest_updates(&discovery.packages, &plan)?;
+	let manifest_updates = [
+		cargo_updates,
+		npm_updates,
+		deno_updates,
+		dart_updates,
+		jvm_updates,
+	]
+	.concat();
 	let versioned_file_updates =
 		build_versioned_file_updates(root, &configuration, &discovery.packages, &plan)?;
 	let release_targets =

--- a/crates/monochange_config/Cargo.toml
+++ b/crates/monochange_config/Cargo.toml
@@ -24,6 +24,7 @@ monochange_deno = { workspace = true }
 monochange_gitea = { workspace = true }
 monochange_github = { workspace = true }
 monochange_gitlab = { workspace = true }
+monochange_jvm = { workspace = true }
 monochange_npm = { workspace = true }
 regex = { workspace = true, default-features = true }
 semver = { workspace = true, default-features = true }

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -337,6 +337,8 @@ struct RawEcosystems {
 	deno: RawEcosystemSettings,
 	#[serde(default)]
 	dart: RawEcosystemSettings,
+	#[serde(default)]
+	jvm: RawEcosystemSettings,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -827,6 +829,7 @@ fn package_type_to_ecosystem_type(package_type: PackageType) -> EcosystemType {
 		PackageType::Npm => EcosystemType::Npm,
 		PackageType::Deno => EcosystemType::Deno,
 		PackageType::Dart | PackageType::Flutter => EcosystemType::Dart,
+		PackageType::Jvm => EcosystemType::Jvm,
 	}
 }
 
@@ -942,6 +945,8 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		normalize_ecosystem_settings(&contents, "deno", EcosystemType::Deno, ecosystems.deno)?;
 	let dart_ecosystem =
 		normalize_ecosystem_settings(&contents, "dart", EcosystemType::Dart, ecosystems.dart)?;
+	let jvm_ecosystem =
+		normalize_ecosystem_settings(&contents, "jvm", EcosystemType::Jvm, ecosystems.jvm)?;
 	let defaults_changelog_policy = defaults
 		.changelog
 		.as_ref()
@@ -998,6 +1003,7 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 					EcosystemType::Npm => npm_ecosystem.versioned_files.clone(),
 					EcosystemType::Deno => deno_ecosystem.versioned_files.clone(),
 					EcosystemType::Dart => dart_ecosystem.versioned_files.clone(),
+					EcosystemType::Jvm => jvm_ecosystem.versioned_files.clone(),
 				}
 			};
 			let mut versioned_files = inherited_versioned_files;
@@ -1207,6 +1213,7 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		("npm", &npm_ecosystem),
 		("deno", &deno_ecosystem),
 		("dart", &dart_ecosystem),
+		("jvm", &jvm_ecosystem),
 	] {
 		let declared_packages = packages
 			.iter()
@@ -1252,6 +1259,7 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		npm: npm_ecosystem,
 		deno: deno_ecosystem,
 		dart: dart_ecosystem,
+		jvm: jvm_ecosystem,
 	})
 }
 
@@ -2073,6 +2081,7 @@ fn path_is_supported_for_ecosystem(path: &Path, ecosystem_type: EcosystemType) -
 		EcosystemType::Npm => monochange_npm::supported_versioned_file_kind(path).is_some(),
 		EcosystemType::Deno => monochange_deno::supported_versioned_file_kind(path).is_some(),
 		EcosystemType::Dart => monochange_dart::supported_versioned_file_kind(path).is_some(),
+		EcosystemType::Jvm => monochange_jvm::supported_versioned_file_kind(path).is_some(),
 	}
 }
 
@@ -2223,6 +2232,7 @@ fn validate_versioned_files(
 							EcosystemType::Npm => "npm",
 							EcosystemType::Deno => "deno",
 							EcosystemType::Dart => "dart",
+							EcosystemType::Jvm => "jvm",
 						}
 					),
 					vec![config_section_label(
@@ -2286,6 +2296,7 @@ fn expected_manifest_name(package_type: PackageType) -> &'static str {
 		PackageType::Npm => "package.json",
 		PackageType::Deno => "deno.json",
 		PackageType::Dart | PackageType::Flutter => "pubspec.yaml",
+		PackageType::Jvm => "build.gradle.kts",
 	}
 }
 
@@ -3406,6 +3417,7 @@ fn ecosystem_matches_package_type(ecosystem: Ecosystem, package_type: PackageTyp
 			| (Ecosystem::Deno, PackageType::Deno)
 			| (Ecosystem::Dart, PackageType::Dart)
 			| (Ecosystem::Flutter, PackageType::Flutter)
+			| (Ecosystem::Jvm, PackageType::Jvm)
 	)
 }
 
@@ -3460,6 +3472,7 @@ pub fn validate_versioned_files_content(root: &Path) -> MonochangeResult<Vec<Str
 		("npm", &configuration.npm),
 		("deno", &configuration.deno),
 		("dart", &configuration.dart),
+		("jvm", &configuration.jvm),
 	];
 	for &(eco_name, settings) in ecosystem_entries {
 		if !settings.versioned_files.is_empty() {
@@ -3630,6 +3643,13 @@ fn validate_ecosystem_version_readable(
 			if yaml.get("version").and_then(|v| v.as_str()).is_none() {
 				return Err(MonochangeError::Config(format!(
 					"{owner_kind} `{owner_id}` versioned file `{display_path}` does not contain a `version` string field"
+				)));
+			}
+		}
+		EcosystemType::Jvm => {
+			if contents.trim().is_empty() {
+				return Err(MonochangeError::Config(format!(
+					"{owner_kind} `{owner_id}` versioned file `{display_path}` is empty"
 				)));
 			}
 		}

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -882,6 +882,7 @@ fn sample_workspace_configuration() -> WorkspaceConfiguration {
 		npm: EcosystemSettings::default(),
 		deno: EcosystemSettings::default(),
 		dart: EcosystemSettings::default(),
+		jvm: EcosystemSettings::default(),
 	}
 }
 

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -187,6 +187,7 @@ pub enum Ecosystem {
 	Deno,
 	Dart,
 	Flutter,
+	Jvm,
 }
 
 impl Ecosystem {
@@ -198,6 +199,7 @@ impl Ecosystem {
 			Self::Deno => "deno",
 			Self::Dart => "dart",
 			Self::Flutter => "flutter",
+			Self::Jvm => "jvm",
 		}
 	}
 }
@@ -348,6 +350,7 @@ pub enum PackageType {
 	Deno,
 	Dart,
 	Flutter,
+	Jvm,
 }
 
 impl PackageType {
@@ -359,6 +362,7 @@ impl PackageType {
 			Self::Deno => "deno",
 			Self::Dart => "dart",
 			Self::Flutter => "flutter",
+			Self::Jvm => "jvm",
 		}
 	}
 }
@@ -378,13 +382,14 @@ pub enum EcosystemType {
 	Npm,
 	Deno,
 	Dart,
+	Jvm,
 }
 
 impl EcosystemType {
 	#[must_use]
 	pub fn default_prefix(self) -> &'static str {
 		match self {
-			Self::Cargo => "",
+			Self::Cargo | Self::Jvm => "",
 			Self::Npm | Self::Deno | Self::Dart => "^",
 		}
 	}
@@ -396,6 +401,7 @@ impl EcosystemType {
 			Self::Npm => &["dependencies", "devDependencies", "peerDependencies"],
 			Self::Deno => &["imports"],
 			Self::Dart => &["dependencies", "dev_dependencies"],
+			Self::Jvm => &["dependencies"],
 		}
 	}
 }
@@ -2484,6 +2490,7 @@ pub struct WorkspaceConfiguration {
 	pub npm: EcosystemSettings,
 	pub deno: EcosystemSettings,
 	pub dart: EcosystemSettings,
+	pub jvm: EcosystemSettings,
 }
 
 impl WorkspaceConfiguration {

--- a/crates/monochange_jvm/Cargo.toml
+++ b/crates/monochange_jvm/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "monochange_jvm"
+version = { workspace = true }
+categories = { workspace = true }
+documentation = "https://docs.rs/monochange_jvm"
+edition = { workspace = true }
+include = { workspace = true }
+keywords = ["cli", "changelog", "releases", "versioning", "monorepo"]
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+description = "JVM ecosystem adapter for monochange — discovers Gradle and Maven projects"
+
+[dependencies]
+glob = { workspace = true, default-features = true }
+monochange_core = { workspace = true }
+regex = { workspace = true, default-features = true }
+semver = { workspace = true, default-features = true }
+toml = { workspace = true, default-features = true }
+toml_edit = { workspace = true, default-features = true }
+walkdir = { workspace = true, default-features = true }
+
+[dev-dependencies]
+insta = { workspace = true, default-features = true }
+monochange_test_helpers = { version = "0.0.0", path = "../../testing/monochange_test_helpers" }
+rstest = { workspace = true, default-features = true }
+similar-asserts = { workspace = true, default-features = true }
+tempfile = { workspace = true, default-features = true }
+
+[lints]
+workspace = true

--- a/crates/monochange_jvm/Cargo.toml
+++ b/crates/monochange_jvm/Cargo.toml
@@ -19,6 +19,7 @@ regex = { workspace = true, default-features = true }
 semver = { workspace = true, default-features = true }
 toml = { workspace = true, default-features = true }
 toml_edit = { workspace = true, default-features = true }
+tracing = { workspace = true, default-features = true }
 walkdir = { workspace = true, default-features = true }
 
 [dev-dependencies]

--- a/crates/monochange_jvm/src/__tests.rs
+++ b/crates/monochange_jvm/src/__tests.rs
@@ -1,0 +1,687 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use monochange_core::DependencyKind;
+use monochange_core::Ecosystem;
+use monochange_core::EcosystemAdapter;
+use monochange_core::PackageRecord;
+use monochange_core::PublishState;
+use semver::Version;
+
+use crate::discover_jvm_projects;
+use crate::parse_gradle_dependencies;
+use crate::parse_gradle_subprojects;
+use crate::parse_gradle_version;
+use crate::parse_maven_artifact_id;
+use crate::parse_maven_dependencies;
+use crate::parse_maven_version;
+use crate::update_gradle_build_version;
+use crate::update_pom_version;
+use crate::update_version_catalog_text;
+use crate::JvmAdapter;
+use crate::JvmVersionedFileKind;
+
+fn fixture_path(relative: &str) -> PathBuf {
+	monochange_test_helpers::fs::fixture_path_from(env!("CARGO_MANIFEST_DIR"), relative)
+}
+
+// -- adapter --
+
+#[test]
+fn adapter_reports_jvm_ecosystem() {
+	assert_eq!(JvmAdapter.ecosystem(), Ecosystem::Jvm);
+}
+
+#[test]
+fn adapter_discover_delegates_to_discover_jvm_projects() {
+	let root = fixture_path("jvm/maven-single");
+	let discovery = JvmAdapter
+		.discover(&root)
+		.unwrap_or_else(|error| panic!("discover: {error}"));
+	assert_eq!(discovery.packages.len(), 1);
+	assert_eq!(discovery.packages.first().unwrap().name, "my-app");
+}
+
+// -- supported_versioned_file_kind --
+
+#[test]
+fn supported_versioned_file_kind_recognizes_jvm_files() {
+	use crate::supported_versioned_file_kind;
+	assert_eq!(
+		supported_versioned_file_kind("build.gradle.kts".as_ref()),
+		Some(JvmVersionedFileKind::GradleBuild)
+	);
+	assert_eq!(
+		supported_versioned_file_kind("build.gradle".as_ref()),
+		Some(JvmVersionedFileKind::GradleBuild)
+	);
+	assert_eq!(
+		supported_versioned_file_kind("libs.versions.toml".as_ref()),
+		Some(JvmVersionedFileKind::VersionCatalog)
+	);
+	assert_eq!(
+		supported_versioned_file_kind("gradle.lockfile".as_ref()),
+		Some(JvmVersionedFileKind::GradleLock)
+	);
+	assert_eq!(
+		supported_versioned_file_kind("pom.xml".as_ref()),
+		Some(JvmVersionedFileKind::MavenPom)
+	);
+	assert_eq!(supported_versioned_file_kind("Cargo.toml".as_ref()), None);
+}
+
+// -- parse_gradle_version --
+
+#[test]
+fn parse_gradle_version_extracts_version_from_build_file() {
+	let contents = "group = \"com.example\"\nversion = \"1.2.3\"\n";
+	assert_eq!(parse_gradle_version(contents), Some(Version::new(1, 2, 3)));
+}
+
+#[test]
+fn parse_gradle_version_returns_none_without_version() {
+	let contents = "group = \"com.example\"\n";
+	assert_eq!(parse_gradle_version(contents), None);
+}
+
+#[test]
+fn parse_gradle_version_handles_non_semver() {
+	let contents = "version = \"SNAPSHOT\"\n";
+	assert_eq!(parse_gradle_version(contents), None);
+}
+
+// -- parse_gradle_subprojects --
+
+#[test]
+fn parse_gradle_subprojects_extracts_include_directives() {
+	let path = fixture_path("jvm/gradle-multi/settings.gradle.kts");
+	let subprojects = parse_gradle_subprojects(&path);
+	assert!(
+		subprojects.contains(&"core".to_string()),
+		"missing core: {subprojects:?}"
+	);
+	assert!(
+		subprojects.contains(&"api".to_string()),
+		"missing api: {subprojects:?}"
+	);
+}
+
+#[test]
+fn parse_gradle_subprojects_handles_colon_prefixed_names() {
+	use std::fs;
+	let tempdir = tempfile::tempdir().unwrap();
+	let settings = tempdir.path().join("settings.gradle.kts");
+	fs::write(&settings, "include(\":core\", \":api\")\n").unwrap();
+	let subprojects = parse_gradle_subprojects(&settings);
+	assert!(subprojects.contains(&"core".to_string()));
+	assert!(subprojects.contains(&"api".to_string()));
+}
+
+#[test]
+fn parse_gradle_subprojects_returns_empty_for_no_includes() {
+	let path = fixture_path("jvm/gradle-single/settings.gradle.kts");
+	let subprojects = parse_gradle_subprojects(&path);
+	assert!(subprojects.is_empty());
+}
+
+// -- parse_gradle_dependencies --
+
+#[test]
+fn parse_gradle_dependencies_extracts_all_configurations() {
+	let contents = r#"dependencies {
+    implementation("com.google.guava:guava:33.0.0-jre")
+    api("com.example:core:1.0.0")
+    compileOnly("org.projectlombok:lombok:1.18.30")
+    testImplementation("junit:junit:4.13.2")
+}"#;
+	let deps = parse_gradle_dependencies(contents);
+
+	let runtime: Vec<&str> = deps
+		.iter()
+		.filter(|d| d.kind == DependencyKind::Runtime)
+		.map(|d| d.name.as_str())
+		.collect();
+	assert!(runtime.contains(&"guava"), "missing guava: {runtime:?}");
+	assert!(runtime.contains(&"core"), "missing core: {runtime:?}");
+	assert!(
+		runtime.contains(&"lombok"),
+		"compileOnly should be runtime: {runtime:?}"
+	);
+
+	let dev: Vec<&str> = deps
+		.iter()
+		.filter(|d| d.kind == DependencyKind::Development)
+		.map(|d| d.name.as_str())
+		.collect();
+	assert!(dev.contains(&"junit"), "missing junit: {dev:?}");
+
+	let optional = deps.iter().find(|d| d.name == "lombok").unwrap();
+	assert!(optional.optional, "compileOnly should be optional");
+}
+
+#[test]
+fn parse_gradle_dependencies_handles_empty_file() {
+	let deps = parse_gradle_dependencies("plugins { application }\n");
+	assert!(deps.is_empty());
+}
+
+// -- parse_maven_artifact_id --
+
+#[test]
+fn parse_maven_artifact_id_extracts_artifact() {
+	let contents = "<project>\n  <artifactId>my-app</artifactId>\n</project>";
+	assert_eq!(
+		parse_maven_artifact_id(contents),
+		Some("my-app".to_string())
+	);
+}
+
+#[test]
+fn parse_maven_artifact_id_returns_none_without_artifact() {
+	let contents = "<project>\n  <groupId>com.example</groupId>\n</project>";
+	assert_eq!(parse_maven_artifact_id(contents), None);
+}
+
+// -- parse_maven_version --
+
+#[test]
+fn parse_maven_version_extracts_semver() {
+	let contents = "<project>\n  <version>2.1.0</version>\n</project>";
+	assert_eq!(parse_maven_version(contents), Some(Version::new(2, 1, 0)));
+}
+
+#[test]
+fn parse_maven_version_skips_property_references() {
+	let contents = "<project>\n  <version>${revision}</version>\n</project>";
+	assert_eq!(parse_maven_version(contents), None);
+}
+
+#[test]
+fn parse_maven_version_returns_none_without_version() {
+	let contents = "<project>\n  <artifactId>test</artifactId>\n</project>";
+	assert_eq!(parse_maven_version(contents), None);
+}
+
+// -- parse_maven_dependencies --
+
+#[test]
+fn parse_maven_dependencies_extracts_deps_with_scopes() {
+	let contents = r"<project>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>6.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>4.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>";
+	let deps = parse_maven_dependencies(contents);
+	assert_eq!(deps.len(), 3);
+
+	let spring = deps.iter().find(|d| d.name == "spring-core").unwrap();
+	assert_eq!(spring.kind, DependencyKind::Runtime);
+	assert_eq!(spring.version_constraint.as_deref(), Some("6.1.0"));
+
+	let junit = deps.iter().find(|d| d.name == "junit").unwrap();
+	assert_eq!(junit.kind, DependencyKind::Development);
+
+	let servlet = deps.iter().find(|d| d.name == "javax.servlet-api").unwrap();
+	assert_eq!(servlet.kind, DependencyKind::Build);
+}
+
+#[test]
+fn parse_maven_dependencies_skips_property_versions() {
+	let contents = r"<project>
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>";
+	let deps = parse_maven_dependencies(contents);
+	assert_eq!(deps.len(), 1);
+	assert_eq!(deps.first().unwrap().version_constraint, None);
+}
+
+// -- discover_jvm_projects --
+
+#[test]
+fn discover_jvm_projects_finds_gradle_multi_project() {
+	let root = fixture_path("jvm/gradle-multi");
+	let discovery =
+		discover_jvm_projects(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+
+	assert_eq!(discovery.packages.len(), 2);
+	let names: Vec<&str> = discovery.packages.iter().map(|p| p.name.as_str()).collect();
+	assert!(names.contains(&"core"), "missing core: {names:?}");
+	assert!(names.contains(&"api"), "missing api: {names:?}");
+
+	let core = discovery
+		.packages
+		.iter()
+		.find(|p| p.name == "core")
+		.unwrap();
+	assert_eq!(core.current_version, Some(Version::new(1, 0, 0)));
+	assert_eq!(core.ecosystem, Ecosystem::Jvm);
+	assert_eq!(
+		core.metadata.get("build_tool").map(String::as_str),
+		Some("gradle")
+	);
+}
+
+#[test]
+fn discover_jvm_projects_finds_maven_single_project() {
+	let root = fixture_path("jvm/maven-single");
+	let discovery =
+		discover_jvm_projects(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+
+	assert_eq!(discovery.packages.len(), 1);
+	let pkg = discovery.packages.first().unwrap();
+	assert_eq!(pkg.name, "my-app");
+	assert_eq!(pkg.current_version, Some(Version::new(2, 1, 0)));
+	assert_eq!(
+		pkg.metadata.get("build_tool").map(String::as_str),
+		Some("maven")
+	);
+}
+
+#[test]
+fn discover_jvm_projects_finds_maven_multi_module() {
+	let root = fixture_path("jvm/maven-multi");
+	let discovery =
+		discover_jvm_projects(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+
+	let names: Vec<&str> = discovery.packages.iter().map(|p| p.name.as_str()).collect();
+	assert!(names.contains(&"core"), "missing core: {names:?}");
+	assert!(names.contains(&"api"), "missing api: {names:?}");
+	assert!(names.contains(&"parent"), "missing parent: {names:?}");
+}
+
+#[test]
+fn discover_jvm_projects_extracts_gradle_dependencies() {
+	let root = fixture_path("jvm/gradle-multi");
+	let discovery =
+		discover_jvm_projects(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+
+	let api = discovery.packages.iter().find(|p| p.name == "api").unwrap();
+	let dep_names: Vec<&str> = api
+		.declared_dependencies
+		.iter()
+		.map(|d| d.name.as_str())
+		.collect();
+	assert!(
+		dep_names.contains(&"core"),
+		"api should depend on core: {dep_names:?}"
+	);
+	assert!(
+		dep_names.contains(&"guava"),
+		"api should depend on guava: {dep_names:?}"
+	);
+}
+
+#[test]
+fn discover_jvm_projects_extracts_maven_dependencies() {
+	let root = fixture_path("jvm/maven-single");
+	let discovery =
+		discover_jvm_projects(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+
+	let pkg = discovery.packages.first().unwrap();
+	let runtime: Vec<&str> = pkg
+		.declared_dependencies
+		.iter()
+		.filter(|d| d.kind == DependencyKind::Runtime)
+		.map(|d| d.name.as_str())
+		.collect();
+	assert!(runtime.contains(&"spring-core"));
+
+	let dev: Vec<&str> = pkg
+		.declared_dependencies
+		.iter()
+		.filter(|d| d.kind == DependencyKind::Development)
+		.map(|d| d.name.as_str())
+		.collect();
+	assert!(dev.contains(&"junit"));
+}
+
+#[test]
+fn discover_jvm_projects_handles_maven_property_version() {
+	let root = fixture_path("jvm/no-version");
+	let discovery =
+		discover_jvm_projects(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+
+	assert_eq!(discovery.packages.len(), 1);
+	let pkg = discovery.packages.first().unwrap();
+	assert_eq!(pkg.name, "no-version");
+	assert_eq!(
+		pkg.current_version, None,
+		"property-based version should be None"
+	);
+}
+
+#[test]
+fn discover_jvm_projects_handles_nonexistent_directory() {
+	let discovery = discover_jvm_projects(std::path::Path::new("/nonexistent/path"));
+	let result = discovery.unwrap_or_else(|error| panic!("unexpected error: {error}"));
+	assert!(result.packages.is_empty());
+}
+
+// -- discover_lockfiles --
+
+#[test]
+fn discover_lockfiles_returns_empty_without_lockfile() {
+	let root = fixture_path("jvm/gradle-single");
+	let package = PackageRecord::new(
+		Ecosystem::Jvm,
+		"standalone-app",
+		root.join("build.gradle.kts"),
+		root.clone(),
+		Some(Version::new(3, 0, 0)),
+		PublishState::Public,
+	);
+	let lockfiles = crate::discover_lockfiles(&package);
+	assert!(lockfiles.is_empty());
+}
+
+// -- default_lockfile_commands --
+
+#[test]
+fn default_lockfile_commands_infers_gradle_for_gradle_projects() {
+	let root = fixture_path("jvm/gradle-single");
+	let package = PackageRecord::new(
+		Ecosystem::Jvm,
+		"standalone-app",
+		root.join("build.gradle.kts"),
+		root.clone(),
+		Some(Version::new(3, 0, 0)),
+		PublishState::Public,
+	);
+	let commands = crate::default_lockfile_commands(&package);
+	assert_eq!(commands.len(), 1);
+	assert!(
+		commands.first().unwrap().command.contains("gradle"),
+		"should infer gradle command"
+	);
+}
+
+#[test]
+fn default_lockfile_commands_returns_empty_for_maven() {
+	let root = fixture_path("jvm/maven-single");
+	let package = PackageRecord::new(
+		Ecosystem::Jvm,
+		"my-app",
+		root.join("pom.xml"),
+		root.clone(),
+		Some(Version::new(2, 1, 0)),
+		PublishState::Public,
+	);
+	let commands = crate::default_lockfile_commands(&package);
+	assert!(commands.is_empty(), "Maven has no lockfile commands");
+}
+
+// -- update_gradle_build_version --
+
+#[test]
+fn update_gradle_build_version_replaces_version() {
+	let input = "group = \"com.example\"\nversion = \"1.0.0\"\n";
+	let result = update_gradle_build_version(input, "2.0.0");
+	assert!(result.contains("version = \"2.0.0\""));
+	assert!(!result.contains("1.0.0"));
+}
+
+#[test]
+fn update_gradle_build_version_preserves_other_content() {
+	let input = "plugins { application }\ngroup = \"com.example\"\nversion = \"1.0.0\"\n";
+	let result = update_gradle_build_version(input, "2.0.0");
+	assert!(result.contains("plugins { application }"));
+	assert!(result.contains("group = \"com.example\""));
+	assert!(result.contains("version = \"2.0.0\""));
+}
+
+#[test]
+fn update_gradle_build_version_handles_no_version() {
+	let input = "group = \"com.example\"\n";
+	let result = update_gradle_build_version(input, "2.0.0");
+	assert_eq!(result, input, "should not modify when no version found");
+}
+
+// -- update_version_catalog_text --
+
+#[test]
+fn update_version_catalog_text_updates_versions() {
+	let input = "[versions]\nguava = \"33.0.0-jre\"\njunit = \"4.13.2\"\n";
+	let deps = BTreeMap::from([("guava".to_string(), "34.0.0-jre".to_string())]);
+	let result =
+		update_version_catalog_text(input, &deps).unwrap_or_else(|error| panic!("update: {error}"));
+	assert!(result.contains("guava = \"34.0.0-jre\""));
+	assert!(
+		result.contains("junit = \"4.13.2\""),
+		"should preserve junit"
+	);
+}
+
+#[test]
+fn update_version_catalog_text_returns_original_when_no_deps() {
+	let input = "[versions]\nguava = \"33.0.0\"\n";
+	let result = update_version_catalog_text(input, &BTreeMap::new())
+		.unwrap_or_else(|error| panic!("update: {error}"));
+	assert_eq!(result, input);
+}
+
+#[test]
+fn update_version_catalog_text_handles_missing_versions_section() {
+	let input = "[libraries]\nguava = { module = \"com.google.guava:guava\" }\n";
+	let deps = BTreeMap::from([("guava".to_string(), "34.0.0".to_string())]);
+	let result =
+		update_version_catalog_text(input, &deps).unwrap_or_else(|error| panic!("update: {error}"));
+	assert_eq!(
+		result, input,
+		"should not modify when no [versions] section"
+	);
+}
+
+// -- update_pom_version --
+
+#[test]
+fn update_pom_version_replaces_project_version() {
+	let input =
+		"<project>\n  <artifactId>test</artifactId>\n  <version>1.0.0</version>\n</project>";
+	let result = update_pom_version(input, "2.0.0");
+	assert!(result.contains("<version>2.0.0</version>"));
+	assert!(!result.contains("1.0.0"));
+}
+
+#[test]
+fn update_pom_version_preserves_other_content() {
+	let input =
+		"<project>\n  <groupId>com.example</groupId>\n  <version>1.0.0</version>\n</project>";
+	let result = update_pom_version(input, "2.0.0");
+	assert!(result.contains("<groupId>com.example</groupId>"));
+	assert!(result.contains("<version>2.0.0</version>"));
+}
+
+#[test]
+fn update_pom_version_handles_no_version() {
+	let input = "<project>\n  <artifactId>test</artifactId>\n</project>";
+	let result = update_pom_version(input, "2.0.0");
+	assert_eq!(result, input);
+}
+
+// -- should_descend --
+
+#[test]
+fn discover_jvm_projects_skips_build_and_gradle_directories() {
+	use std::fs;
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+
+	// Create a valid Maven project at root
+	fs::write(
+		root.join("pom.xml"),
+		"<project>\n  <artifactId>root</artifactId>\n  <version>1.0.0</version>\n</project>\n",
+	)
+	.unwrap();
+
+	// Create projects in directories that should be skipped
+	for dir in &[".gradle", "build", ".mvn", "target"] {
+		let sub_dir = root.join(dir);
+		fs::create_dir_all(&sub_dir).unwrap();
+		fs::write(
+			sub_dir.join("pom.xml"),
+			format!(
+				"<project>\n  <artifactId>{dir}</artifactId>\n  <version>0.0.1</version>\n</project>\n"
+			),
+		)
+		.unwrap();
+	}
+
+	let discovery = discover_jvm_projects(root).unwrap_or_else(|error| panic!("discover: {error}"));
+	assert_eq!(
+		discovery.packages.len(),
+		1,
+		"should only find root project: {:?}",
+		discovery
+			.packages
+			.iter()
+			.map(|p| &p.name)
+			.collect::<Vec<_>>()
+	);
+	assert_eq!(discovery.packages.first().unwrap().name, "root");
+}
+
+#[test]
+fn discover_jvm_projects_warns_on_missing_subproject_directory() {
+	use std::fs;
+	let tempdir = tempfile::tempdir().unwrap();
+	let root = tempdir.path();
+	fs::write(
+		root.join("settings.gradle.kts"),
+		"include(\"nonexistent\")\n",
+	)
+	.unwrap();
+	let discovery = discover_jvm_projects(root).unwrap_or_else(|error| panic!("discover: {error}"));
+	assert!(
+		discovery.warnings.iter().any(|w| w.contains("nonexistent")),
+		"expected warning about missing subproject: {:?}",
+		discovery.warnings
+	);
+}
+
+#[test]
+fn discover_jvm_projects_finds_groovy_build_files() {
+	use std::fs;
+	let tempdir = tempfile::tempdir().unwrap();
+	let root = tempdir.path();
+	fs::write(root.join("settings.gradle.kts"), "include(\"lib\")\n").unwrap();
+	let lib_dir = root.join("lib");
+	fs::create_dir_all(&lib_dir).unwrap();
+	fs::write(
+		lib_dir.join("build.gradle"),
+		"group = 'com.example'\nversion = \"2.0.0\"\n",
+	)
+	.unwrap();
+	let discovery = discover_jvm_projects(root).unwrap_or_else(|error| panic!("discover: {error}"));
+	assert_eq!(discovery.packages.len(), 1);
+	assert_eq!(
+		discovery.packages.first().unwrap().current_version,
+		Some(Version::new(2, 0, 0))
+	);
+}
+
+#[test]
+fn discover_jvm_projects_skips_subproject_without_build_file() {
+	use std::fs;
+	let tempdir = tempfile::tempdir().unwrap();
+	let root = tempdir.path();
+	fs::write(root.join("settings.gradle.kts"), "include(\"empty\")\n").unwrap();
+	let empty_dir = root.join("empty");
+	fs::create_dir_all(&empty_dir).unwrap();
+	let discovery = discover_jvm_projects(root).unwrap_or_else(|error| panic!("discover: {error}"));
+	assert!(discovery.packages.is_empty());
+}
+
+#[test]
+fn default_lockfile_commands_prefers_gradlew_wrapper() {
+	use std::fs;
+	let tempdir = tempfile::tempdir().unwrap();
+	let root = tempdir.path();
+	fs::write(root.join("gradlew"), "#!/bin/sh\n").unwrap();
+	fs::write(root.join("build.gradle.kts"), "version = \"1.0.0\"\n").unwrap();
+	let package = PackageRecord::new(
+		Ecosystem::Jvm,
+		"test",
+		root.join("build.gradle.kts"),
+		root.to_path_buf(),
+		Some(Version::new(1, 0, 0)),
+		PublishState::Public,
+	);
+	let commands = crate::default_lockfile_commands(&package);
+	assert_eq!(commands.len(), 1);
+	assert!(
+		commands.first().unwrap().command.contains("gradlew"),
+		"should prefer gradlew: {}",
+		commands.first().unwrap().command
+	);
+}
+
+#[test]
+fn parse_gradle_subprojects_handles_simple_include_syntax() {
+	use std::fs;
+	let tempdir = tempfile::tempdir().unwrap();
+	let settings = tempdir.path().join("settings.gradle");
+	fs::write(&settings, "include \"core\"\ninclude \"api\"\n").unwrap();
+	let subprojects = parse_gradle_subprojects(&settings);
+	assert!(subprojects.contains(&"core".to_string()));
+	assert!(subprojects.contains(&"api".to_string()));
+}
+
+#[test]
+fn parse_maven_dependencies_handles_no_dependencies() {
+	let contents = "<project>\n  <artifactId>test</artifactId>\n</project>";
+	let deps = parse_maven_dependencies(contents);
+	assert!(deps.is_empty());
+}
+
+#[test]
+fn parse_gradle_dependencies_extracts_version_constraints() {
+	let contents = r#"dependencies {
+    implementation("com.example:lib:1.2.3")
+}"#;
+	let deps = parse_gradle_dependencies(contents);
+	assert_eq!(deps.len(), 1);
+	assert_eq!(
+		deps.first().unwrap().version_constraint.as_deref(),
+		Some("1.2.3")
+	);
+}
+
+#[test]
+fn discover_jvm_projects_skips_already_discovered_maven_dirs() {
+	// When a directory is already discovered via Gradle, Maven pom.xml should be skipped
+	let root = fixture_path("jvm/gradle-multi");
+	let discovery =
+		discover_jvm_projects(&root).unwrap_or_else(|error| panic!("discover: {error}"));
+	// Should only have Gradle subprojects, not duplicated Maven
+	let build_tools: Vec<&str> = discovery
+		.packages
+		.iter()
+		.filter_map(|p| p.metadata.get("build_tool").map(String::as_str))
+		.collect();
+	assert!(
+		build_tools.iter().all(|t| *t == "gradle"),
+		"all should be gradle: {build_tools:?}"
+	);
+}

--- a/crates/monochange_jvm/src/lib.rs
+++ b/crates/monochange_jvm/src/lib.rs
@@ -1,0 +1,533 @@
+#![deny(clippy::all)]
+#![forbid(clippy::indexing_slicing)]
+
+//! # `monochange_jvm`
+//!
+//! `monochange_jvm` discovers JVM projects from Gradle multi-project builds
+//! and Maven multi-module projects.
+//!
+//! ## Why use it?
+//!
+//! - discover Gradle and Maven projects in monorepos with one adapter
+//! - normalize JVM project manifests and dependency edges for the shared
+//!   planner
+//! - infer `./gradlew dependencies --write-locks` or `go mod tidy` as the
+//!   default lockfile refresh command
+//!
+//! ## Public entry points
+//!
+//! - `discover_jvm_projects(root)` discovers JVM projects
+//! - `JvmAdapter` exposes the shared adapter interface
+//!
+//! ## Scope
+//!
+//! - Gradle `settings.gradle.kts` / `settings.gradle` multi-project parsing
+//! - `build.gradle.kts` / `build.gradle` version and dependency extraction
+//! - Gradle Version Catalogs (`gradle/libs.versions.toml`) version management
+//! - Maven `pom.xml` multi-module and version parsing
+//! - lockfile command inference for Gradle projects
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
+use monochange_core::normalize_path;
+use monochange_core::AdapterDiscovery;
+use monochange_core::DependencyKind;
+use monochange_core::Ecosystem;
+use monochange_core::EcosystemAdapter;
+use monochange_core::LockfileCommandExecution;
+use monochange_core::MonochangeError;
+use monochange_core::MonochangeResult;
+use monochange_core::PackageDependency;
+use monochange_core::PackageRecord;
+use monochange_core::PublishState;
+use monochange_core::ShellConfig;
+use regex::Regex;
+use semver::Version;
+use toml_edit::DocumentMut;
+use toml_edit::Item;
+use walkdir::DirEntry;
+use walkdir::WalkDir;
+
+pub const GRADLE_SETTINGS_KTS: &str = "settings.gradle.kts";
+pub const GRADLE_SETTINGS: &str = "settings.gradle";
+pub const GRADLE_BUILD_KTS: &str = "build.gradle.kts";
+pub const GRADLE_BUILD: &str = "build.gradle";
+pub const GRADLE_LOCKFILE: &str = "gradle.lockfile";
+pub const VERSION_CATALOG: &str = "libs.versions.toml";
+pub const MAVEN_POM: &str = "pom.xml";
+
+pub struct JvmAdapter;
+
+#[must_use]
+pub const fn adapter() -> JvmAdapter {
+	JvmAdapter
+}
+
+impl EcosystemAdapter for JvmAdapter {
+	fn ecosystem(&self) -> Ecosystem {
+		Ecosystem::Jvm
+	}
+
+	fn discover(&self, root: &Path) -> MonochangeResult<AdapterDiscovery> {
+		discover_jvm_projects(root)
+	}
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum JvmVersionedFileKind {
+	GradleBuild,
+	VersionCatalog,
+	GradleLock,
+	MavenPom,
+}
+
+#[must_use]
+pub fn supported_versioned_file_kind(path: &Path) -> Option<JvmVersionedFileKind> {
+	let file_name = path
+		.file_name()
+		.and_then(|name| name.to_str())
+		.unwrap_or_default();
+	match file_name {
+		GRADLE_BUILD_KTS | GRADLE_BUILD => Some(JvmVersionedFileKind::GradleBuild),
+		VERSION_CATALOG => Some(JvmVersionedFileKind::VersionCatalog),
+		GRADLE_LOCKFILE => Some(JvmVersionedFileKind::GradleLock),
+		MAVEN_POM => Some(JvmVersionedFileKind::MavenPom),
+		_ => None,
+	}
+}
+
+pub fn discover_lockfiles(package: &PackageRecord) -> Vec<PathBuf> {
+	let manifest_dir = package
+		.manifest_path
+		.parent()
+		.map_or_else(|| package.workspace_root.clone(), Path::to_path_buf);
+	let mut lockfiles: Vec<PathBuf> = [manifest_dir.join(GRADLE_LOCKFILE)]
+		.into_iter()
+		.filter(|path| path.exists())
+		.collect();
+	// Also check workspace root for a shared lockfile
+	if manifest_dir != package.workspace_root {
+		lockfiles.extend(
+			[package.workspace_root.join(GRADLE_LOCKFILE)]
+				.into_iter()
+				.filter(|path| path.exists()),
+		);
+	}
+	lockfiles.dedup();
+	lockfiles
+}
+
+pub fn default_lockfile_commands(package: &PackageRecord) -> Vec<LockfileCommandExecution> {
+	let build_tool = detect_build_tool(package);
+	match build_tool {
+		BuildTool::Gradle => {
+			let cwd = package
+				.manifest_path
+				.parent()
+				.unwrap_or(&package.workspace_root)
+				.to_path_buf();
+			// Prefer gradlew wrapper if it exists
+			let command = if cwd.join("gradlew").exists() {
+				"./gradlew dependencies --write-locks"
+			} else {
+				"gradle dependencies --write-locks"
+			};
+			vec![LockfileCommandExecution {
+				command: command.to_string(),
+				cwd,
+				shell: ShellConfig::None,
+			}]
+		}
+		BuildTool::Maven => Vec::new(), // Maven has no native lockfile
+	}
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BuildTool {
+	Gradle,
+	Maven,
+}
+
+fn detect_build_tool(package: &PackageRecord) -> BuildTool {
+	let file_name = package
+		.manifest_path
+		.file_name()
+		.and_then(|name| name.to_str())
+		.unwrap_or_default();
+	if file_name == MAVEN_POM {
+		BuildTool::Maven
+	} else {
+		BuildTool::Gradle
+	}
+}
+
+/// Update a Gradle `build.gradle.kts` file's version declaration.
+///
+/// Replaces `version = "1.2.3"` with the new version.
+pub fn update_gradle_build_version(contents: &str, new_version: &str) -> String {
+	let re = Regex::new(r#"(?m)(version\s*=\s*)"([^"]+)""#)
+		.unwrap_or_else(|_| unreachable!("gradle version regex should be valid"));
+	re.replace(contents, |caps: &regex::Captures<'_>| {
+		let prefix = caps.get(1).map_or("version = ", |m| m.as_str());
+		format!("{prefix}\"{new_version}\"")
+	})
+	.to_string()
+}
+
+/// Update version entries in a Gradle Version Catalog (`libs.versions.toml`).
+pub fn update_version_catalog_text(
+	contents: &str,
+	versioned_deps: &std::collections::BTreeMap<String, String>,
+) -> Result<String, toml_edit::TomlError> {
+	if versioned_deps.is_empty() {
+		return Ok(contents.to_string());
+	}
+	let mut document = contents.parse::<DocumentMut>()?;
+	if let Some(versions) = document
+		.get_mut("versions")
+		.and_then(Item::as_table_like_mut)
+	{
+		for (name, version) in versioned_deps {
+			if let Some(existing) = versions.get_mut(name) {
+				if let Some(existing_value) = existing.as_value() {
+					let mut new_value = toml_edit::Value::from(version.as_str());
+					*new_value.decor_mut() = existing_value.decor().clone();
+					*existing = Item::Value(new_value);
+				}
+			}
+		}
+	}
+	Ok(document.to_string())
+}
+
+/// Update the `<version>` element in a Maven `pom.xml` file.
+///
+/// Only updates the top-level project version, not dependency versions.
+pub fn update_pom_version(contents: &str, new_version: &str) -> String {
+	let re = Regex::new(r"(?s)(<project[^>]*>.*?<version>)([^<]+)(</version>)")
+		.unwrap_or_else(|_| unreachable!("pom version regex should be valid"));
+	re.replace(contents, |caps: &regex::Captures<'_>| {
+		let before = caps.get(1).map_or("", |m| m.as_str());
+		let after = caps.get(3).map_or("", |m| m.as_str());
+		format!("{before}{new_version}{after}")
+	})
+	.to_string()
+}
+
+pub fn discover_jvm_projects(root: &Path) -> MonochangeResult<AdapterDiscovery> {
+	let mut packages = Vec::new();
+	let mut warnings = Vec::new();
+	let mut included_dirs = BTreeSet::new();
+
+	// Phase 1: Gradle multi-project discovery via settings files
+	for settings_path in find_settings_files(root) {
+		let settings_dir = settings_path.parent().unwrap_or_else(|| Path::new("."));
+		let subproject_names = parse_gradle_subprojects(&settings_path);
+		included_dirs.insert(normalize_path(settings_dir));
+
+		for subproject_name in &subproject_names {
+			let subproject_dir = settings_dir.join(subproject_name);
+			if !subproject_dir.is_dir() {
+				warnings.push(format!(
+					"Gradle subproject `{subproject_name}` not found at {}",
+					subproject_dir.display()
+				));
+				continue;
+			}
+			let build_file = find_gradle_build_file(&subproject_dir);
+			let Some(build_file) = build_file else {
+				continue;
+			};
+			match parse_gradle_project(&build_file, root, subproject_name) {
+				Ok(Some(package)) => {
+					included_dirs.insert(normalize_path(&subproject_dir));
+					packages.push(package);
+				}
+				Ok(None) => {}
+				Err(error) => {
+					warnings.push(format!("skipped {}: {error}", build_file.display()));
+				}
+			}
+		}
+	}
+
+	// Phase 2: Maven multi-module discovery via pom.xml
+	for pom_path in find_all_pom_files(root) {
+		let pom_dir = pom_path.parent().unwrap_or_else(|| Path::new("."));
+		let normalized = normalize_path(pom_dir);
+		if included_dirs.contains(&normalized) {
+			continue;
+		}
+		match parse_maven_project(&pom_path, root) {
+			Ok(Some(package)) => {
+				included_dirs.insert(normalized);
+				packages.push(package);
+			}
+			Ok(None) => {}
+			Err(error) => {
+				warnings.push(format!("skipped {}: {error}", pom_path.display()));
+			}
+		}
+	}
+
+	packages.sort_by(|left, right| left.id.cmp(&right.id));
+	packages.dedup_by(|left, right| left.id == right.id);
+
+	Ok(AdapterDiscovery { packages, warnings })
+}
+
+fn find_settings_files(root: &Path) -> Vec<PathBuf> {
+	let mut files = Vec::new();
+	for name in [GRADLE_SETTINGS_KTS, GRADLE_SETTINGS] {
+		let path = root.join(name);
+		if path.exists() {
+			files.push(path);
+			break; // Prefer .kts over .gradle
+		}
+	}
+	files
+}
+
+fn find_gradle_build_file(dir: &Path) -> Option<PathBuf> {
+	let kts = dir.join(GRADLE_BUILD_KTS);
+	if kts.exists() {
+		return Some(kts);
+	}
+	let groovy = dir.join(GRADLE_BUILD);
+	if groovy.exists() {
+		return Some(groovy);
+	}
+	None
+}
+
+/// Parse `include(...)` directives from a Gradle settings file.
+fn parse_gradle_subprojects(settings_path: &Path) -> Vec<String> {
+	let contents = fs::read_to_string(settings_path).unwrap_or_default();
+	let re = Regex::new(r#"include\s*\(\s*"([^"]+)"\s*(?:,\s*"([^"]+)"\s*)*\)"#)
+		.unwrap_or_else(|_| unreachable!("include regex should be valid"));
+
+	let mut subprojects = Vec::new();
+	for caps in re.captures_iter(&contents) {
+		for i in 1..caps.len() {
+			if let Some(m) = caps.get(i) {
+				let name = m.as_str().trim_start_matches(':');
+				if !name.is_empty() {
+					subprojects.push(name.to_string());
+				}
+			}
+		}
+	}
+
+	// Also handle comma-separated include without parens: include "a", "b"
+	let simple_re = Regex::new(r#"(?m)^include\s+"([^"]+)""#)
+		.unwrap_or_else(|_| unreachable!("simple include regex should be valid"));
+	for caps in simple_re.captures_iter(&contents) {
+		if let Some(m) = caps.get(1) {
+			let name = m.as_str().trim_start_matches(':');
+			if !name.is_empty() && !subprojects.contains(&name.to_string()) {
+				subprojects.push(name.to_string());
+			}
+		}
+	}
+
+	subprojects
+}
+
+fn parse_gradle_project(
+	build_file: &Path,
+	root: &Path,
+	project_name: &str,
+) -> MonochangeResult<Option<PackageRecord>> {
+	let contents = fs::read_to_string(build_file).map_err(|error| {
+		MonochangeError::Io(format!("failed to read {}: {error}", build_file.display()))
+	})?;
+
+	let version = parse_gradle_version(&contents);
+
+	let mut record = PackageRecord::new(
+		Ecosystem::Jvm,
+		project_name,
+		normalize_path(build_file),
+		normalize_path(root),
+		version,
+		PublishState::Public,
+	);
+
+	record.declared_dependencies = parse_gradle_dependencies(&contents);
+
+	// Store build tool metadata
+	record
+		.metadata
+		.insert("build_tool".to_string(), "gradle".to_string());
+
+	Ok(Some(record))
+}
+
+/// Parse the version from a Gradle build file.
+///
+/// Looks for `version = "1.2.3"` or `version "1.2.3"`.
+fn parse_gradle_version(contents: &str) -> Option<Version> {
+	let re = Regex::new(r#"(?m)^\s*version\s*=?\s*"([^"]+)""#).ok()?;
+	re.captures(contents)
+		.and_then(|caps| caps.get(1))
+		.and_then(|m| Version::parse(m.as_str()).ok())
+}
+
+/// Parse dependencies from a Gradle build file.
+///
+/// Matches patterns like:
+/// - `implementation("group:artifact:version")`
+/// - `implementation "group:artifact:version"`
+/// - `testImplementation("group:artifact:version")`
+/// - `api("group:artifact:version")`
+fn parse_gradle_dependencies(contents: &str) -> Vec<PackageDependency> {
+	let re = Regex::new(
+		r#"(?m)(implementation|api|compileOnly|runtimeOnly|testImplementation|testRuntimeOnly|testCompileOnly)\s*[\("]"?([^":\)]+):([^":\)]+)(?::([^":\)]+))?"?\s*["\)]"#,
+	);
+
+	let Ok(re) = re else {
+		return Vec::new();
+	};
+
+	let mut deps = Vec::new();
+	for caps in re.captures_iter(contents) {
+		let config = caps.get(1).map(|m| m.as_str()).unwrap_or_default();
+		let artifact = caps.get(3).map(|m| m.as_str().to_string());
+		let version = caps.get(4).map(|m| m.as_str().to_string());
+
+		let kind = if config.starts_with("test") {
+			DependencyKind::Development
+		} else {
+			DependencyKind::Runtime
+		};
+
+		if let Some(name) = artifact {
+			deps.push(PackageDependency {
+				name,
+				kind,
+				version_constraint: version,
+				optional: config == "compileOnly",
+			});
+		}
+	}
+
+	deps
+}
+
+fn parse_maven_project(pom_path: &Path, root: &Path) -> MonochangeResult<Option<PackageRecord>> {
+	let contents = fs::read_to_string(pom_path).map_err(|error| {
+		MonochangeError::Io(format!("failed to read {}: {error}", pom_path.display()))
+	})?;
+
+	let name = parse_maven_artifact_id(&contents);
+	let Some(name) = name else {
+		return Ok(None);
+	};
+
+	let version = parse_maven_version(&contents);
+
+	let mut record = PackageRecord::new(
+		Ecosystem::Jvm,
+		&name,
+		normalize_path(pom_path),
+		normalize_path(root),
+		version,
+		PublishState::Public,
+	);
+
+	record.declared_dependencies = parse_maven_dependencies(&contents);
+
+	record
+		.metadata
+		.insert("build_tool".to_string(), "maven".to_string());
+
+	Ok(Some(record))
+}
+
+/// Parse the `<artifactId>` from a Maven pom.xml.
+fn parse_maven_artifact_id(contents: &str) -> Option<String> {
+	// Match the first <artifactId> that is a direct child of <project>
+	// (not inside <dependency>, <parent>, etc.)
+	let re = Regex::new(r"(?s)<project[^>]*>.*?<artifactId>([^<]+)</artifactId>").ok()?;
+	re.captures(contents)
+		.and_then(|caps| caps.get(1))
+		.map(|m| m.as_str().trim().to_string())
+}
+
+/// Parse the `<version>` from a Maven pom.xml.
+fn parse_maven_version(contents: &str) -> Option<Version> {
+	let re = Regex::new(r"(?s)<project[^>]*>.*?<version>([^<]+)</version>").ok()?;
+	re.captures(contents)
+		.and_then(|caps| caps.get(1))
+		.and_then(|m| {
+			let version = m.as_str().trim();
+			// Skip Maven property references like ${revision}
+			if version.starts_with("${") {
+				return None;
+			}
+			Version::parse(version).ok()
+		})
+}
+
+/// Parse dependencies from a Maven pom.xml.
+fn parse_maven_dependencies(contents: &str) -> Vec<PackageDependency> {
+	let dep_re = Regex::new(
+		r"(?s)<dependency>\s*<groupId>[^<]+</groupId>\s*<artifactId>([^<]+)</artifactId>(?:\s*<version>([^<]+)</version>)?(?:\s*<scope>([^<]+)</scope>)?",
+	);
+
+	let Ok(re) = dep_re else {
+		return Vec::new();
+	};
+
+	let mut deps = Vec::new();
+	for caps in re.captures_iter(contents) {
+		let name = caps.get(1).map(|m| m.as_str().trim().to_string());
+		let version = caps
+			.get(2)
+			.map(|m| m.as_str().trim().to_string())
+			.filter(|v| !v.starts_with("${"));
+		let scope = caps.get(3).map(|m| m.as_str().trim().to_string());
+
+		let kind = match scope.as_deref() {
+			Some("test") => DependencyKind::Development,
+			Some("provided" | "system") => DependencyKind::Build,
+			_ => DependencyKind::Runtime,
+		};
+
+		if let Some(name) = name {
+			deps.push(PackageDependency {
+				name,
+				kind,
+				version_constraint: version,
+				optional: false,
+			});
+		}
+	}
+
+	deps
+}
+
+fn find_all_pom_files(root: &Path) -> Vec<PathBuf> {
+	WalkDir::new(root)
+		.into_iter()
+		.filter_entry(should_descend)
+		.filter_map(Result::ok)
+		.filter(|entry| entry.file_name() == MAVEN_POM)
+		.map(DirEntry::into_path)
+		.map(|path| normalize_path(&path))
+		.collect()
+}
+
+fn should_descend(entry: &DirEntry) -> bool {
+	let file_name = entry.file_name().to_string_lossy();
+	!matches!(
+		file_name.as_ref(),
+		".git" | "node_modules" | "target" | ".devenv" | "book" | ".gradle" | "build" | ".mvn"
+	)
+}
+
+#[cfg(test)]
+mod __tests;

--- a/crates/monochange_jvm/src/lib.rs
+++ b/crates/monochange_jvm/src/lib.rs
@@ -217,6 +217,7 @@ pub fn update_pom_version(contents: &str, new_version: &str) -> String {
 	.to_string()
 }
 
+#[tracing::instrument(skip_all)]
 pub fn discover_jvm_projects(root: &Path) -> MonochangeResult<AdapterDiscovery> {
 	let mut packages = Vec::new();
 	let mut warnings = Vec::new();
@@ -275,6 +276,8 @@ pub fn discover_jvm_projects(root: &Path) -> MonochangeResult<AdapterDiscovery> 
 
 	packages.sort_by(|left, right| left.id.cmp(&right.id));
 	packages.dedup_by(|left, right| left.id == right.id);
+
+	tracing::debug!(packages = packages.len(), "discovered jvm projects");
 
 	Ok(AdapterDiscovery { packages, warnings })
 }

--- a/docs/src/guide/03-discovery.md
+++ b/docs/src/guide/03-discovery.md
@@ -10,6 +10,7 @@ Supported sources in this milestone:
 - npm workspaces, pnpm workspaces, Bun workspaces, and standalone `package.json` packages
 - Deno workspaces and standalone `deno.json` / `deno.jsonc` packages
 - Dart and Flutter workspaces plus standalone `pubspec.yaml` packages
+- Gradle multi-project builds and Maven multi-module projects
 
 <!-- {/discoverySupportedSources} -->
 

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -241,6 +241,8 @@ When you do not configure `lockfile_commands`, monochange infers sensible defaul
   - `pnpm-lock.yaml` → `pnpm install --lockfile-only`
   - `bun.lock` / `bun.lockb` → `bun install --lockfile-only`
 - Dart / Flutter: `dart pub get` or `flutter pub get`
+- JVM (Gradle): `./gradlew dependencies --write-locks` (prefers wrapper, falls back to `gradle`)
+- JVM (Maven): no inferred default (Maven has no native lockfile)
 - Deno: no inferred default today
 
 If you configure `lockfile_commands` for an ecosystem, monochange stops inferring defaults for that ecosystem and those commands fully own lockfile refresh.
@@ -481,6 +483,10 @@ enabled = true
 [ecosystems.dart]
 enabled = true
 lockfile_commands = [{ command = "flutter pub get", cwd = "packages/mobile" }]
+
+[ecosystems.jvm]
+enabled = true
+lockfile_commands = [{ command = "./gradlew dependencies --write-locks" }]
 ```
 
 <!-- {/configurationEcosystemSettingsSnippet} -->

--- a/docs/src/readme.md
+++ b/docs/src/readme.md
@@ -85,7 +85,7 @@ If you want a slower, more guided walkthrough, continue with [Start here](./guid
 
 <!-- {=projectMilestoneCapabilities} -->
 
-- discover Cargo, npm/pnpm/Bun, Deno, Dart, and Flutter packages
+- discover Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, and JVM (Gradle/Maven) packages
 - normalize dependency edges across ecosystems
 - coordinate shared package groups from `monochange.toml`
 - compute release plans from explicit change input

--- a/fixtures/tests/jvm/gradle-multi/api/build.gradle.kts
+++ b/fixtures/tests/jvm/gradle-multi/api/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    id("java-library")
+}
+
+group = "com.example"
+version = "1.0.0"
+
+dependencies {
+    api("com.example:core:1.0.0")
+    implementation("com.google.guava:guava:33.0.0-jre")
+    compileOnly("org.projectlombok:lombok:1.18.30")
+    testImplementation("junit:junit:4.13.2")
+}

--- a/fixtures/tests/jvm/gradle-multi/core/build.gradle.kts
+++ b/fixtures/tests/jvm/gradle-multi/core/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    id("java-library")
+}
+
+group = "com.example"
+version = "1.0.0"
+
+dependencies {
+    implementation("com.google.guava:guava:33.0.0-jre")
+    testImplementation("junit:junit:4.13.2")
+}

--- a/fixtures/tests/jvm/gradle-multi/gradle/libs.versions.toml
+++ b/fixtures/tests/jvm/gradle-multi/gradle/libs.versions.toml
@@ -1,0 +1,7 @@
+[versions]
+guava = "33.0.0-jre"
+junit = "4.13.2"
+
+[libraries]
+guava = { module = "com.google.guava:guava", version.ref = "guava" }
+junit = { module = "junit:junit", version.ref = "junit" }

--- a/fixtures/tests/jvm/gradle-multi/settings.gradle.kts
+++ b/fixtures/tests/jvm/gradle-multi/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "my-monorepo"
+include("core", "api")

--- a/fixtures/tests/jvm/gradle-single/build.gradle.kts
+++ b/fixtures/tests/jvm/gradle-single/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    application
+}
+
+group = "com.example"
+version = "3.0.0"
+
+dependencies {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.16.0")
+}

--- a/fixtures/tests/jvm/gradle-single/settings.gradle.kts
+++ b/fixtures/tests/jvm/gradle-single/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "standalone-app"

--- a/fixtures/tests/jvm/maven-multi/api/pom.xml
+++ b/fixtures/tests/jvm/maven-multi/api/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>api</artifactId>
+    <version>1.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.1.1</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/fixtures/tests/jvm/maven-multi/core/pom.xml
+++ b/fixtures/tests/jvm/maven-multi/core/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>core</artifactId>
+    <version>1.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.9</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/fixtures/tests/jvm/maven-multi/pom.xml
+++ b/fixtures/tests/jvm/maven-multi/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>core</module>
+        <module>api</module>
+    </modules>
+</project>

--- a/fixtures/tests/jvm/maven-single/pom.xml
+++ b/fixtures/tests/jvm/maven-single/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>my-app</artifactId>
+    <version>2.1.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>6.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/fixtures/tests/jvm/no-version/pom.xml
+++ b/fixtures/tests/jvm/no-version/pom.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>no-version</artifactId>
+    <version>${revision}</version>
+</project>

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@
 
 It discovers packages, normalizes dependency data, applies group rules, turns explicit change files into release plans, and can run config-defined release preparation from those same inputs.
 
-Use it when your repository has outgrown one-ecosystem release tooling and you want one model for Cargo, npm/pnpm/Bun, Deno, and Dart/Flutter.
+Use it when your repository has outgrown one-ecosystem release tooling and you want one model for Cargo, npm/pnpm/Bun, Deno, Dart/Flutter, and JVM (Gradle/Maven).
 
 <!-- {/projectReadmeOverview} -->
 
@@ -151,7 +151,7 @@ See [Advanced: Assistant setup and MCP](docs/src/guide/09-assistant-setup.md) fo
 
 <!-- {=projectMilestoneCapabilities} -->
 
-- discover Cargo, npm/pnpm/Bun, Deno, Dart, and Flutter packages
+- discover Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, and JVM (Gradle/Maven) packages
 - normalize dependency edges across ecosystems
 - coordinate shared package groups from `monochange.toml`
 - compute release plans from explicit change input
@@ -194,6 +194,8 @@ See [Advanced: Assistant setup and MCP](docs/src/guide/09-assistant-setup.md) fo
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__deno-orange?logo=rust)](https://crates.io/crates/monochange_deno) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__deno-1f425f?logo=docs.rs)](https://docs.rs/monochange_deno/)
 - `monochange_dart` — Dart and Flutter workspace discovery.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__dart-orange?logo=rust)](https://crates.io/crates/monochange_dart) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__dart-1f425f?logo=docs.rs)](https://docs.rs/monochange_dart/)
+- `monochange_jvm` — Gradle and Maven project discovery.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__jvm-orange?logo=rust)](https://crates.io/crates/monochange_jvm) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__jvm-1f425f?logo=docs.rs)](https://docs.rs/monochange_jvm/)
 
 <!-- {/projectCrateCatalog} -->
 

--- a/skills/monochange/REFERENCE.md
+++ b/skills/monochange/REFERENCE.md
@@ -10,6 +10,7 @@ Use it when a repository needs one release-planning model across:
 - npm / pnpm / Bun
 - Deno
 - Dart / Flutter
+- JVM (Gradle / Maven)
 
 It discovers packages, normalizes dependency relationships, applies package and group rules from `monochange.toml`, reads explicit `.changeset/*.md` files, and turns those inputs into deterministic release plans.
 
@@ -209,6 +210,7 @@ Lockfile refresh is command-driven. monochange infers defaults when not configur
 - Cargo: `cargo generate-lockfile`
 - npm-family: detects owned lockfiles and runs the matching command (`npm install --package-lock-only`, `pnpm install --lockfile-only`, `bun install --lockfile-only`)
 - Dart / Flutter: `dart pub get` or `flutter pub get`
+- JVM (Gradle): `./gradlew dependencies --write-locks` (Maven has no lockfile)
 - Deno: no inferred default
 
 Explicit configuration overrides inference:

--- a/skills/monochange/SKILL.md
+++ b/skills/monochange/SKILL.md
@@ -110,7 +110,7 @@ description: Guides agents through monochange discovery, changesets, release pla
 
 ### Lockfile commands
 
-Lockfile refresh is command-driven via `[ecosystems.<name>].lockfile_commands`. monochange infers sensible defaults for Cargo, npm-family, and Dart/Flutter. Explicit configuration overrides inference.
+Lockfile refresh is command-driven via `[ecosystems.<name>].lockfile_commands`. monochange infers sensible defaults for Cargo, npm-family, Dart/Flutter, and Gradle. Explicit configuration overrides inference.
 
 ### Release titles
 


### PR DESCRIPTION
Closes #135

## Summary

Add a complete `monochange_jvm` adapter crate that discovers Gradle multi-project builds and Maven multi-module projects.

## Adapter implementation

- **Gradle multi-project**: Parses `settings.gradle.kts` / `settings.gradle` for `include(...)` directives, discovers `build.gradle.kts` / `build.gradle` in each subproject
- **Maven multi-module**: Discovers `pom.xml` files with `<artifactId>`, `<version>`, and dependency extraction
- **Version parsing**: Gradle `version = "x.y.z"` and Maven `<version>x.y.z</version>`, skipping Maven property refs
- **Dependency extraction**: Gradle configurations (`implementation`, `api`, `compileOnly`, `testImplementation`) and Maven scopes (`test` → Development, `provided` → Build)
- **Version Catalogs**: Updates `[versions]` entries in `gradle/libs.versions.toml`
- **Lockfile inference**: `./gradlew dependencies --write-locks` for Gradle (prefers wrapper), none for Maven
- **Build tool metadata**: Stores `build_tool: "gradle"` or `build_tool: "maven"` in package metadata

## Documentation

Updated across all surfaces: discovery guide, configuration guide, init template, skill files, project templates, mdt consumer blocks.

## Test plan

- [x] 46 tests covering Gradle and Maven discovery, parsing, version updates, lockfile commands, Version Catalogs, and edge cases
- [x] Fixture-driven: gradle-multi, gradle-single, maven-single, maven-multi, no-version
- [x] `cargo clippy -p monochange_jvm --all-targets -- -D warnings` passes
- [x] `cargo test -p monochange_jvm -p monochange_core -p monochange_config -p monochange --lib` — 549 tests pass
- [x] `mdt check` — all consumer blocks in sync
- [x] `dprint check` — formatting clean
- [x] ~90% line coverage (remaining uncovered: IO error paths, struct definitions)