### PR TITLE
fix: hide progress during interactive CLI steps

### DIFF
--- a/.changeset/interactive-progress-loader.md
+++ b/.changeset/interactive-progress-loader.md
@@ -1,0 +1,23 @@
+---
+monochange: patch
+monochange_core: patch
+---
+
+Interactive change authoring no longer shows the CLI progress spinner while the user is choosing options in the terminal.
+
+You can also disable progress output for interactive-capable steps explicitly:
+
+```toml
+[[cli.change-interactive.steps]]
+type = "CreateChangeFile"
+show_progress = false
+inputs = { interactive = true }
+```
+
+```toml
+[[cli.some-command.steps]]
+type = "Command"
+show_progress = false
+command = "fzf"
+shell = true
+```

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -448,6 +448,7 @@ fn render_cli_commands_toml_handles_manifest_and_command_step_variants() {
 				)]),
 			},
 			monochange_core::CliStepDefinition::Command {
+				show_progress: None,
 				name: None,
 				when: None,
 				command: "echo hello".to_string(),
@@ -461,6 +462,7 @@ fn render_cli_commands_toml_handles_manifest_and_command_step_variants() {
 				)]),
 			},
 			monochange_core::CliStepDefinition::Command {
+				show_progress: None,
 				name: None,
 				when: None,
 				command: "echo through-shell".to_string(),
@@ -495,6 +497,7 @@ fn render_cli_commands_toml_handles_manifest_and_command_step_variants() {
 				)]),
 			},
 			monochange_core::CliStepDefinition::Command {
+				show_progress: None,
 				name: None,
 				when: None,
 				command: "echo custom-shell".to_string(),
@@ -1856,6 +1859,7 @@ fn command_step_without_dry_run_override_reports_skipped_command() {
 		help_text: None,
 		inputs: Vec::new(),
 		steps: vec![monochange_core::CliStepDefinition::Command {
+			show_progress: None,
 			name: None,
 			when: None,
 			command: "echo hello".to_string(),
@@ -1888,6 +1892,7 @@ fn command_step_rejects_unparseable_commands() {
 		help_text: None,
 		inputs: Vec::new(),
 		steps: vec![monochange_core::CliStepDefinition::Command {
+			show_progress: None,
 			name: None,
 			when: None,
 			command: "\"unterminated".to_string(),
@@ -1925,6 +1930,7 @@ fn command_step_rejects_empty_commands() {
 		help_text: None,
 		inputs: Vec::new(),
 		steps: vec![monochange_core::CliStepDefinition::Command {
+			show_progress: None,
 			name: None,
 			when: None,
 			command: String::new(),
@@ -1958,6 +1964,7 @@ fn command_step_reports_process_spawn_failures() {
 		help_text: None,
 		inputs: Vec::new(),
 		steps: vec![monochange_core::CliStepDefinition::Command {
+			show_progress: None,
 			name: None,
 			when: None,
 			command: "definitely-not-a-real-command-12345".to_string(),
@@ -1995,6 +2002,7 @@ fn command_step_reports_nonzero_exit_status_without_stderr() {
 		help_text: None,
 		inputs: Vec::new(),
 		steps: vec![monochange_core::CliStepDefinition::Command {
+			show_progress: None,
 			name: None,
 			when: None,
 			command: "sh -c 'exit 7'".to_string(),
@@ -2031,6 +2039,7 @@ fn command_step_reports_stderr_text_for_nonzero_exit_status() {
 		help_text: None,
 		inputs: Vec::new(),
 		steps: vec![monochange_core::CliStepDefinition::Command {
+			show_progress: None,
 			name: None,
 			when: None,
 			command: "sh -c 'echo boom 1>&2; exit 1'".to_string(),
@@ -2812,6 +2821,7 @@ fn should_execute_cli_step_runs_when_condition_is_true() {
 		("extra".to_string(), vec!["true".to_string()]),
 	]);
 	let step = monochange_core::CliStepDefinition::Command {
+		show_progress: None,
 		name: None,
 		when: Some("{{ inputs.run && inputs.extra }}".to_string()),
 		command: "printf hi".to_string(),
@@ -2832,6 +2842,7 @@ fn should_execute_cli_step_skips_when_condition_is_false() {
 	let context = cli_context_for_when_evaluation_tests();
 	let step_inputs = BTreeMap::from([("run".to_string(), vec!["false".to_string()])]);
 	let step = monochange_core::CliStepDefinition::Command {
+		show_progress: None,
 		name: None,
 		when: Some("{{ inputs.run }}".to_string()),
 		command: "printf hi".to_string(),
@@ -2852,6 +2863,7 @@ fn should_execute_cli_step_skips_for_zero_value() {
 	let context = cli_context_for_when_evaluation_tests();
 	let step_inputs = BTreeMap::from([("run".to_string(), vec!["0".to_string()])]);
 	let step = monochange_core::CliStepDefinition::Command {
+		show_progress: None,
 		name: None,
 		when: Some("{{ inputs.run }}".to_string()),
 		command: "printf hi".to_string(),
@@ -2872,6 +2884,7 @@ fn should_execute_cli_step_trims_and_treats_1_as_true() {
 	let context = cli_context_for_when_evaluation_tests();
 	let step_inputs = BTreeMap::from([("run".to_string(), vec![" 1 ".to_string()])]);
 	let step = monochange_core::CliStepDefinition::Command {
+		show_progress: None,
 		name: None,
 		when: Some("{{ inputs.run }}".to_string()),
 		command: "printf hi".to_string(),
@@ -2892,6 +2905,7 @@ fn should_execute_cli_step_skips_with_not_operator() {
 	let context = cli_context_for_when_evaluation_tests();
 	let step_inputs = BTreeMap::from([("skip".to_string(), vec!["true".to_string()])]);
 	let step = monochange_core::CliStepDefinition::Command {
+		show_progress: None,
 		name: None,
 		when: Some("{{ ! inputs.skip }}".to_string()),
 		command: "printf hi".to_string(),
@@ -2912,6 +2926,7 @@ fn should_execute_cli_step_rejects_unknown_template_reference() {
 	let context = cli_context_for_when_evaluation_tests();
 	let step_inputs = BTreeMap::from([("run".to_string(), vec!["true".to_string()])]);
 	let step = monochange_core::CliStepDefinition::Command {
+		show_progress: None,
 		name: None,
 		when: Some("{{ inputs.missing }}".to_string()),
 		command: "printf hi".to_string(),
@@ -2935,6 +2950,7 @@ fn should_execute_cli_step_rejects_non_scalar_condition_value() {
 	let step_inputs =
 		BTreeMap::from([("list".to_string(), vec!["a".to_string(), "b".to_string()])]);
 	let step = monochange_core::CliStepDefinition::Command {
+		show_progress: None,
 		name: None,
 		when: Some("{{ inputs.list }}".to_string()),
 		command: "printf hi".to_string(),
@@ -3978,6 +3994,7 @@ fn execute_cli_command_change_step_requires_reason_input() {
 		help_text: None,
 		inputs: Vec::new(),
 		steps: vec![monochange_core::CliStepDefinition::CreateChangeFile {
+			show_progress: None,
 			name: None,
 			when: None,
 			inputs: BTreeMap::new(),

--- a/crates/monochange/src/cli_progress.rs
+++ b/crates/monochange/src/cli_progress.rs
@@ -38,6 +38,7 @@ pub(crate) struct CliProgressReporter {
 	total_steps: usize,
 	writer_lock: Arc<Mutex<()>>,
 	active_spinner: Option<SpinnerState>,
+	command_started: bool,
 }
 
 struct SpinnerState {
@@ -61,6 +62,7 @@ impl CliProgressReporter {
 			total_steps: cli_command.steps.len(),
 			writer_lock: Arc::new(Mutex::new(())),
 			active_spinner: None,
+			command_started: false,
 		}
 	}
 
@@ -69,7 +71,7 @@ impl CliProgressReporter {
 	}
 
 	pub(crate) fn command_started(&mut self) {
-		if !self.enabled {
+		if !self.enabled || self.command_started {
 			return;
 		}
 		let suffix = if self.dry_run { " (dry-run)" } else { "" };
@@ -79,10 +81,11 @@ impl CliProgressReporter {
 			self.paint(&format!("running `{}`", self.command_name), Style::Header),
 			suffix,
 		));
+		self.command_started = true;
 	}
 
 	pub(crate) fn command_finished(&mut self, duration: Duration) {
-		if !self.enabled {
+		if !self.enabled || !self.command_started {
 			return;
 		}
 		self.stop_spinner();
@@ -98,6 +101,7 @@ impl CliProgressReporter {
 		if !self.enabled {
 			return;
 		}
+		self.command_started();
 		let message = self.step_message(step_index, step);
 		if self.animate {
 			self.start_spinner(message);
@@ -115,6 +119,7 @@ impl CliProgressReporter {
 		if !self.enabled {
 			return;
 		}
+		self.command_started();
 		self.stop_spinner();
 		let mut line = format!(
 			"{} {} — {}",
@@ -142,6 +147,7 @@ impl CliProgressReporter {
 		if !self.enabled {
 			return;
 		}
+		self.command_started();
 		self.stop_spinner();
 		self.print_line(&format!(
 			"{} {} {}",
@@ -169,6 +175,7 @@ impl CliProgressReporter {
 		if !self.enabled {
 			return;
 		}
+		self.command_started();
 		self.stop_spinner();
 		self.print_line(&format!(
 			"{} {} {}",
@@ -192,6 +199,7 @@ impl CliProgressReporter {
 		if !self.enabled || text.trim().is_empty() {
 			return;
 		}
+		self.command_started();
 		let stream_label = match stream {
 			CommandStream::Stdout => self.paint("stdout", Style::Muted),
 			CommandStream::Stderr => self.paint("stderr", Style::Warning),
@@ -365,11 +373,13 @@ mod tests {
 			total_steps: 3,
 			writer_lock: Arc::new(Mutex::new(())),
 			active_spinner: None,
+			command_started: false,
 		}
 	}
 
 	fn named_command_step(name: &str) -> CliStepDefinition {
 		CliStepDefinition::Command {
+			show_progress: None,
 			name: Some(name.to_string()),
 			when: None,
 			command: "echo hi".to_string(),

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -427,15 +427,17 @@ pub(crate) fn execute_cli_command_with_options(
 	let mut output = None;
 	let command_started_at = Instant::now();
 	let mut progress = CliProgressReporter::new(cli_command, dry_run, quiet);
-	progress.command_started();
 
 	for (step_index, step) in cli_command.steps.iter().enumerate() {
 		let step_started_at = Instant::now();
 		let step_inputs = resolve_step_inputs(&context, step)?;
 		context.last_step_inputs = step_inputs.clone();
+		let show_progress = step_shows_progress(step, &step_inputs);
 
 		if !should_execute_cli_step(step, &context, &step_inputs)? {
-			progress.step_skipped(step_index, step, step.when());
+			if show_progress {
+				progress.step_skipped(step_index, step, step.when());
+			}
 			if let Some(condition) = step.when() {
 				tracing::debug!(step = step.kind_name(), condition = %condition, "skipped CLI step");
 				context.command_logs.push(format!(
@@ -446,7 +448,9 @@ pub(crate) fn execute_cli_command_with_options(
 			continue;
 		}
 
-		progress.step_started(step_index, step);
+		if show_progress {
+			progress.step_started(step_index, step);
+		}
 		tracing::debug!(step = step.kind_name(), "executing CLI step");
 		let mut step_phase_timings = Vec::new();
 		let step_result: MonochangeResult<()> = (|| {
@@ -785,6 +789,7 @@ pub(crate) fn execute_cli_command_with_options(
 						&mut context,
 						step,
 						&mut progress,
+						show_progress,
 						CommandStepOptions {
 							command,
 							dry_run_command: dry_run_command.as_deref(),
@@ -799,16 +804,20 @@ pub(crate) fn execute_cli_command_with_options(
 			}
 		})();
 		if let Err(error) = step_result {
-			let progress_error = progress_error_detail(&error).to_string();
-			progress.step_failed(step_index, step, step_started_at.elapsed(), &progress_error);
+			if show_progress {
+				let progress_error = progress_error_detail(&error).to_string();
+				progress.step_failed(step_index, step, step_started_at.elapsed(), &progress_error);
+			}
 			return Err(error);
 		}
-		progress.step_finished(
-			step_index,
-			step,
-			step_started_at.elapsed(),
-			&step_phase_timings,
-		);
+		if show_progress {
+			progress.step_finished(
+				step_index,
+				step,
+				step_started_at.elapsed(),
+				&step_phase_timings,
+			);
+		}
 	}
 
 	progress.command_finished(command_started_at.elapsed());
@@ -1051,10 +1060,26 @@ struct CommandStepOptions<'a> {
 	step_inputs: &'a BTreeMap<String, Vec<String>>,
 }
 
+fn step_shows_progress(
+	step: &CliStepDefinition,
+	step_inputs: &BTreeMap<String, Vec<String>>,
+) -> bool {
+	if matches!(step, CliStepDefinition::CreateChangeFile { .. })
+		&& step_inputs
+			.get("interactive")
+			.and_then(|values| values.first())
+			.is_some_and(|value| value == "true")
+	{
+		return false;
+	}
+	step.show_progress().unwrap_or(true)
+}
+
 fn run_cli_command_command(
 	context: &mut CliContext,
 	step: &CliStepDefinition,
 	progress: &mut CliProgressReporter,
+	show_progress: bool,
 	options: CommandStepOptions<'_>,
 ) -> MonochangeResult<()> {
 	let command_to_run = if context.dry_run {
@@ -1100,7 +1125,7 @@ fn run_cli_command_command(
 	};
 	process_command.current_dir(&context.root);
 
-	let output = if progress.is_enabled() {
+	let output = if progress.is_enabled() && show_progress {
 		run_process_with_streaming(&mut process_command, progress, step, &interpolated)?
 	} else {
 		let output = process_command.output().map_err(|error| {
@@ -2311,6 +2336,37 @@ mod tests {
 	}
 
 	#[test]
+	fn step_shows_progress_disables_interactive_change_steps_by_default() {
+		let step = CliStepDefinition::CreateChangeFile {
+			show_progress: None,
+			name: Some("interactive change".to_string()),
+			when: None,
+			inputs: BTreeMap::new(),
+		};
+		let mut step_inputs = BTreeMap::new();
+		step_inputs.insert("interactive".to_string(), vec!["true".to_string()]);
+		assert!(!step_shows_progress(&step, &step_inputs));
+		step_inputs.insert("interactive".to_string(), vec!["false".to_string()]);
+		assert!(step_shows_progress(&step, &step_inputs));
+	}
+
+	#[test]
+	fn step_shows_progress_respects_explicit_step_flags() {
+		let step = CliStepDefinition::Command {
+			show_progress: Some(false),
+			name: Some("interactive shell".to_string()),
+			when: None,
+			command: "echo hello".to_string(),
+			dry_run_command: None,
+			shell: ShellConfig::Default,
+			id: None,
+			variables: None,
+			inputs: BTreeMap::new(),
+		};
+		assert!(!step_shows_progress(&step, &BTreeMap::new()));
+	}
+
+	#[test]
 	fn drain_stream_events_collects_stdout_stderr_and_handles_closed_channels() {
 		let cli_command = CliCommandDefinition {
 			name: "release".to_string(),
@@ -2320,6 +2376,7 @@ mod tests {
 		};
 		let mut progress = CliProgressReporter::new(&cli_command, false, false);
 		let step = CliStepDefinition::Command {
+			show_progress: None,
 			name: Some("stream output".to_string()),
 			when: None,
 			command: "echo hello".to_string(),
@@ -2378,6 +2435,7 @@ mod tests {
 			help_text: None,
 			inputs: Vec::new(),
 			steps: vec![CliStepDefinition::Command {
+				show_progress: None,
 				name: Some("fail loud".to_string()),
 				when: None,
 				command: "printf 'boom\\n' >&2; exit 3".to_string(),

--- a/crates/monochange/src/monochange.init.toml
+++ b/crates/monochange/src/monochange.init.toml
@@ -548,6 +548,9 @@ comment_on_failure = true
 {% endraw -%}
 #                     to forward values from command inputs without losing
 #                     list/boolean types.
+#   show_progress   — optional boolean for interactive CreateChangeFile / Command
+#                     steps. Set false when spinner output would interfere with
+#                     prompts or a custom terminal UI.
 #
 # Command step fields:
 #   command         — the command to run (supports minijinja interpolation)

--- a/crates/monochange/tests/cli_progress.rs
+++ b/crates/monochange/tests/cli_progress.rs
@@ -117,6 +117,102 @@ fn run_tty_command(workspace: &Path, command_name: &str) -> String {
 	transcript
 }
 
+#[cfg(unix)]
+fn run_tty_interactive_change(workspace: &Path, output_path: &Path) -> (i32, String) {
+	const SCRIPT: &str = r"
+import os
+import pty
+import select
+import subprocess
+import sys
+import time
+
+workspace = os.environ['MC_WORKSPACE']
+output_path = os.environ['MC_OUTPUT']
+mc_bin = os.environ['MC_BIN']
+master, slave = pty.openpty()
+proc = subprocess.Popen(
+    [mc_bin, 'change', '--interactive', '--reason', 'interactive reason', '--details', 'interactive details', '--output', output_path],
+    cwd=workspace,
+    stdin=slave,
+    stdout=slave,
+    stderr=slave,
+    text=False,
+    close_fds=True,
+    env={**os.environ, 'NO_COLOR': '1'},
+)
+os.close(slave)
+transcript = bytearray()
+
+def drain(seconds):
+    end = time.time() + seconds
+    while time.time() < end:
+        ready, _, _ = select.select([master], [], [], 0.05)
+        if master in ready:
+            try:
+                data = os.read(master, 4096)
+            except OSError:
+                break
+            if not data:
+                break
+            transcript.extend(data)
+        if proc.poll() is not None:
+            break
+
+def send(data, pause=0.0):
+    try:
+        os.write(master, data)
+    except OSError:
+        return False
+    if pause:
+        time.sleep(pause)
+    return True
+
+drain(0.5)
+if send(b' ', 0.1):
+    send(b'\r')
+drain(0.5)
+if send(b'\x1b[B', 0.1):
+    send(b'\r')
+drain(0.5)
+send(b'\r')
+drain(0.5)
+send(b'\r')
+drain(0.5)
+proc.wait(timeout=10)
+drain(0.2)
+os.close(master)
+sys.stdout.buffer.write(transcript)
+sys.stderr.write(f'__MC_EXIT_STATUS__={proc.returncode}\n')
+sys.exit(0)
+";
+
+	let output = std::process::Command::new("python3")
+		.arg("-c")
+		.arg(SCRIPT)
+		.env("MC_BIN", insta_cmd::get_cargo_bin("mc"))
+		.env("MC_WORKSPACE", workspace)
+		.env("MC_OUTPUT", output_path)
+		.output()
+		.unwrap_or_else(|error| panic!("interactive tty python harness: {error}"));
+	assert!(
+		output.status.success(),
+		"interactive tty python harness failed:\n{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	let stderr =
+		String::from_utf8(output.stderr).unwrap_or_else(|error| panic!("tty stderr utf8: {error}"));
+	let status_code = stderr
+		.lines()
+		.find_map(|line| line.strip_prefix(EXIT_STATUS_MARKER))
+		.unwrap_or_else(|| panic!("missing tty exit status marker:\n{stderr}"))
+		.parse::<i32>()
+		.unwrap_or_else(|error| panic!("parse tty exit status: {error}\n{stderr}"));
+	let transcript = String::from_utf8(output.stdout)
+		.unwrap_or_else(|error| panic!("interactive tty output utf8: {error}"));
+	(status_code, normalize_tty_transcript(&transcript))
+}
+
 #[cfg(not(unix))]
 fn run_tty_command(_workspace: &Path, _command_name: &str) -> String {
 	String::new()
@@ -186,9 +282,35 @@ steps = [
 }
 
 #[test]
+#[cfg(unix)]
+fn interactive_change_cli_hides_progress_output_on_tty() {
+	let tempdir = setup_fixture("monochange/release-base");
+	let output_path = tempdir.path().join(".changeset/interactive.md");
+
+	let (status, transcript) = run_tty_interactive_change(tempdir.path(), &output_path);
+
+	assert_eq!(
+		status, 0,
+		"unexpected interactive transcript:\n{transcript}"
+	);
+	assert!(!transcript.contains("running `change`"), "{transcript}");
+	assert!(!transcript.contains("[1/1]"), "{transcript}");
+	assert!(!transcript.contains("finished"), "{transcript}");
+	assert!(transcript.contains("wrote change file .changeset/interactive.md"));
+	assert!(
+		output_path.exists(),
+		"interactive change file should be created"
+	);
+}
+
+#[test]
 #[cfg(not(unix))]
 fn release_progress_streams_named_steps_on_tty() {}
 
 #[test]
 #[cfg(not(unix))]
 fn release_progress_renders_skipped_failed_steps_and_stderr_on_tty() {}
+
+#[test]
+#[cfg(not(unix))]
+fn interactive_change_cli_hides_progress_output_on_tty() {}

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -54,6 +54,7 @@ use crate::WorkspaceConfiguration;
 use crate::WorkspaceDefaults;
 use crate::default_cli_commands;
 use crate::git::git_checkout_branch_command;
+use crate::git::git_command;
 use crate::git::git_current_branch;
 use crate::git::git_push_branch_command;
 use crate::materialize_dependency_edges;
@@ -71,6 +72,34 @@ fn must_err<T, E>(result: Result<T, E>, context: &str) -> E {
 		Ok(_) => panic!("{context}"),
 		Err(error) => error,
 	}
+}
+
+fn init_git_repository(root: &Path) {
+	let init = git_command(root)
+		.args(["init", "-b", "main"])
+		.output()
+		.unwrap_or_else(|error| panic!("git init: {error}"));
+	if init.status.success() {
+		return;
+	}
+	let fallback = git_command(root)
+		.arg("init")
+		.output()
+		.unwrap_or_else(|error| panic!("git init fallback: {error}"));
+	assert!(
+		fallback.status.success(),
+		"git init failed:\n{}",
+		String::from_utf8_lossy(&init.stderr)
+	);
+	let checkout = git_command(root)
+		.args(["checkout", "-B", "main"])
+		.output()
+		.unwrap_or_else(|error| panic!("git checkout -B main: {error}"));
+	assert!(
+		checkout.status.success(),
+		"git checkout -B main failed:\n{}",
+		String::from_utf8_lossy(&checkout.stderr)
+	);
 }
 
 #[test]
@@ -113,12 +142,7 @@ fn git_push_branch_command_builds_expected_arguments() {
 fn git_current_branch_reports_checked_out_branch_name() {
 	let tempdir = must_ok(tempdir(), "tempdir");
 	let root = tempdir.path();
-	let output = std::process::Command::new("git")
-		.args(["init", "-b", "main"])
-		.current_dir(root)
-		.output()
-		.unwrap_or_else(|error| panic!("git init: {error}"));
-	assert!(output.status.success());
+	init_git_repository(root);
 	let branch = must_ok(git_current_branch(root), "current branch");
 	assert_eq!(branch, "main");
 }
@@ -127,19 +151,13 @@ fn git_current_branch_reports_checked_out_branch_name() {
 fn git_current_branch_reports_detached_head_as_an_error() {
 	let tempdir = must_ok(tempdir(), "tempdir");
 	let root = tempdir.path();
-	let init = std::process::Command::new("git")
-		.args(["init", "-b", "main"])
-		.current_dir(root)
-		.output()
-		.unwrap_or_else(|error| panic!("git init: {error}"));
-	assert!(init.status.success());
+	init_git_repository(root);
 	for args in [
 		["config", "user.name", "monochange Tests"],
 		["config", "user.email", "monochange@example.com"],
 	] {
-		let output = std::process::Command::new("git")
+		let output = git_command(root)
 			.args(args)
-			.current_dir(root)
 			.output()
 			.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
 		assert!(output.status.success());
@@ -153,9 +171,8 @@ fn git_current_branch_reports_detached_head_as_an_error() {
 		&["commit", "-m", "initial"][..],
 		&["checkout", "--detach"][..],
 	] {
-		let output = std::process::Command::new("git")
+		let output = git_command(root)
 			.args(args)
-			.current_dir(root)
 			.output()
 			.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
 		assert!(output.status.success());
@@ -567,6 +584,7 @@ fn cli_step_definition_kind_name_covers_all_variants() {
 		),
 		(
 			CliStepDefinition::CreateChangeFile {
+				show_progress: None,
 				name: None,
 				when: None,
 				inputs: BTreeMap::new(),
@@ -648,6 +666,7 @@ fn cli_step_definition_kind_name_covers_all_variants() {
 		),
 		(
 			CliStepDefinition::Command {
+				show_progress: None,
 				name: None,
 				when: None,
 				command: "echo".into(),
@@ -663,6 +682,35 @@ fn cli_step_definition_kind_name_covers_all_variants() {
 	for (step, expected) in cases {
 		assert_eq!(step.kind_name(), expected);
 	}
+}
+
+#[test]
+fn cli_step_show_progress_returns_configured_values_for_interactive_steps() {
+	let create_change = CliStepDefinition::CreateChangeFile {
+		show_progress: Some(false),
+		name: None,
+		when: None,
+		inputs: BTreeMap::new(),
+	};
+	let command = CliStepDefinition::Command {
+		show_progress: Some(true),
+		name: None,
+		when: None,
+		command: "echo hi".to_string(),
+		dry_run_command: None,
+		shell: ShellConfig::None,
+		id: None,
+		variables: None,
+		inputs: BTreeMap::new(),
+	};
+	let validate = CliStepDefinition::Validate {
+		name: None,
+		when: None,
+		inputs: BTreeMap::new(),
+	};
+	assert_eq!(create_change.show_progress(), Some(false));
+	assert_eq!(command.show_progress(), Some(true));
+	assert_eq!(validate.show_progress(), None);
 }
 
 #[test]
@@ -691,6 +739,7 @@ fn cli_step_name_returns_explicit_names_for_all_variants() {
 			inputs: BTreeMap::new(),
 		},
 		CliStepDefinition::CreateChangeFile {
+			show_progress: None,
 			name: Some(expected.to_string()),
 			when: None,
 			inputs: BTreeMap::new(),
@@ -742,6 +791,7 @@ fn cli_step_name_returns_explicit_names_for_all_variants() {
 			inputs: BTreeMap::new(),
 		},
 		CliStepDefinition::Command {
+			show_progress: None,
 			name: Some(expected.to_string()),
 			when: None,
 			command: "echo hi".to_string(),
@@ -760,6 +810,7 @@ fn cli_step_name_returns_explicit_names_for_all_variants() {
 #[test]
 fn valid_input_names_returns_none_for_command_steps() {
 	let step = CliStepDefinition::Command {
+		show_progress: None,
 		name: None,
 		when: None,
 		command: "echo hi".into(),
@@ -823,6 +874,7 @@ fn valid_input_names_returns_expected_names_for_retarget_release() {
 #[test]
 fn valid_input_names_returns_expected_names_for_create_change_file() {
 	let step = CliStepDefinition::CreateChangeFile {
+		show_progress: None,
 		name: None,
 		when: None,
 		inputs: BTreeMap::new(),
@@ -899,6 +951,7 @@ fn expected_input_kind_returns_correct_types_for_affected_packages() {
 #[test]
 fn expected_input_kind_returns_none_for_command_steps() {
 	let step = CliStepDefinition::Command {
+		show_progress: None,
 		name: None,
 		when: None,
 		command: "echo".into(),
@@ -925,6 +978,7 @@ fn expected_input_kind_returns_none_for_commit_release() {
 fn expected_input_kind_returns_correct_types_for_create_change_file() {
 	use crate::CliInputKind;
 	let step = CliStepDefinition::CreateChangeFile {
+		show_progress: None,
 		name: None,
 		when: None,
 		inputs: BTreeMap::new(),

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -1279,6 +1279,8 @@ pub enum CliStepDefinition {
 		#[serde(default)]
 		when: Option<String>,
 		#[serde(default)]
+		show_progress: Option<bool>,
+		#[serde(default)]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Prepare a release and expose structured `release.*` context to later
@@ -1395,6 +1397,8 @@ pub enum CliStepDefinition {
 		name: Option<String>,
 		#[serde(default)]
 		when: Option<String>,
+		#[serde(default)]
+		show_progress: Option<bool>,
 		command: String,
 		#[serde(default, alias = "dry_run")]
 		dry_run_command: Option<String>,
@@ -1469,6 +1473,16 @@ impl CliStepDefinition {
 			| Self::DiagnoseChangesets { when, .. }
 			| Self::RetargetRelease { when, .. }
 			| Self::Command { when, .. } => when.as_deref(),
+		}
+	}
+
+	#[must_use]
+	pub fn show_progress(&self) -> Option<bool> {
+		match self {
+			Self::CreateChangeFile { show_progress, .. } | Self::Command { show_progress, .. } => {
+				*show_progress
+			}
+			_ => None,
 		}
 	}
 
@@ -2841,6 +2855,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 				},
 			],
 			steps: vec![CliStepDefinition::CreateChangeFile {
+				show_progress: None,
 				name: None,
 				when: None,
 				inputs: BTreeMap::new(),

--- a/docs/src/reference/cli-steps/00-index.md
+++ b/docs/src/reference/cli-steps/00-index.md
@@ -100,6 +100,10 @@ Use that when:
 - you want to hardcode a value for one step but not the entire command
 - you want to pass list or boolean values through direct template references such as `"{{ inputs.changed_paths }}"`
 
+### Step-local `show_progress`
+
+Interactive steps do not show the spinner by default when monochange is waiting on the user. For step kinds that support it, you can also set `show_progress = false` to suppress progress output explicitly.
+
 ### Structured template namespaces
 
 When you compose `Command` steps after built-in steps, monochange exposes structured context values such as:

--- a/docs/src/reference/cli-steps/03-create-change-file.md
+++ b/docs/src/reference/cli-steps/03-create-change-file.md
@@ -50,6 +50,7 @@ None. `CreateChangeFile` is standalone.
 - writes a new changeset file
 - reports the written path
 - does not prepare release state for later steps
+- automatically hides the progress spinner during interactive prompting so the selector UI stays readable
 
 ## Example
 
@@ -123,6 +124,7 @@ help_text = "Create a change file interactively"
 
 [[cli.change-interactive.steps]]
 type = "CreateChangeFile"
+show_progress = false
 inputs = { interactive = true }
 ```
 

--- a/docs/src/reference/cli-steps/13-command.md
+++ b/docs/src/reference/cli-steps/13-command.md
@@ -31,6 +31,7 @@ Use `Command` for what is truly custom.
 - `id` — optional identifier that exposes `steps.<id>.stdout` and `steps.<id>.stderr` to later steps
 - `variables` — optional custom variable mapping for command substitution
 - `inputs` — optional step-local input overrides
+- `show_progress` — optional boolean; set to `false` when the command itself is interactive and spinner output would get in the way
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- hide progress spinners automatically for interactive `CreateChangeFile` flows so terminal prompts stay readable
- add `show_progress = false` support for interactive-capable `CreateChangeFile` and `Command` steps
- document the new behavior and harden the affected git-branch tests that were failing under the full push-hook environment

## Testing
- `cargo test -p monochange_core`
- `cargo test -p monochange --lib --test cli_progress --test changeset_target_metadata`
- `cargo test -p monochange --lib --tests --no-run`
- `devenv shell fix:all`
- `cargo run -q -p monochange --bin mc -- validate`
- `cargo run -q -p monochange --bin mc -- affected --changed-paths .changeset/interactive-progress-loader.md --changed-paths crates/monochange/src/__tests.rs --changed-paths crates/monochange/src/cli_progress.rs --changed-paths crates/monochange/src/cli_runtime.rs --changed-paths crates/monochange/src/monochange.init.toml --changed-paths crates/monochange/tests/cli_progress.rs --changed-paths crates/monochange_core/src/__tests.rs --changed-paths crates/monochange_core/src/lib.rs --changed-paths docs/src/reference/cli-steps/00-index.md --changed-paths docs/src/reference/cli-steps/03-create-change-file.md --changed-paths docs/src/reference/cli-steps/13-command.md`
