### PR TITLE
perf: reuse prepared release state across follow-up commands

### DIFF
--- a/.changeset/prepared-release-reuse.md
+++ b/.changeset/prepared-release-reuse.md
@@ -1,0 +1,32 @@
+---
+monochange: minor
+---
+
+#### reuse prepared release state across follow-up commands
+
+`PrepareRelease`-driven commands can now reuse a matching prepared release artifact instead of rebuilding the same release state from scratch every time. `mc release` writes a reusable cache under `.monochange/prepared-release-cache.json`, and later commands with a `PrepareRelease` step automatically pick it up when the workspace still matches.
+
+**Before:**
+
+```bash
+mc release
+mc release-pr --dry-run
+```
+
+Every follow-up command recalculated release planning state independently, even when the release files, git status, and `HEAD` still matched the earlier run.
+
+**After:**
+
+```bash
+mc release
+mc release-pr --dry-run
+```
+
+Warm follow-up commands now reuse the prepared artifact automatically when it is still valid. If you need to pass the prepared state between explicit commands or CI steps, you can also pin the artifact path yourself:
+
+```bash
+mc release --prepared-release /tmp/release-plan.json
+mc release-pr --prepared-release /tmp/release-plan.json --format json
+```
+
+The cached artifact is invalidated when `HEAD`, workspace status, tracked release inputs, or relevant configuration drift, so monochange keeps the fast path without reusing stale release data.

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .devenv*
 .pre-commit-config.yaml
 devenv.local.nix
+.monochange/*
 
 **/dist/**
 node_modules/

--- a/crates/monochange/benches/cli_commands.rs
+++ b/crates/monochange/benches/cli_commands.rs
@@ -193,6 +193,22 @@ fn release_pr_args(dry_run: bool) -> Vec<OsString> {
 	args
 }
 
+fn command_args(command: &str, dry_run: bool) -> Vec<OsString> {
+	let mut args = vec![OsString::from("mc"), OsString::from(command)];
+	if dry_run {
+		args.push(OsString::from("--dry-run"));
+	}
+	args.push(OsString::from("--format"));
+	args.push(OsString::from("json"));
+	args
+}
+
+fn run_command(root: &Path, command: &str, dry_run: bool) -> String {
+	temp_env::with_vars([("MONOCHANGE_RELEASE_DATE", Some("2026-04-06"))], || {
+		monochange::run_with_args_in_dir("mc", command_args(command, dry_run), root).unwrap()
+	})
+}
+
 fn run_release_pr_command(root: &Path, dry_run: bool, github_api_url: Option<&str>) -> String {
 	temp_env::with_vars(
 		[
@@ -586,6 +602,43 @@ fn bench_release_pr(c: &mut Criterion) {
 	group.finish();
 }
 
+fn bench_prepared_release_cache(c: &mut Criterion) {
+	let mut group = c.benchmark_group("prepared_release_cache");
+	group.sample_size(10);
+
+	group.bench_function("commit_release_after_release", |b| {
+		b.iter_batched(
+			|| {
+				let tempdir = setup_scenario_workspace("prepared-release/source-github-follow-up");
+				seed_release_pr_git_repository(tempdir.path());
+				let _ = run_command(tempdir.path(), "release", false);
+				tempdir
+			},
+			|tempdir| {
+				let _ = run_command(tempdir.path(), "commit-release", false);
+			},
+			BatchSize::LargeInput,
+		);
+	});
+
+	group.bench_function("release_pr_dry_run_after_release", |b| {
+		b.iter_batched(
+			|| {
+				let tempdir = setup_scenario_workspace("prepared-release/source-github-follow-up");
+				seed_release_pr_git_repository(tempdir.path());
+				let _ = run_command(tempdir.path(), "release", false);
+				tempdir
+			},
+			|tempdir| {
+				let _ = run_command(tempdir.path(), "release-pr", true);
+			},
+			BatchSize::LargeInput,
+		);
+	});
+
+	group.finish();
+}
+
 criterion_group!(
 	benches,
 	bench_config_load,
@@ -597,5 +650,6 @@ criterion_group!(
 	bench_prepare_release_apply_cargo_lockfile_refresh,
 	bench_prepare_release_with_git_history,
 	bench_release_pr,
+	bench_prepared_release_cache,
 );
 criterion_main!(benches);

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -243,12 +243,19 @@ pub(crate) fn build_cli_command_subcommand(cli_command: &CliCommandDefinition) -
 		);
 
 	if command_supports_release_diff_preview(cli_command) {
-		command = command.arg(
-			Arg::new("diff")
-				.long("diff")
-				.help("Show unified file diffs for prepared release changes")
-				.action(ArgAction::SetTrue),
-		);
+		command = command
+			.arg(
+				Arg::new("diff")
+					.long("diff")
+					.help("Show unified file diffs for prepared release changes")
+					.action(ArgAction::SetTrue),
+			)
+			.arg(
+				Arg::new("prepared-release")
+					.long("prepared-release")
+					.help("Read or write the prepared release artifact at a specific path")
+					.value_name("PATH"),
+			);
 	}
 
 	if let Some(after_help) = cli_command_after_help(cli_command) {

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -35,6 +35,8 @@ use crate::cli::command_supports_release_diff_preview;
 use crate::cli_progress::CliProgressReporter;
 use crate::cli_progress::CommandStream;
 use crate::cli_progress::ProgressFormat;
+use crate::maybe_load_prepared_release_execution;
+use crate::save_prepared_release_execution;
 use crate::*;
 
 pub(crate) fn execute_matches(
@@ -69,6 +71,10 @@ pub(crate) fn execute_matches(
 			},
 			|value| parse_progress_format(value),
 		)?;
+	let prepared_release_path = command_supports_release_diff_preview(cli_command)
+		.then(|| cli_command_matches.get_one::<String>("prepared-release"))
+		.flatten()
+		.map(PathBuf::from);
 	let inputs = collect_cli_command_inputs(cli_command, cli_command_matches);
 	if show_diff {
 		execute_cli_command_with_options(
@@ -80,18 +86,23 @@ pub(crate) fn execute_matches(
 				quiet,
 				show_diff: true,
 				inputs,
+				prepared_release_path,
 				progress_format,
 			},
 		)
 	} else {
-		execute_cli_command_quiet(
+		execute_cli_command_with_options(
 			root,
 			configuration,
 			cli_command,
-			dry_run,
-			quiet,
-			inputs,
-			progress_format,
+			ExecuteCliCommandOptions {
+				dry_run,
+				quiet,
+				show_diff: false,
+				inputs,
+				prepared_release_path,
+				progress_format,
+			},
 		)
 	}
 }
@@ -401,36 +412,17 @@ pub(crate) fn execute_cli_command(
 	dry_run: bool,
 	inputs: BTreeMap<String, Vec<String>>,
 ) -> MonochangeResult<String> {
-	execute_cli_command_quiet(
-		root,
-		configuration,
-		cli_command,
-		dry_run,
-		false,
-		inputs,
-		ProgressFormat::Auto,
-	)
-}
-
-fn execute_cli_command_quiet(
-	root: &Path,
-	configuration: &monochange_core::WorkspaceConfiguration,
-	cli_command: &CliCommandDefinition,
-	dry_run: bool,
-	quiet: bool,
-	inputs: BTreeMap<String, Vec<String>>,
-	progress_format: ProgressFormat,
-) -> MonochangeResult<String> {
 	execute_cli_command_with_options(
 		root,
 		configuration,
 		cli_command,
 		ExecuteCliCommandOptions {
 			dry_run,
-			quiet,
+			quiet: false,
 			show_diff: false,
 			inputs,
-			progress_format,
+			prepared_release_path: None,
+			progress_format: ProgressFormat::Auto,
 		},
 	)
 }
@@ -440,6 +432,7 @@ pub(crate) struct ExecuteCliCommandOptions {
 	quiet: bool,
 	show_diff: bool,
 	inputs: BTreeMap<String, Vec<String>>,
+	prepared_release_path: Option<PathBuf>,
 	progress_format: ProgressFormat,
 }
 
@@ -455,6 +448,7 @@ pub(crate) fn execute_cli_command_with_options(
 		quiet,
 		show_diff,
 		inputs,
+		prepared_release_path,
 		progress_format,
 	} = options;
 	let mut context = CliContext {
@@ -629,8 +623,19 @@ pub(crate) fn execute_cli_command_with_options(
 				CliStepDefinition::PrepareRelease { .. } => {
 					let build_file_diffs = context.show_diff
 						|| steps_reference_release_file_diffs(&cli_command.steps[step_index + 1..]);
-					let prepared_execution =
-						prepare_release_execution_with_file_diffs(root, dry_run, build_file_diffs)?;
+					let prepared_execution = if let Some(loaded) =
+						maybe_load_prepared_release_execution(
+							root,
+							configuration,
+							prepared_release_path.as_deref(),
+							dry_run,
+							build_file_diffs,
+						)? {
+						context.command_logs.push(loaded.message);
+						loaded.execution
+					} else {
+						prepare_release_execution_with_file_diffs(root, dry_run, build_file_diffs)?
+					};
 					step_phase_timings.clone_from(&prepared_execution.phase_timings);
 					context.prepared_file_diffs = prepared_execution.file_diffs;
 					context.prepared_release = Some(prepared_execution.prepared_release);
@@ -880,6 +885,18 @@ pub(crate) fn execute_cli_command_with_options(
 	progress.command_finished(command_started_at.elapsed());
 
 	if let Some(prepared_release) = &context.prepared_release {
+		if let Err(error) = save_prepared_release_execution(
+			root,
+			configuration,
+			prepared_release,
+			&context.prepared_file_diffs,
+			prepared_release_path.as_deref(),
+		) {
+			if prepared_release_path.is_some() {
+				return Err(error);
+			}
+			tracing::warn!(%error, "failed to save prepared release artifact");
+		}
 		let format = cli_command_output_format(&context.last_step_inputs)?;
 		return match format {
 			OutputFormat::Json => {

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -215,6 +215,7 @@ pub use release_record::execute_release_retarget;
 pub use release_record::plan_release_retarget;
 use release_record::render_release_record_discovery;
 pub use release_record::retarget_release;
+use serde::Deserialize;
 use serde::Serialize;
 use serde_json::json;
 pub(crate) use versioned_files::*;
@@ -250,11 +251,15 @@ mod cli_runtime;
 mod git_support;
 mod interactive;
 mod mcp;
+mod prepared_release_cache;
 mod release_artifacts;
 mod release_record;
 mod tracing_setup;
 mod versioned_files;
 mod workspace_ops;
+
+pub(crate) use prepared_release_cache::maybe_load_prepared_release_execution;
+pub(crate) use prepared_release_cache::save_prepared_release_execution;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 pub enum OutputFormat {
@@ -297,7 +302,7 @@ pub enum AssistOutputFormat {
 	Json,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ReleaseTarget {
 	pub id: String,
 	pub kind: ReleaseOwnerKind,
@@ -311,7 +316,7 @@ pub struct ReleaseTarget {
 	pub rendered_changelog_title: String,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PreparedChangelog {
 	pub owner_id: String,
 	pub owner_kind: ReleaseOwnerKind,
@@ -321,7 +326,7 @@ pub struct PreparedChangelog {
 	pub rendered: String,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PreparedRelease {
 	pub plan: ReleasePlan,
 	pub changeset_paths: Vec<PathBuf>,

--- a/crates/monochange/src/prepared_release_cache.rs
+++ b/crates/monochange/src/prepared_release_cache.rs
@@ -477,9 +477,19 @@ mod tests {
 	}
 
 	fn git(root: &Path, args: &[&str]) {
-		let output = Command::new("git")
-			.current_dir(root)
-			.args(args)
+		let mut command = Command::new("git");
+		command.current_dir(root).args(args);
+		for variable in [
+			"GIT_DIR",
+			"GIT_WORK_TREE",
+			"GIT_COMMON_DIR",
+			"GIT_INDEX_FILE",
+			"GIT_OBJECT_DIRECTORY",
+			"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+		] {
+			command.env_remove(variable);
+		}
+		let output = command
 			.output()
 			.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
 		assert!(

--- a/crates/monochange/src/prepared_release_cache.rs
+++ b/crates/monochange/src/prepared_release_cache.rs
@@ -1,0 +1,636 @@
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use monochange_core::MonochangeError;
+use monochange_core::MonochangeResult;
+use monochange_core::WorkspaceConfiguration;
+use monochange_core::git::git_command_output;
+use monochange_core::git::git_error_detail;
+use monochange_core::git::git_head_commit;
+use serde::Deserialize;
+use serde::Serialize;
+use similar::TextDiff;
+
+use crate::PreparedFileDiff;
+use crate::PreparedRelease;
+use crate::PreparedReleaseExecution;
+use crate::StepPhaseTiming;
+use crate::resolve_config_path;
+use crate::root_relative;
+
+const PREPARED_RELEASE_ARTIFACT_SCHEMA_VERSION: u32 = 1;
+const DEFAULT_PREPARED_RELEASE_CACHE_PATH: &str = ".monochange/prepared-release-cache.json";
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct LoadedPreparedReleaseExecution {
+	pub(crate) execution: PreparedReleaseExecution,
+	pub(crate) message: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PreparedReleaseArtifact {
+	schema_version: u32,
+	configuration_snapshot: String,
+	head_commit: String,
+	worktree_status: Vec<String>,
+	tracked_paths: Vec<PreparedReleaseTrackedPath>,
+	prepared_release: PreparedRelease,
+	#[serde(default)]
+	file_diffs: Vec<PersistedPreparedFileDiff>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PreparedReleaseTrackedPath {
+	path: PathBuf,
+	state: PreparedReleaseTrackedPathState,
+	hash: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum PreparedReleaseTrackedPathState {
+	File,
+	Deleted,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PersistedPreparedFileDiff {
+	path: PathBuf,
+	diff: String,
+	display_diff: String,
+}
+
+pub(crate) fn default_prepared_release_cache_path(root: &Path) -> PathBuf {
+	root.join(DEFAULT_PREPARED_RELEASE_CACHE_PATH)
+}
+
+pub(crate) fn resolve_prepared_release_artifact_path(
+	root: &Path,
+	explicit_path: Option<&Path>,
+) -> PathBuf {
+	explicit_path.map_or_else(
+		|| default_prepared_release_cache_path(root),
+		|path| resolve_config_path(root, path),
+	)
+}
+
+pub(crate) fn load_prepared_release_execution(
+	root: &Path,
+	configuration: &WorkspaceConfiguration,
+	explicit_path: Option<&Path>,
+	current_dry_run: bool,
+	build_file_diffs: bool,
+) -> MonochangeResult<Option<LoadedPreparedReleaseExecution>> {
+	let artifact_path = resolve_prepared_release_artifact_path(root, explicit_path);
+	if !artifact_path.exists() {
+		return Ok(None);
+	}
+
+	let artifact = read_prepared_release_artifact(&artifact_path)?;
+	validate_prepared_release_artifact(
+		root,
+		configuration,
+		&artifact_path,
+		&artifact,
+		current_dry_run,
+		build_file_diffs,
+	)?;
+
+	let load_started_at = Instant::now();
+	let file_diffs = artifact
+		.file_diffs
+		.into_iter()
+		.map(|file_diff| {
+			PreparedFileDiff {
+				path: file_diff.path,
+				diff: file_diff.diff,
+				display_diff: file_diff.display_diff,
+			}
+		})
+		.collect();
+	let execution = PreparedReleaseExecution {
+		prepared_release: artifact.prepared_release,
+		file_diffs,
+		phase_timings: vec![StepPhaseTiming {
+			label: "load prepared release artifact".to_string(),
+			duration: load_started_at.elapsed(),
+		}],
+	};
+	let message = format!(
+		"reused prepared release artifact `{}`",
+		root_relative(root, &artifact_path).display()
+	);
+	Ok(Some(LoadedPreparedReleaseExecution { execution, message }))
+}
+
+pub(crate) fn maybe_load_prepared_release_execution(
+	root: &Path,
+	configuration: &WorkspaceConfiguration,
+	explicit_path: Option<&Path>,
+	current_dry_run: bool,
+	build_file_diffs: bool,
+) -> MonochangeResult<Option<LoadedPreparedReleaseExecution>> {
+	match load_prepared_release_execution(
+		root,
+		configuration,
+		explicit_path,
+		current_dry_run,
+		build_file_diffs,
+	) {
+		Ok(Some(loaded)) => Ok(Some(loaded)),
+		Ok(None) => Ok(None),
+		Err(error) if explicit_path.is_none() => {
+			tracing::warn!(%error, "ignoring stale prepared release artifact");
+			Ok(None)
+		}
+		Err(error) => Err(error),
+	}
+}
+
+pub(crate) fn save_prepared_release_execution(
+	root: &Path,
+	configuration: &WorkspaceConfiguration,
+	prepared_release: &PreparedRelease,
+	file_diffs: &[PreparedFileDiff],
+	explicit_path: Option<&Path>,
+) -> MonochangeResult<()> {
+	let artifact_path = resolve_prepared_release_artifact_path(root, explicit_path);
+	ensure_prepared_release_artifact_ignored(root, &artifact_path)?;
+	let parent = artifact_path.parent().map(Path::to_path_buf);
+	if let Some(parent) = parent {
+		fs::create_dir_all(&parent).map_err(|error| {
+			MonochangeError::Io(format!(
+				"failed to create prepared release artifact directory {}: {error}",
+				parent.display()
+			))
+		})?;
+	}
+
+	let artifact = PreparedReleaseArtifact {
+		schema_version: PREPARED_RELEASE_ARTIFACT_SCHEMA_VERSION,
+		configuration_snapshot: configuration_snapshot(configuration)?,
+		head_commit: git_head_commit(root)?,
+		worktree_status: git_status_snapshot(root, Some(&artifact_path))?,
+		tracked_paths: tracked_path_snapshots(root, prepared_release)?,
+		prepared_release: prepared_release.clone(),
+		file_diffs: file_diffs
+			.iter()
+			.map(|file_diff| {
+				PersistedPreparedFileDiff {
+					path: file_diff.path.clone(),
+					diff: file_diff.diff.clone(),
+					display_diff: file_diff.display_diff.clone(),
+				}
+			})
+			.collect(),
+	};
+	let rendered = serde_json::to_string_pretty(&artifact).map_err(|error| {
+		MonochangeError::Config(format!(
+			"failed to serialize prepared release artifact: {error}"
+		))
+	})?;
+	fs::write(&artifact_path, rendered).map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to write prepared release artifact {}: {error}",
+			artifact_path.display()
+		))
+	})
+}
+
+fn read_prepared_release_artifact(path: &Path) -> MonochangeResult<PreparedReleaseArtifact> {
+	let contents = fs::read_to_string(path).map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to read prepared release artifact {}: {error}",
+			path.display()
+		))
+	})?;
+	serde_json::from_str(&contents).map_err(|error| {
+		MonochangeError::Config(format!(
+			"failed to parse prepared release artifact {}: {error}",
+			path.display()
+		))
+	})
+}
+
+fn validate_prepared_release_artifact(
+	root: &Path,
+	configuration: &WorkspaceConfiguration,
+	artifact_path: &Path,
+	artifact: &PreparedReleaseArtifact,
+	current_dry_run: bool,
+	build_file_diffs: bool,
+) -> MonochangeResult<()> {
+	if artifact.schema_version != PREPARED_RELEASE_ARTIFACT_SCHEMA_VERSION {
+		return Err(stale_artifact_error(
+			artifact_path,
+			format!(
+				"schema version {} does not match supported version {}",
+				artifact.schema_version, PREPARED_RELEASE_ARTIFACT_SCHEMA_VERSION
+			),
+		));
+	}
+
+	if !current_dry_run && artifact.prepared_release.dry_run {
+		return Err(stale_artifact_error(
+			artifact_path,
+			"dry-run artifacts cannot drive non-dry-run follow-up commands",
+		));
+	}
+
+	if configuration_snapshot(configuration)? != artifact.configuration_snapshot {
+		return Err(stale_artifact_error(
+			artifact_path,
+			"workspace configuration changed",
+		));
+	}
+
+	let current_head = git_head_commit(root)?;
+	if current_head != artifact.head_commit {
+		return Err(stale_artifact_error(
+			artifact_path,
+			format!(
+				"HEAD changed from {} to {}",
+				artifact.head_commit, current_head
+			),
+		));
+	}
+
+	let current_status = git_status_snapshot(root, Some(artifact_path))?;
+	if current_status != artifact.worktree_status {
+		return Err(stale_artifact_error(
+			artifact_path,
+			"workspace status no longer matches the saved prepared release",
+		));
+	}
+
+	let current_tracked_paths = tracked_path_snapshots(root, &artifact.prepared_release)?;
+	if current_tracked_paths != artifact.tracked_paths {
+		return Err(stale_artifact_error(
+			artifact_path,
+			"workspace content drifted from the saved prepared release",
+		));
+	}
+
+	if build_file_diffs && artifact.file_diffs.is_empty() {
+		return Err(stale_artifact_error(
+			artifact_path,
+			"diff previews were not captured in the saved prepared release",
+		));
+	}
+
+	Ok(())
+}
+
+fn stale_artifact_error(path: &Path, detail: impl AsRef<str>) -> MonochangeError {
+	MonochangeError::Config(format!(
+		"prepared release artifact `{}` is stale: {}",
+		path.display(),
+		detail.as_ref()
+	))
+}
+
+fn configuration_snapshot(configuration: &WorkspaceConfiguration) -> MonochangeResult<String> {
+	serde_json::to_string(configuration).map_err(|error| {
+		MonochangeError::Config(format!(
+			"failed to serialize workspace configuration for prepared release caching: {error}"
+		))
+	})
+}
+
+fn git_status_snapshot(root: &Path, excluded_path: Option<&Path>) -> MonochangeResult<Vec<String>> {
+	let output = git_command_output(
+		root,
+		&["status", "--short", "--untracked-files=all", "--porcelain"],
+	)
+	.map_err(|error| MonochangeError::Io(format!("failed to read git status: {error}")))?;
+	if !output.status.success() {
+		return Err(MonochangeError::Config(format!(
+			"failed to read git status: {}",
+			git_error_detail(&output)
+		)));
+	}
+
+	let excluded = excluded_path.map(|path| root_relative(root, path));
+	let mut lines = String::from_utf8_lossy(&output.stdout)
+		.lines()
+		.map(str::to_string)
+		.filter(|line| {
+			let Some(excluded) = &excluded else {
+				return true;
+			};
+			status_line_path(line).is_none_or(|path| path != *excluded)
+		})
+		.collect::<Vec<_>>();
+	lines.sort();
+	Ok(lines)
+}
+
+fn status_line_path(line: &str) -> Option<PathBuf> {
+	if line.len() < 4 {
+		return None;
+	}
+	Some(PathBuf::from(line[3..].trim()))
+}
+
+fn tracked_path_snapshots(
+	root: &Path,
+	prepared_release: &PreparedRelease,
+) -> MonochangeResult<Vec<PreparedReleaseTrackedPath>> {
+	let mut tracked_paths = prepared_release.changed_files.clone();
+	tracked_paths.extend(prepared_release.deleted_changesets.clone());
+	tracked_paths.sort();
+	tracked_paths.dedup();
+
+	tracked_paths
+		.into_iter()
+		.map(|path| {
+			let absolute_path = resolve_config_path(root, &path);
+			if absolute_path.exists() {
+				Ok(PreparedReleaseTrackedPath {
+					path,
+					state: PreparedReleaseTrackedPathState::File,
+					hash: Some(hash_file_at_path(root, &absolute_path)?),
+				})
+			} else {
+				Ok(PreparedReleaseTrackedPath {
+					path,
+					state: PreparedReleaseTrackedPathState::Deleted,
+					hash: None,
+				})
+			}
+		})
+		.collect()
+}
+
+fn hash_file_at_path(root: &Path, path: &Path) -> MonochangeResult<String> {
+	let relative_path = root_relative(root, path);
+	let relative = relative_path.to_string_lossy().into_owned();
+	let output = git_command_output(root, &["hash-object", "--", &relative]).map_err(|error| {
+		MonochangeError::Io(format!("failed to hash {}: {error}", path.display()))
+	})?;
+	if !output.status.success() {
+		return Err(MonochangeError::Config(format!(
+			"failed to hash {}: {}",
+			path.display(),
+			git_error_detail(&output)
+		)));
+	}
+	Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn ensure_prepared_release_artifact_ignored(
+	root: &Path,
+	artifact_path: &Path,
+) -> MonochangeResult<()> {
+	let monochange_dir = root.join(".monochange");
+	if !artifact_path.starts_with(&monochange_dir) {
+		return Ok(());
+	}
+
+	let output = git_command_output(root, &["rev-parse", "--git-path", "info/exclude"]).map_err(
+		|error| MonochangeError::Io(format!("failed to resolve git exclude path: {error}")),
+	)?;
+	if !output.status.success() {
+		// Non-git workspaces can still use the artifact; the ignore rule is only
+		// needed to keep git status clean when a repository exists.
+		return Ok(());
+	}
+
+	let exclude_path = {
+		let raw_path = PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
+		if raw_path.is_absolute() {
+			raw_path
+		} else {
+			root.join(raw_path)
+		}
+	};
+	if let Some(parent) = exclude_path.parent() {
+		fs::create_dir_all(parent).map_err(|error| {
+			MonochangeError::Io(format!(
+				"failed to create git exclude directory {}: {error}",
+				parent.display()
+			))
+		})?;
+	}
+	let existing = fs::read_to_string(&exclude_path).unwrap_or_default();
+	if existing.lines().any(|line| line.trim() == ".monochange/") {
+		return Ok(());
+	}
+
+	let mut updated = existing;
+	if !updated.is_empty() && !updated.ends_with('\n') {
+		updated.push('\n');
+	}
+	updated.push_str(".monochange/\n");
+	fs::write(&exclude_path, updated).map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to update git exclude file {}: {error}",
+			exclude_path.display()
+		))
+	})
+}
+
+#[allow(dead_code)]
+fn render_unified_file_diff(path: &Path, before: &[u8], after: &[u8]) -> String {
+	let before_text = String::from_utf8_lossy(before);
+	let after_text = String::from_utf8_lossy(after);
+	let context_radius = before_text.lines().count().max(after_text.lines().count());
+	let diff = TextDiff::from_lines(before_text.as_ref(), after_text.as_ref());
+	let mut unified = diff.unified_diff();
+	unified.context_radius(context_radius).header(
+		&format!("a/{}", path.display()),
+		&format!("b/{}", path.display()),
+	);
+	unified.to_string().trim_end_matches('\n').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+	use std::process::Command;
+
+	use monochange_config::load_workspace_configuration;
+	use monochange_test_helpers::fs::setup_scenario_workspace_from;
+	use tempfile::TempDir;
+
+	use super::*;
+
+	fn setup_prepared_release_repo() -> TempDir {
+		let tempdir = setup_scenario_workspace_from(
+			env!("CARGO_MANIFEST_DIR"),
+			"prepared-release/source-github-follow-up",
+		);
+		let root = tempdir.path();
+		git(root, &["init", "-b", "main"]);
+		git(root, &["config", "user.name", "monochange tests"]);
+		git(root, &["config", "user.email", "monochange@example.com"]);
+		git(root, &["add", "."]);
+		git(
+			root,
+			&["-c", "commit.gpgsign=false", "commit", "-m", "initial"],
+		);
+		tempdir
+	}
+
+	fn git(root: &Path, args: &[&str]) {
+		let output = Command::new("git")
+			.current_dir(root)
+			.args(args)
+			.output()
+			.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
+		assert!(
+			output.status.success(),
+			"git {args:?} failed: {}{}",
+			String::from_utf8_lossy(&output.stdout),
+			String::from_utf8_lossy(&output.stderr)
+		);
+	}
+
+	fn explicit_artifact_path(root: &Path) -> PathBuf {
+		root.join(".monochange/unit-prepared-release.json")
+	}
+
+	fn save_artifact(root: &Path, dry_run: bool, explicit_path: &Path) -> WorkspaceConfiguration {
+		let configuration = load_workspace_configuration(root)
+			.unwrap_or_else(|error| panic!("load workspace configuration: {error}"));
+		let prepared = crate::prepare_release_execution_with_file_diffs(root, dry_run, false)
+			.unwrap_or_else(|error| panic!("prepare release execution: {error}"));
+		save_prepared_release_execution(
+			root,
+			&configuration,
+			&prepared.prepared_release,
+			&prepared.file_diffs,
+			Some(explicit_path),
+		)
+		.unwrap_or_else(|error| panic!("save prepared release artifact: {error}"));
+		configuration
+	}
+
+	#[test]
+	fn load_prepared_release_execution_rejects_non_dry_run_follow_up_from_dry_run_artifact() {
+		let tempdir = setup_prepared_release_repo();
+		let root = tempdir.path();
+		let artifact_path = explicit_artifact_path(root);
+		let configuration = save_artifact(root, true, &artifact_path);
+
+		let error = load_prepared_release_execution(
+			root,
+			&configuration,
+			Some(&artifact_path),
+			false,
+			false,
+		)
+		.unwrap_err();
+		assert!(error.to_string().contains("dry-run artifacts"));
+	}
+
+	#[test]
+	fn load_prepared_release_execution_rejects_configuration_drift() {
+		let tempdir = setup_prepared_release_repo();
+		let root = tempdir.path();
+		let artifact_path = explicit_artifact_path(root);
+		let _original_configuration = save_artifact(root, true, &artifact_path);
+		fs::write(
+			root.join("monochange.toml"),
+			fs::read_to_string(root.join("monochange.toml"))
+				.unwrap_or_else(|error| panic!("read monochange.toml: {error}"))
+				.replacen("repo = \"monochange\"", "repo = \"monochange-next\"", 1),
+		)
+		.unwrap_or_else(|error| panic!("write monochange.toml: {error}"));
+		let changed_configuration = load_workspace_configuration(root)
+			.unwrap_or_else(|error| panic!("reload workspace configuration: {error}"));
+
+		let error = load_prepared_release_execution(
+			root,
+			&changed_configuration,
+			Some(&artifact_path),
+			true,
+			false,
+		)
+		.unwrap_err();
+		assert!(
+			error
+				.to_string()
+				.contains("workspace configuration changed")
+		);
+	}
+
+	#[test]
+	fn load_prepared_release_execution_rejects_schema_mismatch() {
+		let tempdir = setup_prepared_release_repo();
+		let root = tempdir.path();
+		let artifact_path = explicit_artifact_path(root);
+		let configuration = save_artifact(root, true, &artifact_path);
+		let mut artifact = read_prepared_release_artifact(&artifact_path)
+			.unwrap_or_else(|error| panic!("read prepared release artifact: {error}"));
+		artifact.schema_version += 1;
+		fs::write(
+			&artifact_path,
+			serde_json::to_string_pretty(&artifact)
+				.unwrap_or_else(|error| panic!("serialize artifact: {error}")),
+		)
+		.unwrap_or_else(|error| panic!("rewrite artifact: {error}"));
+
+		let error = load_prepared_release_execution(
+			root,
+			&configuration,
+			Some(&artifact_path),
+			true,
+			false,
+		)
+		.unwrap_err();
+		assert!(error.to_string().contains("schema version"));
+	}
+
+	#[test]
+	fn maybe_load_prepared_release_execution_ignores_stale_default_cache() {
+		let tempdir = setup_prepared_release_repo();
+		let root = tempdir.path();
+		let default_path = default_prepared_release_cache_path(root);
+		let configuration = load_workspace_configuration(root)
+			.unwrap_or_else(|error| panic!("load workspace configuration: {error}"));
+		let prepared = crate::prepare_release_execution_with_file_diffs(root, false, false)
+			.unwrap_or_else(|error| panic!("prepare release execution: {error}"));
+		save_prepared_release_execution(
+			root,
+			&configuration,
+			&prepared.prepared_release,
+			&prepared.file_diffs,
+			None,
+		)
+		.unwrap_or_else(|error| panic!("save default prepared release artifact: {error}"));
+		assert!(default_path.is_file());
+		fs::write(
+			root.join("crates/core/CHANGELOG.md"),
+			"# Changelog\n\nautomatic drift\n",
+		)
+		.unwrap_or_else(|error| panic!("write drifted changelog: {error}"));
+
+		let loaded =
+			maybe_load_prepared_release_execution(root, &configuration, None, false, false)
+				.unwrap_or_else(|error| panic!("maybe load prepared release execution: {error}"));
+		assert!(loaded.is_none());
+	}
+
+	#[test]
+	fn load_prepared_release_execution_rejects_missing_diff_previews_when_requested() {
+		let tempdir = setup_prepared_release_repo();
+		let root = tempdir.path();
+		let artifact_path = explicit_artifact_path(root);
+		let configuration = save_artifact(root, false, &artifact_path);
+
+		let error = load_prepared_release_execution(
+			root,
+			&configuration,
+			Some(&artifact_path),
+			false,
+			true,
+		)
+		.unwrap_err();
+		assert!(error.to_string().contains("diff previews"));
+	}
+}

--- a/crates/monochange/tests/prepared_release_artifacts.rs
+++ b/crates/monochange/tests/prepared_release_artifacts.rs
@@ -1,0 +1,191 @@
+use std::ffi::OsString;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+mod test_support;
+use test_support::setup_scenario_workspace;
+
+fn run_cli<I>(root: &Path, args: I) -> monochange_core::MonochangeResult<String>
+where
+	I: IntoIterator<Item = OsString>,
+{
+	monochange::run_with_args_in_dir("mc", args, root)
+}
+
+fn run_json<I>(root: &Path, args: I) -> serde_json::Value
+where
+	I: IntoIterator<Item = OsString>,
+{
+	let output = run_cli(root, args).unwrap_or_else(|error| panic!("command output: {error}"));
+	serde_json::from_str(&output).unwrap_or_else(|error| panic!("parse json: {error}"))
+}
+
+fn git(root: &Path, args: &[&str]) {
+	let output = Command::new("git")
+		.current_dir(root)
+		.args(args)
+		.output()
+		.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
+	assert!(
+		output.status.success(),
+		"git {args:?} failed: {}{}",
+		String::from_utf8_lossy(&output.stdout),
+		String::from_utf8_lossy(&output.stderr)
+	);
+}
+
+fn git_output(root: &Path, args: &[&str]) -> String {
+	let output = Command::new("git")
+		.current_dir(root)
+		.args(args)
+		.output()
+		.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
+	assert!(
+		output.status.success(),
+		"git {args:?} failed: {}{}",
+		String::from_utf8_lossy(&output.stdout),
+		String::from_utf8_lossy(&output.stderr)
+	);
+	String::from_utf8(output.stdout)
+		.unwrap_or_else(|error| panic!("git stdout utf8: {error}"))
+		.trim()
+		.to_string()
+}
+
+fn init_git_repo(root: &Path) {
+	git(root, &["init", "-b", "main"]);
+	git(root, &["config", "user.name", "monochange tests"]);
+	git(root, &["config", "user.email", "monochange@example.com"]);
+	git(root, &["add", "."]);
+	git(root, &["commit", "-m", "initial"]);
+}
+
+fn command_args(args: &[&str]) -> Vec<OsString> {
+	std::iter::once(OsString::from("mc"))
+		.chain(args.iter().map(|value| OsString::from(*value)))
+		.collect()
+}
+
+#[test]
+fn explicit_prepared_release_artifact_drives_follow_up_release_pr() {
+	let tempdir = setup_scenario_workspace("prepared-release/source-github-follow-up");
+	let root = tempdir.path();
+	let artifact_path = root.join(".monochange/custom-prepared-release.json");
+	let artifact = artifact_path.display().to_string();
+	init_git_repo(root);
+
+	run_cli(
+		root,
+		command_args(&[
+			"release",
+			"--format",
+			"json",
+			"--prepared-release",
+			&artifact,
+		]),
+	)
+	.unwrap_or_else(|error| panic!("release output: {error}"));
+
+	assert!(artifact_path.is_file());
+	assert!(!root.join(".changeset/feature.md").exists());
+
+	let value = run_json(
+		root,
+		command_args(&[
+			"release-pr",
+			"--dry-run",
+			"--format",
+			"json",
+			"--prepared-release",
+			&artifact,
+		]),
+	);
+	assert_eq!(
+		value.pointer("/releaseRequest/provider"),
+		Some(&serde_json::Value::String("github".to_string()))
+	);
+	assert_eq!(
+		value.pointer("/releaseRequest/headBranch"),
+		Some(&serde_json::Value::String(
+			"monochange/release/release-pr".to_string()
+		))
+	);
+}
+
+#[test]
+fn automatic_prepared_release_cache_survives_commit_and_release_pr_follow_ups() {
+	let tempdir = setup_scenario_workspace("prepared-release/source-github-follow-up");
+	let root = tempdir.path();
+	init_git_repo(root);
+
+	run_cli(root, command_args(&["release", "--format", "json"]))
+		.unwrap_or_else(|error| panic!("release output: {error}"));
+	assert!(
+		root.join(".monochange/prepared-release-cache.json")
+			.is_file()
+	);
+	assert!(!root.join(".changeset/feature.md").exists());
+
+	run_cli(root, command_args(&["commit-release", "--format", "json"]))
+		.unwrap_or_else(|error| panic!("commit-release output: {error}"));
+	assert_eq!(git_output(root, &["status", "--short"]), "");
+	assert_eq!(
+		git_output(root, &["log", "-1", "--pretty=%s"]),
+		"chore(release): prepare release"
+	);
+
+	let value = run_json(
+		root,
+		command_args(&["release-pr", "--dry-run", "--format", "json"]),
+	);
+	assert_eq!(
+		value.pointer("/releaseRequest/title"),
+		Some(&serde_json::Value::String(
+			"chore(release): prepare release".to_string()
+		))
+	);
+	assert_eq!(git_output(root, &["status", "--short"]), "");
+}
+
+#[test]
+fn prepared_release_artifact_rejects_workspace_content_drift() {
+	let tempdir = setup_scenario_workspace("prepared-release/source-github-follow-up");
+	let root = tempdir.path();
+	let artifact_path = root.join(".monochange/custom-prepared-release.json");
+	let artifact = artifact_path.display().to_string();
+	init_git_repo(root);
+
+	run_cli(
+		root,
+		command_args(&[
+			"release",
+			"--format",
+			"json",
+			"--prepared-release",
+			&artifact,
+		]),
+	)
+	.unwrap_or_else(|error| panic!("release output: {error}"));
+	fs::write(
+		root.join("crates/core/CHANGELOG.md"),
+		"# Changelog\n\nmanual drift\n",
+	)
+	.unwrap_or_else(|error| panic!("write changelog drift: {error}"));
+
+	let error = run_cli(
+		root,
+		command_args(&[
+			"release-pr",
+			"--dry-run",
+			"--format",
+			"json",
+			"--prepared-release",
+			&artifact,
+		]),
+	)
+	.unwrap_err();
+	let message = error.to_string();
+	assert!(message.contains("prepared release artifact"));
+	assert!(message.contains("workspace"));
+}

--- a/crates/monochange/tests/prepared_release_artifacts.rs
+++ b/crates/monochange/tests/prepared_release_artifacts.rs
@@ -22,9 +22,7 @@ where
 }
 
 fn git(root: &Path, args: &[&str]) {
-	let output = Command::new("git")
-		.current_dir(root)
-		.args(args)
+	let output = git_command(root, args)
 		.output()
 		.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
 	assert!(
@@ -36,9 +34,7 @@ fn git(root: &Path, args: &[&str]) {
 }
 
 fn git_output(root: &Path, args: &[&str]) -> String {
-	let output = Command::new("git")
-		.current_dir(root)
-		.args(args)
+	let output = git_command(root, args)
 		.output()
 		.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
 	assert!(
@@ -53,12 +49,31 @@ fn git_output(root: &Path, args: &[&str]) -> String {
 		.to_string()
 }
 
+fn git_command(root: &Path, args: &[&str]) -> Command {
+	let mut command = Command::new("git");
+	command.current_dir(root).args(args);
+	for variable in [
+		"GIT_DIR",
+		"GIT_WORK_TREE",
+		"GIT_COMMON_DIR",
+		"GIT_INDEX_FILE",
+		"GIT_OBJECT_DIRECTORY",
+		"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+	] {
+		command.env_remove(variable);
+	}
+	command
+}
+
 fn init_git_repo(root: &Path) {
 	git(root, &["init", "-b", "main"]);
 	git(root, &["config", "user.name", "monochange tests"]);
 	git(root, &["config", "user.email", "monochange@example.com"]);
 	git(root, &["add", "."]);
-	git(root, &["commit", "-m", "initial"]);
+	git(
+		root,
+		&["-c", "commit.gpgsign=false", "commit", "-m", "initial"],
+	);
 }
 
 fn command_args(args: &[&str]) -> Vec<OsString> {

--- a/docs/src/reference/cli-steps/07-prepare-release.md
+++ b/docs/src/reference/cli-steps/07-prepare-release.md
@@ -124,6 +124,28 @@ Typical production commands look like:
 
 Because the later steps all depend on the same prepared state, you should generally do one `PrepareRelease` and then fan out from it with several typed steps rather than trying to run several independent release commands.
 
+### Reuse prepared state across separate commands
+
+When you do need to split the workflow across separate commands, monochange can now reuse a prepared release artifact instead of recomputing the release plan from scratch.
+
+The default path is automatic:
+
+```bash
+mc release
+mc release-pr --dry-run
+```
+
+`mc release` stores the prepared state in `.monochange/prepared-release-cache.json`, and later commands with a `PrepareRelease` step reuse it when the git `HEAD`, workspace status, tracked release inputs, and relevant configuration still match.
+
+If you need to pass the artifact between explicit jobs or custom commands, use `--prepared-release`:
+
+```bash
+mc release --prepared-release /tmp/release-plan.json
+mc release-pr --prepared-release /tmp/release-plan.json --format json
+```
+
+If the artifact is stale, monochange falls back to a fresh `PrepareRelease` run instead of trusting outdated release data.
+
 ## Good fit / bad fit
 
 **Good fit:**

--- a/fixtures/tests/prepared-release/source-github-follow-up/workspace/.changeset/feature.md
+++ b/fixtures/tests/prepared-release/source-github-follow-up/workspace/.changeset/feature.md
@@ -1,0 +1,5 @@
+---
+core: minor
+---
+
+add prepared release reuse coverage

--- a/fixtures/tests/prepared-release/source-github-follow-up/workspace/Cargo.toml
+++ b/fixtures/tests/prepared-release/source-github-follow-up/workspace/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[workspace.package]
+version = "1.0.0"
+
+[workspace.dependencies]
+workflow-core = { path = "./crates/core", version = "1.0.0" }

--- a/fixtures/tests/prepared-release/source-github-follow-up/workspace/crates/core/CHANGELOG.md
+++ b/fixtures/tests/prepared-release/source-github-follow-up/workspace/crates/core/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/fixtures/tests/prepared-release/source-github-follow-up/workspace/crates/core/Cargo.toml
+++ b/fixtures/tests/prepared-release/source-github-follow-up/workspace/crates/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "workflow-core"
+version = { workspace = true }
+edition = "2021"

--- a/fixtures/tests/prepared-release/source-github-follow-up/workspace/crates/core/src/lib.rs
+++ b/fixtures/tests/prepared-release/source-github-follow-up/workspace/crates/core/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn prepared_release_fixture() -> &'static str {
+	"prepared-release"
+}

--- a/fixtures/tests/prepared-release/source-github-follow-up/workspace/monochange.toml
+++ b/fixtures/tests/prepared-release/source-github-follow-up/workspace/monochange.toml
@@ -1,0 +1,65 @@
+[defaults]
+package_type = "cargo"
+changelog = "{{ path }}/CHANGELOG.md"
+
+[package.core]
+path = "crates/core"
+tag = true
+release = true
+
+[source]
+provider = "github"
+owner = "ifiokjr"
+repo = "monochange"
+
+[source.releases]
+source = "github_generated"
+generate_notes = true
+
+[source.pull_requests]
+base = "main"
+branch_prefix = "monochange/release"
+labels = ["release"]
+auto_merge = true
+
+[ecosystems.cargo]
+enabled = true
+
+[cli.release]
+
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
+[[cli.release.steps]]
+type = "PrepareRelease"
+
+[cli.commit-release]
+
+[[cli.commit-release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
+[[cli.commit-release.steps]]
+type = "PrepareRelease"
+
+[[cli.commit-release.steps]]
+type = "CommitRelease"
+
+[cli.release-pr]
+
+[[cli.release-pr.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
+[[cli.release-pr.steps]]
+type = "PrepareRelease"
+
+[[cli.release-pr.steps]]
+type = "OpenReleaseRequest"

--- a/testing/monochange_test_helpers/src/git.rs
+++ b/testing/monochange_test_helpers/src/git.rs
@@ -2,9 +2,7 @@ use std::path::Path;
 use std::process::Command;
 
 pub fn git(root: &Path, args: &[&str]) {
-	let output = Command::new("git")
-		.current_dir(root)
-		.args(args)
+	let output = git_command(root, args)
 		.output()
 		.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
 	assert!(
@@ -16,9 +14,7 @@ pub fn git(root: &Path, args: &[&str]) {
 }
 
 pub fn git_output(root: &Path, args: &[&str]) -> String {
-	let output = Command::new("git")
-		.current_dir(root)
-		.args(args)
+	let output = git_command(root, args)
 		.output()
 		.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
 	assert!(
@@ -32,4 +28,24 @@ pub fn git_output(root: &Path, args: &[&str]) -> String {
 
 pub fn git_output_trimmed(root: &Path, args: &[&str]) -> String {
 	git_output(root, args).trim().to_string()
+}
+
+fn git_command(root: &Path, args: &[&str]) -> Command {
+	let mut command = Command::new("git");
+	command.current_dir(root);
+	for variable in [
+		"GIT_DIR",
+		"GIT_WORK_TREE",
+		"GIT_COMMON_DIR",
+		"GIT_INDEX_FILE",
+		"GIT_OBJECT_DIRECTORY",
+		"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+	] {
+		command.env_remove(variable);
+	}
+	if matches!(args.first(), Some(&"commit")) {
+		command.args(["-c", "commit.gpgsign=false"]);
+	}
+	command.args(args);
+	command
 }


### PR DESCRIPTION
Fixes #174

## Summary
- add durable prepared-release artifact reuse for follow-up commands with a default `.monochange/prepared-release-cache.json` cache and explicit `--prepared-release` support
- validate cached artifacts against `HEAD`, git status, tracked release inputs, config snapshots, and dry-run/diff compatibility before reusing them
- add warm-path integration coverage and prepared-release benchmarks, plus docs and changeset updates for the new reuse flow

## Validation
- `devenv shell mc affected --verify --changed-paths .gitignore --changed-paths .changeset/prepared-release-reuse.md --changed-paths crates/monochange/benches/cli_commands.rs --changed-paths crates/monochange/src/cli.rs --changed-paths crates/monochange/src/cli_runtime.rs --changed-paths crates/monochange/src/lib.rs --changed-paths crates/monochange/src/prepared_release_cache.rs --changed-paths crates/monochange/tests/prepared_release_artifacts.rs --changed-paths docs/src/reference/cli-steps/07-prepare-release.md --changed-paths fixtures/tests/prepared-release/source-github-follow-up/workspace/.changeset/feature.md --changed-paths fixtures/tests/prepared-release/source-github-follow-up/workspace/Cargo.toml --changed-paths fixtures/tests/prepared-release/source-github-follow-up/workspace/crates/core/CHANGELOG.md --changed-paths fixtures/tests/prepared-release/source-github-follow-up/workspace/crates/core/Cargo.toml --changed-paths fixtures/tests/prepared-release/source-github-follow-up/workspace/crates/core/src/lib.rs --changed-paths fixtures/tests/prepared-release/source-github-follow-up/workspace/monochange.toml`
- `devenv shell mc validate`
- `devenv shell test:all`
- `devenv shell cargo llvm-cov -p monochange --lcov --output-path target/prepared-release.lcov --lib --test prepared_release_artifacts`
- changed-line coverage against `origin/main...HEAD`: 100%
