### PR TITLE
feat: default release output to markdown and add quiet flag

### DIFF
--- a/.changeset/prepare-release-markdown-quiet.md
+++ b/.changeset/prepare-release-markdown-quiet.md
@@ -1,0 +1,69 @@
+---
+monochange: patch
+monochange_core: patch
+---
+
+#### improve release output readability and add `--quiet`
+
+`mc release` now defaults to `--format markdown` so dry-run release output is easier to scan in terminals and logs. The markdown view keeps the same release information as `--format text`, but it groups the output into clearer sections and renders file diffs inside fenced `diff` blocks.
+
+**Before:**
+
+```bash
+mc release --dry-run
+```
+
+```text
+command `release` completed (dry-run)
+released packages: workflow-app, workflow-core
+release targets:
+- package app -> app/v1.0.1 (tag: false, release: false)
+- package core -> core/v1.1.0 (tag: false, release: false)
+changed files:
+- crates/app/Cargo.toml
+- crates/core/Cargo.toml
+```
+
+**After:**
+
+```bash
+mc release --dry-run
+```
+
+```markdown
+# `release` (dry-run)
+
+## Summary
+
+- **Released packages:** `workflow-app`, `workflow-core`
+
+## Release targets
+
+- **package `app`** → `app/v1.0.1`
+  - tag: no · release: no
+- **package `core`** → `core/v1.1.0`
+  - tag: no · release: no
+
+## Changed files
+
+- `crates/app/Cargo.toml`
+- `crates/core/Cargo.toml`
+```
+
+`--format text` and `--format json` still work the same, so existing automation can stay on the previous text or JSON contract when needed.
+
+All CLI commands also now accept `--quiet` / `-q`. Quiet mode suppresses stdout and stderr output, and for command-driven workflows it behaves like `--dry-run` so release planning, command steps, and other mutations are skipped while still preserving the command exit status.
+
+**Before:**
+
+```bash
+mc release
+```
+
+**After:**
+
+```bash
+mc --quiet release
+```
+
+Use `--quiet` in CI jobs that only care about success or failure and do not want progress logs, warnings, or rendered release summaries in the job output.

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -26,6 +26,7 @@ use semver::Version;
 use tempfile::tempdir;
 
 use crate::CliContext;
+use crate::PreparedFileDiff;
 use crate::add_change_file;
 use crate::add_interactive_change_file;
 use crate::affected_packages;
@@ -115,7 +116,7 @@ fn cli_help_returns_success_output() {
 	let output = run_with_args("mc", [OsString::from("mc"), OsString::from("--help")])
 		.unwrap_or_else(|error| panic!("help output: {error}"));
 
-	assert!(output.contains("Usage: mc <COMMAND>"));
+	assert!(output.contains("Usage: mc"));
 	assert!(output.contains("assist"));
 	assert!(output.contains("mcp"));
 	assert!(output.contains("change"));
@@ -1261,8 +1262,8 @@ fn command_release_dry_run_discovers_changesets_without_mutating_files() {
 	)
 	.unwrap_or_else(|error| panic!("command output: {error}"));
 
-	assert!(output.contains("command `release` completed (dry-run)"));
-	assert!(output.contains("version: 1.1.0"));
+	assert!(output.contains("# `release` (dry-run)"));
+	assert!(output.contains("1.1.0"));
 	assert!(output.contains("workflow-app"));
 	assert!(output.contains("workflow-core"));
 	assert_eq!(
@@ -1348,8 +1349,9 @@ fn command_release_updates_manifests_changelogs_and_deletes_changesets() {
 	let release_version = fs::read_to_string(tempdir.path().join("release-version.txt"))
 		.unwrap_or_else(|error| panic!("release version output: {error}"));
 
-	assert!(output.contains("command `release` completed"));
-	assert!(output.contains("group sdk -> v1.1.0"));
+	assert!(output.contains("# `release`"));
+	assert!(output.contains("group `sdk`"));
+	assert!(output.contains("v1.1.0"));
 	assert!(workspace_manifest.contains("version = \"1.1.0\""));
 	assert!(core_changelog.contains("## 1.1.0"));
 	assert!(core_changelog.contains("- add release command"));
@@ -2780,6 +2782,7 @@ fn cli_context_for_when_evaluation_tests() -> CliContext {
 	CliContext {
 		root: PathBuf::from("."),
 		dry_run: false,
+		quiet: false,
 		show_diff: false,
 		inputs: BTreeMap::new(),
 		last_step_inputs: BTreeMap::new(),
@@ -3287,8 +3290,8 @@ fn commit_release_command_creates_local_commit_with_release_record() {
 	let commit_body = git_output_in_temp_repo(root, &["log", "-1", "--pretty=%B"]);
 	let status = git_output_in_temp_repo(root, &["status", "--short"]);
 
-	assert!(output.contains("release commit:"));
-	assert!(output.contains("status: completed"));
+	assert!(output.contains("## Release commit"));
+	assert!(output.contains("- **Status:** completed"));
 	assert_eq!(commit_subject, "chore(release): prepare release");
 	assert!(commit_body.contains("## monochange Release Record"));
 	assert!(commit_body.contains("\"command\": \"commit-release\""));
@@ -3475,6 +3478,7 @@ fn template_context_exposes_release_commit_namespace() {
 	let context = CliContext {
 		root: PathBuf::from("."),
 		dry_run: true,
+		quiet: false,
 		show_diff: false,
 		inputs: BTreeMap::new(),
 		last_step_inputs: BTreeMap::new(),
@@ -3516,6 +3520,7 @@ fn template_context_exposes_retarget_namespace() {
 	let context = CliContext {
 		root: PathBuf::from("."),
 		dry_run: true,
+		quiet: false,
 		show_diff: false,
 		inputs: BTreeMap::new(),
 		last_step_inputs: BTreeMap::new(),
@@ -3558,6 +3563,7 @@ fn template_context_exposes_manifest_affected_steps_and_custom_variables() {
 	let context = CliContext {
 		root: PathBuf::from("."),
 		dry_run: true,
+		quiet: false,
 		show_diff: false,
 		inputs: BTreeMap::new(),
 		last_step_inputs: BTreeMap::new(),
@@ -3658,6 +3664,7 @@ fn render_cli_command_result_prefers_retarget_report() {
 	let context = CliContext {
 		root: PathBuf::from("."),
 		dry_run: true,
+		quiet: false,
 		show_diff: false,
 		inputs: BTreeMap::new(),
 		last_step_inputs: BTreeMap::new(),
@@ -3693,6 +3700,7 @@ fn render_cli_command_result_renders_release_follow_up_sections() {
 	let context = CliContext {
 		root: PathBuf::from("."),
 		dry_run: true,
+		quiet: false,
 		show_diff: false,
 		inputs: BTreeMap::new(),
 		last_step_inputs: BTreeMap::new(),
@@ -3720,6 +3728,51 @@ fn render_cli_command_result_renders_release_follow_up_sections() {
 	assert!(rendered.contains("release request:"));
 	assert!(rendered.contains("issue comments:"));
 	assert!(rendered.contains("changed files:"));
+}
+
+#[test]
+fn render_cli_command_markdown_result_uses_markdown_sections_for_prepare_release() {
+	let cli_command = monochange_core::CliCommandDefinition {
+		name: "release".to_string(),
+		help_text: None,
+		inputs: Vec::new(),
+		steps: Vec::new(),
+	};
+	let context = CliContext {
+		root: PathBuf::from("."),
+		dry_run: true,
+		quiet: false,
+		show_diff: true,
+		inputs: BTreeMap::new(),
+		last_step_inputs: BTreeMap::new(),
+		prepared_release: Some(sample_prepared_release_for_cli_render()),
+		prepared_file_diffs: vec![PreparedFileDiff {
+			path: PathBuf::from("Cargo.toml"),
+			diff: "@@ -1 +1 @@".to_string(),
+			display_diff: "diff --git a/Cargo.toml b/Cargo.toml\n@@ -1 +1 @@".to_string(),
+		}],
+		release_manifest_path: Some(PathBuf::from("target/release-manifest.json")),
+		release_requests: Vec::new(),
+		release_results: Vec::new(),
+		release_request: None,
+		release_request_result: None,
+		release_commit_report: None,
+		issue_comment_plans: Vec::new(),
+		issue_comment_results: Vec::new(),
+		changeset_policy_evaluation: None,
+		changeset_diagnostics: None,
+		retarget_report: None,
+		step_outputs: BTreeMap::new(),
+		command_logs: vec!["skipped command `cargo publish` (dry-run)".to_string()],
+	};
+	let rendered = crate::render_cli_command_markdown_result(&cli_command, &context);
+	assert!(rendered.contains("# `release` (dry-run)"));
+	assert!(rendered.contains("## Summary"));
+	assert!(rendered.contains("## Release targets"));
+	assert!(rendered.contains("## File diffs"));
+	assert!(rendered.contains("```diff"));
+	assert!(rendered.contains("## Commands"));
+	assert!(rendered.contains("skipped command `cargo publish` (dry-run)"));
 }
 
 #[test]
@@ -4198,7 +4251,7 @@ fn execute_matches_rejects_unknown_cli_command_names() {
 	let matches = clap::Command::new("dummy")
 		.try_get_matches_from(["dummy"])
 		.unwrap_or_else(|error| panic!("matches: {error}"));
-	let error = crate::execute_matches(tempdir.path(), &configuration, "missing", &matches)
+	let error = crate::execute_matches(tempdir.path(), &configuration, "missing", &matches, false)
 		.err()
 		.unwrap_or_else(|| panic!("expected unknown command error"));
 	assert!(error.to_string().contains("unknown command `missing`"));
@@ -7182,6 +7235,31 @@ fn build_command_and_configured_change_type_choices_include_runtime_metadata() {
 }
 
 #[test]
+fn apply_runtime_prepare_release_markdown_defaults_promotes_release_format_defaults() {
+	let mut cli = monochange_core::default_cli_commands();
+	let release = cli
+		.iter_mut()
+		.find(|command| command.name == "release")
+		.unwrap_or_else(|| panic!("expected release command"));
+	release.inputs[0].default = Some("text".to_string());
+	release.inputs[0].choices = vec!["text".to_string(), "json".to_string()];
+
+	crate::apply_runtime_prepare_release_markdown_defaults(&mut cli);
+
+	let release = cli
+		.iter()
+		.find(|command| command.name == "release")
+		.unwrap_or_else(|| panic!("expected release command after runtime defaults"));
+	let format = release
+		.inputs
+		.iter()
+		.find(|input| input.name == "format")
+		.unwrap_or_else(|| panic!("expected release format input"));
+	assert_eq!(format.default.as_deref(), Some("markdown"));
+	assert_eq!(format.choices.first().map(String::as_str), Some("markdown"));
+}
+
+#[test]
 fn apply_runtime_change_type_choices_updates_only_unconfigured_change_inputs() {
 	let configuration = monochange_core::WorkspaceConfiguration {
 		root_path: PathBuf::from("."),
@@ -7825,7 +7903,7 @@ fn command_release_without_diff_skips_file_diff_previews() {
 	)
 	.unwrap_or_else(|error| panic!("release without diff: {error}"));
 	set_force_build_file_diff_previews_error(false);
-	assert!(output.contains("command `release` completed"));
+	assert!(output.contains("# `release`"));
 }
 
 #[test]
@@ -7916,7 +7994,11 @@ fn format_publish_state_and_source_operation_labels_are_stable() {
 }
 
 #[test]
-fn parse_output_format_accepts_text_and_json_and_rejects_invalid_values() {
+fn parse_output_format_accepts_markdown_text_and_json_and_rejects_invalid_values() {
+	assert_eq!(
+		crate::parse_output_format("markdown").unwrap(),
+		crate::OutputFormat::Markdown
+	);
 	assert_eq!(
 		crate::parse_output_format("text").unwrap(),
 		crate::OutputFormat::Text
@@ -8122,6 +8204,7 @@ fn tracked_release_pull_request_paths_include_manifest_path_and_deduplicate() {
 	let context = CliContext {
 		root: PathBuf::from("."),
 		dry_run: true,
+		quiet: false,
 		show_diff: false,
 		inputs: BTreeMap::new(),
 		last_step_inputs: BTreeMap::new(),
@@ -8619,6 +8702,24 @@ fn batch_changeset_contexts_resolves_introduced_and_updated_commits() {
 }
 
 #[test]
+fn extract_quiet_from_args_detects_short_and_long_flags() {
+	assert!(crate::extract_quiet_from_args([
+		OsString::from("mc"),
+		OsString::from("--quiet"),
+		OsString::from("release"),
+	]));
+	assert!(crate::extract_quiet_from_args([
+		OsString::from("mc"),
+		OsString::from("-q"),
+		OsString::from("discover"),
+	]));
+	assert!(!crate::extract_quiet_from_args([
+		OsString::from("mc"),
+		OsString::from("release"),
+	]));
+}
+
+#[test]
 fn extract_log_level_returns_none_when_flag_absent() {
 	let args = ["mc", "discover", "--format", "json"];
 	assert_eq!(
@@ -8677,7 +8778,7 @@ fn cli_accepts_log_level_flag_without_error() {
 	)
 	.unwrap_or_else(|error| panic!("log-level with help: {error}"));
 
-	assert!(output.contains("Usage: mc <COMMAND>"));
+	assert!(output.contains("Usage: mc"));
 }
 
 #[test]
@@ -8692,7 +8793,7 @@ fn cli_accepts_log_level_equals_syntax_without_error() {
 	)
 	.unwrap_or_else(|error| panic!("log-level equals with help: {error}"));
 
-	assert!(output.contains("Usage: mc <COMMAND>"));
+	assert!(output.contains("Usage: mc"));
 }
 
 #[test]

--- a/crates/monochange/src/bin/mc.rs
+++ b/crates/monochange/src/bin/mc.rs
@@ -1,6 +1,9 @@
 fn main() {
+	let quiet = std::env::args_os().any(|arg| matches!(arg.to_str(), Some("--quiet" | "-q")));
 	if let Err(error) = monochange::run_from_env("mc") {
-		eprintln!("{}", error.render());
+		if !quiet {
+			eprintln!("{}", error.render());
+		}
 		std::process::exit(1);
 	}
 }

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -73,9 +73,35 @@ pub(crate) fn cli_commands_from_config(
 		Ok(configuration) => {
 			let mut cli = configuration.cli.clone();
 			apply_runtime_change_type_choices(&mut cli, configuration);
+			apply_runtime_prepare_release_markdown_defaults(&mut cli);
 			cli
 		}
 		Err(_) => default_cli_commands(),
+	}
+}
+
+pub(crate) fn apply_runtime_prepare_release_markdown_defaults(cli: &mut [CliCommandDefinition]) {
+	for cli_command in cli {
+		if !command_supports_release_diff_preview(cli_command) {
+			continue;
+		}
+		let Some(format_input) = cli_command
+			.inputs
+			.iter_mut()
+			.find(|input| input.name == "format")
+		else {
+			continue;
+		};
+		if !format_input
+			.choices
+			.iter()
+			.any(|choice| choice == "markdown")
+		{
+			format_input.choices.insert(0, "markdown".to_string());
+		}
+		if format_input.default.as_deref() == Some("text") {
+			format_input.default = Some("markdown".to_string());
+		}
 	}
 }
 
@@ -100,6 +126,14 @@ pub(crate) fn build_command_with_cli(
 					.help("Set tracing filter (e.g. debug, monochange=trace)")
 					.value_name("FILTER")
 					.hide(true),
+			)
+			.arg(
+				Arg::new("quiet")
+					.long("quiet")
+					.short('q')
+					.global(true)
+					.help("Suppress stdout/stderr output and run in dry-run mode when supported")
+					.action(ArgAction::SetTrue),
 			)
 			.subcommand(
 				Command::new("init")

--- a/crates/monochange/src/cli_progress.rs
+++ b/crates/monochange/src/cli_progress.rs
@@ -46,9 +46,10 @@ struct SpinnerState {
 }
 
 impl CliProgressReporter {
-	pub(crate) fn new(cli_command: &CliCommandDefinition, dry_run: bool) -> Self {
+	pub(crate) fn new(cli_command: &CliCommandDefinition, dry_run: bool, quiet: bool) -> Self {
 		let color_enabled = env::var("TERM").is_ok_and(|term| term != "dumb");
-		let enabled = io::stderr().is_terminal() && env::var_os("MONOCHANGE_NO_PROGRESS").is_none();
+		let enabled =
+			!quiet && io::stderr().is_terminal() && env::var_os("MONOCHANGE_NO_PROGRESS").is_none();
 		let color = enabled && env::var_os("NO_COLOR").is_none() && color_enabled;
 		let animate = enabled && color;
 		Self {

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::io::BufRead;
 use std::io::BufReader;
+use std::io::IsTerminal;
 use std::io::Read;
 use std::path::Path;
 use std::path::PathBuf;
@@ -41,6 +42,7 @@ pub(crate) fn execute_matches(
 	configuration: &monochange_core::WorkspaceConfiguration,
 	cli_command_name: &str,
 	cli_command_matches: &ArgMatches,
+	quiet: bool,
 ) -> MonochangeResult<String> {
 	let Some(cli_command) = configuration
 		.cli
@@ -52,14 +54,22 @@ pub(crate) fn execute_matches(
 		)));
 	};
 
-	let dry_run = cli_command_matches.get_flag("dry-run");
+	let dry_run = quiet || cli_command_matches.get_flag("dry-run");
 	let show_diff =
 		command_supports_release_diff_preview(cli_command) && cli_command_matches.get_flag("diff");
 	let inputs = collect_cli_command_inputs(cli_command, cli_command_matches);
 	if show_diff {
-		execute_cli_command_with_options(root, configuration, cli_command, dry_run, true, inputs)
+		execute_cli_command_with_options(
+			root,
+			configuration,
+			cli_command,
+			dry_run,
+			quiet,
+			true,
+			inputs,
+		)
 	} else {
-		execute_cli_command(root, configuration, cli_command, dry_run, inputs)
+		execute_cli_command_quiet(root, configuration, cli_command, dry_run, quiet, inputs)
 	}
 }
 
@@ -352,6 +362,7 @@ fn build_issue_comment_results_for_source(
 	result
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn execute_cli_command(
 	root: &Path,
 	configuration: &monochange_core::WorkspaceConfiguration,
@@ -359,7 +370,26 @@ pub(crate) fn execute_cli_command(
 	dry_run: bool,
 	inputs: BTreeMap<String, Vec<String>>,
 ) -> MonochangeResult<String> {
-	execute_cli_command_with_options(root, configuration, cli_command, dry_run, false, inputs)
+	execute_cli_command_quiet(root, configuration, cli_command, dry_run, false, inputs)
+}
+
+fn execute_cli_command_quiet(
+	root: &Path,
+	configuration: &monochange_core::WorkspaceConfiguration,
+	cli_command: &CliCommandDefinition,
+	dry_run: bool,
+	quiet: bool,
+	inputs: BTreeMap<String, Vec<String>>,
+) -> MonochangeResult<String> {
+	execute_cli_command_with_options(
+		root,
+		configuration,
+		cli_command,
+		dry_run,
+		quiet,
+		false,
+		inputs,
+	)
 }
 
 #[tracing::instrument(skip_all, fields(command = cli_command.name))]
@@ -368,12 +398,14 @@ pub(crate) fn execute_cli_command_with_options(
 	configuration: &monochange_core::WorkspaceConfiguration,
 	cli_command: &CliCommandDefinition,
 	dry_run: bool,
+	quiet: bool,
 	show_diff: bool,
 	inputs: BTreeMap<String, Vec<String>>,
 ) -> MonochangeResult<String> {
 	let mut context = CliContext {
 		root: root.to_path_buf(),
 		dry_run,
+		quiet,
 		show_diff,
 		last_step_inputs: inputs.clone(),
 		inputs,
@@ -395,7 +427,7 @@ pub(crate) fn execute_cli_command_with_options(
 	};
 	let mut output = None;
 	let command_started_at = Instant::now();
-	let mut progress = CliProgressReporter::new(cli_command, dry_run);
+	let mut progress = CliProgressReporter::new(cli_command, dry_run, quiet);
 	progress.command_started();
 
 	for (step_index, step) in cli_command.steps.iter().enumerate() {
@@ -424,8 +456,10 @@ pub(crate) fn execute_cli_command_with_options(
 					validate_workspace(root)?;
 					validate_cargo_workspace_version_groups(root)?;
 					let warnings = validate_versioned_files_content(root)?;
-					for warning in &warnings {
-						eprintln!("warning: {warning}");
+					if !context.quiet {
+						for warning in &warnings {
+							eprintln!("warning: {warning}");
+						}
 					}
 					output = Some(format!(
 						"workspace validation passed for {}",
@@ -670,7 +704,7 @@ pub(crate) fn execute_cli_command_with_options(
 						.cloned()
 						.unwrap_or_default();
 					let changed_paths = if let Some(rev) = &since {
-						if !explicit_paths.is_empty() {
+						if !context.quiet && !explicit_paths.is_empty() {
 							eprintln!(
 								"warning: --since takes priority; --changed-paths was ignored"
 							);
@@ -799,6 +833,7 @@ pub(crate) fn execute_cli_command_with_options(
 					},
 				)
 			}
+			OutputFormat::Markdown => Ok(render_cli_command_markdown_result(cli_command, &context)),
 			OutputFormat::Text => Ok(render_cli_command_result(cli_command, &context)),
 		};
 	}
@@ -812,10 +847,14 @@ pub(crate) fn execute_cli_command_with_options(
 					))
 				})?
 			}
-			OutputFormat::Text => render_cli_command_result(cli_command, &context),
+			OutputFormat::Markdown | OutputFormat::Text => {
+				render_cli_command_result(cli_command, &context)
+			}
 		};
 		if evaluation.enforce && evaluation.status == ChangesetPolicyStatus::Failed {
-			println!("{rendered}");
+			if !context.quiet {
+				println!("{rendered}");
+			}
 			return Err(MonochangeError::Config(evaluation.summary.clone()));
 		}
 		return Ok(rendered);
@@ -834,7 +873,7 @@ pub(crate) fn execute_cli_command_with_options(
 					))
 				})?
 			}
-			OutputFormat::Text => render_changeset_diagnostics(report),
+			OutputFormat::Markdown | OutputFormat::Text => render_changeset_diagnostics(report),
 		};
 		return Ok(rendered);
 	}
@@ -845,7 +884,7 @@ pub(crate) fn execute_cli_command_with_options(
 				serde_json::to_string_pretty(report)
 					.unwrap_or_else(|error| panic!("retarget report serialization bug: {error}"))
 			}
-			OutputFormat::Text => render_retarget_release_report(report),
+			OutputFormat::Markdown | OutputFormat::Text => render_retarget_release_report(report),
 		};
 		return Ok(rendered);
 	}
@@ -1872,10 +1911,259 @@ pub(crate) fn render_cli_command_result(
 			lines.push(format!("- {log}"));
 		}
 	}
-	lines.join(
-		"
-",
+	lines.join("\n")
+}
+
+pub(crate) fn render_cli_command_markdown_result(
+	cli_command: &CliCommandDefinition,
+	context: &CliContext,
+) -> String {
+	if context.prepared_release.is_none() {
+		return render_cli_command_result(cli_command, context);
+	}
+
+	let color = stdout_supports_color();
+	let mut sections = vec![format!(
+		"# {}{}",
+		paint_markdown_inline(
+			&format!("`{}`", cli_command.name),
+			MarkdownStyle::Title,
+			color
+		),
+		if context.dry_run {
+			format!(
+				" {}",
+				paint_markdown_inline("(dry-run)", MarkdownStyle::Muted, color)
+			)
+		} else {
+			String::new()
+		}
+	)];
+
+	if let Some(prepared_release) = &context.prepared_release {
+		let mut summary = Vec::new();
+		if let Some(version) = &prepared_release.version {
+			summary.push(format!(
+				"- **Version:** {}",
+				paint_markdown_inline(&format!("`{version}`"), MarkdownStyle::Code, color)
+			));
+		}
+		if !prepared_release.released_packages.is_empty() {
+			summary.push(format!(
+				"- **Released packages:** {}",
+				prepared_release
+					.released_packages
+					.iter()
+					.map(|package| {
+						paint_markdown_inline(&format!("`{package}`"), MarkdownStyle::Code, color)
+					})
+					.collect::<Vec<_>>()
+					.join(", ")
+			));
+		}
+		if !summary.is_empty() {
+			sections.push(render_markdown_section("Summary", &summary, color));
+		}
+		if !prepared_release.release_targets.is_empty() {
+			let mut lines = Vec::new();
+			for target in &prepared_release.release_targets {
+				lines.push(format!(
+					"- **{} {}** → {}",
+					target.kind,
+					paint_markdown_inline(&format!("`{}`", target.id), MarkdownStyle::Code, color),
+					paint_markdown_inline(
+						&format!("`{}`", target.tag_name),
+						MarkdownStyle::Code,
+						color,
+					),
+				));
+				lines.push(format!(
+					"  - tag: {} · release: {}",
+					yes_no(target.tag),
+					yes_no(target.release)
+				));
+			}
+			sections.push(render_markdown_section("Release targets", &lines, color));
+		}
+		if let Some(path) = &context.release_manifest_path {
+			sections.push(render_markdown_section(
+				"Release manifest",
+				&[format!(
+					"- {}",
+					paint_markdown_inline(
+						&format!("`{}`", path.display()),
+						MarkdownStyle::Code,
+						color,
+					)
+				)],
+				color,
+			));
+		}
+		if !context.release_results.is_empty() {
+			let lines = context
+				.release_results
+				.iter()
+				.map(|release| format!("- {release}"))
+				.collect::<Vec<_>>();
+			sections.push(render_markdown_section("Releases", &lines, color));
+		}
+		if let Some(release_commit_report) = &context.release_commit_report {
+			sections.push(render_markdown_section(
+				"Release commit",
+				&render_release_commit_report_markdown(release_commit_report, color),
+				color,
+			));
+		}
+		if let Some(release_request_result) = &context.release_request_result {
+			sections.push(render_markdown_section(
+				"Release request",
+				&[format!("- {release_request_result}")],
+				color,
+			));
+		}
+		if !context.issue_comment_results.is_empty() {
+			let lines = context
+				.issue_comment_results
+				.iter()
+				.map(|issue_comment| format!("- {issue_comment}"))
+				.collect::<Vec<_>>();
+			sections.push(render_markdown_section("Issue comments", &lines, color));
+		}
+		if !prepared_release.changed_files.is_empty() {
+			let lines = prepared_release
+				.changed_files
+				.iter()
+				.map(|path| {
+					format!(
+						"- {}",
+						paint_markdown_inline(
+							&format!("`{}`", path.display()),
+							MarkdownStyle::Code,
+							color,
+						)
+					)
+				})
+				.collect::<Vec<_>>();
+			sections.push(render_markdown_section("Changed files", &lines, color));
+		}
+		if context.show_diff && !context.prepared_file_diffs.is_empty() {
+			let mut lines = Vec::new();
+			for file_diff in &context.prepared_file_diffs {
+				lines.push(format!(
+					"### {}",
+					paint_markdown_inline(
+						&format!("`{}`", file_diff.path.display()),
+						MarkdownStyle::Subtitle,
+						color,
+					)
+				));
+				lines.push("```diff".to_string());
+				lines.extend(file_diff.display_diff.lines().map(ToString::to_string));
+				lines.push("```".to_string());
+				lines.push(String::new());
+			}
+			while lines.last().is_some_and(String::is_empty) {
+				lines.pop();
+			}
+			sections.push(render_markdown_section("File diffs", &lines, color));
+		}
+		if !prepared_release.deleted_changesets.is_empty() {
+			let lines = prepared_release
+				.deleted_changesets
+				.iter()
+				.map(|path| {
+					format!(
+						"- {}",
+						paint_markdown_inline(
+							&format!("`{}`", path.display()),
+							MarkdownStyle::Code,
+							color,
+						)
+					)
+				})
+				.collect::<Vec<_>>();
+			sections.push(render_markdown_section("Deleted changesets", &lines, color));
+		}
+	}
+	if !context.command_logs.is_empty() {
+		let lines = context
+			.command_logs
+			.iter()
+			.map(|log| format!("- {log}"))
+			.collect::<Vec<_>>();
+		sections.push(render_markdown_section("Commands", &lines, color));
+	}
+	sections.join("\n\n")
+}
+
+#[derive(Clone, Copy)]
+enum MarkdownStyle {
+	Title,
+	Subtitle,
+	Code,
+	Muted,
+}
+
+fn stdout_supports_color() -> bool {
+	std::io::stdout().is_terminal()
+		&& std::env::var_os("NO_COLOR").is_none()
+		&& std::env::var("TERM").is_ok_and(|term| term != "dumb")
+}
+
+fn paint_markdown_inline(text: &str, style: MarkdownStyle, color: bool) -> String {
+	if !color {
+		return text.to_string();
+	}
+	let code = match style {
+		MarkdownStyle::Title => "36;1",
+		MarkdownStyle::Subtitle => "37;1",
+		MarkdownStyle::Code => "35",
+		MarkdownStyle::Muted => "2",
+	};
+	format!("\u{1b}[{code}m{text}\u{1b}[0m")
+}
+
+fn render_markdown_section(title: &str, lines: &[String], color: bool) -> String {
+	if lines.is_empty() {
+		return format!(
+			"## {}",
+			paint_markdown_inline(title, MarkdownStyle::Subtitle, color)
+		);
+	}
+	format!(
+		"## {}\n\n{}",
+		paint_markdown_inline(title, MarkdownStyle::Subtitle, color),
+		lines.join("\n")
 	)
+}
+
+fn render_release_commit_report_markdown(report: &CommitReleaseReport, color: bool) -> Vec<String> {
+	let mut lines = vec![format!("- **Subject:** {}", report.subject)];
+	if let Some(commit) = &report.commit {
+		lines.push(format!(
+			"- **Commit:** {}",
+			paint_markdown_inline(
+				&format!("`{}`", short_commit_sha(commit)),
+				MarkdownStyle::Code,
+				color,
+			)
+		));
+	}
+	if !report.tracked_paths.is_empty() {
+		lines.push("- **Tracked paths:**".to_string());
+		lines.extend(report.tracked_paths.iter().map(|path| {
+			format!(
+				"  - {}",
+				paint_markdown_inline(&format!("`{}`", path.display()), MarkdownStyle::Code, color,)
+			)
+		}));
+	}
+	lines.push(format!("- **Status:** {}", report.status.replace('_', "-")));
+	lines
+}
+
+fn yes_no(value: bool) -> &'static str {
+	if value { "yes" } else { "no" }
 }
 
 fn cli_command_output_format(
@@ -1890,6 +2178,7 @@ fn cli_command_output_format(
 pub(crate) fn parse_output_format(value: &str) -> MonochangeResult<OutputFormat> {
 	match value {
 		"text" => Ok(OutputFormat::Text),
+		"markdown" => Ok(OutputFormat::Markdown),
 		"json" => Ok(OutputFormat::Json),
 		other => {
 			Err(MonochangeError::Config(format!(
@@ -1929,6 +2218,7 @@ mod tests {
 		CliContext {
 			root: PathBuf::from("."),
 			dry_run: false,
+			quiet: false,
 			show_diff: false,
 			inputs: BTreeMap::new(),
 			last_step_inputs: BTreeMap::new(),
@@ -2029,7 +2319,7 @@ mod tests {
 			inputs: Vec::new(),
 			steps: Vec::new(),
 		};
-		let mut progress = CliProgressReporter::new(&cli_command, false);
+		let mut progress = CliProgressReporter::new(&cli_command, false, false);
 		let step = CliStepDefinition::Command {
 			name: Some("stream output".to_string()),
 			when: None,

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -70,6 +70,8 @@ use clap::error::ErrorKind;
 #[cfg(test)]
 pub(crate) use cli::apply_runtime_change_type_choices;
 #[cfg(test)]
+pub(crate) use cli::apply_runtime_prepare_release_markdown_defaults;
+#[cfg(test)]
 pub(crate) use cli::build_assist_subcommand;
 #[cfg(test)]
 pub(crate) use cli::build_cli_command_subcommand;
@@ -108,6 +110,8 @@ pub(crate) use cli_runtime::parse_change_bump;
 pub(crate) use cli_runtime::parse_direct_template_reference;
 #[cfg(test)]
 pub(crate) use cli_runtime::parse_output_format;
+#[cfg(test)]
+pub(crate) use cli_runtime::render_cli_command_markdown_result;
 #[cfg(test)]
 pub(crate) use cli_runtime::render_cli_command_result;
 #[cfg(test)]
@@ -255,6 +259,7 @@ mod workspace_ops;
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 pub enum OutputFormat {
 	Text,
+	Markdown,
 	Json,
 }
 
@@ -480,6 +485,7 @@ struct CommitReleaseReport {
 struct CliContext {
 	root: PathBuf,
 	dry_run: bool,
+	quiet: bool,
 	show_diff: bool,
 	inputs: BTreeMap<String, Vec<String>>,
 	last_step_inputs: BTreeMap<String, Vec<String>>,
@@ -512,9 +518,10 @@ pub fn run_from_env(bin_name: &'static str) -> MonochangeResult<()> {
 	let log_level = extract_log_level_from_args();
 	tracing_setup::init_tracing(log_level.as_deref());
 
+	let quiet = extract_quiet_from_args(std::env::args_os());
 	let args = std::env::args_os();
 	let output = run_with_args(bin_name, args)?;
-	if !output.is_empty() {
+	if !quiet && !output.is_empty() {
 		println!("{output}");
 	}
 	Ok(())
@@ -522,6 +529,17 @@ pub fn run_from_env(bin_name: &'static str) -> MonochangeResult<()> {
 
 fn extract_log_level_from_args() -> Option<String> {
 	extract_log_level(std::env::args())
+}
+
+fn quiet_from_os_arg(arg: &OsString) -> bool {
+	matches!(arg.to_str(), Some("--quiet" | "-q"))
+}
+
+fn extract_quiet_from_args<I>(args: I) -> bool
+where
+	I: IntoIterator<Item = OsString>,
+{
+	args.into_iter().any(|arg| quiet_from_os_arg(&arg))
 }
 
 fn extract_log_level<I>(args: I) -> Option<String>
@@ -556,6 +574,7 @@ where
 	let args = args.into_iter().collect::<Vec<_>>();
 	let configuration = load_workspace_configuration(root);
 	let cli = cli_commands_from_config(&configuration);
+	let quiet = extract_quiet_from_args(args.iter().cloned());
 	let matches = match build_command_with_cli(bin_name, &cli).try_get_matches_from(args) {
 		Ok(matches) => matches,
 		Err(error)
@@ -571,10 +590,16 @@ where
 
 	match matches.subcommand() {
 		Some(("init", init_matches)) => {
+			if quiet {
+				return Ok(String::new());
+			}
 			let path = init_workspace(root, init_matches.get_flag("force"))?;
 			Ok(format!("wrote {}", path.display()))
 		}
 		Some(("populate", _)) => {
+			if quiet {
+				return Ok(String::new());
+			}
 			let result = populate_workspace(root)?;
 			if result.added_commands.is_empty() {
 				Ok(format!(
@@ -622,6 +647,9 @@ where
 			run_assist(assistant, format)
 		}
 		Some(("mcp", _)) => {
+			if quiet {
+				return Ok(String::new());
+			}
 			let runtime = tokio::runtime::Runtime::new()
 				.map_err(|error| MonochangeError::Config(error.to_string()))?;
 			runtime.block_on(mcp::run_server());
@@ -644,7 +672,13 @@ where
 		}
 		Some((cli_command_name, cli_command_matches)) => {
 			let configuration = configuration?;
-			execute_matches(root, &configuration, cli_command_name, cli_command_matches)
+			execute_matches(
+				root,
+				&configuration,
+				cli_command_name,
+				cli_command_matches,
+				quiet,
+			)
 		}
 		None => Err(MonochangeError::Config("unknown command".to_string())),
 	}

--- a/crates/monochange/src/main.rs
+++ b/crates/monochange/src/main.rs
@@ -1,6 +1,9 @@
 fn main() {
+	let quiet = std::env::args_os().any(|arg| matches!(arg.to_str(), Some("--quiet" | "-q")));
 	if let Err(error) = monochange::run_from_env("monochange") {
-		eprintln!("{}", error.render());
+		if !quiet {
+			eprintln!("{}", error.render());
+		}
 		std::process::exit(1);
 	}
 }

--- a/crates/monochange/src/monochange.init.toml
+++ b/crates/monochange/src/monochange.init.toml
@@ -608,7 +608,7 @@ steps = [{ type = "CreateChangeFile" }]
 [cli.release]
 help_text = "Prepare a release from discovered change files"
 inputs = [
-	{ name = "format", type = "choice", choices = ["text", "json"], default = "text" },
+	{ name = "format", type = "choice", choices = ["markdown", "text", "json"], default = "markdown" },
 ]
 steps = [{ type = "PrepareRelease" }]
 

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -770,7 +770,7 @@ pub(crate) fn render_discovery_report(
 			serde_json::to_string_pretty(&json_discovery_report(report))
 				.map_err(|error| MonochangeError::Discovery(error.to_string()))
 		}
-		OutputFormat::Text => Ok(text_discovery_report(report)),
+		OutputFormat::Markdown | OutputFormat::Text => Ok(text_discovery_report(report)),
 	}
 }
 

--- a/crates/monochange/src/release_record.rs
+++ b/crates/monochange/src/release_record.rs
@@ -36,7 +36,9 @@ pub(crate) fn render_release_record_discovery(
 			serde_json::to_string_pretty(&discovery)
 				.map_err(|error| MonochangeError::Discovery(error.to_string()))
 		}
-		OutputFormat::Text => Ok(text_release_record_discovery(&discovery)),
+		OutputFormat::Markdown | OutputFormat::Text => {
+			Ok(text_release_record_discovery(&discovery))
+		}
 	}
 }
 

--- a/crates/monochange/tests/cli_main_binary.rs
+++ b/crates/monochange/tests/cli_main_binary.rs
@@ -18,3 +18,21 @@ fn monochange_binary_prints_help() {
 fn monochange_binary_renders_cli_errors() {
 	assert_cmd_snapshot!(monochange_cli().arg("not-a-command"));
 }
+
+#[test]
+fn monochange_binary_quiet_suppresses_cli_errors() {
+	let output = monochange_cli()
+		.arg("--quiet")
+		.arg("not-a-command")
+		.output()
+		.unwrap_or_else(|error| panic!("quiet cli error output: {error}"));
+	assert!(!output.status.success());
+	assert!(
+		output.stdout.is_empty(),
+		"quiet mode should suppress stdout"
+	);
+	assert!(
+		output.stderr.is_empty(),
+		"quiet mode should suppress stderr"
+	);
+}

--- a/crates/monochange/tests/cli_output.rs
+++ b/crates/monochange/tests/cli_output.rs
@@ -111,6 +111,21 @@ fn change_cli_writes_explicit_versions_when_requested() {
 }
 
 #[test]
+fn release_dry_run_cli_defaults_to_markdown_output() {
+	let mut settings = snapshot_settings();
+	settings.set_snapshot_suffix(current_test_name());
+	let _guard = settings.bind_to_scope();
+
+	let tempdir = setup_scenario_workspace("cli-output/ungrouped-basic");
+	assert_cmd_snapshot!(
+		release_cli_command()
+			.current_dir(tempdir.path())
+			.arg("release")
+			.arg("--dry-run")
+	);
+}
+
+#[test]
 fn release_dry_run_cli_patches_parent_packages_when_dependencies_change() {
 	let mut settings = snapshot_settings();
 	settings.set_snapshot_suffix(current_test_name());
@@ -297,6 +312,39 @@ fn release_cli_writes_group_changelog_and_skips_packages_without_changelogs() {
 	assert!(!tempdir.path().join("crates/app/changelog.md").exists());
 	assert!(workspace_manifest.contains("version = \"1.1.0\""));
 	assert!(group_versioned_file.contains("version = \"1.1.0\""));
+}
+
+#[test]
+fn release_quiet_suppresses_output_and_skips_workspace_mutation() {
+	let tempdir = setup_scenario_workspace("cli-output/group-basic");
+	let before_root_changelog = fs::read_to_string(tempdir.path().join("changelog.md"))
+		.unwrap_or_else(|error| panic!("group changelog before quiet release: {error}"));
+	let before_workspace_manifest = fs::read_to_string(tempdir.path().join("Cargo.toml"))
+		.unwrap_or_else(|error| panic!("workspace manifest before quiet release: {error}"));
+
+	let output = release_cli_command()
+		.current_dir(tempdir.path())
+		.arg("--quiet")
+		.arg("release")
+		.output()
+		.unwrap_or_else(|error| panic!("quiet release output: {error}"));
+	assert!(output.status.success(), "quiet release failed unexpectedly");
+	assert!(
+		output.stdout.is_empty(),
+		"quiet release should suppress stdout"
+	);
+	assert!(
+		output.stderr.is_empty(),
+		"quiet release should suppress stderr"
+	);
+
+	let after_root_changelog = fs::read_to_string(tempdir.path().join("changelog.md"))
+		.unwrap_or_else(|error| panic!("group changelog after quiet release: {error}"));
+	let after_workspace_manifest = fs::read_to_string(tempdir.path().join("Cargo.toml"))
+		.unwrap_or_else(|error| panic!("workspace manifest after quiet release: {error}"));
+
+	assert_eq!(before_root_changelog, after_root_changelog);
+	assert_eq!(before_workspace_manifest, after_workspace_manifest);
 }
 
 #[test]

--- a/crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_prints_help.snap
+++ b/crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_prints_help.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/monochange/tests/cli_main_binary.rs
+assertion_line: 14
 info:
   program: monochange
   args:
@@ -12,7 +13,7 @@ exit_code: 0
 ----- stdout -----
 Manage versions and releases for your multiplatform, multilanguage monorepo
 
-Usage: monochange <COMMAND>
+Usage: monochange [OPTIONS] <COMMAND>
 
 Commands:
   init            Generate monochange.toml with detected packages, groups, and default CLI commands
@@ -30,7 +31,8 @@ Commands:
   help            Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help  Print help
+  -q, --quiet  Suppress stdout/stderr output and run in dry-run mode when supported
+  -h, --help   Print help
 
 
 ----- stderr -----

--- a/crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_renders_cli_errors.snap
+++ b/crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_renders_cli_errors.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/monochange/tests/cli_main_binary.rs
+assertion_line: 19
 info:
   program: monochange
   args:
@@ -14,6 +15,6 @@ exit_code: 1
 ----- stderr -----
 config error: error: unrecognized subcommand 'not-a-command'
 
-Usage: monochange <COMMAND>
+Usage: monochange [OPTIONS] <COMMAND>
 
 For more information, try '--help'.

--- a/crates/monochange/tests/snapshots/cli_output__change_cli_help_documents_package_and_group_targeting_rules@change_cli_help_documents_package_and_group_targeting_rules.snap
+++ b/crates/monochange/tests/snapshots/cli_output__change_cli_help_documents_package_and_group_targeting_rules@change_cli_help_documents_package_and_group_targeting_rules.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/monochange/tests/cli_output.rs
-assertion_line: 31
+assertion_line: 36
 info:
   program: mc
   args:
@@ -8,6 +8,7 @@ info:
     - "--help"
   env:
     NO_COLOR: "1"
+    RUST_LOG: ""
 ---
 success: true
 exit_code: 0
@@ -19,6 +20,7 @@ Usage: mc change [OPTIONS]
 Options:
       --dry-run            Run the command in dry-run mode when supported
   -i, --interactive        Select packages, bumps, and options interactively
+  -q, --quiet              Suppress stdout/stderr output and run in dry-run mode when supported
       --package <PACKAGE>  Package or group to include in the change
       --bump <BUMP>        Requested semantic version bump [default: patch] [possible values: none, patch, minor, major]
       --version <VERSION>  Pin an explicit version for this release

--- a/crates/monochange/tests/snapshots/cli_output__release_dry_run_cli_defaults_to_markdown_output@release_dry_run_cli_defaults_to_markdown_output.snap
+++ b/crates/monochange/tests/snapshots/cli_output__release_dry_run_cli_defaults_to_markdown_output@release_dry_run_cli_defaults_to_markdown_output.snap
@@ -1,0 +1,35 @@
+---
+source: crates/monochange/tests/cli_output.rs
+assertion_line: 120
+info:
+  program: mc
+  args:
+    - release
+    - "--dry-run"
+  env:
+    MONOCHANGE_RELEASE_DATE: 2026-04-06
+    NO_COLOR: "1"
+    RUST_LOG: ""
+---
+success: true
+exit_code: 0
+----- stdout -----
+# `release` (dry-run)
+
+## Summary
+
+- **Released packages:** `workflow-app`, `workflow-core`
+
+## Release targets
+
+- **package `app`** → `app/v1.0.1`
+  - tag: no · release: no
+- **package `core`** → `core/v1.1.0`
+  - tag: no · release: no
+
+## Changed files
+
+- `crates/app/Cargo.toml`
+- `crates/core/Cargo.toml`
+
+----- stderr -----

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -424,6 +424,28 @@ fn default_cli_commands_expose_validate_discover_change_release_and_affected() {
 }
 
 #[test]
+fn default_release_command_prefers_markdown_output() {
+	let release = default_cli_commands()
+		.into_iter()
+		.find(|command| command.name == "release")
+		.unwrap_or_else(|| panic!("expected release command"));
+	let format = release
+		.inputs
+		.iter()
+		.find(|input| input.name == "format")
+		.unwrap_or_else(|| panic!("expected release format input"));
+	assert_eq!(format.default.as_deref(), Some("markdown"));
+	assert_eq!(
+		format.choices,
+		vec![
+			"markdown".to_string(),
+			"text".to_string(),
+			"json".to_string(),
+		]
+	);
+}
+
+#[test]
 fn cli_step_definition_kind_name_covers_all_variants() {
 	use std::collections::BTreeMap;
 	let cases: Vec<(CliStepDefinition, &str)> = vec![

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -2854,8 +2854,12 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 				kind: CliInputKind::Choice,
 				help_text: Some("Output format".to_string()),
 				required: false,
-				default: Some("text".to_string()),
-				choices: vec!["text".to_string(), "json".to_string()],
+				default: Some("markdown".to_string()),
+				choices: vec![
+					"markdown".to_string(),
+					"text".to_string(),
+					"json".to_string(),
+				],
 				short: None,
 			}],
 			steps: vec![CliStepDefinition::PrepareRelease {

--- a/docs/src/guide/00-start-here.md
+++ b/docs/src/guide/00-start-here.md
@@ -74,8 +74,10 @@ Use group ids only when the change is intentionally owned by the whole group.
 ## 6. Preview the release plan safely
 
 ```bash
-mc release --dry-run --format json
+mc release --dry-run
 ```
+
+By default this now renders a human-friendly markdown preview in the terminal. Use `--format json` when you want structured output for tooling, or `--format text` when you explicitly want the older plain-text rendering.
 
 Stop here on your first run. This previews the release plan without publishing anything.
 
@@ -89,6 +91,8 @@ A good first-time mental model is:
 4. Groups synchronize packages that intentionally share release identity.
 
 That is why most beginner flows should start with package ids, not groups.
+
+If you need a silent safety check, run `mc release --quiet`. Quiet mode suppresses stdout/stderr and keeps release-oriented commands in dry-run behavior.
 
 ## If you hit a problem
 

--- a/docs/src/guide/06-release-planning.md
+++ b/docs/src/guide/06-release-planning.md
@@ -102,6 +102,8 @@ mc release --dry-run --format json
 
 <!-- {/projectPlanCommand} -->
 
+For human-readable local output, `mc release --dry-run` now defaults to terminal-friendly markdown. Use `--format text` when you want the older plain-text style, or keep `--format json` for automation.
+
 Preferred repository command flow:
 
 <!-- {=projectDryRunCommand} -->
@@ -119,7 +121,9 @@ mc release --dry-run --diff
 mc release --dry-run --format json --diff
 ```
 
-Text output renders unified diffs directly in the terminal. JSON output wraps the normal manifest payload under `manifest` and adds `fileDiffs` entries for each changed file.
+Markdown and text output render unified diffs directly in the terminal. JSON output wraps the normal manifest payload under `manifest` and adds `fileDiffs` entries for each changed file.
+
+When you want command semantics without any command-line noise, add `--quiet`. Quiet mode suppresses stdout/stderr and uses dry-run behavior for release-oriented commands so the workspace stays unchanged.
 
 <!-- {=projectReleaseCommand} -->
 
@@ -246,6 +250,8 @@ Planning rules in this milestone:
 - CLI text and JSON output render workspace paths relative to the repository root for stable snapshots and automation
 
 <!-- {/releasePlanningRules} -->
+
+Across release-oriented commands, global `--quiet` suppresses stdout/stderr and reuses dry-run behavior for commands that support it.
 
 ## Concurrency
 

--- a/docs/src/readme.md
+++ b/docs/src/readme.md
@@ -70,6 +70,8 @@ When you are ready to prepare the release locally, run `mc release`.
 
 <!-- {/projectCoreWorkflow} -->
 
+For human-readable local output, `mc release --dry-run` now defaults to terminal-friendly markdown. Use `--format json` for automation, `--format text` when you explicitly want the older plain-text rendering, and `--quiet` when you want dry-run behavior without stdout/stderr output.
+
 If you want a slower, more guided walkthrough, continue with [Start here](./guide/00-start-here.md) and [Your first release plan](./guide/02-setup.md).
 
 ## What to read next

--- a/docs/src/reference/cli-steps/00-index.md
+++ b/docs/src/reference/cli-steps/00-index.md
@@ -55,6 +55,7 @@ That means composition is explicit:
 - a step can only consume state created by an earlier step in the same command
 - a later step never runs "in parallel" with an earlier one
 - `--dry-run` flows through the whole command and changes the behavior of steps that support previews
+- `--quiet` suppresses stdout/stderr and reuses dry-run behavior for commands that support it
 - a plain `Command` step can bridge monochange and external tools, but built-in steps are preferable when you want stable semantics, structured JSON, or provider-aware behavior
 
 In practice, most workflows fit one of four patterns:

--- a/docs/src/reference/cli-steps/07-prepare-release.md
+++ b/docs/src/reference/cli-steps/07-prepare-release.md
@@ -50,8 +50,10 @@ It can produce:
 - updated changelogs
 - deleted or consumed changeset files
 - release target information
-- final command output in text or JSON form
+- final command output in markdown, text, or JSON form
 - structured `release.*` template values for later `Command` steps
+
+Built-in release-oriented commands now default their human-readable `format` input to `markdown`. Use `text` when you explicitly want the older plain-text style, or `json` for automation.
 
 It also fills the shorthand template values commonly used by `Command` steps:
 
@@ -141,3 +143,4 @@ Because the later steps all depend on the same prepared state, you should genera
 - putting `PublishRelease` or `OpenReleaseRequest` before `PrepareRelease`
 - assuming `PrepareRelease` is just a read-only planner in non-dry-run mode
 - forgetting that later `Command` steps can consume its structured output directly
+- forgetting that `--quiet` suppresses stdout/stderr and forces dry-run behavior when the command supports dry-run semantics

--- a/docs/src/reference/cli-steps/07-prepare-release.md
+++ b/docs/src/reference/cli-steps/07-prepare-release.md
@@ -24,7 +24,7 @@ If your command eventually needs release metadata, start with `PrepareRelease` r
 
 ## Inputs
 
-- `format` — `text` or `json`
+- `format` — `markdown`, `text`, or `json`
 
 ## Step-level `when` condition
 


### PR DESCRIPTION
## Summary
- default prepare-release-driven commands to `--format markdown` at runtime and keep `text`/`json` support intact
- render release summaries in a more readable markdown layout and add a global `--quiet` / `-q` flag that suppresses stdout/stderr while using dry-run behavior when supported
- cover the new behavior with unit tests, integration snapshots, and binary CLI tests

## Testing
- `devenv shell fix:all`
- `devenv shell mc validate`
- `cargo test -p monochange --lib`
- `cargo test -p monochange --test cli_output --test cli_main_binary`
- `cargo test -p monochange_core`
- `cargo llvm-cov -p monochange --lib --test cli_output --test cli_main_binary --summary-only`
- `cargo run -q -p monochange --bin mc -- affected --changed-paths .changeset/prepare-release-markdown-quiet.md --changed-paths crates/monochange/src/cli.rs --changed-paths crates/monochange/src/cli_runtime.rs --changed-paths crates/monochange/src/cli_progress.rs --changed-paths crates/monochange/src/lib.rs --changed-paths crates/monochange/src/main.rs --changed-paths crates/monochange/src/bin/mc.rs --changed-paths crates/monochange/src/release_artifacts.rs --changed-paths crates/monochange/src/release_record.rs --changed-paths crates/monochange/src/monochange.init.toml --changed-paths crates/monochange/src/__tests.rs --changed-paths crates/monochange/tests/cli_output.rs --changed-paths crates/monochange/tests/cli_main_binary.rs --changed-paths crates/monochange_core/src/lib.rs --changed-paths crates/monochange_core/src/__tests.rs --changed-paths docs/src/reference/cli-steps/07-prepare-release.md --changed-paths crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_prints_help.snap --changed-paths crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_renders_cli_errors.snap --changed-paths crates/monochange/tests/snapshots/cli_output__change_cli_help_documents_package_and_group_targeting_rules@change_cli_help_documents_package_and_group_targeting_rules.snap --changed-paths crates/monochange/tests/snapshots/cli_output__release_dry_run_cli_defaults_to_markdown_output@release_dry_run_cli_defaults_to_markdown_output.snap`
