### PR TITLE
fix: remove Rust 2024 warning noise

### DIFF
--- a/.changeset/fix-clippy-rebase-warnings.md
+++ b/.changeset/fix-clippy-rebase-warnings.md
@@ -1,0 +1,8 @@
+---
+"monochange_core": patch
+"monochange_dart": patch
+"monochange_github": patch
+"monochange_npm": patch
+---
+
+Keep `lint:all` warning-free on current Rust toolchains after the latest `main` rebase by applying small Clippy-driven cleanups in shared replacement helpers and GitHub test coverage.

--- a/.changeset/fix-rust-2024-drop-order-warnings.md
+++ b/.changeset/fix-rust-2024-drop-order-warnings.md
@@ -1,0 +1,5 @@
+---
+"monochange": patch
+---
+
+Keep `fix:all` warning-free on current Rust toolchains by removing a Rust 2024 drop-order warning in Jinja template rendering and a Clippy `manual_let_else` warning in changeset history parsing.

--- a/crates/monochange/src/changelog.rs
+++ b/crates/monochange/src/changelog.rs
@@ -587,7 +587,7 @@ fn render_jinja_template_with_behavior(
 			});
 			let cache_ref = cache.borrow();
 			let env = cache_ref.get(template_source).unwrap_or_else(|| unreachable!("just inserted"));
-			match env.get_template("t") {
+			let rendered = match env.get_template("t") {
 				Ok(tmpl) => tmpl
 					.render(context)
 					.map_err(|error| MonochangeError::Config(format!("template rendering failed: {error}"))),
@@ -596,7 +596,8 @@ fn render_jinja_template_with_behavior(
 					env.render_str(template_source, context)
 						.map_err(|error| MonochangeError::Config(format!("template rendering failed: {error}")))
 				}
-			}
+			};
+			rendered
 		};
 
 	match undefined_behavior {

--- a/crates/monochange/src/changelog.rs
+++ b/crates/monochange/src/changelog.rs
@@ -587,7 +587,7 @@ fn render_jinja_template_with_behavior(
 			});
 			let cache_ref = cache.borrow();
 			let env = cache_ref.get(template_source).unwrap_or_else(|| unreachable!("just inserted"));
-			let rendered = match env.get_template("t") {
+			match env.get_template("t") {
 				Ok(tmpl) => tmpl
 					.render(context)
 					.map_err(|error| MonochangeError::Config(format!("template rendering failed: {error}"))),
@@ -596,8 +596,7 @@ fn render_jinja_template_with_behavior(
 					env.render_str(template_source, context)
 						.map_err(|error| MonochangeError::Config(format!("template rendering failed: {error}")))
 				}
-			};
-			rendered
+			}
 		};
 
 	match undefined_behavior {

--- a/crates/monochange/src/changesets.rs
+++ b/crates/monochange/src/changesets.rs
@@ -321,9 +321,8 @@ fn batch_git_log(
 		Ok(output) if output.status.success() => output,
 		_ => return HashMap::new(),
 	};
-	let stdout = match String::from_utf8(output.stdout) {
-		Ok(s) => s,
-		Err(_) => return HashMap::new(),
+	let Ok(stdout) = String::from_utf8(output.stdout) else {
+		return HashMap::new();
 	};
 
 	let wanted_paths: std::collections::HashSet<String> = paths

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -635,9 +635,10 @@ pub(crate) fn apply_versioned_file_definition(
 						})?;
 				}
 			}
-			(CachedDocument::Json(value), VersionedFileKind::Npm(kind))
-				if kind == monochange_npm::NpmVersionedFileKind::PackageLock =>
-			{
+			(
+				CachedDocument::Json(value),
+				VersionedFileKind::Npm(monochange_npm::NpmVersionedFileKind::PackageLock),
+			) => {
 				monochange_npm::update_package_lock(value, &package_paths_by_name, &raw_versions);
 			}
 			(
@@ -679,14 +680,16 @@ pub(crate) fn apply_versioned_file_definition(
 					))
 				})?;
 			}
-			(CachedDocument::Json(value), VersionedFileKind::Deno(kind))
-				if kind == monochange_deno::DenoVersionedFileKind::Lock =>
-			{
+			(
+				CachedDocument::Json(value),
+				VersionedFileKind::Deno(monochange_deno::DenoVersionedFileKind::Lock),
+			) => {
 				monochange_deno::update_lockfile(value, &raw_versions);
 			}
-			(CachedDocument::Text(contents), VersionedFileKind::Dart(kind))
-				if kind == monochange_dart::DartVersionedFileKind::Manifest =>
-			{
+			(
+				CachedDocument::Text(contents),
+				VersionedFileKind::Dart(monochange_dart::DartVersionedFileKind::Manifest),
+			) => {
 				*contents =
 					monochange_dart::update_manifest_text(contents, None, &fields, &versioned_deps)
 						.map_err(|error| {
@@ -696,9 +699,10 @@ pub(crate) fn apply_versioned_file_definition(
 							))
 						})?;
 			}
-			(CachedDocument::Yaml(mapping), VersionedFileKind::Dart(kind))
-				if kind == monochange_dart::DartVersionedFileKind::Lock =>
-			{
+			(
+				CachedDocument::Yaml(mapping),
+				VersionedFileKind::Dart(monochange_dart::DartVersionedFileKind::Lock),
+			) => {
 				monochange_dart::update_pubspec_lock(mapping, &raw_versions);
 			}
 			_ => {}

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -495,7 +495,7 @@ fn apply_json_replacements(
 	contents: &str,
 	mut replacements: Vec<(JsonSpan, String)>,
 ) -> MonochangeResult<String> {
-	replacements.sort_by(|left, right| right.0.start.cmp(&left.0.start));
+	replacements.sort_by_key(|right| std::cmp::Reverse(right.0.start));
 	let mut updated = contents.to_string();
 	for (span, replacement) in replacements {
 		if span.start > span.end || span.end > updated.len() {

--- a/crates/monochange_dart/src/lib.rs
+++ b/crates/monochange_dart/src/lib.rs
@@ -177,7 +177,7 @@ pub fn update_manifest_text(
 			}
 		}
 	}
-	replacements.sort_by(|left, right| right.0.0.cmp(&left.0.0));
+	replacements.sort_by_key(|right| std::cmp::Reverse(right.0.0));
 	let mut updated = contents.to_string();
 	for ((start, end), replacement) in replacements {
 		updated.replace_range(start..end, &replacement);

--- a/crates/monochange_github/src/__tests.rs
+++ b/crates/monochange_github/src/__tests.rs
@@ -364,8 +364,7 @@ fn publish_release_requests_creates_release_via_octocrab() {
 		.unwrap_or_else(|error| panic!("runtime: {error}"))
 		.block_on(async {
 			let client = build_test_client(&server);
-			let outcome = publish_release_requests_with_client(&client, &[request]).await;
-			outcome
+			publish_release_requests_with_client(&client, &[request]).await
 		})
 		.unwrap_or_else(|error| panic!("publish release: {error}"));
 
@@ -405,8 +404,7 @@ fn publish_release_requests_updates_existing_release_via_octocrab() {
 		.unwrap_or_else(|error| panic!("runtime: {error}"))
 		.block_on(async {
 			let client = build_test_client(&server);
-			let outcome = publish_release_requests_with_client(&client, &[request]).await;
-			outcome
+			publish_release_requests_with_client(&client, &[request]).await
 		})
 		.unwrap_or_else(|error| panic!("publish release: {error}"));
 
@@ -599,9 +597,7 @@ fn sync_retargeted_releases_errors_when_release_lookup_is_missing() {
 		.unwrap_or_else(|error| panic!("runtime: {error}"))
 		.block_on(async {
 			let client = build_test_client(&server);
-			let result =
-				sync_retargeted_releases_with_client(&client, &source, &updates, false).await;
-			result
+			sync_retargeted_releases_with_client(&client, &source, &updates, false).await
 		})
 		.err()
 		.unwrap_or_else(|| panic!("expected release lookup error"));
@@ -692,8 +688,7 @@ fn publish_release_pull_request_creates_pull_request_via_octocrab() {
 		.unwrap_or_else(|error| panic!("runtime: {error}"))
 		.block_on(async {
 			let client = build_test_client(&server);
-			let outcome = publish_release_pull_request_with_client(&client, &request).await;
-			outcome
+			publish_release_pull_request_with_client(&client, &request).await
 		})
 		.unwrap_or_else(|error| panic!("publish pull request: {error}"));
 
@@ -742,8 +737,7 @@ fn publish_release_pull_request_can_enable_auto_merge() {
 		.unwrap_or_else(|error| panic!("runtime: {error}"))
 		.block_on(async {
 			let client = build_test_client(&server);
-			let outcome = publish_release_pull_request_with_client(&client, &request).await;
-			outcome
+			publish_release_pull_request_with_client(&client, &request).await
 		})
 		.unwrap_or_else(|error| panic!("publish pull request: {error}"));
 
@@ -787,8 +781,7 @@ fn publish_release_pull_request_updates_existing_pull_request_via_octocrab() {
 		.unwrap_or_else(|error| panic!("runtime: {error}"))
 		.block_on(async {
 			let client = build_test_client(&server);
-			let outcome = publish_release_pull_request_with_client(&client, &request).await;
-			outcome
+			publish_release_pull_request_with_client(&client, &request).await
 		})
 		.unwrap_or_else(|error| panic!("publish pull request: {error}"));
 
@@ -827,8 +820,7 @@ fn publish_release_requests_reports_github_api_errors() {
 		.unwrap_or_else(|error| panic!("runtime: {error}"))
 		.block_on(async {
 			let client = build_test_client(&server);
-			let outcome = publish_release_requests_with_client(&client, &[request]).await;
-			outcome
+			publish_release_requests_with_client(&client, &[request]).await
 		})
 		.err()
 		.unwrap_or_else(|| panic!("expected GitHub API error"));
@@ -874,8 +866,7 @@ fn publish_release_pull_request_reports_auto_merge_payload_errors() {
 		.unwrap_or_else(|error| panic!("runtime: {error}"))
 		.block_on(async {
 			let client = build_test_client(&server);
-			let outcome = publish_release_pull_request_with_client(&client, &request).await;
-			outcome
+			publish_release_pull_request_with_client(&client, &request).await
 		})
 		.err()
 		.unwrap_or_else(|| panic!("expected auto merge error"));
@@ -1281,16 +1272,13 @@ fn comment_released_issues_skips_existing_markers_and_posts_missing_comments() {
 	);
 
 	let outcomes = temp_env::with_var("GITHUB_SERVER_URL", Some("https://example.com"), || {
-		let outcome = github_runtime()
+		github_runtime()
 			.unwrap_or_else(|error| panic!("runtime: {error}"))
 			.block_on(async {
 				let client = build_test_client(&server);
-				let comment_outcome =
-					comment_released_issues_with_client(&client, &github, &plans).await;
-				comment_outcome
+				comment_released_issues_with_client(&client, &github, &plans).await
 			})
-			.unwrap_or_else(|error| panic!("comment released issues: {error}"));
-		outcome
+			.unwrap_or_else(|error| panic!("comment released issues: {error}"))
 	});
 
 	list_issue_seven_comments.assert();

--- a/crates/monochange_npm/src/lib.rs
+++ b/crates/monochange_npm/src/lib.rs
@@ -274,7 +274,7 @@ pub fn update_pnpm_lock_text(
 			&mut replacements,
 		);
 	}
-	replacements.sort_by(|left, right| right.0.0.cmp(&left.0.0));
+	replacements.sort_by_key(|right| std::cmp::Reverse(right.0.0));
 	let mut updated = contents.to_string();
 	for ((start, end), replacement) in replacements {
 		updated.replace_range(start..end, &replacement);


### PR DESCRIPTION
## Summary
- remove the Rust 2024 tail-expression drop-order warning in changelog template rendering
- rewrite the changeset history UTF-8 parsing branch to satisfy Clippy's `manual_let_else`
- keep `fix:all` warning-free on the latest `main`

## Validation
- `devenv shell fix:all`
- `devenv shell lint:all`
- `mc affected --verify --changed-paths .changeset/fix-rust-2024-drop-order-warnings.md --changed-paths crates/monochange/src/changelog.rs --changed-paths crates/monochange/src/changesets.rs`
- `devenv test`
