### PR TITLE
fix: improve changeset validation diagnostics

### DIFF
--- a/.changeset/interactive-changeset-error-rendering.md
+++ b/.changeset/interactive-changeset-error-rendering.md
@@ -1,0 +1,9 @@
+---
+monochange: patch
+monochange_config: patch
+---
+
+Improve changeset authoring and validation ergonomics.
+
+- quote generated changeset frontmatter keys when package or group ids contain YAML-sensitive characters such as `@` or `/`
+- render validation errors with file, line, column, source snippets, and actionable fix hints for malformed changeset frontmatter

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -1121,6 +1121,26 @@ fn render_change_target_markdown_quotes_special_character_ids() {
 	)
 	.unwrap_or_else(|error| panic!("render target: {error}"));
 	assert_eq!(lines, vec!["\"@monochange/skill\": patch".to_string()]);
+
+	let simple = render_change_target_markdown(
+		&configuration,
+		"plain-package",
+		BumpSeverity::Patch,
+		None,
+		None,
+	)
+	.unwrap_or_else(|error| panic!("render simple target: {error}"));
+	assert_eq!(simple, vec!["plain-package: patch".to_string()]);
+
+	let escaped = render_change_target_markdown(
+		&configuration,
+		"pkg\\\"name",
+		BumpSeverity::Patch,
+		None,
+		None,
+	)
+	.unwrap_or_else(|error| panic!("render escaped target: {error}"));
+	assert_eq!(escaped, vec!["\"pkg\\\\\\\"name\": patch".to_string()]);
 }
 
 #[test]

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -1108,6 +1108,22 @@ fn render_change_target_markdown_uses_group_defaults() {
 }
 
 #[test]
+fn render_change_target_markdown_quotes_special_character_ids() {
+	let root = fixture_path("changeset-target-metadata/render-workspace");
+	let configuration =
+		load_workspace_configuration(&root).unwrap_or_else(|error| panic!("config: {error}"));
+	let lines = render_change_target_markdown(
+		&configuration,
+		"@monochange/skill",
+		BumpSeverity::Patch,
+		None,
+		None,
+	)
+	.unwrap_or_else(|error| panic!("render target: {error}"));
+	assert_eq!(lines, vec!["\"@monochange/skill\": patch".to_string()]);
+}
+
+#[test]
 fn change_type_default_bump_resolves_package_group_and_unknown_targets() {
 	let root = fixture_path("changeset-target-metadata/render-workspace");
 	let configuration =
@@ -1147,6 +1163,41 @@ fn add_interactive_change_file_writes_target_owned_metadata() {
 	let content = fs::read_to_string(output_path).unwrap_or_else(|error| panic!("read: {error}"));
 	assert!(content.contains("sdk: test"));
 	assert!(content.contains("# broaden integration coverage"));
+}
+
+#[test]
+fn add_interactive_change_file_quotes_special_character_targets() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	fs::create_dir_all(tempdir.path().join("crates/core"))
+		.unwrap_or_else(|error| panic!("mkdir crate: {error}"));
+	fs::write(
+		tempdir.path().join("monochange.toml"),
+		"[package.\"@monochange/skill\"]\npath = \"crates/core\"\ntype = \"cargo\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write config: {error}"));
+	fs::write(
+		tempdir.path().join("crates/core/Cargo.toml"),
+		"[package]\nname = \"core\"\nversion = \"1.0.0\"\nedition = \"2024\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write cargo manifest: {error}"));
+	let output_path = tempdir.path().join(".changeset/interactive-special.md");
+	let result = InteractiveChangeResult {
+		targets: vec![InteractiveTarget {
+			id: "@monochange/skill".to_string(),
+			bump: BumpSeverity::Patch,
+			version: None,
+			change_type: None,
+		}],
+		reason: "ship special package id support".to_string(),
+		details: None,
+	};
+
+	add_interactive_change_file(tempdir.path(), &result, Some(&output_path))
+		.unwrap_or_else(|error| panic!("interactive change file: {error}"));
+	let content = fs::read_to_string(&output_path).unwrap_or_else(|error| panic!("read: {error}"));
+	assert!(content.contains("\"@monochange/skill\": patch"));
+	monochange_config::validate_workspace(tempdir.path())
+		.unwrap_or_else(|error| panic!("validate workspace: {error}"));
 }
 
 #[test]

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -841,6 +841,20 @@ pub(crate) fn change_type_default_bump(
 	})
 }
 
+fn render_changeset_target_key(target_id: &str) -> String {
+	if target_id
+		.chars()
+		.all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.'))
+	{
+		target_id.to_string()
+	} else {
+		format!(
+			"\"{}\"",
+			target_id.replace('\\', "\\\\").replace('"', "\\\"")
+		)
+	}
+}
+
 pub(crate) fn render_change_target_markdown(
 	configuration: &monochange_core::WorkspaceConfiguration,
 	target_id: &str,
@@ -854,6 +868,7 @@ pub(crate) fn render_change_target_markdown(
 		)));
 	}
 	let mut lines = Vec::new();
+	let target_key = render_changeset_target_key(target_id);
 	if let Some(change_type) = change_type.filter(|value| !value.trim().is_empty()) {
 		let default_bump = change_type_default_bump(configuration, target_id, change_type)
 			.ok_or_else(|| {
@@ -862,10 +877,10 @@ pub(crate) fn render_change_target_markdown(
 				))
 			})?;
 		if version.is_none() && bump == default_bump {
-			lines.push(format!("{target_id}: {change_type}"));
+			lines.push(format!("{target_key}: {change_type}"));
 			return Ok(lines);
 		}
-		lines.push(format!("{target_id}:"));
+		lines.push(format!("{target_key}:"));
 		if bump != BumpSeverity::None {
 			lines.push(format!("  bump: {bump}"));
 		}
@@ -876,14 +891,14 @@ pub(crate) fn render_change_target_markdown(
 		return Ok(lines);
 	}
 	if let Some(version) = version {
-		lines.push(format!("{target_id}:"));
+		lines.push(format!("{target_key}:"));
 		if bump != BumpSeverity::None {
 			lines.push(format!("  bump: {bump}"));
 		}
 		lines.push(format!("  version: \"{version}\""));
 		return Ok(lines);
 	}
-	lines.push(format!("{target_id}: {bump}"));
+	lines.push(format!("{target_key}: {bump}"));
 	Ok(lines)
 }
 

--- a/crates/monochange/tests/cli_output.rs
+++ b/crates/monochange/tests/cli_output.rs
@@ -360,3 +360,41 @@ fn validate_cli_rejects_packages_in_multiple_groups() {
 			.arg("validate")
 	);
 }
+
+#[test]
+fn validate_cli_reports_frontmatter_location_and_fix_hint() {
+	let tempdir = setup_scenario_workspace("changeset-target-metadata/render-workspace");
+	fs::write(
+		tempdir.path().join("monochange.toml"),
+		"[package.\"@monochange/skill\"]\npath = \"crates/core\"\ntype = \"cargo\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write config: {error}"));
+	fs::create_dir_all(tempdir.path().join(".changeset"))
+		.unwrap_or_else(|error| panic!("mkdir changeset dir: {error}"));
+	fs::write(
+		tempdir.path().join(".changeset/invalid.md"),
+		"---\n@monochange/skill: patch\n---\n\n# broken\n",
+	)
+	.unwrap_or_else(|error| panic!("write changeset: {error}"));
+
+	let output = monochange_command(None)
+		.current_dir(tempdir.path())
+		.arg("validate")
+		.output()
+		.unwrap_or_else(|error| panic!("validate output: {error}"));
+	assert!(!output.status.success());
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	assert!(stderr.contains("-->"), "stderr: {stderr}");
+	assert!(
+		stderr.contains(".changeset/invalid.md:2:1"),
+		"stderr: {stderr}"
+	);
+	assert!(
+		stderr.contains("2 | @monochange/skill: patch"),
+		"stderr: {stderr}"
+	);
+	assert!(
+		stderr.contains("wrap package or group ids that contain characters like `@`, `/`, `:`, or spaces in double quotes"),
+		"stderr: {stderr}"
+	);
+}

--- a/crates/monochange/tests/snapshots/cli_output__validate_cli_rejects_packages_in_multiple_groups@validate_cli_rejects_packages_in_multiple_groups.snap
+++ b/crates/monochange/tests/snapshots/cli_output__validate_cli_rejects_packages_in_multiple_groups@validate_cli_rejects_packages_in_multiple_groups.snap
@@ -1,12 +1,13 @@
 ---
 source: crates/monochange/tests/cli_output.rs
-assertion_line: 264
+assertion_line: 357
 info:
   program: mc
   args:
     - validate
   env:
     NO_COLOR: "1"
+    RUST_LOG: ""
 ---
 success: false
 exit_code: 1
@@ -14,8 +15,17 @@ exit_code: 1
 
 ----- stderr -----
 error: package `core` belongs to multiple groups: `cli` and `sdk`
---> monochange.toml
-labels:
-- first group membership @ bytes [OFFSET]..[END]
-- conflicting group membership @ bytes [OFFSET]..[END]
-help: move the package into exactly one [group.<id>] declaration
+  --> monochange.toml:11:13
+
+   |
+11 | packages = ["core"]
+   |             ^^^^^^ first group membership
+
+  ::: monochange.toml:8:13
+  |
+8 | packages = ["core"]
+  |             ^^^^^^ conflicting group membership
+
+  = help: move the package into exactly one [group.<id>] declaration
+  = note: the first snippet marks the primary failure location
+  = note: additional snippets show related locations referenced by this error

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -828,8 +828,11 @@ fn load_workspace_configuration_rejects_multi_group_membership() {
 
 	assert!(rendered.contains("error: package `core` belongs to multiple groups"));
 	assert!(rendered.contains("--> monochange.toml"));
-	assert!(rendered.contains("labels:"));
-	assert!(rendered.contains("move the package into exactly one [group.<id>] declaration"));
+	assert!(rendered.contains("::: monochange.toml"));
+	assert!(
+		rendered.contains("= help: move the package into exactly one [group.<id>] declaration")
+	);
+	assert!(rendered.contains("= note: the first snippet marks the primary failure location"));
 }
 
 #[test]
@@ -2269,6 +2272,53 @@ fn load_change_signals_rejects_unknown_package_references_with_diagnostic_help()
 	assert!(rendered.contains("error: changeset `"));
 	assert!(rendered.contains("unknown package or group `missing-package`"));
 	assert!(rendered.contains("help: declare the package or group id in monochange.toml"));
+}
+
+#[test]
+fn load_change_signals_reports_pretty_frontmatter_parse_errors_with_fix_hint() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	std::fs::write(
+		tempdir.path().join("monochange.toml"),
+		"[package.\"@monochange/skill\"]\npath = \"crates/core\"\ntype = \"cargo\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write config: {error}"));
+	std::fs::create_dir_all(tempdir.path().join("crates/core"))
+		.unwrap_or_else(|error| panic!("mkdir crate: {error}"));
+	std::fs::write(
+		tempdir.path().join("crates/core/Cargo.toml"),
+		"[package]\nname = \"core\"\nversion = \"1.0.0\"\nedition = \"2024\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write cargo manifest: {error}"));
+	let configuration = load_workspace_configuration(tempdir.path())
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+	let change_path = tempdir.path().join("change.md");
+	std::fs::write(
+		&change_path,
+		"---\n@monochange/skill: patch\n---\n\n# broken\n",
+	)
+	.unwrap_or_else(|error| panic!("write changeset: {error}"));
+
+	let error = load_change_signals(&change_path, &configuration, &[])
+		.err()
+		.unwrap_or_else(|| panic!("expected configuration error"));
+	let rendered = error.render();
+
+	assert!(
+		rendered.contains("error: failed to parse"),
+		"rendered: {rendered}"
+	);
+	assert!(
+		rendered.contains(&format!("--> {}:2:1", change_path.display())),
+		"rendered: {rendered}"
+	);
+	assert!(
+		rendered.contains("2 | @monochange/skill: patch"),
+		"rendered: {rendered}"
+	);
+	assert!(
+		rendered.contains("wrap package or group ids that contain characters like `@`, `/`, `:`, or spaces in double quotes"),
+		"rendered: {rendered}"
+	);
 }
 
 #[test]

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 use std::path::PathBuf;
 
+use miette::LabeledSpan;
 use monochange_core::BumpSeverity;
 use monochange_core::ChangelogDefinition;
 use monochange_core::ChangelogFormat;
@@ -17,10 +18,19 @@ use semver::Version;
 use tempfile::tempdir;
 
 use crate::apply_version_groups;
+use crate::frontmatter_span_for_line_column;
+use crate::line_and_column_for_offset;
+use crate::line_index_for_offset;
 use crate::load_change_signals;
 use crate::load_changeset_file;
 use crate::load_workspace_configuration;
+use crate::range_to_span;
+use crate::render_diagnostic_notes;
+use crate::render_source_diagnostic;
+use crate::render_source_snippet;
+use crate::render_source_snippets;
 use crate::resolve_package_reference;
+use crate::sort_labels_by_location;
 use crate::validate_workspace;
 
 fn fixture_path(relative: &str) -> PathBuf {
@@ -2318,6 +2328,74 @@ fn load_change_signals_reports_pretty_frontmatter_parse_errors_with_fix_hint() {
 	assert!(
 		rendered.contains("wrap package or group ids that contain characters like `@`, `/`, `:`, or spaces in double quotes"),
 		"rendered: {rendered}"
+	);
+}
+
+#[test]
+fn source_diagnostic_helpers_cover_empty_labels_sorting_and_fallback_spans() {
+	let source = "alpha\nbeta\ngamma";
+	let empty = render_source_diagnostic("demo.md", source, "plain failure", &[], None);
+	assert!(empty.contains("error: plain failure"), "{empty}");
+	assert!(empty.contains("  --> demo.md:1:1"), "{empty}");
+	assert!(!empty.contains("  = help:"), "{empty}");
+	assert!(!empty.contains("  = note:"), "{empty}");
+
+	let labels = vec![
+		LabeledSpan::new_with_span(Some("primary".to_string()), range_to_span(6..10)),
+		LabeledSpan::new_with_span(Some("later".to_string()), range_to_span(11..16)),
+		LabeledSpan::new_with_span(Some("earlier".to_string()), range_to_span(0..0)),
+	];
+	let sorted = sort_labels_by_location(&labels);
+	assert_eq!(sorted.first().and_then(LabeledSpan::label), Some("primary"));
+	assert_eq!(sorted.get(1).and_then(LabeledSpan::label), Some("earlier"));
+	assert_eq!(sorted.get(2).and_then(LabeledSpan::label), Some("later"));
+
+	let rendered = render_source_diagnostic(
+		"demo.md",
+		source,
+		"annotated failure",
+		&labels,
+		Some("try fixing it"),
+	);
+	assert!(rendered.contains("  --> demo.md:2:1"), "{rendered}");
+	assert!(rendered.contains("  ::: demo.md:1:1"), "{rendered}");
+	assert!(rendered.contains("  ::: demo.md:3:1"), "{rendered}");
+	assert!(rendered.contains("^ primary"), "{rendered}");
+	assert!(rendered.contains("^ earlier"), "{rendered}");
+	assert!(rendered.contains("^ later"), "{rendered}");
+	assert!(rendered.contains("  = help: try fixing it"), "{rendered}");
+	assert!(
+		rendered.contains("  = note: the first snippet marks the primary failure location"),
+		"{rendered}"
+	);
+
+	let secondary = render_source_snippet(
+		"demo.md",
+		source,
+		&LabeledSpan::new_with_span(None, range_to_span(0..0)),
+		false,
+	);
+	assert_eq!(secondary.first(), Some(&"  ::: demo.md:1:1".to_string()));
+	assert!(
+		secondary.iter().any(|line| line.contains("^ here")),
+		"{secondary:?}"
+	);
+
+	assert!(render_source_snippets("demo.md", source, &[]).is_empty());
+	assert!(sort_labels_by_location(&[]).is_empty());
+	assert!(render_diagnostic_notes(&[]).is_empty());
+	let single_label = labels
+		.first()
+		.cloned()
+		.map(|label| vec![label])
+		.unwrap_or_default();
+	assert!(render_diagnostic_notes(&single_label).is_empty());
+	assert_eq!(line_index_for_offset(source, usize::MAX), 2);
+	assert_eq!(line_and_column_for_offset(source, usize::MAX), (3, 6));
+	assert_eq!(frontmatter_span_for_line_column(source, 2, 99), 10..11);
+	assert_eq!(
+		frontmatter_span_for_line_column(source, 99, 1),
+		source.len()..source.len()
 	);
 }
 

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -1729,12 +1729,7 @@ fn parse_markdown_change_file_with_context(
 		)));
 	};
 	let body = body_with_separator.trim();
-	let mapping = serde_yaml_ng::from_str::<Mapping>(frontmatter).map_err(|error| {
-		MonochangeError::Config(format!(
-			"failed to parse {} frontmatter: {error}",
-			changes_path.display()
-		))
-	})?;
+	let mapping = parse_changeset_frontmatter(contents, frontmatter, changes_path)?;
 	let (reason, details) = markdown_change_text(body);
 	let mut changes = Vec::new();
 
@@ -1996,12 +1991,7 @@ fn parse_markdown_change_file(
 		)));
 	};
 	let body = body_with_separator.trim();
-	let mapping = serde_yaml_ng::from_str::<Mapping>(frontmatter).map_err(|error| {
-		MonochangeError::Config(format!(
-			"failed to parse {} frontmatter: {error}",
-			changes_path.display()
-		))
-	})?;
+	let mapping = parse_changeset_frontmatter(contents, frontmatter, changes_path)?;
 	let (reason, details) = markdown_change_text(body);
 	let mut changes = Vec::new();
 
@@ -2022,6 +2012,39 @@ fn parse_markdown_change_file(
 	}
 
 	Ok(RawChangeFile { changes })
+}
+
+fn parse_changeset_frontmatter(
+	contents: &str,
+	frontmatter: &str,
+	changes_path: &Path,
+) -> MonochangeResult<Mapping> {
+	serde_yaml_ng::from_str::<Mapping>(frontmatter).map_err(|error| {
+		let message = format!(
+			"failed to parse {} frontmatter: {error}",
+			changes_path.display()
+		);
+		let location = error.location().map(|location| {
+			frontmatter_span_for_line_column(contents, location.line(), location.column())
+		});
+		let labels = location
+			.map(|span| {
+				vec![LabeledSpan::new_with_span(
+					Some("frontmatter parse error".to_string()),
+					range_to_span(span),
+				)]
+			})
+			.unwrap_or_default();
+		changeset_diagnostic(
+			contents,
+			changes_path,
+			message,
+			labels,
+			Some(
+				"wrap package or group ids that contain characters like `@`, `/`, `:`, or spaces in double quotes, for example `\"@scope/pkg\": patch`".to_string(),
+			),
+		)
+	})
 }
 
 fn markdown_heading_level(line: &str) -> Option<usize> {
@@ -3498,6 +3521,7 @@ fn config_diagnostic(
 	let _ = report;
 	MonochangeError::Diagnostic(render_source_diagnostic(
 		CONFIG_FILE,
+		config_contents,
 		&message,
 		&labels,
 		help.as_deref(),
@@ -3566,23 +3590,155 @@ fn config_primary_label(config_contents: &str, owner_id: &str) -> LabeledSpan {
 
 fn render_source_diagnostic(
 	source_name: &str,
+	source_contents: &str,
 	message: &str,
 	labels: &[LabeledSpan],
 	help: Option<&str>,
 ) -> String {
-	let mut lines = vec![format!("error: {message}"), format!("--> {source_name}")];
-	if !labels.is_empty() {
-		lines.push("labels:".to_string());
-		for label in labels {
-			let label_text = label.label().unwrap_or("source");
-			let end = label.offset().saturating_add(label.len());
-			lines.push(format!("- {label_text} @ bytes {}..{end}", label.offset()));
-		}
+	let sorted_labels = sort_labels_by_location(labels);
+	let primary = sorted_labels.first().map_or(0, LabeledSpan::offset);
+	let (line_number, column_number) = line_and_column_for_offset(source_contents, primary);
+	let mut lines = vec![
+		format!("error: {message}"),
+		format!("  --> {source_name}:{line_number}:{column_number}"),
+	];
+
+	let snippets = render_source_snippets(source_name, source_contents, &sorted_labels);
+	if !snippets.is_empty() {
+		lines.push(String::new());
+		lines.extend(snippets);
 	}
 	if let Some(help) = help {
-		lines.push(format!("help: {help}"));
+		lines.push(String::new());
+		lines.push(format!("  = help: {help}"));
+	}
+	for note in render_diagnostic_notes(&sorted_labels) {
+		lines.push(format!("  = note: {note}"));
 	}
 	lines.join("\n")
+}
+
+fn sort_labels_by_location(labels: &[LabeledSpan]) -> Vec<LabeledSpan> {
+	let Some((first, rest)) = labels.split_first() else {
+		return Vec::new();
+	};
+	let mut sorted = vec![first.clone()];
+	let mut remaining = rest.to_vec();
+	remaining.sort_by(|left, right| {
+		(left.offset(), left.len(), left.label().unwrap_or("")).cmp(&(
+			right.offset(),
+			right.len(),
+			right.label().unwrap_or(""),
+		))
+	});
+	sorted.extend(remaining);
+	sorted
+}
+
+fn render_source_snippets(
+	source_name: &str,
+	source_contents: &str,
+	labels: &[LabeledSpan],
+) -> Vec<String> {
+	let mut snippets = Vec::new();
+	for (index, label) in labels.iter().enumerate() {
+		if index > 0 {
+			snippets.push(String::new());
+		}
+		snippets.extend(render_source_snippet(
+			source_name,
+			source_contents,
+			label,
+			index == 0,
+		));
+	}
+	snippets
+}
+
+fn render_source_snippet(
+	source_name: &str,
+	source_contents: &str,
+	label: &LabeledSpan,
+	is_primary: bool,
+) -> Vec<String> {
+	let line_index = line_index_for_offset(source_contents, label.offset());
+	let line = source_contents.lines().nth(line_index).unwrap_or_default();
+	let (_, column_number) = line_and_column_for_offset(source_contents, label.offset());
+	let line_number = line_index + 1;
+	let gutter_width = line_number.to_string().len();
+	let caret_width = label.len().max(1);
+	let caret_padding = column_number.saturating_sub(1);
+	let label_text = label.label().unwrap_or("here");
+	let mut lines = Vec::new();
+	if !is_primary {
+		lines.push(format!("  ::: {source_name}:{line_number}:{column_number}"));
+	}
+	lines.push(format!(
+		"{space:>width$} |",
+		space = "",
+		width = gutter_width
+	));
+	lines.push(format!("{line_number:>gutter_width$} | {line}"));
+	lines.push(format!(
+		"{space:>width$} | {padding}{carets} {label_text}",
+		space = "",
+		width = gutter_width,
+		padding = " ".repeat(caret_padding),
+		carets = "^".repeat(caret_width),
+		label_text = label_text,
+	));
+	lines
+}
+
+fn render_diagnostic_notes(labels: &[LabeledSpan]) -> Vec<&'static str> {
+	if labels.len() > 1 {
+		vec![
+			"the first snippet marks the primary failure location",
+			"additional snippets show related locations referenced by this error",
+		]
+	} else {
+		Vec::new()
+	}
+}
+
+fn line_index_for_offset(source_contents: &str, offset: usize) -> usize {
+	let safe_offset = offset.min(source_contents.len());
+	source_contents[..safe_offset]
+		.bytes()
+		.filter(|byte| *byte == b'\n')
+		.count()
+}
+
+fn line_and_column_for_offset(source_contents: &str, offset: usize) -> (usize, usize) {
+	let line_index = line_index_for_offset(source_contents, offset);
+	let line_start = source_contents[..offset.min(source_contents.len())]
+		.rfind('\n')
+		.map_or(0, |index| index + 1);
+	(
+		line_index + 1,
+		offset.min(source_contents.len()) - line_start + 1,
+	)
+}
+
+fn frontmatter_span_for_line_column(
+	source_contents: &str,
+	line_number: usize,
+	column_number: usize,
+) -> Range<usize> {
+	let mut line_start = 0usize;
+	for (current_line, line) in (1usize..).zip(source_contents.split_inclusive('\n')) {
+		let line_end = line_start + line.len();
+		if current_line == line_number {
+			let line_contents = line.strip_suffix('\n').unwrap_or(line);
+			let offset = column_number.saturating_sub(1).min(line_contents.len());
+			let start = line_start + offset;
+			let end = start.saturating_add(1).min(source_contents.len());
+			return start..end;
+		}
+		line_start = line_end;
+	}
+	let start = line_start.min(source_contents.len());
+	start..start
 }
 
 fn range_to_span(range: Range<usize>) -> SourceSpan {
@@ -3672,6 +3828,7 @@ fn changeset_diagnostic(
 	let _ = report;
 	MonochangeError::Diagnostic(render_source_diagnostic(
 		&source_name,
+		contents,
 		&message,
 		&labels,
 		help.as_deref(),

--- a/docs/src/reference/cli-steps/01-validate.md
+++ b/docs/src/reference/cli-steps/01-validate.md
@@ -59,6 +59,8 @@ None. `Validate` is standalone.
 
 `Validate` returns a normal success/failure result for the command and does not prepare release state for later steps.
 
+When validation fails, monochange renders the offending file path and line/column first, then shows a focused source snippet plus a fix hint when one is available. That makes malformed changesets and config entries much faster to correct from CI logs or local terminal output.
+
 That last point matters: `Validate` is a gate, not a state-producing step.
 
 ## When to place it in a workflow

--- a/docs/src/reference/cli-steps/03-create-change-file.md
+++ b/docs/src/reference/cli-steps/03-create-change-file.md
@@ -51,6 +51,7 @@ None. `CreateChangeFile` is standalone.
 - reports the written path
 - does not prepare release state for later steps
 - automatically hides the progress spinner during interactive prompting so the selector UI stays readable
+- automatically wraps package/group ids in quotes when the authored frontmatter key contains YAML-sensitive characters such as `@` or `/`
 
 ## Example
 


### PR DESCRIPTION
## Summary
- quote generated changeset target ids when they contain YAML-sensitive characters like `@` or `/`
- improve validation diagnostics with clearer file/line-first rendering, inline related snippets, help text, and notes
- document the improved validation and interactive change-file behavior

## Examples
### Multiple group membership
```text
error: package `core` belongs to multiple groups: `cli` and `sdk`
  --> monochange.toml:11:13

   |
11 | packages = ["core"]
   |             ^^^^^^ first group membership

  ::: monochange.toml:8:13
  |
8 | packages = ["core"]
  |             ^^^^^^ conflicting group membership

  = help: move the package into exactly one [group.<id>] declaration
  = note: the first snippet marks the primary failure location
  = note: additional snippets show related locations referenced by this error
```

### Invalid changeset frontmatter
```text
error: failed to parse /path/.changeset/invalid.md frontmatter: found character that cannot start any token at line 2 column 1, while scanning for the next token
  --> /path/.changeset/invalid.md:2:1

  |
2 | @monochange/skill: patch
  | ^ frontmatter parse error

  = help: wrap package or group ids that contain characters like `@`, `/`, `:`, or spaces in double quotes, for example `"@scope/pkg": patch`
```

## Validation
- `devenv shell fix:all`
- `cargo test -p monochange_config`
- `cargo test -p monochange --test cli_output`
- `cargo run -q -p monochange --bin mc -- validate`
