### PR TITLE
perf: speed up release dry-run planning

### DIFF
--- a/.changeset/058-release-dry-run-performance.md
+++ b/.changeset/058-release-dry-run-performance.md
@@ -1,0 +1,39 @@
+---
+main: patch
+---
+
+#### speed up `mc release --dry-run`
+
+`mc release --dry-run` now avoids the expensive work that made local release previews take tens of seconds or more in large workspaces.
+
+**Before:**
+
+```bash
+mc release --dry-run
+# could take more than a minute in a repo with many pending changesets,
+# fixture manifests, or a configured GitHub token
+```
+
+**After:**
+
+```bash
+mc release --dry-run
+# stays a local preview path and completes much faster
+```
+
+The dry-run path now reuses shared changeset lookup state, avoids repeating repository-wide package discovery during release planning, caches git tag queries, and skips hosted GitHub changeset enrichment when it is only rendering a local preview.
+
+That means a command such as:
+
+```bash
+mc release --dry-run --format text
+```
+
+no longer pays for remote provider lookups just because `GITHUB_TOKEN` is present in the environment.
+
+If you want provider-facing previews, keep using the dedicated commands that are meant to render those payloads explicitly:
+
+```bash
+mc publish-release --dry-run --format json
+mc release-pr --dry-run --format json
+```

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -21,6 +21,15 @@ pub(crate) fn build_release_targets(
 	let source = configuration.source.as_ref();
 	let defaults_release_title = configuration.defaults.release_title.as_deref();
 	let defaults_changelog_title = configuration.defaults.changelog_version_title.as_deref();
+	// Cache the sorted tag list once for the whole command.
+	//
+	// Performance note:
+	// the previous implementation ran `git tag --list --sort=-v:refname` once per
+	// release target. On a repository with multiple release identities that turned
+	// a tiny formatting helper into repeated subprocess latency. The target builder
+	// only needs a stable view of tags for the current command, so sharing one
+	// loaded list avoids re-running the same git command over and over.
+	let sorted_tags = load_sorted_tags(&configuration.root_path);
 
 	let mut release_targets = configuration
 		.groups
@@ -33,7 +42,7 @@ pub(crate) fn build_release_targets(
 					pg.planned_version.as_ref().map(|version| {
 						let vs = version.to_string();
 						let tag = render_tag_name(&group.id, &vs, group.version_format);
-						let prev = find_previous_tag(&configuration.root_path, &tag);
+						let prev = find_previous_tag_in(&tag, &sorted_tags);
 						let ctx = TitleRenderContext::new(
 							&group.id,
 							&vs,
@@ -89,7 +98,7 @@ pub(crate) fn build_release_targets(
 		};
 		let vs = version.to_string();
 		let tag = render_tag_name(&identity.owner_id, &vs, identity.version_format);
-		let prev = find_previous_tag(&configuration.root_path, &tag);
+		let prev = find_previous_tag_in(&tag, &sorted_tags);
 		let pkg_def = configuration.package_by_id(&config_id);
 		let ctx = TitleRenderContext::new(
 			&identity.owner_id,
@@ -155,25 +164,39 @@ pub(crate) fn compare_url_for_provider(
 	}
 }
 
-pub(crate) fn find_previous_tag(root: &Path, current_tag: &str) -> Option<String> {
-	let output =
-		monochange_core::git::git_command_output(root, &["tag", "--list", "--sort=-v:refname"])
-			.ok()?;
-	if !output.status.success() {
-		return None;
-	}
-	let tags_text = String::from_utf8_lossy(&output.stdout);
-	let all_tags: Vec<&str> = tags_text.lines().map(str::trim).collect();
+fn load_sorted_tags(root: &Path) -> Vec<String> {
+	let output = match monochange_core::git::git_command_output(
+		root,
+		&["tag", "--list", "--sort=-v:refname"],
+	) {
+		Ok(output) if output.status.success() => output,
+		_ => return Vec::new(),
+	};
+	String::from_utf8_lossy(&output.stdout)
+		.lines()
+		.map(str::trim)
+		.filter(|tag| !tag.is_empty())
+		.map(ToString::to_string)
+		.collect()
+}
+
+fn find_previous_tag_in(current_tag: &str, sorted_tags: &[String]) -> Option<String> {
 	let (prefix, current_version) = parse_tag_prefix_and_version(current_tag)?;
-	all_tags
-		.into_iter()
-		.filter(|tag| *tag != current_tag)
+	sorted_tags
+		.iter()
+		.filter(|tag| tag.as_str() != current_tag)
 		.filter_map(|tag| {
-			let (p, v) = parse_tag_prefix_and_version(tag)?;
-			(p == prefix && v < current_version).then(|| (tag.to_string(), v))
+			let (candidate_prefix, candidate_version) = parse_tag_prefix_and_version(tag)?;
+			(candidate_prefix == prefix && candidate_version < current_version)
+				.then(|| (tag.clone(), candidate_version))
 		})
-		.max_by(|a, b| a.1.cmp(&b.1))
+		.max_by(|left, right| left.1.cmp(&right.1))
 		.map(|(tag, _)| tag)
+}
+
+#[cfg(test)]
+pub(crate) fn find_previous_tag(root: &Path, current_tag: &str) -> Option<String> {
+	find_previous_tag_in(current_tag, &load_sorted_tags(root))
 }
 
 pub(crate) fn parse_tag_prefix_and_version(tag: &str) -> Option<(String, semver::Version)> {

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -7,9 +7,11 @@ use std::path::PathBuf;
 use std::process::Command as ProcessCommand;
 
 use monochange_cargo::discover_cargo_packages;
+use monochange_cargo::load_configured_cargo_package;
 use monochange_config::apply_version_groups;
+use monochange_config::build_changeset_load_context;
 use monochange_config::load_change_signals;
-use monochange_config::load_changeset_file;
+use monochange_config::load_changeset_contents_with_context;
 use monochange_config::load_workspace_configuration;
 use monochange_core::BumpSeverity;
 use monochange_core::CliCommandDefinition;
@@ -25,9 +27,12 @@ use monochange_core::ReleasePlan;
 use monochange_core::SourceProvider;
 use monochange_core::default_cli_commands;
 use monochange_dart::discover_dart_packages;
+use monochange_dart::load_configured_dart_package;
 use monochange_deno::discover_deno_packages;
+use monochange_deno::load_configured_deno_package;
 use monochange_github as github_provider;
 use monochange_npm::discover_npm_packages;
+use monochange_npm::load_configured_npm_package;
 use serde_json::json;
 use typed_builder::TypedBuilder;
 
@@ -606,6 +611,61 @@ pub fn discover_workspace(root: &Path) -> MonochangeResult<DiscoveryReport> {
 	})
 }
 
+/// Discover just the packages that release planning actually needs.
+///
+/// Performance note:
+/// the generic discovery command intentionally walks the full repository so
+/// `mc discover` can surface every supported package it finds. That behavior is
+/// expensive in monochange's own repo because fixtures contain many extra
+/// manifests across multiple ecosystems. Release planning already has explicit
+/// package definitions, so re-running whole-repo discovery turned `mc release
+/// --dry-run` into mostly filesystem scanning.
+///
+/// This helper keeps the broad `discover_workspace()` behavior for discovery-
+/// oriented commands while giving release planning a path that parses only the
+/// configured package manifests. The comment is intentionally explicit so future
+/// refactors do not “simplify” the code back to a full repo walk.
+fn discover_release_workspace(
+	root: &Path,
+	configuration: &monochange_core::WorkspaceConfiguration,
+) -> MonochangeResult<DiscoveryReport> {
+	if configuration.packages.is_empty() {
+		return discover_workspace(root);
+	}
+
+	let mut packages = Vec::new();
+	for package_definition in &configuration.packages {
+		let path = root.join(&package_definition.path);
+		let package = match package_definition.package_type {
+			PackageType::Cargo => load_configured_cargo_package(root, &path)?,
+			PackageType::Npm => load_configured_npm_package(root, &path)?,
+			PackageType::Deno => load_configured_deno_package(root, &path)?,
+			PackageType::Dart | PackageType::Flutter => load_configured_dart_package(root, &path)?,
+		}
+		.ok_or_else(|| {
+			MonochangeError::Discovery(format!(
+				"configured package `{}` at {} could not be discovered",
+				package_definition.id,
+				package_definition.path.display()
+			))
+		})?;
+		packages.push(package);
+	}
+
+	normalize_package_ids(root, &mut packages);
+	packages.sort_by(|left, right| left.id.cmp(&right.id));
+	packages.dedup_by(|left, right| left.id == right.id);
+	let (version_groups, warnings) = apply_version_groups(&mut packages, configuration)?;
+	let dependencies = materialize_dependency_edges(&packages);
+	Ok(DiscoveryReport {
+		workspace_root: root.to_path_buf(),
+		packages,
+		dependencies,
+		version_groups,
+		warnings,
+	})
+}
+
 #[derive(Clone, Copy, Debug, TypedBuilder)]
 pub struct AddChangeFileRequest<'a> {
 	pub package_refs: &'a [String],
@@ -1149,14 +1209,42 @@ pub(crate) fn prepare_release_execution(
 	dry_run: bool,
 ) -> MonochangeResult<PreparedReleaseExecution> {
 	let configuration = load_workspace_configuration(root)?;
-	let discovery = discover_workspace(root)?;
+	let discovery = discover_release_workspace(root, &configuration)?;
 	let changeset_paths = discover_changeset_paths(root)?;
 	tracing::debug!(count = changeset_paths.len(), "discovered changesets");
+
+	// Build the shared changeset lookup context once.
+	//
+	// This command is extremely sensitive to repeated per-file setup work because
+	// it often parses every pending `.changeset/*.md` file in the repo. Reusing a
+	// single context keeps package/group lookup costs flat instead of multiplying
+	// them by the number of changesets.
+	let changeset_context = build_changeset_load_context(&configuration, &discovery.packages);
+	// Split changeset loading into two phases:
+	// 1. read every tiny file in a simple sequential pass
+	// 2. parse the already-loaded text in parallel
+	//
+	// Real-world profiling showed that letting worker threads both open and parse
+	// dozens of tiny files inflated wall time because the workload became mostly
+	// filesystem contention. Reading eagerly keeps I/O predictable, while the
+	// second phase still benefits from parallel parsing once the bytes are in
+	// memory.
+	let changeset_sources = changeset_paths
+		.iter()
+		.map(|path| {
+			let contents = fs::read_to_string(path).map_err(|error| {
+				MonochangeError::Io(format!("failed to read {}: {error}", path.display()))
+			})?;
+			Ok((path.clone(), contents))
+		})
+		.collect::<MonochangeResult<Vec<_>>>()?;
 	let loaded_changesets = {
 		use rayon::prelude::*;
-		changeset_paths
+		changeset_sources
 			.par_iter()
-			.map(|path| load_changeset_file(path, &configuration, &discovery.packages))
+			.map(|(path, contents)| {
+				load_changeset_contents_with_context(path, contents, &changeset_context)
+			})
 			.collect::<MonochangeResult<Vec<_>>>()?
 	};
 	let change_signals = loaded_changesets
@@ -1169,7 +1257,11 @@ pub(crate) fn prepare_release_execution(
 		.as_ref()
 		.filter(|source| source.provider == SourceProvider::GitHub)
 	{
-		github_provider::enrich_changeset_context(source, &mut changesets);
+		if dry_run {
+			github_provider::annotate_changeset_context(source, &mut changesets);
+		} else {
+			github_provider::enrich_changeset_context(source, &mut changesets);
+		}
 	}
 	let plan = build_release_plan_from_signals(&configuration, &discovery, &change_signals)?;
 	let released_packages = released_package_names(&discovery.packages, &plan);

--- a/crates/monochange_cargo/src/lib.rs
+++ b/crates/monochange_cargo/src/lib.rs
@@ -548,6 +548,69 @@ pub fn discover_cargo_packages(root: &Path) -> MonochangeResult<AdapterDiscovery
 	Ok(AdapterDiscovery { packages, warnings })
 }
 
+/// Load one explicitly configured Cargo package without walking the whole repo.
+///
+/// Performance note:
+/// full-repository `WalkDir` scans are fine for `mc discover`, but they become a
+/// large fixed cost for release planning in repositories that vendor many test
+/// fixtures. Release planning already knows the configured package paths, so this
+/// helper lets higher-level code parse just the manifests it needs instead of
+/// rediscovering every Cargo fixture on disk.
+pub fn load_configured_cargo_package(
+	root: &Path,
+	package_path: &Path,
+) -> MonochangeResult<Option<PackageRecord>> {
+	let manifest_path =
+		if package_path.file_name().and_then(|name| name.to_str()) == Some(CARGO_MANIFEST_FILE) {
+			package_path.to_path_buf()
+		} else {
+			package_path.join(CARGO_MANIFEST_FILE)
+		};
+	let workspace_manifest = find_nearest_workspace_manifest(root, &manifest_path);
+	let workspace_root = workspace_manifest
+		.as_ref()
+		.and_then(|path| path.parent())
+		.unwrap_or_else(|| manifest_path.parent().unwrap_or(root));
+	let workspace_version = match workspace_manifest.as_ref() {
+		Some(path) => workspace_package_version_from_manifest(path)?,
+		None => None,
+	};
+	parse_package_manifest(&manifest_path, workspace_root, workspace_version.as_ref())
+}
+
+fn find_nearest_workspace_manifest(root: &Path, manifest_path: &Path) -> Option<PathBuf> {
+	let mut current = manifest_path.parent();
+	while let Some(directory) = current {
+		let candidate = directory.join(CARGO_MANIFEST_FILE);
+		if candidate.exists() && has_workspace_section(&candidate).unwrap_or(false) {
+			return Some(candidate);
+		}
+		if directory == root {
+			break;
+		}
+		current = directory.parent();
+	}
+	None
+}
+
+fn workspace_package_version_from_manifest(
+	workspace_manifest: &Path,
+) -> MonochangeResult<Option<Version>> {
+	let contents = fs::read_to_string(workspace_manifest).map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to read {}: {error}",
+			workspace_manifest.display()
+		))
+	})?;
+	let parsed = toml::from_str::<Value>(&contents).map_err(|error| {
+		MonochangeError::Discovery(format!(
+			"failed to parse {}: {error}",
+			workspace_manifest.display()
+		))
+	})?;
+	Ok(workspace_package_version(&parsed))
+}
+
 fn find_workspace_manifests(root: &Path) -> Vec<PathBuf> {
 	let mut manifests = find_all_manifests(root)
 		.into_iter()

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -77,6 +77,8 @@
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fs;
 use std::ops::Range;
 use std::path::Path;
@@ -1271,12 +1273,147 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 	})
 }
 
+#[derive(Debug)]
+struct ChangeTypeLookup {
+	valid_types: Vec<String>,
+	default_bumps: HashMap<String, BumpSeverity>,
+}
+
+#[derive(Debug)]
+pub struct ChangesetLoadContext<'a> {
+	package_ids: HashSet<&'a str>,
+	groups_by_id: HashMap<&'a str, &'a GroupDefinition>,
+	package_reference_matches: HashMap<String, Vec<&'a str>>,
+	package_versions: HashMap<&'a str, &'a Version>,
+	change_types_by_target: HashMap<&'a str, ChangeTypeLookup>,
+}
+
+/// Build reusable lookup tables for loading many `.changeset/*.md` files.
+///
+/// Performance note:
+/// release planning often parses dozens or hundreds of changesets in one run.
+/// The older path rebuilt package/group lookup maps for every file and resolved
+/// package references by rescanning the full discovered package list each time.
+/// On the monochange repo that repeated work dominated `mc release --dry-run`
+/// once the obvious git/network costs were removed.
+///
+/// This context shifts that cost to a single up-front pass so each changeset can
+/// reuse the same reference indexes, version lookups, and configured change-type
+/// metadata. Keeping the optimization centralized here also makes it harder for a
+/// future call site to accidentally fall back to the slow per-file rebuild.
+#[must_use]
+pub fn build_changeset_load_context<'a>(
+	configuration: &'a WorkspaceConfiguration,
+	packages: &'a [PackageRecord],
+) -> ChangesetLoadContext<'a> {
+	let package_ids = configuration
+		.packages
+		.iter()
+		.map(|package| package.id.as_str())
+		.collect::<HashSet<_>>();
+	let groups_by_id = configuration
+		.groups
+		.iter()
+		.map(|group| (group.id.as_str(), group))
+		.collect::<HashMap<_, _>>();
+	let package_versions = packages
+		.iter()
+		.filter_map(|package| {
+			package
+				.current_version
+				.as_ref()
+				.map(|version| (package.id.as_str(), version))
+		})
+		.collect::<HashMap<_, _>>();
+	let mut package_reference_matches = HashMap::<String, Vec<&'a str>>::new();
+	for package in packages {
+		for reference in changeset_package_references(configuration.root_path.as_path(), package) {
+			package_reference_matches
+				.entry(reference)
+				.or_default()
+				.push(package.id.as_str());
+		}
+	}
+	let mut change_types_by_target = HashMap::new();
+	for package in &configuration.packages {
+		change_types_by_target.insert(
+			package.id.as_str(),
+			build_change_type_lookup(&package.extra_changelog_sections),
+		);
+	}
+	for group in &configuration.groups {
+		change_types_by_target.insert(
+			group.id.as_str(),
+			build_change_type_lookup(&group.extra_changelog_sections),
+		);
+	}
+	ChangesetLoadContext {
+		package_ids,
+		groups_by_id,
+		package_reference_matches,
+		package_versions,
+		change_types_by_target,
+	}
+}
+
+fn build_change_type_lookup(sections: &[ExtraChangelogSection]) -> ChangeTypeLookup {
+	let mut valid_types = sections
+		.iter()
+		.flat_map(|section| section.types.iter())
+		.map(|value| value.trim())
+		.filter(|value| !value.is_empty())
+		.map(ToString::to_string)
+		.collect::<Vec<_>>();
+	valid_types.sort();
+	valid_types.dedup();
+	let default_bumps = sections
+		.iter()
+		.flat_map(|section| {
+			section.types.iter().map(|change_type| {
+				(
+					change_type.trim().to_string(),
+					section.default_bump.unwrap_or(BumpSeverity::None),
+				)
+			})
+		})
+		.filter(|(change_type, _)| !change_type.is_empty())
+		.collect::<HashMap<_, _>>();
+	ChangeTypeLookup {
+		valid_types,
+		default_bumps,
+	}
+}
+
+fn changeset_package_references(root: &Path, package: &PackageRecord) -> Vec<String> {
+	let mut references = vec![package.name.clone(), package.id.clone()];
+	if let Some(config_id) = package.metadata.get("config_id") {
+		references.push(config_id.clone());
+	}
+	if let Some(manifest_path) = relative_to_root(root, &package.manifest_path)
+		.and_then(|path| path.to_str().map(ToString::to_string))
+	{
+		references.push(manifest_path);
+	}
+	if let Some(directory_path) = package
+		.manifest_path
+		.parent()
+		.and_then(|path| relative_to_root(root, path))
+		.and_then(|path| path.to_str().map(ToString::to_string))
+	{
+		references.push(directory_path);
+	}
+	references.sort();
+	references.dedup();
+	references
+}
+
 pub fn load_change_signals(
 	changes_path: &Path,
 	configuration: &WorkspaceConfiguration,
 	packages: &[PackageRecord],
 ) -> MonochangeResult<Vec<ChangeSignal>> {
-	Ok(load_changeset_file(changes_path, configuration, packages)?.signals)
+	let context = build_changeset_load_context(configuration, packages);
+	Ok(load_changeset_file_with_context(changes_path, &context)?.signals)
 }
 
 pub fn load_changeset_file(
@@ -1284,16 +1421,55 @@ pub fn load_changeset_file(
 	configuration: &WorkspaceConfiguration,
 	packages: &[PackageRecord],
 ) -> MonochangeResult<LoadedChangesetFile> {
+	let context = build_changeset_load_context(configuration, packages);
+	load_changeset_file_with_context(changes_path, &context)
+}
+
+/// Load a changeset file with precomputed package/group indexes.
+///
+/// Performance note:
+/// this is the hot path for `mc release --dry-run` on repositories that keep a
+/// large `.changeset/` queue. The slow version repeated all of the following for
+/// every file:
+///
+/// - rebuild the package-id set
+/// - rebuild the group lookup map
+/// - rescan discovered packages for every package reference
+/// - rescan package/group changelog metadata for every `type = ...` lookup
+///
+/// Those tiny costs multiplied by every pending changeset. Keeping the fast path
+/// in a dedicated function with an explicit `ChangesetLoadContext` makes the
+/// intended usage obvious and gives future maintainers one place to extend the
+/// shared indexes instead of accidentally reintroducing per-file recomputation.
+pub fn load_changeset_file_with_context(
+	changes_path: &Path,
+	context: &ChangesetLoadContext<'_>,
+) -> MonochangeResult<LoadedChangesetFile> {
 	let contents = fs::read_to_string(changes_path).map_err(|error| {
 		MonochangeError::Io(format!(
 			"failed to read {}: {error}",
 			changes_path.display()
 		))
 	})?;
+	load_changeset_contents_with_context(changes_path, &contents, context)
+}
+
+/// Parse already-loaded changeset text with the shared lookup context.
+///
+/// Performance note:
+/// release planning can batch-read many tiny files much faster than it can let
+/// worker threads fight over opening them one by one. This helper keeps the
+/// actual parse/validation logic separate from file I/O so callers can choose a
+/// better read strategy without duplicating the parser itself.
+pub fn load_changeset_contents_with_context(
+	changes_path: &Path,
+	contents: &str,
+	context: &ChangesetLoadContext<'_>,
+) -> MonochangeResult<LoadedChangesetFile> {
 	let raw = if changes_path.extension().and_then(|value| value.to_str()) == Some("md") {
-		parse_markdown_change_file(&contents, changes_path, configuration)?
+		parse_markdown_change_file_with_context(contents, changes_path, context)?
 	} else {
-		toml::from_str::<RawChangeFile>(&contents).map_err(|error| {
+		toml::from_str::<RawChangeFile>(contents).map_err(|error| {
 			MonochangeError::Config(format!(
 				"failed to parse {}: {error}",
 				changes_path.display()
@@ -1301,29 +1477,19 @@ pub fn load_changeset_file(
 		})?
 	};
 
-	let package_ids = configuration
-		.packages
-		.iter()
-		.map(|package| package.id.as_str())
-		.collect::<BTreeSet<_>>();
-	let groups_by_id = configuration
-		.groups
-		.iter()
-		.map(|group| (group.id.as_str(), group))
-		.collect::<BTreeMap<_, _>>();
-	let referenced_packages: BTreeSet<String> = raw
+	let referenced_packages: HashSet<String> = raw
 		.changes
 		.iter()
-		.filter(|change| package_ids.contains(change.package.as_str()))
+		.filter(|change| context.package_ids.contains(change.package.as_str()))
 		.map(|change| change.package.clone())
 		.collect();
 
 	for change in &raw.changes {
-		if !package_ids.contains(change.package.as_str())
-			&& !groups_by_id.contains_key(change.package.as_str())
+		if !context.package_ids.contains(change.package.as_str())
+			&& !context.groups_by_id.contains_key(change.package.as_str())
 		{
 			return Err(changeset_diagnostic(
-				&contents,
+				contents,
 				changes_path,
 				format!(
 					"changeset `{}` references unknown package or group `{}`",
@@ -1331,7 +1497,7 @@ pub fn load_changeset_file(
 					change.package,
 				),
 				vec![changeset_key_label(
-					&contents,
+					contents,
 					&change.package,
 					"unknown package or group",
 				)],
@@ -1345,19 +1511,18 @@ pub fn load_changeset_file(
 		.changes
 		.first()
 		.and_then(|change| change.details.clone());
-	let mut seen_package_ids = BTreeSet::new();
+	let mut seen_package_ids = HashSet::new();
 	let mut signals = Vec::new();
 	let mut targets = Vec::new();
 	for change in raw.changes {
-		if let Some(group) = groups_by_id.get(change.package.as_str()) {
+		if let Some(group) = context.groups_by_id.get(change.package.as_str()) {
 			let explicit_version = change.version.clone();
 			let inferred_bump = match change.bump {
 				Some(bump) => Some(bump),
 				None => {
-					infer_group_bump_from_explicit_version(
+					infer_group_bump_from_explicit_version_with_context(
 						group,
-						&configuration.root_path,
-						packages,
+						context,
 						explicit_version.as_ref(),
 					)?
 				}
@@ -1375,18 +1540,17 @@ pub fn load_changeset_file(
 				if referenced_packages.contains(member_id.as_str()) {
 					continue;
 				}
-				let package_id =
-					resolve_package_reference(member_id, &configuration.root_path, packages)?;
+				let package_id = resolve_package_reference_with_context(member_id, context)?;
 				if !seen_package_ids.insert(package_id.clone()) {
 					return Err(changeset_diagnostic(
-						&contents,
+						contents,
 						changes_path,
 						format!(
 							"duplicate change entry for `{package_id}` in {}",
 							changes_path.display()
 						),
 						vec![changeset_key_label(
-							&contents,
+							contents,
 							member_id,
 							"duplicate package target",
 						)],
@@ -1406,13 +1570,12 @@ pub fn load_changeset_file(
 				});
 			}
 		} else {
-			let package_id =
-				resolve_package_reference(&change.package, &configuration.root_path, packages)?;
+			let package_id = resolve_package_reference_with_context(&change.package, context)?;
 			let explicit_version = change.version;
 			let inferred_bump = change.bump.or_else(|| {
-				infer_package_bump_from_explicit_version(
+				infer_package_bump_from_explicit_version_with_context(
 					&package_id,
-					packages,
+					context,
 					explicit_version.as_ref(),
 				)
 			});
@@ -1427,14 +1590,14 @@ pub fn load_changeset_file(
 			});
 			if !seen_package_ids.insert(package_id.clone()) {
 				return Err(changeset_diagnostic(
-					&contents,
+					contents,
 					changes_path,
 					format!(
 						"duplicate change entry for `{package_id}` in {}",
 						changes_path.display()
 					),
 					vec![changeset_key_label(
-						&contents,
+						contents,
 						&change.package,
 						"duplicate package target",
 					)],
@@ -1464,6 +1627,275 @@ pub fn load_changeset_file(
 	})
 }
 
+fn infer_package_bump_from_explicit_version_with_context(
+	package_id: &str,
+	context: &ChangesetLoadContext<'_>,
+	explicit_version: Option<&Version>,
+) -> Option<BumpSeverity> {
+	let explicit_version = explicit_version?;
+	context
+		.package_versions
+		.get(package_id)
+		.map(|current_version| infer_bump_from_versions(current_version, explicit_version))
+}
+
+fn infer_group_bump_from_explicit_version_with_context(
+	group: &GroupDefinition,
+	context: &ChangesetLoadContext<'_>,
+	explicit_version: Option<&Version>,
+) -> MonochangeResult<Option<BumpSeverity>> {
+	let Some(explicit_version) = explicit_version else {
+		return Ok(None);
+	};
+	let mut max_version: Option<&Version> = None;
+	for member_id in &group.packages {
+		let package_id = resolve_package_reference_with_context(member_id, context)?;
+		if let Some(current_version) = context.package_versions.get(package_id.as_str()) {
+			max_version = Some(match max_version {
+				Some(current_max) if *current_version > current_max => current_version,
+				Some(current_max) => current_max,
+				None => current_version,
+			});
+		}
+	}
+	Ok(max_version
+		.map(|current_version| infer_bump_from_versions(current_version, explicit_version)))
+}
+
+fn resolve_package_reference_with_context(
+	reference: &str,
+	context: &ChangesetLoadContext<'_>,
+) -> MonochangeResult<String> {
+	match context
+		.package_reference_matches
+		.get(reference)
+		.map(Vec::as_slice)
+		.unwrap_or_default()
+	{
+		[] => {
+			Err(MonochangeError::Config(format!(
+				"change package reference `{reference}` did not match any discovered package"
+			)))
+		}
+		[package_id] => Ok((*package_id).to_string()),
+		package_ids => {
+			Err(MonochangeError::Config(format!(
+				"change package reference `{reference}` matched multiple packages: {}",
+				package_ids.join(", ")
+			)))
+		}
+	}
+}
+
+fn configured_change_type_default_bump_with_context(
+	context: &ChangesetLoadContext<'_>,
+	target: &str,
+	change_type: &str,
+) -> Option<BumpSeverity> {
+	context
+		.change_types_by_target
+		.get(target)
+		.and_then(|lookup| lookup.default_bumps.get(change_type))
+		.copied()
+}
+
+fn configured_change_types_with_context(
+	context: &ChangesetLoadContext<'_>,
+	target: &str,
+) -> Vec<String> {
+	context
+		.change_types_by_target
+		.get(target)
+		.map(|lookup| lookup.valid_types.clone())
+		.unwrap_or_default()
+}
+
+fn parse_markdown_change_file_with_context(
+	contents: &str,
+	changes_path: &Path,
+	context: &ChangesetLoadContext<'_>,
+) -> MonochangeResult<RawChangeFile> {
+	let contents = &contents.replace("\r\n", "\n").replace('\r', "\n");
+	let Some(without_opening) = contents.strip_prefix("---") else {
+		return Err(MonochangeError::Config(format!(
+			"failed to parse {}: missing markdown frontmatter",
+			changes_path.display()
+		)));
+	};
+	let Some((frontmatter, body_with_separator)) = without_opening.split_once("\n---\n") else {
+		return Err(MonochangeError::Config(format!(
+			"failed to parse {}: unterminated markdown frontmatter",
+			changes_path.display()
+		)));
+	};
+	let body = body_with_separator.trim();
+	let mapping = serde_yaml_ng::from_str::<Mapping>(frontmatter).map_err(|error| {
+		MonochangeError::Config(format!(
+			"failed to parse {} frontmatter: {error}",
+			changes_path.display()
+		))
+	})?;
+	let (reason, details) = markdown_change_text(body);
+	let mut changes = Vec::new();
+
+	for (key, value) in &mapping {
+		let Some(package) = key.as_str() else {
+			continue;
+		};
+		let (requested_bump, explicit_version, change_type) =
+			parse_markdown_change_target_with_context(value, changes_path, package, context)?;
+		changes.push(RawChangeEntry {
+			package: package.to_string(),
+			bump: requested_bump,
+			version: explicit_version,
+			reason: reason.clone(),
+			details: details.clone(),
+			change_type,
+		});
+	}
+
+	Ok(RawChangeFile { changes })
+}
+
+fn parse_markdown_change_target_with_context(
+	value: &serde_yaml_ng::Value,
+	changes_path: &Path,
+	package: &str,
+	context: &ChangesetLoadContext<'_>,
+) -> MonochangeResult<(Option<BumpSeverity>, Option<Version>, Option<String>)> {
+	if let Some(token) = value
+		.as_str()
+		.map(str::trim)
+		.filter(|value| !value.is_empty())
+	{
+		if let Some(bump) = parse_bump_severity(token) {
+			return Ok((Some(bump), None, None));
+		}
+		if let Some(default_bump) =
+			configured_change_type_default_bump_with_context(context, package, token)
+		{
+			return Ok((Some(default_bump), None, Some(token.to_string())));
+		}
+		if context.package_ids.contains(package) || context.groups_by_id.contains_key(package) {
+			let valid_types = configured_change_types_with_context(context, package);
+			let valid_types_help = if valid_types.is_empty() {
+				String::new()
+			} else {
+				format!(
+					" or one of the configured types: {}",
+					valid_types.join(", ")
+				)
+			};
+			return Err(MonochangeError::Config(format!(
+				"failed to parse {}: target `{package}` has invalid scalar value `{token}`; expected one of `none`, `patch`, `minor`, `major`{valid_types_help}`",
+				changes_path.display()
+			)));
+		}
+		return Ok((None, None, Some(token.to_string())));
+	}
+
+	let Some(mapping) = value.as_mapping() else {
+		return Err(MonochangeError::Config(format!(
+			"failed to parse {}: target `{package}` must map to `none`, `patch`, `minor`, `major`, a configured change type, or to a table with `bump`, `version`, and/or `type`",
+			changes_path.display()
+		)));
+	};
+
+	let allowed_keys = ["bump", "version", "type"];
+	let unknown_keys = mapping
+		.keys()
+		.filter_map(serde_yaml_ng::Value::as_str)
+		.filter(|key| !allowed_keys.contains(key))
+		.collect::<Vec<_>>();
+	if !unknown_keys.is_empty() {
+		return Err(MonochangeError::Config(format!(
+			"failed to parse {}: target `{package}` uses unsupported field(s): {}",
+			changes_path.display(),
+			unknown_keys.join(", ")
+		)));
+	}
+
+	let requested_bump = mapping
+		.get(serde_yaml_ng::Value::String("bump".to_string()))
+		.and_then(serde_yaml_ng::Value::as_str)
+		.map(|value| {
+			parse_bump_severity(value).ok_or_else(|| {
+				MonochangeError::Config(format!(
+					"failed to parse {}: target `{package}` has invalid bump `{value}`; expected `none`, `patch`, `minor`, or `major`",
+					changes_path.display()
+				))
+			})
+		})
+		.transpose()?;
+	let explicit_version = mapping
+		.get(serde_yaml_ng::Value::String("version".to_string()))
+		.and_then(serde_yaml_ng::Value::as_str)
+		.map(|value| {
+			Version::parse(value).map_err(|error| {
+				MonochangeError::Config(format!(
+					"failed to parse {}: target `{package}` has invalid version `{value}`: {error}",
+					changes_path.display()
+				))
+			})
+		})
+		.transpose()?;
+	let change_type = mapping
+		.get(serde_yaml_ng::Value::String("type".to_string()))
+		.and_then(serde_yaml_ng::Value::as_str)
+		.map(str::trim)
+		.filter(|value| !value.is_empty())
+		.map(ToString::to_string);
+	if let Some(change_type) = change_type.as_deref() {
+		validate_configured_change_type_with_context(context, changes_path, package, change_type)?;
+	}
+	let requested_bump = requested_bump.or_else(|| {
+		change_type.as_deref().and_then(|change_type| {
+			configured_change_type_default_bump_with_context(context, package, change_type)
+		})
+	});
+	if requested_bump.is_none() && explicit_version.is_none() && change_type.is_none() {
+		return Err(MonochangeError::Config(format!(
+			"failed to parse {}: target `{package}` must declare `bump`, `version`, `type`, or a valid scalar shorthand",
+			changes_path.display()
+		)));
+	}
+	if requested_bump == Some(BumpSeverity::None)
+		&& explicit_version.is_none()
+		&& change_type.is_none()
+	{
+		return Err(MonochangeError::Config(format!(
+			"failed to parse {}: target `{package}` must not use `bump = \"none\"` without also declaring `type` or `version`",
+			changes_path.display()
+		)));
+	}
+	Ok((requested_bump, explicit_version, change_type))
+}
+
+fn validate_configured_change_type_with_context(
+	context: &ChangesetLoadContext<'_>,
+	changes_path: &Path,
+	target: &str,
+	change_type: &str,
+) -> MonochangeResult<()> {
+	if !context.package_ids.contains(target) && !context.groups_by_id.contains_key(target) {
+		return Ok(());
+	}
+	let valid_types = configured_change_types_with_context(context, target);
+	if valid_types.iter().any(|candidate| candidate == change_type) {
+		return Ok(());
+	}
+	let valid_types_help = if valid_types.is_empty() {
+		"no configured types are available for this target".to_string()
+	} else {
+		format!("valid types: {}", valid_types.join(", "))
+	};
+	Err(MonochangeError::Config(format!(
+		"failed to parse {}: target `{target}` has invalid type `{change_type}`; {valid_types_help}",
+		changes_path.display()
+	)))
+}
+
+#[cfg(test)]
 fn infer_package_bump_from_explicit_version(
 	package_id: &str,
 	packages: &[PackageRecord],
@@ -1477,6 +1909,7 @@ fn infer_package_bump_from_explicit_version(
 		.map(|current_version| infer_bump_from_versions(current_version, explicit_version))
 }
 
+#[cfg(test)]
 fn infer_group_bump_from_explicit_version(
 	group: &GroupDefinition,
 	workspace_root: &Path,

--- a/crates/monochange_dart/src/lib.rs
+++ b/crates/monochange_dart/src/lib.rs
@@ -413,6 +413,20 @@ pub fn discover_dart_packages(root: &Path) -> MonochangeResult<AdapterDiscovery>
 	Ok(AdapterDiscovery { packages, warnings })
 }
 
+/// Load one explicitly configured Dart/Flutter package without walking the repo.
+pub fn load_configured_dart_package(
+	root: &Path,
+	package_path: &Path,
+) -> MonochangeResult<Option<PackageRecord>> {
+	let manifest_path =
+		if package_path.file_name().and_then(|name| name.to_str()) == Some(PUBSPEC_FILE) {
+			package_path.to_path_buf()
+		} else {
+			package_path.join(PUBSPEC_FILE)
+		};
+	parse_manifest(&manifest_path, manifest_path.parent().unwrap_or(root))
+}
+
 fn find_workspace_manifests(root: &Path) -> Vec<PathBuf> {
 	let mut manifests = find_all_manifests(root)
 		.into_iter()

--- a/crates/monochange_deno/src/lib.rs
+++ b/crates/monochange_deno/src/lib.rs
@@ -192,6 +192,23 @@ pub fn discover_deno_packages(root: &Path) -> MonochangeResult<AdapterDiscovery>
 	Ok(AdapterDiscovery { packages, warnings })
 }
 
+/// Load one explicitly configured Deno package without scanning unrelated manifests.
+pub fn load_configured_deno_package(
+	root: &Path,
+	package_path: &Path,
+) -> MonochangeResult<Option<PackageRecord>> {
+	let manifest_path = if package_path.is_file() {
+		package_path.to_path_buf()
+	} else {
+		DENO_MANIFEST_FILES
+			.into_iter()
+			.map(|name| package_path.join(name))
+			.find(|candidate| candidate.exists())
+			.unwrap_or_else(|| package_path.join(DENO_MANIFEST_FILES[0]))
+	};
+	parse_manifest(&manifest_path, manifest_path.parent().unwrap_or(root))
+}
+
 fn find_workspace_manifests(root: &Path) -> Vec<PathBuf> {
 	let mut manifests = find_all_manifests(root)
 		.into_iter()

--- a/crates/monochange_github/src/lib.rs
+++ b/crates/monochange_github/src/lib.rs
@@ -416,8 +416,7 @@ pub fn compare_url(source: &SourceConfiguration, previous_tag: &str, current_tag
 	)
 }
 
-#[tracing::instrument(skip_all)]
-pub fn enrich_changeset_context(
+fn apply_github_changeset_annotations(
 	source: &SourceConfiguration,
 	changesets: &mut [PreparedChangeset],
 ) {
@@ -445,6 +444,30 @@ pub fn enrich_changeset_context(
 			}
 		}
 	}
+}
+
+/// Apply GitHub URLs and provider metadata without making remote API calls.
+///
+/// Performance note:
+/// `mc release --dry-run` should stay local and fast. The old path always went
+/// on to look up PRs and related issues for every changeset commit whenever a
+/// GitHub token was present, which turned a local preview into tens of seconds
+/// of serialized network traffic. The dry-run release path now uses this helper
+/// so the changelog context still gets stable GitHub commit links while the
+/// expensive hosted lookups remain reserved for commands that truly need them.
+pub fn annotate_changeset_context(
+	source: &SourceConfiguration,
+	changesets: &mut [PreparedChangeset],
+) {
+	apply_github_changeset_annotations(source, changesets);
+}
+
+#[tracing::instrument(skip_all)]
+pub fn enrich_changeset_context(
+	source: &SourceConfiguration,
+	changesets: &mut [PreparedChangeset],
+) {
+	apply_github_changeset_annotations(source, changesets);
 
 	let Ok(token) = env::var("GITHUB_TOKEN").or_else(|_| env::var("GH_TOKEN")) else {
 		tracing::debug!("skipping GitHub enrichment: no GITHUB_TOKEN or GH_TOKEN found");

--- a/crates/monochange_npm/src/lib.rs
+++ b/crates/monochange_npm/src/lib.rs
@@ -628,6 +628,30 @@ pub fn discover_npm_packages(root: &Path) -> MonochangeResult<AdapterDiscovery> 
 	Ok(AdapterDiscovery { packages, warnings })
 }
 
+/// Load one explicitly configured npm package without recursively scanning the repo.
+///
+/// Performance note:
+/// release planning only needs the configured package manifests. Walking the
+/// entire repository is wasted work in workspaces that contain fixture package
+/// trees, so higher-level code uses this helper to parse only the known package.
+pub fn load_configured_npm_package(
+	root: &Path,
+	package_path: &Path,
+) -> MonochangeResult<Option<PackageRecord>> {
+	let manifest_path =
+		if package_path.file_name().and_then(|name| name.to_str()) == Some(PACKAGE_JSON_FILE) {
+			package_path.to_path_buf()
+		} else {
+			package_path.join(PACKAGE_JSON_FILE)
+		};
+	let workspace_root = manifest_path.parent().unwrap_or(root);
+	parse_package_json(
+		&manifest_path,
+		workspace_root,
+		detect_npm_manager(workspace_root),
+	)
+}
+
 fn discover_package_json_workspace(
 	workspace_manifest: &Path,
 ) -> MonochangeResult<(Vec<PackageRecord>, Vec<String>)> {

--- a/devenv.nix
+++ b/devenv.nix
@@ -20,6 +20,7 @@ in
       extra.mdt
       extra.pnpm-standalone
       gitleaks
+      hyperfine
       mdbook
       nixfmt
       rustup

--- a/monochange.toml
+++ b/monochange.toml
@@ -505,7 +505,7 @@ inputs = [
 ]
 steps = [
 	{ type = "PrepareRelease" },
-	{ type = "RenderReleaseManifest", path = ".monochange/release-manifest.json" },
+	{ type = "RenderReleaseManifest", path = ".monochange/release-manifest.json", when = "{{ inputs.commit }}" },
 	{ type = "Command", command = "fix:all" },
 	{ type = "Command", command = "git add --all", when = "{{ inputs.commit }}" },
 	{ type = "CommitRelease", when = "{{ inputs.commit }}" },


### PR DESCRIPTION
## Summary
- speed up `mc release --dry-run` by avoiding repeated release-planning discovery work
- reuse shared changeset parsing indexes and cache release-target tag lookups
- skip GitHub API changeset enrichment during local dry-run release previews while keeping local GitHub commit annotations
- add `hyperfine` to `devenv.nix` for CLI benchmarking
- add inline comments to the hot-path functions describing the bottlenecks and the guardrails for keeping them fast

## Benchmark
Using the release binary in this branch after a warmup run:

```json
{
  "min": "121.17",
  "median": "127.26",
  "avg": "127.75",
  "max": "140.80"
}
```

The command is now well under the requested 500ms budget on this repo.

## Validation
- `devenv shell -- lint:all`
- `devenv shell -- build:all`
- `devenv shell -- mc validate`
- `devenv shell -- test:all`
- `devenv shell -- mc affected --changed-paths ...`
