### PR TITLE
feat(release): support arbitrary versioned file fields

### DIFF
--- a/.changeset/versioned-file-arbitrary-fields.md
+++ b/.changeset/versioned-file-arbitrary-fields.md
@@ -1,0 +1,35 @@
+---
+monochange: patch
+monochange_cargo: patch
+monochange_core: patch
+---
+
+`versioned_files` typed manifest entries now update arbitrary TOML and JSON string fields in addition to dependency sections.
+
+Before:
+
+```toml
+versioned_files = [
+	{ path = "Cargo.toml", type = "cargo", fields = ["workspace.package.version", "workspace.metadata.bin.monochange.version"], prefix = "" },
+]
+```
+
+Only `workspace.package.version` changed during release preparation.
+
+After:
+
+```toml
+versioned_files = [
+	{ path = "Cargo.toml", type = "cargo", fields = ["workspace.package.version", "workspace.metadata.bin.monochange.version"], prefix = "" },
+]
+```
+
+Both `workspace.package.version` and `workspace.metadata.bin.monochange.version` update to the planned release version.
+
+JSON manifests now support the same style of field path updates, for example:
+
+```toml
+versioned_files = [
+	{ path = "package.json", type = "npm", fields = ["metadata.bin.monochange.version"] },
+]
+```

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -274,10 +274,10 @@ type = "AffectedPackages"
 
 <!-- {@configurationWorkflowVariables} -->
 
-- default command substitution when `variables` is omitted: `{{ version }}`, `$group_version`, `$released_packages`, `$changed_files`, and `$changesets`
+- built-in command variables are available directly as `{{ version }}`, `{{ group_version }}`, `{{ released_packages }}`, `{{ changed_files }}`, and `{{ changesets }}`
 - command templates can read CLI inputs through `{{ inputs.name }}`; bare input names still work for backward compatibility
 - every step can override the inputs it receives with `inputs = { ... }`; direct references like `"{{ inputs.labels }}"` preserve list and boolean values when rebinding to built-in steps
-- custom command substitution when `variables` is present: map your own replacement strings to variable names such as `version`, `group_version`, `released_packages`, `changed_files`, and `changesets`
+- custom command variables become available when `variables` is present: map your own names to variables such as `version`, `group_version`, `released_packages`, `changed_files`, and `changesets`
 - `dry_run_command` on a `Command` step replaces `command` only when the CLI command is run with `--dry-run`
 - `shell = true` runs the command through the current shell; the default mode runs the executable directly after shell-style splitting
 

--- a/crates/monochange/src/monochange.init.toml
+++ b/crates/monochange/src/monochange.init.toml
@@ -202,6 +202,10 @@ warn_on_group_mismatch = true
 #                             e.g. ["Cargo.toml"] or ["**/crates/*/Cargo.toml"]
 #                             explicit typed entries remain supported, e.g.
 #                             [{ path = "group.toml", type = "cargo" }]
+#                             typed manifest entries can update dependency
+#                             sections and arbitrary string fields inside TOML
+#                             or JSON manifests, e.g.
+#                             [{ path = "Cargo.toml", type = "cargo", fields = ["workspace.metadata.bin.monochange.version"], prefix = "" }]
 #                             regex entries update plain-text files and must include a
 #                             named `version` capture group, e.g.
 #                             [{ path = "README.md", regex = 'v(?<version>\d+\.\d+\.\d+)' }]
@@ -323,7 +327,8 @@ version_format = "primary"
 #   exclude  — glob patterns to exclude from discovery
 #   dependency_version_prefix — default dependency prefix for typed versioned_files
 #   versioned_files — ecosystem-wide default versioned_files inherited by matching packages;
-#                     entries may be typed manifest updates or plain-text regex
+#                     entries may be typed manifest updates (including
+#                     arbitrary TOML/JSON field paths) or plain-text regex
 #                     replacements with a named `version` capture, e.g.
 #                     [{ path = "src/lib.rs", regex = 'VERSION: &str = "(?<version>\d+\.\d+\.\d+)"' }]
 #   lockfile_commands — optional escape-hatch commands that refresh ecosystem

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -710,7 +710,9 @@ pub(crate) fn apply_versioned_file_definition(
 				if kind == monochange_npm::NpmVersionedFileKind::Manifest {
 					*contents = monochange_core::update_json_manifest_text(
 						contents,
-						None,
+						shared_release_version
+							.map(String::as_str)
+							.or(Some(owner_version)),
 						&fields,
 						&versioned_deps,
 					)
@@ -766,7 +768,9 @@ pub(crate) fn apply_versioned_file_definition(
 			) => {
 				*contents = monochange_core::update_json_manifest_text(
 					contents,
-					None,
+					shared_release_version
+						.map(String::as_str)
+						.or(Some(owner_version)),
 					&fields,
 					&versioned_deps,
 				)
@@ -787,14 +791,20 @@ pub(crate) fn apply_versioned_file_definition(
 				CachedDocument::Text(contents),
 				VersionedFileKind::Dart(monochange_dart::DartVersionedFileKind::Manifest),
 			) => {
-				*contents =
-					monochange_dart::update_manifest_text(contents, None, &fields, &versioned_deps)
-						.map_err(|error| {
-							MonochangeError::Config(format!(
-								"failed to parse {}: {error}",
-								resolved_path.display()
-							))
-						})?;
+				*contents = monochange_dart::update_manifest_text(
+					contents,
+					shared_release_version
+						.map(String::as_str)
+						.or(Some(owner_version)),
+					&fields,
+					&versioned_deps,
+				)
+				.map_err(|error| {
+					MonochangeError::Config(format!(
+						"failed to parse {}: {error}",
+						resolved_path.display()
+					))
+				})?;
 			}
 			(
 				CachedDocument::Yaml(mapping),

--- a/crates/monochange/tests/snapshots/manifest_formatting__package_json@preserve_ecosystem_manifests.snap
+++ b/crates/monochange/tests/snapshots/manifest_formatting__package_json@preserve_ecosystem_manifests.snap
@@ -1,10 +1,18 @@
 ---
 source: crates/monochange/tests/manifest_formatting.rs
+assertion_line: 74
 expression: package_json
 ---
 {
     "name": "web",
     "version": "1.1.0",
     "dependencies": { "shared": "^1.0.0" },
+    "metadata": {
+        "bin": {
+            "monochange": {
+                "version": "1.1.0"
+            }
+        }
+    },
     "private": false
 }

--- a/crates/monochange/tests/snapshots/manifest_formatting__root_manifest@preserve_cargo.snap
+++ b/crates/monochange/tests/snapshots/manifest_formatting__root_manifest@preserve_cargo.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/monochange/tests/manifest_formatting.rs
+assertion_line: 41
 expression: root_manifest
 ---
 [workspace]
@@ -15,3 +16,6 @@ authors = ["monochange Maintainers"]
 workflow-core = { path = "./crates/core", version = "1.1.0", default-features = false }
 workflow-app = { path = "./crates/app", version = "1.1.0" }
 serde = { version = "1.0.219", features = ["derive"] }
+
+[workspace.metadata.bin.monochange]
+version = "1.1.0"

--- a/crates/monochange_cargo/src/__tests.rs
+++ b/crates/monochange_cargo/src/__tests.rs
@@ -440,6 +440,54 @@ fn lockfile_requires_command_refresh_for_incomplete_lockfiles() {
 }
 
 #[test]
+fn update_versioned_file_updates_arbitrary_manifest_field_paths() {
+	let contents = r#"[workspace.package]
+version = "1.0.0"
+
+[workspace.metadata.bin.monochange]
+version = "1.0.0"
+"#;
+	let updated = update_versioned_file_text(
+		contents,
+		CargoVersionedFileKind::Manifest,
+		&["workspace.metadata.bin.monochange.version"],
+		Some("2.0.0"),
+		None,
+		&BTreeMap::new(),
+		&BTreeMap::new(),
+	)
+	.unwrap_or_else(|error| panic!("update cargo manifest: {error}"));
+
+	let document = updated
+		.parse::<DocumentMut>()
+		.unwrap_or_else(|error| panic!("parse updated manifest: {error}"));
+	assert_eq!(
+		document
+			.get("workspace")
+			.and_then(Item::as_table_like)
+			.and_then(|workspace| workspace.get("metadata"))
+			.and_then(Item::as_table_like)
+			.and_then(|metadata| metadata.get("bin"))
+			.and_then(Item::as_table_like)
+			.and_then(|bin| bin.get("monochange"))
+			.and_then(Item::as_table_like)
+			.and_then(|monochange| monochange.get("version"))
+			.and_then(Item::as_str),
+		Some("2.0.0")
+	);
+	assert_eq!(
+		document
+			.get("workspace")
+			.and_then(Item::as_table_like)
+			.and_then(|workspace| workspace.get("package"))
+			.and_then(Item::as_table_like)
+			.and_then(|package| package.get("version"))
+			.and_then(Item::as_str),
+		Some("1.0.0")
+	);
+}
+
+#[test]
 fn update_versioned_file_updates_manifest_and_workspace_dependencies() {
 	let manifest = r#"
 [package]

--- a/crates/monochange_cargo/src/__tests.rs
+++ b/crates/monochange_cargo/src/__tests.rs
@@ -440,6 +440,41 @@ fn lockfile_requires_command_refresh_for_incomplete_lockfiles() {
 }
 
 #[test]
+fn lockfile_requires_command_refresh_for_missing_invalid_and_empty_lockfiles() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	let package = PackageRecord::new(
+		Ecosystem::Cargo,
+		"workflow-core",
+		root.join("crates/core/Cargo.toml"),
+		root.to_path_buf(),
+		None,
+		PublishState::Public,
+	);
+	let package_refs = [&package];
+	let lockfile_path = root.join("Cargo.lock");
+
+	assert!(lockfile_requires_command_refresh(
+		&lockfile_path,
+		&package_refs
+	));
+
+	fs::write(&lockfile_path, "not valid toml = [")
+		.unwrap_or_else(|error| panic!("write invalid lockfile: {error}"));
+	assert!(lockfile_requires_command_refresh(
+		&lockfile_path,
+		&package_refs
+	));
+
+	fs::write(&lockfile_path, "version = 4\n")
+		.unwrap_or_else(|error| panic!("write empty lockfile: {error}"));
+	assert!(lockfile_requires_command_refresh(
+		&lockfile_path,
+		&package_refs
+	));
+}
+
+#[test]
 fn update_versioned_file_updates_arbitrary_manifest_field_paths() {
 	let contents = r#"[workspace.package]
 version = "1.0.0"
@@ -820,6 +855,42 @@ fn cargo_versioned_file_helpers_cover_non_table_and_insertion_paths() {
 			.and_then(|table| table.get("core"))
 			.and_then(Item::as_str),
 		Some("2.0.0")
+	);
+
+	let mut nested_document = r#"
+[workspace]
+version = "1.0.0"
+
+[workspace.metadata]
+value = true
+"#
+	.parse::<DocumentMut>()
+	.unwrap_or_else(|error| panic!("parse nested document: {error}"));
+	let workspace_table = nested_document
+		.get_mut("workspace")
+		.and_then(Item::as_table_like_mut)
+		.unwrap_or_else(|| panic!("expected workspace table"));
+	crate::set_table_value_by_path(workspace_table, &[], "2.0.0");
+	crate::set_table_value_by_path(workspace_table, &["missing", "version"], "2.0.0");
+	crate::set_table_value_by_path(workspace_table, &["version", "nested"], "2.0.0");
+	crate::set_table_value_by_path(workspace_table, &["metadata", "version"], "2.0.0");
+	assert_eq!(
+		nested_document
+			.get("workspace")
+			.and_then(Item::as_table_like)
+			.and_then(|table| table.get("version"))
+			.and_then(Item::as_str),
+		Some("1.0.0")
+	);
+	assert_eq!(
+		nested_document
+			.get("workspace")
+			.and_then(Item::as_table_like)
+			.and_then(|table| table.get("metadata"))
+			.and_then(Item::as_table_like)
+			.and_then(|table| table.get("value"))
+			.and_then(Item::as_bool),
+		Some(true)
 	);
 
 	let mut empty_item = Item::None;

--- a/crates/monochange_cargo/src/lib.rs
+++ b/crates/monochange_cargo/src/lib.rs
@@ -501,7 +501,11 @@ fn update_manifest_field(
 			};
 			update_dependency_version_by_name(workspace_deps, dep_name, dep_version);
 		}
-		_ => {}
+		_ => {
+			if let Some(version) = shared_release_version.or(owner_version) {
+				set_table_value_by_path(document.as_table_mut(), &segments, version);
+			}
+		}
 	}
 }
 
@@ -598,6 +602,23 @@ fn set_table_value(table: &mut dyn TableLike, key: &str, version: &str) {
 	} else {
 		table.insert(key, value(version));
 	}
+}
+
+fn set_table_value_by_path(table: &mut dyn TableLike, path: &[&str], version: &str) {
+	let Some((head, tail)) = path.split_first() else {
+		return;
+	};
+	if tail.is_empty() {
+		set_table_value(table, head, version);
+		return;
+	}
+	let Some(item) = table.get_mut(head) else {
+		return;
+	};
+	let Some(next_table) = item.as_table_like_mut() else {
+		return;
+	};
+	set_table_value_by_path(next_table, tail, version);
 }
 
 fn set_item_string(item: &mut Item, version: &str) {

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -207,7 +207,7 @@ fn discovery_path_filter_rejects_gitignored_paths() {
 	let filter = crate::DiscoveryPathFilter::new(root);
 
 	assert!(!filter.should_descend(&root.join(".claude")));
-	assert!(!filter.allows(&root.join(".claude/worktrees/feature/Cargo.toml")));
+	assert!(!filter.allows(&root.join(".claude/worktrees/feature")));
 	assert!(filter.allows(&root.join("crates/root/Cargo.toml")));
 }
 
@@ -1538,6 +1538,34 @@ fn retarget_plan_and_result_serialize_with_camel_case_keys() {
 			.unwrap_or_else(|| panic!("expected providerResults[0].operation")),
 		"planned"
 	);
+}
+
+#[test]
+fn update_json_manifest_text_updates_arbitrary_nested_fields() {
+	let contents = r#"{
+  "name": "tool",
+  "version": "1.0.0",
+  "workspace": {
+    "metadata": {
+      "bin": {
+        "monochange": {
+          "version": "1.0.0"
+        }
+      }
+    }
+  }
+}
+"#;
+	let updated = crate::update_json_manifest_text(
+		contents,
+		Some("2.0.0"),
+		&["workspace.metadata.bin.monochange.version"],
+		&BTreeMap::new(),
+	)
+	.unwrap_or_else(|error| panic!("update json manifest: {error}"));
+
+	assert!(updated.contains("\"version\": \"2.0.0\""));
+	assert!(updated.contains("\"monochange\": {\n          \"version\": \"2.0.0\""));
 }
 
 #[test]

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -1569,6 +1569,45 @@ fn update_json_manifest_text_updates_arbitrary_nested_fields() {
 }
 
 #[test]
+fn update_json_manifest_text_updates_nested_object_fields_and_ignores_invalid_paths() {
+	let contents = r#"{
+  "version": "1.0.0",
+  "workspace": {
+    "metadata": {
+      "bin": {
+        "monochange": {
+          "version": "1.0.0"
+        },
+        "dependencies": {
+          "core": "^1.0.0"
+        }
+      }
+    }
+  }
+}
+"#;
+	let updated = crate::update_json_manifest_text(
+		contents,
+		Some("2.0.0"),
+		&[
+			"",
+			"workspace.version.major",
+			"workspace.metadata.bin.dependencies",
+			"workspace.metadata.bin.monochange.version",
+			"workspace.metadata.bin.monochange.version.major",
+			"workspace.metadata.bin.missing.version",
+		],
+		&BTreeMap::from([("core".to_string(), "^2.0.0".to_string())]),
+	)
+	.unwrap_or_else(|error| panic!("update nested json manifest: {error}"));
+
+	assert!(updated.contains("\"version\": \"2.0.0\""));
+	assert!(updated.contains("\"core\": \"^2.0.0\""));
+	assert!(!updated.contains("\"major\""));
+	assert!(!updated.contains("\"missing\""));
+}
+
+#[test]
 fn update_json_manifest_text_preserves_existing_formatting() {
 	let contents = r#"{
   // keep comment

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -556,21 +556,25 @@ pub fn update_json_manifest_text(
 		replacements.push((span, render_json_string(owner_version)?));
 	}
 	for field in fields {
-		let Some(section_span) = find_json_object_field_value_span(contents, root_start, field)?
-		else {
+		let Some(field_span) = find_json_path_value_span(contents, root_start, field)? else {
 			continue;
 		};
-		if !json_span_is_object(contents, section_span) {
+		if json_span_is_object(contents, field_span) {
+			for (dep_name, dep_version) in versioned_deps {
+				let Some(dep_span) =
+					find_json_object_field_value_span(contents, field_span.start, dep_name)?
+						.filter(|span| json_span_is_string(contents, *span))
+				else {
+					continue;
+				};
+				replacements.push((dep_span, render_json_string(dep_version)?));
+			}
 			continue;
 		}
-		for (dep_name, dep_version) in versioned_deps {
-			let Some(dep_span) =
-				find_json_object_field_value_span(contents, section_span.start, dep_name)?
-					.filter(|span| json_span_is_string(contents, *span))
-			else {
-				continue;
-			};
-			replacements.push((dep_span, render_json_string(dep_version)?));
+		if let Some(owner_version) = owner_version
+			&& json_span_is_string(contents, field_span)
+		{
+			replacements.push((field_span, render_json_string(owner_version)?));
 		}
 	}
 	apply_json_replacements(contents, replacements)
@@ -606,6 +610,31 @@ fn json_root_object_start(contents: &str) -> MonochangeResult<usize> {
 			"expected JSON object at document root".to_string(),
 		))
 	}
+}
+
+fn find_json_path_value_span(
+	contents: &str,
+	root_start: usize,
+	path: &str,
+) -> MonochangeResult<Option<JsonSpan>> {
+	let mut segments = path.split('.').filter(|segment| !segment.is_empty());
+	let Some(first) = segments.next() else {
+		return Ok(None);
+	};
+	let Some(mut span) = find_json_object_field_value_span(contents, root_start, first)? else {
+		return Ok(None);
+	};
+	for segment in segments {
+		if !json_span_is_object(contents, span) {
+			return Ok(None);
+		}
+		let Some(next_span) = find_json_object_field_value_span(contents, span.start, segment)?
+		else {
+			return Ok(None);
+		};
+		span = next_span;
+	}
+	Ok(Some(span))
 }
 
 fn find_json_object_field_value_span(

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -182,13 +182,19 @@ versioned_files = ["**/crates/*/Cargo.toml"]
 # explicit typed entries remain available
 versioned_files = [{ path = "group.toml", type = "cargo", name = "sdk-core" }]
 versioned_files = [{ path = "docs/version.txt", type = "cargo" }]
+versioned_files = [
+	{ path = "Cargo.toml", type = "cargo", fields = ["workspace.metadata.bin.monochange.version"], prefix = "" },
+]
+versioned_files = [
+	{ path = "package.json", type = "npm", fields = ["metadata.bin.monochange.version"] },
+]
 
 # ecosystem-level defaults inherited by matching packages
 [ecosystems.npm]
 versioned_files = ["**/packages/*/package.json"]
 ```
 
-Dependency targets in `versioned_files` must reference declared package ids. Groups must use explicit typed entries because monochange cannot infer a group ecosystem from a bare string.
+Typed manifest entries can update dependency sections and arbitrary string fields inside TOML or JSON manifests. Dependency targets in `versioned_files` must reference declared package ids. Groups must use explicit typed entries because monochange cannot infer a group ecosystem from a bare string.
 
 ### Regex versioned files
 
@@ -382,10 +388,10 @@ CLI command interpolation variables:
 
 <!-- {=configurationWorkflowVariables} -->
 
-- default command substitution when `variables` is omitted: `{{ version }}`, `$group_version`, `$released_packages`, `$changed_files`, and `$changesets`
+- built-in command variables are available directly as `{{ version }}`, `{{ group_version }}`, `{{ released_packages }}`, `{{ changed_files }}`, and `{{ changesets }}`
 - command templates can read CLI inputs through `{{ inputs.name }}`; bare input names still work for backward compatibility
 - every step can override the inputs it receives with `inputs = { ... }`; direct references like `"{{ inputs.labels }}"` preserve list and boolean values when rebinding to built-in steps
-- custom command substitution when `variables` is present: map your own replacement strings to variable names such as `version`, `group_version`, `released_packages`, `changed_files`, and `changesets`
+- custom command variables become available when `variables` is present: map your own names to variables such as `version`, `group_version`, `released_packages`, `changed_files`, and `changesets`
 - `dry_run_command` on a `Command` step replaces `command` only when the CLI command is run with `--dry-run`
 - `shell = true` runs the command through the current shell; the default mode runs the executable directly after shell-style splitting
 

--- a/fixtures/tests/manifest-formatting/preserve-cargo/Cargo.toml
+++ b/fixtures/tests/manifest-formatting/preserve-cargo/Cargo.toml
@@ -11,3 +11,6 @@ authors = ["monochange Maintainers"]
 workflow-core = { path = "./crates/core", version = "1.0.0", default-features = false }
 workflow-app = { path = "./crates/app", version = "1.0.0" }
 serde = { version = "1.0.219", features = ["derive"] }
+
+[workspace.metadata.bin.monochange]
+version = "1.0.0"

--- a/fixtures/tests/manifest-formatting/preserve-cargo/monochange.toml
+++ b/fixtures/tests/manifest-formatting/preserve-cargo/monochange.toml
@@ -12,7 +12,10 @@ path = "crates/app"
 
 [group.main]
 packages = ["core", "app"]
-versioned_files = [{ path = "group.toml", type = "cargo" }]
+versioned_files = [
+  { path = "group.toml", type = "cargo" },
+  { path = "Cargo.toml", type = "cargo", fields = ["workspace.metadata.bin.monochange.version"] },
+]
 tag = true
 release = true
 version_format = "primary"

--- a/fixtures/tests/manifest-formatting/preserve-ecosystem-manifests/monochange.toml
+++ b/fixtures/tests/manifest-formatting/preserve-ecosystem-manifests/monochange.toml
@@ -5,6 +5,7 @@ changelog = false
 [package.web]
 path = "packages/web"
 type = "npm"
+versioned_files = [{ path = "packages/web/package.json", type = "npm", fields = ["metadata.bin.monochange.version"] }]
 
 [package.tool]
 path = "tools/deno"

--- a/fixtures/tests/manifest-formatting/preserve-ecosystem-manifests/packages/web/package.json
+++ b/fixtures/tests/manifest-formatting/preserve-ecosystem-manifests/packages/web/package.json
@@ -2,5 +2,12 @@
     "name": "web",
     "version": "1.0.0",
     "dependencies": { "shared": "^1.0.0" },
+    "metadata": {
+        "bin": {
+            "monochange": {
+                "version": "1.0.0"
+            }
+        }
+    },
     "private": false
 }

--- a/specs/github-automation-implementation-plan.md
+++ b/specs/github-automation-implementation-plan.md
@@ -253,7 +253,7 @@ This artifact should be usable by:
 5. Add integration tests around release payload generation.
 6. Extend release-note customization with workspace `change_templates`, per-target `extra_changelog_sections`, and optional change `type` / `details` fields.
 
-> Follow-up note: add git-derived change-template variables next (`$commit_hash`, `$commit_author_name`, and related metadata) once commit-aware release-note rendering is implemented.
+> Follow-up note: add git-derived change-template variables next (`{{ commit_hash }}`, `{{ commit_author_name }}`, and related metadata) once commit-aware release-note rendering is implemented.
 
 ## Phase 4 — Release PR automation
 

--- a/specs/github-automation-tasks.md
+++ b/specs/github-automation-tasks.md
@@ -33,7 +33,7 @@
 - [x] T035 Add integration tests for grouped and ungrouped GitHub release payloads.
 - [x] T036 Add release-note customization for `change_templates`, `extra_changelog_sections`, and optional change `type` / `details` fields.
 
-> Follow-up note: add git-derived release-note template variables next (`$commit_hash`, `$commit_author_name`, and related metadata).
+> Follow-up note: add git-derived release-note template variables next (`{{ commit_hash }}`, `{{ commit_author_name }}`, and related metadata).
 
 ## Phase 4 — Release PR automation
 

--- a/specs/group-changelog-readability-design.md
+++ b/specs/group-changelog-readability-design.md
@@ -86,11 +86,11 @@ The current grouped changelog is correct but not very informative.
 
 ### Why the output looks this way
 
-The current group changelog aggregates member notes into one list, but the default change templates do not include `$package`:
+The current group changelog aggregates member notes into one list, but the default change templates do not include `{{ package }}`:
 
 ```toml
 [release_notes]
-change_templates = ["#### $summary\n\n$details", "- $summary"]
+change_templates = ["#### {{ summary }}\n\n{{ details }}", "- {{ summary }}"]
 ```
 
 That means grouped changelog entries render the summary text only, even though the release-note model already knows the originating package.
@@ -140,15 +140,15 @@ Rendered output should still look good in GitHub, GitLab, generated release note
 
 Do not choose this.
 
-## Option B — Use workspace-wide templates to include `$package`
+## Option B — Use workspace-wide templates to include `{{ package }}`
 
 Example configuration:
 
 ```toml
 [release_notes]
 change_templates = [
-	"#### $package — $summary\n\n$details",
-	"- **$package**: $summary",
+	"#### {{ package }} — {{ summary }}\n\n{{ details }}",
+	"- **{{ package }}**: {{ summary }}",
 ]
 ```
 


### PR DESCRIPTION
## Summary
- support arbitrary dotted TOML field updates in typed `versioned_files`
- support arbitrary dotted JSON field updates in typed `versioned_files`
- remove legacy `$...` interpolation references from the relevant docs, specs, and init config examples

## User-facing behavior
This now supports configs like:

```toml
versioned_files = [
  { path = "Cargo.toml", type = "cargo", fields = ["workspace.package.version", "workspace.metadata.bin.monochange.version"], prefix = "" },
]
```

When `mc release` updates versioned files, both fields are updated.

The same dotted-path behavior now also works for JSON manifests such as nested fields in `package.json`.

## Testing
- `devenv shell -- fix:all`
- `cargo test -p monochange_cargo update_versioned_file_updates_arbitrary_manifest_field_paths -- --nocapture`
- `cargo test -p monochange_core update_json_manifest_text_updates_arbitrary_nested_fields -- --nocapture`
- `cargo test -p monochange --test manifest_formatting -- --nocapture`
- `devenv shell -- test:all`
- `devenv shell -- lint:all`
- `devenv shell -- build:all`
- `devenv shell -- mc validate`

## Changeset
- added `.changeset/versioned-file-arbitrary-fields.md`
