### PR TITLE
perf: short-circuit release pull request updates

### DIFF
--- a/.changeset/release-pr-performance-short-circuit.md
+++ b/.changeset/release-pr-performance-short-circuit.md
@@ -1,0 +1,41 @@
+---
+"monochange": patch
+"monochange_core": patch
+"monochange_gitea": patch
+"monochange_github": patch
+"monochange_gitlab": patch
+---
+
+#### skip redundant hosted release request updates
+
+Release request creation now avoids a second round of hosted work when the open pull request or merge request already matches the prepared release branch state. This makes reruns cheaper for GitHub, GitLab, and Gitea adapter callers, and it adds a real `Skipped` outcome so callers can tell the difference between "updated" and "already aligned".
+
+Before:
+
+```sh
+mc release-pr --format json
+# always prepared a branch push and provider update path
+```
+
+After:
+
+```sh
+mc release-pr --format json
+# still prepares the release request, but hosted adapters now skip redundant
+# push and metadata updates when the existing request already matches HEAD
+```
+
+If you call the provider crates directly, `SourceChangeRequestOperation` now exposes the no-op state explicitly:
+
+```rust
+use monochange_core::SourceChangeRequestOperation;
+
+let operation = SourceChangeRequestOperation::Skipped;
+assert_eq!(operation.to_string(), "skipped");
+```
+
+The benchmark suite now also includes a real hosted `release-pr` creation path alongside the existing dry-run preview benchmark:
+
+```sh
+cargo bench -p monochange --bench cli_commands release_pr -- --noplot
+```

--- a/crates/monochange/benches/cli_commands.rs
+++ b/crates/monochange/benches/cli_commands.rs
@@ -1,11 +1,16 @@
+use std::ffi::OsString;
 use std::fs;
 use std::path::Path;
+use std::process::Command;
 
 use criterion::BatchSize;
 use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::criterion_group;
 use criterion::criterion_main;
+use httpmock::Method::GET;
+use httpmock::Method::POST;
+use httpmock::MockServer;
 
 /// Generate a workspace fixture with N cargo packages and M changesets.
 fn generate_fixture(root: &Path, num_packages: usize, num_changesets: usize) {
@@ -142,7 +147,61 @@ fn enable_explicit_cargo_refresh_command(root: &Path) {
 			"{config}\n[[ecosystems.cargo.lockfile_commands]]\ncommand = \"cargo generate-lockfile\"\ncwd = \".\"\n"
 		),
 	)
-	.unwrap();
+		.unwrap();
+}
+
+fn setup_scenario_workspace(relative: &str) -> tempfile::TempDir {
+	monochange_test_helpers::fs::setup_scenario_workspace_from(env!("CARGO_MANIFEST_DIR"), relative)
+}
+
+fn git(root: &Path, args: &[&str]) {
+	let output = Command::new("git")
+		.current_dir(root)
+		.args(args)
+		.output()
+		.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
+	assert!(
+		output.status.success(),
+		"git {args:?} failed: {}{}",
+		String::from_utf8_lossy(&output.stdout),
+		String::from_utf8_lossy(&output.stderr)
+	);
+}
+
+fn seed_release_pr_git_repository(root: &Path) {
+	let bare = root.join(".bench-origin.git");
+	git(root, &["init", "-b", "main"]);
+	git(root, &["config", "user.name", "monochange Bench"]);
+	git(root, &["config", "user.email", "monochange@example.com"]);
+	git(root, &["add", "."]);
+	git(root, &["commit", "-m", "initial"]);
+	git(root, &["init", "--bare", bare.to_string_lossy().as_ref()]);
+	git(
+		root,
+		&["remote", "add", "origin", bare.to_string_lossy().as_ref()],
+	);
+	git(root, &["push", "-u", "origin", "main"]);
+}
+
+fn release_pr_args(dry_run: bool) -> Vec<OsString> {
+	let mut args = vec![OsString::from("mc"), OsString::from("release-pr")];
+	if dry_run {
+		args.push(OsString::from("--dry-run"));
+	}
+	args.push(OsString::from("--format"));
+	args.push(OsString::from("json"));
+	args
+}
+
+fn run_release_pr_command(root: &Path, dry_run: bool, github_api_url: Option<&str>) -> String {
+	temp_env::with_vars(
+		[
+			("MONOCHANGE_RELEASE_DATE", Some("2026-04-06")),
+			("GITHUB_TOKEN", Some("bench-token")),
+			("GITHUB_API_URL", github_api_url),
+		],
+		|| monochange::run_with_args_in_dir("mc", release_pr_args(dry_run), root).unwrap(),
+	)
 }
 
 const SCALES: &[(usize, usize)] = &[(5, 10), (20, 50), (50, 200)];
@@ -467,6 +526,66 @@ fn bench_prepare_release_with_git_history(c: &mut Criterion) {
 	group.finish();
 }
 
+fn bench_release_pr(c: &mut Criterion) {
+	let mut group = c.benchmark_group("release_pr");
+	group.sample_size(10);
+
+	group.bench_function("dry_run_preview", |b| {
+		b.iter_batched(
+			|| setup_scenario_workspace("source/github"),
+			|tempdir| {
+				let _ = run_release_pr_command(tempdir.path(), true, None);
+			},
+			BatchSize::LargeInput,
+		);
+	});
+
+	group.bench_function("github_create", |b| {
+		b.iter_batched(
+			|| {
+				let tempdir = setup_scenario_workspace("source/github");
+				seed_release_pr_git_repository(tempdir.path());
+				let server = MockServer::start();
+				server.mock(|when, then| {
+					when.method(GET).path("/repos/ifiokjr/monochange/pulls");
+					then.status(200)
+						.header("content-type", "application/json")
+						.body("[]");
+				});
+				server.mock(|when, then| {
+					when.method(POST).path("/repos/ifiokjr/monochange/pulls");
+					then.status(201)
+						.header("content-type", "application/json")
+						.body(
+							"{\"number\":7,\"html_url\":\"https://example.com/pr/7\",\"node_id\":\"PR_node\"}",
+						);
+				});
+				server.mock(|when, then| {
+					when.method(POST)
+						.path("/repos/ifiokjr/monochange/issues/7/labels");
+					then.status(200)
+						.header("content-type", "application/json")
+						.body("[]");
+				});
+				server.mock(|when, then| {
+					when.method(POST).path("/graphql");
+					then.status(200)
+						.header("content-type", "application/json")
+						.body("{\"enablePullRequestAutoMerge\":{\"pullRequest\":{\"number\":7}}}");
+				});
+				(tempdir, server)
+			},
+			|(tempdir, server)| {
+				let api_url = server.base_url();
+				let _ = run_release_pr_command(tempdir.path(), false, Some(api_url.as_str()));
+			},
+			BatchSize::LargeInput,
+		);
+	});
+
+	group.finish();
+}
+
 criterion_group!(
 	benches,
 	bench_config_load,
@@ -477,5 +596,6 @@ criterion_group!(
 	bench_prepare_release_apply,
 	bench_prepare_release_apply_cargo_lockfile_refresh,
 	bench_prepare_release_with_git_history,
+	bench_release_pr,
 );
 criterion_main!(benches);

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -8194,6 +8194,12 @@ fn format_publish_state_and_source_operation_labels_are_stable() {
 		),
 		"updated"
 	);
+	assert_eq!(
+		crate::format_change_request_operation(
+			&monochange_core::SourceChangeRequestOperation::Skipped
+		),
+		"skipped"
+	);
 }
 
 #[test]

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -567,7 +567,12 @@ where
 }
 
 #[tracing::instrument(skip_all, fields(bin_name))]
-fn run_with_args_in_dir<I>(bin_name: &'static str, args: I, root: &Path) -> MonochangeResult<String>
+#[doc(hidden)]
+pub fn run_with_args_in_dir<I>(
+	bin_name: &'static str,
+	args: I,
+	root: &Path,
+) -> MonochangeResult<String>
 where
 	I: IntoIterator<Item = OsString>,
 {

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -1107,6 +1107,7 @@ pub(crate) fn format_change_request_operation(
 	match operation {
 		SourceChangeRequestOperation::Created => "created",
 		SourceChangeRequestOperation::Updated => "updated",
+		SourceChangeRequestOperation::Skipped => "skipped",
 	}
 }
 

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -56,6 +56,7 @@ use crate::default_cli_commands;
 use crate::git::git_checkout_branch_command;
 use crate::git::git_command;
 use crate::git::git_current_branch;
+use crate::git::git_head_commit;
 use crate::git::git_push_branch_command;
 use crate::materialize_dependency_edges;
 use crate::render_release_notes;
@@ -206,6 +207,66 @@ fn git_current_branch_reports_missing_directory_as_io_error() {
 	);
 	assert!(
 		matches!(error, MonochangeError::Io(message) if message.contains("failed to read current git branch"))
+	);
+}
+
+#[test]
+fn git_head_commit_reports_current_commit_sha() {
+	let tempdir = must_ok(tempdir(), "tempdir");
+	let root = tempdir.path();
+	init_git_repository(root);
+	for args in [
+		["config", "user.name", "monochange Tests"],
+		["config", "user.email", "monochange@example.com"],
+		["config", "commit.gpgsign", "false"],
+	] {
+		let output = git_command(root)
+			.args(args)
+			.output()
+			.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
+		assert!(
+			output.status.success(),
+			"git {args:?} failed: {}",
+			String::from_utf8_lossy(&output.stderr)
+		);
+	}
+	must_ok(
+		fs::write(root.join("README.md"), "hello\n"),
+		"write README.md",
+	);
+	for args in [&["add", "README.md"][..], &["commit", "-m", "initial"][..]] {
+		let output = git_command(root)
+			.args(args)
+			.output()
+			.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
+		assert!(
+			output.status.success(),
+			"git {args:?} failed: {}",
+			String::from_utf8_lossy(&output.stderr)
+		);
+	}
+
+	let sha = must_ok(git_head_commit(root), "head commit");
+	assert_eq!(sha.len(), 40);
+}
+
+#[test]
+fn git_head_commit_reports_unborn_head_as_config_error() {
+	let tempdir = must_ok(tempdir(), "tempdir");
+	let root = tempdir.path();
+	init_git_repository(root);
+	let error = must_err(git_head_commit(root), "expected unborn HEAD config error");
+	assert!(
+		matches!(error, MonochangeError::Config(message) if message.contains("failed to read HEAD commit"))
+	);
+}
+
+#[test]
+fn source_change_request_operation_serializes_skipped_variant() {
+	assert_eq!(
+		serde_json::to_value(crate::SourceChangeRequestOperation::Skipped)
+			.unwrap_or_else(|error| panic!("serialize skipped operation: {error}")),
+		json!("skipped")
 	);
 }
 

--- a/crates/monochange_core/src/git.rs
+++ b/crates/monochange_core/src/git.rs
@@ -76,6 +76,18 @@ pub fn git_current_branch(root: &Path) -> MonochangeResult<String> {
 	Ok(git_stdout_trimmed(&output))
 }
 
+pub fn git_head_commit(root: &Path) -> MonochangeResult<String> {
+	let output = git_command_output(root, &["rev-parse", "HEAD"])
+		.map_err(|error| MonochangeError::Io(format!("failed to read HEAD commit: {error}")))?;
+	if !output.status.success() {
+		return Err(MonochangeError::Config(format!(
+			"failed to read HEAD commit: {}",
+			git_error_detail(&output)
+		)));
+	}
+	Ok(git_stdout_trimmed(&output))
+}
+
 #[tracing::instrument(skip_all, fields(args = ?args))]
 pub fn git_command_output(root: &Path, args: &[&str]) -> std::io::Result<Output> {
 	let mut command = git_command(root);

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -2648,6 +2648,7 @@ pub struct SourceChangeRequest {
 pub enum SourceChangeRequestOperation {
 	Created,
 	Updated,
+	Skipped,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/crates/monochange_gitea/src/__tests.rs
+++ b/crates/monochange_gitea/src/__tests.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::thread;
 
 use httpmock::Method::GET;
 use httpmock::Method::PATCH;
@@ -14,6 +15,7 @@ use monochange_core::HostedActorSourceKind;
 use monochange_core::HostedCommitRef;
 use monochange_core::HostingCapabilities;
 use monochange_core::HostingProviderKind;
+use monochange_core::MonochangeResult;
 use monochange_core::PreparedChangeset;
 use monochange_core::ProviderBotSettings;
 use monochange_core::ProviderMergeRequestSettings;
@@ -747,7 +749,7 @@ fn publish_pull_request_updates_existing_pull_request() {
 		then.status(200)
 			.header("content-type", "application/json")
 			.body(
-				"[{\"number\":12,\"html_url\":\"https://codeberg.org/org/monochange/pulls/12\"}]",
+				"[{\"number\":12,\"html_url\":\"https://codeberg.org/org/monochange/pulls/12\",\"title\":\"old title\",\"body\":\"old body\",\"base\":{\"ref\":\"main\"},\"head\":{\"sha\":\"old-sha\"},\"labels\":[]}]",
 			);
 	});
 	let update = server.mock(|when, then| {
@@ -785,6 +787,80 @@ fn publish_pull_request_updates_existing_pull_request() {
 	update.assert();
 	labels.assert();
 	assert_eq!(outcome.operation, SourceChangeRequestOperation::Updated);
+}
+
+#[test]
+fn join_existing_pull_request_lookup_reports_panicked_thread() {
+	let error = join_existing_pull_request_lookup(thread::spawn(
+		|| -> MonochangeResult<Option<GiteaExistingPullRequest>> {
+			panic!("boom");
+		},
+	))
+	.err()
+	.unwrap_or_else(|| panic!("expected join error"));
+	assert!(
+		error
+			.to_string()
+			.contains("failed to join Gitea pull request lookup thread")
+	);
+}
+
+#[etest::etest(skip=env::var_os("PRE_COMMIT").is_some())]
+fn publish_release_pull_request_skips_push_when_existing_pull_request_matches_local_head() {
+	let server = MockServer::start();
+	let (_tempdir, repo) = seed_git_repository();
+	let source = sample_source(
+		Some(format!("{}/api/v1", server.base_url())),
+		Some("https://codeberg.org".to_string()),
+	);
+	let request = build_release_pull_request_request(&source, &sample_manifest());
+
+	git(&repo, &["checkout", "-B", &request.head_branch]);
+	git(&repo, &["add", "-A", "--", "release.txt"]);
+	git(&repo, &["commit", "-m", "prepare release branch"]);
+	git(&repo, &["push", "-u", "origin", &request.head_branch]);
+	let head_commit = git_output(&repo, &["rev-parse", "HEAD"]).trim().to_string();
+	let labels = request
+		.labels
+		.iter()
+		.map(|label| format!("{{\"name\":{label:?}}}"))
+		.collect::<Vec<_>>()
+		.join(",");
+	let list = server.mock(|when, then| {
+		when.method(GET)
+			.path("/api/v1/repos/org/monochange/pulls")
+			.query_param("state", "open")
+			.query_param("head", "org:monochange/release/release")
+			.query_param("base", "main");
+			then.status(200)
+				.header("content-type", "application/json")
+				.body(format!(
+					"[{{\"number\":12,\"html_url\":\"https://codeberg.org/org/monochange/pulls/12\",\"title\":{title:?},\"body\":{body:?},\"base\":{{\"ref\":{base:?}}},\"head\":{{\"sha\":{head:?}}},\"labels\":[{labels}]}}]",
+					title = request.title,
+					body = request.body,
+					base = request.base_branch,
+					labels = labels,
+					head = head_commit,
+				));
+		});
+	git(
+		&repo,
+		&[
+			"remote",
+			"set-url",
+			"origin",
+			"/definitely/missing/gitea-origin.git",
+		],
+	);
+
+	let outcome = with_gitea_env(Some("token"), || {
+		publish_release_pull_request(&source, &repo, &request, &[PathBuf::from("release.txt")])
+			.unwrap_or_else(|error| panic!("publish pull request: {error}"))
+	});
+
+	list.assert();
+	assert_eq!(outcome.operation, SourceChangeRequestOperation::Skipped);
+	assert_eq!(outcome.number, 12);
 }
 
 fn sample_source(api_url: Option<String>, host: Option<String>) -> SourceConfiguration {

--- a/crates/monochange_gitea/src/lib.rs
+++ b/crates/monochange_gitea/src/lib.rs
@@ -3,6 +3,7 @@
 use std::env;
 use std::path::Path;
 use std::path::PathBuf;
+use std::thread;
 
 use monochange_core::CommitMessage;
 use monochange_core::HostingCapabilities;
@@ -26,6 +27,7 @@ use monochange_core::SourceReleaseRequest;
 use monochange_core::git::git_checkout_branch_command;
 use monochange_core::git::git_commit_paths_command;
 use monochange_core::git::git_current_branch;
+use monochange_core::git::git_head_commit;
 use monochange_core::git::git_push_branch_command;
 use monochange_core::git::git_stage_paths_command;
 use monochange_core::git::run_command;
@@ -193,6 +195,34 @@ struct GiteaPullRequestResponse {
 	html_url: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct GiteaExistingPullRequestLabel {
+	name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GiteaExistingPullRequestBase {
+	#[serde(rename = "ref")]
+	ref_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GiteaExistingPullRequestHead {
+	sha: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GiteaExistingPullRequest {
+	number: u64,
+	html_url: Option<String>,
+	title: String,
+	body: Option<String>,
+	base: GiteaExistingPullRequestBase,
+	head: GiteaExistingPullRequestHead,
+	#[serde(default)]
+	labels: Vec<GiteaExistingPullRequestLabel>,
+}
+
 fn gitea_host(source: &SourceConfiguration) -> &str {
 	source
 		.host
@@ -297,15 +327,38 @@ pub fn publish_release_pull_request(
 	request: &SourceChangeRequest,
 	tracked_paths: &[PathBuf],
 ) -> MonochangeResult<SourceChangeRequestOutcome> {
+	let lookup_source = source.clone();
+	let lookup_request = request.clone();
+	let existing_pull_request = thread::spawn(move || {
+		let client = gitea_client()?;
+		let token = gitea_token()?;
+		let api_base = gitea_api_base(&lookup_source)?;
+		lookup_existing_pull_request(&client, &token, &api_base, &lookup_request)
+	});
 	git_checkout_branch(root, &request.head_branch)?;
 	git_stage_paths(root, tracked_paths)?;
 	git_commit_paths(root, &request.commit_message)?;
-	git_push_branch(root, &request.head_branch)?;
+	let head_commit = git_head_commit(root)?;
+	let existing = join_existing_pull_request_lookup(existing_pull_request)?;
+	let head_matches_existing = existing
+		.as_ref()
+		.and_then(|pull_request| pull_request.head.sha.as_deref())
+		== Some(head_commit.as_str());
+	if !head_matches_existing {
+		git_push_branch(root, &request.head_branch)?;
+	}
 
 	let client = gitea_client()?;
 	let token = gitea_token()?;
 	let api_base = gitea_api_base(source)?;
-	publish_pull_request(&client, &token, &api_base, request)
+	publish_pull_request_with_existing(
+		&client,
+		&token,
+		&api_base,
+		request,
+		existing.as_ref(),
+		&head_commit,
+	)
 }
 
 fn publish_release_request(
@@ -374,38 +427,59 @@ fn publish_release_request(
 	})
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 fn publish_pull_request(
 	client: &Client,
 	token: &str,
 	api_base: &str,
 	request: &SourceChangeRequest,
 ) -> MonochangeResult<SourceChangeRequestOutcome> {
-	let list_url = format!(
-		"{api_base}/repos/{}/{}/pulls?state=open&head={}:{}&base={}",
-		request.owner,
-		request.repo,
-		encode(&request.owner),
-		encode(&request.head_branch),
-		encode(&request.base_branch),
-	);
-	let existing = get_json::<Vec<GiteaPullRequestResponse>>(client, token, &list_url)?
-		.into_iter()
-		.next();
+	let existing = lookup_existing_pull_request(client, token, api_base, request)?;
+	publish_pull_request_with_existing(client, token, api_base, request, existing.as_ref(), "")
+}
+
+fn publish_pull_request_with_existing(
+	client: &Client,
+	token: &str,
+	api_base: &str,
+	request: &SourceChangeRequest,
+	existing: Option<&GiteaExistingPullRequest>,
+	head_commit: &str,
+) -> MonochangeResult<SourceChangeRequestOutcome> {
+	let labels_match = existing.is_some_and(|pull_request| {
+		request.labels.iter().all(|label| {
+			pull_request
+				.labels
+				.iter()
+				.any(|existing_label| existing_label.name == *label)
+		})
+	});
+	let content_matches = existing.is_some_and(|pull_request| {
+		pull_request.title == request.title
+			&& pull_request.body.as_deref().unwrap_or_default() == request.body
+			&& pull_request.base.ref_name == request.base_branch
+	});
+	let head_matches_existing =
+		existing.and_then(|pull_request| pull_request.head.sha.as_deref()) == Some(head_commit);
 	let response: GiteaPullRequestResponse = if let Some(existing_pr) = &existing {
-		let update_url = format!(
-			"{api_base}/repos/{}/{}/pulls/{}",
-			request.owner, request.repo, existing_pr.number
-		);
-		patch_json(
-			client,
-			token,
-			&update_url,
-			&GiteaPullRequestUpdatePayload {
+		if content_matches {
+			GiteaPullRequestResponse {
+				number: existing_pr.number,
+				html_url: existing_pr.html_url.clone(),
+			}
+		} else {
+			let update_url = format!(
+				"{api_base}/repos/{}/{}/pulls/{}",
+				request.owner, request.repo, existing_pr.number
+			);
+			let update_payload = GiteaPullRequestUpdatePayload {
 				title: &request.title,
 				body: &request.body,
 				base: &request.base_branch,
-			},
-		)?
+			};
+
+			patch_json(client, token, &update_url, &update_payload)?
+		}
 	} else {
 		let create_url = format!("{api_base}/repos/{}/{}/pulls", request.owner, request.repo);
 		post_json(
@@ -420,7 +494,7 @@ fn publish_pull_request(
 			},
 		)?
 	};
-	if !request.labels.is_empty() {
+	if !request.labels.is_empty() && !labels_match {
 		let labels_url = format!(
 			"{api_base}/repos/{}/{}/issues/{}/labels",
 			request.owner, request.repo, response.number
@@ -439,13 +513,44 @@ fn publish_pull_request(
 		repository: request.repository.clone(),
 		number: response.number,
 		head_branch: request.head_branch.clone(),
-		operation: if existing.is_some() {
-			SourceChangeRequestOperation::Updated
-		} else {
+		operation: if existing.is_none() {
 			SourceChangeRequestOperation::Created
+		} else if content_matches && labels_match && head_matches_existing {
+			SourceChangeRequestOperation::Skipped
+		} else {
+			SourceChangeRequestOperation::Updated
 		},
 		url: response.html_url,
 	})
+}
+
+fn lookup_existing_pull_request(
+	client: &Client,
+	token: &str,
+	api_base: &str,
+	request: &SourceChangeRequest,
+) -> MonochangeResult<Option<GiteaExistingPullRequest>> {
+	let list_url = format!(
+		"{api_base}/repos/{}/{}/pulls?state=open&head={}:{}&base={}",
+		request.owner,
+		request.repo,
+		encode(&request.owner),
+		encode(&request.head_branch),
+		encode(&request.base_branch),
+	);
+	Ok(
+		get_json::<Vec<GiteaExistingPullRequest>>(client, token, &list_url)?
+			.into_iter()
+			.next(),
+	)
+}
+
+fn join_existing_pull_request_lookup(
+	handle: thread::JoinHandle<MonochangeResult<Option<GiteaExistingPullRequest>>>,
+) -> MonochangeResult<Option<GiteaExistingPullRequest>> {
+	handle.join().map_err(|_| {
+		MonochangeError::Config("failed to join Gitea pull request lookup thread".to_string())
+	})?
 }
 
 fn gitea_client() -> MonochangeResult<Client> {

--- a/crates/monochange_github/src/__tests.rs
+++ b/crates/monochange_github/src/__tests.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::thread;
 
 use httpmock::Method::GET;
 use httpmock::Method::PATCH;
@@ -17,6 +18,7 @@ use monochange_core::HostedIssueRelationshipKind;
 use monochange_core::HostingCapabilities;
 use monochange_core::HostingProviderKind;
 use monochange_core::MonochangeError;
+use monochange_core::MonochangeResult;
 use monochange_core::PreparedChangeset;
 use monochange_core::ProviderBotSettings;
 use monochange_core::ProviderMergeRequestSettings;
@@ -769,7 +771,7 @@ fn publish_release_pull_request_updates_existing_pull_request_via_octocrab() {
 		then.status(200)
 			.header("content-type", "application/json")
 			.body(
-				"[{\"number\":9,\"html_url\":\"https://example.com/pr/9\",\"node_id\":\"PR_node\"}]",
+				"[{\"number\":9,\"html_url\":\"https://example.com/pr/9\",\"node_id\":\"PR_node\",\"title\":\"old title\",\"body\":\"old body\",\"base\":{\"ref\":\"main\"},\"head\":{\"sha\":\"old-sha\"},\"labels\":[]}]",
 			);
 	});
 	let update_pull_request = server.mock(|when, then| {
@@ -802,6 +804,116 @@ fn publish_release_pull_request_updates_existing_pull_request_via_octocrab() {
 	add_labels.assert();
 	assert_eq!(outcome.operation, GitHubPullRequestOperation::Updated);
 	assert_eq!(outcome.number, 9);
+}
+
+#[test]
+fn publish_release_pull_request_skips_matching_existing_pull_request() {
+	let server = MockServer::start();
+	let request = sample_pull_request_request();
+	let existing = GitHubExistingPullRequest {
+		number: 9,
+		html_url: Some("https://example.com/pr/9".to_string()),
+		node_id: "PR_node".to_string(),
+		title: request.title.clone(),
+		body: Some(request.body.clone()),
+		base: GitHubExistingPullRequestBase {
+			ref_name: request.base_branch.clone(),
+		},
+		head: GitHubExistingPullRequestHead {
+			sha: Some("head-sha".to_string()),
+		},
+		labels: request
+			.labels
+			.iter()
+			.cloned()
+			.map(|name| GitHubExistingPullRequestLabel { name })
+			.collect(),
+	};
+
+	let outcome = github_runtime()
+		.unwrap_or_else(|error| panic!("runtime: {error}"))
+		.block_on(async {
+			let client = build_test_client(&server);
+			publish_release_pull_request_with_existing_pull_request(
+				&client,
+				&request,
+				Some(&existing),
+				"head-sha",
+			)
+			.await
+		})
+		.unwrap_or_else(|error| panic!("publish pull request: {error}"));
+
+	assert_eq!(outcome.operation, GitHubPullRequestOperation::Skipped);
+	assert_eq!(outcome.number, 9);
+	assert_eq!(outcome.url.as_deref(), Some("https://example.com/pr/9"));
+}
+
+#[test]
+fn join_existing_pull_request_lookup_reports_panicked_thread() {
+	let error = join_existing_pull_request_lookup(thread::spawn(
+		|| -> MonochangeResult<Option<GitHubExistingPullRequest>> {
+			panic!("boom");
+		},
+	))
+	.err()
+	.unwrap_or_else(|| panic!("expected join error"));
+	assert!(
+		error
+			.to_string()
+			.contains("failed to join GitHub pull request lookup thread")
+	);
+}
+
+#[test]
+fn publish_release_pull_request_marks_matching_auto_merge_request_as_updated() {
+	let server = MockServer::start();
+	let enable_auto_merge = server.mock(|when, then| {
+		when.method(POST).path("/graphql");
+		then.status(200)
+			.header("content-type", "application/json")
+			.body("{\"enablePullRequestAutoMerge\":{\"pullRequest\":{\"number\":9}}}");
+	});
+	let mut request = sample_pull_request_request();
+	request.auto_merge = true;
+	let existing = GitHubExistingPullRequest {
+		number: 9,
+		html_url: Some("https://example.com/pr/9".to_string()),
+		node_id: "PR_node".to_string(),
+		title: request.title.clone(),
+		body: Some(request.body.clone()),
+		base: GitHubExistingPullRequestBase {
+			ref_name: request.base_branch.clone(),
+		},
+		head: GitHubExistingPullRequestHead {
+			sha: Some("head-sha".to_string()),
+		},
+		labels: request
+			.labels
+			.iter()
+			.cloned()
+			.map(|name| GitHubExistingPullRequestLabel { name })
+			.collect(),
+	};
+
+	let outcome = github_runtime()
+		.unwrap_or_else(|error| panic!("runtime: {error}"))
+		.block_on(async {
+			let client = build_test_client(&server);
+			publish_release_pull_request_with_existing_pull_request(
+				&client,
+				&request,
+				Some(&existing),
+				"head-sha",
+			)
+			.await
+		})
+		.unwrap_or_else(|error| panic!("publish pull request: {error}"));
+
+	assert_eq!(outcome.operation, GitHubPullRequestOperation::Updated);
+	assert_eq!(outcome.number, 9);
+	assert_eq!(outcome.url.as_deref(), Some("https://example.com/pr/9"));
+	enable_auto_merge.assert();
 }
 
 #[test]
@@ -892,6 +1004,54 @@ fn publish_release_pull_request_reports_auto_merge_payload_errors() {
 			.to_string()
 			.contains("auto merge returned no pull request payload")
 	);
+}
+
+#[etest::etest(skip=env::var_os("PRE_COMMIT").is_some())]
+fn publish_release_pull_request_skips_push_when_existing_pull_request_matches_local_head() {
+	let server = MockServer::start();
+	let (tempdir, repo) = seed_git_repository();
+	let source = sample_source(Some(server.base_url()));
+	let request = sample_pull_request_request();
+
+	git(&repo, &["checkout", "-B", &request.head_branch]);
+	git(&repo, &["add", "-A", "--", "release.txt"]);
+	git(&repo, &["commit", "-m", "prepare release branch"]);
+	git(&repo, &["push", "-u", "origin", &request.head_branch]);
+	let head_commit = git_output(&repo, &["rev-parse", "HEAD"]).trim().to_string();
+	let list_pull_requests = server.mock(|when, then| {
+		when.method(GET).path("/repos/ifiokjr/monochange/pulls");
+		then.status(200)
+			.header("content-type", "application/json")
+			.body(format!(
+				"[{{\"number\":9,\"html_url\":\"https://example.com/pr/9\",\"node_id\":\"PR_node\",\"title\":{title:?},\"body\":{body:?},\"base\":{{\"ref\":{base:?}}},\"head\":{{\"sha\":{head:?}}},\"labels\":[{{\"name\":\"release\"}},{{\"name\":\"automated\"}}]}}]",
+				title = request.title,
+				body = request.body,
+				base = request.base_branch,
+				head = head_commit,
+			));
+	});
+	git(
+		&repo,
+		&[
+			"remote",
+			"set-url",
+			"origin",
+			tempdir
+				.path()
+				.join("missing.git")
+				.to_string_lossy()
+				.as_ref(),
+		],
+	);
+
+	let outcome = with_github_env(Some("token"), || {
+		publish_release_pull_request(&source, &repo, &request, &[PathBuf::from("release.txt")])
+			.unwrap_or_else(|error| panic!("publish pull request: {error}"))
+	});
+
+	list_pull_requests.assert();
+	assert_eq!(outcome.operation, GitHubPullRequestOperation::Skipped);
+	assert_eq!(outcome.number, 9);
 }
 
 #[etest::etest(skip=env::var_os("PRE_COMMIT").is_some())]
@@ -1505,6 +1665,19 @@ fn build_test_client(server: &MockServer) -> Octocrab {
 		.unwrap_or_else(|error| panic!("octocrab client: {error}"))
 }
 
+fn sample_source(api_url: Option<String>) -> SourceConfiguration {
+	SourceConfiguration {
+		provider: SourceProvider::GitHub,
+		owner: "ifiokjr".to_string(),
+		repo: "monochange".to_string(),
+		host: None,
+		api_url,
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+		bot: ProviderBotSettings::default(),
+	}
+}
+
 fn sample_manifest() -> ReleaseManifest {
 	ReleaseManifest {
 		command: "release".to_string(),
@@ -1556,4 +1729,34 @@ fn sample_manifest() -> ReleaseManifest {
 			compatibility_evidence: Vec::new(),
 		},
 	}
+}
+
+fn with_github_env<R>(token: Option<&str>, action: impl FnOnce() -> R) -> R {
+	temp_env::with_var("GITHUB_TOKEN", token, action)
+}
+
+fn seed_git_repository() -> (tempfile::TempDir, PathBuf) {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let bare = tempdir.path().join("origin.git");
+	let repo = tempdir.path().join("repo");
+	git(
+		tempdir.path(),
+		&["init", "--bare", bare.to_string_lossy().as_ref()],
+	);
+	git(tempdir.path(), &["init", repo.to_string_lossy().as_ref()]);
+	git(&repo, &["config", "user.name", "monochange Tests"]);
+	git(&repo, &["config", "user.email", "monochange@example.com"]);
+	std::fs::write(repo.join("release.txt"), "before\n")
+		.unwrap_or_else(|error| panic!("write release file: {error}"));
+	git(&repo, &["add", "release.txt"]);
+	git(&repo, &["commit", "-m", "initial"]);
+	git(&repo, &["branch", "-M", "main"]);
+	git(
+		&repo,
+		&["remote", "add", "origin", bare.to_string_lossy().as_ref()],
+	);
+	git(&repo, &["push", "-u", "origin", "main"]);
+	std::fs::write(repo.join("release.txt"), "after\n")
+		.unwrap_or_else(|error| panic!("update release file: {error}"));
+	(tempdir, repo)
 }

--- a/crates/monochange_github/src/lib.rs
+++ b/crates/monochange_github/src/lib.rs
@@ -95,6 +95,7 @@ use std::env;
 use std::fmt::Write as _;
 use std::path::Path;
 use std::path::PathBuf;
+use std::thread;
 
 use monochange_core::CommitMessage;
 use monochange_core::HostedActorRef;
@@ -128,6 +129,7 @@ use monochange_core::SourceReleaseRequest;
 use monochange_core::git::git_checkout_branch_command;
 use monochange_core::git::git_commit_paths_command;
 use monochange_core::git::git_current_branch;
+use monochange_core::git::git_head_commit;
 use monochange_core::git::git_push_branch_command;
 use monochange_core::git::git_stage_paths_command;
 use monochange_core::git::run_command;
@@ -233,6 +235,35 @@ struct GitHubPullRequestUpdatePayload<'a> {
 #[derive(Debug, Serialize)]
 struct GitHubLabelsPayload<'a> {
 	labels: &'a [String],
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubExistingPullRequestLabel {
+	name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubExistingPullRequestBase {
+	#[serde(rename = "ref")]
+	ref_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubExistingPullRequestHead {
+	sha: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubExistingPullRequest {
+	number: u64,
+	html_url: Option<String>,
+	node_id: String,
+	title: String,
+	body: Option<String>,
+	base: GitHubExistingPullRequestBase,
+	head: GitHubExistingPullRequestHead,
+	#[serde(default)]
+	labels: Vec<GitHubExistingPullRequestLabel>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -924,16 +955,34 @@ pub fn publish_release_pull_request(
 	request: &GitHubPullRequestRequest,
 	tracked_paths: &[PathBuf],
 ) -> MonochangeResult<GitHubPullRequestOutcome> {
+	let lookup_source = source.clone();
+	let lookup_request = request.clone();
+	let existing_pull_request =
+		thread::spawn(move || lookup_existing_pull_request(&lookup_source, &lookup_request));
 	git_checkout_branch(root, &request.head_branch)?;
 	git_stage_paths(root, tracked_paths)?;
 	git_commit_paths(root, &request.commit_message)?;
-	git_push_branch(root, &request.head_branch)?;
+	let head_commit = git_head_commit(root)?;
+	let existing = join_existing_pull_request_lookup(existing_pull_request)?;
+	let head_matches_existing = existing
+		.as_ref()
+		.and_then(|pull_request| pull_request.head.sha.as_deref())
+		== Some(head_commit.as_str());
+	if !head_matches_existing {
+		git_push_branch(root, &request.head_branch)?;
+	}
 
 	let runtime = github_runtime()?;
 	runtime.block_on(async {
 		let client = github_client_from_env(source)?;
 
-		publish_release_pull_request_with_client(&client, request).await
+		publish_release_pull_request_with_existing_pull_request(
+			&client,
+			request,
+			existing.as_ref(),
+			&head_commit,
+		)
+		.await
 	})
 }
 
@@ -1013,20 +1062,60 @@ async fn publish_release_request_with_client(
 	})
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 async fn publish_release_pull_request_with_client(
 	client: &Octocrab,
 	request: &GitHubPullRequestRequest,
 ) -> MonochangeResult<GitHubPullRequestOutcome> {
 	let existing = lookup_existing_pull_request_with_client(client, request).await?;
+	publish_release_pull_request_with_existing_pull_request(client, request, existing.as_ref(), "")
+		.await
+}
+
+async fn publish_release_pull_request_with_existing_pull_request(
+	client: &Octocrab,
+	request: &GitHubPullRequestRequest,
+	existing: Option<&GitHubExistingPullRequest>,
+	head_commit: &str,
+) -> MonochangeResult<GitHubPullRequestOutcome> {
+	let labels_match = existing.is_some_and(|pull_request| {
+		request.labels.iter().all(|label| {
+			pull_request
+				.labels
+				.iter()
+				.any(|existing_label| existing_label.name == *label)
+		})
+	});
+	let content_matches = existing.is_some_and(|pull_request| {
+		pull_request.title == request.title
+			&& pull_request.body.as_deref().unwrap_or_default() == request.body
+			&& pull_request.base.ref_name == request.base_branch
+	});
+	let head_matches_existing =
+		existing.and_then(|pull_request| pull_request.head.sha.as_deref()) == Some(head_commit);
 	let (operation, pull_request) = match existing {
-		Some(existing) => {
+		Some(existing_pull_request) if content_matches => {
+			(
+				if head_matches_existing && labels_match && !request.auto_merge {
+					GitHubPullRequestOperation::Skipped
+				} else {
+					GitHubPullRequestOperation::Updated
+				},
+				GitHubPullRequestResponse {
+					number: existing_pull_request.number,
+					html_url: existing_pull_request.html_url.clone(),
+					node_id: existing_pull_request.node_id.clone(),
+				},
+			)
+		}
+		Some(existing_pull_request) => {
 			(
 				GitHubPullRequestOperation::Updated,
 				patch_json::<_, GitHubPullRequestResponse>(
 					client,
 					&format!(
 						"/repos/{}/{}/pulls/{}",
-						request.owner, request.repo, existing.number
+						request.owner, request.repo, existing_pull_request.number
 					),
 					&GitHubPullRequestUpdatePayload {
 						title: &request.title,
@@ -1055,7 +1144,7 @@ async fn publish_release_pull_request_with_client(
 			)
 		}
 	};
-	if !request.labels.is_empty() {
+	if !request.labels.is_empty() && !labels_match {
 		let _: serde_json::Value = post_json(
 			client,
 			&format!(
@@ -1166,7 +1255,7 @@ async fn lookup_existing_release_with_client(
 async fn lookup_existing_pull_request_with_client(
 	client: &Octocrab,
 	request: &GitHubPullRequestRequest,
-) -> MonochangeResult<Option<GitHubPullRequestResponse>> {
+) -> MonochangeResult<Option<GitHubExistingPullRequest>> {
 	let path = format!(
 		"/repos/{}/{}/pulls?state=open&head={}:{}&base={}&per_page=1",
 		request.owner,
@@ -1175,8 +1264,19 @@ async fn lookup_existing_pull_request_with_client(
 		encode(&request.head_branch),
 		encode(&request.base_branch)
 	);
-	let pull_requests = get_json::<Vec<GitHubPullRequestResponse>>(client, &path).await?;
+	let pull_requests = get_json::<Vec<GitHubExistingPullRequest>>(client, &path).await?;
 	Ok(pull_requests.into_iter().next())
+}
+
+fn lookup_existing_pull_request(
+	source: &SourceConfiguration,
+	request: &GitHubPullRequestRequest,
+) -> MonochangeResult<Option<GitHubExistingPullRequest>> {
+	let runtime = github_runtime()?;
+	runtime.block_on(async {
+		let client = github_client_from_env(source)?;
+		lookup_existing_pull_request_with_client(&client, request).await
+	})
 }
 
 async fn enable_pull_request_auto_merge_with_client(
@@ -1301,6 +1401,14 @@ where
 	client.patch(path, Some(body)).await.map_err(|error| {
 		MonochangeError::Config(format!("GitHub API PATCH `{path}` failed: {error}"))
 	})
+}
+
+fn join_existing_pull_request_lookup(
+	handle: thread::JoinHandle<MonochangeResult<Option<GitHubExistingPullRequest>>>,
+) -> MonochangeResult<Option<GitHubExistingPullRequest>> {
+	handle.join().map_err(|_| {
+		MonochangeError::Config("failed to join GitHub pull request lookup thread".to_string())
+	})?
 }
 
 fn git_checkout_branch(root: &Path, branch: &str) -> MonochangeResult<()> {

--- a/crates/monochange_gitlab/src/__tests.rs
+++ b/crates/monochange_gitlab/src/__tests.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::thread;
 
 use httpmock::Method::GET;
 use httpmock::Method::PATCH;
@@ -15,6 +16,7 @@ use monochange_core::HostedActorSourceKind;
 use monochange_core::HostedCommitRef;
 use monochange_core::HostingCapabilities;
 use monochange_core::HostingProviderKind;
+use monochange_core::MonochangeResult;
 use monochange_core::PreparedChangeset;
 use monochange_core::ProviderBotSettings;
 use monochange_core::ProviderMergeRequestSettings;
@@ -796,7 +798,7 @@ fn publish_merge_request_updates_existing_merge_request() {
 		then.status(200)
 			.header("content-type", "application/json")
 			.body(
-				"[{\"iid\":12,\"web_url\":\"https://gitlab.example.com/group/monochange/-/merge_requests/12\"}]",
+				"[{\"iid\":12,\"web_url\":\"https://gitlab.example.com/group/monochange/-/merge_requests/12\",\"title\":\"old title\",\"description\":\"old body\",\"target_branch\":\"main\",\"labels\":[],\"sha\":\"old-sha\"}]",
 			);
 	});
 	let update = server.mock(|when, then| {
@@ -825,6 +827,73 @@ fn publish_merge_request_updates_existing_merge_request() {
 	list.assert();
 	update.assert();
 	assert_eq!(outcome.operation, SourceChangeRequestOperation::Updated);
+}
+
+#[test]
+fn join_existing_merge_request_lookup_reports_panicked_thread() {
+	let error = join_existing_merge_request_lookup(thread::spawn(
+		|| -> MonochangeResult<Option<GitLabExistingMergeRequest>> {
+			panic!("boom");
+		},
+	))
+	.err()
+	.unwrap_or_else(|| panic!("expected join error"));
+	assert!(
+		error
+			.to_string()
+			.contains("failed to join GitLab merge request lookup thread")
+	);
+}
+
+#[etest::etest(skip=env::var_os("PRE_COMMIT").is_some())]
+fn publish_release_pull_request_skips_push_when_existing_merge_request_matches_local_head() {
+	let server = MockServer::start();
+	let (_tempdir, repo) = seed_git_repository();
+	let source = sample_source(Some(format!("{}/api/v4", server.base_url())));
+	let request = build_release_pull_request_request(&source, &sample_manifest());
+
+	git(&repo, &["checkout", "-B", &request.head_branch]);
+	git(&repo, &["add", "-A", "--", "release.txt"]);
+	git(&repo, &["commit", "-m", "prepare release branch"]);
+	git(&repo, &["push", "-u", "origin", &request.head_branch]);
+	let head_commit = git_output(&repo, &["rev-parse", "HEAD"]).trim().to_string();
+	let labels = serde_json::to_string(&request.labels)
+		.unwrap_or_else(|error| panic!("labels json: {error}"));
+	let list = server.mock(|when, then| {
+		when.method(GET)
+			.path("/api/v4/projects/group%2Fmonochange/merge_requests")
+			.query_param("state", "opened")
+			.query_param("source_branch", "monochange/release/release")
+			.query_param("target_branch", "main");
+			then.status(200)
+				.header("content-type", "application/json")
+				.body(format!(
+					"[{{\"iid\":12,\"web_url\":\"https://gitlab.example.com/group/monochange/-/merge_requests/12\",\"title\":{title:?},\"description\":{body:?},\"target_branch\":{base:?},\"labels\":{labels},\"sha\":{head:?}}}]",
+					title = request.title,
+					body = request.body,
+					base = request.base_branch,
+					labels = labels,
+					head = head_commit,
+				));
+		});
+	git(
+		&repo,
+		&[
+			"remote",
+			"set-url",
+			"origin",
+			"/definitely/missing/gitlab-origin.git",
+		],
+	);
+
+	let outcome = with_gitlab_env(Some("token"), || {
+		publish_release_pull_request(&source, &repo, &request, &[PathBuf::from("release.txt")])
+			.unwrap_or_else(|error| panic!("publish merge request: {error}"))
+	});
+
+	list.assert();
+	assert_eq!(outcome.operation, SourceChangeRequestOperation::Skipped);
+	assert_eq!(outcome.number, 12);
 }
 
 fn sample_source(api_url: Option<String>) -> SourceConfiguration {

--- a/crates/monochange_gitlab/src/lib.rs
+++ b/crates/monochange_gitlab/src/lib.rs
@@ -3,6 +3,7 @@
 use std::env;
 use std::path::Path;
 use std::path::PathBuf;
+use std::thread;
 
 use monochange_core::CommitMessage;
 use monochange_core::HostingCapabilities;
@@ -26,6 +27,7 @@ use monochange_core::SourceReleaseRequest;
 use monochange_core::git::git_checkout_branch_command;
 use monochange_core::git::git_commit_paths_command;
 use monochange_core::git::git_current_branch;
+use monochange_core::git::git_head_commit;
 use monochange_core::git::git_push_branch_command;
 use monochange_core::git::git_stage_paths_command;
 use monochange_core::git::run_command;
@@ -199,6 +201,18 @@ struct GitLabMergeRequestResponse {
 	web_url: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct GitLabExistingMergeRequest {
+	iid: u64,
+	web_url: Option<String>,
+	title: String,
+	description: Option<String>,
+	target_branch: String,
+	#[serde(default)]
+	labels: Vec<String>,
+	sha: Option<String>,
+}
+
 fn gitlab_host(source: &SourceConfiguration) -> &str {
 	source
 		.host
@@ -303,15 +317,36 @@ pub fn publish_release_pull_request(
 	request: &SourceChangeRequest,
 	tracked_paths: &[PathBuf],
 ) -> MonochangeResult<SourceChangeRequestOutcome> {
+	let lookup_source = source.clone();
+	let lookup_request = request.clone();
+	let existing_merge_request = thread::spawn(move || {
+		let client = gitlab_client()?;
+		let token = gitlab_token()?;
+		let api_base = gitlab_api_base(&lookup_source)?;
+		lookup_existing_merge_request(&client, &token, &api_base, &lookup_request)
+	});
 	git_checkout_branch(root, &request.head_branch)?;
 	git_stage_paths(root, tracked_paths)?;
 	git_commit_paths(root, &request.commit_message)?;
-	git_push_branch(root, &request.head_branch)?;
+	let head_commit = git_head_commit(root)?;
+	let existing = join_existing_merge_request_lookup(existing_merge_request)?;
+	let head_matches_existing =
+		existing.as_ref().and_then(|mr| mr.sha.as_deref()) == Some(head_commit.as_str());
+	if !head_matches_existing {
+		git_push_branch(root, &request.head_branch)?;
+	}
 
 	let client = gitlab_client()?;
 	let token = gitlab_token()?;
 	let api_base = gitlab_api_base(source)?;
-	publish_merge_request(&client, &token, &api_base, request)
+	publish_merge_request_with_existing(
+		&client,
+		&token,
+		&api_base,
+		request,
+		existing.as_ref(),
+		&head_commit,
+	)
 }
 
 fn publish_release_request(
@@ -368,39 +403,64 @@ fn publish_release_request(
 	})
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 fn publish_merge_request(
 	client: &Client,
 	token: &str,
 	api_base: &str,
 	request: &SourceChangeRequest,
 ) -> MonochangeResult<SourceChangeRequestOutcome> {
-	let project_id = encode(&format!("{}/{}", request.owner, request.repo)).into_owned();
-	let list_url = format!(
-		"{api_base}/projects/{project_id}/merge_requests?state=opened&source_branch={}&target_branch={}",
-		encode(&request.head_branch),
-		encode(&request.base_branch),
-	);
-	let create_url = format!("{api_base}/projects/{project_id}/merge_requests");
+	let existing = lookup_existing_merge_request(client, token, api_base, request)?;
+	publish_merge_request_with_existing(client, token, api_base, request, existing.as_ref(), "")
+}
+
+fn publish_merge_request_with_existing(
+	client: &Client,
+	token: &str,
+	api_base: &str,
+	request: &SourceChangeRequest,
+	existing: Option<&GitLabExistingMergeRequest>,
+	head_commit: &str,
+) -> MonochangeResult<SourceChangeRequestOutcome> {
 	let labels = request.labels.join(",");
-	let existing = get_json::<Vec<GitLabMergeRequestResponse>>(client, token, &list_url)?
-		.into_iter()
-		.next();
+	let labels_match = existing.is_some_and(|merge_request| {
+		let mut existing_labels = merge_request.labels.clone();
+		existing_labels.sort();
+		existing_labels.dedup();
+		let mut requested_labels = request.labels.clone();
+		requested_labels.sort();
+		requested_labels.dedup();
+		existing_labels == requested_labels
+	});
+	let content_matches = existing.is_some_and(|merge_request| {
+		merge_request.title == request.title
+			&& merge_request.description.as_deref().unwrap_or_default() == request.body
+			&& merge_request.target_branch == request.base_branch
+	});
+	let head_matches_existing =
+		existing.and_then(|merge_request| merge_request.sha.as_deref()) == Some(head_commit);
+	let project_id = encode(&format!("{}/{}", request.owner, request.repo)).into_owned();
+	let create_url = format!("{api_base}/projects/{project_id}/merge_requests");
 	let response: GitLabMergeRequestResponse = if let Some(existing_mr) = &existing {
-		let update_url = format!(
-			"{api_base}/projects/{project_id}/merge_requests/{}",
-			existing_mr.iid
-		);
-		put_json(
-			client,
-			token,
-			&update_url,
-			&GitLabMergeRequestUpdatePayload {
+		if content_matches && labels_match {
+			GitLabMergeRequestResponse {
+				iid: existing_mr.iid,
+				web_url: existing_mr.web_url.clone(),
+			}
+		} else {
+			let update_url = format!(
+				"{api_base}/projects/{project_id}/merge_requests/{}",
+				existing_mr.iid
+			);
+			let update_payload = GitLabMergeRequestUpdatePayload {
 				title: &request.title,
 				target_branch: &request.base_branch,
 				description: &request.body,
 				labels: &labels,
-			},
-		)?
+			};
+
+			put_json(client, token, &update_url, &update_payload)?
+		}
 	} else {
 		post_json(
 			client,
@@ -420,13 +480,42 @@ fn publish_merge_request(
 		repository: request.repository.clone(),
 		number: response.iid,
 		head_branch: request.head_branch.clone(),
-		operation: if existing.is_some() {
-			SourceChangeRequestOperation::Updated
-		} else {
+		operation: if existing.is_none() {
 			SourceChangeRequestOperation::Created
+		} else if content_matches && labels_match && head_matches_existing {
+			SourceChangeRequestOperation::Skipped
+		} else {
+			SourceChangeRequestOperation::Updated
 		},
 		url: response.web_url,
 	})
+}
+
+fn lookup_existing_merge_request(
+	client: &Client,
+	token: &str,
+	api_base: &str,
+	request: &SourceChangeRequest,
+) -> MonochangeResult<Option<GitLabExistingMergeRequest>> {
+	let project_id = encode(&format!("{}/{}", request.owner, request.repo)).into_owned();
+	let list_url = format!(
+		"{api_base}/projects/{project_id}/merge_requests?state=opened&source_branch={}&target_branch={}",
+		encode(&request.head_branch),
+		encode(&request.base_branch),
+	);
+	Ok(
+		get_json::<Vec<GitLabExistingMergeRequest>>(client, token, &list_url)?
+			.into_iter()
+			.next(),
+	)
+}
+
+fn join_existing_merge_request_lookup(
+	handle: thread::JoinHandle<MonochangeResult<Option<GitLabExistingMergeRequest>>>,
+) -> MonochangeResult<Option<GitLabExistingMergeRequest>> {
+	handle.join().map_err(|_| {
+		MonochangeError::Config("failed to join GitLab merge request lookup thread".to_string())
+	})?
 }
 
 fn gitlab_client() -> MonochangeResult<Client> {


### PR DESCRIPTION
## Summary
- short-circuit hosted release pull request updates when the existing request already matches the local branch head, title, body, base branch, and labels
- overlap local git preparation with hosted existing-PR lookup for GitHub, GitLab, and Gitea, and surface `Skipped` as a first-class release request operation
- add `release_pr` CLI benchmarks, including the mocked hosted create path, and extend provider tests so the changed executable lines are fully covered

## Validation
- `devenv shell fix:all`
- `devenv shell lint:all`
- `devenv shell build:all`
- `devenv shell test:all`
- `devenv shell mc validate`
- `devenv shell cargo bench -p monochange --bench cli_commands release_pr -- --noplot`
- changed executable line coverage for touched production files: 100%

## Benchmarks
- `release_pr/dry_run_preview`: ~14.4 ms
- `release_pr/github_create`: ~604 ms

Fixes #175
