### PR TITLE
feat: speed up release preparation and execution

### DIFF
--- a/.changeset/014-release-performance.md
+++ b/.changeset/014-release-performance.md
@@ -1,0 +1,60 @@
+---
+monochange: minor
+monochange_core: minor
+monochange_github: patch
+monochange_gitlab: patch
+monochange_gitea: patch
+---
+
+#### stream named release steps and keep `mc release` on the fast path
+
+`mc release` now streams progress as each step runs, shows configured step names in the TTY UI, and keeps the real non-dry-run prepare path much closer to `--dry-run` latency by overlapping hosted changeset enrichment with local release planning. Provider release branches also skip redundant `git checkout` work when the branch is already selected.
+
+**Before:**
+
+```toml
+[cli.release]
+[[cli.release.steps]]
+type = "PrepareRelease"
+
+[[cli.release.steps]]
+type = "CommitRelease"
+```
+
+```bash
+mc release
+```
+
+The command waited for each phase to complete before showing the final result, provider enrichment always ran inline, and release-step output did not surface explicit step display names in the progress UI.
+
+**After:**
+
+```toml
+[cli.release]
+[[cli.release.steps]]
+type = "PrepareRelease"
+name = "Plan release"
+
+[[cli.release.steps]]
+type = "CommitRelease"
+name = "Write release commit"
+```
+
+```bash
+mc release
+```
+
+TTY runs now stream named step progress with loading indicators and richer terminal formatting, and release-preparation diagnostics record per-phase timings so you can see where time is spent.
+
+Representative output:
+
+```text
+○ Plan release
+● Plan release (324ms)
+○ Write release commit
+● Write release commit (41ms)
+```
+
+`monochange_github` now batches hosted review-request enrichment instead of issuing one lookup per changeset, and all hosted providers skip no-op branch checkouts during release branch preparation. The real `mc release` benchmark suite also includes the mutating non-dry-run prepare path, so performance regressions are visible without having to infer them from `--dry-run` alone.
+
+For Cargo workspaces, the built-in fast path continues to prefer direct lockfile text rewrites during `mc release`. If you need a full dependency-resolution refresh afterwards, configure explicit `[ecosystems.cargo].lockfile_commands` or run `cargo generate-lockfile` manually after the release step finishes.

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -5390,7 +5390,9 @@ fn resolve_versioned_prefix_prefers_explicit_then_ecosystem_then_default() {
 	configuration.npm.dependency_version_prefix = Some("workspace:".to_string());
 	configuration.deno.dependency_version_prefix = None;
 	let context = crate::VersionedFileUpdateContext {
-		package_by_record_id: BTreeMap::new(),
+		package_by_config_id: BTreeMap::new(),
+		package_by_native_name: BTreeMap::new(),
+		current_versions_by_native_name: BTreeMap::new(),
 		released_versions_by_native_name: BTreeMap::new(),
 		configuration: &configuration,
 	};
@@ -5429,6 +5431,56 @@ fn resolve_versioned_prefix_prefers_explicit_then_ecosystem_then_default() {
 	assert_eq!(
 		crate::resolve_versioned_prefix(&fallback, &context),
 		monochange_core::EcosystemType::Deno.default_prefix()
+	);
+}
+
+#[test]
+fn build_versioned_file_updates_skips_unreleased_package_definitions() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_fixture("monochange/release-base", tempdir.path());
+
+	let mut configuration = load_workspace_configuration(tempdir.path())
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+	configuration.groups.clear();
+	let discovery =
+		discover_workspace(tempdir.path()).unwrap_or_else(|error| panic!("discovery: {error}"));
+	let released_core = discovery
+		.packages
+		.iter()
+		.find(|package| package.metadata.get("config_id").map(String::as_str) == Some("core"))
+		.unwrap_or_else(|| panic!("expected core package"));
+	let plan = monochange_core::ReleasePlan {
+		workspace_root: tempdir.path().to_path_buf(),
+		decisions: vec![monochange_core::ReleaseDecision {
+			package_id: released_core.id.clone(),
+			trigger_type: "changeset".to_string(),
+			recommended_bump: BumpSeverity::Minor,
+			planned_version: Some(
+				Version::parse("1.1.0").unwrap_or_else(|error| panic!("planned version: {error}")),
+			),
+			group_id: None,
+			reasons: vec!["release".to_string()],
+			upstream_sources: Vec::new(),
+			warnings: Vec::new(),
+		}],
+		groups: Vec::new(),
+		warnings: Vec::new(),
+		unresolved_items: Vec::new(),
+		compatibility_evidence: Vec::new(),
+	};
+
+	let updates = crate::build_versioned_file_updates(
+		tempdir.path(),
+		&configuration,
+		&discovery.packages,
+		&plan,
+	)
+	.unwrap_or_else(|error| panic!("versioned file updates: {error}"));
+
+	assert_eq!(updates.len(), 1);
+	assert_eq!(
+		updates[0].path,
+		tempdir.path().join("crates/core/extra.toml")
 	);
 }
 
@@ -5878,6 +5930,122 @@ fn build_manifest_updates_report_parse_and_io_errors() {
 		crate::build_deno_manifest_updates(&[deno_missing], &unreleased_plan)
 			.unwrap_or_else(|error| panic!("unreleased deno updates: {error}"))
 			.is_empty()
+	);
+}
+
+#[test]
+fn build_cargo_manifest_updates_updates_dependents_of_released_packages() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let core_manifest = tempdir.path().join("crates/core/Cargo.toml");
+	let app_manifest = tempdir.path().join("crates/app/Cargo.toml");
+	fs::create_dir_all(core_manifest.parent().expect("core manifest parent"))
+		.unwrap_or_else(|error| panic!("create core dir: {error}"));
+	fs::create_dir_all(app_manifest.parent().expect("app manifest parent"))
+		.unwrap_or_else(|error| panic!("create app dir: {error}"));
+	fs::write(
+		&core_manifest,
+		"[package]\nname = \"workflow-core\"\nversion = \"1.0.0\"\nedition = \"2021\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write core Cargo.toml: {error}"));
+	fs::write(
+		&app_manifest,
+		"[package]\nname = \"workflow-app\"\nversion = \"1.0.0\"\nedition = \"2021\"\n\n[dependencies]\nworkflow-core = { path = \"../core\", version = \"1.0.0\" }\n",
+	)
+	.unwrap_or_else(|error| panic!("write app Cargo.toml: {error}"));
+
+	let core = monochange_core::PackageRecord::new(
+		Ecosystem::Cargo,
+		"workflow-core",
+		core_manifest,
+		tempdir.path().to_path_buf(),
+		Some(Version::parse("1.0.0").unwrap_or_else(|error| panic!("version: {error}"))),
+		monochange_core::PublishState::Public,
+	);
+	let mut app = monochange_core::PackageRecord::new(
+		Ecosystem::Cargo,
+		"workflow-app",
+		app_manifest.clone(),
+		tempdir.path().to_path_buf(),
+		Some(Version::parse("1.0.0").unwrap_or_else(|error| panic!("version: {error}"))),
+		monochange_core::PublishState::Public,
+	);
+	app.declared_dependencies
+		.push(monochange_core::PackageDependency {
+			name: "workflow-core".to_string(),
+			kind: monochange_core::DependencyKind::Runtime,
+			version_constraint: Some("1.0.0".to_string()),
+			optional: false,
+		});
+
+	let plan = monochange_core::ReleasePlan {
+		workspace_root: tempdir.path().to_path_buf(),
+		decisions: vec![monochange_core::ReleaseDecision {
+			package_id: core.id.clone(),
+			trigger_type: "changeset".to_string(),
+			recommended_bump: BumpSeverity::Minor,
+			planned_version: Some(
+				Version::parse("1.1.0").unwrap_or_else(|error| panic!("planned version: {error}")),
+			),
+			group_id: None,
+			reasons: vec!["release".to_string()],
+			upstream_sources: Vec::new(),
+			warnings: Vec::new(),
+		}],
+		groups: Vec::new(),
+		warnings: Vec::new(),
+		unresolved_items: Vec::new(),
+		compatibility_evidence: Vec::new(),
+	};
+
+	let updates = crate::build_cargo_manifest_updates(&[core, app], &plan)
+		.unwrap_or_else(|error| panic!("cargo manifest updates: {error}"));
+	let app_update_index = updates
+		.iter()
+		.position(|update| update.path.ends_with("crates/app/Cargo.toml"));
+	assert!(app_update_index.is_some());
+	let app_update = &updates[app_update_index.unwrap_or(0)];
+	let app_update_content = String::from_utf8_lossy(&app_update.content);
+
+	assert!(app_update_content.contains("version = \"1.1.0\""));
+}
+
+#[test]
+fn build_npm_manifest_updates_reports_read_errors() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let npm_missing = monochange_core::PackageRecord::new(
+		Ecosystem::Npm,
+		"web",
+		tempdir.path().join("missing/package.json"),
+		tempdir.path().to_path_buf(),
+		Some(Version::parse("1.0.0").unwrap_or_else(|error| panic!("version: {error}"))),
+		monochange_core::PublishState::Public,
+	);
+	let plan = monochange_core::ReleasePlan {
+		workspace_root: tempdir.path().to_path_buf(),
+		decisions: vec![monochange_core::ReleaseDecision {
+			package_id: npm_missing.id.clone(),
+			trigger_type: "changeset".to_string(),
+			recommended_bump: BumpSeverity::Minor,
+			planned_version: Some(
+				Version::parse("1.1.0").unwrap_or_else(|error| panic!("planned version: {error}")),
+			),
+			group_id: None,
+			reasons: vec!["release".to_string()],
+			upstream_sources: Vec::new(),
+			warnings: Vec::new(),
+		}],
+		groups: Vec::new(),
+		warnings: Vec::new(),
+		unresolved_items: Vec::new(),
+		compatibility_evidence: Vec::new(),
+	};
+
+	let error = crate::build_npm_manifest_updates(std::slice::from_ref(&npm_missing), &plan)
+		.err()
+		.unwrap_or_else(|| panic!("expected npm read error"));
+	assert!(
+		error.to_string().contains("failed to read"),
+		"error: {error}"
 	);
 }
 
@@ -6827,9 +6995,27 @@ fn versioned_test_context<'a>(
 	packages: &'a [monochange_core::PackageRecord],
 ) -> crate::VersionedFileUpdateContext<'a> {
 	crate::VersionedFileUpdateContext {
-		package_by_record_id: packages
+		package_by_config_id: packages
 			.iter()
-			.map(|package| (package.id.as_str(), package))
+			.filter_map(|package| {
+				package
+					.metadata
+					.get("config_id")
+					.map(|config_id| (config_id.as_str(), package))
+			})
+			.collect(),
+		package_by_native_name: packages
+			.iter()
+			.map(|package| (package.name.as_str(), package))
+			.collect(),
+		current_versions_by_native_name: packages
+			.iter()
+			.filter_map(|package| {
+				package
+					.current_version
+					.as_ref()
+					.map(|version| (package.name.clone(), version.to_string()))
+			})
 			.collect(),
 		released_versions_by_native_name,
 		configuration,

--- a/crates/monochange/src/changesets.rs
+++ b/crates/monochange/src/changesets.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use super::*;
 
 pub(crate) fn diagnose_changesets(
@@ -263,10 +265,7 @@ fn batch_load_changeset_contexts(
 		.map(|cs| root_relative(root, &cs.path))
 		.collect();
 
-	// Single git log for all introduced commits (--diff-filter=A).
-	let introduced_map = batch_git_log(root, &relative_paths, true);
-	// Single git log for all last-updated commits.
-	let last_updated_map = batch_git_log(root, &relative_paths, false);
+	let (introduced_map, last_updated_map) = batch_git_log(root, &relative_paths);
 
 	relative_paths
 		.iter()
@@ -285,45 +284,63 @@ fn batch_load_changeset_contexts(
 }
 
 /// Run a single `git log` command covering the entire `.changeset/` directory
-/// and return a map from relative path to the relevant revision.
+/// and return both the introduced and last-updated revision maps.
 ///
-/// For `introduced=true`: finds the commit that first added each file.
-/// For `introduced=false`: finds the most recent commit that touched each file.
-///
-/// This replaces N individual `git log` subprocess calls with a single call
-/// that walks the history once.
-#[tracing::instrument(skip_all, fields(count = paths.len(), introduced))]
+/// This replaces two independent history walks with one pass over the same git
+/// log stream. The first time we see a file is its latest update; the last
+/// added entry we see for the file is the commit that introduced it.
+#[tracing::instrument(skip_all, fields(count = paths.len()))]
 fn batch_git_log(
 	root: &Path,
 	paths: &[PathBuf],
-	introduced: bool,
-) -> std::collections::HashMap<String, ChangesetRevision> {
+) -> (
+	std::collections::HashMap<String, ChangesetRevision>,
+	std::collections::HashMap<String, ChangesetRevision>,
+) {
 	use std::collections::HashMap;
 
 	if paths.is_empty() {
-		return HashMap::new();
+		return (HashMap::new(), HashMap::new());
 	}
 
-	// Use NUL-delimited output to safely handle any filenames.
-	// Format: <commit-fields>\x1f\n<filename>\n\x00 per entry.
 	let mut command = ProcessCommand::new("git");
 	command
 		.current_dir(root)
 		.arg("log")
 		.arg("--format=%H%x1f%an%x1f%ae%x1f%aI%x1f%cI")
-		.arg("--name-only");
-	if introduced {
-		command.arg("--diff-filter=A");
-	}
+		.arg("--name-status");
 	command.arg("--").arg(".changeset/");
 
 	let output = match command.output() {
 		Ok(output) if output.status.success() => output,
-		_ => return HashMap::new(),
+		_ => return (HashMap::new(), HashMap::new()),
 	};
-	let Ok(stdout) = String::from_utf8(output.stdout) else {
-		return HashMap::new();
+	parse_batch_git_log_bytes(&output.stdout, paths)
+}
+
+fn parse_batch_git_log_bytes(
+	stdout: &[u8],
+	paths: &[PathBuf],
+) -> (
+	std::collections::HashMap<String, ChangesetRevision>,
+	std::collections::HashMap<String, ChangesetRevision>,
+) {
+	use std::collections::HashMap;
+
+	let Ok(stdout) = std::str::from_utf8(stdout) else {
+		return (HashMap::new(), HashMap::new());
 	};
+	parse_batch_git_log_output(stdout, paths)
+}
+
+fn parse_batch_git_log_output(
+	stdout: &str,
+	paths: &[PathBuf],
+) -> (
+	std::collections::HashMap<String, ChangesetRevision>,
+	std::collections::HashMap<String, ChangesetRevision>,
+) {
+	use std::collections::HashMap;
 
 	let wanted_paths: std::collections::HashSet<String> = paths
 		.iter()
@@ -332,11 +349,11 @@ fn batch_git_log(
 
 	// Parse the git log output. Format is blocks separated by blank lines:
 	// <sha>\x1f<name>\x1f<email>\x1f<author_date>\x1f<commit_date>
-	// <filename1>
-	// <filename2>
+	// <status>\t<filename>
 	//
 	// (blank line between commits)
-	let mut result: HashMap<String, ChangesetRevision> = HashMap::new();
+	let mut introduced = HashMap::new();
+	let mut last_updated = HashMap::new();
 
 	let mut current_fields: Option<Vec<&str>> = None;
 	for line in stdout.lines() {
@@ -359,21 +376,14 @@ fn batch_git_log(
 		if fields.len() != 5 {
 			continue;
 		}
-		let file_path = trimmed;
-		if !wanted_paths.contains(file_path) {
+		let mut parts = trimmed.splitn(2, '\t');
+		let Some(status) = parts.next() else {
 			continue;
-		}
-		// For "introduced": we want the LAST (oldest) match per file since
-		// git log outputs newest first. For "last_updated": we want the
-		// FIRST (newest) match.
-		let dominated = if introduced {
-			// Keep overwriting — last write wins = oldest commit.
-			false
-		} else {
-			// Only take the first match = newest commit.
-			result.contains_key(file_path)
 		};
-		if dominated {
+		let Some(file_path) = parts.next() else {
+			continue;
+		};
+		if !wanted_paths.contains(file_path) {
 			continue;
 		}
 		let [sha, author_name, author_email, authored_at, committed_at] = fields.as_slice() else {
@@ -402,10 +412,15 @@ fn batch_git_log(
 			}),
 			review_request: None,
 		};
-		result.insert(file_path.to_string(), revision);
+		last_updated
+			.entry(file_path.to_string())
+			.or_insert_with(|| revision.clone());
+		if status == "A" {
+			introduced.insert(file_path.to_string(), revision);
+		}
 	}
 
-	result
+	(introduced, last_updated)
 }
 
 pub(crate) fn short_commit_sha(sha: &str) -> String {
@@ -478,14 +493,17 @@ pub(crate) fn released_package_names(
 	packages: &[PackageRecord],
 	plan: &ReleasePlan,
 ) -> Vec<String> {
+	let package_by_id = packages
+		.iter()
+		.map(|package| (package.id.as_str(), package))
+		.collect::<BTreeMap<_, _>>();
 	let mut released_packages = plan
 		.decisions
 		.iter()
 		.filter(|decision| decision.recommended_bump.is_release())
 		.filter_map(|decision| {
-			packages
-				.iter()
-				.find(|package| package.id == decision.package_id)
+			package_by_id
+				.get(decision.package_id.as_str())
 				.map(|package| package.name.clone())
 		})
 		.collect::<Vec<_>>();
@@ -596,4 +614,48 @@ pub(crate) fn render_changeset_markdown(
 	}
 	lines.push(String::new());
 	Ok(lines.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+	use std::path::Path;
+	use std::path::PathBuf;
+
+	use super::batch_git_log;
+	use super::parse_batch_git_log_bytes;
+	use super::parse_batch_git_log_output;
+
+	#[test]
+	fn batch_git_log_returns_empty_maps_for_empty_paths() {
+		let (introduced, last_updated) = batch_git_log(Path::new("."), &[]);
+		assert!(introduced.is_empty());
+		assert!(last_updated.is_empty());
+	}
+
+	#[test]
+	fn batch_git_log_returns_empty_maps_when_git_log_fails() {
+		let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let (introduced, last_updated) =
+			batch_git_log(tempdir.path(), &[PathBuf::from(".changeset/feature.md")]);
+		assert!(introduced.is_empty());
+		assert!(last_updated.is_empty());
+	}
+
+	#[test]
+	fn parse_batch_git_log_bytes_returns_empty_maps_for_invalid_utf8_output() {
+		let (introduced, last_updated) =
+			parse_batch_git_log_bytes(b"\xff", &[PathBuf::from(".changeset/feature.md")]);
+		assert!(introduced.is_empty());
+		assert!(last_updated.is_empty());
+	}
+
+	#[test]
+	fn parse_batch_git_log_output_ignores_malformed_name_status_lines() {
+		let (introduced, last_updated) = parse_batch_git_log_output(
+			"abc123\x1fIfiok\x1fifiok@example.com\x1f2026-04-06T00:00:00Z\x1f2026-04-06T00:00:00Z\nM\n",
+			&[PathBuf::from(".changeset/feature.md")],
+		);
+		assert!(introduced.is_empty());
+		assert!(last_updated.is_empty());
+	}
 }

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -15,7 +15,6 @@ use std::time::Instant;
 
 use clap::ArgMatches;
 use clap::parser::ValueSource;
-use monochange_config::load_workspace_configuration;
 use monochange_core::ChangesetPolicyStatus;
 use monochange_core::CliCommandDefinition;
 use monochange_core::CliInputKind;
@@ -482,7 +481,6 @@ pub(crate) fn execute_cli_command_with_options(
 						.is_some_and(|value| value == "true");
 
 					if is_interactive {
-						let configuration = load_workspace_configuration(root)?;
 						let options = interactive::InteractiveOptions {
 							reason: step_inputs
 								.get("reason")
@@ -493,7 +491,7 @@ pub(crate) fn execute_cli_command_with_options(
 								.and_then(|values| values.first())
 								.cloned(),
 						};
-						let result = interactive::run_interactive_change(&configuration, &options)?;
+						let result = interactive::run_interactive_change(configuration, &options)?;
 						let output_path = step_inputs
 							.get("output")
 							.and_then(|values| values.first())
@@ -603,7 +601,7 @@ pub(crate) fn execute_cli_command_with_options(
 								.to_string(),
 						)
 					})?;
-					let source = load_workspace_configuration(root)?.source.ok_or_else(|| {
+					let source = configuration.source.clone().ok_or_else(|| {
 						MonochangeError::Config(
 							"`PublishRelease` requires `[source]` configuration".to_string(),
 						)
@@ -644,7 +642,7 @@ pub(crate) fn execute_cli_command_with_options(
 								.to_string(),
 						)
 					})?;
-					let source = load_workspace_configuration(root)?.source.ok_or_else(|| {
+					let source = configuration.source.clone().ok_or_else(|| {
 						MonochangeError::Config(
 							"`OpenReleaseRequest` requires `[source]` configuration".to_string(),
 						)
@@ -671,8 +669,9 @@ pub(crate) fn execute_cli_command_with_options(
 								.to_string(),
 						)
 					})?;
-					let source = load_workspace_configuration(root)?
+					let source = configuration
 						.source
+						.clone()
 						.filter(|source| source.provider == SourceProvider::GitHub)
 						.ok_or_else(|| {
 							MonochangeError::Config(

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -18,6 +18,10 @@ pub(crate) fn build_release_targets(
 	changeset_paths: &[PathBuf],
 ) -> Vec<ReleaseTarget> {
 	let changes_count = changeset_paths.len();
+	let package_by_id = packages
+		.iter()
+		.map(|package| (package.id.as_str(), package))
+		.collect::<BTreeMap<_, _>>();
 	let source = configuration.source.as_ref();
 	let defaults_release_title = configuration.defaults.release_title.as_deref();
 	let defaults_changelog_title = configuration.defaults.changelog_version_title.as_deref();
@@ -82,7 +86,7 @@ pub(crate) fn build_release_targets(
 		.iter()
 		.filter(|d| d.recommended_bump.is_release() && d.group_id.is_none())
 	{
-		let Some(package) = packages.iter().find(|p| p.id == decision.package_id) else {
+		let Some(package) = package_by_id.get(decision.package_id.as_str()).copied() else {
 			continue;
 		};
 		let Some(version) = decision.planned_version.as_ref() else {
@@ -133,6 +137,27 @@ pub(crate) fn build_release_targets(
 	}
 	release_targets.sort_by(|left, right| left.id.cmp(&right.id));
 	release_targets
+}
+
+pub(crate) fn build_manifest_updates_parallel(
+	packages: &[PackageRecord],
+	plan: &ReleasePlan,
+) -> MonochangeResult<Vec<FileUpdate>> {
+	let ((cargo_updates, npm_updates), (deno_updates, dart_updates)) = rayon::join(
+		|| {
+			rayon::join(
+				|| build_cargo_manifest_updates(packages, plan),
+				|| build_npm_manifest_updates(packages, plan),
+			)
+		},
+		|| {
+			rayon::join(
+				|| build_deno_manifest_updates(packages, plan),
+				|| build_dart_manifest_updates(packages, plan),
+			)
+		},
+	);
+	Ok([cargo_updates?, npm_updates?, deno_updates?, dart_updates?].concat())
 }
 
 pub(crate) fn render_tag_name(id: &str, version: &str, version_format: VersionFormat) -> String {
@@ -316,6 +341,8 @@ pub(crate) fn build_cargo_manifest_updates(
 	packages: &[PackageRecord],
 	plan: &ReleasePlan,
 ) -> MonochangeResult<Vec<FileUpdate>> {
+	use rayon::prelude::*;
+
 	let released_versions = plan
 		.decisions
 		.iter()
@@ -339,43 +366,43 @@ pub(crate) fn build_cargo_manifest_updates(
 		return Ok(Vec::new());
 	}
 
-	let mut updated_documents = BTreeMap::<PathBuf, String>::new();
-	for package in packages
+	let mut updated_documents = packages
 		.iter()
 		.filter(|package| package.ecosystem == Ecosystem::Cargo)
-	{
-		let should_update_manifest = released_versions.contains_key(&package.id)
-			|| package
-				.declared_dependencies
-				.iter()
-				.any(|dependency| released_versions_by_name.contains_key(&dependency.name));
-		if !should_update_manifest {
-			continue;
-		}
-
-		let contents = fs::read_to_string(&package.manifest_path).map_err(|error| {
-			MonochangeError::Io(format!(
-				"failed to read {}: {error}",
-				package.manifest_path.display()
-			))
-		})?;
-		let updated = monochange_cargo::update_versioned_file_text(
-			&contents,
-			monochange_cargo::CargoVersionedFileKind::Manifest,
-			&["dependencies", "dev-dependencies", "build-dependencies"],
-			released_versions.get(&package.id).map(String::as_str),
-			None,
-			&released_versions_by_name,
-			&BTreeMap::new(),
-		)
-		.map_err(|error| {
-			MonochangeError::Config(format!(
-				"failed to parse {}: {error}",
-				package.manifest_path.display()
-			))
-		})?;
-		updated_documents.insert(package.manifest_path.clone(), updated);
-	}
+		.par_bridge()
+		.filter_map(|package| {
+			let should_update_manifest = released_versions.contains_key(&package.id)
+				|| package
+					.declared_dependencies
+					.iter()
+					.any(|dependency| released_versions_by_name.contains_key(&dependency.name));
+			should_update_manifest.then_some(package)
+		})
+		.map(|package| {
+			let contents = fs::read_to_string(&package.manifest_path).map_err(|error| {
+				MonochangeError::Io(format!(
+					"failed to read {}: {error}",
+					package.manifest_path.display()
+				))
+			})?;
+			let updated = monochange_cargo::update_versioned_file_text(
+				&contents,
+				monochange_cargo::CargoVersionedFileKind::Manifest,
+				&["dependencies", "dev-dependencies", "build-dependencies"],
+				released_versions.get(&package.id).map(String::as_str),
+				None,
+				&released_versions_by_name,
+				&BTreeMap::new(),
+			)
+			.map_err(|error| {
+				MonochangeError::Config(format!(
+					"failed to parse {}: {error}",
+					package.manifest_path.display()
+				))
+			})?;
+			Ok((package.manifest_path.clone(), updated))
+		})
+		.collect::<MonochangeResult<BTreeMap<_, _>>>()?;
 
 	for workspace_root in packages
 		.iter()
@@ -448,112 +475,131 @@ pub(crate) fn build_npm_manifest_updates(
 	packages: &[PackageRecord],
 	plan: &ReleasePlan,
 ) -> MonochangeResult<Vec<FileUpdate>> {
+	use rayon::prelude::*;
+
 	let released_versions = released_versions_by_record_id(plan);
-	let mut updates = Vec::new();
-	for package in packages
+	packages
 		.iter()
 		.filter(|package| package.ecosystem == Ecosystem::Npm)
-	{
-		let Some(version) = released_versions.get(&package.id) else {
-			continue;
-		};
-		let contents = fs::read_to_string(&package.manifest_path).map_err(|error| {
-			MonochangeError::Io(format!(
-				"failed to read {}: {error}",
-				package.manifest_path.display()
-			))
-		})?;
-		let rendered = monochange_core::update_json_manifest_text(
-			&contents,
-			Some(version),
-			&[],
-			&BTreeMap::new(),
-		)
-		.map_err(|error| {
-			MonochangeError::Config(format!(
-				"failed to parse {}: {error}",
-				package.manifest_path.display()
-			))
-		})?;
-		updates.push(FileUpdate {
-			path: package.manifest_path.clone(),
-			content: rendered.into_bytes(),
-		});
-	}
-	Ok(updates)
+		.par_bridge()
+		.filter_map(|package| {
+			released_versions
+				.get(&package.id)
+				.map(|version| (package, version))
+		})
+		.map(|(package, version)| {
+			let contents = fs::read_to_string(&package.manifest_path).map_err(|error| {
+				MonochangeError::Io(format!(
+					"failed to read {}: {error}",
+					package.manifest_path.display()
+				))
+			})?;
+			let rendered = monochange_core::update_json_manifest_text(
+				&contents,
+				Some(version),
+				&[],
+				&BTreeMap::new(),
+			)
+			.map_err(|error| {
+				MonochangeError::Config(format!(
+					"failed to parse {}: {error}",
+					package.manifest_path.display()
+				))
+			})?;
+			Ok(FileUpdate {
+				path: package.manifest_path.clone(),
+				content: rendered.into_bytes(),
+			})
+		})
+		.collect()
 }
 
 pub(crate) fn build_deno_manifest_updates(
 	packages: &[PackageRecord],
 	plan: &ReleasePlan,
 ) -> MonochangeResult<Vec<FileUpdate>> {
+	use rayon::prelude::*;
+
 	let released_versions = released_versions_by_record_id(plan);
-	let mut updates = Vec::new();
-	for package in packages
+	packages
 		.iter()
 		.filter(|package| package.ecosystem == Ecosystem::Deno)
-	{
-		let Some(version) = released_versions.get(&package.id) else {
-			continue;
-		};
-		let contents = fs::read_to_string(&package.manifest_path).map_err(|error| {
-			MonochangeError::Io(format!(
-				"failed to read {}: {error}",
-				package.manifest_path.display()
-			))
-		})?;
-		let rendered = monochange_core::update_json_manifest_text(
-			&contents,
-			Some(version),
-			&[],
-			&BTreeMap::new(),
-		)
-		.map_err(|error| {
-			MonochangeError::Config(format!(
-				"failed to parse {}: {error}",
-				package.manifest_path.display()
-			))
-		})?;
-		updates.push(FileUpdate {
-			path: package.manifest_path.clone(),
-			content: rendered.into_bytes(),
-		});
-	}
-	Ok(updates)
+		.par_bridge()
+		.filter_map(|package| {
+			released_versions
+				.get(&package.id)
+				.map(|version| (package, version))
+		})
+		.map(|(package, version)| {
+			let contents = fs::read_to_string(&package.manifest_path).map_err(|error| {
+				MonochangeError::Io(format!(
+					"failed to read {}: {error}",
+					package.manifest_path.display()
+				))
+			})?;
+			let rendered = monochange_core::update_json_manifest_text(
+				&contents,
+				Some(version),
+				&[],
+				&BTreeMap::new(),
+			)
+			.map_err(|error| {
+				MonochangeError::Config(format!(
+					"failed to parse {}: {error}",
+					package.manifest_path.display()
+				))
+			})?;
+			Ok(FileUpdate {
+				path: package.manifest_path.clone(),
+				content: rendered.into_bytes(),
+			})
+		})
+		.collect()
 }
 
 pub(crate) fn build_dart_manifest_updates(
 	packages: &[PackageRecord],
 	plan: &ReleasePlan,
 ) -> MonochangeResult<Vec<FileUpdate>> {
+	use rayon::prelude::*;
+
 	let released_versions = released_versions_by_record_id(plan);
-	let mut updates = Vec::new();
-	for package in packages.iter().filter(|package| {
-		package.ecosystem == Ecosystem::Dart || package.ecosystem == Ecosystem::Flutter
-	}) {
-		let Some(version) = released_versions.get(&package.id) else {
-			continue;
-		};
-		let contents = fs::read_to_string(&package.manifest_path).map_err(|error| {
-			MonochangeError::Io(format!(
-				"failed to read {}: {error}",
-				package.manifest_path.display()
-			))
-		})?;
-		let rendered =
-			monochange_dart::update_manifest_text(&contents, Some(version), &[], &BTreeMap::new())
-				.map_err(|error| {
-					MonochangeError::Config(format!(
-						"failed to parse {}: {error}",
-						package.manifest_path.display()
-					))
-				})?;
-		updates.push(FileUpdate {
-			path: package.manifest_path.clone(),
-			content: rendered.into_bytes(),
-		});
-	}
-	Ok(updates)
+	packages
+		.iter()
+		.filter(|package| {
+			package.ecosystem == Ecosystem::Dart || package.ecosystem == Ecosystem::Flutter
+		})
+		.par_bridge()
+		.filter_map(|package| {
+			released_versions
+				.get(&package.id)
+				.map(|version| (package, version))
+		})
+		.map(|(package, version)| {
+			let contents = fs::read_to_string(&package.manifest_path).map_err(|error| {
+				MonochangeError::Io(format!(
+					"failed to read {}: {error}",
+					package.manifest_path.display()
+				))
+			})?;
+			let rendered = monochange_dart::update_manifest_text(
+				&contents,
+				Some(version),
+				&[],
+				&BTreeMap::new(),
+			)
+			.map_err(|error| {
+				MonochangeError::Config(format!(
+					"failed to parse {}: {error}",
+					package.manifest_path.display()
+				))
+			})?;
+			Ok(FileUpdate {
+				path: package.manifest_path.clone(),
+				content: rendered.into_bytes(),
+			})
+		})
+		.collect()
 }
 
 pub(crate) fn apply_file_updates(updates: &[FileUpdate]) -> MonochangeResult<()> {

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -3,7 +3,9 @@ use regex::Regex;
 use super::*;
 
 pub(crate) struct VersionedFileUpdateContext<'a> {
-	pub(crate) package_by_record_id: BTreeMap<&'a str, &'a PackageRecord>,
+	pub(crate) package_by_config_id: BTreeMap<&'a str, &'a PackageRecord>,
+	pub(crate) package_by_native_name: BTreeMap<&'a str, &'a PackageRecord>,
+	pub(crate) current_versions_by_native_name: BTreeMap<String, String>,
 	pub(crate) released_versions_by_native_name: BTreeMap<String, String>,
 	pub(crate) configuration: &'a monochange_core::WorkspaceConfiguration,
 }
@@ -76,9 +78,27 @@ pub(crate) fn build_versioned_file_updates(
 		return Ok(Vec::new());
 	}
 	let released_versions_by_record_id = released_versions_by_record_id(plan);
-	let package_by_record_id = packages
+	let package_by_config_id = packages
 		.iter()
-		.map(|package| (package.id.as_str(), package))
+		.filter_map(|package| {
+			package
+				.metadata
+				.get("config_id")
+				.map(|config_id| (config_id.as_str(), package))
+		})
+		.collect::<BTreeMap<_, _>>();
+	let package_by_native_name = packages
+		.iter()
+		.map(|package| (package.name.as_str(), package))
+		.collect::<BTreeMap<_, _>>();
+	let current_versions_by_native_name = packages
+		.iter()
+		.filter_map(|package| {
+			package
+				.current_version
+				.as_ref()
+				.map(|version| (package.name.clone(), version.to_string()))
+		})
 		.collect::<BTreeMap<_, _>>();
 	let released_versions_by_config_id = packages
 		.iter()
@@ -100,7 +120,9 @@ pub(crate) fn build_versioned_file_updates(
 		.collect::<BTreeMap<_, _>>();
 	let shared_release_version = shared_release_version(plan);
 	let context = VersionedFileUpdateContext {
-		package_by_record_id,
+		package_by_config_id,
+		package_by_native_name,
+		current_versions_by_native_name,
 		released_versions_by_native_name,
 		configuration,
 	};
@@ -111,9 +133,8 @@ pub(crate) fn build_versioned_file_updates(
 			continue;
 		};
 		let matched_package = context
-			.package_by_record_id
-			.values()
-			.find(|package| package.metadata.get("config_id") == Some(&package_definition.id));
+			.package_by_config_id
+			.get(package_definition.id.as_str());
 		let dep_names = if let Some(name) = matched_package.map(|package| package.name.clone()) {
 			vec![name]
 		} else {
@@ -154,9 +175,8 @@ pub(crate) fn build_versioned_file_updates(
 			.iter()
 			.map(|member_id| {
 				context
-					.package_by_record_id
-					.values()
-					.find(|package| package.metadata.get("config_id") == Some(member_id))
+					.package_by_config_id
+					.get(member_id.as_str())
 					.map_or_else(|| member_id.clone(), |package| package.name.clone())
 			})
 			.collect::<Vec<_>>();
@@ -664,8 +684,10 @@ pub(crate) fn apply_versioned_file_definition(
 		let package_paths_by_name = dep_names
 			.iter()
 			.filter_map(|name| {
-				context.package_by_record_id.values().find_map(|package| {
-					(package.name == *name).then(|| {
+				context
+					.package_by_native_name
+					.get(name.as_str())
+					.map(|package| {
 						(
 							name.clone(),
 							relative_to_root(
@@ -684,7 +706,6 @@ pub(crate) fn apply_versioned_file_definition(
 							}),
 						)
 					})
-				})
 			})
 			.collect::<BTreeMap<_, _>>();
 		let mut document = read_cached_document(updates, &resolved_path, ecosystem_type)?;
@@ -747,16 +768,10 @@ pub(crate) fn apply_versioned_file_definition(
 				let old_versions = dep_names
 					.iter()
 					.filter_map(|name| {
-						context.package_by_record_id.values().find_map(|package| {
-							(package.name == *name)
-								.then_some(
-									package
-										.current_version
-										.as_ref()
-										.map(|version| (name.clone(), version.to_string())),
-								)
-								.flatten()
-						})
+						context
+							.current_versions_by_native_name
+							.get(name)
+							.map(|version| (name.clone(), version.clone()))
 					})
 					.collect::<BTreeMap<_, _>>();
 				*contents =

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command as ProcessCommand;
+use std::thread::JoinHandle;
 use std::time::Instant;
 
 use monochange_cargo::discover_cargo_packages;
@@ -622,11 +623,26 @@ pub fn discover_workspace(root: &Path) -> MonochangeResult<DiscoveryReport> {
 	let mut warnings = Vec::new();
 	let mut packages = Vec::new();
 
+	let ((cargo_discovery, npm_discovery), (deno_discovery, dart_discovery)) = rayon::join(
+		|| {
+			rayon::join(
+				|| discover_cargo_packages(root),
+				|| discover_npm_packages(root),
+			)
+		},
+		|| {
+			rayon::join(
+				|| discover_deno_packages(root),
+				|| discover_dart_packages(root),
+			)
+		},
+	);
+
 	for discovery in [
-		discover_cargo_packages(root)?,
-		discover_npm_packages(root)?,
-		discover_deno_packages(root)?,
-		discover_dart_packages(root)?,
+		cargo_discovery?,
+		npm_discovery?,
+		deno_discovery?,
+		dart_discovery?,
 	] {
 		warnings.extend(discovery.warnings);
 		packages.extend(discovery.packages);
@@ -1319,16 +1335,32 @@ pub(crate) fn prepare_release_execution_with_file_diffs(
 		.iter()
 		.flat_map(|changeset| changeset.signals.clone())
 		.collect::<Vec<_>>();
-	let mut changesets =
+	let prepared_changesets =
 		measure_prepare_phase(&mut phase_timings, "build prepared changesets", || {
 			Ok(build_prepared_changesets(root, &loaded_changesets))
 		})?;
-	if let Some(source) = configuration.source.as_ref() {
+	let mut changesets = Some(prepared_changesets);
+	let background_changeset_context =
+		configuration
+			.source
+			.as_ref()
+			.filter(|_| !dry_run)
+			.map(|source| {
+				assert!(changesets.is_some());
+				spawn_source_changeset_context_task(
+					source.clone(),
+					dry_run,
+					changesets.take().unwrap_or_default(),
+				)
+			});
+	if let Some(source) = configuration.source.as_ref().filter(|_| dry_run) {
 		apply_source_changeset_context_with_timing(
 			&mut phase_timings,
 			source,
 			dry_run,
-			&mut changesets,
+			changesets
+				.as_mut()
+				.unwrap_or_else(|| panic!("changesets should exist for dry-run annotation")),
 		);
 	}
 	let plan = measure_prepare_phase(&mut phase_timings, "build release plan", || {
@@ -1345,31 +1377,82 @@ pub(crate) fn prepare_release_execution_with_file_diffs(
 		));
 	}
 
-	let changelog_targets =
-		measure_prepare_phase(&mut phase_timings, "resolve changelog targets", || {
-			resolve_changelog_targets(&configuration, &discovery.packages)
-		})?;
-	let manifest_updates =
-		measure_prepare_phase(&mut phase_timings, "build manifest updates", || {
-			let cargo_updates = build_cargo_manifest_updates(&discovery.packages, &plan)?;
-			let npm_updates = build_npm_manifest_updates(&discovery.packages, &plan)?;
-			let deno_updates = build_deno_manifest_updates(&discovery.packages, &plan)?;
-			let dart_updates = build_dart_manifest_updates(&discovery.packages, &plan)?;
-			Ok([cargo_updates, npm_updates, deno_updates, dart_updates].concat())
-		})?;
-	let versioned_file_updates =
-		measure_prepare_phase(&mut phase_timings, "build versioned file updates", || {
-			build_versioned_file_updates(root, &configuration, &discovery.packages, &plan)
-		})?;
-	let release_targets =
-		measure_prepare_phase(&mut phase_timings, "build release targets", || {
-			Ok(build_release_targets(
-				&configuration,
-				&discovery.packages,
-				&plan,
-				&changeset_paths,
-			))
-		})?;
+	let (
+		(changelog_targets_result, manifest_updates_result),
+		((versioned_file_updates_result, release_targets_result), lockfile_commands_result),
+	) = rayon::join(
+		|| {
+			rayon::join(
+				|| {
+					capture_prepare_phase("resolve changelog targets", || {
+						resolve_changelog_targets(&configuration, &discovery.packages)
+					})
+				},
+				|| {
+					capture_prepare_phase("build manifest updates", || {
+						build_manifest_updates_parallel(&discovery.packages, &plan)
+					})
+				},
+			)
+		},
+		|| {
+			rayon::join(
+				|| {
+					rayon::join(
+						|| {
+							capture_prepare_phase("build versioned file updates", || {
+								build_versioned_file_updates(
+									root,
+									&configuration,
+									&discovery.packages,
+									&plan,
+								)
+							})
+						},
+						|| {
+							capture_prepare_phase("build release targets", || {
+								Ok(build_release_targets(
+									&configuration,
+									&discovery.packages,
+									&plan,
+									&changeset_paths,
+								))
+							})
+						},
+					)
+				},
+				|| {
+					capture_prepare_phase("build lockfile refresh plan", || {
+						build_lockfile_command_executions(
+							root,
+							&configuration,
+							&discovery.packages,
+							&plan,
+						)
+					})
+				},
+			)
+		},
+	);
+	phase_timings.extend([
+		changelog_targets_result.1,
+		manifest_updates_result.1,
+		versioned_file_updates_result.1,
+		release_targets_result.1,
+		lockfile_commands_result.1,
+	]);
+	let changelog_targets = changelog_targets_result.0?;
+	let manifest_updates = manifest_updates_result.0?;
+	let versioned_file_updates = versioned_file_updates_result.0?;
+	let release_targets = release_targets_result.0?;
+	let lockfile_commands = lockfile_commands_result.0?;
+	let changesets = if let Some(handle) = background_changeset_context {
+		join_source_changeset_context_task(&mut phase_timings, handle)?
+	} else {
+		changesets
+			.take()
+			.unwrap_or_else(|| panic!("changesets should be available after local planning"))
+	};
 	let changelog_updates =
 		measure_prepare_phase(&mut phase_timings, "build changelog updates", || {
 			build_changelog_updates(
@@ -1395,10 +1478,6 @@ pub(crate) fn prepare_release_execution_with_file_diffs(
 		changelog_file_updates.clone(),
 	]
 	.concat();
-	let lockfile_commands =
-		measure_prepare_phase(&mut phase_timings, "build lockfile refresh plan", || {
-			build_lockfile_command_executions(root, &configuration, &discovery.packages, &plan)
-		})?;
 	tracing::debug!(
 		manifest_updates = manifest_updates.len(),
 		lockfile_commands = lockfile_commands.len(),
@@ -1508,6 +1587,22 @@ fn measure_prepare_phase<T>(
 	result
 }
 
+fn capture_prepare_phase<T>(
+	label: impl Into<String>,
+	action: impl FnOnce() -> MonochangeResult<T>,
+) -> (MonochangeResult<T>, StepPhaseTiming) {
+	let label = label.into();
+	let started_at = Instant::now();
+	let result = action();
+	(
+		result,
+		StepPhaseTiming {
+			label,
+			duration: started_at.elapsed(),
+		},
+	)
+}
+
 fn record_prepare_phase_timing(
 	phase_timings: &mut Vec<StepPhaseTiming>,
 	label: impl Into<String>,
@@ -1548,6 +1643,36 @@ fn apply_source_changeset_context_with_timing(
 	let started_at = Instant::now();
 	apply_source_changeset_context(source, dry_run, changesets);
 	record_prepare_phase_timing(phase_timings, label, started_at);
+}
+
+fn spawn_source_changeset_context_task(
+	source: SourceConfiguration,
+	dry_run: bool,
+	mut changesets: Vec<PreparedChangeset>,
+) -> JoinHandle<(Vec<PreparedChangeset>, StepPhaseTiming)> {
+	std::thread::spawn(move || {
+		let label = changeset_context_phase_label(&source, dry_run);
+		let started_at = Instant::now();
+		apply_source_changeset_context(&source, dry_run, &mut changesets);
+		(
+			changesets,
+			StepPhaseTiming {
+				label,
+				duration: started_at.elapsed(),
+			},
+		)
+	})
+}
+
+fn join_source_changeset_context_task(
+	phase_timings: &mut Vec<StepPhaseTiming>,
+	handle: JoinHandle<(Vec<PreparedChangeset>, StepPhaseTiming)>,
+) -> MonochangeResult<Vec<PreparedChangeset>> {
+	let (changesets, timing) = handle.join().map_err(|_| {
+		MonochangeError::Io("background changeset context enrichment panicked".to_string())
+	})?;
+	phase_timings.push(timing);
+	Ok(changesets)
 }
 
 fn apply_source_changeset_context(
@@ -2216,5 +2341,57 @@ repo = "monochange"
 				.iter()
 				.any(|phase| phase.label == "annotate changeset context via gitlab")
 		);
+	}
+
+	#[test]
+	fn prepare_release_execution_tracks_github_background_context_phase_timing() {
+		let fixture = monochange_test_helpers::fs::setup_fixture_from(
+			env!("CARGO_MANIFEST_DIR"),
+			"monochange/release-base",
+		);
+		let config_path = fixture.path().join("monochange.toml");
+		let mut config = fs::read_to_string(&config_path)
+			.unwrap_or_else(|error| panic!("read monochange.toml: {error}"));
+		config.push_str(
+			r#"
+
+[source]
+provider = "github"
+owner = "ifiokjr"
+repo = "monochange"
+"#,
+		);
+		fs::write(&config_path, config)
+			.unwrap_or_else(|error| panic!("write monochange.toml: {error}"));
+
+		let prepared = prepare_release_execution_with_file_diffs(fixture.path(), false, false)
+			.unwrap_or_else(|error| panic!("prepare release: {error}"));
+
+		assert!(
+			prepared
+				.phase_timings
+				.iter()
+				.any(|phase| phase.label == "enrich changeset context via github")
+		);
+	}
+
+	#[test]
+	fn join_source_changeset_context_task_reports_background_panic() {
+		let mut phase_timings = Vec::new();
+		let handle = std::thread::spawn(|| -> (Vec<PreparedChangeset>, StepPhaseTiming) {
+			panic!("boom");
+		});
+
+		let error = join_source_changeset_context_task(&mut phase_timings, handle)
+			.err()
+			.unwrap_or_else(|| panic!("expected join error"));
+
+		assert!(
+			error
+				.to_string()
+				.contains("background changeset context enrichment panicked"),
+			"error: {error}"
+		);
+		assert!(phase_timings.is_empty());
 	}
 }

--- a/crates/monochange/tests/release_apply.rs
+++ b/crates/monochange/tests/release_apply.rs
@@ -1,0 +1,53 @@
+use std::fs;
+
+use serde_json::Value;
+
+mod test_support;
+use test_support::monochange_command;
+use test_support::setup_scenario_workspace;
+
+#[test]
+fn release_apply_with_github_source_updates_workspace_and_deletes_changesets() {
+	let tempdir = setup_scenario_workspace("monochange/release-apply-github");
+	let root = tempdir.path();
+
+	let output = monochange_command(Some("2026-04-06"))
+		.current_dir(root)
+		.arg("release")
+		.arg("--format")
+		.arg("json")
+		.output()
+		.unwrap_or_else(|error| panic!("release command: {error}"));
+	assert!(
+		output.status.success(),
+		"release failed: {}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+
+	let parsed: Value = serde_json::from_slice(&output.stdout)
+		.unwrap_or_else(|error| panic!("release json: {error}"));
+	assert_eq!(parsed["version"].as_str(), Some("1.1.0"));
+	assert_eq!(parsed["dryRun"].as_bool(), Some(false));
+	assert!(
+		!root.join(".changeset/feature.md").exists(),
+		"expected release apply to delete processed changeset"
+	);
+	assert!(
+		fs::read_to_string(root.join("Cargo.toml"))
+			.unwrap_or_else(|error| panic!("read Cargo.toml: {error}"))
+			.contains("version = \"1.1.0\""),
+		"expected release apply to update the workspace manifest"
+	);
+	assert!(
+		fs::read_to_string(root.join("crates/core/extra.toml"))
+			.unwrap_or_else(|error| panic!("read crates/core/extra.toml: {error}"))
+			.contains("version = \"1.1.0\""),
+		"expected release apply to update configured package versioned files"
+	);
+	assert!(
+		fs::read_to_string(root.join("group.toml"))
+			.unwrap_or_else(|error| panic!("read group.toml: {error}"))
+			.contains("version = \"1.1.0\""),
+		"expected release apply to update configured versioned files"
+	);
+}

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -20,6 +20,7 @@ use crate::EcosystemSettings;
 use crate::GroupChangelogInclude;
 use crate::GroupDefinition;
 use crate::HostingProviderKind;
+use crate::MonochangeError;
 use crate::PackageDefinition;
 use crate::PackageDependency;
 use crate::PackageRecord;
@@ -53,9 +54,34 @@ use crate::WorkspaceConfiguration;
 use crate::WorkspaceDefaults;
 use crate::default_cli_commands;
 use crate::git::git_checkout_branch_command;
+use crate::git::git_current_branch;
 use crate::git::git_push_branch_command;
 use crate::materialize_dependency_edges;
 use crate::render_release_notes;
+
+fn must_ok<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> T {
+	match result {
+		Ok(value) => value,
+		Err(error) => panic!("{context}: {error}"),
+	}
+}
+
+fn must_err<T, E>(result: Result<T, E>, context: &str) -> E {
+	match result {
+		Ok(_) => panic!("{context}"),
+		Err(error) => error,
+	}
+}
+
+#[test]
+fn must_ok_panics_on_errors() {
+	assert!(std::panic::catch_unwind(|| must_ok::<(), _>(Err("boom"), "context")).is_err());
+}
+
+#[test]
+fn must_err_panics_on_ok_results() {
+	assert!(std::panic::catch_unwind(|| must_err(Ok::<(), &str>(()), "context")).is_err());
+}
 
 #[test]
 fn git_checkout_branch_command_builds_expected_arguments() {
@@ -81,6 +107,80 @@ fn git_push_branch_command_builds_expected_arguments() {
 		]
 	);
 	assert_eq!(command.get_current_dir(), Some(root.as_path()));
+}
+
+#[test]
+fn git_current_branch_reports_checked_out_branch_name() {
+	let tempdir = must_ok(tempdir(), "tempdir");
+	let root = tempdir.path();
+	let output = std::process::Command::new("git")
+		.args(["init", "-b", "main"])
+		.current_dir(root)
+		.output()
+		.unwrap_or_else(|error| panic!("git init: {error}"));
+	assert!(output.status.success());
+	let branch = must_ok(git_current_branch(root), "current branch");
+	assert_eq!(branch, "main");
+}
+
+#[test]
+fn git_current_branch_reports_detached_head_as_an_error() {
+	let tempdir = must_ok(tempdir(), "tempdir");
+	let root = tempdir.path();
+	let init = std::process::Command::new("git")
+		.args(["init", "-b", "main"])
+		.current_dir(root)
+		.output()
+		.unwrap_or_else(|error| panic!("git init: {error}"));
+	assert!(init.status.success());
+	for args in [
+		["config", "user.name", "monochange Tests"],
+		["config", "user.email", "monochange@example.com"],
+	] {
+		let output = std::process::Command::new("git")
+			.args(args)
+			.current_dir(root)
+			.output()
+			.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
+		assert!(output.status.success());
+	}
+	must_ok(
+		fs::write(root.join("README.md"), "hello\n"),
+		"write README.md",
+	);
+	for args in [
+		&["add", "README.md"][..],
+		&["commit", "-m", "initial"][..],
+		&["checkout", "--detach"][..],
+	] {
+		let output = std::process::Command::new("git")
+			.args(args)
+			.current_dir(root)
+			.output()
+			.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
+		assert!(output.status.success());
+	}
+
+	let error = must_err(git_current_branch(root), "expected detached-head error");
+	assert!(
+		error
+			.to_string()
+			.contains("failed to read current git branch"),
+		"error: {error}"
+	);
+}
+
+#[test]
+fn git_current_branch_reports_missing_directory_as_io_error() {
+	let tempdir = must_ok(tempdir(), "tempdir");
+	let missing_root = tempdir.path().join("missing");
+	let error = must_err(
+		git_current_branch(&missing_root),
+		"expected missing-directory error",
+	);
+	assert!(
+		matches!(error, MonochangeError::Io(message) if message.contains("failed to read current git branch"))
+	);
 }
 
 #[test]

--- a/crates/monochange_core/src/git.rs
+++ b/crates/monochange_core/src/git.rs
@@ -62,6 +62,20 @@ pub fn git_push_branch_command(root: &Path, branch: &str) -> Command {
 	command
 }
 
+pub fn git_current_branch(root: &Path) -> MonochangeResult<String> {
+	let output =
+		git_command_output(root, &["symbolic-ref", "--short", "HEAD"]).map_err(|error| {
+			MonochangeError::Io(format!("failed to read current git branch: {error}"))
+		})?;
+	if !output.status.success() {
+		return Err(MonochangeError::Config(format!(
+			"failed to read current git branch: {}",
+			git_error_detail(&output)
+		)));
+	}
+	Ok(git_stdout_trimmed(&output))
+}
+
 #[tracing::instrument(skip_all, fields(args = ?args))]
 pub fn git_command_output(root: &Path, args: &[&str]) -> std::io::Result<Output> {
 	let mut command = git_command(root);

--- a/crates/monochange_gitea/src/__tests.rs
+++ b/crates/monochange_gitea/src/__tests.rs
@@ -39,6 +39,18 @@ use tempfile::tempdir;
 
 use super::*;
 
+fn must_ok<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> T {
+	match result {
+		Ok(value) => value,
+		Err(error) => panic!("{context}: {error}"),
+	}
+}
+
+#[test]
+fn must_ok_panics_on_errors() {
+	assert!(std::panic::catch_unwind(|| must_ok::<(), _>(Err("boom"), "context")).is_err());
+}
+
 #[test]
 fn build_release_requests_uses_gitea_provider() {
 	let source = sample_source(None, Some("https://codeberg.org".to_string()));
@@ -691,6 +703,35 @@ fn git_commit_paths_treats_clean_worktrees_as_already_committed() {
 	assert_eq!(
 		git_output(&repo, &["rev-list", "--count", "HEAD"]).trim(),
 		"1"
+	);
+}
+
+#[etest::etest(skip=env::var_os("PRE_COMMIT").is_some())]
+fn git_checkout_branch_is_noop_when_branch_is_already_checked_out() {
+	let tempdir = must_ok(tempdir(), "tempdir");
+	let repo = tempdir.path().join("repo");
+	git(tempdir.path(), &["init", repo.to_string_lossy().as_ref()]);
+	git(&repo, &["config", "user.name", "monochange Tests"]);
+	git(&repo, &["config", "user.email", "monochange@example.com"]);
+	must_ok(
+		std::fs::write(repo.join("release.txt"), "initial\n"),
+		"write release file",
+	);
+	git(&repo, &["add", "release.txt"]);
+	git(&repo, &["commit", "-m", "initial"]);
+
+	must_ok(
+		git_checkout_branch(&repo, "monochange/release/release"),
+		"checkout branch",
+	);
+	must_ok(
+		git_checkout_branch(&repo, "monochange/release/release"),
+		"repeat checkout branch",
+	);
+
+	assert_eq!(
+		git_output(&repo, &["rev-parse", "--abbrev-ref", "HEAD"]).trim(),
+		"monochange/release/release"
 	);
 }
 

--- a/crates/monochange_gitea/src/lib.rs
+++ b/crates/monochange_gitea/src/lib.rs
@@ -25,6 +25,7 @@ use monochange_core::SourceReleaseOutcome;
 use monochange_core::SourceReleaseRequest;
 use monochange_core::git::git_checkout_branch_command;
 use monochange_core::git::git_commit_paths_command;
+use monochange_core::git::git_current_branch;
 use monochange_core::git::git_push_branch_command;
 use monochange_core::git::git_stage_paths_command;
 use monochange_core::git::run_command;
@@ -588,6 +589,9 @@ where
 }
 
 fn git_checkout_branch(root: &Path, branch: &str) -> MonochangeResult<()> {
+	if matches!(git_current_branch(root).as_deref(), Ok(current) if current == branch) {
+		return Ok(());
+	}
 	run_command(
 		git_checkout_branch_command(root, branch),
 		"prepare release pull request branch",

--- a/crates/monochange_github/src/__tests.rs
+++ b/crates/monochange_github/src/__tests.rs
@@ -42,6 +42,18 @@ use tempfile::tempdir;
 
 use super::*;
 
+fn must_ok<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> T {
+	match result {
+		Ok(value) => value,
+		Err(error) => panic!("{context}: {error}"),
+	}
+}
+
+#[test]
+fn must_ok_panics_on_errors() {
+	assert!(std::panic::catch_unwind(|| must_ok::<(), _>(Err("boom"), "context")).is_err());
+}
+
 #[test]
 fn build_release_requests_uses_matching_monochange_changelog_bodies() {
 	let github = SourceConfiguration {
@@ -904,13 +916,23 @@ fn git_helpers_prepare_commit_and_push_release_branch() {
 		&["remote", "add", "origin", bare.to_string_lossy().as_ref()],
 	);
 	git(&repo, &["push", "-u", "origin", "main"]);
-	std::fs::write(repo.join("release.txt"), "after\n")
-		.unwrap_or_else(|error| panic!("update release file: {error}"));
+	must_ok(
+		std::fs::write(repo.join("release.txt"), "after\n"),
+		"update release file",
+	);
 
-	git_checkout_branch(&repo, "monochange/release/release")
-		.unwrap_or_else(|error| panic!("checkout branch: {error}"));
-	git_stage_paths(&repo, &[PathBuf::from("release.txt")])
-		.unwrap_or_else(|error| panic!("stage paths: {error}"));
+	must_ok(
+		git_checkout_branch(&repo, "monochange/release/release"),
+		"checkout branch",
+	);
+	must_ok(
+		git_checkout_branch(&repo, "monochange/release/release"),
+		"repeat checkout branch",
+	);
+	must_ok(
+		git_stage_paths(&repo, &[PathBuf::from("release.txt")]),
+		"stage paths",
+	);
 	git_commit_paths(
 		&repo,
 		&CommitMessage {

--- a/crates/monochange_github/src/lib.rs
+++ b/crates/monochange_github/src/lib.rs
@@ -127,6 +127,7 @@ use monochange_core::SourceReleaseOutcome;
 use monochange_core::SourceReleaseRequest;
 use monochange_core::git::git_checkout_branch_command;
 use monochange_core::git::git_commit_paths_command;
+use monochange_core::git::git_current_branch;
 use monochange_core::git::git_push_branch_command;
 use monochange_core::git::git_stage_paths_command;
 use monochange_core::git::run_command;
@@ -1303,6 +1304,9 @@ where
 }
 
 fn git_checkout_branch(root: &Path, branch: &str) -> MonochangeResult<()> {
+	if matches!(git_current_branch(root).as_deref(), Ok(current) if current == branch) {
+		return Ok(());
+	}
 	run_command(
 		git_checkout_branch_command(root, branch),
 		"prepare release pull request branch",

--- a/crates/monochange_gitlab/src/__tests.rs
+++ b/crates/monochange_gitlab/src/__tests.rs
@@ -40,6 +40,18 @@ use tempfile::tempdir;
 
 use super::*;
 
+fn must_ok<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> T {
+	match result {
+		Ok(value) => value,
+		Err(error) => panic!("{context}: {error}"),
+	}
+}
+
+#[test]
+fn must_ok_panics_on_errors() {
+	assert!(std::panic::catch_unwind(|| must_ok::<(), _>(Err("boom"), "context")).is_err());
+}
+
 #[test]
 fn build_release_requests_uses_gitlab_provider() {
 	let source = sample_source(None);
@@ -740,6 +752,35 @@ fn git_commit_paths_treats_clean_worktrees_as_already_committed() {
 	assert_eq!(
 		git_output(&repo, &["rev-list", "--count", "HEAD"]).trim(),
 		"1"
+	);
+}
+
+#[etest::etest(skip=env::var_os("PRE_COMMIT").is_some())]
+fn git_checkout_branch_is_noop_when_branch_is_already_checked_out() {
+	let tempdir = must_ok(tempdir(), "tempdir");
+	let repo = tempdir.path().join("repo");
+	git(tempdir.path(), &["init", repo.to_string_lossy().as_ref()]);
+	git(&repo, &["config", "user.name", "monochange Tests"]);
+	git(&repo, &["config", "user.email", "monochange@example.com"]);
+	must_ok(
+		std::fs::write(repo.join("release.txt"), "initial\n"),
+		"write release file",
+	);
+	git(&repo, &["add", "release.txt"]);
+	git(&repo, &["commit", "-m", "initial"]);
+
+	must_ok(
+		git_checkout_branch(&repo, "monochange/release/release"),
+		"checkout branch",
+	);
+	must_ok(
+		git_checkout_branch(&repo, "monochange/release/release"),
+		"repeat checkout branch",
+	);
+
+	assert_eq!(
+		git_output(&repo, &["rev-parse", "--abbrev-ref", "HEAD"]).trim(),
+		"monochange/release/release"
 	);
 }
 

--- a/crates/monochange_gitlab/src/lib.rs
+++ b/crates/monochange_gitlab/src/lib.rs
@@ -25,6 +25,7 @@ use monochange_core::SourceReleaseOutcome;
 use monochange_core::SourceReleaseRequest;
 use monochange_core::git::git_checkout_branch_command;
 use monochange_core::git::git_commit_paths_command;
+use monochange_core::git::git_current_branch;
 use monochange_core::git::git_push_branch_command;
 use monochange_core::git::git_stage_paths_command;
 use monochange_core::git::run_command;
@@ -605,6 +606,9 @@ where
 }
 
 fn git_checkout_branch(root: &Path, branch: &str) -> MonochangeResult<()> {
+	if matches!(git_current_branch(root).as_deref(), Ok(current) if current == branch) {
+		return Ok(());
+	}
 	run_command(
 		git_checkout_branch_command(root, branch),
 		"prepare release merge request branch",

--- a/fixtures/tests/monochange/release-apply-github/workspace/.changeset/feature.md
+++ b/fixtures/tests/monochange/release-apply-github/workspace/.changeset/feature.md
@@ -1,0 +1,5 @@
+---
+core: minor
+---
+
+#### add release command

--- a/fixtures/tests/monochange/release-apply-github/workspace/Cargo.toml
+++ b/fixtures/tests/monochange/release-apply-github/workspace/Cargo.toml
@@ -1,0 +1,10 @@
+[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[workspace.package]
+version = "1.0.0"
+
+[workspace.dependencies]
+workflow-core = { path = "./crates/core", version = "1.0.0" }
+workflow-app = { path = "./crates/app", version = "1.0.0" }

--- a/fixtures/tests/monochange/release-apply-github/workspace/changelog.md
+++ b/fixtures/tests/monochange/release-apply-github/workspace/changelog.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/fixtures/tests/monochange/release-apply-github/workspace/crates/app/Cargo.toml
+++ b/fixtures/tests/monochange/release-apply-github/workspace/crates/app/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "workflow-app"
+version = { workspace = true }
+edition = "2021"
+
+[dependencies]
+workflow-core = { workspace = true }

--- a/fixtures/tests/monochange/release-apply-github/workspace/crates/app/changelog.md
+++ b/fixtures/tests/monochange/release-apply-github/workspace/crates/app/changelog.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/fixtures/tests/monochange/release-apply-github/workspace/crates/core/Cargo.toml
+++ b/fixtures/tests/monochange/release-apply-github/workspace/crates/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "workflow-core"
+version = { workspace = true }
+edition = "2021"

--- a/fixtures/tests/monochange/release-apply-github/workspace/crates/core/changelog.md
+++ b/fixtures/tests/monochange/release-apply-github/workspace/crates/core/changelog.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/fixtures/tests/monochange/release-apply-github/workspace/crates/core/extra.toml
+++ b/fixtures/tests/monochange/release-apply-github/workspace/crates/core/extra.toml
@@ -1,0 +1,3 @@
+[package]
+name = "workflow-core"
+version = "1.0.0"

--- a/fixtures/tests/monochange/release-apply-github/workspace/group.toml
+++ b/fixtures/tests/monochange/release-apply-github/workspace/group.toml
@@ -1,0 +1,4 @@
+[workspace.package]
+version = "1.0.0"
+[workspace.dependencies]
+workflow-core = { version = "1.0.0" }

--- a/fixtures/tests/monochange/release-apply-github/workspace/monochange.toml
+++ b/fixtures/tests/monochange/release-apply-github/workspace/monochange.toml
@@ -1,0 +1,38 @@
+[defaults]
+parent_bump = "patch"
+package_type = "cargo"
+changelog = "{{ path }}/changelog.md"
+
+[package.core]
+path = "crates/core"
+versioned_files = [{ path = "crates/core/extra.toml", type = "cargo" }]
+
+[package.app]
+path = "crates/app"
+
+[group.sdk]
+packages = ["core", "app"]
+changelog = "changelog.md"
+versioned_files = [{ path = "group.toml", type = "cargo" }]
+tag = true
+release = true
+version_format = "primary"
+
+[ecosystems.cargo]
+enabled = true
+
+[source]
+provider = "github"
+owner = "ifiokjr"
+repo = "monochange"
+
+[cli.release]
+
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
+[[cli.release.steps]]
+type = "PrepareRelease"


### PR DESCRIPTION
## Summary
- speed up release preparation and non-dry-run release execution by overlapping hosted enrichment with local planning and parallelizing key workspace/release phases
- add provider no-op checkout optimizations plus a real `mc release` benchmark path and a non-dry-run integration fixture
- expand coverage for the changed execution paths, including changed-line coverage for the touched code

## Validation
- `fix:all`
- `cargo test -p monochange -p monochange_core -p monochange_github -p monochange_gitlab -p monochange_gitea`
- `lint:all`
- `build:all`
- `mc validate`
- changed executable lines touched by this branch report 100% coverage

## Notes
- adds integration coverage for non-dry-run `mc release` via `crates/monochange/tests/release_apply.rs`
- includes the real non-dry-run benchmark path in `crates/monochange/benches/cli_commands.rs`

## Follow-up issues
- #170
- #171
- #174
- #175
- #176
- #177
- #178
- #179
- #180
- #181