### PR TITLE
test: reduce cli progress integration overhead

### DIFF
--- a/.changeset/test-speed-up-slow-tests.md
+++ b/.changeset/test-speed-up-slow-tests.md
@@ -1,0 +1,14 @@
+---
+"monochange": patch
+---
+
+Improve the CLI progress integration test harness to reduce unnecessary waiting during TTY transcript collection.
+
+Before:
+
+- contributor test runs spent extra time waiting after streamed progress output finished
+
+After:
+
+- the TTY progress integration harness drains output as soon as the subprocess exits
+- the streamed progress fixture uses a shorter delay while still exercising live output rendering

--- a/crates/monochange/tests/cli_progress.rs
+++ b/crates/monochange/tests/cli_progress.rs
@@ -155,7 +155,6 @@ import pty
 import select
 import subprocess
 import sys
-import time
 
 workspace = os.environ['MC_WORKSPACE']
 command_name = os.environ['MC_COMMAND']
@@ -173,31 +172,31 @@ proc = subprocess.Popen(
 )
 os.close(slave)
 transcript = bytearray()
-while True:
-    ready, _, _ = select.select([master], [], [], 0.05)
-    if master in ready:
-        try:
-            data = os.read(master, 4096)
-        except OSError:
-            break
-        if not data:
-            break
-        transcript.extend(data)
-    if proc.poll() is not None and not ready:
-        break
-proc.wait(timeout=10)
-time.sleep(0.1)
-while True:
-    ready, _, _ = select.select([master], [], [], 0.01)
+
+def drain(timeout=0.01):
+    ready, _, _ = select.select([master], [], [], timeout)
     if master not in ready:
-        break
+        return False
     try:
         data = os.read(master, 4096)
     except OSError:
-        break
+        return False
     if not data:
-        break
+        return False
     transcript.extend(data)
+    return True
+
+while True:
+    saw_output = drain(0.01)
+    if proc.poll() is not None and not saw_output:
+        break
+proc.wait(timeout=10)
+idle_polls = 0
+while idle_polls < 5:
+    if drain(0.05):
+        idle_polls = 0
+    else:
+        idle_polls += 1
 os.close(master)
 sys.stdout.buffer.write(transcript)
 sys.stderr.write(f'__MC_EXIT_STATUS__={proc.returncode}\n')
@@ -348,7 +347,7 @@ fn release_progress_streams_named_steps_on_tty() {
 		r#"
 steps = [
 	{ type = "PrepareRelease", name = "plan release" },
-	{ type = "Command", name = "stream summary", shell = true, command = "printf 'streamed line 1\n'; sleep 0.1; printf 'streamed line 2\n'" },
+	{ type = "Command", name = "stream summary", shell = true, command = "printf 'streamed line 1\n'; sleep 0.01; printf 'streamed line 2\n'" },
 ]
 	"#,
 	);


### PR DESCRIPTION
## Summary
- reduce extra wait time in the TTY progress transcript harness
- shorten the streamed output delay in the `release_progress_streams_named_steps_on_tty` fixture
- add a changeset so changeset policy stays green

## What I checked
- ran `cargo nextest run -p monochange --tests --status-level slow --final-status-level slow`
- ran `devenv shell fix:all`
- ran `mc affected --changed-paths crates/monochange/tests/cli_progress.rs --changed-paths .changeset/test-speed-up-slow-tests.md`

## Notes
I profiled the `monochange` test suite and only made the low-risk improvement that clearly reduced avoidable waiting in the TTY progress integration path. Some other >1s tests are still dominated by heavier git/process setup or intentional integration coverage, so they were not changed in this PR.