### PR TITLE
chore: update issue title conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,9 @@
 
 - The project name is always written in **all lowercase**: `monochange`.
 - Never use `MonoChange`, `Monochange`, or `MONOCHANGE` in prose, docs, comments, or string literals.
+- Issue titles must use Title Case and must not use conventional-commit prefixes such as `feat:` or `fix:`.
+- Pull request titles must use conventional-commit style prefixes.
+- Commit titles must use conventional-commit style prefixes.
 - **Rust code exception**: standard Rust naming conventions apply.
   - Structs and enums may use PascalCase (e.g. `MonochangeError`, `MonochangeResult`).
   - Constants use UPPER_SNAKE_CASE (e.g. `MONOCHANGE_VERSION`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 
 - The project name is always written in **all lowercase**: `monochange`.
 - Never use `MonoChange`, `Monochange`, or `MONOCHANGE` in prose, docs, comments, or string literals.
-- Issue titles must use Title Case and must not use conventional-commit prefixes such as `feat:` or `fix:`.
+- Issue titles must use sentence case, must not end with a full stop, and must not use conventional-commit prefixes such as `feat:` or `fix:`.
 - Pull request titles must use conventional-commit style prefixes.
 - Commit titles must use conventional-commit style prefixes.
 - **Rust code exception**: standard Rust naming conventions apply.


### PR DESCRIPTION
## Summary

- document the issue-title convention in `AGENTS.md`
- clarify that issues use sentence case without trailing full stops
- keep conventional-commit style for PR titles and commit titles

## Validation

- docs-only change
- no tests required