### PR TITLE
refactor: simplify benchmarks

### DIFF
--- a/.changeset/034-release-record-schema.md
+++ b/.changeset/034-release-record-schema.md
@@ -15,9 +15,9 @@ use monochange_core::ReleaseManifest;
 After, downstream tooling can also work with durable commit-history records:
 
 ```rust
+use monochange_core::ReleaseRecord;
 use monochange_core::parse_release_record_block;
 use monochange_core::render_release_record_block;
-use monochange_core::ReleaseRecord;
 ```
 
 This release-record contract includes:

--- a/.changeset/061-simplify-benchmarks.md
+++ b/.changeset/061-simplify-benchmarks.md
@@ -1,0 +1,16 @@
+---
+monochange: minor
+monochange_core: minor
+monochange_config: minor
+monochange_cargo: minor
+monochange_npm: minor
+monochange_dart: minor
+monochange_deno: minor
+monochange_github: minor
+monochange_gitlab: minor
+monochange_gitea: minor
+monochange_graph: minor
+monochange_semver: minor
+---
+
+Upgrade to Rust edition 2024 (minimum 1.90.0) with nightly toolchain for formatting. Remove redundant `#![deny(clippy::all)]`. Simplify CI benchmark workflow. Criterion benchmarks now work on edition 2024.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
           mkdir -p target
           cargo bench -p monochange --bench cli_commands -- \
             --output-format bencher \
-            "config_load" "discover" "validate" "changeset_loading" "prepare_release_dry_run" \
+            "config_load|discover|validate|changeset_loading|prepare_release_dry_run" \
             2>&1 | tee /tmp/bench-output.txt | grep "^test " > target/benchmark-results.txt || true
           echo "--- raw output (last 10 lines) ---"
           tail -10 /tmp/bench-output.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,8 @@ jobs:
           cargo bench -p monochange --bench cli_commands -- \
             --output-format bencher \
             "config_load" "discover" "validate" "changeset_loading" "prepare_release_dry_run" \
-            2>&1 | grep "^test " > target/benchmark-results.txt
+            > /tmp/bench-stdout.txt 2>&1
+          grep "^test " /tmp/bench-stdout.txt > target/benchmark-results.txt || true
           cat target/benchmark-results.txt
         shell: devenv shell -- bash -e {0}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,13 +131,15 @@ jobs:
       - name: run criterion benchmarks
         run: |
           mkdir -p target
+          set +e
           cargo bench -p monochange --bench cli_commands -- \
             --output-format bencher \
             "config_load" "discover" "validate" "changeset_loading" "prepare_release_dry_run" \
-            > /tmp/bench-stdout.txt 2>&1
-          grep "^test " /tmp/bench-stdout.txt > target/benchmark-results.txt || true
+            2>&1 | tee /tmp/bench-output.txt
+          grep "^test " /tmp/bench-output.txt > target/benchmark-results.txt || true
+          echo "Benchmark results:"
           cat target/benchmark-results.txt
-        shell: devenv shell -- bash -e {0}
+        shell: devenv shell -- bash {0}
 
       - name: compare benchmarks and comment on PR
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,13 +141,19 @@ jobs:
           cat target/benchmark-results.txt
         shell: devenv shell -- bash -e {0}
 
-      - name: upload benchmark results
+      - name: compare benchmarks and comment on PR
+        uses: benchmark-action/github-action-benchmark@v1
         if: always()
-        uses: actions/upload-artifact@v4
         with:
-          name: criterion-benchmark-results
-          path: target/benchmark-results.txt
-          retention-days: 90
+          tool: cargo
+          output-file-path: target/benchmark-results.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-on-alert: true
+          alert-threshold: "150%"
+          fail-on-alert: false
+          comment-always: ${{ github.event_name == 'pull_request' }}
+          save-data-file: ${{ github.ref == 'refs/heads/main' }}
+          auto-push: ${{ github.ref == 'refs/heads/main' }}
 
   benchmark-binary:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,17 +131,18 @@ jobs:
       - name: run criterion benchmarks
         run: |
           mkdir -p target
-          set +e
           cargo bench -p monochange --bench cli_commands -- \
             --output-format bencher \
             "config_load" "discover" "validate" "changeset_loading" "prepare_release_dry_run" \
-            2>&1 | tee /tmp/bench-output.txt
-          grep "^test " /tmp/bench-output.txt > target/benchmark-results.txt || true
-          echo "Benchmark results:"
+            2>&1 | tee /tmp/bench-output.txt | grep "^test " > target/benchmark-results.txt || true
+          echo "--- raw output (last 10 lines) ---"
+          tail -10 /tmp/bench-output.txt
+          echo "--- filtered results ---"
           cat target/benchmark-results.txt
-        shell: devenv shell -- bash {0}
+        shell: devenv shell -- bash -e {0}
 
       - name: compare benchmarks and comment on PR
+        if: hashFiles('target/benchmark-results.txt') != ''
         uses: benchmark-action/github-action-benchmark@v1
         with:
           tool: cargo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,25 +128,15 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: run benchmarks
+      - name: run criterion benchmarks
         run: |
-          set +e
           mkdir -p target
           cargo bench -p monochange --bench cli_commands -- \
             --output-format bencher \
             "config_load" "discover" "validate" "changeset_loading" "prepare_release_dry_run" \
-            > /tmp/bench-raw.txt 2>&1
-          bench_exit=$?
-          grep "^test " /tmp/bench-raw.txt > target/benchmark-results.txt || true
-          echo "Benchmark exit code: $bench_exit"
-          echo "Results:"
+            2>&1 | grep "^test " > target/benchmark-results.txt
           cat target/benchmark-results.txt
-          if [ ! -s target/benchmark-results.txt ]; then
-            echo "Raw output:"
-            tail -30 /tmp/bench-raw.txt
-          fi
-          [ -s target/benchmark-results.txt ]
-        shell: devenv shell -- bash {0}
+        shell: devenv shell -- bash -e {0}
 
       - name: compare benchmarks and comment on PR
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,19 +141,13 @@ jobs:
           cat target/benchmark-results.txt
         shell: devenv shell -- bash -e {0}
 
-      - name: compare benchmarks and comment on PR
-        uses: benchmark-action/github-action-benchmark@v1
+      - name: upload benchmark results
         if: always()
+        uses: actions/upload-artifact@v4
         with:
-          tool: cargo
-          output-file-path: target/benchmark-results.txt
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-on-alert: true
-          alert-threshold: "150%"
-          fail-on-alert: false
-          comment-always: ${{ github.event_name == 'pull_request' }}
-          save-data-file: ${{ github.ref == 'refs/heads/main' }}
-          auto-push: ${{ github.ref == 'refs/heads/main' }}
+          name: criterion-benchmark-results
+          path: target/benchmark-results.txt
+          retention-days: 90
 
   benchmark-binary:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,19 +141,13 @@ jobs:
           cat target/benchmark-results.txt
         shell: devenv shell -- bash -e {0}
 
-      - name: compare benchmarks and comment on PR
-        if: hashFiles('target/benchmark-results.txt') != ''
-        uses: benchmark-action/github-action-benchmark@v1
+      - name: upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          tool: cargo
-          output-file-path: target/benchmark-results.txt
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-on-alert: true
-          alert-threshold: "150%"
-          fail-on-alert: false
-          comment-always: ${{ github.event_name == 'pull_request' }}
-          save-data-file: ${{ github.ref == 'refs/heads/main' }}
-          auto-push: ${{ github.ref == 'refs/heads/main' }}
+          name: criterion-benchmark-results
+          path: target/benchmark-results.txt
+          retention-days: 90
 
   benchmark-binary:
     if: github.event_name == 'pull_request'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,13 +36,13 @@ resolver = "2"
 version = "0.0.0"
 authors = ["Ifiok Jr. <ifiokotung@gmail.com>"]
 categories = ["development-tools"]
-edition = "2021"
+edition = "2024"
 homepage = "https://github.com/ifiokjr/monochange"
 include = ["src/**/*.rs", "Cargo.toml", "readme.md"]
 license = "Unlicense"
 readme = "readme.md"
 repository = "https://github.com/ifiokjr/monochange"
-rust-version = "1.86.0"
+rust-version = "1.90.0"
 
 [workspace.dependencies]
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,4 +2,4 @@ disallowed-methods = [
 	{ path = "std::result::Result::expect", reason = "hides errors; use `unwrap_or_else(|error| panic!(...))`" },
 ]
 
-msrv = "1.86.0"
+msrv = "1.90.0"

--- a/crates/monochange/benches/cli_commands.rs
+++ b/crates/monochange/benches/cli_commands.rs
@@ -1,10 +1,10 @@
 use std::fs;
 use std::path::Path;
 
-use criterion::criterion_group;
-use criterion::criterion_main;
 use criterion::BenchmarkId;
 use criterion::Criterion;
+use criterion::criterion_group;
+use criterion::criterion_main;
 
 /// Generate a workspace fixture with N cargo packages and M changesets.
 fn generate_fixture(root: &Path, num_packages: usize, num_changesets: usize) {

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -25,12 +25,14 @@ use monochange_test_helpers::snapshot_settings;
 use semver::Version;
 use tempfile::tempdir;
 
+use crate::CliContext;
 use crate::add_change_file;
 use crate::add_interactive_change_file;
 use crate::affected_packages;
 use crate::build_command_for_root;
 use crate::build_lockfile_command_executions;
-use crate::cli_runtime::{normalize_when_expression, should_execute_cli_step};
+use crate::cli_runtime::normalize_when_expression;
+use crate::cli_runtime::should_execute_cli_step;
 use crate::discover_workspace;
 use crate::interactive::InteractiveChangeResult;
 use crate::interactive::InteractiveTarget;
@@ -41,7 +43,6 @@ use crate::release_artifacts::set_force_build_file_diff_previews_error;
 use crate::render_change_target_markdown;
 use crate::run_with_args;
 use crate::run_with_args_in_dir;
-use crate::CliContext;
 
 fn fixture_path(relative: &str) -> PathBuf {
 	monochange_test_helpers::fs::fixture_path_from(env!("CARGO_MANIFEST_DIR"), relative)
@@ -135,7 +136,9 @@ fn repair_release_help_describes_retargeting_workflow() {
 	)
 	.unwrap_or_else(|error| panic!("repair-release help: {error}"));
 
-	assert!(output.contains("Repair a recent release by moving its release tags to a later commit"));
+	assert!(
+		output.contains("Repair a recent release by moving its release tags to a later commit")
+	);
 	assert!(output.contains("mc repair-release --from v1.2.3 --dry-run"));
 	assert!(output.contains("--sync-provider=false"));
 }
@@ -580,9 +583,11 @@ fn validate_command_reports_invalid_changeset_targets() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected validation failure"));
-	assert!(error
-		.to_string()
-		.contains("unknown package or group `missing`"));
+	assert!(
+		error
+			.to_string()
+			.contains("unknown package or group `missing`")
+	);
 }
 
 #[test]
@@ -592,22 +597,30 @@ fn discover_workspace_aggregates_packages_from_multiple_ecosystems() {
 		discover_workspace(&fixture_root).unwrap_or_else(|error| panic!("discovery: {error}"));
 
 	assert_eq!(discovery.packages.len(), 4);
-	assert!(discovery
-		.packages
-		.iter()
-		.any(|package| package.ecosystem == Ecosystem::Cargo));
-	assert!(discovery
-		.packages
-		.iter()
-		.any(|package| package.ecosystem == Ecosystem::Npm));
-	assert!(discovery
-		.packages
-		.iter()
-		.any(|package| package.ecosystem == Ecosystem::Deno));
-	assert!(discovery
-		.packages
-		.iter()
-		.any(|package| package.ecosystem == Ecosystem::Dart));
+	assert!(
+		discovery
+			.packages
+			.iter()
+			.any(|package| package.ecosystem == Ecosystem::Cargo)
+	);
+	assert!(
+		discovery
+			.packages
+			.iter()
+			.any(|package| package.ecosystem == Ecosystem::Npm)
+	);
+	assert!(
+		discovery
+			.packages
+			.iter()
+			.any(|package| package.ecosystem == Ecosystem::Deno)
+	);
+	assert!(
+		discovery
+			.packages
+			.iter()
+			.any(|package| package.ecosystem == Ecosystem::Dart)
+	);
 	assert_eq!(discovery.dependencies.len(), 3);
 	assert_eq!(discovery.version_groups.len(), 1);
 	let version_group = discovery
@@ -637,18 +650,24 @@ fn workspace_discover_json_output_contains_contract_fields() {
 	assert_eq!(parsed["packages"].as_array().map(Vec::len), Some(4));
 	assert_eq!(parsed["versionGroups"].as_array().map(Vec::len), Some(1));
 	assert_eq!(parsed["dependencies"].as_array().map(Vec::len), Some(3));
-	assert!(parsed["packages"]
-		.as_array()
-		.unwrap_or_else(|| panic!("packages array"))
-		.iter()
-		.all(|package| package.get("manifestPath").is_some()));
-	assert!(parsed["packages"]
-		.as_array()
-		.unwrap_or_else(|| panic!("packages array"))
-		.iter()
-		.all(|package| package["id"]
-			.as_str()
-			.is_some_and(|id| !id.contains(fixture_root.to_string_lossy().as_ref()))));
+	assert!(
+		parsed["packages"]
+			.as_array()
+			.unwrap_or_else(|| panic!("packages array"))
+			.iter()
+			.all(|package| package.get("manifestPath").is_some())
+	);
+	assert!(
+		parsed["packages"]
+			.as_array()
+			.unwrap_or_else(|| panic!("packages array"))
+			.iter()
+			.all(|package| {
+				package["id"]
+					.as_str()
+					.is_some_and(|id| !id.contains(fixture_root.to_string_lossy().as_ref()))
+			})
+	);
 }
 
 #[test]
@@ -913,9 +932,11 @@ fn changes_add_requires_package_or_interactive_mode() {
 		],
 	)
 	.expect_err("change without package should fail");
-	assert!(error
-		.to_string()
-		.contains("requires at least one `--package` value or `--interactive` mode"));
+	assert!(
+		error
+			.to_string()
+			.contains("requires at least one `--package` value or `--interactive` mode")
+	);
 }
 
 #[test]
@@ -1013,9 +1034,11 @@ fn add_change_file_rejects_none_without_type_or_version() {
 			.build(),
 	)
 	.expect_err("none bump without type/version should fail");
-	assert!(error
-		.to_string()
-		.contains("must not use a `none` bump without also declaring `type` or `version`"));
+	assert!(
+		error
+			.to_string()
+			.contains("must not use a `none` bump without also declaring `type` or `version`")
+	);
 }
 
 #[test]
@@ -1033,9 +1056,11 @@ fn add_change_file_rejects_unknown_change_type() {
 			.build(),
 	)
 	.expect_err("unknown type should fail");
-	assert!(error
-		.to_string()
-		.contains("uses unknown change type `docs`"));
+	assert!(
+		error
+			.to_string()
+			.contains("uses unknown change type `docs`")
+	);
 }
 
 #[test]
@@ -1137,9 +1162,11 @@ fn changes_add_rejects_legacy_evidence_input() {
 	)
 	.expect_err("legacy evidence input should be rejected");
 
-	assert!(error
-		.to_string()
-		.contains("unexpected argument '--evidence'"));
+	assert!(
+		error
+			.to_string()
+			.contains("unexpected argument '--evidence'")
+	);
 }
 
 #[test]
@@ -1159,9 +1186,11 @@ fn changes_add_rejects_unknown_package_references() {
 	.err()
 	.unwrap_or_else(|| panic!("expected failure"));
 
-	assert!(error
-		.to_string()
-		.contains("did not match any discovered package"));
+	assert!(
+		error
+			.to_string()
+			.contains("did not match any discovered package")
+	);
 }
 
 #[test]
@@ -1181,9 +1210,11 @@ fn release_dry_run_rejects_legacy_origin_and_evidence_metadata() {
 	)
 	.expect_err("legacy metadata should be rejected");
 
-	assert!(error
-		.to_string()
-		.contains("target `origin` uses unsupported field(s): core"));
+	assert!(
+		error
+			.to_string()
+			.contains("target `origin` uses unsupported field(s): core")
+	);
 }
 
 #[test]
@@ -1393,14 +1424,16 @@ fn build_lockfile_command_executions_skips_default_deno_commands() {
 	)
 	.unwrap_or_else(|error| panic!("plan: {error}"));
 
-	assert!(build_lockfile_command_executions(
-		tempdir.path(),
-		&configuration,
-		&discovery.packages,
-		&plan,
-	)
-	.unwrap_or_else(|error| panic!("lockfile commands: {error}"))
-	.is_empty());
+	assert!(
+		build_lockfile_command_executions(
+			tempdir.path(),
+			&configuration,
+			&discovery.packages,
+			&plan,
+		)
+		.unwrap_or_else(|error| panic!("lockfile commands: {error}"))
+		.is_empty()
+	);
 }
 
 #[test]
@@ -1725,9 +1758,11 @@ fn command_unknown_commands_suggest_available_cli() {
 	.err()
 	.unwrap_or_else(|| panic!("expected command suggestion"));
 
-	assert!(error
-		.to_string()
-		.contains("unrecognized subcommand 'ship-it'"));
+	assert!(
+		error
+			.to_string()
+			.contains("unrecognized subcommand 'ship-it'")
+	);
 }
 
 #[test]
@@ -1844,9 +1879,11 @@ fn command_step_rejects_unparseable_commands() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected parse failure"));
-	assert!(error
-		.to_string()
-		.contains("failed to parse command `\"unterminated`"));
+	assert!(
+		error
+			.to_string()
+			.contains("failed to parse command `\"unterminated`")
+	);
 }
 
 #[test]
@@ -1910,9 +1947,11 @@ fn command_step_reports_process_spawn_failures() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected process spawn failure"));
-	assert!(error
-		.to_string()
-		.contains("failed to run command `definitely-not-a-real-command-12345`"));
+	assert!(
+		error
+			.to_string()
+			.contains("failed to run command `definitely-not-a-real-command-12345`")
+	);
 }
 
 #[test]
@@ -2628,9 +2667,11 @@ fn step_override_forwards_multi_value_list_reference_as_list() {
 	.unwrap_or_else(|error| panic!("pr-check output: {error}"));
 	let json: serde_json::Value = serde_json::from_str(&output)
 		.unwrap_or_else(|error| panic!("json: {error}; output={output}"));
-	assert!(json["matchedPaths"]
-		.as_array()
-		.is_some_and(|p| p.iter().any(|v| v == "crates/core/src/lib.rs")));
+	assert!(
+		json["matchedPaths"]
+			.as_array()
+			.is_some_and(|p| p.iter().any(|v| v == "crates/core/src/lib.rs"))
+	);
 }
 
 #[test]
@@ -2735,8 +2776,10 @@ fn should_execute_cli_step_runs_when_condition_is_true() {
 		variables: None,
 		inputs: BTreeMap::new(),
 	};
-	assert!(should_execute_cli_step(&step, &context, &step_inputs)
-		.unwrap_or_else(|error| { panic!("when condition: {error}") }));
+	assert!(
+		should_execute_cli_step(&step, &context, &step_inputs)
+			.unwrap_or_else(|error| { panic!("when condition: {error}") })
+	);
 }
 
 #[test]
@@ -2752,8 +2795,10 @@ fn should_execute_cli_step_skips_when_condition_is_false() {
 		variables: None,
 		inputs: BTreeMap::new(),
 	};
-	assert!(!should_execute_cli_step(&step, &context, &step_inputs)
-		.unwrap_or_else(|error| { panic!("when condition: {error}") }));
+	assert!(
+		!should_execute_cli_step(&step, &context, &step_inputs)
+			.unwrap_or_else(|error| { panic!("when condition: {error}") })
+	);
 }
 
 #[test]
@@ -2769,8 +2814,10 @@ fn should_execute_cli_step_skips_for_zero_value() {
 		variables: None,
 		inputs: BTreeMap::new(),
 	};
-	assert!(!should_execute_cli_step(&step, &context, &step_inputs)
-		.unwrap_or_else(|error| { panic!("when condition: {error}") }));
+	assert!(
+		!should_execute_cli_step(&step, &context, &step_inputs)
+			.unwrap_or_else(|error| { panic!("when condition: {error}") })
+	);
 }
 
 #[test]
@@ -2786,8 +2833,10 @@ fn should_execute_cli_step_trims_and_treats_1_as_true() {
 		variables: None,
 		inputs: BTreeMap::new(),
 	};
-	assert!(should_execute_cli_step(&step, &context, &step_inputs)
-		.unwrap_or_else(|error| { panic!("when condition: {error}") }));
+	assert!(
+		should_execute_cli_step(&step, &context, &step_inputs)
+			.unwrap_or_else(|error| { panic!("when condition: {error}") })
+	);
 }
 
 #[test]
@@ -2803,8 +2852,10 @@ fn should_execute_cli_step_skips_with_not_operator() {
 		variables: None,
 		inputs: BTreeMap::new(),
 	};
-	assert!(!should_execute_cli_step(&step, &context, &step_inputs)
-		.unwrap_or_else(|error| { panic!("when condition: {error}") }));
+	assert!(
+		!should_execute_cli_step(&step, &context, &step_inputs)
+			.unwrap_or_else(|error| { panic!("when condition: {error}") })
+	);
 }
 
 #[test]
@@ -2821,9 +2872,11 @@ fn should_execute_cli_step_rejects_unknown_template_reference() {
 		inputs: BTreeMap::new(),
 	};
 	let error = should_execute_cli_step(&step, &context, &step_inputs).unwrap_err();
-	assert!(error
-		.to_string()
-		.contains("failed to evaluate `when` condition `{{ inputs.missing }}`"));
+	assert!(
+		error
+			.to_string()
+			.contains("failed to evaluate `when` condition `{{ inputs.missing }}`")
+	);
 }
 
 #[test]
@@ -2846,8 +2899,9 @@ fn should_execute_cli_step_rejects_non_scalar_condition_value() {
 
 #[test]
 fn lookup_template_value_traverses_nested_objects() {
-	use super::lookup_template_value;
 	use serde_json::json;
+
+	use super::lookup_template_value;
 	let v = json!({"inputs": {"message": "hello"}});
 	assert_eq!(
 		lookup_template_value(&v, "inputs.message"),
@@ -2857,24 +2911,27 @@ fn lookup_template_value_traverses_nested_objects() {
 
 #[test]
 fn lookup_template_value_traverses_array_by_index() {
-	use super::lookup_template_value;
 	use serde_json::json;
+
+	use super::lookup_template_value;
 	let v = json!({"items": ["a", "b", "c"]});
 	assert_eq!(lookup_template_value(&v, "items.1"), Some(&json!("b")));
 }
 
 #[test]
 fn lookup_template_value_returns_none_for_missing_key() {
-	use super::lookup_template_value;
 	use serde_json::json;
+
+	use super::lookup_template_value;
 	let v = json!({"inputs": {}});
 	assert_eq!(lookup_template_value(&v, "inputs.missing"), None);
 }
 
 #[test]
 fn lookup_template_value_returns_none_for_primitive_descent() {
-	use super::lookup_template_value;
 	use serde_json::json;
+
+	use super::lookup_template_value;
 	let v = json!({"foo": "string_value"});
 	assert_eq!(lookup_template_value(&v, "foo.nested"), None);
 }
@@ -2890,8 +2947,9 @@ fn template_value_to_input_values_null_returns_empty() {
 
 #[test]
 fn template_value_to_input_values_number_returns_string() {
-	use super::template_value_to_input_values;
 	use serde_json::json;
+
+	use super::template_value_to_input_values;
 	assert_eq!(
 		template_value_to_input_values(&json!(42)),
 		vec!["42".to_string()]
@@ -2904,8 +2962,9 @@ fn template_value_to_input_values_number_returns_string() {
 
 #[test]
 fn template_value_to_input_values_array_flattens_elements() {
-	use super::template_value_to_input_values;
 	use serde_json::json;
+
+	use super::template_value_to_input_values;
 	assert_eq!(
 		template_value_to_input_values(&json!(["a", "b", "c"])),
 		vec!["a", "b", "c"]
@@ -2918,8 +2977,9 @@ fn template_value_to_input_values_array_flattens_elements() {
 
 #[test]
 fn template_value_to_input_values_object_returns_json_serialization() {
-	use super::template_value_to_input_values;
 	use serde_json::json;
+
+	use super::template_value_to_input_values;
 	let obj = json!({"k": "v"});
 	let result = template_value_to_input_values(&obj);
 	assert_eq!(result.len(), 1);
@@ -2962,10 +3022,12 @@ fn build_release_commit_message_uses_default_title_without_source() {
 
 	let commit_message = crate::build_release_commit_message(None, &manifest);
 	assert_eq!(commit_message.subject, "chore(release): prepare release");
-	assert!(commit_message
-		.body
-		.as_deref()
-		.is_some_and(|body| body.contains("## monochange Release Record")));
+	assert!(
+		commit_message
+			.body
+			.as_deref()
+			.is_some_and(|body| body.contains("## monochange Release Record"))
+	);
 }
 
 #[test]
@@ -3353,9 +3415,11 @@ fn repair_release_command_rejects_non_descendant_targets_without_force() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected non-descendant error"));
-	assert!(error
-		.to_string()
-		.contains("is not a descendant of release-record commit"));
+	assert!(
+		error
+			.to_string()
+			.contains("is not a descendant of release-record commit")
+	);
 }
 
 #[test]
@@ -3634,9 +3698,11 @@ fn execute_cli_command_retarget_release_requires_from_input() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected missing from input error"));
-	assert!(error
-		.to_string()
-		.contains("`RetargetRelease` requires a `from` input"));
+	assert!(
+		error
+			.to_string()
+			.contains("`RetargetRelease` requires a `from` input")
+	);
 }
 
 #[test]
@@ -3814,9 +3880,11 @@ fn execute_cli_command_change_step_requires_reason_input() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected missing reason error"));
-	assert!(error
-		.to_string()
-		.contains("command `change` requires a `--reason` value"));
+	assert!(
+		error
+			.to_string()
+			.contains("command `change` requires a `--reason` value")
+	);
 }
 
 #[test]
@@ -3979,9 +4047,11 @@ fn parse_boolean_step_input_rejects_invalid_values() {
 	let error = crate::parse_boolean_step_input(&inputs, "force")
 		.err()
 		.unwrap_or_else(|| panic!("expected invalid boolean error"));
-	assert!(error
-		.to_string()
-		.contains("invalid boolean value `maybe` for `force`"));
+	assert!(
+		error
+			.to_string()
+			.contains("invalid boolean value `maybe` for `force`")
+	);
 }
 
 #[test]
@@ -4192,9 +4262,11 @@ fn plan_release_retarget_rejects_non_descendant_without_force() {
 		crate::plan_release_retarget(root, &discovery, &branch_commit, false, false, true, None)
 			.err()
 			.unwrap_or_else(|| panic!("expected non-descendant error"));
-	assert!(error
-		.to_string()
-		.contains("is not a descendant of release-record commit"));
+	assert!(
+		error
+			.to_string()
+			.contains("is not a descendant of release-record commit")
+	);
 }
 
 #[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
@@ -4284,9 +4356,11 @@ fn retarget_release_reports_missing_tags() {
 	let error = crate::retarget_release(root, &discovery, "HEAD", false, false, true, None)
 		.err()
 		.unwrap_or_else(|| panic!("expected missing tag error"));
-	assert!(error
-		.to_string()
-		.contains("release tag v1.2.3 could not be found"));
+	assert!(
+		error
+			.to_string()
+			.contains("release tag v1.2.3 could not be found")
+	);
 }
 
 #[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
@@ -4378,11 +4452,13 @@ fn plan_release_retarget_marks_unsupported_provider_sync_in_dry_run() {
 		provider_update.operation,
 		monochange_core::RetargetProviderOperation::Unsupported
 	);
-	assert!(provider_update
-		.message
-		.as_deref()
-		.unwrap_or("")
-		.contains("gitlab"));
+	assert!(
+		provider_update
+			.message
+			.as_deref()
+			.unwrap_or("")
+			.contains("gitlab")
+	);
 
 	let result = crate::execute_release_retarget(root, Some(&source), &plan)
 		.unwrap_or_else(|error| panic!("execute retarget: {error}"));
@@ -4454,9 +4530,11 @@ fn plan_release_retarget_rejects_provider_kind_mismatches() {
 		crate::plan_release_retarget(root, &discovery, "HEAD", false, false, true, Some(&source))
 			.err()
 			.unwrap_or_else(|| panic!("expected provider mismatch error"));
-	assert!(error
-		.to_string()
-		.contains("does not match configured source provider"));
+	assert!(
+		error
+			.to_string()
+			.contains("does not match configured source provider")
+	);
 }
 
 #[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
@@ -4490,9 +4568,11 @@ fn plan_release_retarget_rejects_repository_mismatches() {
 		crate::plan_release_retarget(root, &discovery, "HEAD", false, false, true, Some(&source))
 			.err()
 			.unwrap_or_else(|| panic!("expected repository mismatch error"));
-	assert!(error
-		.to_string()
-		.contains("does not match configured source repository"));
+	assert!(
+		error
+			.to_string()
+			.contains("does not match configured source repository")
+	);
 }
 
 #[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
@@ -4555,7 +4635,9 @@ fn execute_release_retarget_delegates_github_provider_sync() {
 			.path("/repos/ifiokjr/monochange/releases/tags/v1.2.3");
 		then.status(200)
 			.header("content-type", "application/json")
-			.body("{\"id\":42,\"html_url\":\"https://example.com/releases/42\",\"target_commitish\":\"abc1234\"}");
+			.body(
+				"{\"id\":42,\"html_url\":\"https://example.com/releases/42\",\"target_commitish\":\"abc1234\"}",
+			);
 	});
 	let update_release = server.mock(|when, then| {
 		when.method(PATCH)
@@ -4675,9 +4757,11 @@ fn git_is_ancestor_reports_missing_worktree_directory_errors() {
 	let error = crate::git_support::git_is_ancestor(&missing, "abc", "def")
 		.err()
 		.unwrap_or_else(|| panic!("expected git spawn error"));
-	assert!(error
-		.to_string()
-		.contains("failed to compare commit ancestry"));
+	assert!(
+		error
+			.to_string()
+			.contains("failed to compare commit ancestry")
+	);
 }
 
 #[test]
@@ -4771,9 +4855,11 @@ fn execute_release_retarget_rejects_unsupported_provider_sync_in_real_mode() {
 	let error = crate::execute_release_retarget(tempdir.path(), Some(&source), &plan)
 		.err()
 		.unwrap_or_else(|| panic!("expected unsupported provider error"));
-	assert!(error
-		.to_string()
-		.contains("provider sync is not yet supported for gitlab release retargeting"));
+	assert!(
+		error
+			.to_string()
+			.contains("provider sync is not yet supported for gitlab release retargeting")
+	);
 }
 
 #[test]
@@ -4800,9 +4886,11 @@ fn execute_cli_command_commit_release_requires_prepare_release() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected missing PrepareRelease error"));
-	assert!(error
-		.to_string()
-		.contains("`CommitRelease` requires a previous `PrepareRelease` step"));
+	assert!(
+		error
+			.to_string()
+			.contains("`CommitRelease` requires a previous `PrepareRelease` step")
+	);
 }
 
 #[test]
@@ -4811,9 +4899,11 @@ fn git_stage_paths_reports_git_failures() {
 	let error = crate::git_stage_paths(tempdir.path(), &[PathBuf::from("release.txt")])
 		.err()
 		.unwrap_or_else(|| panic!("expected git stage failure"));
-	assert!(error
-		.to_string()
-		.contains("failed to stage release commit files"));
+	assert!(
+		error
+			.to_string()
+			.contains("failed to stage release commit files")
+	);
 }
 
 #[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
@@ -5115,9 +5205,11 @@ fn serialize_cached_document_formats_json_yaml_text_and_bytes() {
 		crate::CachedDocument::Json(serde_json::json!({"name": "web"})),
 	)
 	.unwrap_or_else(|error| panic!("serialize json: {error}"));
-	assert!(String::from_utf8(json.content)
-		.unwrap_or_else(|error| panic!("json utf8: {error}"))
-		.ends_with('\n'));
+	assert!(
+		String::from_utf8(json.content)
+			.unwrap_or_else(|error| panic!("json utf8: {error}"))
+			.ends_with('\n')
+	);
 
 	let mut yaml_mapping = serde_yaml_ng::Mapping::new();
 	yaml_mapping.insert(
@@ -5129,9 +5221,11 @@ fn serialize_cached_document_formats_json_yaml_text_and_bytes() {
 		crate::CachedDocument::Yaml(yaml_mapping),
 	)
 	.unwrap_or_else(|error| panic!("serialize yaml: {error}"));
-	assert!(String::from_utf8(yaml.content)
-		.unwrap_or_else(|error| panic!("yaml utf8: {error}"))
-		.contains("lockfileVersion"));
+	assert!(
+		String::from_utf8(yaml.content)
+			.unwrap_or_else(|error| panic!("yaml utf8: {error}"))
+			.contains("lockfileVersion")
+	);
 
 	let text = crate::serialize_cached_document(
 		Path::new("bun.lock"),
@@ -5243,18 +5337,20 @@ fn build_manifest_updates_preserve_npm_deno_and_dart_formatting() {
 		workspace_root: tempdir.path().to_path_buf(),
 		decisions: packages
 			.iter()
-			.map(|package| monochange_core::ReleaseDecision {
-				package_id: package.id.clone(),
-				trigger_type: "changeset".to_string(),
-				recommended_bump: BumpSeverity::Minor,
-				planned_version: Some(
-					Version::parse("1.1.0")
-						.unwrap_or_else(|error| panic!("planned version: {error}")),
-				),
-				group_id: None,
-				reasons: vec!["release".to_string()],
-				upstream_sources: Vec::new(),
-				warnings: Vec::new(),
+			.map(|package| {
+				monochange_core::ReleaseDecision {
+					package_id: package.id.clone(),
+					trigger_type: "changeset".to_string(),
+					recommended_bump: BumpSeverity::Minor,
+					planned_version: Some(
+						Version::parse("1.1.0")
+							.unwrap_or_else(|error| panic!("planned version: {error}")),
+					),
+					group_id: None,
+					reasons: vec!["release".to_string()],
+					upstream_sources: Vec::new(),
+					warnings: Vec::new(),
+				}
 			})
 			.collect(),
 		groups: Vec::new(),
@@ -5274,7 +5370,10 @@ fn build_manifest_updates_preserve_npm_deno_and_dart_formatting() {
 		String::from_utf8_lossy(&npm_updates[0].content),
 		"{\n    \"name\": \"web\",\n    \"version\": \"1.1.0\",\n    \"private\": false\n}\n"
 	);
-	assert_eq!(String::from_utf8_lossy(&deno_updates[0].content), "{\n  \"name\": \"tool\",\n  \"version\": \"1.1.0\",\n  \"imports\": {\n    \"core\": \"^1.0.0\"\n  }\n}\n");
+	assert_eq!(
+		String::from_utf8_lossy(&deno_updates[0].content),
+		"{\n  \"name\": \"tool\",\n  \"version\": \"1.1.0\",\n  \"imports\": {\n    \"core\": \"^1.0.0\"\n  }\n}\n"
+	);
 	assert_eq!(
 		String::from_utf8_lossy(&dart_updates[0].content),
 		"name: mobile\nversion: '1.1.0' # keep quote\n"
@@ -5343,17 +5442,20 @@ fn build_manifest_updates_report_parse_and_io_errors() {
 			dart_missing.id.clone(),
 		]
 		.into_iter()
-		.map(|package_id| monochange_core::ReleaseDecision {
-			package_id,
-			trigger_type: "changeset".to_string(),
-			recommended_bump: BumpSeverity::Minor,
-			planned_version: Some(
-				Version::parse("1.1.0").unwrap_or_else(|error| panic!("planned version: {error}")),
-			),
-			group_id: None,
-			reasons: vec!["release".to_string()],
-			upstream_sources: Vec::new(),
-			warnings: Vec::new(),
+		.map(|package_id| {
+			monochange_core::ReleaseDecision {
+				package_id,
+				trigger_type: "changeset".to_string(),
+				recommended_bump: BumpSeverity::Minor,
+				planned_version: Some(
+					Version::parse("1.1.0")
+						.unwrap_or_else(|error| panic!("planned version: {error}")),
+				),
+				group_id: None,
+				reasons: vec!["release".to_string()],
+				upstream_sources: Vec::new(),
+				warnings: Vec::new(),
+			}
 		})
 		.collect(),
 		groups: Vec::new(),
@@ -5468,17 +5570,20 @@ fn build_manifest_updates_report_parse_and_io_errors() {
 			cargo_workspace_parse.id.clone(),
 		]
 		.into_iter()
-		.map(|package_id| monochange_core::ReleaseDecision {
-			package_id,
-			trigger_type: "changeset".to_string(),
-			recommended_bump: BumpSeverity::Minor,
-			planned_version: Some(
-				Version::parse("1.1.0").unwrap_or_else(|error| panic!("planned version: {error}")),
-			),
-			group_id: None,
-			reasons: vec!["release".to_string()],
-			upstream_sources: Vec::new(),
-			warnings: Vec::new(),
+		.map(|package_id| {
+			monochange_core::ReleaseDecision {
+				package_id,
+				trigger_type: "changeset".to_string(),
+				recommended_bump: BumpSeverity::Minor,
+				planned_version: Some(
+					Version::parse("1.1.0")
+						.unwrap_or_else(|error| panic!("planned version: {error}")),
+				),
+				group_id: None,
+				reasons: vec!["release".to_string()],
+				upstream_sources: Vec::new(),
+				warnings: Vec::new(),
+			}
 		})
 		.collect(),
 		groups: Vec::new(),
@@ -6150,9 +6255,11 @@ fn apply_versioned_file_definition_reports_invalid_regex_patterns() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected invalid regex error"));
-	assert!(error
-		.to_string()
-		.contains("invalid versioned_files regex `(`"));
+	assert!(
+		error
+			.to_string()
+			.contains("invalid versioned_files regex `(`")
+	);
 }
 
 #[test]
@@ -6588,21 +6695,25 @@ fn filter_group_release_note_change_handles_missing_context_and_direct_group_tar
 	let planned_group = sample_planned_group();
 	let group = sample_group_definition(GroupChangelogInclude::GroupOnly);
 
-	assert!(crate::filter_group_release_note_change(
-		&sample_release_note_change(None),
-		Some(&group),
-		&planned_group,
-		&BTreeMap::new(),
-	)
-	.is_none());
+	assert!(
+		crate::filter_group_release_note_change(
+			&sample_release_note_change(None),
+			Some(&group),
+			&planned_group,
+			&BTreeMap::new(),
+		)
+		.is_none()
+	);
 
-	assert!(crate::filter_group_release_note_change(
-		&sample_release_note_change(Some(".changeset/missing.md")),
-		Some(&group),
-		&planned_group,
-		&BTreeMap::new(),
-	)
-	.is_none());
+	assert!(
+		crate::filter_group_release_note_change(
+			&sample_release_note_change(Some(".changeset/missing.md")),
+			Some(&group),
+			&planned_group,
+			&BTreeMap::new(),
+		)
+		.is_none()
+	);
 
 	let group_changeset = BTreeMap::from([(
 		PathBuf::from(".changeset/group.md"),
@@ -6635,13 +6746,15 @@ fn filter_group_release_note_change_handles_missing_context_and_direct_group_tar
 			change_type: None,
 		}],
 	)]);
-	assert!(crate::filter_group_release_note_change(
-		&sample_release_note_change(Some(".changeset/outside.md")),
-		Some(&group),
-		&planned_group,
-		&outside_group_changeset,
-	)
-	.is_none());
+	assert!(
+		crate::filter_group_release_note_change(
+			&sample_release_note_change(Some(".changeset/outside.md")),
+			Some(&group),
+			&planned_group,
+			&outside_group_changeset,
+		)
+		.is_none()
+	);
 }
 
 #[test]
@@ -6661,13 +6774,15 @@ fn filter_group_release_note_change_respects_member_allowlists() {
 			change_type: None,
 		}],
 	)]);
-	assert!(crate::filter_group_release_note_change(
-		&change,
-		Some(&selected_core),
-		&planned_group,
-		&member_changeset,
-	)
-	.is_some());
+	assert!(
+		crate::filter_group_release_note_change(
+			&change,
+			Some(&selected_core),
+			&planned_group,
+			&member_changeset,
+		)
+		.is_some()
+	);
 
 	let blocked_changeset = BTreeMap::from([(
 		PathBuf::from(".changeset/member.md"),
@@ -6690,13 +6805,15 @@ fn filter_group_release_note_change_respects_member_allowlists() {
 			},
 		],
 	)]);
-	assert!(crate::filter_group_release_note_change(
-		&change,
-		Some(&selected_core),
-		&planned_group,
-		&blocked_changeset,
-	)
-	.is_none());
+	assert!(
+		crate::filter_group_release_note_change(
+			&change,
+			Some(&selected_core),
+			&planned_group,
+			&blocked_changeset,
+		)
+		.is_none()
+	);
 
 	let message = crate::render_group_filtered_update_message("sdk");
 	assert!(message.contains("No group-facing notes were recorded for this release."));
@@ -7305,8 +7422,10 @@ fn render_tag_name_and_provider_urls_follow_provider_conventions() {
 		"core/v1.2.3"
 	);
 	assert!(crate::tag_url_for_provider(&github, "v1.2.3").contains("/releases/tag/v1.2.3"));
-	assert!(crate::compare_url_for_provider(&github, "v1.2.2", "v1.2.3")
-		.contains("compare/v1.2.2...v1.2.3"));
+	assert!(
+		crate::compare_url_for_provider(&github, "v1.2.2", "v1.2.3")
+			.contains("compare/v1.2.2...v1.2.3")
+	);
 
 	let gitlab = monochange_core::SourceConfiguration {
 		provider: monochange_core::SourceProvider::GitLab,
@@ -7437,9 +7556,11 @@ fn build_file_diff_previews_handles_missing_files_and_color_modes() {
 			.unwrap_or_else(|error| panic!("plain previews: {error}"))
 	});
 	assert_eq!(plain_previews.len(), 2);
-	assert!(plain_previews
-		.iter()
-		.all(|preview| preview.display_diff == preview.diff));
+	assert!(
+		plain_previews
+			.iter()
+			.all(|preview| preview.display_diff == preview.diff)
+	);
 	let rendered_plain_diffs = plain_previews
 		.iter()
 		.map(|preview| preview.diff.clone())
@@ -7479,9 +7600,11 @@ fn build_file_diff_previews_reports_directory_read_errors() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected directory read failure"));
-	assert!(error
-		.to_string()
-		.contains(&format!("failed to read {}", directory_path.display())));
+	assert!(
+		error
+			.to_string()
+			.contains(&format!("failed to read {}", directory_path.display()))
+	);
 }
 
 #[test]
@@ -7493,10 +7616,12 @@ fn prepare_release_execution_collects_file_diffs_for_dry_runs() {
 	});
 	assert!(!prepared.prepared_release.changed_files.is_empty());
 	assert!(!prepared.file_diffs.is_empty());
-	assert!(prepared
-		.file_diffs
-		.iter()
-		.all(|file_diff| file_diff.display_diff == file_diff.diff));
+	assert!(
+		prepared
+			.file_diffs
+			.iter()
+			.all(|file_diff| file_diff.display_diff == file_diff.diff)
+	);
 }
 
 #[test]
@@ -7507,9 +7632,11 @@ fn prepare_release_execution_propagates_file_diff_preview_errors() {
 		.err()
 		.unwrap_or_else(|| panic!("expected forced file diff preview error"));
 	set_force_build_file_diff_previews_error(false);
-	assert!(error
-		.to_string()
-		.contains("forced build_file_diff_previews test error"));
+	assert!(
+		error
+			.to_string()
+			.contains("forced build_file_diff_previews test error")
+	);
 }
 
 #[test]
@@ -7519,9 +7646,10 @@ fn default_change_path_sluggifies_first_package_reference() {
 		&["cargo:crates/core/Cargo.toml".to_string()],
 	);
 	assert!(path.starts_with("/workspace/.changeset"));
-	assert!(path
-		.to_string_lossy()
-		.ends_with("-cargo-crates-core-cargo-toml.md"));
+	assert!(
+		path.to_string_lossy()
+			.ends_with("-cargo-crates-core-cargo-toml.md")
+	);
 }
 
 #[test]

--- a/crates/monochange/src/assist.rs
+++ b/crates/monochange/src/assist.rs
@@ -85,8 +85,10 @@ pub(crate) fn run_assist(
 ) -> MonochangeResult<String> {
 	let payload = assistant_setup_payload(assistant);
 	match format {
-		AssistOutputFormat::Json => serde_json::to_string_pretty(&payload)
-			.map_err(|error| MonochangeError::Config(error.to_string())),
+		AssistOutputFormat::Json => {
+			serde_json::to_string_pretty(&payload)
+				.map_err(|error| MonochangeError::Config(error.to_string()))
+		}
 		AssistOutputFormat::Text => {
 			let mcp_config = serde_json::to_string_pretty(&payload["mcp_config"])
 				.map_err(|error| MonochangeError::Config(error.to_string()))?;

--- a/crates/monochange/src/changelog.rs
+++ b/crates/monochange/src/changelog.rs
@@ -1,5 +1,6 @@
-use super::*;
 use typed_builder::TypedBuilder;
+
+use super::*;
 
 #[derive(Clone, Copy, Debug, TypedBuilder)]
 pub(crate) struct ChangelogBuildContext<'a> {
@@ -778,9 +779,11 @@ pub(crate) fn group_changelog_include_allows(
 	match include {
 		GroupChangelogInclude::All => true,
 		GroupChangelogInclude::GroupOnly => false,
-		GroupChangelogInclude::Selected(selected) => in_group_targets
-			.iter()
-			.all(|package_id| selected.contains(package_id)),
+		GroupChangelogInclude::Selected(selected) => {
+			in_group_targets
+				.iter()
+				.all(|package_id| selected.contains(package_id))
+		}
 	}
 }
 
@@ -916,9 +919,11 @@ fn render_release_note_sections(
 		.collect::<BTreeSet<_>>();
 	let resolved_extra_sections = extra_sections
 		.iter()
-		.map(|section| ResolvedSectionDefinition {
-			title: section.name.clone(),
-			types: section.types.clone(),
+		.map(|section| {
+			ResolvedSectionDefinition {
+				title: section.name.clone(),
+				types: section.types.clone(),
+			}
 		})
 		.collect::<Vec<_>>();
 	let mut builtin_entries = BTreeMap::<BuiltinReleaseSection, Vec<String>>::new();
@@ -1033,10 +1038,11 @@ fn format_group_labeled_entry(change: &ReleaseNoteChange, rendered: &str) -> Str
 	if change.package_labels.is_empty() {
 		return rendered.to_string();
 	}
-	if change.package_labels.len() == 1 && !rendered.contains('\n') {
-		if let Some(entry) = rendered.strip_prefix("- ") {
-			return format!("- **{}**: {}", change.package_labels[0], entry);
-		}
+	if change.package_labels.len() == 1
+		&& !rendered.contains('\n')
+		&& let Some(entry) = rendered.strip_prefix("- ")
+	{
+		return format!("- **{}**: {}", change.package_labels[0], entry);
 	}
 	let labels = change
 		.package_labels

--- a/crates/monochange/src/changesets.rs
+++ b/crates/monochange/src/changesets.rs
@@ -204,23 +204,27 @@ pub(crate) fn build_prepared_changesets(
 	loaded_changesets
 		.iter()
 		.enumerate()
-		.map(|(index, changeset)| PreparedChangeset {
-			path: root_relative(root, &changeset.path),
-			summary: changeset.summary.clone(),
-			details: changeset.details.clone(),
-			targets: changeset
-				.targets
-				.iter()
-				.map(|target| PreparedChangesetTarget {
-					id: target.id.clone(),
-					kind: target.kind,
-					bump: target.bump,
-					origin: target.origin.clone(),
-					evidence_refs: target.evidence_refs.clone(),
-					change_type: target.change_type.clone(),
-				})
-				.collect(),
-			context: git_contexts.get(index).cloned(),
+		.map(|(index, changeset)| {
+			PreparedChangeset {
+				path: root_relative(root, &changeset.path),
+				summary: changeset.summary.clone(),
+				details: changeset.details.clone(),
+				targets: changeset
+					.targets
+					.iter()
+					.map(|target| {
+						PreparedChangesetTarget {
+							id: target.id.clone(),
+							kind: target.kind,
+							bump: target.bump,
+							origin: target.origin.clone(),
+							evidence_refs: target.evidence_refs.clone(),
+							change_type: target.change_type.clone(),
+						}
+					})
+					.collect(),
+				context: git_contexts.get(index).cloned(),
+			}
 		})
 		.collect()
 }
@@ -240,13 +244,15 @@ fn batch_load_changeset_contexts(
 	if !root.join(".git").exists() {
 		return loaded_changesets
 			.iter()
-			.map(|_| ChangesetContext {
-				provider: HostingProviderKind::GenericGit,
-				host: None,
-				capabilities: HostingCapabilities::default(),
-				introduced: None,
-				last_updated: None,
-				related_issues: Vec::new(),
+			.map(|_| {
+				ChangesetContext {
+					provider: HostingProviderKind::GenericGit,
+					host: None,
+					capabilities: HostingCapabilities::default(),
+					introduced: None,
+					last_updated: None,
+					related_issues: Vec::new(),
+				}
 			})
 			.collect();
 	}

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -6,10 +6,10 @@ use clap::Arg;
 use clap::ArgAction;
 use clap::Command;
 use monochange_config::load_workspace_configuration;
-use monochange_core::default_cli_commands;
 use monochange_core::CliCommandDefinition;
 use monochange_core::CliInputDefinition;
 use monochange_core::CliInputKind;
+use monochange_core::default_cli_commands;
 
 pub fn build_command(bin_name: &'static str) -> Command {
 	let root = current_dir_or_dot();
@@ -45,15 +45,14 @@ pub(crate) fn apply_runtime_change_type_choices(
 	if choices.is_empty() {
 		return;
 	}
-	if let Some(change_command) = cli.iter_mut().find(|command| command.name == "change") {
-		if let Some(change_type_input) = change_command
+	if let Some(change_command) = cli.iter_mut().find(|command| command.name == "change")
+		&& let Some(change_type_input) = change_command
 			.inputs
 			.iter_mut()
 			.find(|input| input.name == "type" && input.choices.is_empty())
-		{
-			change_type_input.kind = CliInputKind::Choice;
-			change_type_input.choices = choices;
-		}
+	{
+		change_type_input.kind = CliInputKind::Choice;
+		change_type_input.choices = choices;
 	}
 }
 
@@ -89,38 +88,39 @@ pub(crate) fn build_command_with_cli(
 	bin_name: &'static str,
 	cli: &[CliCommandDefinition],
 ) -> Command {
-	let mut command = Command::new(bin_name)
-		.about("Manage versions and releases for your multiplatform, multilanguage monorepo")
-		.subcommand_required(true)
-		.arg_required_else_help(true)
-		.arg(
-			Arg::new("log-level")
-				.long("log-level")
-				.global(true)
-				.help("Set tracing filter (e.g. debug, monochange=trace)")
-				.value_name("FILTER")
-				.hide(true),
-		)
-		.subcommand(
-			Command::new("init")
-				.about("Generate monochange.toml with detected packages, groups, and default CLI commands")
-				.arg(
-					Arg::new("force")
-						.long("force")
-						.help("Overwrite an existing monochange.toml file")
-						.action(ArgAction::SetTrue),
-				),
-		)
-		.subcommand(
-			Command::new("populate")
-				.about("Add any missing built-in CLI commands to monochange.toml so you can customize them"),
-		)
-		.subcommand(build_assist_subcommand())
-		.subcommand(build_release_record_subcommand())
-		.subcommand(
-			Command::new("mcp")
-				.about("Start the monochange MCP (Model Context Protocol) server over stdin/stdout"),
-		);
+	let mut command =
+		Command::new(bin_name)
+			.about("Manage versions and releases for your multiplatform, multilanguage monorepo")
+			.subcommand_required(true)
+			.arg_required_else_help(true)
+			.arg(
+				Arg::new("log-level")
+					.long("log-level")
+					.global(true)
+					.help("Set tracing filter (e.g. debug, monochange=trace)")
+					.value_name("FILTER")
+					.hide(true),
+			)
+			.subcommand(
+				Command::new("init")
+					.about(
+						"Generate monochange.toml with detected packages, groups, and default CLI commands",
+					)
+					.arg(
+						Arg::new("force")
+							.long("force")
+							.help("Overwrite an existing monochange.toml file")
+							.action(ArgAction::SetTrue),
+					),
+			)
+			.subcommand(Command::new("populate").about(
+				"Add any missing built-in CLI commands to monochange.toml so you can customize them",
+			))
+			.subcommand(build_assist_subcommand())
+			.subcommand(build_release_record_subcommand())
+			.subcommand(Command::new("mcp").about(
+				"Start the monochange MCP (Model Context Protocol) server over stdin/stdout",
+			));
 
 	for cli_command in cli {
 		command = command.subcommand(build_cli_command_subcommand(cli_command));
@@ -222,8 +222,9 @@ pub(crate) fn build_cli_command_subcommand(cli_command: &CliCommandDefinition) -
 
 pub(crate) fn cli_command_after_help(cli_command: &CliCommandDefinition) -> Option<&'static str> {
 	match cli_command.name.as_str() {
-		"change" => Some(
-			r#"Examples:
+		"change" => {
+			Some(
+				r#"Examples:
   mc change --package sdk-core --bump patch --reason "fix panic"
   mc change --package sdk-core --bump minor --reason "add API" --output .changeset/sdk-core.md
   mc change --package sdk --bump minor --reason "coordinated release"
@@ -233,9 +234,11 @@ Rules:
   - Use a group id only when the change is intentionally owned by the whole group.
   - Dependents and grouped members are propagated automatically during planning.
   - Legacy manifest paths may still resolve during migration, but declared ids are the stable interface."#,
-		),
-		"release" => Some(
-			r"Examples:
+			)
+		}
+		"release" => {
+			Some(
+				r"Examples:
   mc release --dry-run --format text
   mc release --dry-run --format json
   mc release --dry-run --diff
@@ -245,9 +248,11 @@ Planning reminders:
   - Direct package changes propagate to dependents using defaults.parent_bump.
   - Group synchronization happens before final output is rendered.
   - Explicit versions on grouped members propagate to the whole group.",
-		),
-		"commit-release" => Some(
-			r"Examples:
+			)
+		}
+		"commit-release" => {
+			Some(
+				r"Examples:
   mc commit-release --dry-run --format json
   mc commit-release --dry-run --diff
   mc commit-release
@@ -256,9 +261,11 @@ Commit notes:
   - Reuses the standard monochange release commit subject/body contract.
   - Embeds a durable release record block in the commit body.
   - Can run before OpenReleaseRequest in the same workflow.",
-		),
-		"affected" => Some(
-			r"Examples:
+			)
+		}
+		"affected" => {
+			Some(
+				r"Examples:
   mc affected --changed-paths crates/core/src/lib.rs --format json
   mc affected --since origin/main --verify
 
@@ -266,9 +273,11 @@ Verification reminders:
   - Prefer package ids in .changeset files.
   - Group-owned changesets cover all members of that group.
   - Ignored paths and skip labels are controlled from [changesets.verify].",
-		),
-		"diagnostics" => Some(
-			r"Examples:
+			)
+		}
+		"diagnostics" => {
+			Some(
+				r"Examples:
   mc diagnostics --format json
   mc diagnostics --changeset .changeset/feature.md
 
@@ -277,9 +286,11 @@ Diagnostics include:
   - commit SHA that introduced and last updated each changeset
   - linked review request (when detected)
   - related issue references",
-		),
-		"repair-release" => Some(
-			r"Examples:
+			)
+		}
+		"repair-release" => {
+			Some(
+				r"Examples:
   mc repair-release --from v1.2.3 --dry-run
   mc repair-release --from v1.2.3 --target HEAD --format json
 
@@ -288,7 +299,8 @@ Repair notes:
   - Moves the full release tag set together.
   - Defaults to descendant-only retargets unless --force is set.
   - Hosted release sync runs by default and can be disabled with --sync-provider=false.",
-		),
+			)
+		}
 		_ => None,
 	}
 }
@@ -333,10 +345,10 @@ fn build_cli_command_input_arg(input: &CliInputDefinition) -> Arg {
 		arg = arg.short(short);
 	}
 
-	if let Some(default) = &input.default {
-		if !matches!(input.kind, CliInputKind::Boolean) || default == "true" {
-			arg = arg.default_value(leak_string(default.clone()));
-		}
+	if let Some(default) = &input.default
+		&& (!matches!(input.kind, CliInputKind::Boolean) || default == "true")
+	{
+		arg = arg.default_value(leak_string(default.clone()));
 	}
 
 	arg

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeMap;
 use std::path::Path;
 use std::process::Command as ProcessCommand;
 
-use clap::parser::ValueSource;
 use clap::ArgMatches;
+use clap::parser::ValueSource;
 use monochange_config::load_workspace_configuration;
 use monochange_core::ChangesetPolicyStatus;
 use monochange_core::CliCommandDefinition;
@@ -55,10 +55,12 @@ pub(crate) fn collect_cli_command_inputs(
 	for input in &cli_command.inputs {
 		let value_source = matches.value_source(input.name.as_str());
 		let values = match input.kind {
-			CliInputKind::StringList => matches
-				.get_many::<String>(input.name.as_str())
-				.map(|values| values.cloned().collect::<Vec<_>>())
-				.unwrap_or_default(),
+			CliInputKind::StringList => {
+				matches
+					.get_many::<String>(input.name.as_str())
+					.map(|values| values.cloned().collect::<Vec<_>>())
+					.unwrap_or_default()
+			}
 			CliInputKind::Boolean => {
 				if input.default.as_deref() == Some("true") {
 					matches
@@ -178,10 +180,12 @@ pub(crate) fn template_value_to_input_values(value: &serde_json::Value) -> Vec<S
 		serde_json::Value::Bool(value) => vec![value.to_string()],
 		serde_json::Value::Number(value) => vec![value.to_string()],
 		serde_json::Value::String(value) => vec![value.clone()],
-		serde_json::Value::Array(values) => values
-			.iter()
-			.flat_map(template_value_to_input_values)
-			.collect(),
+		serde_json::Value::Array(values) => {
+			values
+				.iter()
+				.flat_map(template_value_to_input_values)
+				.collect()
+		}
 		serde_json::Value::Object(_) => vec![value.to_string()],
 	}
 }
@@ -606,15 +610,17 @@ pub(crate) fn execute_cli_command_with_options(
 				id,
 				variables,
 				..
-			} => run_cli_command_command(
-				&mut context,
-				command,
-				dry_run_command.as_deref(),
-				shell,
-				id.as_deref(),
-				variables.as_ref(),
-				&step_inputs,
-			)?,
+			} => {
+				run_cli_command_command(
+					&mut context,
+					command,
+					dry_run_command.as_deref(),
+					shell,
+					id.as_deref(),
+					variables.as_ref(),
+					&step_inputs,
+				)?;
+			}
 		}
 	}
 
@@ -643,11 +649,13 @@ pub(crate) fn execute_cli_command_with_options(
 	if let Some(evaluation) = &context.changeset_policy_evaluation {
 		let format = cli_command_output_format(&context.last_step_inputs)?;
 		let rendered = match format {
-			OutputFormat::Json => serde_json::to_string_pretty(evaluation).map_err(|error| {
-				MonochangeError::Config(format!(
-					"failed to render changeset policy evaluation as json: {error}"
-				))
-			})?,
+			OutputFormat::Json => {
+				serde_json::to_string_pretty(evaluation).map_err(|error| {
+					MonochangeError::Config(format!(
+						"failed to render changeset policy evaluation as json: {error}"
+					))
+				})?
+			}
 			OutputFormat::Text => render_cli_command_result(cli_command, &context),
 		};
 		if evaluation.enforce && evaluation.status == ChangesetPolicyStatus::Failed {
@@ -663,11 +671,13 @@ pub(crate) fn execute_cli_command_with_options(
 			.and_then(|values| values.first())
 			.map_or(Ok(OutputFormat::Text), |value| parse_output_format(value))?;
 		let rendered = match format {
-			OutputFormat::Json => serde_json::to_string_pretty(report).map_err(|error| {
-				MonochangeError::Config(format!(
-					"failed to render changeset diagnostics as json: {error}"
-				))
-			})?,
+			OutputFormat::Json => {
+				serde_json::to_string_pretty(report).map_err(|error| {
+					MonochangeError::Config(format!(
+						"failed to render changeset diagnostics as json: {error}"
+					))
+				})?
+			}
 			OutputFormat::Text => render_changeset_diagnostics(report),
 		};
 		return Ok(rendered);
@@ -675,8 +685,10 @@ pub(crate) fn execute_cli_command_with_options(
 	if let Some(report) = &context.retarget_report {
 		let format = cli_command_output_format(&context.last_step_inputs)?;
 		let rendered = match format {
-			OutputFormat::Json => serde_json::to_string_pretty(report)
-				.unwrap_or_else(|error| panic!("retarget report serialization bug: {error}")),
+			OutputFormat::Json => {
+				serde_json::to_string_pretty(report)
+					.unwrap_or_else(|error| panic!("retarget report serialization bug: {error}"))
+			}
 			OutputFormat::Text => render_retarget_release_report(report),
 		};
 		return Ok(rendered);
@@ -746,9 +758,11 @@ fn parse_template_as_boolean(value: &serde_json::Value, condition: &str) -> Mono
 				)))
 			}
 		}
-		serde_json::Value::Object(_) => Err(MonochangeError::Config(format!(
-			"`when` condition `{condition}` is not a scalar boolean value"
-		))),
+		serde_json::Value::Object(_) => {
+			Err(MonochangeError::Config(format!(
+				"`when` condition `{condition}` is not a scalar boolean value"
+			)))
+		}
 	}
 }
 
@@ -785,9 +799,11 @@ fn parse_string_as_boolean(value: &str, condition: &str) -> MonochangeResult<boo
 	match value.as_str() {
 		"true" => Ok(true),
 		"false" | "0" | "" => Ok(false),
-		other => Err(MonochangeError::Config(format!(
-			"`when` condition `{condition}` must be a boolean, got `{other}`"
-		))),
+		other => {
+			Err(MonochangeError::Config(format!(
+				"`when` condition `{condition}` must be a boolean, got `{other}`"
+			)))
+		}
 	}
 }
 
@@ -1183,12 +1199,16 @@ pub(crate) fn parse_boolean_step_input(
 	inputs
 		.get(name)
 		.and_then(|values| values.first())
-		.map(|value| match value.as_str() {
-			"true" => Ok(true),
-			"false" => Ok(false),
-			other => Err(MonochangeError::Config(format!(
-				"invalid boolean value `{other}` for `{name}`"
-			))),
+		.map(|value| {
+			match value.as_str() {
+				"true" => Ok(true),
+				"false" => Ok(false),
+				other => {
+					Err(MonochangeError::Config(format!(
+						"invalid boolean value `{other}` for `{name}`"
+					)))
+				}
+			}
 		})
 		.transpose()
 }
@@ -1348,35 +1368,41 @@ fn cli_command_variable_value(context: &CliContext, variable: CommandVariable) -
 	match variable {
 		CommandVariable::Version => version.to_string(),
 		CommandVariable::GroupVersion => group_version.to_string(),
-		CommandVariable::ReleasedPackages => context
-			.prepared_release
-			.as_ref()
-			.map(|prepared| prepared.released_packages.join(","))
-			.unwrap_or_default(),
-		CommandVariable::ChangedFiles => context
-			.prepared_release
-			.as_ref()
-			.map(|prepared| {
-				prepared
-					.changed_files
-					.iter()
-					.map(|path| path.display().to_string())
-					.collect::<Vec<_>>()
-					.join(" ")
-			})
-			.unwrap_or_default(),
-		CommandVariable::Changesets => context
-			.prepared_release
-			.as_ref()
-			.map(|prepared| {
-				prepared
-					.changeset_paths
-					.iter()
-					.map(|path| path.display().to_string())
-					.collect::<Vec<_>>()
-					.join(" ")
-			})
-			.unwrap_or_default(),
+		CommandVariable::ReleasedPackages => {
+			context
+				.prepared_release
+				.as_ref()
+				.map(|prepared| prepared.released_packages.join(","))
+				.unwrap_or_default()
+		}
+		CommandVariable::ChangedFiles => {
+			context
+				.prepared_release
+				.as_ref()
+				.map(|prepared| {
+					prepared
+						.changed_files
+						.iter()
+						.map(|path| path.display().to_string())
+						.collect::<Vec<_>>()
+						.join(" ")
+				})
+				.unwrap_or_default()
+		}
+		CommandVariable::Changesets => {
+			context
+				.prepared_release
+				.as_ref()
+				.map(|prepared| {
+					prepared
+						.changeset_paths
+						.iter()
+						.map(|path| path.display().to_string())
+						.collect::<Vec<_>>()
+						.join(" ")
+				})
+				.unwrap_or_default()
+		}
 	}
 }
 
@@ -1509,9 +1535,11 @@ pub(crate) fn parse_output_format(value: &str) -> MonochangeResult<OutputFormat>
 	match value {
 		"text" => Ok(OutputFormat::Text),
 		"json" => Ok(OutputFormat::Json),
-		other => Err(MonochangeError::Config(format!(
-			"unsupported output format `{other}`"
-		))),
+		other => {
+			Err(MonochangeError::Config(format!(
+				"unsupported output format `{other}`"
+			)))
+		}
 	}
 }
 
@@ -1521,16 +1549,20 @@ pub(crate) fn parse_change_bump(value: &str) -> MonochangeResult<ChangeBump> {
 		"patch" => Ok(ChangeBump::Patch),
 		"minor" => Ok(ChangeBump::Minor),
 		"major" => Ok(ChangeBump::Major),
-		other => Err(MonochangeError::Config(format!(
-			"unsupported bump `{other}`"
-		))),
+		other => {
+			Err(MonochangeError::Config(format!(
+				"unsupported bump `{other}`"
+			)))
+		}
 	}
 }
 
 #[cfg(test)]
 mod tests {
+	use std::collections::BTreeMap;
+	use std::path::PathBuf;
+
 	use super::*;
-	use std::{collections::BTreeMap, path::PathBuf};
 
 	fn cli_context() -> CliContext {
 		CliContext {

--- a/crates/monochange/src/git_support.rs
+++ b/crates/monochange/src/git_support.rs
@@ -2,15 +2,15 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command as ProcessCommand;
 
+use monochange_core::CommitMessage;
+use monochange_core::MonochangeError;
+use monochange_core::MonochangeResult;
 use monochange_core::git::git_command_output;
 use monochange_core::git::git_commit_paths_command;
 use monochange_core::git::git_error_detail;
 use monochange_core::git::git_stage_paths_command;
 use monochange_core::git::git_stderr_trimmed;
 use monochange_core::git::git_stdout_trimmed;
-use monochange_core::CommitMessage;
-use monochange_core::MonochangeError;
-use monochange_core::MonochangeResult;
 
 pub(crate) fn resolve_git_tag_commit(root: &Path, tag_name: &str) -> MonochangeResult<String> {
 	run_git_capture(

--- a/crates/monochange/src/interactive.rs
+++ b/crates/monochange/src/interactive.rs
@@ -1,10 +1,10 @@
 use std::collections::BTreeSet;
 use std::fmt;
 
-use inquire::validator::Validation;
 use inquire::MultiSelect;
 use inquire::Select;
 use inquire::Text;
+use inquire::validator::Validation;
 use monochange_core::BumpSeverity;
 use monochange_core::MonochangeError;
 use monochange_core::MonochangeResult;
@@ -252,9 +252,11 @@ fn prompt_version_for_target(target: &SelectableTarget) -> MonochangeResult<Opti
 			}
 			match semver::Version::parse(input) {
 				Ok(_) => Ok(Validation::Valid),
-				Err(error) => Ok(Validation::Invalid(
-					format!("invalid semver: {error}").into(),
-				)),
+				Err(error) => {
+					Ok(Validation::Invalid(
+						format!("invalid semver: {error}").into(),
+					))
+				}
 			}
 		})
 		.prompt()
@@ -344,7 +346,11 @@ mod __tests {
 	use monochange_core::VersionFormat;
 	use monochange_core::WorkspaceConfiguration;
 	use monochange_core::WorkspaceDefaults;
+	use monochange_test_helpers::current_test_name;
 
+	use super::InteractiveOptions;
+	use super::SelectableTarget;
+	use super::TargetKind;
 	use super::build_selectable_targets;
 	use super::bump_options;
 	use super::change_type_options;
@@ -352,11 +358,6 @@ mod __tests {
 	use super::parse_selected_bump;
 	use super::prompt_change_type_for_target;
 	use super::run_interactive_change;
-	use super::InteractiveOptions;
-	use super::SelectableTarget;
-	use super::TargetKind;
-
-	use monochange_test_helpers::current_test_name;
 
 	fn fixture_path(relative: &str) -> std::path::PathBuf {
 		monochange_test_helpers::fs::fixture_path_from(env!("CARGO_MANIFEST_DIR"), relative)
@@ -436,9 +437,11 @@ mod __tests {
 		let error = run_interactive_change(&empty_configuration(), &InteractiveOptions::default())
 			.err()
 			.unwrap_or_else(|| panic!("expected interactive error"));
-		assert!(error
-			.to_string()
-			.contains("no packages or groups found in workspace configuration"));
+		assert!(
+			error
+				.to_string()
+				.contains("no packages or groups found in workspace configuration")
+		);
 	}
 
 	#[test]

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -1,5 +1,3 @@
-#![deny(clippy::all)]
-
 //! # `monochange`
 //!
 //! <!-- {=monochangeCrateDocs|trim|linePrefix:"//! ":true} -->
@@ -53,8 +51,81 @@ use std::process::Command as ProcessCommand;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
-use clap::error::ErrorKind;
+#[cfg(test)]
+pub(crate) use assist::assistant_display_name;
+#[cfg(test)]
+pub(crate) use assist::assistant_setup_payload;
+use assist::run_assist;
+pub(crate) use changelog::*;
+pub use changeset_policy::affected_packages;
+pub(crate) use changeset_policy::compute_changed_paths_since;
+pub use changeset_policy::evaluate_changeset_policy;
+pub(crate) use changeset_policy::is_changeset_markdown_path;
+pub(crate) use changeset_policy::normalize_changed_path;
+pub use changeset_policy::verify_changesets;
+pub(crate) use changesets::*;
 use clap::ValueEnum;
+use clap::error::ErrorKind;
+#[cfg(test)]
+pub(crate) use cli::apply_runtime_change_type_choices;
+#[cfg(test)]
+pub(crate) use cli::build_assist_subcommand;
+#[cfg(test)]
+pub(crate) use cli::build_cli_command_subcommand;
+pub use cli::build_command;
+#[cfg(test)]
+pub(crate) use cli::build_command_for_root;
+use cli::build_command_with_cli;
+#[cfg(test)]
+pub(crate) use cli::build_release_record_subcommand;
+#[cfg(test)]
+pub(crate) use cli::cli_command_after_help;
+#[cfg(test)]
+use cli::cli_commands_for_root;
+use cli::cli_commands_from_config;
+#[cfg(test)]
+pub(crate) use cli::configured_change_type_choices;
+use cli::current_dir_or_dot;
+#[cfg(test)]
+pub(crate) use cli_runtime::build_cli_template_context;
+#[cfg(test)]
+pub(crate) use cli_runtime::build_retarget_release_report;
+#[cfg(test)]
+pub(crate) use cli_runtime::collect_cli_command_inputs;
+#[cfg(test)]
+pub(crate) use cli_runtime::execute_cli_command;
+use cli_runtime::execute_matches;
+#[cfg(test)]
+pub(crate) use cli_runtime::inferred_retarget_source_configuration;
+#[cfg(test)]
+pub(crate) use cli_runtime::lookup_template_value;
+#[cfg(test)]
+pub(crate) use cli_runtime::parse_boolean_step_input;
+#[cfg(test)]
+pub(crate) use cli_runtime::parse_change_bump;
+#[cfg(test)]
+pub(crate) use cli_runtime::parse_direct_template_reference;
+#[cfg(test)]
+pub(crate) use cli_runtime::parse_output_format;
+#[cfg(test)]
+pub(crate) use cli_runtime::render_cli_command_result;
+#[cfg(test)]
+pub(crate) use cli_runtime::render_retarget_release_report;
+#[cfg(test)]
+pub(crate) use cli_runtime::retarget_operation_label;
+#[cfg(test)]
+pub(crate) use cli_runtime::template_value_to_input_values;
+use git_support::git_commit_paths;
+use git_support::git_head_commit;
+use git_support::git_stage_paths;
+#[cfg(test)]
+pub(crate) use git_support::read_git_commit_message;
+#[cfg(test)]
+pub(crate) use git_support::run_git_capture;
+#[cfg(test)]
+pub(crate) use git_support::run_git_process;
+#[cfg(test)]
+pub(crate) use git_support::run_git_status;
 use minijinja::Environment;
 use minijinja::UndefinedBehavior;
 use monochange_cargo::RustSemverProvider;
@@ -63,9 +134,6 @@ use monochange_config::load_workspace_configuration;
 use monochange_config::resolve_package_reference;
 use monochange_config::validate_versioned_files_content;
 use monochange_config::validate_workspace;
-use monochange_core::materialize_dependency_edges;
-use monochange_core::relative_to_root;
-use monochange_core::render_release_notes;
 use monochange_core::BumpSeverity;
 use monochange_core::ChangeSignal;
 use monochange_core::ChangelogFormat;
@@ -73,13 +141,13 @@ use monochange_core::ChangelogTarget;
 use monochange_core::ChangesetContext;
 use monochange_core::ChangesetPolicyEvaluation;
 use monochange_core::ChangesetRevision;
+use monochange_core::ChangesetTargetKind;
 use monochange_core::CliCommandDefinition;
+use monochange_core::CommitMessage;
 use monochange_core::DEFAULT_CHANGELOG_VERSION_TITLE_NAMESPACED;
 use monochange_core::DEFAULT_CHANGELOG_VERSION_TITLE_PRIMARY;
 use monochange_core::DEFAULT_RELEASE_TITLE_NAMESPACED;
 use monochange_core::DEFAULT_RELEASE_TITLE_PRIMARY;
-
-use monochange_core::CommitMessage;
 use monochange_core::DiscoveryReport;
 use monochange_core::Ecosystem;
 use monochange_core::ExtraChangelogSection;
@@ -97,9 +165,6 @@ use monochange_core::MonochangeResult;
 use monochange_core::PackageRecord;
 use monochange_core::PreparedChangeset;
 use monochange_core::PreparedChangesetTarget;
-
-use monochange_core::render_release_record_block;
-use monochange_core::ChangesetTargetKind;
 use monochange_core::ReleaseManifest;
 use monochange_core::ReleaseManifestChangelog;
 use monochange_core::ReleaseManifestCompatibilityEvidence;
@@ -129,117 +194,44 @@ use monochange_core::SourceReleaseOutcome;
 use monochange_core::SourceReleaseRequest;
 use monochange_core::VersionFormat;
 use monochange_core::VersionedFileDefinition;
+use monochange_core::materialize_dependency_edges;
+use monochange_core::relative_to_root;
+use monochange_core::render_release_notes;
+use monochange_core::render_release_record_block;
 use monochange_gitea as gitea_provider;
 use monochange_github as github_provider;
 use monochange_gitlab as gitlab_provider;
 use monochange_graph::build_release_plan;
-use monochange_semver::collect_assessments;
 use monochange_semver::CompatibilityProvider;
-use serde::Serialize;
-use serde_json::json;
-
-use assist::run_assist;
-use cli::build_command_with_cli;
-#[cfg(test)]
-use cli::cli_commands_for_root;
-use cli::cli_commands_from_config;
-use cli::current_dir_or_dot;
-use cli_runtime::execute_matches;
-use git_support::git_commit_paths;
-use git_support::git_head_commit;
-use git_support::git_stage_paths;
-use release_record::render_release_record_discovery;
-use workspace_ops::init_workspace;
-use workspace_ops::populate_workspace;
-
-pub use changeset_policy::affected_packages;
-pub use changeset_policy::evaluate_changeset_policy;
-pub use changeset_policy::verify_changesets;
-pub use cli::build_command;
+use monochange_semver::collect_assessments;
+pub(crate) use release_artifacts::*;
 pub use release_record::discover_release_record;
 pub use release_record::execute_release_retarget;
 pub use release_record::plan_release_retarget;
+use release_record::render_release_record_discovery;
 pub use release_record::retarget_release;
-pub use workspace_ops::add_change_file;
-pub use workspace_ops::discover_workspace;
-pub use workspace_ops::plan_release;
-pub use workspace_ops::prepare_release;
-pub use workspace_ops::AddChangeFileRequest;
-
-pub(crate) use changelog::*;
-pub(crate) use changeset_policy::compute_changed_paths_since;
-pub(crate) use changeset_policy::is_changeset_markdown_path;
-pub(crate) use changeset_policy::normalize_changed_path;
-pub(crate) use changesets::*;
-pub(crate) use release_artifacts::*;
+use serde::Serialize;
+use serde_json::json;
 pub(crate) use versioned_files::*;
+pub use workspace_ops::AddChangeFileRequest;
+pub use workspace_ops::add_change_file;
 pub(crate) use workspace_ops::add_interactive_change_file;
-pub(crate) use workspace_ops::prepare_release_execution;
-pub(crate) use workspace_ops::render_change_target_markdown;
-pub(crate) use workspace_ops::validate_cargo_workspace_version_groups;
-
-#[cfg(test)]
-pub(crate) use assist::assistant_display_name;
-#[cfg(test)]
-pub(crate) use assist::assistant_setup_payload;
-#[cfg(test)]
-pub(crate) use cli::apply_runtime_change_type_choices;
-#[cfg(test)]
-pub(crate) use cli::build_assist_subcommand;
-#[cfg(test)]
-pub(crate) use cli::build_cli_command_subcommand;
-#[cfg(test)]
-pub(crate) use cli::build_command_for_root;
-#[cfg(test)]
-pub(crate) use cli::build_release_record_subcommand;
-#[cfg(test)]
-pub(crate) use cli::cli_command_after_help;
-#[cfg(test)]
-pub(crate) use cli::configured_change_type_choices;
-#[cfg(test)]
-pub(crate) use cli_runtime::build_cli_template_context;
-#[cfg(test)]
-pub(crate) use cli_runtime::build_retarget_release_report;
-#[cfg(test)]
-pub(crate) use cli_runtime::collect_cli_command_inputs;
-#[cfg(test)]
-pub(crate) use cli_runtime::execute_cli_command;
-#[cfg(test)]
-pub(crate) use cli_runtime::inferred_retarget_source_configuration;
-#[cfg(test)]
-pub(crate) use cli_runtime::lookup_template_value;
-#[cfg(test)]
-pub(crate) use cli_runtime::parse_boolean_step_input;
-#[cfg(test)]
-pub(crate) use cli_runtime::parse_change_bump;
-#[cfg(test)]
-pub(crate) use cli_runtime::parse_direct_template_reference;
-#[cfg(test)]
-pub(crate) use cli_runtime::parse_output_format;
-#[cfg(test)]
-pub(crate) use cli_runtime::render_cli_command_result;
-#[cfg(test)]
-pub(crate) use cli_runtime::render_retarget_release_report;
-#[cfg(test)]
-pub(crate) use cli_runtime::retarget_operation_label;
-#[cfg(test)]
-pub(crate) use cli_runtime::template_value_to_input_values;
-#[cfg(test)]
-pub(crate) use git_support::read_git_commit_message;
-#[cfg(test)]
-pub(crate) use git_support::run_git_capture;
-#[cfg(test)]
-pub(crate) use git_support::run_git_process;
-#[cfg(test)]
-pub(crate) use git_support::run_git_status;
 #[cfg(test)]
 pub(crate) use workspace_ops::build_lockfile_command_executions;
 #[cfg(test)]
 pub(crate) use workspace_ops::change_type_default_bump;
+pub use workspace_ops::discover_workspace;
+use workspace_ops::init_workspace;
+pub use workspace_ops::plan_release;
+use workspace_ops::populate_workspace;
+pub use workspace_ops::prepare_release;
+pub(crate) use workspace_ops::prepare_release_execution;
+pub(crate) use workspace_ops::render_change_target_markdown;
 #[cfg(test)]
 pub(crate) use workspace_ops::render_cli_commands_toml;
 #[cfg(test)]
 pub(crate) use workspace_ops::render_interactive_changeset_markdown;
+pub(crate) use workspace_ops::validate_cargo_workspace_version_groups;
 
 mod assist;
 mod changelog;
@@ -600,7 +592,7 @@ where
 				Some(value) => {
 					return Err(MonochangeError::Config(format!(
 						"unknown assistant `{value}`"
-					)))
+					)));
 				}
 				None => return Err(MonochangeError::Config("missing assistant".to_string())),
 			};
@@ -613,7 +605,7 @@ where
 				value => {
 					return Err(MonochangeError::Config(format!(
 						"unknown assist output format `{value}`"
-					)))
+					)));
 				}
 			};
 			run_assist(assistant, format)

--- a/crates/monochange/src/mcp.rs
+++ b/crates/monochange/src/mcp.rs
@@ -4,6 +4,9 @@ use std::path::PathBuf;
 use monochange_config::validate_workspace;
 use monochange_core::CliCommandDefinition;
 use monochange_core::ReleaseManifest;
+use rmcp::ErrorData as McpError;
+use rmcp::ServerHandler;
+use rmcp::ServiceExt;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::*;
@@ -11,9 +14,6 @@ use rmcp::schemars;
 use rmcp::tool;
 use rmcp::tool_handler;
 use rmcp::tool_router;
-use rmcp::ErrorData as McpError;
-use rmcp::ServerHandler;
-use rmcp::ServiceExt;
 use serde::Deserialize;
 use serde_json::json;
 
@@ -154,19 +154,23 @@ impl MonochangeMcpServer {
 	) -> Result<CallToolResult, McpError> {
 		let root = resolve_root(params.path.as_deref());
 		match validate_workspace(&root) {
-			Ok(()) => Ok(json_result(json!({
-				"ok": true,
-				"action": "validate",
-				"root": root,
-				"summary": "workspace validation passed"
-			}))),
-			Err(error) => Ok(json_error_result(json!({
-				"ok": false,
-				"action": "validate",
-				"root": root,
-				"summary": error.render(),
-				"error": error.render()
-			}))),
+			Ok(()) => {
+				Ok(json_result(json!({
+					"ok": true,
+					"action": "validate",
+					"root": root,
+					"summary": "workspace validation passed"
+				})))
+			}
+			Err(error) => {
+				Ok(json_error_result(json!({
+					"ok": false,
+					"action": "validate",
+					"root": root,
+					"summary": error.render(),
+					"error": error.render()
+				})))
+			}
 		}
 	}
 
@@ -180,23 +184,27 @@ impl MonochangeMcpServer {
 	) -> Result<CallToolResult, McpError> {
 		let root = resolve_root(params.path.as_deref());
 		match crate::discover_workspace(&root) {
-			Ok(report) => Ok(json_result(json!({
-				"ok": true,
-				"action": "discover",
-				"summary": format!(
-					"Discovered {} package(s) and {} dependency edge(s).",
-					report.packages.len(),
-					report.dependencies.len()
-				),
-				"report": report,
-			}))),
-			Err(error) => Ok(json_error_result(json!({
-				"ok": false,
-				"action": "discover",
-				"root": root,
-				"summary": error.render(),
-				"error": error.render()
-			}))),
+			Ok(report) => {
+				Ok(json_result(json!({
+					"ok": true,
+					"action": "discover",
+					"summary": format!(
+						"Discovered {} package(s) and {} dependency edge(s).",
+						report.packages.len(),
+						report.dependencies.len()
+					),
+					"report": report,
+				})))
+			}
+			Err(error) => {
+				Ok(json_error_result(json!({
+					"ok": false,
+					"action": "discover",
+					"root": root,
+					"summary": error.render(),
+					"error": error.render()
+				})))
+			}
 		}
 	}
 
@@ -223,20 +231,24 @@ impl MonochangeMcpServer {
 				.output(output)
 				.build(),
 		) {
-			Ok(path) => Ok(json_result(json!({
-				"ok": true,
-				"action": "change",
-				"root": root,
-				"path": path,
-				"summary": format!("Wrote change file {}", path.display())
-			}))),
-			Err(error) => Ok(json_error_result(json!({
-				"ok": false,
-				"action": "change",
-				"root": root,
-				"summary": error.render(),
-				"error": error.render()
-			}))),
+			Ok(path) => {
+				Ok(json_result(json!({
+					"ok": true,
+					"action": "change",
+					"root": root,
+					"path": path,
+					"summary": format!("Wrote change file {}", path.display())
+				})))
+			}
+			Err(error) => {
+				Ok(json_error_result(json!({
+					"ok": false,
+					"action": "change",
+					"root": root,
+					"summary": error.render(),
+					"error": error.render()
+				})))
+			}
 		}
 	}
 
@@ -250,22 +262,26 @@ impl MonochangeMcpServer {
 	) -> Result<CallToolResult, McpError> {
 		let root = resolve_root(params.path.as_deref());
 		match crate::prepare_release(&root, true) {
-			Ok(prepared_release) => Ok(json_result(json!({
-				"ok": true,
-				"action": "release_preview",
-				"summary": format!(
-					"Prepared dry-run release preview with {} release target(s).",
-					prepared_release.release_targets.len()
-				),
-				"release": prepared_release_value(&prepared_release)
-			}))),
-			Err(error) => Ok(json_error_result(json!({
-				"ok": false,
-				"action": "release_preview",
-				"root": root,
-				"summary": error.render(),
-				"error": error.render()
-			}))),
+			Ok(prepared_release) => {
+				Ok(json_result(json!({
+					"ok": true,
+					"action": "release_preview",
+					"summary": format!(
+						"Prepared dry-run release preview with {} release target(s).",
+						prepared_release.release_targets.len()
+					),
+					"release": prepared_release_value(&prepared_release)
+				})))
+			}
+			Err(error) => {
+				Ok(json_error_result(json!({
+					"ok": false,
+					"action": "release_preview",
+					"root": root,
+					"summary": error.render(),
+					"error": error.render()
+				})))
+			}
 		}
 	}
 
@@ -291,13 +307,15 @@ impl MonochangeMcpServer {
 					"manifest": manifest,
 				})))
 			}
-			Err(error) => Ok(json_error_result(json!({
-				"ok": false,
-				"action": "release_manifest",
-				"root": root,
-				"summary": error.render(),
-				"error": error.render()
-			}))),
+			Err(error) => {
+				Ok(json_error_result(json!({
+					"ok": false,
+					"action": "release_manifest",
+					"root": root,
+					"summary": error.render(),
+					"error": error.render()
+				})))
+			}
 		}
 	}
 
@@ -311,19 +329,23 @@ impl MonochangeMcpServer {
 	) -> Result<CallToolResult, McpError> {
 		let root = resolve_root(params.path.as_deref());
 		match crate::affected_packages(&root, &params.changed_paths, &params.labels) {
-			Ok(evaluation) => Ok(json_result(json!({
-				"ok": evaluation.status != monochange_core::ChangesetPolicyStatus::Failed,
-				"action": "affected_packages",
-				"summary": evaluation.summary,
-				"evaluation": evaluation,
-			}))),
-			Err(error) => Ok(json_error_result(json!({
-				"ok": false,
-				"action": "affected_packages",
-				"root": root,
-				"summary": error.render(),
-				"error": error.render()
-			}))),
+			Ok(evaluation) => {
+				Ok(json_result(json!({
+					"ok": evaluation.status != monochange_core::ChangesetPolicyStatus::Failed,
+					"action": "affected_packages",
+					"summary": evaluation.summary,
+					"evaluation": evaluation,
+				})))
+			}
+			Err(error) => {
+				Ok(json_error_result(json!({
+					"ok": false,
+					"action": "affected_packages",
+					"root": root,
+					"summary": error.render(),
+					"error": error.render()
+				})))
+			}
 		}
 	}
 }
@@ -353,18 +375,18 @@ mod __tests {
 	use monochange_test_helpers::copy_directory;
 	use monochange_test_helpers::current_test_name;
 	use monochange_test_helpers::snapshot_settings;
-	use rmcp::handler::server::wrapper::Parameters;
 	use rmcp::ServerHandler;
+	use rmcp::handler::server::wrapper::Parameters;
 	use tempfile::tempdir;
 
-	use super::json_error_result;
-	use super::json_result;
-	use super::resolve_root;
 	use super::AffectedParam;
 	use super::ChangeParam;
 	use super::McpChangeBump;
 	use super::MonochangeMcpServer;
 	use super::PathParam;
+	use super::json_error_result;
+	use super::json_result;
+	use super::resolve_root;
 
 	fn setup_fixture(relative: &str) -> tempfile::TempDir {
 		monochange_test_helpers::fs::setup_fixture_from(env!("CARGO_MANIFEST_DIR"), relative)
@@ -402,8 +424,11 @@ mod __tests {
 	#[test]
 	fn get_info_exposes_tool_instructions_and_capabilities() {
 		let info = MonochangeMcpServer::new().get_info();
-		assert!(info.instructions.as_ref().is_some_and(|text| text
-			.contains("monochange manages versions and releases across Cargo, npm, Deno, and Dart/Flutter workspaces")));
+		assert!(info.instructions.as_ref().is_some_and(|text| {
+			text.contains(
+				"monochange manages versions and releases across Cargo, npm, Deno, and Dart/Flutter workspaces",
+			)
+		}));
 		assert!(info.capabilities.tools.is_some());
 	}
 

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -1,7 +1,6 @@
-use std::io::IsTerminal;
-
 #[cfg(test)]
 use std::cell::Cell;
+use std::io::IsTerminal;
 
 use similar::TextDiff;
 
@@ -413,9 +412,11 @@ pub(crate) fn build_cargo_manifest_updates(
 
 	Ok(updated_documents
 		.into_iter()
-		.map(|(path, document)| FileUpdate {
-			path,
-			content: document.into_bytes(),
+		.map(|(path, document)| {
+			FileUpdate {
+				path,
+				content: document.into_bytes(),
+			}
 		})
 		.collect())
 }
@@ -742,8 +743,10 @@ pub(crate) fn render_discovery_report(
 	format: OutputFormat,
 ) -> MonochangeResult<String> {
 	match format {
-		OutputFormat::Json => serde_json::to_string_pretty(&json_discovery_report(report))
-			.map_err(|error| MonochangeError::Discovery(error.to_string())),
+		OutputFormat::Json => {
+			serde_json::to_string_pretty(&json_discovery_report(report))
+				.map_err(|error| MonochangeError::Discovery(error.to_string()))
+		}
 		OutputFormat::Text => Ok(text_discovery_report(report)),
 	}
 }
@@ -761,17 +764,19 @@ pub(crate) fn build_release_manifest(
 		release_targets: prepared_release
 			.release_targets
 			.iter()
-			.map(|target| ReleaseManifestTarget {
-				id: target.id.clone(),
-				kind: target.kind,
-				version: target.version.clone(),
-				tag: target.tag,
-				release: target.release,
-				version_format: target.version_format,
-				tag_name: target.tag_name.clone(),
-				members: target.members.clone(),
-				rendered_title: target.rendered_title.clone(),
-				rendered_changelog_title: target.rendered_changelog_title.clone(),
+			.map(|target| {
+				ReleaseManifestTarget {
+					id: target.id.clone(),
+					kind: target.kind,
+					version: target.version.clone(),
+					tag: target.tag,
+					release: target.release,
+					version_format: target.version_format,
+					tag_name: target.tag_name.clone(),
+					members: target.members.clone(),
+					rendered_title: target.rendered_title.clone(),
+					rendered_changelog_title: target.rendered_changelog_title.clone(),
+				}
 			})
 			.collect(),
 		released_packages: prepared_release.released_packages.clone(),
@@ -779,13 +784,15 @@ pub(crate) fn build_release_manifest(
 		changelogs: prepared_release
 			.changelogs
 			.iter()
-			.map(|changelog| ReleaseManifestChangelog {
-				owner_id: changelog.owner_id.clone(),
-				owner_kind: changelog.owner_kind,
-				path: changelog.path.clone(),
-				format: changelog.format,
-				notes: changelog.notes.clone(),
-				rendered: changelog.rendered.clone(),
+			.map(|changelog| {
+				ReleaseManifestChangelog {
+					owner_id: changelog.owner_id.clone(),
+					owner_kind: changelog.owner_kind,
+					path: changelog.path.clone(),
+					format: changelog.format,
+					notes: changelog.notes.clone(),
+					rendered: changelog.rendered.clone(),
+				}
 			})
 			.collect(),
 		changesets: prepared_release.changesets.clone(),
@@ -796,24 +803,28 @@ pub(crate) fn build_release_manifest(
 				.plan
 				.decisions
 				.iter()
-				.map(|decision| ReleaseManifestPlanDecision {
-					package: decision.package_id.clone(),
-					bump: decision.recommended_bump,
-					trigger: decision.trigger_type.clone(),
-					planned_version: decision.planned_version.as_ref().map(ToString::to_string),
-					reasons: decision.reasons.clone(),
-					upstream_sources: decision.upstream_sources.clone(),
+				.map(|decision| {
+					ReleaseManifestPlanDecision {
+						package: decision.package_id.clone(),
+						bump: decision.recommended_bump,
+						trigger: decision.trigger_type.clone(),
+						planned_version: decision.planned_version.as_ref().map(ToString::to_string),
+						reasons: decision.reasons.clone(),
+						upstream_sources: decision.upstream_sources.clone(),
+					}
 				})
 				.collect(),
 			groups: prepared_release
 				.plan
 				.groups
 				.iter()
-				.map(|group| ReleaseManifestPlanGroup {
-					id: group.group_id.clone(),
-					planned_version: group.planned_version.as_ref().map(ToString::to_string),
-					members: group.members.clone(),
-					bump: group.recommended_bump,
+				.map(|group| {
+					ReleaseManifestPlanGroup {
+						id: group.group_id.clone(),
+						planned_version: group.planned_version.as_ref().map(ToString::to_string),
+						members: group.members.clone(),
+						bump: group.recommended_bump,
+					}
 				})
 				.collect(),
 			warnings: prepared_release.plan.warnings.clone(),
@@ -822,13 +833,15 @@ pub(crate) fn build_release_manifest(
 				.plan
 				.compatibility_evidence
 				.iter()
-				.map(|assessment| ReleaseManifestCompatibilityEvidence {
-					package: assessment.package_id.clone(),
-					provider: assessment.provider_id.clone(),
-					severity: assessment.severity,
-					summary: assessment.summary.clone(),
-					confidence: assessment.confidence.clone(),
-					evidence_location: assessment.evidence_location.clone(),
+				.map(|assessment| {
+					ReleaseManifestCompatibilityEvidence {
+						package: assessment.package_id.clone(),
+						provider: assessment.provider_id.clone(),
+						severity: assessment.severity,
+						summary: assessment.summary.clone(),
+						confidence: assessment.confidence.clone(),
+						evidence_location: assessment.evidence_location.clone(),
+					}
 				})
 				.collect(),
 		},
@@ -851,15 +864,17 @@ pub(crate) fn build_release_record(
 		release_targets: manifest
 			.release_targets
 			.iter()
-			.map(|target| ReleaseRecordTarget {
-				id: target.id.clone(),
-				kind: target.kind,
-				version: target.version.clone(),
-				version_format: target.version_format,
-				tag: target.tag,
-				release: target.release,
-				tag_name: target.tag_name.clone(),
-				members: target.members.clone(),
+			.map(|target| {
+				ReleaseRecordTarget {
+					id: target.id.clone(),
+					kind: target.kind,
+					version: target.version.clone(),
+					version_format: target.version_format,
+					tag: target.tag,
+					release: target.release,
+					tag_name: target.tag_name.clone(),
+					members: target.members.clone(),
+				}
 			})
 			.collect(),
 		released_packages: manifest.released_packages.clone(),
@@ -870,11 +885,13 @@ pub(crate) fn build_release_record(
 			.map(|changelog| changelog.path.clone())
 			.collect(),
 		deleted_changesets: manifest.deleted_changesets.clone(),
-		provider: source.map(|source| ReleaseRecordProvider {
-			kind: source.provider,
-			owner: source.owner.clone(),
-			repo: source.repo.clone(),
-			host: source.host.clone(),
+		provider: source.map(|source| {
+			ReleaseRecordProvider {
+				kind: source.provider,
+				owner: source.owner.clone(),
+				repo: source.repo.clone(),
+				host: source.host.clone(),
+			}
 		}),
 	}
 }

--- a/crates/monochange/src/release_record.rs
+++ b/crates/monochange/src/release_record.rs
@@ -1,8 +1,5 @@
 use std::path::Path;
 
-use monochange_core::parse_release_record_block;
-use monochange_core::release_record_release_tag_names;
-use monochange_core::release_record_tag_names;
 use monochange_core::MonochangeError;
 use monochange_core::MonochangeResult;
 use monochange_core::ReleaseRecordDiscovery;
@@ -14,7 +11,11 @@ use monochange_core::RetargetResult;
 use monochange_core::RetargetTagResult;
 use monochange_core::SourceConfiguration;
 use monochange_core::SourceProvider;
+use monochange_core::parse_release_record_block;
+use monochange_core::release_record_release_tag_names;
+use monochange_core::release_record_tag_names;
 
+use crate::OutputFormat;
 use crate::git_support::first_parent_commits;
 use crate::git_support::git_is_ancestor;
 use crate::git_support::move_git_tag;
@@ -23,7 +24,6 @@ use crate::git_support::read_git_commit_message;
 use crate::git_support::resolve_git_commit_ref;
 use crate::git_support::resolve_git_tag_commit;
 use crate::github_provider;
-use crate::OutputFormat;
 
 pub(crate) fn render_release_record_discovery(
 	root: &Path,
@@ -32,8 +32,10 @@ pub(crate) fn render_release_record_discovery(
 ) -> MonochangeResult<String> {
 	let discovery = discover_release_record(root, from)?;
 	match format {
-		OutputFormat::Json => serde_json::to_string_pretty(&discovery)
-			.map_err(|error| MonochangeError::Discovery(error.to_string())),
+		OutputFormat::Json => {
+			serde_json::to_string_pretty(&discovery)
+				.map_err(|error| MonochangeError::Discovery(error.to_string()))
+		}
 		OutputFormat::Text => Ok(text_release_record_discovery(&discovery)),
 	}
 }
@@ -70,14 +72,14 @@ pub fn discover_release_record(
 					"release record in commit {} uses unsupported schemaVersion {}",
 					crate::short_commit_sha(&commit),
 					version
-				)))
+				)));
 			}
 			Err(error) => {
 				return Err(MonochangeError::Discovery(format!(
 					"found a malformed monochange release record in commit {}: {}",
 					crate::short_commit_sha(&commit),
 					error
-				)))
+				)));
 			}
 		}
 	}
@@ -132,27 +134,33 @@ pub fn plan_release_retarget(
 	});
 	let provider_updates = if sync_provider {
 		match provider {
-			Some(provider) => release_record_release_tag_names(&discovery.record)
-				.into_iter()
-				.map(|tag_name| RetargetProviderResult {
-					provider,
-					tag_name,
-					target_commit: target_commit.clone(),
-					operation: match provider {
-						SourceProvider::GitHub => RetargetProviderOperation::Planned,
-						SourceProvider::GitLab | SourceProvider::Gitea => {
-							RetargetProviderOperation::Unsupported
+			Some(provider) => {
+				release_record_release_tag_names(&discovery.record)
+					.into_iter()
+					.map(|tag_name| {
+						RetargetProviderResult {
+							provider,
+							tag_name,
+							target_commit: target_commit.clone(),
+							operation: match provider {
+								SourceProvider::GitHub => RetargetProviderOperation::Planned,
+								SourceProvider::GitLab | SourceProvider::Gitea => {
+									RetargetProviderOperation::Unsupported
+								}
+							},
+							url: None,
+							message: match provider {
+								SourceProvider::GitHub => None,
+								SourceProvider::GitLab | SourceProvider::Gitea => {
+									Some(format!(
+										"provider sync is not yet supported for {provider} release retargeting"
+									))
+								}
+							},
 						}
-					},
-					url: None,
-					message: match provider {
-						SourceProvider::GitHub => None,
-						SourceProvider::GitLab | SourceProvider::Gitea => Some(format!(
-							"provider sync is not yet supported for {provider} release retargeting"
-						)),
-					},
-				})
-				.collect(),
+					})
+					.collect()
+			}
 			None => Vec::new(),
 		}
 	} else {
@@ -290,16 +298,18 @@ pub(crate) fn sync_retargeted_provider_releases(
 			if dry_run {
 				Ok(tag_results
 					.iter()
-					.map(|update| RetargetProviderResult {
-						provider: source.provider,
-						tag_name: update.tag_name.clone(),
-						target_commit: update.to_commit.clone(),
-						operation: RetargetProviderOperation::Unsupported,
-						url: None,
-						message: Some(format!(
-							"provider sync is not yet supported for {} release retargeting",
-							source.provider
-						)),
+					.map(|update| {
+						RetargetProviderResult {
+							provider: source.provider,
+							tag_name: update.tag_name.clone(),
+							target_commit: update.to_commit.clone(),
+							operation: RetargetProviderOperation::Unsupported,
+							url: None,
+							message: Some(format!(
+								"provider sync is not yet supported for {} release retargeting",
+								source.provider
+							)),
+						}
 					})
 					.collect())
 			} else {

--- a/crates/monochange/src/tracing_setup.rs
+++ b/crates/monochange/src/tracing_setup.rs
@@ -1,6 +1,6 @@
+use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt;
 use tracing_subscriber::fmt::format::FmtSpan;
-use tracing_subscriber::EnvFilter;
 
 /// Initialize the tracing subscriber for CLI diagnostics.
 ///
@@ -11,10 +11,12 @@ use tracing_subscriber::EnvFilter;
 pub(crate) fn init_tracing(log_level: Option<&str>) {
 	let filter = match EnvFilter::try_from_default_env() {
 		Ok(env_filter) => env_filter,
-		Err(_) => match log_level {
-			Some(level) => EnvFilter::new(level),
-			None => return,
-		},
+		Err(_) => {
+			match log_level {
+				Some(level) => EnvFilter::new(level),
+				None => return,
+			}
+		}
 	};
 
 	let subscriber = fmt::Subscriber::builder()

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -1,6 +1,6 @@
-use super::*;
-
 use regex::Regex;
+
+use super::*;
 
 pub(crate) struct VersionedFileUpdateContext<'a> {
 	pub(crate) package_by_record_id: BTreeMap<&'a str, &'a PackageRecord>,
@@ -190,9 +190,11 @@ fn render_cached_document_bytes(
 			rendered.push('\n');
 			Ok(rendered.into_bytes())
 		}
-		CachedDocument::Yaml(mapping) => serde_yaml_ng::to_string(&mapping)
-			.map(String::into_bytes)
-			.map_err(|error| MonochangeError::Config(error.to_string())),
+		CachedDocument::Yaml(mapping) => {
+			serde_yaml_ng::to_string(&mapping)
+				.map(String::into_bytes)
+				.map_err(|error| MonochangeError::Config(error.to_string()))
+		}
 		CachedDocument::Text(contents) => Ok(contents.into_bytes()),
 		CachedDocument::Bytes(contents) => Ok(contents),
 	}
@@ -384,11 +386,13 @@ pub(crate) fn resolve_versioned_prefix(
 		.ecosystem_type
 		.expect("typed versioned_files should always have an ecosystem type");
 	let ecosystem_prefix = match ecosystem_type {
-		monochange_core::EcosystemType::Cargo => context
-			.configuration
-			.cargo
-			.dependency_version_prefix
-			.clone(),
+		monochange_core::EcosystemType::Cargo => {
+			context
+				.configuration
+				.cargo
+				.dependency_version_prefix
+				.clone()
+		}
 		monochange_core::EcosystemType::Npm => {
 			context.configuration.npm.dependency_version_prefix.clone()
 		}
@@ -631,14 +635,10 @@ pub(crate) fn apply_versioned_file_definition(
 						})?;
 				}
 			}
-			(CachedDocument::Json(value), VersionedFileKind::Npm(kind)) => {
-				if kind == monochange_npm::NpmVersionedFileKind::PackageLock {
-					monochange_npm::update_package_lock(
-						value,
-						&package_paths_by_name,
-						&raw_versions,
-					);
-				}
+			(CachedDocument::Json(value), VersionedFileKind::Npm(kind))
+				if kind == monochange_npm::NpmVersionedFileKind::PackageLock =>
+			{
+				monochange_npm::update_package_lock(value, &package_paths_by_name, &raw_versions);
 			}
 			(
 				CachedDocument::Bytes(contents),
@@ -679,31 +679,27 @@ pub(crate) fn apply_versioned_file_definition(
 					))
 				})?;
 			}
-			(CachedDocument::Json(value), VersionedFileKind::Deno(kind)) => {
-				if kind == monochange_deno::DenoVersionedFileKind::Lock {
-					monochange_deno::update_lockfile(value, &raw_versions);
-				}
+			(CachedDocument::Json(value), VersionedFileKind::Deno(kind))
+				if kind == monochange_deno::DenoVersionedFileKind::Lock =>
+			{
+				monochange_deno::update_lockfile(value, &raw_versions);
 			}
-			(CachedDocument::Text(contents), VersionedFileKind::Dart(kind)) => {
-				if kind == monochange_dart::DartVersionedFileKind::Manifest {
-					*contents = monochange_dart::update_manifest_text(
-						contents,
-						None,
-						&fields,
-						&versioned_deps,
-					)
-					.map_err(|error| {
-						MonochangeError::Config(format!(
-							"failed to parse {}: {error}",
-							resolved_path.display()
-						))
-					})?;
-				}
+			(CachedDocument::Text(contents), VersionedFileKind::Dart(kind))
+				if kind == monochange_dart::DartVersionedFileKind::Manifest =>
+			{
+				*contents =
+					monochange_dart::update_manifest_text(contents, None, &fields, &versioned_deps)
+						.map_err(|error| {
+							MonochangeError::Config(format!(
+								"failed to parse {}: {error}",
+								resolved_path.display()
+							))
+						})?;
 			}
-			(CachedDocument::Yaml(mapping), VersionedFileKind::Dart(kind)) => {
-				if kind == monochange_dart::DartVersionedFileKind::Lock {
-					monochange_dart::update_pubspec_lock(mapping, &raw_versions);
-				}
+			(CachedDocument::Yaml(mapping), VersionedFileKind::Dart(kind))
+				if kind == monochange_dart::DartVersionedFileKind::Lock =>
+			{
+				monochange_dart::update_pubspec_lock(mapping, &raw_versions);
 			}
 			_ => {}
 		}

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -11,7 +11,6 @@ use monochange_config::apply_version_groups;
 use monochange_config::load_change_signals;
 use monochange_config::load_changeset_file;
 use monochange_config::load_workspace_configuration;
-use monochange_core::default_cli_commands;
 use monochange_core::BumpSeverity;
 use monochange_core::CliCommandDefinition;
 use monochange_core::DiscoveryReport;
@@ -24,6 +23,7 @@ use monochange_core::PackageRecord;
 use monochange_core::PackageType;
 use monochange_core::ReleasePlan;
 use monochange_core::SourceProvider;
+use monochange_core::default_cli_commands;
 use monochange_dart::discover_dart_packages;
 use monochange_deno::discover_deno_packages;
 use monochange_github as github_provider;
@@ -1063,10 +1063,12 @@ fn read_optional_file(path: &Path) -> MonochangeResult<Option<Vec<u8>>> {
 		{
 			Ok(None)
 		}
-		Err(error) => Err(MonochangeError::Io(format!(
-			"failed to read {}: {error}",
-			path.display()
-		))),
+		Err(error) => {
+			Err(MonochangeError::Io(format!(
+				"failed to read {}: {error}",
+				path.display()
+			)))
+		}
 	}
 }
 
@@ -1238,13 +1240,15 @@ pub(crate) fn prepare_release_execution(
 	changed_files.dedup();
 	let changelogs = changelog_updates
 		.iter()
-		.map(|update| PreparedChangelog {
-			owner_id: update.owner_id.clone(),
-			owner_kind: update.owner_kind,
-			path: root_relative(root, &update.file.path),
-			format: update.format,
-			notes: update.notes.clone(),
-			rendered: update.rendered.clone(),
+		.map(|update| {
+			PreparedChangelog {
+				owner_id: update.owner_id.clone(),
+				owner_kind: update.owner_kind,
+				path: root_relative(root, &update.file.path),
+				format: update.format,
+				notes: update.notes.clone(),
+				rendered: update.rendered.clone(),
+			}
 		})
 		.collect::<Vec<_>>();
 	let updated_changelogs = changelogs
@@ -1298,10 +1302,12 @@ pub(crate) fn prepare_release_execution(
 
 #[cfg(test)]
 mod workspace_ops_tests {
-	use super::*;
-	use monochange_core::ShellConfig;
 	#[cfg(unix)]
 	use std::os::unix::fs::PermissionsExt;
+
+	use monochange_core::ShellConfig;
+
+	use super::*;
 
 	fn setup_workspace_ops_fixture() -> tempfile::TempDir {
 		monochange_test_helpers::fs::setup_fixture_from(
@@ -1373,9 +1379,11 @@ mod workspace_ops_tests {
 		)
 		.err()
 		.unwrap_or_else(|| panic!("expected empty command error"));
-		assert!(empty_error
-			.to_string()
-			.contains("lockfile command must not be empty"));
+		assert!(
+			empty_error
+				.to_string()
+				.contains("lockfile command must not be empty")
+		);
 
 		let spawn_error = run_lockfile_command(
 			fixture.path(),
@@ -1388,9 +1396,11 @@ mod workspace_ops_tests {
 		)
 		.err()
 		.unwrap_or_else(|| panic!("expected spawn error"));
-		assert!(spawn_error
-			.to_string()
-			.contains("failed to run lockfile command"));
+		assert!(
+			spawn_error
+				.to_string()
+				.contains("failed to run lockfile command")
+		);
 
 		let no_stderr_error = run_lockfile_command(
 			fixture.path(),
@@ -1461,9 +1471,11 @@ mod workspace_ops_tests {
 		let updates =
 			collect_workspace_file_updates(fixture.path(), temp_root.path(), &[], &[lockfile_cmd])
 				.unwrap_or_else(|error| panic!("collect updates: {error}"));
-		assert!(updates
-			.iter()
-			.any(|update| update.path.ends_with("generated.txt")));
+		assert!(
+			updates
+				.iter()
+				.any(|update| update.path.ends_with("generated.txt"))
+		);
 
 		let mut paths = BTreeSet::new();
 		collect_workspace_files(fixture.path(), fixture.path(), &mut paths)
@@ -1475,9 +1487,11 @@ mod workspace_ops_tests {
 	#[test]
 	fn file_helpers_report_missing_and_invalid_paths() {
 		let fixture = setup_workspace_ops_fixture();
-		assert!(read_optional_file(&fixture.path().join("missing.txt"))
-			.unwrap_or_else(|error| panic!("missing file lookup: {error}"))
-			.is_none());
+		assert!(
+			read_optional_file(&fixture.path().join("missing.txt"))
+				.unwrap_or_else(|error| panic!("missing file lookup: {error}"))
+				.is_none()
+		);
 		let read_error = read_optional_file(fixture.path())
 			.err()
 			.unwrap_or_else(|| panic!("expected directory read error"));
@@ -1497,9 +1511,11 @@ mod workspace_ops_tests {
 		)
 		.err()
 		.unwrap_or_else(|| panic!("expected strip-prefix error"));
-		assert!(strip_prefix_error
-			.to_string()
-			.contains("was outside workspace root"));
+		assert!(
+			strip_prefix_error
+				.to_string()
+				.contains("was outside workspace root")
+		);
 
 		let temp_root = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 		let destination_file = temp_root.path().join("not-a-directory");

--- a/crates/monochange/tests/affected.rs
+++ b/crates/monochange/tests/affected.rs
@@ -6,10 +6,12 @@ use rstest::rstest;
 use serde_json::Value;
 
 mod test_support;
-use test_support::{
-	copy_directory, current_test_name, fixture_path, monochange_command, setup_scenario_workspace,
-	snapshot_settings,
-};
+use test_support::copy_directory;
+use test_support::current_test_name;
+use test_support::fixture_path;
+use test_support::monochange_command;
+use test_support::setup_scenario_workspace;
+use test_support::snapshot_settings;
 
 #[rstest]
 #[case::detects_package_changes(

--- a/crates/monochange/tests/changelog_formats.rs
+++ b/crates/monochange/tests/changelog_formats.rs
@@ -4,9 +4,10 @@ use insta::assert_snapshot;
 use rstest::rstest;
 
 mod test_support;
-use test_support::{
-	current_test_name, monochange_command, setup_scenario_workspace, snapshot_settings,
-};
+use test_support::current_test_name;
+use test_support::monochange_command;
+use test_support::setup_scenario_workspace;
+use test_support::snapshot_settings;
 
 #[rstest]
 #[case::defaults_keep_a("defaults-keep-a")]

--- a/crates/monochange/tests/changeset_context.rs
+++ b/crates/monochange/tests/changeset_context.rs
@@ -6,7 +6,8 @@ use monochange_test_helpers::git_output;
 use serde_json::Value;
 
 mod test_support;
-use test_support::{monochange_command, setup_scenario_workspace};
+use test_support::monochange_command;
+use test_support::setup_scenario_workspace;
 
 #[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
 fn release_manifest_records_git_changeset_context_and_renders_context_templates() {

--- a/crates/monochange/tests/changeset_policy.rs
+++ b/crates/monochange/tests/changeset_policy.rs
@@ -5,9 +5,10 @@ use rstest::rstest;
 use serde_json::Value;
 
 mod test_support;
-use test_support::{
-	current_test_name, monochange_command, setup_scenario_workspace, snapshot_settings,
-};
+use test_support::current_test_name;
+use test_support::monochange_command;
+use test_support::setup_scenario_workspace;
+use test_support::snapshot_settings;
 
 #[rstest]
 #[case::skip_label(

--- a/crates/monochange/tests/changeset_target_metadata.rs
+++ b/crates/monochange/tests/changeset_target_metadata.rs
@@ -4,7 +4,8 @@ use std::path::Path;
 use serde_json::Value;
 
 mod test_support;
-use test_support::{monochange_command, setup_scenario_workspace};
+use test_support::monochange_command;
+use test_support::setup_scenario_workspace;
 
 fn cli() -> std::process::Command {
 	monochange_command(Some("2026-04-06"))
@@ -230,6 +231,8 @@ fn release_rejects_legacy_reserved_metadata_blocks() {
 		.output()
 		.unwrap_or_else(|error| panic!("release output: {error}"));
 	assert!(!output.status.success());
-	assert!(String::from_utf8_lossy(&output.stderr)
-		.contains("target `origin` uses unsupported field(s): core"));
+	assert!(
+		String::from_utf8_lossy(&output.stderr)
+			.contains("target `origin` uses unsupported field(s): core")
+	);
 }

--- a/crates/monochange/tests/cli_main_binary.rs
+++ b/crates/monochange/tests/cli_main_binary.rs
@@ -1,5 +1,7 @@
-use insta_cmd::{assert_cmd_snapshot, get_cargo_bin};
 use std::process::Command;
+
+use insta_cmd::assert_cmd_snapshot;
+use insta_cmd::get_cargo_bin;
 
 fn monochange_cli() -> Command {
 	let mut command = Command::new(get_cargo_bin("monochange"));

--- a/crates/monochange/tests/cli_output.rs
+++ b/crates/monochange/tests/cli_output.rs
@@ -4,9 +4,10 @@ use insta::assert_snapshot;
 use insta_cmd::assert_cmd_snapshot;
 
 mod test_support;
-use test_support::{
-	current_test_name, monochange_command, setup_scenario_workspace, snapshot_settings,
-};
+use test_support::current_test_name;
+use test_support::monochange_command;
+use test_support::setup_scenario_workspace;
+use test_support::snapshot_settings;
 
 fn release_cli_command() -> std::process::Command {
 	monochange_command(Some("2026-04-06"))
@@ -19,9 +20,11 @@ fn validate_cli_succeeds_for_valid_workspace() {
 	let _guard = settings.bind_to_scope();
 
 	let tempdir = setup_scenario_workspace("monochange/validate-workspace");
-	assert_cmd_snapshot!(monochange_command(None)
-		.current_dir(tempdir.path())
-		.arg("validate"));
+	assert_cmd_snapshot!(
+		monochange_command(None)
+			.current_dir(tempdir.path())
+			.arg("validate")
+	);
 }
 
 #[test]
@@ -40,11 +43,13 @@ fn discover_cli_json_reports_relative_paths_and_stable_ids() {
 	let _guard = settings.bind_to_scope();
 
 	let tempdir = setup_scenario_workspace("cli-output/discover-mixed");
-	assert_cmd_snapshot!(monochange_command(None)
-		.current_dir(tempdir.path())
-		.arg("discover")
-		.arg("--format")
-		.arg("json"));
+	assert_cmd_snapshot!(
+		monochange_command(None)
+			.current_dir(tempdir.path())
+			.arg("discover")
+			.arg("--format")
+			.arg("json")
+	);
 }
 
 #[test]
@@ -56,17 +61,19 @@ fn change_cli_writes_requested_file_contents() {
 	let tempdir = setup_scenario_workspace("cli-output/ungrouped-basic");
 	let output_path = tempdir.path().join("feature.md");
 
-	assert_cmd_snapshot!(monochange_command(None)
-		.current_dir(tempdir.path())
-		.arg("change")
-		.arg("--package")
-		.arg("core")
-		.arg("--bump")
-		.arg("minor")
-		.arg("--reason")
-		.arg("document cli snapshots")
-		.arg("--output")
-		.arg(&output_path));
+	assert_cmd_snapshot!(
+		monochange_command(None)
+			.current_dir(tempdir.path())
+			.arg("change")
+			.arg("--package")
+			.arg("core")
+			.arg("--bump")
+			.arg("minor")
+			.arg("--reason")
+			.arg("document cli snapshots")
+			.arg("--output")
+			.arg(&output_path)
+	);
 
 	let change_file =
 		fs::read_to_string(&output_path).unwrap_or_else(|error| panic!("change file: {error}"));
@@ -82,19 +89,21 @@ fn change_cli_writes_explicit_versions_when_requested() {
 	let tempdir = setup_scenario_workspace("cli-output/ungrouped-basic");
 	let output_path = tempdir.path().join("versioned.md");
 
-	assert_cmd_snapshot!(monochange_command(None)
-		.current_dir(tempdir.path())
-		.arg("change")
-		.arg("--package")
-		.arg("core")
-		.arg("--bump")
-		.arg("major")
-		.arg("--version")
-		.arg("2.0.0")
-		.arg("--reason")
-		.arg("promote to stable")
-		.arg("--output")
-		.arg(&output_path));
+	assert_cmd_snapshot!(
+		monochange_command(None)
+			.current_dir(tempdir.path())
+			.arg("change")
+			.arg("--package")
+			.arg("core")
+			.arg("--bump")
+			.arg("major")
+			.arg("--version")
+			.arg("2.0.0")
+			.arg("--reason")
+			.arg("promote to stable")
+			.arg("--output")
+			.arg(&output_path)
+	);
 
 	let change_file =
 		fs::read_to_string(&output_path).unwrap_or_else(|error| panic!("change file: {error}"));
@@ -108,12 +117,14 @@ fn release_dry_run_cli_patches_parent_packages_when_dependencies_change() {
 	let _guard = settings.bind_to_scope();
 
 	let tempdir = setup_scenario_workspace("cli-output/ungrouped-basic");
-	assert_cmd_snapshot!(release_cli_command()
-		.current_dir(tempdir.path())
-		.arg("release")
-		.arg("--dry-run")
-		.arg("--format")
-		.arg("text"));
+	assert_cmd_snapshot!(
+		release_cli_command()
+			.current_dir(tempdir.path())
+			.arg("release")
+			.arg("--dry-run")
+			.arg("--format")
+			.arg("text")
+	);
 }
 
 #[test]
@@ -123,12 +134,14 @@ fn release_dry_run_cli_uses_explicit_group_versions_from_member_changes() {
 	let _guard = settings.bind_to_scope();
 
 	let tempdir = setup_scenario_workspace("cli-output/group-explicit-version");
-	assert_cmd_snapshot!(release_cli_command()
-		.current_dir(tempdir.path())
-		.arg("release")
-		.arg("--dry-run")
-		.arg("--format")
-		.arg("text"));
+	assert_cmd_snapshot!(
+		release_cli_command()
+			.current_dir(tempdir.path())
+			.arg("release")
+			.arg("--dry-run")
+			.arg("--format")
+			.arg("text")
+	);
 }
 
 #[test]
@@ -138,12 +151,14 @@ fn release_dry_run_cli_json_exposes_group_owned_release_targets() {
 	let _guard = settings.bind_to_scope();
 
 	let tempdir = setup_scenario_workspace("cli-output/group-basic");
-	assert_cmd_snapshot!(release_cli_command()
-		.current_dir(tempdir.path())
-		.arg("release")
-		.arg("--dry-run")
-		.arg("--format")
-		.arg("json"));
+	assert_cmd_snapshot!(
+		release_cli_command()
+			.current_dir(tempdir.path())
+			.arg("release")
+			.arg("--dry-run")
+			.arg("--format")
+			.arg("json")
+	);
 }
 
 #[test]
@@ -153,13 +168,15 @@ fn release_dry_run_cli_text_renders_diff_preview() {
 	let _guard = settings.bind_to_scope();
 
 	let tempdir = setup_scenario_workspace("cli-output/group-basic");
-	assert_cmd_snapshot!(release_cli_command()
-		.current_dir(tempdir.path())
-		.arg("release")
-		.arg("--dry-run")
-		.arg("--diff")
-		.arg("--format")
-		.arg("text"));
+	assert_cmd_snapshot!(
+		release_cli_command()
+			.current_dir(tempdir.path())
+			.arg("release")
+			.arg("--dry-run")
+			.arg("--diff")
+			.arg("--format")
+			.arg("text")
+	);
 }
 
 #[test]
@@ -169,13 +186,15 @@ fn release_dry_run_cli_json_renders_diff_preview() {
 	let _guard = settings.bind_to_scope();
 
 	let tempdir = setup_scenario_workspace("cli-output/group-basic");
-	assert_cmd_snapshot!(release_cli_command()
-		.current_dir(tempdir.path())
-		.arg("release")
-		.arg("--dry-run")
-		.arg("--diff")
-		.arg("--format")
-		.arg("json"));
+	assert_cmd_snapshot!(
+		release_cli_command()
+			.current_dir(tempdir.path())
+			.arg("release")
+			.arg("--dry-run")
+			.arg("--diff")
+			.arg("--format")
+			.arg("json")
+	);
 }
 
 #[test]
@@ -185,13 +204,15 @@ fn verify_cli_json_reports_failure_comment() {
 	let _guard = settings.bind_to_scope();
 
 	let tempdir = setup_scenario_workspace("cli-output/changeset-policy-no-changeset");
-	assert_cmd_snapshot!(monochange_command(None)
-		.current_dir(tempdir.path())
-		.arg("affected")
-		.arg("--format")
-		.arg("json")
-		.arg("--changed-paths")
-		.arg("crates/core/src/lib.rs"));
+	assert_cmd_snapshot!(
+		monochange_command(None)
+			.current_dir(tempdir.path())
+			.arg("affected")
+			.arg("--format")
+			.arg("json")
+			.arg("--changed-paths")
+			.arg("crates/core/src/lib.rs")
+	);
 }
 
 #[test]
@@ -201,10 +222,12 @@ fn release_pr_workflow_reports_dry_run_pull_request_preview() {
 	let _guard = settings.bind_to_scope();
 
 	let tempdir = setup_scenario_workspace("cli-output/release-pr-workflow");
-	assert_cmd_snapshot!(release_cli_command()
-		.current_dir(tempdir.path())
-		.arg("release-pr")
-		.arg("--dry-run"));
+	assert_cmd_snapshot!(
+		release_cli_command()
+			.current_dir(tempdir.path())
+			.arg("release-pr")
+			.arg("--dry-run")
+	);
 }
 
 #[test]
@@ -214,10 +237,12 @@ fn release_manifest_workflow_writes_manifest_json() {
 	let _guard = settings.bind_to_scope();
 
 	let tempdir = setup_scenario_workspace("cli-output/release-manifest-workflow");
-	assert_cmd_snapshot!(release_cli_command()
-		.current_dir(tempdir.path())
-		.arg("release-manifest")
-		.arg("--dry-run"));
+	assert_cmd_snapshot!(
+		release_cli_command()
+			.current_dir(tempdir.path())
+			.arg("release-manifest")
+			.arg("--dry-run")
+	);
 
 	let manifest_path = tempdir.path().join(".monochange/release-manifest.json");
 	let manifest = fs::read_to_string(&manifest_path)
@@ -232,9 +257,11 @@ fn release_cli_reports_missing_changesets_cleanly() {
 	let _guard = settings.bind_to_scope();
 
 	let tempdir = setup_scenario_workspace("cli-output/ungrouped-no-changeset");
-	assert_cmd_snapshot!(release_cli_command()
-		.current_dir(tempdir.path())
-		.arg("release"));
+	assert_cmd_snapshot!(
+		release_cli_command()
+			.current_dir(tempdir.path())
+			.arg("release")
+	);
 }
 
 #[test]
@@ -279,7 +306,9 @@ fn validate_cli_rejects_packages_in_multiple_groups() {
 	let _guard = settings.bind_to_scope();
 
 	let tempdir = setup_scenario_workspace("cli-output/multiple-groups-validation");
-	assert_cmd_snapshot!(monochange_command(None)
-		.current_dir(tempdir.path())
-		.arg("validate"));
+	assert_cmd_snapshot!(
+		monochange_command(None)
+			.current_dir(tempdir.path())
+			.arg("validate")
+	);
 }

--- a/crates/monochange/tests/cli_step_input_overrides.rs
+++ b/crates/monochange/tests/cli_step_input_overrides.rs
@@ -1,14 +1,16 @@
 use std::fs;
 use std::path::Path;
 
-use insta::{assert_json_snapshot, assert_snapshot};
+use insta::assert_json_snapshot;
+use insta::assert_snapshot;
 use rstest::rstest;
 use serde_json::Value;
 
 mod test_support;
-use test_support::{
-	current_test_name, monochange_command, setup_scenario_workspace, snapshot_settings,
-};
+use test_support::current_test_name;
+use test_support::monochange_command;
+use test_support::setup_scenario_workspace;
+use test_support::snapshot_settings;
 
 #[test]
 fn validate_step_runs_without_input_overrides() {

--- a/crates/monochange/tests/cli_step_when.rs
+++ b/crates/monochange/tests/cli_step_when.rs
@@ -1,7 +1,10 @@
-use std::{fs, path::Path, process::Output};
+use std::fs;
+use std::path::Path;
+use std::process::Output;
 
 mod test_support;
-use test_support::{monochange_command, setup_scenario_workspace};
+use test_support::monochange_command;
+use test_support::setup_scenario_workspace;
 
 #[test]
 fn cli_step_when_supports_logical_and_for_command_steps() {

--- a/crates/monochange/tests/github_releases.rs
+++ b/crates/monochange/tests/github_releases.rs
@@ -2,9 +2,10 @@ use insta::assert_json_snapshot;
 use rstest::rstest;
 
 mod test_support;
-use test_support::{
-	current_test_name, run_json_command, setup_scenario_workspace, snapshot_settings,
-};
+use test_support::current_test_name;
+use test_support::run_json_command;
+use test_support::setup_scenario_workspace;
+use test_support::snapshot_settings;
 
 #[rstest]
 #[case::group("group")]

--- a/crates/monochange/tests/manifest_formatting.rs
+++ b/crates/monochange/tests/manifest_formatting.rs
@@ -3,7 +3,9 @@ use std::fs;
 use insta::assert_snapshot;
 
 mod test_support;
-use test_support::{monochange_command, setup_scenario_workspace, snapshot_settings};
+use test_support::monochange_command;
+use test_support::setup_scenario_workspace;
+use test_support::snapshot_settings;
 
 #[test]
 fn release_preserves_cargo_manifest_formatting_while_updating_versions() {

--- a/crates/monochange/tests/pre_stable_versioning.rs
+++ b/crates/monochange/tests/pre_stable_versioning.rs
@@ -1,11 +1,13 @@
-use insta::{assert_json_snapshot, assert_snapshot};
+use insta::assert_json_snapshot;
+use insta::assert_snapshot;
 use rstest::rstest;
 use serde_json::Value;
 
 mod test_support;
-use test_support::{
-	monochange_command, run_json_command, setup_scenario_workspace, snapshot_settings,
-};
+use test_support::monochange_command;
+use test_support::run_json_command;
+use test_support::setup_scenario_workspace;
+use test_support::snapshot_settings;
 
 #[rstest]
 #[case::pre_stable_major_text("pre-stable-versioning/pre-stable-major", "pre_stable_major_text")]

--- a/crates/monochange/tests/release_group_propagation.rs
+++ b/crates/monochange/tests/release_group_propagation.rs
@@ -2,7 +2,9 @@ use insta::assert_json_snapshot;
 use serde_json::Value;
 
 mod test_support;
-use test_support::{run_json_command, setup_scenario_workspace, snapshot_settings};
+use test_support::run_json_command;
+use test_support::setup_scenario_workspace;
+use test_support::snapshot_settings;
 
 #[test]
 fn grouped_member_changes_patch_dependents_outside_the_group() {

--- a/crates/monochange/tests/release_notes_and_propagation.rs
+++ b/crates/monochange/tests/release_notes_and_propagation.rs
@@ -1,13 +1,15 @@
 use std::fs;
 
-use insta::{assert_json_snapshot, assert_snapshot};
+use insta::assert_json_snapshot;
+use insta::assert_snapshot;
 use rstest::rstest;
 use serde_json::Value;
 
 mod test_support;
-use test_support::{
-	current_test_name, monochange_command, setup_scenario_workspace, snapshot_settings,
-};
+use test_support::current_test_name;
+use test_support::monochange_command;
+use test_support::setup_scenario_workspace;
+use test_support::snapshot_settings;
 
 #[rstest]
 #[case::ungrouped_patch("ungrouped-patch")]

--- a/crates/monochange/tests/release_pull_requests.rs
+++ b/crates/monochange/tests/release_pull_requests.rs
@@ -2,9 +2,10 @@ use insta::assert_json_snapshot;
 use rstest::rstest;
 
 mod test_support;
-use test_support::{
-	current_test_name, run_json_command, setup_scenario_workspace, snapshot_settings,
-};
+use test_support::current_test_name;
+use test_support::run_json_command;
+use test_support::setup_scenario_workspace;
+use test_support::snapshot_settings;
 
 #[rstest]
 #[case::group("group")]

--- a/crates/monochange/tests/release_record.rs
+++ b/crates/monochange/tests/release_record.rs
@@ -3,22 +3,24 @@ use std::path::Path;
 
 use insta::assert_json_snapshot;
 use insta::assert_snapshot;
-use monochange_core::render_release_record_block;
 use monochange_core::ReleaseOwnerKind;
 use monochange_core::ReleaseRecord;
 use monochange_core::ReleaseRecordProvider;
 use monochange_core::ReleaseRecordTarget;
 use monochange_core::SourceProvider;
 use monochange_core::VersionFormat;
+use monochange_core::render_release_record_block;
 use monochange_test_helpers::git;
 use monochange_test_helpers::git_output_trimmed;
 use serde_json::Value;
 use tempfile::TempDir;
 
 mod test_support;
-use test_support::{
-	current_test_name, fixture_path, monochange_command, setup_fixture, snapshot_settings,
-};
+use test_support::current_test_name;
+use test_support::fixture_path;
+use test_support::monochange_command;
+use test_support::setup_fixture;
+use test_support::snapshot_settings;
 
 #[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
 fn release_record_command_reports_record_from_tag_as_json() {

--- a/crates/monochange/tests/source_providers.rs
+++ b/crates/monochange/tests/source_providers.rs
@@ -2,9 +2,10 @@ use insta::assert_json_snapshot;
 use rstest::rstest;
 
 mod test_support;
-use test_support::{
-	current_test_name, run_json_command, setup_scenario_workspace, snapshot_settings,
-};
+use test_support::current_test_name;
+use test_support::run_json_command;
+use test_support::setup_scenario_workspace;
+use test_support::snapshot_settings;
 
 #[rstest]
 #[case::gitlab_publish_release("source/gitlab", "publish-release")]

--- a/crates/monochange/tests/test_support.rs
+++ b/crates/monochange/tests/test_support.rs
@@ -2,14 +2,14 @@ use std::path::Path;
 use std::process::Command;
 
 use insta_cmd::get_cargo_bin;
-use serde_json::{Map, Value};
-
 #[allow(unused_imports)]
 pub use monochange_test_helpers::copy_directory;
 #[allow(unused_imports)]
 pub use monochange_test_helpers::current_test_name;
 #[allow(unused_imports)]
 pub use monochange_test_helpers::snapshot_settings;
+use serde_json::Map;
+use serde_json::Value;
 
 #[allow(dead_code)]
 pub fn fixture_path(relative: &str) -> std::path::PathBuf {

--- a/crates/monochange_cargo/src/__tests.rs
+++ b/crates/monochange_cargo/src/__tests.rs
@@ -2,19 +2,21 @@ use std::collections::BTreeMap;
 use std::path::Path;
 use std::path::PathBuf;
 
-use monochange_core::materialize_dependency_edges;
 use monochange_core::ChangeSignal;
 use monochange_core::CompatibilityAssessment;
 use monochange_core::Ecosystem;
 use monochange_core::EcosystemAdapter;
 use monochange_core::PackageRecord;
 use monochange_core::PublishState;
+use monochange_core::materialize_dependency_edges;
 use monochange_semver::CompatibilityProvider;
 use tempfile::tempdir;
 use toml::Value;
 use toml_edit::DocumentMut;
 use toml_edit::Item;
 
+use crate::CargoVersionedFileKind;
+use crate::RustSemverProvider;
 use crate::adapter;
 use crate::default_lockfile_commands;
 use crate::dependency_constraint;
@@ -28,8 +30,6 @@ use crate::supported_versioned_file_kind;
 use crate::update_versioned_file_text;
 use crate::validate_workspace_version_groups;
 use crate::workspace_package_version;
-use crate::CargoVersionedFileKind;
-use crate::RustSemverProvider;
 
 #[test]
 fn discovers_cargo_workspace_members() {
@@ -38,19 +38,25 @@ fn discovers_cargo_workspace_members() {
 		.unwrap_or_else(|error| panic!("cargo discovery: {error}"));
 
 	assert_eq!(discovery.packages.len(), 2);
-	assert!(discovery
-		.packages
-		.iter()
-		.any(|package| package.name == "cargo-core"));
-	assert!(discovery
-		.packages
-		.iter()
-		.any(|package| package.name == "cargo-app"));
+	assert!(
+		discovery
+			.packages
+			.iter()
+			.any(|package| package.name == "cargo-core")
+	);
+	assert!(
+		discovery
+			.packages
+			.iter()
+			.any(|package| package.name == "cargo-app")
+	);
 	let dependency_edges = materialize_dependency_edges(&discovery.packages);
 	assert_eq!(dependency_edges.len(), 1);
-	assert!(dependency_edges
-		.iter()
-		.any(|edge| edge.to_package_id.contains("crates/core/Cargo.toml")));
+	assert!(
+		dependency_edges
+			.iter()
+			.any(|edge| edge.to_package_id.contains("crates/core/Cargo.toml"))
+	);
 }
 
 #[test]
@@ -962,10 +968,9 @@ fn discover_cargo_packages_reports_workspace_warnings_and_private_packages() {
 		.unwrap_or_else(|error| panic!("cargo discovery: {error}"));
 
 	assert_eq!(discovery.packages.len(), 3);
-	assert!(discovery
-		.warnings
-		.iter()
-		.any(|warning| warning.contains("missing/*") && warning.contains("matched no packages")));
+	assert!(discovery.warnings.iter().any(|warning| {
+		warning.contains("missing/*") && warning.contains("matched no packages")
+	}));
 	let excluded_package = discovery
 		.packages
 		.iter()
@@ -1090,9 +1095,11 @@ fn cargo_manifest_helpers_cover_workspace_and_error_paths() {
 	let invalid_workspace_error = has_workspace_section(&invalid_workspace)
 		.err()
 		.unwrap_or_else(|| panic!("expected invalid workspace error"));
-	assert!(invalid_workspace_error
-		.to_string()
-		.contains("failed to parse"));
+	assert!(
+		invalid_workspace_error
+			.to_string()
+			.contains("failed to parse")
+	);
 
 	let invalid_package_root = Path::new(env!("CARGO_MANIFEST_DIR"))
 		.join("../../fixtures/tests/cargo/invalid-package-name");

--- a/crates/monochange_cargo/src/lib.rs
+++ b/crates/monochange_cargo/src/lib.rs
@@ -1,4 +1,3 @@
-#![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
 //! # `monochange_cargo`
@@ -42,7 +41,6 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use glob::glob;
-use monochange_core::normalize_path;
 use monochange_core::AdapterDiscovery;
 use monochange_core::BumpSeverity;
 use monochange_core::ChangeSignal;
@@ -57,14 +55,15 @@ use monochange_core::PackageDependency;
 use monochange_core::PackageRecord;
 use monochange_core::PublishState;
 use monochange_core::ShellConfig;
+use monochange_core::normalize_path;
 use monochange_semver::CompatibilityProvider;
 use semver::Version;
 use toml::Value;
-use toml_edit::value;
 use toml_edit::DocumentMut;
 use toml_edit::Item;
 use toml_edit::TableLike;
 use toml_edit::Value as EditValue;
+use toml_edit::value;
 use walkdir::DirEntry;
 use walkdir::WalkDir;
 
@@ -135,13 +134,15 @@ pub fn discover_lockfiles(package: &PackageRecord) -> Vec<PathBuf> {
 pub fn default_lockfile_commands(package: &PackageRecord) -> Vec<LockfileCommandExecution> {
 	discover_lockfiles(package)
 		.into_iter()
-		.map(|lockfile| LockfileCommandExecution {
-			command: "cargo generate-lockfile".to_string(),
-			cwd: lockfile
-				.parent()
-				.unwrap_or(&package.workspace_root)
-				.to_path_buf(),
-			shell: ShellConfig::None,
+		.map(|lockfile| {
+			LockfileCommandExecution {
+				command: "cargo generate-lockfile".to_string(),
+				cwd: lockfile
+					.parent()
+					.unwrap_or(&package.workspace_root)
+					.to_path_buf(),
+				shell: ShellConfig::None,
+			}
 		})
 		.collect()
 }
@@ -175,9 +176,11 @@ pub fn validate_workspace_version_groups(packages: &[PackageRecord]) -> Monochan
 		if group_ids.len() > 1 || group_ids.contains(&None) {
 			let details = packages
 				.iter()
-				.map(|package| match &package.version_group_id {
-					Some(group_id) => format!("`{}` in group `{}`", package.name, group_id),
-					None => format!("`{}` not in any group", package.name),
+				.map(|package| {
+					match &package.version_group_id {
+						Some(group_id) => format!("`{}` in group `{}`", package.name, group_id),
+						None => format!("`{}` not in any group", package.name),
+					}
 				})
 				.collect::<Vec<_>>();
 			return Err(MonochangeError::Config(format!(
@@ -775,15 +778,17 @@ fn parse_dependency_table(
 		.map(|table| {
 			table
 				.iter()
-				.map(|(name, value)| PackageDependency {
-					name: name.clone(),
-					kind,
-					version_constraint: dependency_constraint(value),
-					optional: value
-						.as_table()
-						.and_then(|table| table.get("optional"))
-						.and_then(Value::as_bool)
-						.unwrap_or(false),
+				.map(|(name, value)| {
+					PackageDependency {
+						name: name.clone(),
+						kind,
+						version_constraint: dependency_constraint(value),
+						optional: value
+							.as_table()
+							.and_then(|table| table.get("optional"))
+							.and_then(Value::as_bool)
+							.unwrap_or(false),
+					}
 				})
 				.collect::<Vec<_>>()
 		})

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -1,4 +1,5 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::path::PathBuf;
 
 use monochange_core::BumpSeverity;
 use monochange_core::ChangelogDefinition;
@@ -256,9 +257,11 @@ type = "RetargetRelease"
 	let error = load_workspace_configuration(tempdir.path())
 		.err()
 		.unwrap_or_else(|| panic!("expected invalid boolean default error"));
-	assert!(error
-		.to_string()
-		.contains("boolean default must be `true` or `false`"));
+	assert!(
+		error
+			.to_string()
+			.contains("boolean default must be `true` or `false`")
+	);
 }
 
 #[test]
@@ -464,65 +467,79 @@ fn load_workspace_configuration_rejects_missing_expected_manifests() {
 #[test]
 fn load_workspace_configuration_rejects_empty_github_owner_and_repo() {
 	let root_owner = fixture_path("config/rejects-empty-github-owner");
-	assert!(load_workspace_configuration(&root_owner)
-		.err()
-		.unwrap_or_else(|| panic!("expected config error"))
-		.to_string()
-		.contains("[github].owner must not be empty"));
+	assert!(
+		load_workspace_configuration(&root_owner)
+			.err()
+			.unwrap_or_else(|| panic!("expected config error"))
+			.to_string()
+			.contains("[github].owner must not be empty")
+	);
 
 	let root_repo = fixture_path("config/rejects-empty-github-repo");
-	assert!(load_workspace_configuration(&root_repo)
-		.err()
-		.unwrap_or_else(|| panic!("expected config error"))
-		.to_string()
-		.contains("[github].repo must not be empty"));
+	assert!(
+		load_workspace_configuration(&root_repo)
+			.err()
+			.unwrap_or_else(|| panic!("expected config error"))
+			.to_string()
+			.contains("[github].repo must not be empty")
+	);
 }
 
 #[test]
 fn load_workspace_configuration_rejects_invalid_pull_request_settings() {
 	let root = fixture_path("config/rejects-invalid-pr-settings");
-	assert!(load_workspace_configuration(&root)
-		.err()
-		.unwrap_or_else(|| panic!("expected config error"))
-		.to_string()
-		.contains("[github.pull_requests].branch_prefix must not be empty"));
+	assert!(
+		load_workspace_configuration(&root)
+			.err()
+			.unwrap_or_else(|| panic!("expected config error"))
+			.to_string()
+			.contains("[github.pull_requests].branch_prefix must not be empty")
+	);
 }
 
 #[test]
 fn load_workspace_configuration_rejects_empty_pull_request_base_and_title() {
 	let root_base = fixture_path("config/rejects-empty-pr-base");
-	assert!(load_workspace_configuration(&root_base)
-		.err()
-		.unwrap_or_else(|| panic!("expected config error"))
-		.to_string()
-		.contains("[github.pull_requests].base must not be empty"));
+	assert!(
+		load_workspace_configuration(&root_base)
+			.err()
+			.unwrap_or_else(|| panic!("expected config error"))
+			.to_string()
+			.contains("[github.pull_requests].base must not be empty")
+	);
 
 	let root_title = fixture_path("config/rejects-empty-pr-title");
-	assert!(load_workspace_configuration(&root_title)
-		.err()
-		.unwrap_or_else(|| panic!("expected config error"))
-		.to_string()
-		.contains("[github.pull_requests].title must not be empty"));
+	assert!(
+		load_workspace_configuration(&root_title)
+			.err()
+			.unwrap_or_else(|| panic!("expected config error"))
+			.to_string()
+			.contains("[github.pull_requests].title must not be empty")
+	);
 }
 
 #[test]
 fn load_workspace_configuration_rejects_invalid_github_release_note_source_combinations() {
 	let root = fixture_path("config/rejects-invalid-release-source");
-	assert!(load_workspace_configuration(&root)
-		.err()
-		.unwrap_or_else(|| panic!("expected config error"))
-		.to_string()
-		.contains("generate_notes cannot be true"));
+	assert!(
+		load_workspace_configuration(&root)
+			.err()
+			.unwrap_or_else(|| panic!("expected config error"))
+			.to_string()
+			.contains("generate_notes cannot be true")
+	);
 }
 
 #[test]
 fn load_workspace_configuration_rejects_empty_pull_request_labels() {
 	let root = fixture_path("config/rejects-empty-pr-labels");
-	assert!(load_workspace_configuration(&root)
-		.err()
-		.unwrap_or_else(|| panic!("expected config error"))
-		.to_string()
-		.contains("labels must not include empty values"));
+	assert!(
+		load_workspace_configuration(&root)
+			.err()
+			.unwrap_or_else(|| panic!("expected config error"))
+			.to_string()
+			.contains("labels must not include empty values")
+	);
 }
 
 #[test]
@@ -671,7 +688,9 @@ fn load_workspace_configuration_rejects_invalid_group_changelog_include_members(
 		.err()
 		.unwrap_or_else(|| panic!("expected configuration error"));
 	let rendered = error.render();
-	assert!(rendered.contains("group `sdk` changelog include entry `missing` must reference a package declared in that group"));
+	assert!(rendered.contains(
+		"group `sdk` changelog include entry `missing` must reference a package declared in that group"
+	));
 	assert!(rendered.contains("group changelog include member"));
 }
 
@@ -822,8 +841,10 @@ fn load_workspace_configuration_rejects_duplicate_primary_version_format() {
 	let rendered = error.render();
 
 	assert!(rendered.contains("primary release identity"));
-	assert!(rendered
-		.contains("choose a single package or group as the primary outward release identity"));
+	assert!(
+		rendered
+			.contains("choose a single package or group as the primary outward release identity")
+	);
 }
 
 #[test]
@@ -851,10 +872,12 @@ fn load_workspace_configuration_infers_package_versioned_file_types_from_string_
 		.unwrap_or_else(|| panic!("expected package"));
 
 	assert_eq!(package.versioned_files.len(), 2);
-	assert!(package
-		.versioned_files
-		.iter()
-		.all(|definition| definition.ecosystem_type == Some(EcosystemType::Cargo)));
+	assert!(
+		package
+			.versioned_files
+			.iter()
+			.all(|definition| definition.ecosystem_type == Some(EcosystemType::Cargo))
+	);
 }
 
 #[test]
@@ -1012,9 +1035,11 @@ fn load_workspace_configuration_rejects_empty_lockfile_commands() {
 		.err()
 		.unwrap_or_else(|| panic!("expected configuration error"));
 
-	assert!(error
-		.render()
-		.contains("lockfile_commands must provide a non-empty command"));
+	assert!(
+		error
+			.render()
+			.contains("lockfile_commands must provide a non-empty command")
+	);
 }
 
 #[test]
@@ -1024,9 +1049,11 @@ fn load_workspace_configuration_rejects_empty_lockfile_command_cwds() {
 		.err()
 		.unwrap_or_else(|| panic!("expected configuration error"));
 
-	assert!(error
-		.render()
-		.contains("lockfile_commands must provide a non-empty cwd when set"));
+	assert!(
+		error
+			.render()
+			.contains("lockfile_commands must provide a non-empty cwd when set")
+	);
 }
 
 #[test]
@@ -1036,9 +1063,11 @@ fn load_workspace_configuration_rejects_lockfile_command_cwds_outside_the_worksp
 		.err()
 		.unwrap_or_else(|| panic!("expected configuration error"));
 
-	assert!(error
-		.render()
-		.contains("lockfile_commands cwd `/tmp` must stay within the workspace root"));
+	assert!(
+		error
+			.render()
+			.contains("lockfile_commands cwd `/tmp` must stay within the workspace root")
+	);
 }
 
 #[test]
@@ -1048,9 +1077,11 @@ fn load_workspace_configuration_rejects_missing_lockfile_command_cwds() {
 		.err()
 		.unwrap_or_else(|| panic!("expected configuration error"));
 
-	assert!(error
-		.render()
-		.contains("lockfile_commands cwd `packages/missing` does not exist or is not a directory"));
+	assert!(
+		error.render().contains(
+			"lockfile_commands cwd `packages/missing` does not exist or is not a directory"
+		)
+	);
 }
 
 #[test]
@@ -1286,10 +1317,12 @@ fn load_change_signals_accept_group_scalar_type_shorthand_with_default_bump() {
 	assert_eq!(target.id, "sdk");
 	assert_eq!(target.bump, Some(BumpSeverity::Minor));
 	assert_eq!(target.change_type.as_deref(), Some("test"));
-	assert!(changeset
-		.signals
-		.iter()
-		.all(|signal| signal.requested_bump == Some(BumpSeverity::Minor)));
+	assert!(
+		changeset
+			.signals
+			.iter()
+			.all(|signal| signal.requested_bump == Some(BumpSeverity::Minor))
+	);
 }
 
 #[test]
@@ -1376,9 +1409,11 @@ fn load_change_signals_reject_object_type_when_target_has_no_configured_sections
 	let error = load_change_signals(&root.join("change.md"), &configuration, &packages)
 		.err()
 		.unwrap_or_else(|| panic!("expected parse error"));
-	assert!(error
-		.to_string()
-		.contains("no configured types are available for this target"));
+	assert!(
+		error
+			.to_string()
+			.contains("no configured types are available for this target")
+	);
 }
 
 #[test]
@@ -1432,9 +1467,11 @@ fn load_change_signals_reject_none_bump_without_type_or_version() {
 	let error = load_change_signals(&root.join("change.md"), &configuration, &packages)
 		.err()
 		.unwrap_or_else(|| panic!("expected parse error"));
-	assert!(error
-		.to_string()
-		.contains("must not use `bump = \"none\"` without also declaring `type` or `version`"));
+	assert!(
+		error
+			.to_string()
+			.contains("must not use `bump = \"none\"` without also declaring `type` or `version`")
+	);
 }
 
 #[test]
@@ -1454,9 +1491,11 @@ fn load_change_signals_reject_invalid_object_bumps() {
 	let error = load_change_signals(&root.join("change.md"), &configuration, &packages)
 		.err()
 		.unwrap_or_else(|| panic!("expected parse error"));
-	assert!(error
-		.to_string()
-		.contains("has invalid bump `nope`; expected `none`, `patch`, `minor`, or `major`"));
+	assert!(
+		error
+			.to_string()
+			.contains("has invalid bump `nope`; expected `none`, `patch`, `minor`, or `major`")
+	);
 }
 
 #[test]
@@ -1517,9 +1556,11 @@ fn parse_markdown_change_target_rejects_non_scalar_non_mapping_values() {
 	let error =
 		crate::parse_markdown_change_target(&value, Path::new("change.md"), "core", &configuration)
 			.expect_err("sequence values should fail");
-	assert!(error
-		.to_string()
-		.contains("must map to `none`, `patch`, `minor`, `major`, a configured change type"));
+	assert!(
+		error
+			.to_string()
+			.contains("must map to `none`, `patch`, `minor`, `major`, a configured change type")
+	);
 }
 
 #[test]
@@ -1532,9 +1573,11 @@ fn parse_markdown_change_target_rejects_empty_mapping() {
 	let error =
 		crate::parse_markdown_change_target(&value, Path::new("change.md"), "core", &configuration)
 			.expect_err("empty mapping should fail");
-	assert!(error
-		.to_string()
-		.contains("must declare `bump`, `version`, `type`, or a valid scalar shorthand"));
+	assert!(
+		error
+			.to_string()
+			.contains("must declare `bump`, `version`, `type`, or a valid scalar shorthand")
+	);
 }
 
 #[test]
@@ -1582,9 +1625,11 @@ fn load_change_signals_rejects_unterminated_markdown_frontmatter() {
 	let error = load_change_signals(&root.join("change.md"), &configuration, &packages)
 		.err()
 		.unwrap_or_else(|| panic!("expected parse error"));
-	assert!(error
-		.to_string()
-		.contains("unterminated markdown frontmatter"));
+	assert!(
+		error
+			.to_string()
+			.contains("unterminated markdown frontmatter")
+	);
 }
 
 #[test]
@@ -1660,9 +1705,11 @@ fn load_change_signals_expands_group_targets_into_member_packages() {
 		.unwrap_or_else(|error| panic!("change signals: {error}"));
 
 	assert_eq!(signals.len(), 2);
-	assert!(signals
-		.iter()
-		.all(|signal| signal.requested_bump == Some(BumpSeverity::Minor)));
+	assert!(
+		signals
+			.iter()
+			.all(|signal| signal.requested_bump == Some(BumpSeverity::Minor))
+	);
 }
 
 #[test]
@@ -1781,10 +1828,12 @@ fn load_changeset_file_preserves_group_targets_and_source_paths() {
 	assert_eq!(target.origin, "direct-change");
 	assert_eq!(target.explicit_version, None);
 	assert_eq!(changeset.signals.len(), 2);
-	assert!(changeset
-		.signals
-		.iter()
-		.all(|signal| signal.source_path == root.join("change.md")));
+	assert!(
+		changeset
+			.signals
+			.iter()
+			.all(|signal| signal.source_path == root.join("change.md"))
+	);
 }
 
 #[test]
@@ -1827,9 +1876,11 @@ fn load_workspace_configuration_rejects_publish_github_release_without_github_co
 	let error = load_workspace_configuration(&root)
 		.err()
 		.unwrap_or_else(|| panic!("expected github CLI command config error"));
-	assert!(error
-		.to_string()
-		.contains("uses `PublishRelease` but `[source]` is not configured"));
+	assert!(
+		error
+			.to_string()
+			.contains("uses `PublishRelease` but `[source]` is not configured")
+	);
 }
 
 #[test]
@@ -1838,9 +1889,11 @@ fn load_workspace_configuration_rejects_open_release_pull_request_without_github
 	let error = load_workspace_configuration(&root)
 		.err()
 		.unwrap_or_else(|| panic!("expected github CLI command config error"));
-	assert!(error
-		.to_string()
-		.contains("uses `OpenReleaseRequest` but `[source]` is not configured"));
+	assert!(
+		error
+			.to_string()
+			.contains("uses `OpenReleaseRequest` but `[source]` is not configured")
+	);
 }
 
 #[test]
@@ -1867,10 +1920,12 @@ fn load_workspace_configuration_accepts_comment_released_issues_for_github() {
 	let root = fixture_path("config/accepts-comment-github");
 	let configuration = load_workspace_configuration(&root)
 		.unwrap_or_else(|error| panic!("configuration: {error}"));
-	assert!(configuration
-		.cli
-		.iter()
-		.any(|command| command.name == "comment"));
+	assert!(
+		configuration
+			.cli
+			.iter()
+			.any(|command| command.name == "comment")
+	);
 }
 
 #[test]
@@ -1879,9 +1934,11 @@ fn load_workspace_configuration_rejects_enforce_changeset_policy_without_github_
 	let error = load_workspace_configuration(&root)
 		.err()
 		.unwrap_or_else(|| panic!("expected verification CLI command config error"));
-	assert!(error
-		.to_string()
-		.contains("uses `AffectedPackages` but `[changesets.verify].enabled` is false"));
+	assert!(
+		error
+			.to_string()
+			.contains("uses `AffectedPackages` but `[changesets.verify].enabled` is false")
+	);
 }
 
 #[test]
@@ -1890,9 +1947,11 @@ fn load_workspace_configuration_rejects_affected_packages_without_path_inputs() 
 	let error = load_workspace_configuration(&root)
 		.err()
 		.unwrap_or_else(|| panic!("expected verification CLI command config error"));
-	assert!(error
-		.to_string()
-		.contains("declares neither a `changed_paths` nor a `since` input"));
+	assert!(
+		error
+			.to_string()
+			.contains("declares neither a `changed_paths` nor a `since` input")
+	);
 }
 
 #[test]
@@ -1900,10 +1959,12 @@ fn load_workspace_configuration_accepts_affected_packages_step_input_overrides()
 	let root = fixture_path("config/affected-step-overrides");
 	let configuration = load_workspace_configuration(&root)
 		.unwrap_or_else(|error| panic!("configuration: {error}"));
-	assert!(configuration
-		.cli
-		.iter()
-		.any(|command| command.name == "pr-check"));
+	assert!(
+		configuration
+			.cli
+			.iter()
+			.any(|command| command.name == "pr-check")
+	);
 }
 
 #[test]
@@ -1911,22 +1972,26 @@ fn load_workspace_configuration_accepts_affected_packages_with_since_in_step_ove
 	let root = fixture_path("config/affected-step-since");
 	let configuration = load_workspace_configuration(&root)
 		.unwrap_or_else(|error| panic!("configuration: {error}"));
-	assert!(configuration
-		.cli
-		.iter()
-		.any(|command| command.name == "pr-check"));
+	assert!(
+		configuration
+			.cli
+			.iter()
+			.any(|command| command.name == "pr-check")
+	);
 }
 
 #[test]
-fn load_workspace_configuration_rejects_affected_packages_when_step_override_provides_no_path_source(
-) {
+fn load_workspace_configuration_rejects_affected_packages_when_step_override_provides_no_path_source()
+ {
 	let root = fixture_path("config/rejects-affected-no-source");
 	let error = load_workspace_configuration(&root)
 		.err()
 		.unwrap_or_else(|| panic!("expected config error"));
-	assert!(error
-		.to_string()
-		.contains("declares neither a `changed_paths` nor a `since` input"));
+	assert!(
+		error
+			.to_string()
+			.contains("declares neither a `changed_paths` nor a `since` input")
+	);
 }
 
 #[test]
@@ -2149,9 +2214,11 @@ fn load_workspace_configuration_rejects_unknown_change_template_variables() {
 	let error = load_workspace_configuration(&root)
 		.err()
 		.unwrap_or_else(|| panic!("expected config error"));
-	assert!(error
-		.render()
-		.contains("unsupported variables: commit_hash"));
+	assert!(
+		error
+			.render()
+			.contains("unsupported variables: commit_hash")
+	);
 }
 
 #[test]
@@ -2181,9 +2248,11 @@ fn load_workspace_configuration_rejects_legacy_workflows_namespace() {
 		.err()
 		.unwrap_or_else(|| panic!("expected configuration error"));
 
-	assert!(error
-		.to_string()
-		.contains("legacy `[[workflows]]` configuration is no longer supported"));
+	assert!(
+		error
+			.to_string()
+			.contains("legacy `[[workflows]]` configuration is no longer supported")
+	);
 }
 
 #[test]
@@ -2208,9 +2277,11 @@ fn load_workspace_configuration_rejects_both_source_and_legacy_github_config() {
 	let error = load_workspace_configuration(&root)
 		.err()
 		.unwrap_or_else(|| panic!("expected config error"));
-	assert!(error
-		.to_string()
-		.contains("configure either `[source]` or legacy `[github]`"));
+	assert!(
+		error
+			.to_string()
+			.contains("configure either `[source]` or legacy `[github]`")
+	);
 }
 
 #[test]
@@ -2513,9 +2584,11 @@ fn validate_source_and_changeset_settings_reject_empty_values() {
 		}))
 		.err()
 		.unwrap_or_else(|| panic!("expected source validation error"));
-	assert!(source_error
-		.to_string()
-		.contains("[source].owner must not be empty"));
+	assert!(
+		source_error
+			.to_string()
+			.contains("[source].owner must not be empty")
+	);
 
 	let changeset_error = crate::validate_changesets_configuration(
 		&monochange_core::ChangesetSettings {
@@ -2528,9 +2601,11 @@ fn validate_source_and_changeset_settings_reject_empty_values() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected changeset validation error"));
-	assert!(changeset_error
-		.to_string()
-		.contains("[changesets.verify].skip_labels must not include empty values"));
+	assert!(
+		changeset_error
+			.to_string()
+			.contains("[changesets.verify].skip_labels must not include empty values")
+	);
 }
 
 #[test]
@@ -2548,9 +2623,11 @@ fn validate_package_and_github_settings_cover_duplicate_and_pattern_errors() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected duplicate path error"));
-	assert!(duplicate_path_error
-		.to_string()
-		.contains("package path `crates/core` is already used by `core`"));
+	assert!(
+		duplicate_path_error
+			.to_string()
+			.contains("package path `crates/core` is already used by `core`")
+	);
 
 	let mut primary_core = package_definition("core", "crates/core");
 	primary_core.version_format = monochange_core::VersionFormat::Primary;
@@ -2564,9 +2641,11 @@ fn validate_package_and_github_settings_cover_duplicate_and_pattern_errors() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected duplicate primary error"));
-	assert!(duplicate_primary_error
-		.to_string()
-		.contains("`version_format = \"primary\"` is already used by `core`"));
+	assert!(
+		duplicate_primary_error
+			.to_string()
+			.contains("`version_format = \"primary\"` is already used by `core`")
+	);
 
 	let github_error =
 		crate::validate_github_configuration(Some(&monochange_core::GitHubConfiguration {
@@ -2587,9 +2666,11 @@ fn validate_package_and_github_settings_cover_duplicate_and_pattern_errors() {
 		}))
 		.err()
 		.unwrap_or_else(|| panic!("expected invalid github glob error"));
-	assert!(github_error
-		.to_string()
-		.contains("[github.bot.changesets].changed_paths contains invalid glob pattern"));
+	assert!(
+		github_error
+			.to_string()
+			.contains("[github.bot.changesets].changed_paths contains invalid glob pattern")
+	);
 
 	let package_pattern_error = crate::validate_changesets_configuration(
 		&monochange_core::ChangesetSettings::default(),
@@ -2600,9 +2681,11 @@ fn validate_package_and_github_settings_cover_duplicate_and_pattern_errors() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected invalid package path pattern error"));
-	assert!(package_pattern_error
-		.to_string()
-		.contains("[package.core].ignored_paths must not include empty values"));
+	assert!(
+		package_pattern_error
+			.to_string()
+			.contains("[package.core].ignored_paths must not include empty values")
+	);
 }
 
 #[test]
@@ -2705,9 +2788,11 @@ fn validate_versioned_files_content_rejects_unparseable_version() {
 	let error = crate::validate_versioned_files_content(&root)
 		.err()
 		.unwrap_or_else(|| panic!("expected error for missing version field"));
-	assert!(error
-		.to_string()
-		.contains("does not contain a readable version field"));
+	assert!(
+		error
+			.to_string()
+			.contains("does not contain a readable version field")
+	);
 }
 
 #[test]

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(unused_assignments)]
-#![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
 //! # `monochange_config`
@@ -91,8 +90,6 @@ use miette::Report;
 use miette::SourceSpan;
 use minijinja::Environment;
 use minijinja::UndefinedBehavior;
-use monochange_core::default_cli_commands;
-use monochange_core::relative_to_root;
 use monochange_core::BumpSeverity;
 use monochange_core::ChangeSignal;
 use monochange_core::ChangelogDefinition;
@@ -106,7 +103,6 @@ use monochange_core::CliInputDefinition;
 use monochange_core::CliInputKind;
 use monochange_core::CliStepDefinition;
 use monochange_core::CliStepInputValue;
-
 use monochange_core::Ecosystem;
 use monochange_core::EcosystemSettings;
 use monochange_core::EcosystemType;
@@ -133,6 +129,8 @@ use monochange_core::VersionGroup;
 use monochange_core::VersionedFileDefinition;
 use monochange_core::WorkspaceConfiguration;
 use monochange_core::WorkspaceDefaults;
+use monochange_core::default_cli_commands;
+use monochange_core::relative_to_root;
 use regex::Regex;
 use semver::Version;
 use serde::Deserialize;
@@ -636,20 +634,24 @@ fn render_changelog_path_template(template: &str, package_path: &Path) -> String
 impl RawChangelogConfig {
 	fn as_defaults_definition(&self) -> ChangelogDefinition {
 		match self {
-			Self::Legacy(definition) => match definition {
-				RawChangelogDefinition::Enabled(false) => ChangelogDefinition::Disabled,
-				RawChangelogDefinition::Enabled(true) => ChangelogDefinition::PackageDefault,
-				RawChangelogDefinition::Path(path_pattern) => {
-					ChangelogDefinition::PathPattern(path_pattern.clone())
+			Self::Legacy(definition) => {
+				match definition {
+					RawChangelogDefinition::Enabled(false) => ChangelogDefinition::Disabled,
+					RawChangelogDefinition::Enabled(true) => ChangelogDefinition::PackageDefault,
+					RawChangelogDefinition::Path(path_pattern) => {
+						ChangelogDefinition::PathPattern(path_pattern.clone())
+					}
 				}
-			},
-			Self::Detailed(table) => match (table.enabled.unwrap_or(true), &table.path) {
-				(false, _) => ChangelogDefinition::Disabled,
-				(true, Some(path_pattern)) => {
-					ChangelogDefinition::PathPattern(path_pattern.clone())
+			}
+			Self::Detailed(table) => {
+				match (table.enabled.unwrap_or(true), &table.path) {
+					(false, _) => ChangelogDefinition::Disabled,
+					(true, Some(path_pattern)) => {
+						ChangelogDefinition::PathPattern(path_pattern.clone())
+					}
+					(true, None) => ChangelogDefinition::PackageDefault,
 				}
-				(true, None) => ChangelogDefinition::PackageDefault,
-			},
+			}
 		}
 	}
 
@@ -682,20 +684,24 @@ impl RawChangelogConfig {
 		treat_string_as_pattern: bool,
 	) -> Option<PathBuf> {
 		match self {
-			Self::Legacy(definition) => match definition {
-				RawChangelogDefinition::Enabled(false) => None,
-				RawChangelogDefinition::Enabled(true) => Some(package_path.join("CHANGELOG.md")),
-				RawChangelogDefinition::Path(path) => {
-					if treat_string_as_pattern {
-						Some(PathBuf::from(render_changelog_path_template(
-							path,
-							package_path,
-						)))
-					} else {
-						Some(PathBuf::from(path))
+			Self::Legacy(definition) => {
+				match definition {
+					RawChangelogDefinition::Enabled(false) => None,
+					RawChangelogDefinition::Enabled(true) => {
+						Some(package_path.join("CHANGELOG.md"))
+					}
+					RawChangelogDefinition::Path(path) => {
+						if treat_string_as_pattern {
+							Some(PathBuf::from(render_changelog_path_template(
+								path,
+								package_path,
+							)))
+						} else {
+							Some(PathBuf::from(path))
+						}
 					}
 				}
-			},
+			}
 			Self::Detailed(table) => {
 				if matches!(table.enabled, Some(false)) {
 					return None;
@@ -719,10 +725,12 @@ impl RawChangelogConfig {
 
 	fn resolve_for_group(&self) -> Option<PathBuf> {
 		match self {
-			Self::Legacy(definition) => match definition {
-				RawChangelogDefinition::Enabled(false | true) => None,
-				RawChangelogDefinition::Path(path) => Some(PathBuf::from(path)),
-			},
+			Self::Legacy(definition) => {
+				match definition {
+					RawChangelogDefinition::Enabled(false | true) => None,
+					RawChangelogDefinition::Path(path) => Some(PathBuf::from(path)),
+				}
+			}
 			Self::Detailed(table) => {
 				if matches!(table.enabled, Some(false)) {
 					return None;
@@ -1107,87 +1115,95 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 			comment_on_failure: changesets.verify.comment_on_failure,
 		},
 	};
-	let source = source.map(|source| SourceConfiguration {
-		provider: source.provider,
-		owner: source.owner,
-		repo: source.repo,
-		host: source.host,
-		api_url: source.api_url,
-		releases: ProviderReleaseSettings {
-			enabled: source.releases.enabled,
-			draft: source.releases.draft,
-			prerelease: source.releases.prerelease,
-			generate_notes: source.releases.generate_notes,
-			source: source.releases.source,
-		},
-		pull_requests: ProviderMergeRequestSettings {
-			enabled: source.pull_requests.enabled,
-			branch_prefix: source.pull_requests.branch_prefix,
-			base: source.pull_requests.base,
-			title: source.pull_requests.title,
-			labels: source.pull_requests.labels,
-			auto_merge: source.pull_requests.auto_merge,
-		},
-		bot: ProviderBotSettings {
-			changesets: ProviderChangesetBotSettings {
-				enabled: source.bot.changesets.enabled,
-				required: source.bot.changesets.required,
-				skip_labels: source.bot.changesets.skip_labels,
-				comment_on_failure: source.bot.changesets.comment_on_failure,
-				changed_paths: source.bot.changesets.changed_paths,
-				ignored_paths: source.bot.changesets.ignored_paths,
-			},
-		},
-	});
-	let legacy_github = if let Some(source) = &source {
-		(source.provider == SourceProvider::GitHub).then(|| GitHubConfiguration {
-			owner: source.owner.clone(),
-			repo: source.repo.clone(),
-			releases: source.releases.clone(),
-			pull_requests: source.pull_requests.clone(),
-			bot: source.bot.clone(),
-		})
-	} else {
-		github.map(|github| GitHubConfiguration {
-			owner: github.owner,
-			repo: github.repo,
+	let source = source.map(|source| {
+		SourceConfiguration {
+			provider: source.provider,
+			owner: source.owner,
+			repo: source.repo,
+			host: source.host,
+			api_url: source.api_url,
 			releases: ProviderReleaseSettings {
-				enabled: github.releases.enabled,
-				draft: github.releases.draft,
-				prerelease: github.releases.prerelease,
-				generate_notes: github.releases.generate_notes,
-				source: github.releases.source,
+				enabled: source.releases.enabled,
+				draft: source.releases.draft,
+				prerelease: source.releases.prerelease,
+				generate_notes: source.releases.generate_notes,
+				source: source.releases.source,
 			},
 			pull_requests: ProviderMergeRequestSettings {
-				enabled: github.pull_requests.enabled,
-				branch_prefix: github.pull_requests.branch_prefix,
-				base: github.pull_requests.base,
-				title: github.pull_requests.title,
-				labels: github.pull_requests.labels,
-				auto_merge: github.pull_requests.auto_merge,
+				enabled: source.pull_requests.enabled,
+				branch_prefix: source.pull_requests.branch_prefix,
+				base: source.pull_requests.base,
+				title: source.pull_requests.title,
+				labels: source.pull_requests.labels,
+				auto_merge: source.pull_requests.auto_merge,
 			},
 			bot: ProviderBotSettings {
 				changesets: ProviderChangesetBotSettings {
-					enabled: github.bot.changesets.enabled,
-					required: github.bot.changesets.required,
-					skip_labels: github.bot.changesets.skip_labels,
-					comment_on_failure: github.bot.changesets.comment_on_failure,
-					changed_paths: github.bot.changesets.changed_paths,
-					ignored_paths: github.bot.changesets.ignored_paths,
+					enabled: source.bot.changesets.enabled,
+					required: source.bot.changesets.required,
+					skip_labels: source.bot.changesets.skip_labels,
+					comment_on_failure: source.bot.changesets.comment_on_failure,
+					changed_paths: source.bot.changesets.changed_paths,
+					ignored_paths: source.bot.changesets.ignored_paths,
 				},
 			},
+		}
+	});
+	let legacy_github = if let Some(source) = &source {
+		(source.provider == SourceProvider::GitHub).then(|| {
+			GitHubConfiguration {
+				owner: source.owner.clone(),
+				repo: source.repo.clone(),
+				releases: source.releases.clone(),
+				pull_requests: source.pull_requests.clone(),
+				bot: source.bot.clone(),
+			}
+		})
+	} else {
+		github.map(|github| {
+			GitHubConfiguration {
+				owner: github.owner,
+				repo: github.repo,
+				releases: ProviderReleaseSettings {
+					enabled: github.releases.enabled,
+					draft: github.releases.draft,
+					prerelease: github.releases.prerelease,
+					generate_notes: github.releases.generate_notes,
+					source: github.releases.source,
+				},
+				pull_requests: ProviderMergeRequestSettings {
+					enabled: github.pull_requests.enabled,
+					branch_prefix: github.pull_requests.branch_prefix,
+					base: github.pull_requests.base,
+					title: github.pull_requests.title,
+					labels: github.pull_requests.labels,
+					auto_merge: github.pull_requests.auto_merge,
+				},
+				bot: ProviderBotSettings {
+					changesets: ProviderChangesetBotSettings {
+						enabled: github.bot.changesets.enabled,
+						required: github.bot.changesets.required,
+						skip_labels: github.bot.changesets.skip_labels,
+						comment_on_failure: github.bot.changesets.comment_on_failure,
+						changed_paths: github.bot.changesets.changed_paths,
+						ignored_paths: github.bot.changesets.ignored_paths,
+					},
+				},
+			}
 		})
 	};
 	let source = source.or_else(|| {
-		legacy_github.as_ref().map(|github| SourceConfiguration {
-			provider: SourceProvider::GitHub,
-			owner: github.owner.clone(),
-			repo: github.repo.clone(),
-			host: None,
-			api_url: None,
-			releases: github.releases.clone(),
-			pull_requests: github.pull_requests.clone(),
-			bot: github.bot.clone(),
+		legacy_github.as_ref().map(|github| {
+			SourceConfiguration {
+				provider: SourceProvider::GitHub,
+				owner: github.owner.clone(),
+				repo: github.repo.clone(),
+				host: None,
+				api_url: None,
+				releases: github.releases.clone(),
+				pull_requests: github.pull_requests.clone(),
+				bot: github.bot.clone(),
+			}
 		})
 	});
 
@@ -1337,12 +1353,14 @@ pub fn load_changeset_file(
 			let explicit_version = change.version.clone();
 			let inferred_bump = match change.bump {
 				Some(bump) => Some(bump),
-				None => infer_group_bump_from_explicit_version(
-					group,
-					&configuration.root_path,
-					packages,
-					explicit_version.as_ref(),
-				)?,
+				None => {
+					infer_group_bump_from_explicit_version(
+						group,
+						&configuration.root_path,
+						packages,
+						explicit_version.as_ref(),
+					)?
+				}
 			};
 			targets.push(LoadedChangesetTarget {
 				id: change.package.clone(),
@@ -1509,14 +1527,18 @@ pub fn resolve_package_reference(
 ) -> MonochangeResult<String> {
 	let matching_package_ids = find_matching_package_ids(reference, workspace_root, packages);
 	match matching_package_ids.as_slice() {
-		[] => Err(MonochangeError::Config(format!(
-			"change package reference `{reference}` did not match any discovered package"
-		))),
+		[] => {
+			Err(MonochangeError::Config(format!(
+				"change package reference `{reference}` did not match any discovered package"
+			)))
+		}
 		[package_id] => Ok(package_id.clone()),
-		_ => Err(MonochangeError::Config(format!(
-			"change package reference `{reference}` matched multiple packages: {}",
-			matching_package_ids.join(", ")
-		))),
+		_ => {
+			Err(MonochangeError::Config(format!(
+				"change package reference `{reference}` matched multiple packages: {}",
+				matching_package_ids.join(", ")
+			)))
+		}
 	}
 }
 
@@ -2176,9 +2198,10 @@ fn validate_versioned_files(
 			));
 		};
 
-		if let Some(name) = &versioned_file.name {
-			if !declared_packages.contains(name.as_str()) {
-				return Err(config_diagnostic(
+		if let Some(name) = &versioned_file.name
+			&& !declared_packages.contains(name.as_str())
+		{
+			return Err(config_diagnostic(
 					config_contents,
 					format!(
 						"{owner_id} references unknown versioned file name `{name}`"
@@ -2192,7 +2215,6 @@ fn validate_versioned_files(
 					)],
 					Some("reference a declared package id from `versioned_files` or remove the name entry".to_string()),
 				));
-			}
 		}
 		if path_uses_glob(&versioned_file.path) {
 			let pattern = root
@@ -2694,14 +2716,14 @@ fn validate_cli(cli: &[CliCommandDefinition]) -> MonochangeResult<()> {
 
 		let mut seen_step_ids: BTreeSet<String> = BTreeSet::new();
 		for step in &cli_command.steps {
-			if let Some(condition) = step.when() {
-				if condition.trim().is_empty() {
-					return Err(MonochangeError::Config(format!(
-						"CLI command `{}` step `{}` has an empty `when` condition",
-						cli_command.name,
-						step.kind_name()
-					)));
-				}
+			if let Some(condition) = step.when()
+				&& condition.trim().is_empty()
+			{
+				return Err(MonochangeError::Config(format!(
+					"CLI command `{}` step `{}` has an empty `when` condition",
+					cli_command.name,
+					step.kind_name()
+				)));
 			}
 			for input_name in step.inputs().keys() {
 				if input_name.trim().is_empty() {
@@ -2828,8 +2850,7 @@ fn validate_cli_runtime_requirements(
 			if !source_capabilities(source.provider).released_issue_comments {
 				return Err(MonochangeError::Config(format!(
 					"CLI command `{}` uses `CommentReleasedIssues` but `[source].provider = \"{}\"` does not support released-issue comments",
-					cli_command.name,
-					source.provider
+					cli_command.name, source.provider
 				)));
 			}
 		}
@@ -2853,13 +2874,13 @@ fn validate_cli_runtime_requirements(
 						cli_command.name
 					)));
 				}
-				if let Some(label_input) = cli_command_input(cli_command, "label") {
-					if !matches!(label_input.kind, CliInputKind::StringList) {
-						return Err(MonochangeError::Config(format!(
-							"CLI command `{}` input `label` must use type `string_list` when used with `AffectedPackages`",
-							cli_command.name
-						)));
-					}
+				if let Some(label_input) = cli_command_input(cli_command, "label")
+					&& !matches!(label_input.kind, CliInputKind::StringList)
+				{
+					return Err(MonochangeError::Config(format!(
+						"CLI command `{}` input `label` must use type `string_list` when used with `AffectedPackages`",
+						cli_command.name
+					)));
 				}
 				validate_step_override_kind(
 					cli_command,
@@ -2955,34 +2976,38 @@ fn validate_step_input_overrides(
 
 	for (name, value) in overrides {
 		// Reject unknown input names (Command steps accept anything).
-		if let Some(names) = valid_names {
-			if !names.contains(&name.as_str()) {
-				let available = if names.is_empty() {
-					"this step accepts no inputs".to_string()
-				} else {
-					format!("valid inputs: {}", names.join(", "))
-				};
-				return Err(MonochangeError::Config(format!(
-					"CLI command `{}` step `{}` has unknown input override `{}`; {}",
-					cli_command.name,
-					step.kind_name(),
-					name,
-					available,
-				)));
-			}
+		if let Some(names) = valid_names
+			&& !names.contains(&name.as_str())
+		{
+			let available = if names.is_empty() {
+				"this step accepts no inputs".to_string()
+			} else {
+				format!("valid inputs: {}", names.join(", "))
+			};
+			return Err(MonochangeError::Config(format!(
+				"CLI command `{}` step `{}` has unknown input override `{}`; {}",
+				cli_command.name,
+				step.kind_name(),
+				name,
+				available,
+			)));
 		}
 
 		// Validate value type against expected kind.
 		if let Some(expected_kind) = step.expected_input_kind(name) {
 			let type_ok = match expected_kind {
-				CliInputKind::Boolean => matches!(
-					value,
-					CliStepInputValue::Boolean(_) | CliStepInputValue::String(_)
-				),
-				CliInputKind::StringList => matches!(
-					value,
-					CliStepInputValue::String(_) | CliStepInputValue::List(_)
-				),
+				CliInputKind::Boolean => {
+					matches!(
+						value,
+						CliStepInputValue::Boolean(_) | CliStepInputValue::String(_)
+					)
+				}
+				CliInputKind::StringList => {
+					matches!(
+						value,
+						CliStepInputValue::String(_) | CliStepInputValue::List(_)
+					)
+				}
 				CliInputKind::String | CliInputKind::Path | CliInputKind::Choice => {
 					matches!(value, CliStepInputValue::String(_))
 				}
@@ -3604,8 +3629,8 @@ fn validate_ecosystem_version_readable(
 		EcosystemType::Npm | EcosystemType::Deno => {
 			let json: serde_json::Value = serde_json::from_str(&contents).map_err(|error| {
 				MonochangeError::Config(format!(
-						"{owner_kind} `{owner_id}` versioned file `{display_path}` is not valid JSON: {error}"
-					))
+					"{owner_kind} `{owner_id}` versioned file `{display_path}` is not valid JSON: {error}"
+				))
 			})?;
 
 			let field_name = match fields {

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -4,9 +4,6 @@ use std::path::PathBuf;
 use semver::Version;
 use serde_json::json;
 
-use crate::default_cli_commands;
-use crate::materialize_dependency_edges;
-use crate::render_release_notes;
 use crate::BumpSeverity;
 use crate::ChangelogFormat;
 use crate::ChangelogTarget;
@@ -14,9 +11,6 @@ use crate::ChangesetPolicyStatus;
 use crate::ChangesetVerificationSettings;
 use crate::CliStepDefinition;
 use crate::DependencyKind;
-
-use crate::git::git_checkout_branch_command;
-use crate::git::git_push_branch_command;
 use crate::Ecosystem;
 use crate::EcosystemSettings;
 use crate::GroupChangelogInclude;
@@ -26,6 +20,11 @@ use crate::PackageDependency;
 use crate::PackageRecord;
 use crate::PackageType;
 use crate::PublishState;
+use crate::RELEASE_RECORD_END_MARKER;
+use crate::RELEASE_RECORD_HEADING;
+use crate::RELEASE_RECORD_KIND;
+use crate::RELEASE_RECORD_SCHEMA_VERSION;
+use crate::RELEASE_RECORD_START_MARKER;
 use crate::ReleaseNotesDocument;
 use crate::ReleaseNotesSection;
 use crate::ReleaseNotesSettings;
@@ -47,11 +46,11 @@ use crate::VersionFormat;
 use crate::VersionedFileDefinition;
 use crate::WorkspaceConfiguration;
 use crate::WorkspaceDefaults;
-use crate::RELEASE_RECORD_END_MARKER;
-use crate::RELEASE_RECORD_HEADING;
-use crate::RELEASE_RECORD_KIND;
-use crate::RELEASE_RECORD_SCHEMA_VERSION;
-use crate::RELEASE_RECORD_START_MARKER;
+use crate::default_cli_commands;
+use crate::git::git_checkout_branch_command;
+use crate::git::git_push_branch_command;
+use crate::materialize_dependency_edges;
+use crate::render_release_notes;
 
 #[test]
 fn git_checkout_branch_command_builds_expected_arguments() {
@@ -107,9 +106,11 @@ fn versioned_file_definition_uses_regex_returns_false_when_unset() {
 
 #[test]
 fn workspace_defaults_default_has_no_extra_changelog_sections() {
-	assert!(WorkspaceDefaults::default()
-		.extra_changelog_sections
-		.is_empty());
+	assert!(
+		WorkspaceDefaults::default()
+			.extra_changelog_sections
+			.is_empty()
+	);
 }
 
 #[test]
@@ -1535,9 +1536,11 @@ fn json_helper_functions_cover_error_paths() {
 	let locate_error = crate::find_json_object_field_value_span("[]", 0, "name")
 		.err()
 		.unwrap_or_else(|| panic!("expected locate error"));
-	assert!(locate_error
-		.to_string()
-		.contains("expected JSON object when locating field"));
+	assert!(
+		locate_error
+			.to_string()
+			.contains("expected JSON object when locating field")
+	);
 
 	for (contents, key) in [
 		("{1:2}", "a"),

--- a/crates/monochange_core/src/git.rs
+++ b/crates/monochange_core/src/git.rs
@@ -82,11 +82,7 @@ pub fn git_stderr_trimmed(output: &Output) -> String {
 pub fn git_error_detail(output: &Output) -> String {
 	let stdout = git_stdout_trimmed(output);
 	let stderr = git_stderr_trimmed(output);
-	if stderr.is_empty() {
-		stdout
-	} else {
-		stderr
-	}
+	if stderr.is_empty() { stdout } else { stderr }
 }
 
 #[must_use]

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -1,4 +1,3 @@
-#![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
 //! # `monochange_core`
@@ -78,8 +77,7 @@ pub const DEFAULT_RELEASE_TITLE_NAMESPACED: &str = "{{ id }} {{ version }} ({{ d
 pub const DEFAULT_CHANGELOG_VERSION_TITLE_PRIMARY: &str =
 	"{% if tag_url %}[{{ version }}]({{ tag_url }}){% else %}{{ version }}{% endif %} ({{ date }})";
 /// Default changelog version title for namespaced versioning (markdown-linked when source configured).
-pub const DEFAULT_CHANGELOG_VERSION_TITLE_NAMESPACED: &str =
-	"{% if tag_url %}{{ id }} [{{ version }}]({{ tag_url }}){% else %}{{ id }} {{ version }}{% endif %} ({{ date }})";
+pub const DEFAULT_CHANGELOG_VERSION_TITLE_NAMESPACED: &str = "{% if tag_url %}{{ id }} [{{ version }}]({{ tag_url }}){% else %}{{ id }} {{ version }}{% endif %} ({{ date }})";
 
 #[derive(Debug, Error)]
 pub enum MonochangeError {
@@ -462,12 +460,11 @@ pub fn update_json_manifest_text(
 ) -> MonochangeResult<String> {
 	let root_start = json_root_object_start(contents)?;
 	let mut replacements = Vec::<(JsonSpan, String)>::new();
-	if let Some(owner_version) = owner_version {
-		if let Some(span) = find_json_object_field_value_span(contents, root_start, "version")?
+	if let Some(owner_version) = owner_version
+		&& let Some(span) = find_json_object_field_value_span(contents, root_start, "version")?
 			.filter(|span| json_span_is_string(contents, *span))
-		{
-			replacements.push((span, render_json_string(owner_version)?));
-		}
+	{
+		replacements.push((span, render_json_string(owner_version)?));
 	}
 	for field in fields {
 		let Some(section_span) = find_json_object_field_value_span(contents, root_start, field)?
@@ -595,9 +592,11 @@ fn skip_json_value(contents: &str, start: usize) -> MonochangeResult<usize> {
 		Some(b'{') => skip_json_object(contents, cursor),
 		Some(b'[') => skip_json_array(contents, cursor),
 		Some(_) => Ok(skip_json_primitive(contents, cursor)),
-		None => Err(MonochangeError::Config(
-			"unexpected end of JSON input".to_string(),
-		)),
+		None => {
+			Err(MonochangeError::Config(
+				"unexpected end of JSON input".to_string(),
+			))
+		}
 	}
 }
 
@@ -612,12 +611,12 @@ fn skip_json_object(contents: &str, object_start: usize) -> MonochangeResult<usi
 			Some(_) => {
 				return Err(MonochangeError::Config(
 					"expected JSON object key".to_string(),
-				))
+				));
 			}
 			None => {
 				return Err(MonochangeError::Config(
 					"unterminated JSON object".to_string(),
-				))
+				));
 			}
 		}
 		let (_, next) = parse_json_string_span(contents, cursor)?;
@@ -671,14 +670,14 @@ fn skip_json_array(contents: &str, array_start: usize) -> MonochangeResult<usize
 					None => {
 						return Err(MonochangeError::Config(
 							"unterminated JSON array".to_string(),
-						))
+						));
 					}
 				}
 			}
 			None => {
 				return Err(MonochangeError::Config(
 					"unterminated JSON array".to_string(),
-				))
+				));
 			}
 		}
 	}
@@ -1028,9 +1027,11 @@ where
 	D: serde::Deserializer<'de>,
 {
 	let value = Option::<CliInputDefault>::deserialize(deserializer)?;
-	Ok(value.map(|value| match value {
-		CliInputDefault::String(value) => value,
-		CliInputDefault::Boolean(value) => value.to_string(),
+	Ok(value.map(|value| {
+		match value {
+			CliInputDefault::String(value) => value,
+			CliInputDefault::Boolean(value) => value.to_string(),
+		}
 	}))
 }
 
@@ -1338,16 +1339,18 @@ impl CliStepDefinition {
 			| Self::PublishRelease { .. }
 			| Self::OpenReleaseRequest { .. }
 			| Self::CommentReleasedIssues { .. } => Some(&["format"]),
-			Self::CreateChangeFile { .. } => Some(&[
-				"interactive",
-				"package",
-				"bump",
-				"version",
-				"reason",
-				"type",
-				"details",
-				"output",
-			]),
+			Self::CreateChangeFile { .. } => {
+				Some(&[
+					"interactive",
+					"package",
+					"bump",
+					"version",
+					"reason",
+					"type",
+					"details",
+					"output",
+				])
+			}
 			Self::AffectedPackages { .. } => {
 				Some(&["format", "changed_paths", "since", "verify", "label"])
 			}
@@ -1371,35 +1374,45 @@ impl CliStepDefinition {
 			| Self::PrepareRelease { .. }
 			| Self::PublishRelease { .. }
 			| Self::OpenReleaseRequest { .. }
-			| Self::CommentReleasedIssues { .. } => match name {
-				"format" => Some(CliInputKind::Choice),
-				_ => None,
-			},
-			Self::CreateChangeFile { .. } => match name {
-				"interactive" => Some(CliInputKind::Boolean),
-				"package" => Some(CliInputKind::StringList),
-				"bump" => Some(CliInputKind::Choice),
-				"version" | "reason" | "type" | "details" => Some(CliInputKind::String),
-				"output" => Some(CliInputKind::Path),
-				_ => None,
-			},
-			Self::AffectedPackages { .. } => match name {
-				"format" => Some(CliInputKind::Choice),
-				"changed_paths" | "label" => Some(CliInputKind::StringList),
-				"since" => Some(CliInputKind::String),
-				"verify" => Some(CliInputKind::Boolean),
-				_ => None,
-			},
-			Self::DiagnoseChangesets { .. } => match name {
-				"format" => Some(CliInputKind::Choice),
-				"changeset" => Some(CliInputKind::StringList),
-				_ => None,
-			},
-			Self::RetargetRelease { .. } => match name {
-				"from" | "target" => Some(CliInputKind::String),
-				"force" | "sync_provider" => Some(CliInputKind::Boolean),
-				_ => None,
-			},
+			| Self::CommentReleasedIssues { .. } => {
+				match name {
+					"format" => Some(CliInputKind::Choice),
+					_ => None,
+				}
+			}
+			Self::CreateChangeFile { .. } => {
+				match name {
+					"interactive" => Some(CliInputKind::Boolean),
+					"package" => Some(CliInputKind::StringList),
+					"bump" => Some(CliInputKind::Choice),
+					"version" | "reason" | "type" | "details" => Some(CliInputKind::String),
+					"output" => Some(CliInputKind::Path),
+					_ => None,
+				}
+			}
+			Self::AffectedPackages { .. } => {
+				match name {
+					"format" => Some(CliInputKind::Choice),
+					"changed_paths" | "label" => Some(CliInputKind::StringList),
+					"since" => Some(CliInputKind::String),
+					"verify" => Some(CliInputKind::Boolean),
+					_ => None,
+				}
+			}
+			Self::DiagnoseChangesets { .. } => {
+				match name {
+					"format" => Some(CliInputKind::Choice),
+					"changeset" => Some(CliInputKind::StringList),
+					_ => None,
+				}
+			}
+			Self::RetargetRelease { .. } => {
+				match name {
+					"from" | "target" => Some(CliInputKind::String),
+					"force" | "sync_provider" => Some(CliInputKind::Boolean),
+					_ => None,
+				}
+			}
 		}
 	}
 }

--- a/crates/monochange_dart/src/__tests.rs
+++ b/crates/monochange_dart/src/__tests.rs
@@ -8,6 +8,7 @@ use monochange_core::PublishState;
 use semver::Version;
 use serde_yaml_ng::Value;
 
+use crate::DartVersionedFileKind;
 use crate::adapter;
 use crate::default_lockfile_commands;
 use crate::discover_dart_packages;
@@ -24,7 +25,6 @@ use crate::yaml_array_strings;
 use crate::yaml_bool;
 use crate::yaml_mapping;
 use crate::yaml_string;
-use crate::DartVersionedFileKind;
 
 #[test]
 fn discovers_dart_workspace_packages() {
@@ -33,14 +33,18 @@ fn discovers_dart_workspace_packages() {
 		.unwrap_or_else(|error| panic!("dart discovery: {error}"));
 
 	assert_eq!(discovery.packages.len(), 2);
-	assert!(discovery
-		.packages
-		.iter()
-		.any(|package| package.name == "dart_shared"));
-	assert!(discovery
-		.packages
-		.iter()
-		.any(|package| package.name == "dart_app"));
+	assert!(
+		discovery
+			.packages
+			.iter()
+			.any(|package| package.name == "dart_shared")
+	);
+	assert!(
+		discovery
+			.packages
+			.iter()
+			.any(|package| package.name == "dart_app")
+	);
 }
 
 #[test]
@@ -50,10 +54,12 @@ fn marks_flutter_packages_with_flutter_ecosystem() {
 	let discovery = discover_dart_packages(&fixture_root)
 		.unwrap_or_else(|error| panic!("flutter discovery: {error}"));
 
-	assert!(discovery
-		.packages
-		.iter()
-		.all(|package| package.ecosystem.as_str() == "flutter"));
+	assert!(
+		discovery
+			.packages
+			.iter()
+			.all(|package| package.ecosystem.as_str() == "flutter")
+	);
 }
 
 #[test]
@@ -339,10 +345,9 @@ fn workspace_and_manifest_helpers_cover_yaml_and_error_paths() {
 	let discovery = discover_workspace_packages(&workspace_manifest)
 		.unwrap_or_else(|error| panic!("workspace discovery: {error}"));
 	assert_eq!(discovery.0.len(), 2);
-	assert!(discovery
-		.1
-		.iter()
-		.any(|warning| warning.contains("missing/*") && warning.contains("matched no packages")));
+	assert!(discovery.1.iter().any(|warning| {
+		warning.contains("missing/*") && warning.contains("matched no packages")
+	}));
 
 	let nameless_manifest: serde_yaml_ng::Mapping = serde_yaml_ng::from_str(
 		r"
@@ -360,16 +365,20 @@ dependencies:
 	let invalid_workspace_error = has_workspace_section(&invalid_workspace)
 		.err()
 		.unwrap_or_else(|| panic!("expected invalid workspace error"));
-	assert!(invalid_workspace_error
-		.to_string()
-		.contains("failed to parse"));
+	assert!(
+		invalid_workspace_error
+			.to_string()
+			.contains("failed to parse")
+	);
 
 	let invalid_package = Path::new(env!("CARGO_MANIFEST_DIR"))
 		.join("../../fixtures/tests/dart/invalid-package/invalid-package.yaml");
 	let invalid_package_error = parse_manifest(&invalid_package, Path::new("."))
 		.err()
 		.unwrap_or_else(|| panic!("expected invalid package error"));
-	assert!(invalid_package_error
-		.to_string()
-		.contains("failed to parse"));
+	assert!(
+		invalid_package_error
+			.to_string()
+			.contains("failed to parse")
+	);
 }

--- a/crates/monochange_dart/src/lib.rs
+++ b/crates/monochange_dart/src/lib.rs
@@ -1,4 +1,3 @@
-#![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
 //! # `monochange_dart`
@@ -40,7 +39,6 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use glob::glob;
-use monochange_core::normalize_path;
 use monochange_core::AdapterDiscovery;
 use monochange_core::DependencyKind;
 use monochange_core::Ecosystem;
@@ -52,6 +50,7 @@ use monochange_core::PackageDependency;
 use monochange_core::PackageRecord;
 use monochange_core::PublishState;
 use monochange_core::ShellConfig;
+use monochange_core::normalize_path;
 use semver::Version;
 use serde_yaml_ng::Mapping;
 use serde_yaml_ng::Value;
@@ -114,13 +113,15 @@ pub fn default_lockfile_commands(package: &PackageRecord) -> Vec<LockfileCommand
 	};
 	discover_lockfiles(package)
 		.into_iter()
-		.map(|lockfile| LockfileCommandExecution {
-			command: command.to_string(),
-			cwd: lockfile
-				.parent()
-				.unwrap_or(&package.workspace_root)
-				.to_path_buf(),
-			shell: ShellConfig::None,
+		.map(|lockfile| {
+			LockfileCommandExecution {
+				command: command.to_string(),
+				cwd: lockfile
+					.parent()
+					.unwrap_or(&package.workspace_root)
+					.to_path_buf(),
+				shell: ShellConfig::None,
+			}
 		})
 		.collect()
 }
@@ -153,13 +154,13 @@ pub fn update_manifest_text(
 	})?;
 	let line_ranges = yaml_line_ranges(contents);
 	let mut replacements = Vec::<((usize, usize), String)>::new();
-	if let Some(owner_version) = owner_version {
-		if let Some(span) = find_yaml_scalar_for_key(contents, &line_ranges, 0, "version") {
-			replacements.push((
-				span,
-				render_yaml_scalar(&contents[span.0..span.1], owner_version),
-			));
-		}
+	if let Some(owner_version) = owner_version
+		&& let Some(span) = find_yaml_scalar_for_key(contents, &line_ranges, 0, "version")
+	{
+		replacements.push((
+			span,
+			render_yaml_scalar(&contents[span.0..span.1], owner_version),
+		));
 	}
 	for field in fields {
 		let Some(section_index) = find_yaml_key_line(contents, &line_ranges, 0, field) else {
@@ -176,7 +177,7 @@ pub fn update_manifest_text(
 			}
 		}
 	}
-	replacements.sort_by(|left, right| right.0 .0.cmp(&left.0 .0));
+	replacements.sort_by(|left, right| right.0.0.cmp(&left.0.0));
 	let mut updated = contents.to_string();
 	for ((start, end), replacement) in replacements {
 		updated.replace_range(start..end, &replacement);
@@ -515,18 +516,22 @@ fn parse_dependencies(parsed: &Mapping) -> Vec<PackageDependency> {
 		.into_iter()
 		.filter_map(|section| yaml_mapping(parsed, section))
 		.flat_map(|dependencies| {
-			dependencies.iter().map(|(name, value)| PackageDependency {
-				name: name.as_str().unwrap_or_default().to_string(),
-				kind: DependencyKind::Runtime,
-				version_constraint: match value {
-					Value::String(text) => Some(text.clone()),
-					Value::Mapping(mapping) => mapping
-						.get(Value::String("version".to_string()))
-						.and_then(Value::as_str)
-						.map(ToString::to_string),
-					_ => None,
-				},
-				optional: false,
+			dependencies.iter().map(|(name, value)| {
+				PackageDependency {
+					name: name.as_str().unwrap_or_default().to_string(),
+					kind: DependencyKind::Runtime,
+					version_constraint: match value {
+						Value::String(text) => Some(text.clone()),
+						Value::Mapping(mapping) => {
+							mapping
+								.get(Value::String("version".to_string()))
+								.and_then(Value::as_str)
+								.map(ToString::to_string)
+						}
+						_ => None,
+					},
+					optional: false,
+				}
 			})
 		})
 		.filter(|dependency| !dependency.name.is_empty())

--- a/crates/monochange_deno/src/__tests.rs
+++ b/crates/monochange_deno/src/__tests.rs
@@ -2,21 +2,21 @@ use std::collections::BTreeMap;
 use std::path::Path;
 use std::path::PathBuf;
 
-use monochange_core::materialize_dependency_edges;
 use monochange_core::Ecosystem;
 use monochange_core::EcosystemAdapter;
 use monochange_core::PackageRecord;
 use monochange_core::PublishState;
+use monochange_core::materialize_dependency_edges;
 use semver::Version;
 use serde_json::json;
 
+use crate::DenoVersionedFileKind;
 use crate::adapter;
 use crate::default_lockfile_commands;
 use crate::discover_deno_packages;
 use crate::discover_lockfiles;
 use crate::supported_versioned_file_kind;
 use crate::update_lockfile;
-use crate::DenoVersionedFileKind;
 
 #[test]
 fn discovers_deno_workspace_packages() {
@@ -25,14 +25,18 @@ fn discovers_deno_workspace_packages() {
 		.unwrap_or_else(|error| panic!("deno discovery: {error}"));
 
 	assert_eq!(discovery.packages.len(), 2);
-	assert!(discovery
-		.packages
-		.iter()
-		.any(|package| package.name == "deno-tool"));
-	assert!(discovery
-		.packages
-		.iter()
-		.any(|package| package.name == "deno-shared"));
+	assert!(
+		discovery
+			.packages
+			.iter()
+			.any(|package| package.name == "deno-tool")
+	);
+	assert!(
+		discovery
+			.packages
+			.iter()
+			.any(|package| package.name == "deno-shared")
+	);
 	let dependency_edges = materialize_dependency_edges(&discovery.packages);
 	assert_eq!(dependency_edges.len(), 1);
 }

--- a/crates/monochange_deno/src/lib.rs
+++ b/crates/monochange_deno/src/lib.rs
@@ -1,4 +1,3 @@
-#![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
 //! # `monochange_deno`
@@ -40,7 +39,6 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use glob::glob;
-use monochange_core::normalize_path;
 use monochange_core::AdapterDiscovery;
 use monochange_core::DependencyKind;
 use monochange_core::Ecosystem;
@@ -51,6 +49,7 @@ use monochange_core::MonochangeResult;
 use monochange_core::PackageDependency;
 use monochange_core::PackageRecord;
 use monochange_core::PublishState;
+use monochange_core::normalize_path;
 use semver::Version;
 use serde_json::Value;
 use walkdir::DirEntry;
@@ -306,11 +305,13 @@ fn parse_dependency_map(parsed: &Value, section: &str) -> Vec<PackageDependency>
 			dependencies
 				.iter()
 				.filter_map(|(name, value)| {
-					value.as_str().map(|constraint| PackageDependency {
-						name: name.clone(),
-						kind: DependencyKind::Runtime,
-						version_constraint: Some(constraint.to_string()),
-						optional: false,
+					value.as_str().map(|constraint| {
+						PackageDependency {
+							name: name.clone(),
+							kind: DependencyKind::Runtime,
+							version_constraint: Some(constraint.to_string()),
+							optional: false,
+						}
 					})
 				})
 				.collect::<Vec<_>>()

--- a/crates/monochange_gitea/src/__tests.rs
+++ b/crates/monochange_gitea/src/__tests.rs
@@ -86,9 +86,11 @@ fn validate_source_configuration_rejects_missing_host_and_unsupported_features()
 	let error = validate_source_configuration(&sample_source(None, None))
 		.err()
 		.unwrap_or_else(|| panic!("expected validation error"));
-	assert!(error
-		.to_string()
-		.contains("[source].host must be set for `provider = \"gitea\"`"));
+	assert!(
+		error
+			.to_string()
+			.contains("[source].host must be set for `provider = \"gitea\"`")
+	);
 
 	let error = validate_source_configuration(&SourceConfiguration {
 		pull_requests: ProviderMergeRequestSettings {
@@ -99,9 +101,11 @@ fn validate_source_configuration_rejects_missing_host_and_unsupported_features()
 	})
 	.err()
 	.unwrap_or_else(|| panic!("expected validation error"));
-	assert!(error
-		.to_string()
-		.contains("[source.pull_requests].auto_merge is not supported"));
+	assert!(
+		error
+			.to_string()
+			.contains("[source.pull_requests].auto_merge is not supported")
+	);
 
 	let error = validate_source_configuration(&SourceConfiguration {
 		releases: ProviderReleaseSettings {
@@ -112,9 +116,11 @@ fn validate_source_configuration_rejects_missing_host_and_unsupported_features()
 	})
 	.err()
 	.unwrap_or_else(|| panic!("expected validation error"));
-	assert!(error
-		.to_string()
-		.contains("provider-generated release notes are not supported"));
+	assert!(
+		error
+			.to_string()
+			.contains("provider-generated release notes are not supported")
+	);
 }
 
 #[test]
@@ -137,9 +143,11 @@ fn gitea_api_base_requires_host_unless_api_url_is_set() {
 	let error = gitea_api_base(&sample_source(None, None))
 		.err()
 		.unwrap_or_else(|| panic!("expected missing host error"));
-	assert!(error
-		.to_string()
-		.contains("[source].host must be set for `provider = \"gitea\"`"));
+	assert!(
+		error
+			.to_string()
+			.contains("[source].host must be set for `provider = \"gitea\"`")
+	);
 }
 
 #[test]
@@ -155,9 +163,11 @@ fn gitea_token_requires_environment_variable() {
 		let error = gitea_token()
 			.err()
 			.unwrap_or_else(|| panic!("expected missing token error"));
-		assert!(error
-			.to_string()
-			.contains("set `GITEA_TOKEN` before running Gitea automation"));
+		assert!(
+			error
+				.to_string()
+				.contains("set `GITEA_TOKEN` before running Gitea automation")
+		);
 	});
 }
 
@@ -179,9 +189,11 @@ fn auth_headers_reject_invalid_gitea_tokens() {
 	let error = auth_headers("bad\nvalue")
 		.err()
 		.unwrap_or_else(|| panic!("expected invalid header error"));
-	assert!(error
-		.to_string()
-		.contains("invalid Gitea token header value"));
+	assert!(
+		error
+			.to_string()
+			.contains("invalid Gitea token header value")
+	);
 }
 
 #[test]
@@ -462,12 +474,14 @@ fn publish_release_pull_request_creates_pull_request_and_labels() {
 	create.assert();
 	labels.assert();
 	assert_eq!(outcome.operation, SourceChangeRequestOperation::Created);
-	assert!(!git_output(
-		&repo,
-		&["rev-parse", "--verify", "monochange/release/release"]
-	)
-	.trim()
-	.is_empty());
+	assert!(
+		!git_output(
+			&repo,
+			&["rev-parse", "--verify", "monochange/release/release"]
+		)
+		.trim()
+		.is_empty()
+	);
 	let commit_body = git_output(&repo, &["log", "-1", "--pretty=%B"]);
 	assert!(commit_body.contains("release body"));
 }
@@ -485,9 +499,11 @@ fn git_commit_paths_reports_io_and_non_noop_failures() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected missing worktree error"));
-	assert!(io_error
-		.to_string()
-		.contains("failed to commit release pull request changes"));
+	assert!(
+		io_error
+			.to_string()
+			.contains("failed to commit release pull request changes")
+	);
 
 	let repo = tempdir.path().join("repo-error");
 	git(tempdir.path(), &["init", repo.to_string_lossy().as_ref()]);
@@ -513,9 +529,11 @@ fn git_commit_paths_reports_io_and_non_noop_failures() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected pre-commit hook failure"));
-	assert!(error
-		.to_string()
-		.contains("failed to commit release pull request changes"));
+	assert!(
+		error
+			.to_string()
+			.contains("failed to commit release pull request changes")
+	);
 }
 
 #[etest::etest(skip=env::var_os("PRE_COMMIT").is_some())]

--- a/crates/monochange_gitea/src/lib.rs
+++ b/crates/monochange_gitea/src/lib.rs
@@ -1,16 +1,9 @@
-#![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
 use std::env;
 use std::path::Path;
 use std::path::PathBuf;
 
-use monochange_core::git::git_checkout_branch_command;
-use monochange_core::git::git_commit_paths_command;
-use monochange_core::git::git_push_branch_command;
-use monochange_core::git::git_stage_paths_command;
-use monochange_core::git::run_command;
-use monochange_core::git::run_commit_command_allow_nothing_to_commit;
 use monochange_core::CommitMessage;
 use monochange_core::MonochangeError;
 use monochange_core::MonochangeResult;
@@ -27,14 +20,20 @@ use monochange_core::SourceProvider;
 use monochange_core::SourceReleaseOperation;
 use monochange_core::SourceReleaseOutcome;
 use monochange_core::SourceReleaseRequest;
+use monochange_core::git::git_checkout_branch_command;
+use monochange_core::git::git_commit_paths_command;
+use monochange_core::git::git_push_branch_command;
+use monochange_core::git::git_stage_paths_command;
+use monochange_core::git::run_command;
+use monochange_core::git::run_commit_command_allow_nothing_to_commit;
 use reqwest::blocking::Client;
-use reqwest::header::HeaderMap;
-use reqwest::header::HeaderValue;
 use reqwest::header::AUTHORIZATION;
 use reqwest::header::CONTENT_TYPE;
-use serde::de::DeserializeOwned;
+use reqwest::header::HeaderMap;
+use reqwest::header::HeaderValue;
 use serde::Deserialize;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use urlencoding::encode;
 
 #[must_use]
@@ -152,19 +151,21 @@ pub fn build_release_requests(
 		.release_targets
 		.iter()
 		.filter(|target| target.release)
-		.map(|target| SourceReleaseRequest {
-			provider: SourceProvider::Gitea,
-			repository: format!("{}/{}", source.owner, source.repo),
-			owner: source.owner.clone(),
-			repo: source.repo.clone(),
-			target_id: target.id.clone(),
-			target_kind: target.kind,
-			tag_name: target.tag_name.clone(),
-			name: target.rendered_title.clone(),
-			body: release_body(source, manifest, target),
-			draft: source.releases.draft,
-			prerelease: source.releases.prerelease,
-			generate_release_notes: source.releases.generate_notes,
+		.map(|target| {
+			SourceReleaseRequest {
+				provider: SourceProvider::Gitea,
+				repository: format!("{}/{}", source.owner, source.repo),
+				owner: source.owner.clone(),
+				repo: source.repo.clone(),
+				target_id: target.id.clone(),
+				target_kind: target.kind,
+				tag_name: target.tag_name.clone(),
+				name: target.rendered_title.clone(),
+				body: release_body(source, manifest, target),
+				draft: source.releases.draft,
+				prerelease: source.releases.prerelease,
+				generate_release_notes: source.releases.generate_notes,
+			}
 		})
 		.collect()
 }
@@ -543,14 +544,16 @@ fn release_body(
 ) -> Option<String> {
 	match source.releases.source {
 		ProviderReleaseNotesSource::GitHubGenerated => None,
-		ProviderReleaseNotesSource::Monochange => manifest
-			.changelogs
-			.iter()
-			.find(|changelog| {
-				changelog.owner_id == target.id && changelog.owner_kind == target.kind
-			})
-			.map(|changelog| changelog.rendered.clone())
-			.or_else(|| Some(minimal_release_body(manifest, target))),
+		ProviderReleaseNotesSource::Monochange => {
+			manifest
+				.changelogs
+				.iter()
+				.find(|changelog| {
+					changelog.owner_id == target.id && changelog.owner_kind == target.kind
+				})
+				.map(|changelog| changelog.rendered.clone())
+				.or_else(|| Some(minimal_release_body(manifest, target)))
+		}
 	}
 }
 

--- a/crates/monochange_github/src/__tests.rs
+++ b/crates/monochange_github/src/__tests.rs
@@ -160,9 +160,11 @@ fn validate_source_configuration_rejects_conflicting_release_note_modes() {
 	})
 	.err()
 	.unwrap_or_else(|| panic!("expected validation error"));
-	assert!(error
-		.to_string()
-		.contains("[source.releases].generate_notes cannot be true"));
+	assert!(
+		error
+			.to_string()
+			.contains("[source.releases].generate_notes cannot be true")
+	);
 }
 
 #[test]
@@ -466,7 +468,9 @@ fn sync_retargeted_releases_updates_existing_release_target_commitish() {
 			.path("/repos/ifiokjr/monochange/releases/tags/v1.2.3");
 		then.status(200)
 			.header("content-type", "application/json")
-			.body("{\"id\":42,\"html_url\":\"https://example.com/releases/42\",\"target_commitish\":\"abc1234\"}");
+			.body(
+				"{\"id\":42,\"html_url\":\"https://example.com/releases/42\",\"target_commitish\":\"abc1234\"}",
+			);
 	});
 	let update_release = server.mock(|when, then| {
 		when.method(PATCH)
@@ -524,7 +528,9 @@ fn sync_retargeted_releases_reports_already_aligned_release() {
 			.path("/repos/ifiokjr/monochange/releases/tags/v1.2.3");
 		then.status(200)
 			.header("content-type", "application/json")
-			.body("{\"id\":42,\"html_url\":\"https://example.com/releases/42\",\"target_commitish\":\"def5678\"}");
+			.body(
+				"{\"id\":42,\"html_url\":\"https://example.com/releases/42\",\"target_commitish\":\"def5678\"}",
+			);
 	});
 	let source = SourceConfiguration {
 		provider: SourceProvider::GitHub,
@@ -601,9 +607,11 @@ fn sync_retargeted_releases_errors_when_release_lookup_is_missing() {
 		.unwrap_or_else(|| panic!("expected release lookup error"));
 
 	release_lookup.assert();
-	assert!(error
-		.to_string()
-		.contains("GitHub release for tag `v1.2.3` could not be found"));
+	assert!(
+		error
+			.to_string()
+			.contains("GitHub release for tag `v1.2.3` could not be found")
+	);
 }
 
 #[test]
@@ -614,7 +622,9 @@ fn sync_retargeted_releases_public_api_uses_source_configuration_and_env() {
 			.path("/repos/ifiokjr/monochange/releases/tags/v1.2.3");
 		then.status(200)
 			.header("content-type", "application/json")
-			.body("{\"id\":42,\"html_url\":\"https://example.com/releases/42\",\"target_commitish\":\"abc1234\"}");
+			.body(
+				"{\"id\":42,\"html_url\":\"https://example.com/releases/42\",\"target_commitish\":\"abc1234\"}",
+			);
 	});
 	let update_release = server.mock(|when, then| {
 		when.method(PATCH)
@@ -753,8 +763,8 @@ fn publish_release_pull_request_updates_existing_pull_request_via_octocrab() {
 		then.status(200)
 			.header("content-type", "application/json")
 			.body(
-			"[{\"number\":9,\"html_url\":\"https://example.com/pr/9\",\"node_id\":\"PR_node\"}]",
-		);
+				"[{\"number\":9,\"html_url\":\"https://example.com/pr/9\",\"node_id\":\"PR_node\"}]",
+			);
 	});
 	let update_pull_request = server.mock(|when, then| {
 		when.method(PATCH).path("/repos/ifiokjr/monochange/pulls/9");
@@ -794,9 +804,11 @@ fn build_github_client_rejects_invalid_base_urls() {
 	let error = build_github_client("token", Some("not a url"))
 		.err()
 		.unwrap_or_else(|| panic!("expected client error"));
-	assert!(error
-		.to_string()
-		.contains("failed to configure GitHub base URL"));
+	assert!(
+		error
+			.to_string()
+			.contains("failed to configure GitHub base URL")
+	);
 }
 
 #[test]
@@ -839,8 +851,8 @@ fn publish_release_pull_request_reports_auto_merge_payload_errors() {
 		then.status(201)
 			.header("content-type", "application/json")
 			.body(
-			"{\"number\":13,\"html_url\":\"https://example.com/pr/13\",\"node_id\":\"PR_node\"}",
-		);
+				"{\"number\":13,\"html_url\":\"https://example.com/pr/13\",\"node_id\":\"PR_node\"}",
+			);
 	});
 	let add_labels = server.mock(|when, then| {
 		when.method(POST)
@@ -872,9 +884,11 @@ fn publish_release_pull_request_reports_auto_merge_payload_errors() {
 	create_pull_request.assert();
 	add_labels.assert();
 	enable_auto_merge.assert();
-	assert!(error
-		.to_string()
-		.contains("auto merge returned no pull request payload"));
+	assert!(
+		error
+			.to_string()
+			.contains("auto merge returned no pull request payload")
+	);
 }
 
 #[etest::etest(skip=env::var_os("PRE_COMMIT").is_some())]
@@ -942,9 +956,11 @@ fn git_commit_paths_reports_io_and_non_noop_failures() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected missing worktree error"));
-	assert!(io_error
-		.to_string()
-		.contains("failed to commit release pull request changes"));
+	assert!(
+		io_error
+			.to_string()
+			.contains("failed to commit release pull request changes")
+	);
 
 	let repo = tempdir.path().join("repo-error");
 	git(tempdir.path(), &["init", repo.to_string_lossy().as_ref()]);
@@ -970,9 +986,11 @@ fn git_commit_paths_reports_io_and_non_noop_failures() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected pre-commit hook failure"));
-	assert!(error
-		.to_string()
-		.contains("failed to commit release pull request changes"));
+	assert!(
+		error
+			.to_string()
+			.contains("failed to commit release pull request changes")
+	);
 }
 
 #[etest::etest(skip=env::var_os("PRE_COMMIT").is_some())]
@@ -1256,9 +1274,11 @@ fn comment_released_issues_skips_existing_markers_and_posts_missing_comments() {
 
 	let plans = plan_released_issue_comments(&github, &manifest);
 	assert_eq!(plans.len(), 2);
-	assert!(plans
-		.iter()
-		.all(|plan| plan.body.contains("Released in v1.2.0.")));
+	assert!(
+		plans
+			.iter()
+			.all(|plan| plan.body.contains("Released in v1.2.0."))
+	);
 
 	let outcomes = temp_env::with_var("GITHUB_SERVER_URL", Some("https://example.com"), || {
 		let outcome = github_runtime()

--- a/crates/monochange_github/src/lib.rs
+++ b/crates/monochange_github/src/lib.rs
@@ -1,4 +1,3 @@
-#![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
 //! # `monochange_github`
@@ -96,12 +95,6 @@ use std::env;
 use std::path::Path;
 use std::path::PathBuf;
 
-use monochange_core::git::git_checkout_branch_command;
-use monochange_core::git::git_commit_paths_command;
-use monochange_core::git::git_push_branch_command;
-use monochange_core::git::git_stage_paths_command;
-use monochange_core::git::run_command;
-use monochange_core::git::run_commit_command_allow_nothing_to_commit;
 use monochange_core::CommitMessage;
 use monochange_core::HostedActorRef;
 use monochange_core::HostedActorSourceKind;
@@ -131,10 +124,16 @@ use monochange_core::SourceProvider;
 use monochange_core::SourceReleaseOperation;
 use monochange_core::SourceReleaseOutcome;
 use monochange_core::SourceReleaseRequest;
+use monochange_core::git::git_checkout_branch_command;
+use monochange_core::git::git_commit_paths_command;
+use monochange_core::git::git_push_branch_command;
+use monochange_core::git::git_stage_paths_command;
+use monochange_core::git::run_command;
+use monochange_core::git::run_commit_command_allow_nothing_to_commit;
 use octocrab::Octocrab;
-use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use serde_json::json;
 use tokio::runtime::Builder as RuntimeBuilder;
 use urlencoding::encode;
@@ -472,19 +471,21 @@ pub fn build_release_requests(
 		.release_targets
 		.iter()
 		.filter(|target| target.release)
-		.map(|target| GitHubReleaseRequest {
-			provider: SourceProvider::GitHub,
-			repository: format!("{}/{}", source.owner, source.repo),
-			owner: source.owner.clone(),
-			repo: source.repo.clone(),
-			target_id: target.id.clone(),
-			target_kind: target.kind,
-			tag_name: target.tag_name.clone(),
-			name: target.rendered_title.clone(),
-			body: release_body(source, manifest, target),
-			draft: source.releases.draft,
-			prerelease: source.releases.prerelease,
-			generate_release_notes: source.releases.generate_notes,
+		.map(|target| {
+			GitHubReleaseRequest {
+				provider: SourceProvider::GitHub,
+				repository: format!("{}/{}", source.owner, source.repo),
+				owner: source.owner.clone(),
+				repo: source.repo.clone(),
+				target_id: target.id.clone(),
+				target_kind: target.kind,
+				tag_name: target.tag_name.clone(),
+				name: target.rendered_title.clone(),
+				body: release_body(source, manifest, target),
+				draft: source.releases.draft,
+				prerelease: source.releases.prerelease,
+				generate_release_notes: source.releases.generate_notes,
+			}
 		})
 		.collect()
 }
@@ -604,14 +605,16 @@ async fn lookup_commit_review_request_with_client(
 	let Some(pull_request) = pull_requests.into_iter().next() else {
 		return Ok(None);
 	};
-	let author = pull_request.user.map(|user| HostedActorRef {
-		provider: HostingProviderKind::GitHub,
-		host: github_host(),
-		id: Some(user.id.to_string()),
-		login: Some(user.login.clone()),
-		display_name: Some(user.login),
-		url: user.html_url,
-		source: HostedActorSourceKind::ReviewRequestAuthor,
+	let author = pull_request.user.map(|user| {
+		HostedActorRef {
+			provider: HostingProviderKind::GitHub,
+			host: github_host(),
+			id: Some(user.id.to_string()),
+			login: Some(user.login.clone()),
+			display_name: Some(user.login),
+			url: user.html_url,
+			source: HostedActorSourceKind::ReviewRequestAuthor,
+		}
 	});
 	let review_request = HostedReviewRequestRef {
 		provider: HostingProviderKind::GitHub,
@@ -679,13 +682,15 @@ async fn load_pull_request_issues_with_client(
 	for issue_number in body.map(extract_issue_numbers).unwrap_or_default() {
 		issues_by_id
 			.entry(format!("#{issue_number}"))
-			.or_insert_with(|| HostedIssueRef {
-				provider: HostingProviderKind::GitHub,
-				host: github_host(),
-				id: format!("#{issue_number}"),
-				title: None,
-				url: Some(github_issue_url(source, issue_number)),
-				relationship: HostedIssueRelationshipKind::ReferencedByReviewRequest,
+			.or_insert_with(|| {
+				HostedIssueRef {
+					provider: HostingProviderKind::GitHub,
+					host: github_host(),
+					id: format!("#{issue_number}"),
+					title: None,
+					url: Some(github_issue_url(source, issue_number)),
+					relationship: HostedIssueRelationshipKind::ReferencedByReviewRequest,
+				}
 			});
 	}
 	Ok(issues_by_id.into_values().collect())
@@ -741,14 +746,14 @@ pub fn plan_released_issue_comments(
 		.flat_map(|context| context.related_issues.iter())
 		.filter(|issue| issue.relationship == HostedIssueRelationshipKind::ClosedByReviewRequest)
 	{
-		plans_by_issue
-			.entry(issue.id.clone())
-			.or_insert_with(|| GitHubIssueCommentPlan {
+		plans_by_issue.entry(issue.id.clone()).or_insert_with(|| {
+			GitHubIssueCommentPlan {
 				repository: format!("{}/{}", source.owner, source.repo),
 				issue_id: issue.id.clone(),
 				issue_url: issue.url.clone(),
 				body: body.clone(),
-			});
+			}
+		});
 	}
 	plans_by_issue.into_values().collect()
 }
@@ -765,8 +770,8 @@ pub fn comment_released_issues(
 	let runtime = github_runtime()?;
 	runtime.block_on(async {
 		let client = github_client_from_env(source)?;
-		let outcome = comment_released_issues_with_client(&client, source, &plans).await;
-		outcome
+
+		comment_released_issues_with_client(&client, source, &plans).await
 	})
 }
 
@@ -842,8 +847,8 @@ pub fn publish_release_requests(
 	let runtime = github_runtime()?;
 	runtime.block_on(async {
 		let client = github_client_from_env(source)?;
-		let outcome = publish_release_requests_with_client(&client, requests).await;
-		outcome
+
+		publish_release_requests_with_client(&client, requests).await
 	})
 }
 
@@ -862,8 +867,8 @@ pub fn publish_release_pull_request(
 	let runtime = github_runtime()?;
 	runtime.block_on(async {
 		let client = github_client_from_env(source)?;
-		let outcome = publish_release_pull_request_with_client(&client, request).await;
-		outcome
+
+		publish_release_pull_request_with_client(&client, request).await
 	})
 }
 
@@ -908,27 +913,31 @@ async fn publish_release_request_with_client(
 	};
 	let existing = lookup_existing_release_with_client(client, request).await?;
 	let (operation, response) = match existing {
-		Some(existing) => (
-			GitHubReleaseOperation::Updated,
-			patch_json::<_, GitHubReleaseResponse>(
-				client,
-				&format!(
-					"/repos/{}/{}/releases/{}",
-					request.owner, request.repo, existing.id
-				),
-				&payload,
+		Some(existing) => {
+			(
+				GitHubReleaseOperation::Updated,
+				patch_json::<_, GitHubReleaseResponse>(
+					client,
+					&format!(
+						"/repos/{}/{}/releases/{}",
+						request.owner, request.repo, existing.id
+					),
+					&payload,
+				)
+				.await?,
 			)
-			.await?,
-		),
-		None => (
-			GitHubReleaseOperation::Created,
-			post_json::<_, GitHubReleaseResponse>(
-				client,
-				&format!("/repos/{}/{}/releases", request.owner, request.repo),
-				&payload,
+		}
+		None => {
+			(
+				GitHubReleaseOperation::Created,
+				post_json::<_, GitHubReleaseResponse>(
+					client,
+					&format!("/repos/{}/{}/releases", request.owner, request.repo),
+					&payload,
+				)
+				.await?,
 			)
-			.await?,
-		),
+		}
 	};
 	Ok(GitHubReleaseOutcome {
 		provider: SourceProvider::GitHub,
@@ -945,37 +954,41 @@ async fn publish_release_pull_request_with_client(
 ) -> MonochangeResult<GitHubPullRequestOutcome> {
 	let existing = lookup_existing_pull_request_with_client(client, request).await?;
 	let (operation, pull_request) = match existing {
-		Some(existing) => (
-			GitHubPullRequestOperation::Updated,
-			patch_json::<_, GitHubPullRequestResponse>(
-				client,
-				&format!(
-					"/repos/{}/{}/pulls/{}",
-					request.owner, request.repo, existing.number
-				),
-				&GitHubPullRequestUpdatePayload {
-					title: &request.title,
-					body: &request.body,
-					base: &request.base_branch,
-				},
+		Some(existing) => {
+			(
+				GitHubPullRequestOperation::Updated,
+				patch_json::<_, GitHubPullRequestResponse>(
+					client,
+					&format!(
+						"/repos/{}/{}/pulls/{}",
+						request.owner, request.repo, existing.number
+					),
+					&GitHubPullRequestUpdatePayload {
+						title: &request.title,
+						body: &request.body,
+						base: &request.base_branch,
+					},
+				)
+				.await?,
 			)
-			.await?,
-		),
-		None => (
-			GitHubPullRequestOperation::Created,
-			post_json::<_, GitHubPullRequestResponse>(
-				client,
-				&format!("/repos/{}/{}/pulls", request.owner, request.repo),
-				&GitHubPullRequestPayload {
-					title: &request.title,
-					head: &request.head_branch,
-					base: &request.base_branch,
-					body: &request.body,
-					draft: false,
-				},
+		}
+		None => {
+			(
+				GitHubPullRequestOperation::Created,
+				post_json::<_, GitHubPullRequestResponse>(
+					client,
+					&format!("/repos/{}/{}/pulls", request.owner, request.repo),
+					&GitHubPullRequestPayload {
+						title: &request.title,
+						head: &request.head_branch,
+						base: &request.base_branch,
+						body: &request.body,
+						draft: false,
+					},
+				)
+				.await?,
 			)
-			.await?,
-		),
+		}
 	};
 	if !request.labels.is_empty() {
 		let _: serde_json::Value = post_json(
@@ -1175,9 +1188,11 @@ where
 		Err(octocrab::Error::GitHub { source, .. }) if source.status_code.as_u16() == 404 => {
 			Ok(None)
 		}
-		Err(error) => Err(MonochangeError::Config(format!(
-			"GitHub API GET `{path}` failed: {error}"
-		))),
+		Err(error) => {
+			Err(MonochangeError::Config(format!(
+				"GitHub API GET `{path}` failed: {error}"
+			)))
+		}
 	}
 }
 
@@ -1187,9 +1202,11 @@ where
 {
 	match client.get::<T, _, _>(path, None::<&()>).await {
 		Ok(value) => Ok(value),
-		Err(error) => Err(MonochangeError::Config(format!(
-			"GitHub API GET `{path}` failed: {error}"
-		))),
+		Err(error) => {
+			Err(MonochangeError::Config(format!(
+				"GitHub API GET `{path}` failed: {error}"
+			)))
+		}
 	}
 }
 
@@ -1256,14 +1273,16 @@ fn release_body(
 ) -> Option<String> {
 	match github.releases.source {
 		ProviderReleaseNotesSource::GitHubGenerated => None,
-		ProviderReleaseNotesSource::Monochange => manifest
-			.changelogs
-			.iter()
-			.find(|changelog| {
-				changelog.owner_id == target.id && changelog.owner_kind == target.kind
-			})
-			.map(|changelog| changelog.rendered.clone())
-			.or_else(|| Some(minimal_release_body(manifest, target))),
+		ProviderReleaseNotesSource::Monochange => {
+			manifest
+				.changelogs
+				.iter()
+				.find(|changelog| {
+					changelog.owner_id == target.id && changelog.owner_kind == target.kind
+				})
+				.map(|changelog| changelog.rendered.clone())
+				.or_else(|| Some(minimal_release_body(manifest, target)))
+		}
 	}
 }
 

--- a/crates/monochange_github/tests/env_wrappers.rs
+++ b/crates/monochange_github/tests/env_wrappers.rs
@@ -10,12 +10,12 @@ use monochange_core::ProviderReleaseSettings;
 use monochange_core::ReleaseOwnerKind;
 use monochange_core::SourceConfiguration;
 use monochange_core::SourceProvider;
-use monochange_github::publish_release_pull_request;
-use monochange_github::publish_release_requests;
 use monochange_github::GitHubPullRequestOperation;
 use monochange_github::GitHubPullRequestRequest;
 use monochange_github::GitHubReleaseOperation;
 use monochange_github::GitHubReleaseRequest;
+use monochange_github::publish_release_pull_request;
+use monochange_github::publish_release_requests;
 use tempfile::tempdir;
 
 #[test]
@@ -76,8 +76,8 @@ fn publish_release_pull_request_uses_git_and_github_env_configuration() {
 		then.status(201)
 			.header("content-type", "application/json")
 			.body(
-			"{\"number\":12,\"html_url\":\"https://example.com/pr/12\",\"node_id\":\"PR_node\"}",
-		);
+				"{\"number\":12,\"html_url\":\"https://example.com/pr/12\",\"node_id\":\"PR_node\"}",
+			);
 	});
 	let add_labels = server.mock(|when, then| {
 		when.method(POST)

--- a/crates/monochange_gitlab/src/__tests.rs
+++ b/crates/monochange_gitlab/src/__tests.rs
@@ -93,9 +93,11 @@ fn validate_source_configuration_rejects_unsupported_gitlab_features() {
 	})
 	.err()
 	.unwrap_or_else(|| panic!("expected validation error"));
-	assert!(error
-		.to_string()
-		.contains("[source.pull_requests].auto_merge is not supported"));
+	assert!(
+		error
+			.to_string()
+			.contains("[source.pull_requests].auto_merge is not supported")
+	);
 
 	let error = validate_source_configuration(&SourceConfiguration {
 		releases: ProviderReleaseSettings {
@@ -106,9 +108,11 @@ fn validate_source_configuration_rejects_unsupported_gitlab_features() {
 	})
 	.err()
 	.unwrap_or_else(|| panic!("expected validation error"));
-	assert!(error
-		.to_string()
-		.contains("[source.releases].draft is not supported"));
+	assert!(
+		error
+			.to_string()
+			.contains("[source.releases].draft is not supported")
+	);
 
 	let error = validate_source_configuration(&SourceConfiguration {
 		releases: ProviderReleaseSettings {
@@ -119,9 +123,11 @@ fn validate_source_configuration_rejects_unsupported_gitlab_features() {
 	})
 	.err()
 	.unwrap_or_else(|| panic!("expected validation error"));
-	assert!(error
-		.to_string()
-		.contains("[source.releases].prerelease is not supported"));
+	assert!(
+		error
+			.to_string()
+			.contains("[source.releases].prerelease is not supported")
+	);
 
 	let error = validate_source_configuration(&SourceConfiguration {
 		releases: ProviderReleaseSettings {
@@ -132,9 +138,11 @@ fn validate_source_configuration_rejects_unsupported_gitlab_features() {
 	})
 	.err()
 	.unwrap_or_else(|| panic!("expected validation error"));
-	assert!(error
-		.to_string()
-		.contains("provider-generated release notes are not supported"));
+	assert!(
+		error
+			.to_string()
+			.contains("provider-generated release notes are not supported")
+	);
 }
 
 #[test]
@@ -194,9 +202,11 @@ fn gitlab_token_supports_primary_and_fallback_environment_variables() {
 			let error = gitlab_token()
 				.err()
 				.unwrap_or_else(|| panic!("expected missing token error"));
-			assert!(error
-				.to_string()
-				.contains("set `GITLAB_TOKEN` (or `GL_TOKEN`) before running GitLab automation"));
+			assert!(
+				error.to_string().contains(
+					"set `GITLAB_TOKEN` (or `GL_TOKEN`) before running GitLab automation"
+				)
+			);
 		},
 	);
 }
@@ -222,9 +232,11 @@ fn auth_headers_reject_invalid_gitlab_tokens() {
 	let error = auth_headers("bad\nvalue")
 		.err()
 		.unwrap_or_else(|| panic!("expected invalid header error"));
-	assert!(error
-		.to_string()
-		.contains("invalid GitLab token header value"));
+	assert!(
+		error
+			.to_string()
+			.contains("invalid GitLab token header value")
+	);
 }
 
 #[test]
@@ -500,12 +512,14 @@ fn publish_release_pull_request_creates_merge_request_and_pushes_branch() {
 	list.assert();
 	create.assert();
 	assert_eq!(outcome.operation, SourceChangeRequestOperation::Created);
-	assert!(!git_output(
-		&repo,
-		&["rev-parse", "--verify", "monochange/release/release"]
-	)
-	.trim()
-	.is_empty());
+	assert!(
+		!git_output(
+			&repo,
+			&["rev-parse", "--verify", "monochange/release/release"]
+		)
+		.trim()
+		.is_empty()
+	);
 	let commit_body = git_output(&repo, &["log", "-1", "--pretty=%B"]);
 	assert!(commit_body.contains("release body"));
 }
@@ -523,9 +537,11 @@ fn git_commit_paths_reports_io_and_non_noop_failures() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected missing worktree error"));
-	assert!(io_error
-		.to_string()
-		.contains("failed to commit release merge request changes"));
+	assert!(
+		io_error
+			.to_string()
+			.contains("failed to commit release merge request changes")
+	);
 
 	let repo = tempdir.path().join("repo-error");
 	git(tempdir.path(), &["init", repo.to_string_lossy().as_ref()]);
@@ -551,9 +567,11 @@ fn git_commit_paths_reports_io_and_non_noop_failures() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected pre-commit hook failure"));
-	assert!(error
-		.to_string()
-		.contains("failed to commit release merge request changes"));
+	assert!(
+		error
+			.to_string()
+			.contains("failed to commit release merge request changes")
+	);
 }
 
 #[etest::etest(skip=env::var_os("PRE_COMMIT").is_some())]

--- a/crates/monochange_gitlab/src/lib.rs
+++ b/crates/monochange_gitlab/src/lib.rs
@@ -1,16 +1,9 @@
-#![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
 use std::env;
 use std::path::Path;
 use std::path::PathBuf;
 
-use monochange_core::git::git_checkout_branch_command;
-use monochange_core::git::git_commit_paths_command;
-use monochange_core::git::git_push_branch_command;
-use monochange_core::git::git_stage_paths_command;
-use monochange_core::git::run_command;
-use monochange_core::git::run_commit_command_allow_nothing_to_commit;
 use monochange_core::CommitMessage;
 use monochange_core::MonochangeError;
 use monochange_core::MonochangeResult;
@@ -27,13 +20,19 @@ use monochange_core::SourceProvider;
 use monochange_core::SourceReleaseOperation;
 use monochange_core::SourceReleaseOutcome;
 use monochange_core::SourceReleaseRequest;
+use monochange_core::git::git_checkout_branch_command;
+use monochange_core::git::git_commit_paths_command;
+use monochange_core::git::git_push_branch_command;
+use monochange_core::git::git_stage_paths_command;
+use monochange_core::git::run_command;
+use monochange_core::git::run_commit_command_allow_nothing_to_commit;
 use reqwest::blocking::Client;
+use reqwest::header::CONTENT_TYPE;
 use reqwest::header::HeaderMap;
 use reqwest::header::HeaderValue;
-use reqwest::header::CONTENT_TYPE;
-use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use urlencoding::encode;
 
 #[must_use]
@@ -158,19 +157,21 @@ pub fn build_release_requests(
 		.release_targets
 		.iter()
 		.filter(|target| target.release)
-		.map(|target| SourceReleaseRequest {
-			provider: SourceProvider::GitLab,
-			repository: format!("{}/{}", source.owner, source.repo),
-			owner: source.owner.clone(),
-			repo: source.repo.clone(),
-			target_id: target.id.clone(),
-			target_kind: target.kind,
-			tag_name: target.tag_name.clone(),
-			name: target.rendered_title.clone(),
-			body: release_body(source, manifest, target),
-			draft: source.releases.draft,
-			prerelease: source.releases.prerelease,
-			generate_release_notes: source.releases.generate_notes,
+		.map(|target| {
+			SourceReleaseRequest {
+				provider: SourceProvider::GitLab,
+				repository: format!("{}/{}", source.owner, source.repo),
+				owner: source.owner.clone(),
+				repo: source.repo.clone(),
+				target_id: target.id.clone(),
+				target_kind: target.kind,
+				tag_name: target.tag_name.clone(),
+				name: target.rendered_title.clone(),
+				body: release_body(source, manifest, target),
+				draft: source.releases.draft,
+				prerelease: source.releases.prerelease,
+				generate_release_notes: source.releases.generate_notes,
+			}
 		})
 		.collect()
 }
@@ -560,14 +561,16 @@ fn release_body(
 ) -> Option<String> {
 	match source.releases.source {
 		ProviderReleaseNotesSource::GitHubGenerated => None,
-		ProviderReleaseNotesSource::Monochange => manifest
-			.changelogs
-			.iter()
-			.find(|changelog| {
-				changelog.owner_id == target.id && changelog.owner_kind == target.kind
-			})
-			.map(|changelog| changelog.rendered.clone())
-			.or_else(|| Some(minimal_release_body(manifest, target))),
+		ProviderReleaseNotesSource::Monochange => {
+			manifest
+				.changelogs
+				.iter()
+				.find(|changelog| {
+					changelog.owner_id == target.id && changelog.owner_kind == target.kind
+				})
+				.map(|changelog| changelog.rendered.clone())
+				.or_else(|| Some(minimal_release_body(manifest, target)))
+		}
 	}
 }
 

--- a/crates/monochange_graph/src/__tests.rs
+++ b/crates/monochange_graph/src/__tests.rs
@@ -12,8 +12,8 @@ use monochange_core::PublishState;
 use monochange_core::VersionGroup;
 use semver::Version;
 
-use crate::build_release_plan;
 use crate::NormalizedGraph;
+use crate::build_release_plan;
 
 fn package(id: &str, version: Version) -> PackageRecord {
 	let manifest_path = PathBuf::from(id.replace(':', "/")).join("manifest");
@@ -380,10 +380,11 @@ fn build_release_plan_propagates_explicit_member_versions_to_group_version() {
 		.first()
 		.unwrap_or_else(|| panic!("expected one group"));
 	assert_eq!(group.planned_version, Some(Version::new(2, 0, 0)));
-	assert!(plan
-		.decisions
-		.iter()
-		.all(|decision| decision.planned_version == Some(Version::new(2, 0, 0))));
+	assert!(
+		plan.decisions
+			.iter()
+			.all(|decision| decision.planned_version == Some(Version::new(2, 0, 0)))
+	);
 }
 
 #[test]
@@ -507,9 +508,11 @@ fn build_release_plan_rejects_explicit_versions_not_greater_than_current() {
 	.err()
 	.unwrap_or_else(|| panic!("expected invalid explicit version error"));
 
-	assert!(error
-		.to_string()
-		.contains("must be greater than current version"));
+	assert!(
+		error
+			.to_string()
+			.contains("must be greater than current version")
+	);
 }
 
 #[test]

--- a/crates/monochange_graph/src/lib.rs
+++ b/crates/monochange_graph/src/lib.rs
@@ -1,4 +1,3 @@
-#![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
 //! # `monochange_graph`
@@ -240,17 +239,15 @@ pub fn build_release_plan(
 				.members
 				.iter()
 				.map(|member| {
-					states
-						.get(member.as_str())
-						.map_or_else(
-							|| {
-								eprintln!(
-									"warning: version group `{group_id}` member `{member}` was not found in discovered packages"
-								);
-								BumpSeverity::None
-							},
-							|state| state.severity,
-						)
+					states.get(member.as_str()).map_or_else(
+						|| {
+							eprintln!(
+								"warning: version group `{group_id}` member `{member}` was not found in discovered packages"
+							);
+							BumpSeverity::None
+						},
+						|state| state.severity,
+					)
 				})
 				.max()
 				.unwrap_or(BumpSeverity::None);
@@ -460,12 +457,12 @@ fn resolve_explicit_version_choice(
 		}
 		warnings.push(message);
 	}
-	if let Some(current_version) = current_version {
-		if chosen_version <= *current_version {
-			return Err(MonochangeError::Config(format!(
-				"explicit version `{chosen_version}` for {owner} must be greater than current version `{current_version}`"
-			)));
-		}
+	if let Some(current_version) = current_version
+		&& chosen_version <= *current_version
+	{
+		return Err(MonochangeError::Config(format!(
+			"explicit version `{chosen_version}` for {owner} must be greater than current version `{current_version}`"
+		)));
 	}
 	Ok(chosen_version)
 }

--- a/crates/monochange_npm/src/__tests.rs
+++ b/crates/monochange_npm/src/__tests.rs
@@ -2,15 +2,16 @@ use std::collections::BTreeMap;
 use std::path::Path;
 use std::path::PathBuf;
 
-use monochange_core::materialize_dependency_edges;
 use monochange_core::Ecosystem;
 use monochange_core::EcosystemAdapter;
 use monochange_core::PackageRecord;
 use monochange_core::PublishState;
+use monochange_core::materialize_dependency_edges;
 use semver::Version;
 use serde_json::json;
 use serde_yaml_ng::Value as YamlValue;
 
+use crate::NpmVersionedFileKind;
 use crate::adapter;
 use crate::default_lockfile_commands;
 use crate::detect_npm_manager;
@@ -29,7 +30,6 @@ use crate::update_package_lock;
 use crate::update_pnpm_lock;
 use crate::update_pnpm_lock_text;
 use crate::workspace_patterns_from_package_json;
-use crate::NpmVersionedFileKind;
 
 #[test]
 fn discovers_npm_workspace_packages() {
@@ -38,14 +38,18 @@ fn discovers_npm_workspace_packages() {
 		.unwrap_or_else(|error| panic!("npm discovery: {error}"));
 
 	assert_eq!(discovery.packages.len(), 2);
-	assert!(discovery
-		.packages
-		.iter()
-		.any(|package| package.name == "npm-web"));
-	assert!(discovery
-		.packages
-		.iter()
-		.any(|package| package.name == "npm-shared"));
+	assert!(
+		discovery
+			.packages
+			.iter()
+			.any(|package| package.name == "npm-web")
+	);
+	assert!(
+		discovery
+			.packages
+			.iter()
+			.any(|package| package.name == "npm-shared")
+	);
 	let dependency_edges = materialize_dependency_edges(&discovery.packages);
 	assert_eq!(dependency_edges.len(), 1);
 }
@@ -58,10 +62,12 @@ fn discovers_pnpm_workspace_globs() {
 		.unwrap_or_else(|error| panic!("pnpm discovery: {error}"));
 
 	assert_eq!(discovery.packages.len(), 2);
-	assert!(discovery
-		.packages
-		.iter()
-		.any(|package| package.name == "pnpm-web"));
+	assert!(
+		discovery
+			.packages
+			.iter()
+			.any(|package| package.name == "pnpm-web")
+	);
 }
 
 #[test]
@@ -542,14 +548,15 @@ fn discovers_object_style_package_json_workspaces_and_warnings() {
 	let discovery = discover_npm_packages(&fixture_root)
 		.unwrap_or_else(|error| panic!("npm discovery: {error}"));
 	assert_eq!(discovery.packages.len(), 3);
-	assert!(discovery
-		.warnings
-		.iter()
-		.any(|warning| warning.contains("missing/*") && warning.contains("matched no packages")));
-	assert!(discovery
-		.packages
-		.iter()
-		.any(|package| package.name == "root-workspace"));
+	assert!(discovery.warnings.iter().any(|warning| {
+		warning.contains("missing/*") && warning.contains("matched no packages")
+	}));
+	assert!(
+		discovery
+			.packages
+			.iter()
+			.any(|package| package.name == "root-workspace")
+	);
 	let private_package = discovery
 		.packages
 		.iter()
@@ -648,9 +655,11 @@ fn explicit_file_workspace_patterns_discover_package_manifests() {
 	);
 	assert_eq!(warnings, Vec::<String>::new());
 	assert_eq!(manifests.len(), 1);
-	assert!(manifests
-		.iter()
-		.any(|path| path.ends_with("packages/web/package.json")));
+	assert!(
+		manifests
+			.iter()
+			.any(|path| path.ends_with("packages/web/package.json"))
+	);
 
 	let discovery = discover_npm_packages(&fixture_root)
 		.unwrap_or_else(|error| panic!("npm discovery: {error}"));

--- a/crates/monochange_npm/src/lib.rs
+++ b/crates/monochange_npm/src/lib.rs
@@ -1,4 +1,3 @@
-#![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
 //! # `monochange_npm`
@@ -41,7 +40,6 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use glob::glob;
-use monochange_core::normalize_path;
 use monochange_core::AdapterDiscovery;
 use monochange_core::DependencyKind;
 use monochange_core::Ecosystem;
@@ -53,6 +51,7 @@ use monochange_core::PackageDependency;
 use monochange_core::PackageRecord;
 use monochange_core::PublishState;
 use monochange_core::ShellConfig;
+use monochange_core::normalize_path;
 use semver::Version;
 use serde_json::Value;
 use serde_yaml_ng::Value as YamlValue;
@@ -168,12 +167,11 @@ pub fn update_package_lock(
 	package_paths_by_name: &BTreeMap<String, PathBuf>,
 	raw_versions: &BTreeMap<String, String>,
 ) {
-	if let Some(root_name) = value.get("name").and_then(Value::as_str) {
-		if let Some(version) = raw_versions.get(root_name) {
-			if let Some(obj) = value.as_object_mut() {
-				obj.insert("version".to_string(), Value::String(version.clone()));
-			}
-		}
+	if let Some(root_name) = value.get("name").and_then(Value::as_str)
+		&& let Some(version) = raw_versions.get(root_name)
+		&& let Some(obj) = value.as_object_mut()
+	{
+		obj.insert("version".to_string(), Value::String(version.clone()));
 	}
 	if let Some(packages) = value.get_mut("packages").and_then(Value::as_object_mut) {
 		for (entry_path, entry_value) in packages {
@@ -187,10 +185,10 @@ pub fn update_package_lock(
 				continue;
 			}
 			for (name, package_dir) in package_paths_by_name {
-				if entry_path == &package_dir.to_string_lossy() {
-					if let Some(version) = raw_versions.get(name) {
-						entry_object.insert("version".to_string(), Value::String(version.clone()));
-					}
+				if entry_path == &package_dir.to_string_lossy()
+					&& let Some(version) = raw_versions.get(name)
+				{
+					entry_object.insert("version".to_string(), Value::String(version.clone()));
 				}
 			}
 		}
@@ -240,12 +238,12 @@ pub fn update_pnpm_lock(
 						}
 					} else if let Some(entry_mapping) = entry.as_mapping_mut() {
 						let version_key = serde_yaml_ng::Value::String("version".to_string());
-						if let Some(version_value) = entry_mapping.get_mut(&version_key) {
-							if let Some(text) = version_value.as_str() {
-								if !text.starts_with("link:") && !text.starts_with("workspace:") {
-									*version_value = serde_yaml_ng::Value::String(version.clone());
-								}
-							}
+						if let Some(version_value) = entry_mapping.get_mut(&version_key)
+							&& let Some(text) = version_value.as_str()
+							&& !text.starts_with("link:")
+							&& !text.starts_with("workspace:")
+						{
+							*version_value = serde_yaml_ng::Value::String(version.clone());
 						}
 					}
 				}
@@ -276,7 +274,7 @@ pub fn update_pnpm_lock_text(
 			&mut replacements,
 		);
 	}
-	replacements.sort_by(|left, right| right.0 .0.cmp(&left.0 .0));
+	replacements.sort_by(|left, right| right.0.0.cmp(&left.0.0));
 	let mut updated = contents.to_string();
 	for ((start, end), replacement) in replacements {
 		updated.replace_range(start..end, &replacement);
@@ -800,11 +798,13 @@ fn parse_dependency_map(
 			dependencies
 				.iter()
 				.filter_map(|(name, version)| {
-					version.as_str().map(|constraint| PackageDependency {
-						name: name.clone(),
-						kind,
-						version_constraint: Some(constraint.to_string()),
-						optional: false,
+					version.as_str().map(|constraint| {
+						PackageDependency {
+							name: name.clone(),
+							kind,
+							version_constraint: Some(constraint.to_string()),
+							optional: false,
+						}
 					})
 				})
 				.collect::<Vec<_>>()

--- a/crates/monochange_semver/src/__tests.rs
+++ b/crates/monochange_semver/src/__tests.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use monochange_core::BumpSeverity;
 use monochange_core::ChangeSignal;
 use monochange_core::CompatibilityAssessment;
@@ -5,15 +7,14 @@ use monochange_core::Ecosystem;
 use monochange_core::PackageRecord;
 use monochange_core::PublishState;
 use semver::Version;
-use std::path::PathBuf;
 
+use crate::CompatibilityProvider;
 use crate::collect_assessments;
 use crate::direct_release_severity;
 use crate::merge_severities;
 use crate::propagated_release_severity;
 use crate::strongest_assessment;
 use crate::strongest_assessment_for_package;
-use crate::CompatibilityProvider;
 
 fn make_assessment(package_id: &str, severity: BumpSeverity) -> CompatibilityAssessment {
 	CompatibilityAssessment {

--- a/crates/monochange_semver/src/lib.rs
+++ b/crates/monochange_semver/src/lib.rs
@@ -1,4 +1,3 @@
-#![deny(clippy::all)]
 #![forbid(clippy::indexing_slicing)]
 
 //! # `monochange_semver`

--- a/dprint.json
+++ b/dprint.json
@@ -5,7 +5,7 @@
 	"exec": {
 		"commands": [
 			{
-				"command": "rustup run stable rustfmt --edition 2021",
+				"command": "rustup run nightly rustfmt --edition 2024",
 				"exts": ["rs"]
 			},
 			{

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.93.1"
+channel = "nightly"
 components = ["rustfmt", "cargo", "clippy", "rust-analyzer"]
 profile = "default"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,11 +1,11 @@
-edition = "2021"
-style_edition = "2021"
+edition = "2024"
+style_edition = "2024"
 unstable_features = true
 condense_wildcard_suffixes = true
 force_multiline_blocks = true
 format_code_in_doc_comments = false
 format_macro_matchers = true
-format_strings = true
+format_strings = false
 group_imports = "StdExternalCrate"
 hard_tabs = true
 imports_granularity = "Item"

--- a/testing/monochange_test_helpers/Cargo.toml
+++ b/testing/monochange_test_helpers/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "monochange_test_helpers"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 license = "Unlicense"
 publish = false
 description = "Internal shared test helpers for monochange"

--- a/testing/monochange_test_helpers/src/fs.rs
+++ b/testing/monochange_test_helpers/src/fs.rs
@@ -1,5 +1,6 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::path::PathBuf;
 use std::thread;
 
 use tempfile::TempDir;

--- a/testing/monochange_test_helpers/src/rmcp.rs
+++ b/testing/monochange_test_helpers/src/rmcp.rs
@@ -2,9 +2,11 @@ pub fn content_text(result: &rmcp::model::CallToolResult) -> String {
 	result
 		.content
 		.first()
-		.and_then(|content| match &content.raw {
-			rmcp::model::RawContent::Text(text) => Some(text.text.clone()),
-			_ => None,
+		.and_then(|content| {
+			match &content.raw {
+				rmcp::model::RawContent::Text(text) => Some(text.text.clone()),
+				_ => None,
+			}
 		})
 		.unwrap_or_default()
 }


### PR DESCRIPTION
## Summary

- **Remove criterion dependency** — use nightly `#[bench]` via `RUSTUP_TOOLCHAIN=nightly`, eliminating the external dependency and the compilation issues with minijinja
- **Extract CI scripts** into standalone files:
  - `.github/scripts/generate-benchmark-fixture.sh` — creates workspace fixtures
  - `.github/scripts/benchmark-binaries.sh` — times CLI commands and outputs markdown table
- **Simplify CI workflow** — benchmark job is now 3 clean steps instead of inline bash; binary comparison calls the scripts directly
- Both benchmark jobs remain `continue-on-error: true`

### Local benchmark results (nightly `#[bench]`)

```
test config_load_5pkg                    ... bench:      54,259 ns/iter
test config_load_50pkg                   ... bench:     293,829 ns/iter
test discover_5pkg                       ... bench:   2,855,677 ns/iter
test discover_50pkg                      ... bench:  70,863,362 ns/iter
test validate_5pkg                       ... bench:     216,200 ns/iter
test validate_50pkg                      ... bench:   3,534,920 ns/iter
test prepare_release_dry_run_5pkg_10cs   ... bench:  48,014,970 ns/iter
test prepare_release_dry_run_20pkg_50cs  ... bench: 221,889,166 ns/iter
test prepare_release_dry_run_50pkg_200cs ... bench: 847,613,300 ns/iter
test prepare_release_git_10commits       ... bench: 125,505,170 ns/iter
test prepare_release_git_100commits      ... bench: 141,003,208 ns/iter
test prepare_release_git_200commits      ... bench: 155,003,025 ns/iter
```

Closes #160

## Test plan

- [x] Nightly benchmarks compile and run locally
- [x] Stable tests (302) still pass
- [x] Scripts are executable and self-contained
- [ ] CI passes