### PR TITLE
perf: benchmark cargo lockfile refresh tradeoffs

### DIFF
--- a/.changeset/cargo-lockfile-fast-path-benchmarks.md
+++ b/.changeset/cargo-lockfile-fast-path-benchmarks.md
@@ -1,0 +1,5 @@
+---
+monochange: patch
+---
+
+Document the Cargo lockfile fast path, add a direct-rewrite versus full-refresh benchmark comparison, and keep `mc release` from shelling out to Cargo unless users opt in with `lockfile_commands`.

--- a/crates/monochange/benches/cli_commands.rs
+++ b/crates/monochange/benches/cli_commands.rs
@@ -62,6 +62,39 @@ fn write_synthetic_cargo_lock(root: &Path, num_packages: usize) {
 	fs::write(root.join("Cargo.lock"), cargo_lock).unwrap();
 }
 
+fn add_dependency_chain_manifests(root: &Path, num_packages: usize) {
+	for i in 1..num_packages {
+		let manifest_path = root.join(format!("crates/pkg-{i}/Cargo.toml"));
+		let manifest = fs::read_to_string(&manifest_path).unwrap();
+		fs::write(
+			&manifest_path,
+			format!(
+				"{manifest}\n[dependencies]\npkg-{} = {{ path = \"../pkg-{}\", version = \"1.0.0\" }}\n",
+				i - 1,
+				i - 1
+			),
+		)
+		.unwrap();
+	}
+}
+
+fn write_dependency_chain_cargo_lock(root: &Path, num_packages: usize) {
+	use std::fmt::Write;
+
+	let mut cargo_lock = String::from("version = 3\n\n");
+	for i in 0..num_packages {
+		let _ = writeln!(
+			cargo_lock,
+			"[[package]]\nname = \"pkg-{i}\"\nversion = \"1.0.0\""
+		);
+		if i > 0 {
+			let _ = writeln!(cargo_lock, "dependencies = [\"pkg-{}\"]", i - 1);
+		}
+		cargo_lock.push('\n');
+	}
+	fs::write(root.join("Cargo.lock"), cargo_lock).unwrap();
+}
+
 fn generate_fixture_with_cargo_lock(root: &Path, num_packages: usize, num_changesets: usize) {
 	generate_fixture(root, num_packages, num_changesets);
 	let config_path = root.join("monochange.toml");
@@ -85,7 +118,30 @@ fn generate_fixture_with_cargo_lock(root: &Path, num_packages: usize, num_change
 	write_synthetic_cargo_lock(root, num_packages);
 }
 
+fn generate_fixture_with_dependency_chain_cargo_lock(
+	root: &Path,
+	num_packages: usize,
+	num_changesets: usize,
+) {
+	generate_fixture_with_cargo_lock(root, num_packages, num_changesets);
+	add_dependency_chain_manifests(root, num_packages);
+	write_dependency_chain_cargo_lock(root, num_packages);
+}
+
+fn enable_explicit_cargo_refresh_command(root: &Path) {
+	let config_path = root.join("monochange.toml");
+	let config = fs::read_to_string(&config_path).unwrap();
+	fs::write(
+		&config_path,
+		format!(
+			"{config}\n[[ecosystems.cargo.lockfile_commands]]\ncommand = \"cargo generate-lockfile\"\ncwd = \".\"\n"
+		),
+	)
+	.unwrap();
+}
+
 const SCALES: &[(usize, usize)] = &[(5, 10), (20, 50), (50, 200)];
+const LOCKFILE_COMPARE_SCALE: (usize, usize) = (20, 50);
 
 fn bench_config_load(c: &mut Criterion) {
 	let mut group = c.benchmark_group("config_load");
@@ -331,6 +387,61 @@ fn bench_prepare_release_apply(c: &mut Criterion) {
 	group.finish();
 }
 
+fn bench_prepare_release_apply_cargo_lockfile_refresh(c: &mut Criterion) {
+	let mut group = c.benchmark_group("prepare_release_apply_cargo_lockfile_refresh");
+	group.sample_size(10);
+
+	let (packages, changesets) = LOCKFILE_COMPARE_SCALE;
+	let label = format!("{packages}pkg_{changesets}cs");
+
+	group.bench_with_input(
+		BenchmarkId::new("direct_rewrite", &label),
+		&(packages, changesets),
+		|b, &(packages, changesets)| {
+			b.iter_batched(
+				|| {
+					let tempdir = tempfile::tempdir().unwrap();
+					generate_fixture_with_dependency_chain_cargo_lock(
+						tempdir.path(),
+						packages,
+						changesets,
+					);
+					tempdir
+				},
+				|tempdir| {
+					monochange::prepare_release(tempdir.path(), false).unwrap();
+				},
+				BatchSize::LargeInput,
+			);
+		},
+	);
+
+	group.bench_with_input(
+		BenchmarkId::new("full_refresh_command", &label),
+		&(packages, changesets),
+		|b, &(packages, changesets)| {
+			b.iter_batched(
+				|| {
+					let tempdir = tempfile::tempdir().unwrap();
+					generate_fixture_with_dependency_chain_cargo_lock(
+						tempdir.path(),
+						packages,
+						changesets,
+					);
+					enable_explicit_cargo_refresh_command(tempdir.path());
+					tempdir
+				},
+				|tempdir| {
+					monochange::prepare_release(tempdir.path(), false).unwrap();
+				},
+				BatchSize::LargeInput,
+			);
+		},
+	);
+
+	group.finish();
+}
+
 fn bench_prepare_release_with_git_history(c: &mut Criterion) {
 	let mut group = c.benchmark_group("prepare_release_git_history");
 	group.sample_size(10);
@@ -359,6 +470,7 @@ criterion_group!(
 	bench_changeset_loading,
 	bench_prepare_release_dry_run,
 	bench_prepare_release_apply,
+	bench_prepare_release_apply_cargo_lockfile_refresh,
 	bench_prepare_release_with_git_history,
 );
 criterion_main!(benches);

--- a/crates/monochange/benches/cli_commands.rs
+++ b/crates/monochange/benches/cli_commands.rs
@@ -29,10 +29,15 @@ fn generate_fixture(root: &Path, num_packages: usize, num_changesets: usize) {
 
 	for i in 0..num_packages {
 		let pkg_dir = root.join(format!("crates/pkg-{i}"));
-		fs::create_dir_all(&pkg_dir).unwrap();
+		fs::create_dir_all(pkg_dir.join("src")).unwrap();
 		fs::write(
 			pkg_dir.join("Cargo.toml"),
 			format!("[package]\nname = \"pkg-{i}\"\nversion = \"1.0.0\"\nedition = \"2021\"\n"),
+		)
+		.unwrap();
+		fs::write(
+			pkg_dir.join("src/lib.rs"),
+			format!("pub const PACKAGE_ID: &str = \"pkg-{i}\";\n"),
 		)
 		.unwrap();
 	}

--- a/crates/monochange/tests/cargo_lockfile_fast_path.rs
+++ b/crates/monochange/tests/cargo_lockfile_fast_path.rs
@@ -1,0 +1,85 @@
+use std::env;
+use std::ffi::OsString;
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+mod test_support;
+use test_support::monochange_command;
+use test_support::setup_fixture;
+
+#[cfg(unix)]
+fn make_executable(path: &Path) {
+	let metadata =
+		fs::metadata(path).unwrap_or_else(|error| panic!("metadata {}: {error}", path.display()));
+	let mut permissions = metadata.permissions();
+	permissions.set_mode(0o755);
+	fs::set_permissions(path, permissions)
+		.unwrap_or_else(|error| panic!("set permissions {}: {error}", path.display()));
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: &Path) {}
+
+fn prefixed_path(bin_dir: &Path) -> OsString {
+	let existing = env::var_os("PATH").unwrap_or_default();
+	let mut combined = env::split_paths(&existing).collect::<Vec<_>>();
+	combined.insert(0, bin_dir.to_path_buf());
+	env::join_paths(combined).unwrap_or_else(|error| panic!("join PATH entries: {error}"))
+}
+
+#[test]
+fn release_keeps_cargo_lockfile_on_direct_rewrite_fast_path() {
+	let tempdir = setup_fixture("monochange/cargo-lock-release");
+	let root = tempdir.path();
+	let manifest_path = root.join("crates/core/Cargo.toml");
+	let manifest = fs::read_to_string(&manifest_path)
+		.unwrap_or_else(|error| panic!("read Cargo.toml: {error}"));
+	fs::write(
+		&manifest_path,
+		format!("{manifest}\n[dependencies]\nserde = \"1.0\"\n"),
+	)
+	.unwrap_or_else(|error| panic!("write Cargo.toml: {error}"));
+
+	let fake_cargo = root.join("tools/bin/cargo");
+	fs::write(
+		&fake_cargo,
+		"#!/bin/sh\nset -eu\ntouch cargo-invoked.txt\nprintf 'cargo should not run on the default fast path\\n' >&2\nexit 99\n",
+	)
+	.unwrap_or_else(|error| panic!("write fake cargo: {error}"));
+	make_executable(&fake_cargo);
+
+	let output = monochange_command(Some("2026-04-06"))
+		.current_dir(root)
+		.env("PATH", prefixed_path(&root.join("tools/bin")))
+		.arg("release")
+		.output()
+		.unwrap_or_else(|error| panic!("release command: {error}"));
+
+	assert!(
+		output.status.success(),
+		"release failed: {}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	let stderr =
+		String::from_utf8(output.stderr).unwrap_or_else(|error| panic!("stderr utf8: {error}"));
+	assert!(
+		stderr.contains("still looks incomplete after monochange rewrote it directly"),
+		"expected manual refresh warning, got: {stderr}"
+	);
+	assert!(
+		stderr.contains("cargo generate-lockfile") && stderr.contains("cargo check"),
+		"expected refresh guidance in warning, got: {stderr}"
+	);
+	assert!(
+		!root.join("cargo-invoked.txt").exists(),
+		"default release path should not invoke cargo"
+	);
+	assert!(
+		fs::read_to_string(root.join("Cargo.lock"))
+			.unwrap_or_else(|error| panic!("read Cargo.lock: {error}"))
+			.contains("version = \"1.1.0\""),
+		"expected direct lockfile rewrite to update Cargo.lock"
+	);
+}

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -250,6 +250,8 @@ If you configure `lockfile_commands` for an ecosystem, monochange stops using th
 
 For Cargo specifically, monochange no longer falls back to `cargo generate-lockfile` automatically when a lockfile looks incomplete. That keeps `mc release` on the fast path and leaves the final dependency-resolution refresh under your control: either configure `[ecosystems.cargo].lockfile_commands` explicitly or run `cargo generate-lockfile` / `cargo check` yourself afterwards.
 
+If you want to measure that tradeoff before opting into a refresh command, run the `prepare_release_apply_cargo_lockfile_refresh` Criterion benchmark. It compares the default `direct_rewrite` path against an explicit `full_refresh_command` run on the same synthetic Cargo workspace.
+
 ```toml
 [ecosystems.npm]
 lockfile_commands = [


### PR DESCRIPTION
## Summary

- add a regression test that proves default Cargo releases stay on the direct-rewrite fast path even when a fake `cargo` binary is present on `PATH`
- add a dedicated Criterion comparison between the default Cargo lockfile rewrite path and an explicit `cargo generate-lockfile` refresh command
- document where to run that benchmark when deciding whether to opt into `[ecosystems.cargo].lockfile_commands`

## Validation

- `devenv shell cargo test -p monochange --test cargo_lockfile_fast_path`
- `devenv shell cargo test -p monochange prepare_release_execution_materializes_configured_lockfile_commands --lib`
- `devenv shell cargo bench -p monochange --bench cli_commands --no-run`
- `devenv shell cargo bench -p monochange --bench cli_commands prepare_release_apply_cargo_lockfile_refresh -- --noplot`
- `devenv shell bash -lc 'mc affected --format json --verify --changed-paths crates/monochange/benches/cli_commands.rs --changed-paths docs/src/guide/04-configuration.md --changed-paths crates/monochange/tests/cargo_lockfile_fast_path.rs --changed-paths .changeset/cargo-lockfile-fast-path-benchmarks.md'`

The local benchmark comparison currently shows the direct rewrite path around `63-72 ms` and the explicit full refresh path around `101-107 ms` on the same synthetic workspace.

Fixes #180