### PR TITLE
refactor(ci): simplify CLI benchmarks with hyperfine

### DIFF
--- a/.github/scripts/benchmark_cli.sh
+++ b/.github/scripts/benchmark_cli.sh
@@ -152,7 +152,7 @@ run_scenario() {
 
 	local fixture_dir
 	fixture_dir="$(mktemp -d -t monochange-bench.XXXXXX)"
-	trap 'rm -rf "$fixture_dir"' RETURN
+	trap "rm -rf '$fixture_dir'" RETURN
 
 	generate_fixture "$fixture_dir" "$packages" "$changesets" "$commits"
 

--- a/.github/scripts/benchmark_cli.sh
+++ b/.github/scripts/benchmark_cli.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WARMUP_RUNS=1
+BENCHMARK_RUNS=6
+
+SCENARIO_IDS=(baseline history_x10)
+SCENARIO_NAMES=("Baseline fixture" "Large history fixture")
+SCENARIO_PACKAGES=(20 200)
+SCENARIO_CHANGESETS=(50 500)
+SCENARIO_COMMITS=(50 500)
+COMMAND_LABELS=(
+	"mc validate"
+	"mc discover --format json"
+	"mc release --dry-run"
+)
+COMMAND_ARGS=(
+	"validate"
+	"discover --format json"
+	"release --dry-run"
+)
+
+render_comment() {
+	local output_path="$1"
+	shift
+
+	{
+		echo "## Binary Benchmark: main vs PR"
+		echo
+		echo "Measured with \`hyperfine --warmup ${WARMUP_RUNS} --runs ${BENCHMARK_RUNS}\`."
+		echo
+		echo "Commands:"
+		local label
+		for label in "${COMMAND_LABELS[@]}"; do
+			echo "- \`${label}\`"
+		done
+
+		local index=0
+		while [ "$#" -gt 0 ]; do
+			local scenario_name="$1"
+			local scenario_description="$2"
+			local table_path="$3"
+			shift 3
+
+			echo
+			echo "### ${scenario_name}"
+			echo
+			echo "Fixture: ${scenario_description}"
+			echo
+			cat "$table_path"
+		done
+	} >"$output_path"
+}
+
+git_commit() {
+	local root="$1"
+	shift
+	git -C "$root" \
+		-c user.name=bench \
+		-c user.email=bench@test \
+		commit -m "$1" >/dev/null
+}
+
+generate_fixture() {
+	local root="$1"
+	local packages="$2"
+	local changesets="$3"
+	local commits="$4"
+
+	mkdir -p "$root/crates" "$root/.changeset"
+
+	{
+		echo '[workspace]'
+		echo 'members = ['
+		local i
+		for i in $(seq 0 $((packages - 1))); do
+			echo "  \"crates/pkg-${i}\","
+		done
+		echo ']'
+		echo 'resolver = "2"'
+	} >"$root/Cargo.toml"
+
+	{
+		echo '[defaults]'
+		echo 'package_type = "cargo"'
+		echo
+		local i
+		for i in $(seq 0 $((packages - 1))); do
+			echo "[package.pkg-${i}]"
+			echo "path = \"crates/pkg-${i}\""
+			echo
+			mkdir -p "$root/crates/pkg-${i}"
+			{
+				echo '[package]'
+				echo "name = \"pkg-${i}\""
+				echo 'version = "1.0.0"'
+				echo 'edition = "2021"'
+			} >"$root/crates/pkg-${i}/Cargo.toml"
+		done
+		echo '[ecosystems.cargo]'
+		echo 'enabled = true'
+	} >"$root/monochange.toml"
+
+	git -C "$root" init -b main >/dev/null
+	git -C "$root" add .
+	git_commit "$root" initial
+
+	local commit_index
+	for commit_index in $(seq 0 $((commits - 1))); do
+		local package_index=$((commit_index % packages))
+		printf '// commit %d\n' "$commit_index" >"$root/crates/pkg-${package_index}/src.rs"
+
+		if [ "$commit_index" -lt "$changesets" ]; then
+			cat >"$root/.changeset/change-$(printf '%04d' "$commit_index").md" <<EOF
+---
+pkg-${package_index}: patch
+---
+
+Fix issue #${commit_index}.
+EOF
+		fi
+
+		git -C "$root" add .
+		git_commit "$root" "change ${commit_index}"
+	done
+
+	if [ "$changesets" -gt "$commits" ]; then
+		local changeset_index
+		for changeset_index in $(seq "$commits" $((changesets - 1))); do
+			local package_index=$((changeset_index % packages))
+			cat >"$root/.changeset/change-$(printf '%04d' "$changeset_index").md" <<EOF
+---
+pkg-${package_index}: patch
+---
+
+Fix issue #${changeset_index}.
+EOF
+			git -C "$root" add .
+			git_commit "$root" "changeset ${changeset_index}"
+		done
+	fi
+}
+
+run_scenario() {
+	local main_bin="$1"
+	local pr_bin="$2"
+	local scenario_name="$3"
+	local packages="$4"
+	local changesets="$5"
+	local commits="$6"
+	local table_path="$7"
+
+	local fixture_dir
+	fixture_dir="$(mktemp -d -t monochange-bench.XXXXXX)"
+	trap 'rm -rf "$fixture_dir"' RETURN
+
+	generate_fixture "$fixture_dir" "$packages" "$changesets" "$commits"
+
+	local hyperfine_args=()
+	local idx
+	for idx in "${!COMMAND_LABELS[@]}"; do
+		hyperfine_args+=(--command-name "main · ${COMMAND_LABELS[$idx]}" "${main_bin} ${COMMAND_ARGS[$idx]}")
+		hyperfine_args+=(--command-name "pr · ${COMMAND_LABELS[$idx]}" "${pr_bin} ${COMMAND_ARGS[$idx]}")
+	done
+
+	(
+		cd "$fixture_dir"
+		hyperfine \
+			--style basic \
+			--warmup "$WARMUP_RUNS" \
+			--runs "$BENCHMARK_RUNS" \
+			--time-unit millisecond \
+			--export-markdown "$table_path" \
+			"${hyperfine_args[@]}"
+	)
+}
+
+run_mode() {
+	local main_bin=""
+	local pr_bin=""
+	local output_path=""
+
+	while [ "$#" -gt 0 ]; do
+		case "$1" in
+		--main-bin)
+			main_bin="$2"
+			shift 2
+			;;
+		--pr-bin)
+			pr_bin="$2"
+			shift 2
+			;;
+		--output)
+			output_path="$2"
+			shift 2
+			;;
+		*)
+			echo "unknown argument: $1" >&2
+			exit 1
+			;;
+		esac
+	done
+
+	local scenario_render_args=()
+	local idx
+	for idx in "${!SCENARIO_IDS[@]}"; do
+		local table_path
+		table_path="$(mktemp -t monochange-bench-table.XXXXXX.md)"
+		run_scenario \
+			"$main_bin" \
+			"$pr_bin" \
+			"${SCENARIO_NAMES[$idx]}" \
+			"${SCENARIO_PACKAGES[$idx]}" \
+			"${SCENARIO_CHANGESETS[$idx]}" \
+			"${SCENARIO_COMMITS[$idx]}" \
+			"$table_path"
+		scenario_render_args+=(
+			"${SCENARIO_NAMES[$idx]}"
+			"${SCENARIO_PACKAGES[$idx]} packages, ${SCENARIO_CHANGESETS[$idx]} changesets, ${SCENARIO_COMMITS[$idx]} commits"
+			"$table_path"
+		)
+	done
+
+	render_comment "$output_path" "${scenario_render_args[@]}"
+}
+
+render_fixture_mode() {
+	local fixture_dir=""
+	local output_path=""
+
+	while [ "$#" -gt 0 ]; do
+		case "$1" in
+		--fixture-dir)
+			fixture_dir="$2"
+			shift 2
+			;;
+		--output)
+			output_path="$2"
+			shift 2
+			;;
+		*)
+			echo "unknown argument: $1" >&2
+			exit 1
+			;;
+		esac
+	done
+
+	render_comment \
+		"$output_path" \
+		"Baseline fixture" \
+		"20 packages, 50 changesets, 50 commits" \
+		"$fixture_dir/baseline.md" \
+		"Large history fixture" \
+		"200 packages, 500 changesets, 500 commits" \
+		"$fixture_dir/history_x10.md"
+}
+
+main() {
+	local mode="${1:-}"
+	shift || true
+
+	case "$mode" in
+	run) run_mode "$@" ;;
+	render-fixture) render_fixture_mode "$@" ;;
+	*)
+		echo "usage: $0 <run|render-fixture> [args...]" >&2
+		exit 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,79 +180,20 @@ jobs:
           git stash pop || true
         shell: devenv shell -- bash -e {0}
 
-      - name: generate benchmark fixture
-        run: |
-          mkdir -p /tmp/bench-fixture/.changeset
-          cd /tmp/bench-fixture
-
-          printf '[workspace]\nmembers = [' > Cargo.toml
-          for i in $(seq 0 19); do
-            [ $i -gt 0 ] && printf ',' >> Cargo.toml
-            printf '"crates/pkg-%d"' $i >> Cargo.toml
-          done
-          printf ']\nresolver = "2"\n' >> Cargo.toml
-
-          printf '[defaults]\npackage_type = "cargo"\n\n' > monochange.toml
-          for i in $(seq 0 19); do
-            printf '[package.pkg-%d]\npath = "crates/pkg-%d"\n\n' $i $i >> monochange.toml
-            mkdir -p crates/pkg-$i
-            printf '[package]\nname = "pkg-%d"\nversion = "1.0.0"\nedition = "2021"\n' $i > crates/pkg-$i/Cargo.toml
-          done
-          printf '[ecosystems.cargo]\nenabled = true\n' >> monochange.toml
-
-          git init -b main
-          git config user.name "bench" && git config user.email "bench@test"
-          git add . && git commit -m "initial"
-          for i in $(seq 0 49); do
-            pkg=$((i % 20))
-            printf -- '---\npkg-%d: patch\n---\n\nFix issue #%d.\n' $pkg $i > .changeset/change-$(printf "%04d" $i).md
-            printf '// commit %d\n' $i > crates/pkg-$pkg/src.rs
-            git add . && git commit -m "change $i"
-          done
-        shell: bash -e {0}
-
-      - name: time CLI commands
+      - name: run CLI benchmarks
         id: bench
         run: |
-          PR_BIN="/tmp/mc-pr"
-          MAIN_BIN="/tmp/mc-main"
-          RESULTS=""
-
-          time_cmd() {
-            local bin="$1"; shift
-            local best=999999
-            for run in 1 2 3; do
-              ms=$( { TIMEFORMAT='%3R'; time "$bin" "$@" > /dev/null 2>&1; } 2>&1 )
-              ms_int=$(echo "$ms * 1000 / 1" | bc)
-              [ "$ms_int" -lt "$best" ] && best=$ms_int
-            done
-            echo "$best"
-          }
-
-          for cmd_args in "validate" "discover --format json" "release --dry-run"; do
-            pr_ms=$(time_cmd "$PR_BIN" $cmd_args)
-            main_ms=$(time_cmd "$MAIN_BIN" $cmd_args)
-            if [ "$main_ms" -gt 0 ]; then
-              pct=$(( (pr_ms * 100) / main_ms ))
-            else
-              pct=0
-            fi
-            RESULTS="${RESULTS}| \`mc ${cmd_args}\` | ${main_ms}ms | ${pr_ms}ms | ${pct}% |\n"
-          done
+          .github/scripts/benchmark_cli.sh run \
+            --main-bin /tmp/mc-main \
+            --pr-bin /tmp/mc-pr \
+            --output /tmp/benchmark-comment.md
 
           {
             echo "results<<ENDOFBENCH"
-            echo "## Binary Benchmark: main vs PR"
-            echo ""
-            echo "Fixture: 20 packages, 50 changesets, 50 git commits"
-            echo ""
-            echo "| Command | main | PR | ratio |"
-            echo "|---------|------|-----|-------|"
-            echo -e "$RESULTS"
+            cat /tmp/benchmark-comment.md
             echo "ENDOFBENCH"
           } >> "$GITHUB_OUTPUT"
-        working-directory: /tmp/bench-fixture
-        shell: bash -e {0}
+        shell: devenv shell -- bash -e {0}
 
       - name: comment benchmark results on PR
         uses: marocchino/sticky-pull-request-comment@v2

--- a/crates/monochange/tests/benchmark_cli_comment.rs
+++ b/crates/monochange/tests/benchmark_cli_comment.rs
@@ -1,0 +1,49 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use insta::assert_snapshot;
+
+mod test_support;
+use test_support::current_test_name;
+use test_support::fixture_path;
+use test_support::snapshot_settings;
+
+fn repo_root() -> std::path::PathBuf {
+	Path::new(env!("CARGO_MANIFEST_DIR"))
+		.join("../..")
+		.canonicalize()
+		.unwrap_or_else(|error| panic!("repo root: {error}"))
+}
+
+#[test]
+fn benchmark_cli_comment_renderer_matches_snapshot() {
+	let mut settings = snapshot_settings();
+	settings.set_snapshot_suffix(current_test_name());
+	let _guard = settings.bind_to_scope();
+
+	let fixture = fixture_path("monochange/benchmark-cli-comment");
+	let output_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let output_path = output_dir.path().join("comment.md");
+	let script_path = repo_root().join(".github/scripts/benchmark_cli.sh");
+
+	let output = Command::new("bash")
+		.arg(&script_path)
+		.arg("render-fixture")
+		.arg("--fixture-dir")
+		.arg(&fixture)
+		.arg("--output")
+		.arg(&output_path)
+		.output()
+		.unwrap_or_else(|error| panic!("render benchmark comment: {error}"));
+
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+
+	let rendered = fs::read_to_string(&output_path)
+		.unwrap_or_else(|error| panic!("read rendered benchmark comment: {error}"));
+	assert_snapshot!(rendered);
+}

--- a/crates/monochange/tests/snapshots/benchmark_cli_comment__benchmark_cli_comment_renderer_matches_snapshot@benchmark_cli_comment_renderer_matches_snapshot.snap
+++ b/crates/monochange/tests/snapshots/benchmark_cli_comment__benchmark_cli_comment_renderer_matches_snapshot@benchmark_cli_comment_renderer_matches_snapshot.snap
@@ -1,0 +1,39 @@
+---
+source: crates/monochange/tests/benchmark_cli_comment.rs
+assertion_line: 48
+expression: rendered
+---
+## Binary Benchmark: main vs PR
+
+Measured with `hyperfine --warmup 1 --runs 6`.
+
+Commands:
+- `mc validate`
+- `mc discover --format json`
+- `mc release --dry-run`
+
+### Baseline fixture
+
+Fixture: 20 packages, 50 changesets, 50 commits
+
+| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
+|:---|---:|---:|---:|---:|
+| `main · mc validate` | 120.0 ± 6.0 | 113.0 | 129.0 | 1.00 |
+| `pr · mc validate` | 126.0 ± 4.0 | 121.0 | 131.0 | 1.05 ± 0.06 |
+| `main · mc discover --format json` | 88.0 ± 3.0 | 84.0 | 92.0 | 1.00 |
+| `pr · mc discover --format json` | 85.0 ± 2.0 | 82.0 | 88.0 | 0.97 ± 0.04 |
+| `main · mc release --dry-run` | 240.0 ± 8.0 | 229.0 | 251.0 | 1.00 |
+| `pr · mc release --dry-run` | 255.0 ± 10.0 | 242.0 | 269.0 | 1.06 ± 0.06 |
+
+### Large history fixture
+
+Fixture: 200 packages, 500 changesets, 500 commits
+
+| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
+|:---|---:|---:|---:|---:|
+| `main · mc validate` | 480.0 ± 12.0 | 462.0 | 495.0 | 1.00 |
+| `pr · mc validate` | 502.0 ± 15.0 | 481.0 | 522.0 | 1.05 ± 0.05 |
+| `main · mc discover --format json` | 390.0 ± 14.0 | 371.0 | 409.0 | 1.00 |
+| `pr · mc discover --format json` | 372.0 ± 11.0 | 358.0 | 388.0 | 0.95 ± 0.04 |
+| `main · mc release --dry-run` | 980.0 ± 28.0 | 942.0 | 1018.0 | 1.00 |
+| `pr · mc release --dry-run` | 1045.0 ± 35.0 | 998.0 | 1091.0 | 1.07 ± 0.05 |

--- a/fixtures/tests/monochange/benchmark-cli-comment/baseline.md
+++ b/fixtures/tests/monochange/benchmark-cli-comment/baseline.md
@@ -1,0 +1,8 @@
+| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
+|:---|---:|---:|---:|---:|
+| `main · mc validate` | 120.0 ± 6.0 | 113.0 | 129.0 | 1.00 |
+| `pr · mc validate` | 126.0 ± 4.0 | 121.0 | 131.0 | 1.05 ± 0.06 |
+| `main · mc discover --format json` | 88.0 ± 3.0 | 84.0 | 92.0 | 1.00 |
+| `pr · mc discover --format json` | 85.0 ± 2.0 | 82.0 | 88.0 | 0.97 ± 0.04 |
+| `main · mc release --dry-run` | 240.0 ± 8.0 | 229.0 | 251.0 | 1.00 |
+| `pr · mc release --dry-run` | 255.0 ± 10.0 | 242.0 | 269.0 | 1.06 ± 0.06 |

--- a/fixtures/tests/monochange/benchmark-cli-comment/history_x10.md
+++ b/fixtures/tests/monochange/benchmark-cli-comment/history_x10.md
@@ -1,0 +1,8 @@
+| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
+|:---|---:|---:|---:|---:|
+| `main · mc validate` | 480.0 ± 12.0 | 462.0 | 495.0 | 1.00 |
+| `pr · mc validate` | 502.0 ± 15.0 | 481.0 | 522.0 | 1.05 ± 0.05 |
+| `main · mc discover --format json` | 390.0 ± 14.0 | 371.0 | 409.0 | 1.00 |
+| `pr · mc discover --format json` | 372.0 ± 11.0 | 358.0 | 388.0 | 0.95 ± 0.04 |
+| `main · mc release --dry-run` | 980.0 ± 28.0 | 942.0 | 1018.0 | 1.00 |
+| `pr · mc release --dry-run` | 1045.0 ± 35.0 | 998.0 | 1091.0 | 1.07 ± 0.05 |


### PR DESCRIPTION
## Summary
- replace the ad-hoc shell timing loop in `benchmark-binary` with a dedicated `hyperfine`-based shell script
- benchmark multiple fixture scenarios in the PR comment, including a larger `200 packages / 500 changesets / 500 commits` case
- add a snapshot-backed test for the generated benchmark PR comment

## Testing
- bash -n .github/scripts/benchmark_cli.sh
- cargo test -p monochange --test benchmark_cli_comment
- devenv shell -- fix:all

## Changeset
- no changeset required; changes are limited to CI/workflow code and tests