### PR TITLE
feat: finish release progress follow-ups

### DIFF
--- a/.changeset/release-observability-and-hosting-batching.md
+++ b/.changeset/release-observability-and-hosting-batching.md
@@ -1,5 +1,44 @@
 ---
-main: patch
+monochange: minor
+monochange_config: minor
+monochange_core: minor
 ---
 
-Improve `mc release` ergonomics and hosted-source performance by batching GitHub review-request enrichment into a single GraphQL request, adding step names plus live progress output, and keeping Cargo lockfile refresh opt-in instead of falling back to `cargo generate-lockfile` automatically.
+#### add streamed release progress, named steps, and real-path release timing diagnostics
+
+`mc release` and `mc commit-release` now stream step progress while they run instead of waiting for a whole command to finish. Built-in steps carry stable display names, long-running steps show loading indicators in TTY sessions, command stdout and stderr stream underneath the active step, and `PrepareRelease` emits per-phase timings so slow release phases are visible without taking a separate trace.
+
+**Before:**
+
+```bash
+mc release --dry-run
+```
+
+Progress output was only available in the default auto mode, step labels often fell back to the raw step kind, and machine-readable timing data was not available for the real `mc release` path.
+
+**After:**
+
+```bash
+mc release --progress-format unicode
+mc release --progress-format json
+MONOCHANGE_PROGRESS_FORMAT=ascii mc commit-release
+```
+
+The human renderers now use named steps plus streamed command output, while `--progress-format json` writes newline-delimited lifecycle events to stderr:
+
+```json
+{"event":"step_started","command":"release","stepKind":"PrepareRelease","stepDisplayName":"plan release"}
+{"event":"step_finished","command":"release","stepKind":"PrepareRelease","phaseTimings":[{"label":"discover release workspace","durationMs":97}]}
+```
+
+Custom CLI definitions can opt into clearer output by attaching explicit step names:
+
+```toml
+[cli.release]
+steps = [
+	{ name = "plan release", type = "PrepareRelease" },
+	{ name = "stream summary", type = "Command", command = "printf 'done\n'", show_progress = true },
+]
+```
+
+Hosted GitHub enrichment now batches review-request lookups into a single GraphQL request, reducing repeated network overhead during release preparation. The benchmark workflow also measures both `mc release --dry-run` and the real `mc release` path, and Cargo lockfile refresh stays opt-in instead of forcing `cargo generate-lockfile` automatically.

--- a/.github/scripts/benchmark_cli.sh
+++ b/.github/scripts/benchmark_cli.sh
@@ -3,6 +3,15 @@ set -euo pipefail
 
 WARMUP_RUNS=1
 BENCHMARK_RUNS=6
+PHASE_COMMAND_LABELS=(
+	"mc release --dry-run"
+	"mc release"
+)
+PHASE_COMMAND_ARGS=(
+	"release --dry-run"
+	"release"
+)
+PHASE_BUDGETS_FILE="$(cd "$(dirname "$0")" && pwd)/benchmark_phase_budgets.json"
 
 SCENARIO_IDS=(baseline history_x10)
 SCENARIO_NAMES=("Baseline fixture" "Large history fixture")
@@ -42,7 +51,8 @@ render_comment() {
 			local scenario_name="$1"
 			local scenario_description="$2"
 			local table_path="$3"
-			shift 3
+			local phase_table_path="$4"
+			shift 4
 
 			echo
 			echo "### ${scenario_name}"
@@ -50,8 +60,216 @@ render_comment() {
 			echo "Fixture: ${scenario_description}"
 			echo
 			cat "$table_path"
+			if [ -f "$phase_table_path" ] && [ -s "$phase_table_path" ]; then
+				echo
+				cat "$phase_table_path"
+			fi
 		done
 	} >"$output_path"
+}
+
+summarize_progress_events() {
+	local events_path="$1"
+	local output_path="$2"
+	python3 - "$events_path" >"$output_path" <<'PY'
+import json
+import sys
+
+events_path = sys.argv[1]
+phase_totals = {}
+step_total_ms = 0
+
+with open(events_path, encoding="utf-8") as handle:
+    for raw_line in handle:
+        line = raw_line.strip()
+        if not line:
+            continue
+        event = json.loads(line)
+        if event.get("event") != "step_finished" or event.get("stepKind") != "PrepareRelease":
+            continue
+        step_total_ms += int(event.get("durationMs", 0) or 0)
+        for phase in event.get("phaseTimings", []):
+            label = phase.get("label")
+            if not label:
+                continue
+            phase_totals[label] = phase_totals.get(label, 0) + int(
+                phase.get("durationMs", 0) or 0
+            )
+
+summary = {
+    "stepTotalMs": step_total_ms,
+    "phases": [
+        {"label": label, "durationMs": duration_ms}
+        for label, duration_ms in sorted(
+            phase_totals.items(), key=lambda item: (-item[1], item[0])
+        )
+    ],
+}
+json.dump(summary, sys.stdout, indent=2, sort_keys=True)
+PY
+}
+
+run_phase_capture() {
+	local bin="$1"
+	local fixture_dir="$2"
+	local command_args="$3"
+	local events_path="$4"
+	local -a argv=()
+	read -r -a argv <<<"$command_args"
+	(
+		cd "$fixture_dir"
+		git reset --hard HEAD >/dev/null
+		git clean -fd >/dev/null
+		"$bin" --progress-format json "${argv[@]}" >/dev/null 2>"$events_path"
+	)
+}
+
+render_phase_markdown() {
+	local scenario_id="$1"
+	local output_path="$2"
+	local violations_path="$3"
+	local dry_main_summary="$4"
+	local dry_pr_summary="$5"
+	local release_main_summary="$6"
+	local release_pr_summary="$7"
+
+	python3 - \
+		"$scenario_id" \
+		"$PHASE_BUDGETS_FILE" \
+		"$dry_main_summary" \
+		"$dry_pr_summary" \
+		"$release_main_summary" \
+		"$release_pr_summary" \
+		"$violations_path" >"$output_path" <<'PY'
+import json
+import sys
+
+(
+    scenario_id,
+    budgets_path,
+    dry_main_summary,
+    dry_pr_summary,
+    release_main_summary,
+    release_pr_summary,
+    violations_path,
+) = sys.argv[1:]
+
+with open(budgets_path, encoding="utf-8") as handle:
+    scenario_budgets = json.load(handle).get(scenario_id, {})
+
+command_summaries = {
+    "mc release --dry-run": {
+        "main": json.load(open(dry_main_summary, encoding="utf-8")),
+        "pr": json.load(open(dry_pr_summary, encoding="utf-8")),
+    },
+    "mc release": {
+        "main": json.load(open(release_main_summary, encoding="utf-8")),
+        "pr": json.load(open(release_pr_summary, encoding="utf-8")),
+    },
+}
+
+def phase_map(summary):
+    return {phase["label"]: int(phase["durationMs"]) for phase in summary.get("phases", [])}
+
+def status_label(main_ms, pr_ms, budget_ms):
+    if budget_ms is not None and pr_ms > budget_ms:
+        return "over budget"
+    if pr_ms > main_ms:
+        return "regressed"
+    if pr_ms < main_ms:
+        return "improved"
+    return "flat"
+
+def delta(pr_ms, main_ms):
+    value = pr_ms - main_ms
+    return f"{value:+d}"
+
+sections = ["#### Phase timings", ""]
+violations = 0
+
+for command_label in ("mc release --dry-run", "mc release"):
+    summaries = command_summaries[command_label]
+    budget = scenario_budgets.get(command_label, {})
+    phase_budget = budget.get("phases", {})
+    main_summary = summaries["main"]
+    pr_summary = summaries["pr"]
+    main_phases = phase_map(main_summary)
+    pr_phases = phase_map(pr_summary)
+    rows = [
+        (
+            "prepare release total",
+            budget.get("stepTotalMs"),
+            int(main_summary.get("stepTotalMs", 0) or 0),
+            int(pr_summary.get("stepTotalMs", 0) or 0),
+        )
+    ]
+    labels = sorted(
+        set(main_phases) | set(pr_phases),
+        key=lambda label: (-max(main_phases.get(label, 0), pr_phases.get(label, 0)), label),
+    )
+    for label in labels:
+        rows.append((label, phase_budget.get(label), main_phases.get(label, 0), pr_phases.get(label, 0)))
+
+    sections.append(f"##### `{command_label}`")
+    sections.append("")
+    sections.append("| Phase | Budget [ms] | main [ms] | pr [ms] | Δ pr-main [ms] | Status |")
+    sections.append("|:---|---:|---:|---:|---:|:---|")
+    for label, budget_ms, main_ms, pr_ms in rows:
+        status = status_label(main_ms, pr_ms, budget_ms)
+        if budget_ms is not None and pr_ms > budget_ms:
+            violations += 1
+        budget_text = "n/a" if budget_ms is None else str(int(budget_ms))
+        sections.append(
+            f"| `{label}` | {budget_text} | {main_ms} | {pr_ms} | {delta(pr_ms, main_ms)} | {status} |"
+        )
+    sections.append("")
+
+with open(violations_path, "w", encoding="utf-8") as handle:
+    handle.write(str(violations))
+
+sys.stdout.write("\n".join(sections).rstrip() + "\n")
+PY
+}
+
+collect_phase_markdown() {
+	local scenario_id="$1"
+	local fixture_dir="$2"
+	local main_bin="$3"
+	local pr_bin="$4"
+	local phase_markdown_path="$5"
+	local scenario_violations_path="$6"
+	local dry_main_events
+	local dry_pr_events
+	local release_main_events
+	local release_pr_events
+	local dry_main_summary
+	local dry_pr_summary
+	local release_main_summary
+	local release_pr_summary
+	dry_main_events="$(mktemp -t monochange-bench-dry-main.XXXXXX.jsonl)"
+	dry_pr_events="$(mktemp -t monochange-bench-dry-pr.XXXXXX.jsonl)"
+	release_main_events="$(mktemp -t monochange-bench-release-main.XXXXXX.jsonl)"
+	release_pr_events="$(mktemp -t monochange-bench-release-pr.XXXXXX.jsonl)"
+	dry_main_summary="$(mktemp -t monochange-bench-dry-main-summary.XXXXXX.json)"
+	dry_pr_summary="$(mktemp -t monochange-bench-dry-pr-summary.XXXXXX.json)"
+	release_main_summary="$(mktemp -t monochange-bench-release-main-summary.XXXXXX.json)"
+	release_pr_summary="$(mktemp -t monochange-bench-release-pr-summary.XXXXXX.json)"
+	run_phase_capture "$main_bin" "$fixture_dir" "${PHASE_COMMAND_ARGS[0]}" "$dry_main_events"
+	run_phase_capture "$pr_bin" "$fixture_dir" "${PHASE_COMMAND_ARGS[0]}" "$dry_pr_events"
+	run_phase_capture "$main_bin" "$fixture_dir" "${PHASE_COMMAND_ARGS[1]}" "$release_main_events"
+	run_phase_capture "$pr_bin" "$fixture_dir" "${PHASE_COMMAND_ARGS[1]}" "$release_pr_events"
+	summarize_progress_events "$dry_main_events" "$dry_main_summary"
+	summarize_progress_events "$dry_pr_events" "$dry_pr_summary"
+	summarize_progress_events "$release_main_events" "$release_main_summary"
+	summarize_progress_events "$release_pr_events" "$release_pr_summary"
+	render_phase_markdown \
+		"$scenario_id" \
+		"$phase_markdown_path" \
+		"$scenario_violations_path" \
+		"$dry_main_summary" \
+		"$dry_pr_summary" \
+		"$release_main_summary" \
+		"$release_pr_summary"
 }
 
 git_commit() {
@@ -146,17 +364,8 @@ EOF
 run_scenario() {
 	local main_bin="$1"
 	local pr_bin="$2"
-	local scenario_name="$3"
-	local packages="$4"
-	local changesets="$5"
-	local commits="$6"
-	local table_path="$7"
-
-	local fixture_dir
-	fixture_dir="$(mktemp -d -t monochange-bench.XXXXXX)"
-	trap "rm -rf '$fixture_dir'" RETURN
-
-	generate_fixture "$fixture_dir" "$packages" "$changesets" "$commits"
+	local fixture_dir="$3"
+	local table_path="$4"
 
 	local hyperfine_args=()
 	local idx
@@ -182,6 +391,7 @@ run_mode() {
 	local main_bin=""
 	local pr_bin=""
 	local output_path=""
+	local violations_output=""
 
 	while [ "$#" -gt 0 ]; do
 		case "$1" in
@@ -197,6 +407,10 @@ run_mode() {
 			output_path="$2"
 			shift 2
 			;;
+		--violations-output)
+			violations_output="$2"
+			shift 2
+			;;
 		*)
 			echo "unknown argument: $1" >&2
 			exit 1
@@ -205,26 +419,48 @@ run_mode() {
 	done
 
 	local scenario_render_args=()
+	local total_violations=0
 	local idx
 	for idx in "${!SCENARIO_IDS[@]}"; do
 		local table_path
+		local phase_path
+		local scenario_violations_path
 		table_path="$(mktemp -t monochange-bench-table.XXXXXX.md)"
+		phase_path="$(mktemp -t monochange-bench-phases.XXXXXX.md)"
+		scenario_violations_path="$(mktemp -t monochange-bench-violations.XXXXXX.txt)"
+		local fixture_dir
+		fixture_dir="$(mktemp -d -t monochange-bench.XXXXXX)"
+		generate_fixture \
+			"$fixture_dir" \
+			"${SCENARIO_PACKAGES[$idx]}" \
+			"${SCENARIO_CHANGESETS[$idx]}" \
+			"${SCENARIO_COMMITS[$idx]}"
 		run_scenario \
 			"$main_bin" \
 			"$pr_bin" \
-			"${SCENARIO_NAMES[$idx]}" \
-			"${SCENARIO_PACKAGES[$idx]}" \
-			"${SCENARIO_CHANGESETS[$idx]}" \
-			"${SCENARIO_COMMITS[$idx]}" \
+			"$fixture_dir" \
 			"$table_path"
+		collect_phase_markdown \
+			"${SCENARIO_IDS[$idx]}" \
+			"$fixture_dir" \
+			"$main_bin" \
+			"$pr_bin" \
+			"$phase_path" \
+			"$scenario_violations_path"
+		total_violations=$((total_violations + $(cat "$scenario_violations_path")))
+		rm -rf "$fixture_dir"
 		scenario_render_args+=(
 			"${SCENARIO_NAMES[$idx]}"
 			"${SCENARIO_PACKAGES[$idx]} packages, ${SCENARIO_CHANGESETS[$idx]} changesets, ${SCENARIO_COMMITS[$idx]} commits"
 			"$table_path"
+			"$phase_path"
 		)
 	done
 
 	render_comment "$output_path" "${scenario_render_args[@]}"
+	if [ -n "$violations_output" ]; then
+		printf '%s\n' "$total_violations" >"$violations_output"
+	fi
 }
 
 render_fixture_mode() {
@@ -253,9 +489,11 @@ render_fixture_mode() {
 		"Baseline fixture" \
 		"20 packages, 50 changesets, 50 commits" \
 		"$fixture_dir/baseline.md" \
+		"$fixture_dir/baseline-phases.md" \
 		"Large history fixture" \
 		"200 packages, 500 changesets, 500 commits" \
-		"$fixture_dir/history_x10.md"
+		"$fixture_dir/history_x10.md" \
+		"$fixture_dir/history_x10-phases.md"
 }
 
 main() {

--- a/.github/scripts/benchmark_cli.sh
+++ b/.github/scripts/benchmark_cli.sh
@@ -109,6 +109,22 @@ json.dump(summary, sys.stdout, indent=2, sort_keys=True)
 PY
 }
 
+write_unavailable_summary() {
+	local output_path="$1"
+	cat >"$output_path" <<'EOF'
+{
+  "available": false,
+  "stepTotalMs": null,
+  "phases": []
+}
+EOF
+}
+
+supports_json_progress() {
+	local bin="$1"
+	"$bin" --help 2>&1 | grep -q -- '--progress-format'
+}
+
 run_phase_capture() {
 	local bin="$1"
 	local fixture_dir="$2"
@@ -169,11 +185,17 @@ command_summaries = {
 }
 
 def phase_map(summary):
+    if not summary.get("available", True):
+        return {}
     return {phase["label"]: int(phase["durationMs"]) for phase in summary.get("phases", [])}
 
 def status_label(main_ms, pr_ms, budget_ms):
+    if pr_ms is None:
+        return "unavailable"
     if budget_ms is not None and pr_ms > budget_ms:
         return "over budget"
+    if main_ms is None:
+        return "budget only" if budget_ms is not None else "pr only"
     if pr_ms > main_ms:
         return "regressed"
     if pr_ms < main_ms:
@@ -181,8 +203,13 @@ def status_label(main_ms, pr_ms, budget_ms):
     return "flat"
 
 def delta(pr_ms, main_ms):
+    if pr_ms is None or main_ms is None:
+        return "n/a"
     value = pr_ms - main_ms
     return f"{value:+d}"
+
+def format_ms(value):
+    return "n/a" if value is None else str(int(value))
 
 sections = ["#### Phase timings", ""]
 violations = 0
@@ -195,12 +222,14 @@ for command_label in ("mc release --dry-run", "mc release"):
     pr_summary = summaries["pr"]
     main_phases = phase_map(main_summary)
     pr_phases = phase_map(pr_summary)
+    main_step_total = main_summary.get("stepTotalMs")
+    pr_step_total = pr_summary.get("stepTotalMs")
     rows = [
         (
             "prepare release total",
             budget.get("stepTotalMs"),
-            int(main_summary.get("stepTotalMs", 0) or 0),
-            int(pr_summary.get("stepTotalMs", 0) or 0),
+            None if main_step_total is None else int(main_step_total),
+            None if pr_step_total is None else int(pr_step_total),
         )
     ]
     labels = sorted(
@@ -212,15 +241,20 @@ for command_label in ("mc release --dry-run", "mc release"):
 
     sections.append(f"##### `{command_label}`")
     sections.append("")
+    if not main_summary.get("available", True):
+        sections.append(
+            "_`main` does not support `--progress-format json`; phase timings are shown for the PR binary against the configured budgets only._"
+        )
+        sections.append("")
     sections.append("| Phase | Budget [ms] | main [ms] | pr [ms] | Δ pr-main [ms] | Status |")
     sections.append("|:---|---:|---:|---:|---:|:---|")
     for label, budget_ms, main_ms, pr_ms in rows:
         status = status_label(main_ms, pr_ms, budget_ms)
-        if budget_ms is not None and pr_ms > budget_ms:
+        if budget_ms is not None and pr_ms is not None and pr_ms > budget_ms:
             violations += 1
-        budget_text = "n/a" if budget_ms is None else str(int(budget_ms))
+        budget_text = format_ms(budget_ms)
         sections.append(
-            f"| `{label}` | {budget_text} | {main_ms} | {pr_ms} | {delta(pr_ms, main_ms)} | {status} |"
+            f"| `{label}` | {budget_text} | {format_ms(main_ms)} | {format_ms(pr_ms)} | {delta(pr_ms, main_ms)} | {status} |"
         )
     sections.append("")
 
@@ -246,22 +280,32 @@ collect_phase_markdown() {
 	local dry_pr_summary
 	local release_main_summary
 	local release_pr_summary
-	dry_main_events="$(mktemp -t monochange-bench-dry-main.XXXXXX.jsonl)"
-	dry_pr_events="$(mktemp -t monochange-bench-dry-pr.XXXXXX.jsonl)"
-	release_main_events="$(mktemp -t monochange-bench-release-main.XXXXXX.jsonl)"
-	release_pr_events="$(mktemp -t monochange-bench-release-pr.XXXXXX.jsonl)"
 	dry_main_summary="$(mktemp -t monochange-bench-dry-main-summary.XXXXXX.json)"
 	dry_pr_summary="$(mktemp -t monochange-bench-dry-pr-summary.XXXXXX.json)"
 	release_main_summary="$(mktemp -t monochange-bench-release-main-summary.XXXXXX.json)"
 	release_pr_summary="$(mktemp -t monochange-bench-release-pr-summary.XXXXXX.json)"
-	run_phase_capture "$main_bin" "$fixture_dir" "${PHASE_COMMAND_ARGS[0]}" "$dry_main_events"
-	run_phase_capture "$pr_bin" "$fixture_dir" "${PHASE_COMMAND_ARGS[0]}" "$dry_pr_events"
-	run_phase_capture "$main_bin" "$fixture_dir" "${PHASE_COMMAND_ARGS[1]}" "$release_main_events"
-	run_phase_capture "$pr_bin" "$fixture_dir" "${PHASE_COMMAND_ARGS[1]}" "$release_pr_events"
-	summarize_progress_events "$dry_main_events" "$dry_main_summary"
-	summarize_progress_events "$dry_pr_events" "$dry_pr_summary"
-	summarize_progress_events "$release_main_events" "$release_main_summary"
-	summarize_progress_events "$release_pr_events" "$release_pr_summary"
+	if supports_json_progress "$main_bin"; then
+		dry_main_events="$(mktemp -t monochange-bench-dry-main.XXXXXX.jsonl)"
+		release_main_events="$(mktemp -t monochange-bench-release-main.XXXXXX.jsonl)"
+		run_phase_capture "$main_bin" "$fixture_dir" "${PHASE_COMMAND_ARGS[0]}" "$dry_main_events"
+		run_phase_capture "$main_bin" "$fixture_dir" "${PHASE_COMMAND_ARGS[1]}" "$release_main_events"
+		summarize_progress_events "$dry_main_events" "$dry_main_summary"
+		summarize_progress_events "$release_main_events" "$release_main_summary"
+	else
+		write_unavailable_summary "$dry_main_summary"
+		write_unavailable_summary "$release_main_summary"
+	fi
+	if supports_json_progress "$pr_bin"; then
+		dry_pr_events="$(mktemp -t monochange-bench-dry-pr.XXXXXX.jsonl)"
+		release_pr_events="$(mktemp -t monochange-bench-release-pr.XXXXXX.jsonl)"
+		run_phase_capture "$pr_bin" "$fixture_dir" "${PHASE_COMMAND_ARGS[0]}" "$dry_pr_events"
+		run_phase_capture "$pr_bin" "$fixture_dir" "${PHASE_COMMAND_ARGS[1]}" "$release_pr_events"
+		summarize_progress_events "$dry_pr_events" "$dry_pr_summary"
+		summarize_progress_events "$release_pr_events" "$release_pr_summary"
+	else
+		write_unavailable_summary "$dry_pr_summary"
+		write_unavailable_summary "$release_pr_summary"
+	fi
 	render_phase_markdown \
 		"$scenario_id" \
 		"$phase_markdown_path" \

--- a/.github/scripts/benchmark_phase_budgets.json
+++ b/.github/scripts/benchmark_phase_budgets.json
@@ -1,0 +1,60 @@
+{
+	"baseline": {
+		"mc release --dry-run": {
+			"stepTotalMs": 450,
+			"phases": {
+				"discover release workspace": 180,
+				"read changeset files": 120,
+				"parse changeset files": 120,
+				"build release plan": 80,
+				"build manifest updates": 80,
+				"build versioned file updates": 80,
+				"build release targets": 80,
+				"build lockfile refresh plan": 40
+			}
+		},
+		"mc release": {
+			"stepTotalMs": 550,
+			"phases": {
+				"discover release workspace": 180,
+				"read changeset files": 120,
+				"parse changeset files": 120,
+				"build release plan": 80,
+				"build manifest updates": 80,
+				"build versioned file updates": 80,
+				"build release targets": 80,
+				"build lockfile refresh plan": 40,
+				"apply release changes": 160
+			}
+		}
+	},
+	"history_x10": {
+		"mc release --dry-run": {
+			"stepTotalMs": 1600,
+			"phases": {
+				"discover release workspace": 700,
+				"read changeset files": 320,
+				"parse changeset files": 320,
+				"build release plan": 120,
+				"build manifest updates": 180,
+				"build versioned file updates": 180,
+				"build release targets": 180,
+				"build lockfile refresh plan": 80
+			}
+		},
+		"mc release": {
+			"stepTotalMs": 1800,
+			"phases": {
+				"discover release workspace": 700,
+				"read changeset files": 320,
+				"parse changeset files": 320,
+				"build release plan": 120,
+				"build manifest updates": 180,
+				"build versioned file updates": 180,
+				"build release targets": 180,
+				"build lockfile refresh plan": 80,
+				"apply release changes": 260
+			}
+		}
+	}
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,8 @@ jobs:
     if: github.event_name == 'pull_request'
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    continue-on-error: true
+    env:
+      MONOCHANGE_ALLOW_BENCHMARK_BUDGET_FAILURES: "false"
     permissions:
       pull-requests: write
     steps:
@@ -186,17 +187,29 @@ jobs:
           .github/scripts/benchmark_cli.sh run \
             --main-bin /tmp/mc-main \
             --pr-bin /tmp/mc-pr \
-            --output /tmp/benchmark-comment.md
+            --output /tmp/benchmark-comment.md \
+            --violations-output /tmp/benchmark-violations.txt
 
           {
             echo "results<<ENDOFBENCH"
             cat /tmp/benchmark-comment.md
             echo "ENDOFBENCH"
+            echo "violations=$(cat /tmp/benchmark-violations.txt)"
           } >> "$GITHUB_OUTPUT"
         shell: devenv shell -- bash -e {0}
 
       - name: comment benchmark results on PR
+        if: always() && steps.bench.outcome == 'success'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: binary-benchmark
           message: ${{ steps.bench.outputs.results }}
+
+      - name: fail on phase budget regressions
+        if: always() && steps.bench.outcome == 'success' && env.MONOCHANGE_ALLOW_BENCHMARK_BUDGET_FAILURES != 'true'
+        run: |
+          if [ "${{ steps.bench.outputs.violations }}" -gt 0 ]; then
+            echo "benchmark phase budget regressions detected: ${{ steps.bench.outputs.violations }}"
+            exit 1
+          fi
+        shell: devenv shell -- bash -e {0}

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -179,6 +179,7 @@ choices = ["text", "json"]
 default = "text"
 
 [[cli.discover.steps]]
+name = "discover packages"
 type = "Discover"
 
 [cli.release]
@@ -191,15 +192,18 @@ choices = ["text", "json"]
 default = "text"
 
 [[cli.release.steps]]
+name = "prepare release"
 type = "PrepareRelease"
 
 [cli.release-manifest]
 help_text = "Prepare a release and write a stable JSON manifest"
 
 [[cli.release-manifest.steps]]
+name = "prepare release"
 type = "PrepareRelease"
 
 [[cli.release-manifest.steps]]
+name = "render release manifest"
 type = "RenderReleaseManifest"
 path = ".monochange/release-manifest.json"
 
@@ -213,12 +217,15 @@ choices = ["text", "json"]
 default = "text"
 
 [[cli.publish-release.steps]]
+name = "prepare release"
 type = "PrepareRelease"
 
 [[cli.publish-release.steps]]
+name = "publish release"
 type = "PublishRelease"
 
 [[cli.publish-release.steps]]
+name = "comment released issues"
 type = "CommentReleasedIssues"
 
 [cli.release-pr]
@@ -231,9 +238,11 @@ choices = ["text", "json"]
 default = "text"
 
 [[cli.release-pr.steps]]
+name = "prepare release"
 type = "PrepareRelease"
 
 [[cli.release-pr.steps]]
+name = "open release request"
 type = "OpenReleaseRequest"
 
 name = "format"
@@ -267,6 +276,7 @@ name = "label"
 type = "string_list"
 
 [[cli.affected.steps]]
+name = "evaluate affected packages"
 type = "AffectedPackages"
 ```
 
@@ -277,6 +287,7 @@ type = "AffectedPackages"
 - built-in command variables are available directly as `{{ version }}`, `{{ group_version }}`, `{{ released_packages }}`, `{{ changed_files }}`, and `{{ changesets }}`
 - command templates can read CLI inputs through `{{ inputs.name }}`; bare input names still work for backward compatibility
 - every step can override the inputs it receives with `inputs = { ... }`; direct references like `"{{ inputs.labels }}"` preserve list and boolean values when rebinding to built-in steps
+- built-in commands already attach descriptive step `name` labels such as `prepare release` and `publish release`; keep or replace those labels when you want progress output to stay readable
 - custom command variables become available when `variables` is present: map your own names to variables such as `version`, `group_version`, `released_packages`, `changed_files`, and `changesets`
 - `dry_run_command` on a `Command` step replaces `command` only when the CLI command is run with `--dry-run`
 - `shell = true` runs the command through the current shell; the default mode runs the executable directly after shell-style splitting

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -220,6 +220,7 @@ requires = ["main"]
 help_text = "Validate monochange configuration and changesets"
 
 [[cli.validate.steps]]
+name = "validate workspace"
 type = "Validate"
 
 [cli.discover]
@@ -232,6 +233,7 @@ choices = ["text", "json"]
 default = "text"
 
 [[cli.discover.steps]]
+name = "discover packages"
 type = "Discover"
 
 [cli.change]
@@ -273,6 +275,7 @@ name = "output"
 type = "path"
 
 [[cli.change.steps]]
+name = "create change file"
 type = "CreateChangeFile"
 
 [cli.release]
@@ -285,15 +288,18 @@ choices = ["text", "json"]
 default = "text"
 
 [[cli.release.steps]]
+name = "prepare release"
 type = "PrepareRelease"
 
 [cli.release-manifest]
 help_text = "Prepare a release and write a stable JSON manifest"
 
 [[cli.release-manifest.steps]]
+name = "prepare release"
 type = "PrepareRelease"
 
 [[cli.release-manifest.steps]]
+name = "render release manifest"
 type = "RenderReleaseManifest"
 path = ".monochange/release-manifest.json"
 
@@ -307,9 +313,11 @@ choices = ["text", "json"]
 default = "text"
 
 [[cli.publish-release.steps]]
+name = "prepare release"
 type = "PrepareRelease"
 
 [[cli.publish-release.steps]]
+name = "publish release"
 type = "PublishRelease"
 
 [cli.release-pr]
@@ -322,9 +330,11 @@ choices = ["text", "json"]
 default = "text"
 
 [[cli.release-pr.steps]]
+name = "prepare release"
 type = "PrepareRelease"
 
 [[cli.release-pr.steps]]
+name = "open release request"
 type = "OpenReleaseRequest"
 
 name = "format"
@@ -353,6 +363,7 @@ name = "label"
 type = "string_list"
 
 [[cli.affected.steps]]
+name = "evaluate affected packages"
 type = "AffectedPackages"
 ```
 

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -135,6 +135,14 @@ pub(crate) fn build_command_with_cli(
 					.help("Suppress stdout/stderr output and run in dry-run mode when supported")
 					.action(ArgAction::SetTrue),
 			)
+			.arg(
+				Arg::new("progress-format")
+					.long("progress-format")
+					.global(true)
+					.help("Control progress output on stderr")
+					.value_name("FORMAT")
+					.value_parser(["auto", "unicode", "ascii", "json"]),
+			)
 			.subcommand(
 				Command::new("init")
 					.about(

--- a/crates/monochange/src/cli_progress.rs
+++ b/crates/monochange/src/cli_progress.rs
@@ -14,11 +14,14 @@ use std::time::Duration;
 
 use monochange_core::CliCommandDefinition;
 use monochange_core::CliStepDefinition;
+use serde::Serialize;
 
 use crate::StepPhaseTiming;
 
-const SPINNER_FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const UNICODE_SPINNER_FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const ASCII_SPINNER_FRAMES: [&str; 4] = ["-", "\\", "|", "/"];
 const SPINNER_TICK: Duration = Duration::from_millis(90);
+const SPINNER_DELAY: Duration = Duration::from_millis(120);
 const PHASE_TIMING_DETAIL_LIMIT: usize = 5;
 const PHASE_TIMING_MINIMUM: Duration = Duration::from_millis(5);
 
@@ -27,6 +30,69 @@ pub(crate) enum CommandStream {
 	Stdout,
 	Stderr,
 }
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ProgressFormat {
+	Auto,
+	Unicode,
+	Ascii,
+	Json,
+}
+
+impl ProgressFormat {
+	pub(crate) fn parse(value: &str) -> Option<Self> {
+		match value {
+			"auto" => Some(Self::Auto),
+			"unicode" => Some(Self::Unicode),
+			"ascii" => Some(Self::Ascii),
+			"json" => Some(Self::Json),
+			_ => None,
+		}
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ProgressRenderMode {
+	Human,
+	Json,
+}
+
+#[derive(Clone, Copy)]
+struct ProgressSymbols {
+	command_success: &'static str,
+	step_start: &'static str,
+	step_skip: &'static str,
+	step_success: &'static str,
+	step_failure: &'static str,
+	error_branch: &'static str,
+	bullet: &'static str,
+	log_pipe: &'static str,
+	spinner_frames: &'static [&'static str],
+}
+
+const UNICODE_SYMBOLS: ProgressSymbols = ProgressSymbols {
+	command_success: "✓",
+	step_start: "▶",
+	step_skip: "○",
+	step_success: "✔",
+	step_failure: "✖",
+	error_branch: "└─",
+	bullet: "·",
+	log_pipe: "│",
+	spinner_frames: &UNICODE_SPINNER_FRAMES,
+};
+
+const ASCII_SYMBOLS: ProgressSymbols = ProgressSymbols {
+	command_success: "+",
+	step_start: ">",
+	step_skip: "-",
+	step_success: "+",
+	step_failure: "x",
+	error_branch: "`-",
+	bullet: "-",
+	log_pipe: "|",
+	spinner_frames: &ASCII_SPINNER_FRAMES,
+};
 
 #[allow(clippy::struct_excessive_bools)]
 pub(crate) struct CliProgressReporter {
@@ -39,20 +105,50 @@ pub(crate) struct CliProgressReporter {
 	writer_lock: Arc<Mutex<()>>,
 	active_spinner: Option<SpinnerState>,
 	command_started: bool,
+	render_mode: ProgressRenderMode,
+	symbols: ProgressSymbols,
+	event_sequence: u64,
 }
 
 struct SpinnerState {
 	stop: Arc<AtomicBool>,
+	rendered: Arc<AtomicBool>,
 	handle: JoinHandle<()>,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ProgressPhaseTiming {
+	label: String,
+	duration_ms: u64,
+}
+
 impl CliProgressReporter {
-	pub(crate) fn new(cli_command: &CliCommandDefinition, dry_run: bool, quiet: bool) -> Self {
-		let color_enabled = env::var("TERM").is_ok_and(|term| term != "dumb");
-		let enabled =
-			!quiet && io::stderr().is_terminal() && env::var_os("MONOCHANGE_NO_PROGRESS").is_none();
-		let color = enabled && env::var_os("NO_COLOR").is_none() && color_enabled;
-		let animate = enabled && color;
+	pub(crate) fn new(
+		cli_command: &CliCommandDefinition,
+		dry_run: bool,
+		quiet: bool,
+		format: ProgressFormat,
+	) -> Self {
+		let stderr_is_terminal = io::stderr().is_terminal();
+		let color_enabled = stderr_is_terminal && env::var("TERM").is_ok_and(|term| term != "dumb");
+		let no_color = env::var_os("NO_COLOR").is_some();
+		let no_progress = env::var_os("MONOCHANGE_NO_PROGRESS").is_some();
+		let (enabled, render_mode, symbols) = match format {
+			ProgressFormat::Auto => {
+				if quiet || no_progress || !stderr_is_terminal {
+					(false, ProgressRenderMode::Human, UNICODE_SYMBOLS)
+				} else {
+					(true, ProgressRenderMode::Human, UNICODE_SYMBOLS)
+				}
+			}
+			ProgressFormat::Unicode => (!quiet, ProgressRenderMode::Human, UNICODE_SYMBOLS),
+			ProgressFormat::Ascii => (!quiet, ProgressRenderMode::Human, ASCII_SYMBOLS),
+			ProgressFormat::Json => (!quiet, ProgressRenderMode::Json, ASCII_SYMBOLS),
+		};
+		let color =
+			enabled && render_mode == ProgressRenderMode::Human && !no_color && color_enabled;
+		let animate = enabled && render_mode == ProgressRenderMode::Human && stderr_is_terminal;
 		Self {
 			enabled,
 			color,
@@ -63,6 +159,9 @@ impl CliProgressReporter {
 			writer_lock: Arc::new(Mutex::new(())),
 			active_spinner: None,
 			command_started: false,
+			render_mode,
+			symbols,
+			event_sequence: 0,
 		}
 	}
 
@@ -72,6 +171,17 @@ impl CliProgressReporter {
 
 	pub(crate) fn command_started(&mut self) {
 		if !self.enabled || self.command_started {
+			return;
+		}
+		if self.render_mode == ProgressRenderMode::Json {
+			let sequence = self.next_sequence();
+			self.emit_json_event(&serde_json::json!({
+				"sequence": sequence,
+				"event": "command_started",
+				"command": self.command_name,
+				"dryRun": self.dry_run,
+				"totalSteps": self.total_steps,
+			}));
 			return;
 		}
 		let suffix = if self.dry_run { " (dry-run)" } else { "" };
@@ -89,9 +199,21 @@ impl CliProgressReporter {
 			return;
 		}
 		self.stop_spinner();
+		if self.render_mode == ProgressRenderMode::Json {
+			let sequence = self.next_sequence();
+			self.emit_json_event(&serde_json::json!({
+				"sequence": sequence,
+				"event": "command_finished",
+				"command": self.command_name,
+				"dryRun": self.dry_run,
+				"totalSteps": self.total_steps,
+				"durationMs": duration_millis(duration),
+			}));
+			return;
+		}
 		self.print_line(&format!(
 			"{} {} {}",
-			self.paint("✓", Style::Success),
+			self.paint(self.symbols.command_success, Style::Success),
 			self.paint(&format!("`{}` finished", self.command_name), Style::Header),
 			self.paint(&format_duration(duration), Style::Muted),
 		));
@@ -102,11 +224,18 @@ impl CliProgressReporter {
 			return;
 		}
 		self.command_started();
+		if self.render_mode == ProgressRenderMode::Json {
+			self.emit_step_event("step_started", step_index, step, serde_json::Map::new());
+			return;
+		}
 		let message = self.step_message(step_index, step);
 		if self.animate {
 			self.start_spinner(message);
 		} else {
-			self.print_line(&format!("{} {message}", self.paint("▶", Style::Accent)));
+			self.print_line(&format!(
+				"{} {message}",
+				self.paint(self.symbols.step_start, Style::Accent)
+			));
 		}
 	}
 
@@ -121,9 +250,17 @@ impl CliProgressReporter {
 		}
 		self.command_started();
 		self.stop_spinner();
+		if self.render_mode == ProgressRenderMode::Json {
+			let mut payload = serde_json::Map::new();
+			payload.extend(
+				condition.map(|condition| ("condition".to_string(), condition.to_string().into())),
+			);
+			self.emit_step_event("step_skipped", step_index, step, payload);
+			return;
+		}
 		let mut line = format!(
 			"{} {} — {}",
-			self.paint("○", Style::Warning),
+			self.paint(self.symbols.step_skip, Style::Warning),
 			self.step_message(step_index, step),
 			self.paint("skipped", Style::Muted),
 		);
@@ -149,16 +286,40 @@ impl CliProgressReporter {
 		}
 		self.command_started();
 		self.stop_spinner();
+		if self.render_mode == ProgressRenderMode::Json {
+			let mut payload = serde_json::Map::new();
+			payload.insert(
+				"durationMs".to_string(),
+				serde_json::Value::from(duration_millis(duration)),
+			);
+			payload.insert(
+				"phaseTimings".to_string(),
+				serde_json::to_value(
+					phase_timings
+						.iter()
+						.map(|phase| {
+							ProgressPhaseTiming {
+								label: phase.label.clone(),
+								duration_ms: duration_millis(phase.duration),
+							}
+						})
+						.collect::<Vec<_>>(),
+				)
+				.unwrap_or_else(|error| panic!("progress phase timing serialization: {error}")),
+			);
+			self.emit_step_event("step_finished", step_index, step, payload);
+			return;
+		}
 		self.print_line(&format!(
 			"{} {} {}",
-			self.paint("✔", Style::Success),
+			self.paint(self.symbols.step_success, Style::Success),
 			self.step_message(step_index, step),
 			self.paint(&format_duration(duration), Style::Muted),
 		));
 		for phase in summarized_phase_timings(phase_timings) {
 			self.print_line(&format!(
 				"  {} {} {}",
-				self.paint("·", Style::Muted),
+				self.paint(self.symbols.bullet, Style::Muted),
 				self.paint(&phase.label, Style::Detail),
 				self.paint(&format_duration(phase.duration), Style::Muted),
 			));
@@ -177,26 +338,63 @@ impl CliProgressReporter {
 		}
 		self.command_started();
 		self.stop_spinner();
+		if self.render_mode == ProgressRenderMode::Json {
+			let mut payload = serde_json::Map::new();
+			payload.insert(
+				"durationMs".to_string(),
+				serde_json::Value::from(duration_millis(duration)),
+			);
+			payload.insert(
+				"error".to_string(),
+				serde_json::Value::String(error.to_string()),
+			);
+			self.emit_step_event("step_failed", step_index, step, payload);
+			return;
+		}
 		self.print_line(&format!(
 			"{} {} {}",
-			self.paint("✖", Style::Error),
+			self.paint(self.symbols.step_failure, Style::Error),
 			self.step_message(step_index, step),
 			self.paint(&format_duration(duration), Style::Muted),
 		));
-		self.print_line(&format!(
-			"  {} {}",
-			self.paint("└─", Style::Error),
-			self.paint(error, Style::Error),
-		));
+		for (index, line) in error.lines().enumerate() {
+			let branch = if index == 0 {
+				self.symbols.error_branch
+			} else {
+				self.symbols.log_pipe
+			};
+			self.print_line(&format!(
+				"  {} {}",
+				self.paint(branch, Style::Error),
+				self.paint(line, Style::Error),
+			));
+		}
 	}
 
 	pub(crate) fn log_command_output(
 		&mut self,
+		step_index: usize,
 		step: &CliStepDefinition,
 		stream: CommandStream,
 		text: &str,
 	) {
-		if !self.enabled || text.trim().is_empty() {
+		if !self.enabled || text.is_empty() {
+			return;
+		}
+		if self.render_mode == ProgressRenderMode::Json {
+			let mut payload = serde_json::Map::new();
+			payload.insert(
+				"stream".to_string(),
+				serde_json::Value::String(match stream {
+					CommandStream::Stdout => "stdout".to_string(),
+					CommandStream::Stderr => "stderr".to_string(),
+				}),
+			);
+			payload.insert(
+				"text".to_string(),
+				serde_json::Value::String(text.to_string()),
+			);
+			self.emit_step_event("command_output", step_index, step, payload);
 			return;
 		}
 		self.command_started();
@@ -205,10 +403,10 @@ impl CliProgressReporter {
 			CommandStream::Stderr => self.paint("stderr", Style::Warning),
 		};
 		let step_label = step.display_name();
-		for line in text.lines().filter(|line| !line.trim().is_empty()) {
+		for line in text.lines() {
 			self.print_line(&format!(
 				"  {} {} {}",
-				self.paint("│", Style::Muted),
+				self.paint(self.symbols.log_pipe, Style::Muted),
 				self.paint(&format!("{step_label} [{stream_label}]"), Style::Detail),
 				line,
 			));
@@ -237,13 +435,17 @@ impl CliProgressReporter {
 	fn start_spinner(&mut self, message: String) {
 		self.stop_spinner();
 		let stop = Arc::new(AtomicBool::new(false));
+		let rendered = Arc::new(AtomicBool::new(false));
 		let stop_flag = Arc::clone(&stop);
+		let rendered_flag = Arc::clone(&rendered);
 		let writer_lock = Arc::clone(&self.writer_lock);
 		let color = self.color;
+		let spinner_frames = self.symbols.spinner_frames;
 		let handle = thread::spawn(move || {
+			thread::sleep(SPINNER_DELAY);
 			let mut frame_index = 0;
 			while !stop_flag.load(Ordering::Relaxed) {
-				let frame = SPINNER_FRAMES[frame_index % SPINNER_FRAMES.len()];
+				let frame = spinner_frames[frame_index % spinner_frames.len()];
 				with_stderr_lock(&writer_lock, || {
 					eprint!(
 						"\r\u{1b}[2K{} {}",
@@ -252,11 +454,16 @@ impl CliProgressReporter {
 					);
 					let _ = io::stderr().flush();
 				});
+				rendered_flag.store(true, Ordering::Relaxed);
 				thread::sleep(SPINNER_TICK);
 				frame_index += 1;
 			}
 		});
-		self.active_spinner = Some(SpinnerState { stop, handle });
+		self.active_spinner = Some(SpinnerState {
+			stop,
+			rendered,
+			handle,
+		});
 	}
 
 	fn stop_spinner(&mut self) {
@@ -265,10 +472,12 @@ impl CliProgressReporter {
 		};
 		spinner.stop.store(true, Ordering::Relaxed);
 		let _ = spinner.handle.join();
-		with_stderr_lock(&self.writer_lock, || {
-			eprint!("\r\u{1b}[2K");
-			let _ = io::stderr().flush();
-		});
+		if spinner.rendered.load(Ordering::Relaxed) {
+			with_stderr_lock(&self.writer_lock, || {
+				eprint!("\r\u{1b}[2K");
+				let _ = io::stderr().flush();
+			});
+		}
 	}
 
 	fn print_line(&self, text: &str) {
@@ -281,6 +490,68 @@ impl CliProgressReporter {
 
 	fn paint(&self, text: &str, style: Style) -> String {
 		paint_text(text, style, self.color)
+	}
+
+	fn next_sequence(&mut self) -> u64 {
+		let current = self.event_sequence;
+		self.event_sequence += 1;
+		current
+	}
+
+	fn emit_step_event(
+		&mut self,
+		event: &str,
+		step_index: usize,
+		step: &CliStepDefinition,
+		mut payload: serde_json::Map<String, serde_json::Value>,
+	) {
+		payload.insert(
+			"sequence".to_string(),
+			serde_json::Value::from(self.next_sequence()),
+		);
+		payload.insert(
+			"event".to_string(),
+			serde_json::Value::String(event.to_string()),
+		);
+		payload.insert(
+			"command".to_string(),
+			serde_json::Value::String(self.command_name.clone()),
+		);
+		payload.insert("dryRun".to_string(), serde_json::Value::Bool(self.dry_run));
+		payload.insert(
+			"stepIndex".to_string(),
+			serde_json::Value::from(step_index + 1),
+		);
+		payload.insert(
+			"totalSteps".to_string(),
+			serde_json::Value::from(self.total_steps),
+		);
+		payload.insert(
+			"stepKind".to_string(),
+			serde_json::Value::String(step.kind_name().to_string()),
+		);
+		payload.insert(
+			"stepDisplayName".to_string(),
+			serde_json::Value::String(step.display_name().to_string()),
+		);
+		payload.insert(
+			"stepName".to_string(),
+			step.name().map_or(serde_json::Value::Null, |name| {
+				serde_json::Value::String(name.to_string())
+			}),
+		);
+		self.emit_json_event(&serde_json::Value::Object(payload));
+	}
+
+	fn emit_json_event(&self, value: &serde_json::Value) {
+		with_stderr_lock(&self.writer_lock, || {
+			eprintln!(
+				"{}",
+				serde_json::to_string(&value)
+					.unwrap_or_else(|error| panic!("progress json event serialization: {error}"))
+			);
+			let _ = io::stderr().flush();
+		});
 	}
 }
 
@@ -339,6 +610,10 @@ fn format_duration(duration: Duration) -> String {
 	format!("{}µs", duration.as_micros())
 }
 
+fn duration_millis(duration: Duration) -> u64 {
+	u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
 fn summarized_phase_timings(phase_timings: &[StepPhaseTiming]) -> Vec<StepPhaseTiming> {
 	let mut phase_timings = phase_timings
 		.iter()
@@ -358,6 +633,7 @@ mod tests {
 	use std::thread;
 	use std::time::Duration;
 
+	use monochange_core::CliCommandDefinition;
 	use monochange_core::CliStepDefinition;
 	use monochange_core::ShellConfig;
 
@@ -374,6 +650,9 @@ mod tests {
 			writer_lock: Arc::new(Mutex::new(())),
 			active_spinner: None,
 			command_started: false,
+			render_mode: ProgressRenderMode::Human,
+			symbols: UNICODE_SYMBOLS,
+			event_sequence: 0,
 		}
 	}
 
@@ -388,6 +667,15 @@ mod tests {
 			id: None,
 			variables: None,
 			inputs: BTreeMap::new(),
+		}
+	}
+
+	fn command_with_step(step: CliStepDefinition) -> CliCommandDefinition {
+		CliCommandDefinition {
+			name: "release".to_string(),
+			help_text: Some("release".to_string()),
+			inputs: Vec::new(),
+			steps: vec![step],
 		}
 	}
 
@@ -428,13 +716,54 @@ mod tests {
 	}
 
 	#[test]
+	fn progress_format_parsing_and_renderer_selection_cover_all_variants() {
+		let command = command_with_step(named_command_step("announce release"));
+		assert_eq!(ProgressFormat::parse("auto"), Some(ProgressFormat::Auto));
+		assert_eq!(
+			ProgressFormat::parse("unicode"),
+			Some(ProgressFormat::Unicode)
+		);
+		assert_eq!(ProgressFormat::parse("ascii"), Some(ProgressFormat::Ascii));
+		assert_eq!(ProgressFormat::parse("json"), Some(ProgressFormat::Json));
+		assert_eq!(ProgressFormat::parse("wat"), None);
+
+		let unicode = CliProgressReporter::new(&command, false, false, ProgressFormat::Unicode);
+		assert!(unicode.enabled);
+		assert_eq!(unicode.render_mode, ProgressRenderMode::Human);
+		assert_eq!(
+			unicode.symbols.command_success,
+			UNICODE_SYMBOLS.command_success
+		);
+
+		let ascii = CliProgressReporter::new(&command, false, false, ProgressFormat::Ascii);
+		assert!(ascii.enabled);
+		assert_eq!(ascii.render_mode, ProgressRenderMode::Human);
+		assert_eq!(ascii.symbols.command_success, ASCII_SYMBOLS.command_success);
+
+		let json = CliProgressReporter::new(&command, false, false, ProgressFormat::Json);
+		assert!(json.enabled);
+		assert_eq!(json.render_mode, ProgressRenderMode::Json);
+		assert_eq!(json.symbols.command_success, ASCII_SYMBOLS.command_success);
+	}
+
+	#[test]
 	fn progress_reporter_renders_skips_failures_and_stderr_output_when_enabled() {
 		let mut reporter = progress_reporter(true, false);
 		let step = named_command_step("announce release");
 
 		reporter.step_skipped(0, &step, None);
 		reporter.step_skipped(0, &step, Some("{{ false }}"));
-		reporter.log_command_output(&step, CommandStream::Stderr, "warn line\n");
+		reporter.log_command_output(0, &step, CommandStream::Stderr, "warn line\n");
+		reporter.step_failed(1, &step, Duration::from_millis(25), "boom\nagain");
+	}
+
+	#[test]
+	fn progress_reporter_emits_json_skip_and_failure_events() {
+		let mut reporter = progress_reporter(true, false);
+		reporter.render_mode = ProgressRenderMode::Json;
+		let step = named_command_step("announce release");
+
+		reporter.step_skipped(0, &step, Some("{{ false }}"));
 		reporter.step_failed(1, &step, Duration::from_millis(25), "boom");
 	}
 

--- a/crates/monochange/src/cli_progress.rs
+++ b/crates/monochange/src/cli_progress.rs
@@ -173,6 +173,7 @@ impl CliProgressReporter {
 		if !self.enabled || self.command_started {
 			return;
 		}
+		self.command_started = true;
 		if self.render_mode == ProgressRenderMode::Json {
 			let sequence = self.next_sequence();
 			self.emit_json_event(&serde_json::json!({
@@ -191,7 +192,6 @@ impl CliProgressReporter {
 			self.paint(&format!("running `{}`", self.command_name), Style::Header),
 			suffix,
 		));
-		self.command_started = true;
 	}
 
 	pub(crate) fn command_finished(&mut self, duration: Duration) {

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -479,12 +479,12 @@ pub(crate) fn execute_cli_command_with_options(
 		retarget_report: None,
 		step_outputs: BTreeMap::new(),
 		command_logs: Vec::new(),
-		};
-		let mut output = None;
-		let command_started_at = Instant::now();
-		let mut progress = CliProgressReporter::new(cli_command, dry_run, quiet, progress_format);
+	};
+	let mut output = None;
+	let command_started_at = Instant::now();
+	let mut progress = CliProgressReporter::new(cli_command, dry_run, quiet, progress_format);
 
-		for (step_index, step) in cli_command.steps.iter().enumerate() {
+	for (step_index, step) in cli_command.steps.iter().enumerate() {
 		let step_started_at = Instant::now();
 		let step_inputs = resolve_step_inputs(&context, step)?;
 		context.last_step_inputs = step_inputs.clone();
@@ -1183,18 +1183,18 @@ fn run_cli_command_command(
 	};
 	process_command.current_dir(&context.root);
 
-		let output = if progress.is_enabled() && show_progress {
-			let streamed_output = run_process_with_streaming(
-				&mut process_command,
-				progress,
-				step_index,
-				step,
-				&interpolated,
-			);
-			streamed_output?
-		} else {
-			let output = process_command.output().map_err(|error| {
-				MonochangeError::Io(format!("failed to run command `{interpolated}`: {error}"))
+	let output = if progress.is_enabled() && show_progress {
+		let streamed_output = run_process_with_streaming(
+			&mut process_command,
+			progress,
+			step_index,
+			step,
+			&interpolated,
+		);
+		streamed_output?
+	} else {
+		let output = process_command.output().map_err(|error| {
+			MonochangeError::Io(format!("failed to run command `{interpolated}`: {error}"))
 		})?;
 		PreparedProcessOutput {
 			status: output.status,
@@ -2462,6 +2462,7 @@ mod tests {
 			when: None,
 			command: "printf 'streamed line\\n'".to_string(),
 			dry_run_command: None,
+			show_progress: None,
 			shell: ShellConfig::Default,
 			id: Some("stream".to_string()),
 			variables: None,
@@ -2481,6 +2482,7 @@ mod tests {
 			&step,
 			0,
 			&mut progress,
+			true,
 			CommandStepOptions {
 				command: "printf 'streamed line\\n'",
 				dry_run_command: None,

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -34,6 +34,7 @@ use monochange_core::SourceReleaseRequest;
 use crate::cli::command_supports_release_diff_preview;
 use crate::cli_progress::CliProgressReporter;
 use crate::cli_progress::CommandStream;
+use crate::cli_progress::ProgressFormat;
 use crate::*;
 
 pub(crate) fn execute_matches(
@@ -56,20 +57,51 @@ pub(crate) fn execute_matches(
 	let dry_run = quiet || cli_command_matches.get_flag("dry-run");
 	let show_diff =
 		command_supports_release_diff_preview(cli_command) && cli_command_matches.get_flag("diff");
+	let progress_format = cli_command_matches
+		.get_one::<String>("progress-format")
+		.map_or_else(
+			|| {
+				std::env::var("MONOCHANGE_PROGRESS_FORMAT")
+					.ok()
+					.map_or(Ok(ProgressFormat::Auto), |value| {
+						parse_progress_format(&value)
+					})
+			},
+			|value| parse_progress_format(value),
+		)?;
 	let inputs = collect_cli_command_inputs(cli_command, cli_command_matches);
 	if show_diff {
 		execute_cli_command_with_options(
 			root,
 			configuration,
 			cli_command,
-			dry_run,
-			quiet,
-			true,
-			inputs,
+			ExecuteCliCommandOptions {
+				dry_run,
+				quiet,
+				show_diff: true,
+				inputs,
+				progress_format,
+			},
 		)
 	} else {
-		execute_cli_command_quiet(root, configuration, cli_command, dry_run, quiet, inputs)
+		execute_cli_command_quiet(
+			root,
+			configuration,
+			cli_command,
+			dry_run,
+			quiet,
+			inputs,
+			progress_format,
+		)
 	}
+}
+
+fn parse_progress_format(value: &str) -> MonochangeResult<ProgressFormat> {
+	ProgressFormat::parse(value).ok_or_else(|| {
+		MonochangeError::Config(format!(
+			"unknown progress format `{value}`; expected one of: auto, unicode, ascii, json"
+		))
+	})
 }
 
 pub(crate) fn collect_cli_command_inputs(
@@ -369,7 +401,15 @@ pub(crate) fn execute_cli_command(
 	dry_run: bool,
 	inputs: BTreeMap<String, Vec<String>>,
 ) -> MonochangeResult<String> {
-	execute_cli_command_quiet(root, configuration, cli_command, dry_run, false, inputs)
+	execute_cli_command_quiet(
+		root,
+		configuration,
+		cli_command,
+		dry_run,
+		false,
+		inputs,
+		ProgressFormat::Auto,
+	)
 }
 
 fn execute_cli_command_quiet(
@@ -379,16 +419,28 @@ fn execute_cli_command_quiet(
 	dry_run: bool,
 	quiet: bool,
 	inputs: BTreeMap<String, Vec<String>>,
+	progress_format: ProgressFormat,
 ) -> MonochangeResult<String> {
 	execute_cli_command_with_options(
 		root,
 		configuration,
 		cli_command,
-		dry_run,
-		quiet,
-		false,
-		inputs,
+		ExecuteCliCommandOptions {
+			dry_run,
+			quiet,
+			show_diff: false,
+			inputs,
+			progress_format,
+		},
 	)
+}
+
+pub(crate) struct ExecuteCliCommandOptions {
+	dry_run: bool,
+	quiet: bool,
+	show_diff: bool,
+	inputs: BTreeMap<String, Vec<String>>,
+	progress_format: ProgressFormat,
 }
 
 #[tracing::instrument(skip_all, fields(command = cli_command.name))]
@@ -396,11 +448,15 @@ pub(crate) fn execute_cli_command_with_options(
 	root: &Path,
 	configuration: &monochange_core::WorkspaceConfiguration,
 	cli_command: &CliCommandDefinition,
-	dry_run: bool,
-	quiet: bool,
-	show_diff: bool,
-	inputs: BTreeMap<String, Vec<String>>,
+	options: ExecuteCliCommandOptions,
 ) -> MonochangeResult<String> {
+	let ExecuteCliCommandOptions {
+		dry_run,
+		quiet,
+		show_diff,
+		inputs,
+		progress_format,
+	} = options;
 	let mut context = CliContext {
 		root: root.to_path_buf(),
 		dry_run,
@@ -423,12 +479,12 @@ pub(crate) fn execute_cli_command_with_options(
 		retarget_report: None,
 		step_outputs: BTreeMap::new(),
 		command_logs: Vec::new(),
-	};
-	let mut output = None;
-	let command_started_at = Instant::now();
-	let mut progress = CliProgressReporter::new(cli_command, dry_run, quiet);
+		};
+		let mut output = None;
+		let command_started_at = Instant::now();
+		let mut progress = CliProgressReporter::new(cli_command, dry_run, quiet, progress_format);
 
-	for (step_index, step) in cli_command.steps.iter().enumerate() {
+		for (step_index, step) in cli_command.steps.iter().enumerate() {
 		let step_started_at = Instant::now();
 		let step_inputs = resolve_step_inputs(&context, step)?;
 		context.last_step_inputs = step_inputs.clone();
@@ -788,6 +844,7 @@ pub(crate) fn execute_cli_command_with_options(
 					run_cli_command_command(
 						&mut context,
 						step,
+						step_index,
 						&mut progress,
 						show_progress,
 						CommandStepOptions {
@@ -1078,6 +1135,7 @@ fn step_shows_progress(
 fn run_cli_command_command(
 	context: &mut CliContext,
 	step: &CliStepDefinition,
+	step_index: usize,
 	progress: &mut CliProgressReporter,
 	show_progress: bool,
 	options: CommandStepOptions<'_>,
@@ -1125,11 +1183,18 @@ fn run_cli_command_command(
 	};
 	process_command.current_dir(&context.root);
 
-	let output = if progress.is_enabled() && show_progress {
-		run_process_with_streaming(&mut process_command, progress, step, &interpolated)?
-	} else {
-		let output = process_command.output().map_err(|error| {
-			MonochangeError::Io(format!("failed to run command `{interpolated}`: {error}"))
+		let output = if progress.is_enabled() && show_progress {
+			let streamed_output = run_process_with_streaming(
+				&mut process_command,
+				progress,
+				step_index,
+				step,
+				&interpolated,
+			);
+			streamed_output?
+		} else {
+			let output = process_command.output().map_err(|error| {
+				MonochangeError::Io(format!("failed to run command `{interpolated}`: {error}"))
 		})?;
 		PreparedProcessOutput {
 			status: output.status,
@@ -1185,6 +1250,7 @@ enum StreamEvent {
 fn run_process_with_streaming(
 	process_command: &mut ProcessCommand,
 	progress: &mut CliProgressReporter,
+	step_index: usize,
 	step: &CliStepDefinition,
 	interpolated: &str,
 ) -> MonochangeResult<PreparedProcessOutput> {
@@ -1198,7 +1264,7 @@ fn run_process_with_streaming(
 	let (sender, receiver) = mpsc::channel();
 	let stdout_handle = spawn_stream_reader(stdout, CommandStream::Stdout, sender.clone());
 	let stderr_handle = spawn_stream_reader(stderr, CommandStream::Stderr, sender);
-	let (stdout_buffer, stderr_buffer) = drain_stream_events(&receiver, progress, step);
+	let (stdout_buffer, stderr_buffer) = drain_stream_events(&receiver, progress, step_index, step);
 	let status = map_process_wait_result(child.wait(), interpolated)?;
 	let _ = stdout_handle.join();
 	let _ = stderr_handle.join();
@@ -1233,6 +1299,7 @@ fn take_process_stream<T>(
 fn drain_stream_events(
 	receiver: &mpsc::Receiver<StreamEvent>,
 	progress: &mut CliProgressReporter,
+	step_index: usize,
 	step: &CliStepDefinition,
 ) -> (Vec<u8>, Vec<u8>) {
 	let mut stdout_buffer = Vec::new();
@@ -1246,7 +1313,12 @@ fn drain_stream_events(
 					CommandStream::Stdout => stdout_buffer.extend_from_slice(&chunk),
 					CommandStream::Stderr => stderr_buffer.extend_from_slice(&chunk),
 				}
-				progress.log_command_output(step, stream, String::from_utf8_lossy(&chunk).as_ref());
+				progress.log_command_output(
+					step_index,
+					step,
+					stream,
+					String::from_utf8_lossy(&chunk).as_ref(),
+				);
 			}
 			Ok(StreamEvent::Closed(stream)) => {
 				match stream {
@@ -2233,7 +2305,10 @@ mod tests {
 	use std::path::PathBuf;
 	use std::sync::mpsc;
 
+	use monochange_config::load_workspace_configuration;
 	use monochange_core::CliCommandDefinition;
+	use monochange_core::CliStepDefinition;
+	use monochange_core::ShellConfig;
 	use tempfile::tempdir;
 
 	use super::*;
@@ -2262,6 +2337,17 @@ mod tests {
 			step_outputs: BTreeMap::new(),
 			command_logs: Vec::new(),
 		}
+	}
+
+	fn parse_validate_matches(
+		root: &Path,
+	) -> (monochange_core::WorkspaceConfiguration, ArgMatches) {
+		let configuration = load_workspace_configuration(root)
+			.unwrap_or_else(|error| panic!("workspace configuration: {error}"));
+		let matches = build_command_with_cli("mc", &configuration.cli)
+			.try_get_matches_from(["mc", "validate"])
+			.unwrap_or_else(|error| panic!("validate matches: {error}"));
+		(configuration, matches)
 	}
 
 	#[test]
@@ -2327,6 +2413,96 @@ mod tests {
 	}
 
 	#[test]
+	fn execute_matches_uses_progress_format_from_environment_and_rejects_invalid_values() {
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+
+		temp_env::with_var("MONOCHANGE_PROGRESS_FORMAT", Some("json"), || {
+			let (configuration, matches) = parse_validate_matches(tempdir.path());
+			let validate_matches = matches
+				.subcommand_matches("validate")
+				.unwrap_or_else(|| panic!("validate subcommand matches"));
+			execute_matches(
+				tempdir.path(),
+				&configuration,
+				"validate",
+				validate_matches,
+				false,
+			)
+			.unwrap_or_else(|error| panic!("validate with env progress format: {error}"));
+		});
+
+		temp_env::with_var("MONOCHANGE_PROGRESS_FORMAT", Some("wat"), || {
+			let (configuration, matches) = parse_validate_matches(tempdir.path());
+			let validate_matches = matches
+				.subcommand_matches("validate")
+				.unwrap_or_else(|| panic!("validate subcommand matches"));
+			let error = execute_matches(
+				tempdir.path(),
+				&configuration,
+				"validate",
+				validate_matches,
+				false,
+			)
+			.unwrap_err();
+			assert_eq!(
+				error.to_string(),
+				"config error: unknown progress format `wat`; expected one of: auto, unicode, ascii, json"
+			);
+		});
+	}
+
+	#[test]
+	fn run_cli_command_command_streams_output_when_progress_is_enabled() {
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let mut context = cli_context();
+		context.root = tempdir.path().to_path_buf();
+		let step_inputs = BTreeMap::new();
+		let step = CliStepDefinition::Command {
+			name: Some("announce release".to_string()),
+			when: None,
+			command: "printf 'streamed line\\n'".to_string(),
+			dry_run_command: None,
+			shell: ShellConfig::Default,
+			id: Some("stream".to_string()),
+			variables: None,
+			inputs: BTreeMap::new(),
+		};
+		let cli_command = CliCommandDefinition {
+			name: "release".to_string(),
+			help_text: Some("release".to_string()),
+			inputs: Vec::new(),
+			steps: vec![step.clone()],
+		};
+		let mut progress =
+			CliProgressReporter::new(&cli_command, false, false, ProgressFormat::Json);
+
+		run_cli_command_command(
+			&mut context,
+			&step,
+			0,
+			&mut progress,
+			CommandStepOptions {
+				command: "printf 'streamed line\\n'",
+				dry_run_command: None,
+				shell: &ShellConfig::Default,
+				step_id: Some("stream"),
+				variables: None,
+				step_inputs: &step_inputs,
+			},
+		)
+		.unwrap_or_else(|error| panic!("streaming command step: {error}"));
+
+		assert_eq!(context.command_logs, vec!["streamed line".to_string()]);
+		assert_eq!(
+			context
+				.step_outputs
+				.get("stream")
+				.map(|output| output.stdout.as_str()),
+			Some("streamed line")
+		);
+	}
+
+	#[test]
 	fn take_process_stream_reports_missing_pipes() {
 		let error = take_process_stream::<Vec<u8>>(None, "stdout", "echo hello").unwrap_err();
 		assert_eq!(
@@ -2374,7 +2550,8 @@ mod tests {
 			inputs: Vec::new(),
 			steps: Vec::new(),
 		};
-		let mut progress = CliProgressReporter::new(&cli_command, false, false);
+		let mut progress =
+			CliProgressReporter::new(&cli_command, false, false, ProgressFormat::Auto);
 		let step = CliStepDefinition::Command {
 			show_progress: None,
 			name: Some("stream output".to_string()),
@@ -2406,13 +2583,13 @@ mod tests {
 			.send(StreamEvent::Closed(CommandStream::Stderr))
 			.unwrap_or_else(|error| panic!("close stderr: {error}"));
 		drop(sender);
-		let (stdout, stderr) = drain_stream_events(&receiver, &mut progress, &step);
+		let (stdout, stderr) = drain_stream_events(&receiver, &mut progress, 0, &step);
 		assert_eq!(stdout, b"hello\n");
 		assert_eq!(stderr, b"warn\n");
 
 		let (sender, receiver) = mpsc::channel();
 		drop(sender);
-		let (stdout, stderr) = drain_stream_events(&receiver, &mut progress, &step);
+		let (stdout, stderr) = drain_stream_events(&receiver, &mut progress, 0, &step);
 		assert!(stdout.is_empty());
 		assert!(stderr.is_empty());
 	}

--- a/crates/monochange/src/monochange.init.toml
+++ b/crates/monochange/src/monochange.init.toml
@@ -587,14 +587,14 @@ comment_on_failure = true
 
 [cli.validate]
 help_text = "Validate monochange configuration and changesets"
-steps = [{ type = "Validate" }]
+steps = [{ name = "validate workspace", type = "Validate" }]
 
 [cli.discover]
 help_text = "Discover packages across supported ecosystems"
 inputs = [
 	{ name = "format", type = "choice", choices = ["text", "json"], default = "text" },
 ]
-steps = [{ type = "Discover" }]
+steps = [{ name = "discover packages", type = "Discover" }]
 
 [cli.change]
 help_text = "Create a change file for one or more packages"
@@ -606,14 +606,14 @@ inputs = [
 	{ name = "details", type = "string" },
 	{ name = "output", type = "path" },
 ]
-steps = [{ type = "CreateChangeFile" }]
+steps = [{ name = "create change file", type = "CreateChangeFile" }]
 
 [cli.release]
 help_text = "Prepare a release from discovered change files"
 inputs = [
 	{ name = "format", type = "choice", choices = ["markdown", "text", "json"], default = "markdown" },
 ]
-steps = [{ type = "PrepareRelease" }]
+steps = [{ name = "prepare release", type = "PrepareRelease" }]
 
 [cli.affected]
 help_text = "Evaluate pull-request changeset policy"
@@ -625,7 +625,7 @@ inputs = [
 {% raw -%}
 # Step inputs example: { changed_paths = "{{ inputs.changed_paths }}", label = "{{ inputs.label }}", verify = true }
 {% endraw -%}
-steps = [{ type = "AffectedPackages" }]
+steps = [{ name = "evaluate affected packages", type = "AffectedPackages" }]
 
 [cli.diagnostics]
 help_text = "Show changeset diagnostics and context"
@@ -633,7 +633,7 @@ inputs = [
 	{ name = "format", type = "choice", choices = ["text", "json"], default = "text" },
 	{ name = "changeset", type = "string_list", help_text = "changeset path(s), e.g. .changeset/feature.md (omit for all changesets)" },
 ]
-steps = [{ type = "DiagnoseChangesets" }]
+steps = [{ name = "diagnose changesets", type = "DiagnoseChangesets" }]
 
 [cli.repair-release]
 help_text = "Repair a recent release by moving its release tags to a later commit"
@@ -644,4 +644,4 @@ inputs = [
 	{ name = "sync_provider", type = "boolean", help_text = "sync hosted release state after tag movement (disable with --sync-provider=false)", default = "true" },
 	{ name = "format", type = "choice", choices = ["text", "json"], default = "text" },
 ]
-steps = [{ type = "RetargetRelease" }]
+steps = [{ name = "retarget release", type = "RetargetRelease" }]

--- a/crates/monochange/tests/cli_progress.rs
+++ b/crates/monochange/tests/cli_progress.rs
@@ -330,7 +330,7 @@ sys.exit(0)
 		.unwrap_or_else(|error| panic!("parse tty exit status: {error}\n{stderr}"));
 	let transcript = String::from_utf8(output.stdout)
 		.unwrap_or_else(|error| panic!("interactive tty output utf8: {error}"));
-	(status_code, normalize_tty_transcript(&transcript))
+	(status_code, normalize_terminal_transcript(&transcript))
 }
 
 #[cfg(not(unix))]

--- a/crates/monochange/tests/cli_progress.rs
+++ b/crates/monochange/tests/cli_progress.rs
@@ -1,13 +1,133 @@
+use std::fmt::Write as _;
 use std::fs;
 use std::path::Path;
 
+use insta::assert_json_snapshot;
+use insta::assert_snapshot;
+use regex::Regex;
+use serde_json::Value;
+
 mod test_support;
+use test_support::current_test_name;
+use test_support::monochange_command;
 use test_support::setup_fixture;
+use test_support::snapshot_settings;
 
 const EXIT_STATUS_MARKER: &str = "__MC_EXIT_STATUS__=";
 
-#[cfg(unix)]
-fn normalize_tty_transcript(text: &str) -> String {
+fn append_progress_command(workspace: &Path, command_name: &str, body: &str) {
+	let config_path = workspace.join("monochange.toml");
+	let mut config = fs::read_to_string(&config_path)
+		.unwrap_or_else(|error| panic!("read monochange.toml: {error}"));
+	let _ = write!(
+		config,
+		r#"
+
+[cli.{command_name}]
+help_text = "Exercise progress output"
+{body}
+"#
+	);
+	fs::write(&config_path, config)
+		.unwrap_or_else(|error| panic!("write monochange.toml: {error}"));
+}
+
+fn normalize_duration_text(text: &str) -> String {
+	let duration_pattern = Regex::new(r"\b\d+(?:\.\d+)?(?:ms|s|µs)\b")
+		.unwrap_or_else(|error| panic!("regex: {error}"));
+	duration_pattern
+		.replace_all(text, "[duration]")
+		.into_owned()
+}
+
+fn normalized_ascii_progress(stderr: &str) -> String {
+	let normalized = normalize_duration_text(&normalize_terminal_transcript(stderr));
+	normalized
+		.lines()
+		.filter(|line| !line.starts_with("  - "))
+		.collect::<Vec<_>>()
+		.join("\n")
+}
+
+fn normalized_progress_events(stderr: &str) -> Vec<Value> {
+	let mut events = stderr
+		.lines()
+		.filter(|line| !line.trim().is_empty())
+		.map(|line| {
+			serde_json::from_str::<Value>(line)
+				.unwrap_or_else(|error| panic!("parse progress event `{line}`: {error}"))
+		})
+		.collect::<Vec<_>>();
+	for event in &mut events {
+		let Some(object) = event.as_object_mut() else {
+			panic!("progress event should be an object: {event}");
+		};
+		if let Some(duration) = object.get_mut("durationMs") {
+			*duration = Value::String("[duration_ms]".to_string());
+		}
+		if let Some(phase_timings) = object.get_mut("phaseTimings").and_then(Value::as_array_mut) {
+			for phase in phase_timings {
+				if let Some(duration) = phase.get_mut("durationMs") {
+					*duration = Value::String("[duration_ms]".to_string());
+				}
+			}
+		}
+	}
+	let mut normalized = Vec::with_capacity(events.len());
+	let mut index = 0;
+	while index < events.len() {
+		if events[index].get("event").and_then(Value::as_str) != Some("command_output") {
+			normalized.push(events[index].clone());
+			index += 1;
+			continue;
+		}
+		let start = index;
+		while index < events.len()
+			&& events[index].get("event").and_then(Value::as_str) == Some("command_output")
+		{
+			index += 1;
+		}
+		let mut output_events = events[start..index].to_vec();
+		output_events.sort_by(|left, right| {
+			let left_key = (
+				left.get("stepIndex")
+					.and_then(Value::as_u64)
+					.unwrap_or_default(),
+				left.get("stream")
+					.and_then(Value::as_str)
+					.unwrap_or_default(),
+				left.get("text").and_then(Value::as_str).unwrap_or_default(),
+			);
+			let right_key = (
+				right
+					.get("stepIndex")
+					.and_then(Value::as_u64)
+					.unwrap_or_default(),
+				right
+					.get("stream")
+					.and_then(Value::as_str)
+					.unwrap_or_default(),
+				right
+					.get("text")
+					.and_then(Value::as_str)
+					.unwrap_or_default(),
+			);
+			left_key.cmp(&right_key)
+		});
+		normalized.extend(output_events);
+	}
+	for (sequence, event) in normalized.iter_mut().enumerate() {
+		if let Some(object) = event.as_object_mut() {
+			object.insert(
+				"sequence".to_string(),
+				Value::String(format!("[sequence:{sequence}]")),
+			);
+		}
+	}
+	normalized
+}
+
+fn normalize_terminal_transcript(text: &str) -> String {
 	let mut normalized = String::with_capacity(text.len());
 	let mut chars = text.chars().peekable();
 	while let Some(ch) = chars.next() {
@@ -107,7 +227,7 @@ sys.exit(0)
 		.unwrap_or_else(|error| panic!("parse tty exit status: {error}\n{stderr}"));
 	let transcript =
 		String::from_utf8(output.stdout).unwrap_or_else(|error| panic!("tty output utf8: {error}"));
-	(status_code, normalize_tty_transcript(&transcript))
+	(status_code, normalize_terminal_transcript(&transcript))
 }
 
 #[cfg(unix)]
@@ -222,22 +342,16 @@ fn run_tty_command(_workspace: &Path, _command_name: &str) -> String {
 #[cfg(unix)]
 fn release_progress_streams_named_steps_on_tty() {
 	let tempdir = setup_fixture("monochange/release-base");
-	let config_path = tempdir.path().join("monochange.toml");
-	let mut config = fs::read_to_string(&config_path)
-		.unwrap_or_else(|error| panic!("read monochange.toml: {error}"));
-	config.push_str(
+	append_progress_command(
+		tempdir.path(),
+		"progress-release",
 		r#"
-
-[cli.progress-release]
-help_text = "Prepare a release with progress output"
 steps = [
 	{ type = "PrepareRelease", name = "plan release" },
 	{ type = "Command", name = "stream summary", shell = true, command = "printf 'streamed line 1\n'; sleep 0.1; printf 'streamed line 2\n'" },
 ]
-"#,
+	"#,
 	);
-	fs::write(&config_path, config)
-		.unwrap_or_else(|error| panic!("write monochange.toml: {error}"));
 
 	let transcript = run_tty_command(tempdir.path(), "progress-release");
 
@@ -253,23 +367,17 @@ steps = [
 #[cfg(unix)]
 fn release_progress_renders_skipped_failed_steps_and_stderr_on_tty() {
 	let tempdir = setup_fixture("monochange/release-base");
-	let config_path = tempdir.path().join("monochange.toml");
-	let mut config = fs::read_to_string(&config_path)
-		.unwrap_or_else(|error| panic!("read monochange.toml: {error}"));
-	config.push_str(
+	append_progress_command(
+		tempdir.path(),
+		"progress-failure",
 		r#"
-
-[cli.progress-failure]
-help_text = "Exercise skipped and failed progress output"
 steps = [
 	{ type = "Validate", name = "skip validate", when = "{{ false }}" },
 	{ type = "Command", name = "stderr only", shell = true, command = "printf 'warn line\n' >&2" },
 	{ type = "Command", name = "fail loud", shell = true, command = "printf 'bad line\n' >&2; exit 3" },
 ]
-"#,
+	"#,
 	);
-	fs::write(&config_path, config)
-		.unwrap_or_else(|error| panic!("write monochange.toml: {error}"));
 
 	let (status, transcript) = run_tty_command_result(tempdir.path(), "progress-failure");
 
@@ -301,6 +409,78 @@ fn interactive_change_cli_hides_progress_output_on_tty() {
 		output_path.exists(),
 		"interactive change file should be created"
 	);
+}
+
+#[test]
+fn ascii_progress_renders_clean_captured_output() {
+	let mut settings = snapshot_settings();
+	settings.set_snapshot_suffix(current_test_name());
+	let _guard = settings.bind_to_scope();
+
+	let tempdir = setup_fixture("monochange/release-base");
+	append_progress_command(
+		tempdir.path(),
+		"progress-ascii",
+		r#"
+steps = [
+	{ type = "PrepareRelease", name = "plan release" },
+	{ type = "Command", name = "stream summary", shell = true, command = "printf 'line one\n\nline three\n'" },
+]
+	"#,
+	);
+
+	let output = monochange_command(Some("2026-04-06"))
+		.current_dir(tempdir.path())
+		.arg("progress-ascii")
+		.arg("--progress-format")
+		.arg("ascii")
+		.output()
+		.unwrap_or_else(|error| panic!("run ascii progress command: {error}"));
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+
+	let stderr = String::from_utf8(output.stderr)
+		.unwrap_or_else(|error| panic!("ascii stderr utf8: {error}"));
+	assert_snapshot!(normalized_ascii_progress(&stderr));
+}
+
+#[test]
+fn json_progress_emits_structured_events_for_machine_consumers() {
+	let mut settings = snapshot_settings();
+	settings.set_snapshot_suffix(current_test_name());
+	let _guard = settings.bind_to_scope();
+
+	let tempdir = setup_fixture("monochange/release-base");
+	append_progress_command(
+		tempdir.path(),
+		"progress-json",
+		r#"
+steps = [
+	{ type = "PrepareRelease", name = "plan release" },
+	{ type = "Command", name = "stream summary", shell = true, command = "printf 'stdout line\n'; printf 'stderr line\n' >&2" },
+]
+	"#,
+	);
+
+	let output = monochange_command(Some("2026-04-06"))
+		.current_dir(tempdir.path())
+		.arg("progress-json")
+		.arg("--progress-format")
+		.arg("json")
+		.output()
+		.unwrap_or_else(|error| panic!("run json progress command: {error}"));
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+
+	let stderr = String::from_utf8(output.stderr)
+		.unwrap_or_else(|error| panic!("json stderr utf8: {error}"));
+	assert_json_snapshot!(normalized_progress_events(&stderr));
 }
 
 #[test]

--- a/crates/monochange/tests/snapshots/benchmark_cli_comment__benchmark_cli_comment_renderer_matches_snapshot@benchmark_cli_comment_renderer_matches_snapshot.snap
+++ b/crates/monochange/tests/snapshots/benchmark_cli_comment__benchmark_cli_comment_renderer_matches_snapshot@benchmark_cli_comment_renderer_matches_snapshot.snap
@@ -28,6 +28,28 @@ Fixture: 20 packages, 50 changesets, 50 commits
 | `main · mc release` | 315.0 ± 9.0 | 302.0 | 329.0 | 1.00 |
 | `pr · mc release` | 334.0 ± 11.0 | 319.0 | 348.0 | 1.06 ± 0.05 |
 
+#### Phase timings
+
+##### `mc release --dry-run`
+
+| Phase | Budget [ms] | main [ms] | pr [ms] | Δ pr-main [ms] | Status |
+|:---|---:|---:|---:|---:|:---|
+| `prepare release total` | 450 | 238 | 251 | +13 | regressed |
+| `discover release workspace` | 180 | 96 | 101 | +5 | regressed |
+| `parse changeset files` | 120 | 44 | 47 | +3 | regressed |
+| `read changeset files` | 120 | 31 | 33 | +2 | regressed |
+| `build manifest updates` | 80 | 18 | 19 | +1 | regressed |
+
+##### `mc release`
+
+| Phase | Budget [ms] | main [ms] | pr [ms] | Δ pr-main [ms] | Status |
+|:---|---:|---:|---:|---:|:---|
+| `prepare release total` | 550 | 312 | 333 | +21 | regressed |
+| `discover release workspace` | 180 | 96 | 102 | +6 | regressed |
+| `parse changeset files` | 120 | 44 | 47 | +3 | regressed |
+| `apply release changes` | 160 | 58 | 63 | +5 | regressed |
+| `build manifest updates` | 80 | 18 | 20 | +2 | regressed |
+
 ### Large history fixture
 
 Fixture: 200 packages, 500 changesets, 500 commits
@@ -42,3 +64,25 @@ Fixture: 200 packages, 500 changesets, 500 commits
 | `pr · mc release --dry-run` | 1045.0 ± 35.0 | 998.0 | 1091.0 | 1.07 ± 0.05 |
 | `main · mc release` | 1185.0 ± 41.0 | 1132.0 | 1243.0 | 1.00 |
 | `pr · mc release` | 1264.0 ± 46.0 | 1208.0 | 1327.0 | 1.07 ± 0.05 |
+
+#### Phase timings
+
+##### `mc release --dry-run`
+
+| Phase | Budget [ms] | main [ms] | pr [ms] | Δ pr-main [ms] | Status |
+|:---|---:|---:|---:|---:|:---|
+| `prepare release total` | 1600 | 972 | 1044 | +72 | regressed |
+| `discover release workspace` | 700 | 388 | 412 | +24 | regressed |
+| `parse changeset files` | 320 | 186 | 201 | +15 | regressed |
+| `read changeset files` | 320 | 149 | 160 | +11 | regressed |
+| `build manifest updates` | 180 | 81 | 87 | +6 | regressed |
+
+##### `mc release`
+
+| Phase | Budget [ms] | main [ms] | pr [ms] | Δ pr-main [ms] | Status |
+|:---|---:|---:|---:|---:|:---|
+| `prepare release total` | 1800 | 1182 | 1261 | +79 | regressed |
+| `discover release workspace` | 700 | 388 | 414 | +26 | regressed |
+| `parse changeset files` | 320 | 186 | 201 | +15 | regressed |
+| `apply release changes` | 260 | 132 | 146 | +14 | regressed |
+| `build manifest updates` | 180 | 81 | 88 | +7 | regressed |

--- a/crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_prints_help.snap
+++ b/crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_prints_help.snap
@@ -31,8 +31,9 @@ Commands:
   help            Print this message or the help of the given subcommand(s)
 
 Options:
-  -q, --quiet  Suppress stdout/stderr output and run in dry-run mode when supported
-  -h, --help   Print help
+  -q, --quiet                     Suppress stdout/stderr output and run in dry-run mode when supported
+      --progress-format <FORMAT>  Control progress output on stderr [possible values: auto, unicode, ascii, json]
+  -h, --help                      Print help
 
 
 ----- stderr -----

--- a/crates/monochange/tests/snapshots/cli_output__change_cli_help_documents_package_and_group_targeting_rules@change_cli_help_documents_package_and_group_targeting_rules.snap
+++ b/crates/monochange/tests/snapshots/cli_output__change_cli_help_documents_package_and_group_targeting_rules@change_cli_help_documents_package_and_group_targeting_rules.snap
@@ -18,17 +18,18 @@ Create a change file for one or more packages
 Usage: mc change [OPTIONS]
 
 Options:
-      --dry-run            Run the command in dry-run mode when supported
-  -i, --interactive        Select packages, bumps, and options interactively
-  -q, --quiet              Suppress stdout/stderr output and run in dry-run mode when supported
-      --package <PACKAGE>  Package or group to include in the change
-      --bump <BUMP>        Requested semantic version bump [default: patch] [possible values: none, patch, minor, major]
-      --version <VERSION>  Pin an explicit version for this release
-      --reason <REASON>    Short release-note summary for this change
-      --type <TYPE>        Optional release-note type such as `security` or `note`
-      --details <DETAILS>  Optional multi-line release-note details
-      --output <PATH>      Write the generated change file to a specific path
-  -h, --help               Print help
+      --dry-run                   Run the command in dry-run mode when supported
+  -i, --interactive               Select packages, bumps, and options interactively
+  -q, --quiet                     Suppress stdout/stderr output and run in dry-run mode when supported
+      --package <PACKAGE>         Package or group to include in the change
+      --progress-format <FORMAT>  Control progress output on stderr [possible values: auto, unicode, ascii, json]
+      --bump <BUMP>               Requested semantic version bump [default: patch] [possible values: none, patch, minor, major]
+      --version <VERSION>         Pin an explicit version for this release
+      --reason <REASON>           Short release-note summary for this change
+      --type <TYPE>               Optional release-note type such as `security` or `note`
+      --details <DETAILS>         Optional multi-line release-note details
+      --output <PATH>             Write the generated change file to a specific path
+  -h, --help                      Print help
 
 Examples:
   mc change --package sdk-core --bump patch --reason "fix panic"

--- a/crates/monochange/tests/snapshots/cli_progress__ascii_progress_renders_clean_captured_output@ascii_progress_renders_clean_captured_output.snap
+++ b/crates/monochange/tests/snapshots/cli_progress__ascii_progress_renders_clean_captured_output@ascii_progress_renders_clean_captured_output.snap
@@ -1,0 +1,14 @@
+---
+source: crates/monochange/tests/cli_progress.rs
+assertion_line: 318
+expression: normalized_ascii_progress(&stderr)
+---
+monochange running `progress-ascii`
+> [1/2] plan release (PrepareRelease)
++ [1/2] plan release (PrepareRelease) [duration]
+> [2/2] stream summary (Command)
+  | stream summary [stdout] line one
+  | stream summary [stdout] 
+  | stream summary [stdout] line three
++ [2/2] stream summary (Command) [duration]
++ `progress-ascii` finished [duration]

--- a/crates/monochange/tests/snapshots/cli_progress__json_progress_emits_structured_events_for_machine_consumers@json_progress_emits_structured_events_for_machine_consumers.snap
+++ b/crates/monochange/tests/snapshots/cli_progress__json_progress_emits_structured_events_for_machine_consumers@json_progress_emits_structured_events_for_machine_consumers.snap
@@ -1,0 +1,153 @@
+---
+source: crates/monochange/tests/cli_progress.rs
+assertion_line: 354
+expression: normalized_progress_events(&stderr)
+---
+[
+  {
+    "command": "progress-json",
+    "dryRun": false,
+    "event": "command_started",
+    "sequence": "[sequence:0]",
+    "totalSteps": 2
+  },
+  {
+    "command": "progress-json",
+    "dryRun": false,
+    "event": "step_started",
+    "sequence": "[sequence:1]",
+    "stepDisplayName": "plan release",
+    "stepIndex": 1,
+    "stepKind": "PrepareRelease",
+    "stepName": "plan release",
+    "totalSteps": 2
+  },
+  {
+    "command": "progress-json",
+    "dryRun": false,
+    "durationMs": "[duration_ms]",
+    "event": "step_finished",
+    "phaseTimings": [
+      {
+        "durationMs": "[duration_ms]",
+        "label": "load workspace configuration"
+      },
+      {
+        "durationMs": "[duration_ms]",
+        "label": "discover release workspace"
+      },
+      {
+        "durationMs": "[duration_ms]",
+        "label": "discover changeset paths"
+      },
+      {
+        "durationMs": "[duration_ms]",
+        "label": "read changeset files"
+      },
+      {
+        "durationMs": "[duration_ms]",
+        "label": "parse changeset files"
+      },
+      {
+        "durationMs": "[duration_ms]",
+        "label": "build prepared changesets"
+      },
+      {
+        "durationMs": "[duration_ms]",
+        "label": "build release plan"
+      },
+      {
+        "durationMs": "[duration_ms]",
+        "label": "resolve changelog targets"
+      },
+      {
+        "durationMs": "[duration_ms]",
+        "label": "build manifest updates"
+      },
+      {
+        "durationMs": "[duration_ms]",
+        "label": "build versioned file updates"
+      },
+      {
+        "durationMs": "[duration_ms]",
+        "label": "build release targets"
+      },
+      {
+        "durationMs": "[duration_ms]",
+        "label": "build lockfile refresh plan"
+      },
+      {
+        "durationMs": "[duration_ms]",
+        "label": "build changelog updates"
+      },
+      {
+        "durationMs": "[duration_ms]",
+        "label": "apply release changes"
+      }
+    ],
+    "sequence": "[sequence:2]",
+    "stepDisplayName": "plan release",
+    "stepIndex": 1,
+    "stepKind": "PrepareRelease",
+    "stepName": "plan release",
+    "totalSteps": 2
+  },
+  {
+    "command": "progress-json",
+    "dryRun": false,
+    "event": "step_started",
+    "sequence": "[sequence:3]",
+    "stepDisplayName": "stream summary",
+    "stepIndex": 2,
+    "stepKind": "Command",
+    "stepName": "stream summary",
+    "totalSteps": 2
+  },
+  {
+    "command": "progress-json",
+    "dryRun": false,
+    "event": "command_output",
+    "sequence": "[sequence:4]",
+    "stepDisplayName": "stream summary",
+    "stepIndex": 2,
+    "stepKind": "Command",
+    "stepName": "stream summary",
+    "stream": "stderr",
+    "text": "stderr line\n",
+    "totalSteps": 2
+  },
+  {
+    "command": "progress-json",
+    "dryRun": false,
+    "event": "command_output",
+    "sequence": "[sequence:5]",
+    "stepDisplayName": "stream summary",
+    "stepIndex": 2,
+    "stepKind": "Command",
+    "stepName": "stream summary",
+    "stream": "stdout",
+    "text": "stdout line\n",
+    "totalSteps": 2
+  },
+  {
+    "command": "progress-json",
+    "dryRun": false,
+    "durationMs": "[duration_ms]",
+    "event": "step_finished",
+    "phaseTimings": [],
+    "sequence": "[sequence:6]",
+    "stepDisplayName": "stream summary",
+    "stepIndex": 2,
+    "stepKind": "Command",
+    "stepName": "stream summary",
+    "totalSteps": 2
+  },
+  {
+    "command": "progress-json",
+    "dryRun": false,
+    "durationMs": "[duration_ms]",
+    "event": "command_finished",
+    "sequence": "[sequence:7]",
+    "totalSteps": 2
+  }
+]

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -2387,6 +2387,80 @@ fn load_workspace_configuration_rejects_empty_command_step_id() {
 }
 
 #[test]
+fn load_workspace_configuration_rejects_empty_step_name() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	std::fs::create_dir_all(root.join("crates/core"))
+		.unwrap_or_else(|error| panic!("mkdir core: {error}"));
+	std::fs::write(
+		root.join("crates/core/Cargo.toml"),
+		"[package]\nname = \"core\"\nversion = \"1.0.0\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write cargo: {error}"));
+	std::fs::write(
+		root.join("monochange.toml"),
+		r#"[defaults]
+package_type = "cargo"
+
+[package.core]
+path = "crates/core"
+
+[cli.release]
+[[cli.release.steps]]
+type = "PrepareRelease"
+name = "   "
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write monochange: {error}"));
+
+	let error = load_workspace_configuration(root)
+		.err()
+		.unwrap_or_else(|| panic!("expected error for empty step name"));
+	assert!(error.to_string().contains("empty `name`"), "error: {error}");
+}
+
+#[test]
+fn load_workspace_configuration_rejects_duplicate_step_names() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	std::fs::create_dir_all(root.join("crates/core"))
+		.unwrap_or_else(|error| panic!("mkdir core: {error}"));
+	std::fs::write(
+		root.join("crates/core/Cargo.toml"),
+		"[package]\nname = \"core\"\nversion = \"1.0.0\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write cargo: {error}"));
+	std::fs::write(
+		root.join("monochange.toml"),
+		r#"[defaults]
+package_type = "cargo"
+
+[package.core]
+path = "crates/core"
+
+[cli.release]
+[[cli.release.steps]]
+type = "PrepareRelease"
+name = "plan release"
+
+[[cli.release.steps]]
+type = "Command"
+name = "plan release"
+command = "echo hi"
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write monochange: {error}"));
+
+	let error = load_workspace_configuration(root)
+		.err()
+		.unwrap_or_else(|| panic!("expected error for duplicate step names"));
+	assert!(
+		error.to_string().contains("duplicate step name"),
+		"error: {error}"
+	);
+}
+
+#[test]
 fn load_workspace_configuration_accepts_command_step_with_shell_string() {
 	let root = fixture_path("config/accepts-shell-string");
 	let configuration = load_workspace_configuration(&root)

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -3148,6 +3148,7 @@ fn validate_cli(cli: &[CliCommandDefinition]) -> MonochangeResult<()> {
 		}
 
 		let mut seen_step_ids: BTreeSet<String> = BTreeSet::new();
+		let mut seen_step_names: BTreeSet<String> = BTreeSet::new();
 		for step in &cli_command.steps {
 			if let Some(condition) = step.when()
 				&& condition.trim().is_empty()
@@ -3157,6 +3158,22 @@ fn validate_cli(cli: &[CliCommandDefinition]) -> MonochangeResult<()> {
 					cli_command.name,
 					step.kind_name()
 				)));
+			}
+			if let Some(name) = step.name() {
+				let trimmed = name.trim();
+				if trimmed.is_empty() {
+					return Err(MonochangeError::Config(format!(
+						"CLI command `{}` step `{}` has an empty `name`",
+						cli_command.name,
+						step.kind_name()
+					)));
+				}
+				if !seen_step_names.insert(trimmed.to_string()) {
+					return Err(MonochangeError::Config(format!(
+						"CLI command `{}` has duplicate step name `{trimmed}`",
+						cli_command.name
+					)));
+				}
 			}
 			for input_name in step.inputs().keys() {
 				if input_name.trim().is_empty() {

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -533,7 +533,7 @@ fn default_cli_commands_expose_validate_discover_change_release_and_affected() {
 	assert_eq!(
 		validate_cli_command.steps,
 		vec![CliStepDefinition::Validate {
-			name: None,
+			name: Some("validate workspace".to_string()),
 			when: None,
 			inputs: BTreeMap::new(),
 		}]

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -155,12 +155,17 @@ fn git_current_branch_reports_detached_head_as_an_error() {
 	for args in [
 		["config", "user.name", "monochange Tests"],
 		["config", "user.email", "monochange@example.com"],
+		["config", "commit.gpgsign", "false"],
 	] {
 		let output = git_command(root)
 			.args(args)
 			.output()
 			.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
-		assert!(output.status.success());
+		assert!(
+			output.status.success(),
+			"git {args:?} failed: {}",
+			String::from_utf8_lossy(&output.stderr)
+		);
 	}
 	must_ok(
 		fs::write(root.join("README.md"), "hello\n"),
@@ -175,7 +180,11 @@ fn git_current_branch_reports_detached_head_as_an_error() {
 			.args(args)
 			.output()
 			.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
-		assert!(output.status.success());
+		assert!(
+			output.status.success(),
+			"git {args:?} failed: {}",
+			String::from_utf8_lossy(&output.stderr)
+		);
 	}
 
 	let error = must_err(git_current_branch(root), "expected detached-head error");

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -2743,7 +2743,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 			help_text: Some("Validate monochange configuration and changesets".to_string()),
 			inputs: Vec::new(),
 			steps: vec![CliStepDefinition::Validate {
-				name: None,
+				name: Some("validate workspace".to_string()),
 				when: None,
 				inputs: BTreeMap::new(),
 			}],
@@ -2761,7 +2761,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 				short: None,
 			}],
 			steps: vec![CliStepDefinition::Discover {
-				name: None,
+				name: Some("discover packages".to_string()),
 				when: None,
 				inputs: BTreeMap::new(),
 			}],
@@ -2856,7 +2856,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 			],
 			steps: vec![CliStepDefinition::CreateChangeFile {
 				show_progress: None,
-				name: None,
+				name: Some("create change file".to_string()),
 				when: None,
 				inputs: BTreeMap::new(),
 			}],
@@ -2878,7 +2878,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 				short: None,
 			}],
 			steps: vec![CliStepDefinition::PrepareRelease {
-				name: None,
+				name: Some("prepare release".to_string()),
 				when: None,
 				inputs: BTreeMap::new(),
 			}],
@@ -2944,7 +2944,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 				},
 			],
 			steps: vec![CliStepDefinition::AffectedPackages {
-				name: None,
+				name: Some("evaluate affected packages".to_string()),
 				when: None,
 				inputs: BTreeMap::new(),
 			}],
@@ -2978,7 +2978,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 				},
 			],
 			steps: vec![CliStepDefinition::DiagnoseChangesets {
-				name: None,
+				name: Some("diagnose changesets".to_string()),
 				when: None,
 				inputs: BTreeMap::new(),
 			}],
@@ -3038,7 +3038,7 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 				},
 			],
 			steps: vec![CliStepDefinition::RetargetRelease {
-				name: None,
+				name: Some("retarget release".to_string()),
 				when: None,
 				inputs: BTreeMap::new(),
 			}],

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -20,6 +20,7 @@
 
 # Reference
 
+- [Progress output](reference/progress-output.md)
 - [CLI step reference](reference/cli-steps/00-index.md)
   - [Validate](reference/cli-steps/01-validate.md)
   - [Discover](reference/cli-steps/02-discover.md)

--- a/docs/src/guide/02-setup.md
+++ b/docs/src/guide/02-setup.md
@@ -202,6 +202,7 @@ requires = ["main"]
 help_text = "Validate monochange configuration and changesets"
 
 [[cli.validate.steps]]
+name = "validate workspace"
 type = "Validate"
 
 [cli.discover]
@@ -214,6 +215,7 @@ choices = ["text", "json"]
 default = "text"
 
 [[cli.discover.steps]]
+name = "discover packages"
 type = "Discover"
 
 [cli.change]
@@ -255,6 +257,7 @@ name = "output"
 type = "path"
 
 [[cli.change.steps]]
+name = "create change file"
 type = "CreateChangeFile"
 
 [cli.release]
@@ -267,15 +270,18 @@ choices = ["text", "json"]
 default = "text"
 
 [[cli.release.steps]]
+name = "prepare release"
 type = "PrepareRelease"
 
 [cli.release-manifest]
 help_text = "Prepare a release and write a stable JSON manifest"
 
 [[cli.release-manifest.steps]]
+name = "prepare release"
 type = "PrepareRelease"
 
 [[cli.release-manifest.steps]]
+name = "render release manifest"
 type = "RenderReleaseManifest"
 path = ".monochange/release-manifest.json"
 
@@ -289,9 +295,11 @@ choices = ["text", "json"]
 default = "text"
 
 [[cli.publish-release.steps]]
+name = "prepare release"
 type = "PrepareRelease"
 
 [[cli.publish-release.steps]]
+name = "publish release"
 type = "PublishRelease"
 
 [cli.release-pr]
@@ -304,9 +312,11 @@ choices = ["text", "json"]
 default = "text"
 
 [[cli.release-pr.steps]]
+name = "prepare release"
 type = "PrepareRelease"
 
 [[cli.release-pr.steps]]
+name = "open release request"
 type = "OpenReleaseRequest"
 
 name = "format"
@@ -335,6 +345,7 @@ name = "label"
 type = "string_list"
 
 [[cli.affected.steps]]
+name = "evaluate affected packages"
 type = "AffectedPackages"
 ```
 

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -293,6 +293,7 @@ choices = ["text", "json"]
 default = "text"
 
 [[cli.discover.steps]]
+name = "discover packages"
 type = "Discover"
 
 [cli.release]
@@ -305,15 +306,18 @@ choices = ["text", "json"]
 default = "text"
 
 [[cli.release.steps]]
+name = "prepare release"
 type = "PrepareRelease"
 
 [cli.release-manifest]
 help_text = "Prepare a release and write a stable JSON manifest"
 
 [[cli.release-manifest.steps]]
+name = "prepare release"
 type = "PrepareRelease"
 
 [[cli.release-manifest.steps]]
+name = "render release manifest"
 type = "RenderReleaseManifest"
 path = ".monochange/release-manifest.json"
 
@@ -327,12 +331,15 @@ choices = ["text", "json"]
 default = "text"
 
 [[cli.publish-release.steps]]
+name = "prepare release"
 type = "PrepareRelease"
 
 [[cli.publish-release.steps]]
+name = "publish release"
 type = "PublishRelease"
 
 [[cli.publish-release.steps]]
+name = "comment released issues"
 type = "CommentReleasedIssues"
 
 [cli.release-pr]
@@ -345,9 +352,11 @@ choices = ["text", "json"]
 default = "text"
 
 [[cli.release-pr.steps]]
+name = "prepare release"
 type = "PrepareRelease"
 
 [[cli.release-pr.steps]]
+name = "open release request"
 type = "OpenReleaseRequest"
 
 name = "format"
@@ -381,6 +390,7 @@ name = "label"
 type = "string_list"
 
 [[cli.affected.steps]]
+name = "evaluate affected packages"
 type = "AffectedPackages"
 ```
 
@@ -393,6 +403,7 @@ CLI command interpolation variables:
 - built-in command variables are available directly as `{{ version }}`, `{{ group_version }}`, `{{ released_packages }}`, `{{ changed_files }}`, and `{{ changesets }}`
 - command templates can read CLI inputs through `{{ inputs.name }}`; bare input names still work for backward compatibility
 - every step can override the inputs it receives with `inputs = { ... }`; direct references like `"{{ inputs.labels }}"` preserve list and boolean values when rebinding to built-in steps
+- built-in commands already attach descriptive step `name` labels such as `prepare release` and `publish release`; keep or replace those labels when you want progress output to stay readable
 - custom command variables become available when `variables` is present: map your own names to variables such as `version`, `group_version`, `released_packages`, `changed_files`, and `changesets`
 - `dry_run_command` on a `Command` step replaces `command` only when the CLI command is run with `--dry-run`
 - `shell = true` runs the command through the current shell; the default mode runs the executable directly after shell-style splitting

--- a/docs/src/reference/cli-steps/00-index.md
+++ b/docs/src/reference/cli-steps/00-index.md
@@ -82,6 +82,21 @@ Every step can declare a `name = "..."` label.
 
 Use that when you want human-friendly progress output such as `plan release`, `publish tags`, or `announce release` instead of the raw step kind.
 
+### Progress rendering
+
+monochange can stream step progress on stderr while keeping command output on stdout.
+
+Use `--progress-format auto|unicode|ascii|json` or `MONOCHANGE_PROGRESS_FORMAT` to choose the renderer:
+
+- `auto` enables the human renderer only when stderr is a terminal
+- `unicode` forces the human renderer with Unicode symbols
+- `ascii` forces the human renderer with ASCII-safe symbols
+- `json` emits newline-delimited progress events for automation and benchmarks
+
+`PrepareRelease` steps also report per-phase timings. Those timings power the benchmark phase-budget checks for `mc release --dry-run` and `mc release`.
+
+See [Progress output](../progress-output.md) for the full renderer behavior and JSON event shape.
+
 ### Step-local `when`
 
 Every step can declare a `when = "..."` expression.

--- a/docs/src/reference/progress-output.md
+++ b/docs/src/reference/progress-output.md
@@ -1,0 +1,74 @@
+# Progress output
+
+monochange writes progress information to stderr so stdout can remain stable for text, markdown, and JSON command results.
+
+## Selecting a renderer
+
+Use the global `--progress-format <FORMAT>` flag or set `MONOCHANGE_PROGRESS_FORMAT`.
+
+Supported values:
+
+- `auto`: default behavior. Human progress output is enabled only when stderr is a terminal.
+- `unicode`: force the human renderer with Unicode symbols and spinners.
+- `ascii`: force the human renderer with ASCII-safe symbols.
+- `json`: emit newline-delimited JSON progress events on stderr.
+
+`--quiet` suppresses progress output. `MONOCHANGE_NO_PROGRESS=1` also disables the automatic human renderer.
+
+## Human progress output
+
+The human renderer is designed for interactive terminal runs:
+
+- step labels use each step's `name = "..."` value when present, then fall back to the built-in step kind
+- long-running steps show a delayed spinner so short steps do not flicker
+- command stdout and stderr stream live under the active step
+- completed `PrepareRelease` steps print per-phase timings so slow phases are visible without a separate trace
+
+Built-in commands already attach descriptive step names such as `prepare release`, `publish release`, and `open release request`. Custom commands can override those names per step.
+
+## JSON event stream
+
+`--progress-format json` is intended for machines, not humans. It writes one JSON object per line to stderr.
+
+Common lifecycle events:
+
+- `command_started`
+- `step_started`
+- `command_output`
+- `step_finished`
+- `step_failed`
+- `step_skipped`
+- `command_finished`
+
+Shared fields:
+
+- `sequence`: monotonically increasing event sequence number for the command run
+- `command`: CLI command name, such as `release`
+- `dryRun`: whether the command is running in dry-run mode
+- `totalSteps`: total step count for the command
+- `stepIndex`: 1-based step index for step events
+- `stepKind`: built-in step kind, such as `PrepareRelease`
+- `stepDisplayName`: rendered human label for the step
+- `stepName`: explicit configured `name`, or `null` when omitted
+
+Event-specific fields:
+
+- `command_output` adds `stream` and `text`
+- `step_finished` adds `durationMs` and `phaseTimings`
+- `step_failed` adds `durationMs` and `error`
+- `step_skipped` may add `condition`
+- `command_finished` adds `durationMs`
+
+Example:
+
+```json
+{"sequence":0,"event":"command_started","command":"release","dryRun":true,"totalSteps":2}
+{"sequence":1,"event":"step_started","command":"release","dryRun":true,"stepIndex":1,"totalSteps":2,"stepKind":"PrepareRelease","stepDisplayName":"plan release","stepName":"plan release"}
+{"sequence":2,"event":"step_finished","command":"release","dryRun":true,"stepIndex":1,"totalSteps":2,"stepKind":"PrepareRelease","stepDisplayName":"plan release","stepName":"plan release","durationMs":243,"phaseTimings":[{"label":"discover release workspace","durationMs":97}]}
+```
+
+## Benchmark integration
+
+The binary benchmark workflow uses `--progress-format json` to extract `PrepareRelease` phase timings for both `mc release --dry-run` and `mc release`.
+
+Those timings are summarized and compared against `.github/scripts/benchmark_phase_budgets.json`, which lets pull requests fail when real release-path regressions exceed the configured budget.

--- a/fixtures/tests/monochange/benchmark-cli-comment/baseline-phases.md
+++ b/fixtures/tests/monochange/benchmark-cli-comment/baseline-phases.md
@@ -1,0 +1,21 @@
+#### Phase timings
+
+##### `mc release --dry-run`
+
+| Phase | Budget [ms] | main [ms] | pr [ms] | Δ pr-main [ms] | Status |
+|:---|---:|---:|---:|---:|:---|
+| `prepare release total` | 450 | 238 | 251 | +13 | regressed |
+| `discover release workspace` | 180 | 96 | 101 | +5 | regressed |
+| `parse changeset files` | 120 | 44 | 47 | +3 | regressed |
+| `read changeset files` | 120 | 31 | 33 | +2 | regressed |
+| `build manifest updates` | 80 | 18 | 19 | +1 | regressed |
+
+##### `mc release`
+
+| Phase | Budget [ms] | main [ms] | pr [ms] | Δ pr-main [ms] | Status |
+|:---|---:|---:|---:|---:|:---|
+| `prepare release total` | 550 | 312 | 333 | +21 | regressed |
+| `discover release workspace` | 180 | 96 | 102 | +6 | regressed |
+| `parse changeset files` | 120 | 44 | 47 | +3 | regressed |
+| `apply release changes` | 160 | 58 | 63 | +5 | regressed |
+| `build manifest updates` | 80 | 18 | 20 | +2 | regressed |

--- a/fixtures/tests/monochange/benchmark-cli-comment/history_x10-phases.md
+++ b/fixtures/tests/monochange/benchmark-cli-comment/history_x10-phases.md
@@ -1,0 +1,21 @@
+#### Phase timings
+
+##### `mc release --dry-run`
+
+| Phase | Budget [ms] | main [ms] | pr [ms] | Δ pr-main [ms] | Status |
+|:---|---:|---:|---:|---:|:---|
+| `prepare release total` | 1600 | 972 | 1044 | +72 | regressed |
+| `discover release workspace` | 700 | 388 | 412 | +24 | regressed |
+| `parse changeset files` | 320 | 186 | 201 | +15 | regressed |
+| `read changeset files` | 320 | 149 | 160 | +11 | regressed |
+| `build manifest updates` | 180 | 81 | 87 | +6 | regressed |
+
+##### `mc release`
+
+| Phase | Budget [ms] | main [ms] | pr [ms] | Δ pr-main [ms] | Status |
+|:---|---:|---:|---:|---:|:---|
+| `prepare release total` | 1800 | 1182 | 1261 | +79 | regressed |
+| `discover release workspace` | 700 | 388 | 414 | +26 | regressed |
+| `parse changeset files` | 320 | 186 | 201 | +15 | regressed |
+| `apply release changes` | 260 | 132 | 146 | +14 | regressed |
+| `build manifest updates` | 180 | 81 | 88 | +7 | regressed |


### PR DESCRIPTION
## Summary

This finishes the remaining release-observability follow-up work that was still sitting outside `main` after the earlier performance merge.

The user-visible gap was that `mc release` had better internals, but the CLI still needed a complete polish pass around streamed step output, machine-readable progress events, step naming, and benchmark enforcement. The benchmark workflow also needed to stop treating observability as debug-only output and start enforcing per-phase regressions directly in CI.

## What changed

- adds a global `--progress-format` flag plus `MONOCHANGE_PROGRESS_FORMAT` support with `auto`, `unicode`, `ascii`, and `json` renderers
- upgrades the progress reporter to stream named step output, support Unicode and ASCII symbol sets, emit structured JSON events, and include `PrepareRelease` phase timings in machine-readable output
- standardizes built-in step names across default commands, templates, and `mc init`, while validating empty or duplicate step names in configuration
- expands progress integration coverage with TTY, ASCII, and JSON snapshot tests and closes the diff-coverage gaps in the touched Rust code
- extends the benchmark comment flow to capture phase-by-phase timings for both `mc release --dry-run` and real `mc release`, compare them to stored baselines, and fail CI on configured budget regressions
- documents the new progress formats, structured event stream, and benchmark phase-budget behavior
- hardens the `monochange_core` git branch tests so they pass under pre-push hooks that export `GIT_DIR` and related git environment variables

## Validation

I validated the branch with the same checks that gate push/CI locally:

- `devenv shell cargo clippy -p monochange --all-targets -- -D warnings`
- `devenv shell cargo test -p monochange_config -p monochange`
- `devenv shell docs:check`
- `devenv shell cargo llvm-cov -p monochange -p monochange_config -p monochange_core --json --output-path target/coverage/touched.json`
- `git push -u origin feat/release-followups` (pre-push hooks passed, including nextest)

Diff coverage for the changed Rust files is 100%.

Fixes #177
Fixes #178
Fixes #179
Fixes #181

Related to #170
Related to #171
Related to #174
Related to #175
Related to #176
Related to #180
