### PR TITLE
perf: make hosted batching provider portable

### DIFF
--- a/.changeset/provider-portable-hosted-batching.md
+++ b/.changeset/provider-portable-hosted-batching.md
@@ -1,0 +1,11 @@
+---
+monochange: patch
+monochange_core: patch
+monochange_gitea: patch
+monochange_github: patch
+monochange_gitlab: patch
+---
+
+#### make hosted batching and release enrichment provider portable
+
+Hosted changeset context, released-issue comments, and release retargeting now run through a shared provider adapter boundary instead of separate GitHub-only orchestration paths. GitHub keeps its batched enrichment fast path, while GitLab and Gitea now share the same capability-driven flow and diagnostics surface.

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -4000,9 +4000,47 @@ fn execute_cli_command_source_follow_up_steps_require_source_configuration() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected github source requirement error"));
-	assert!(error.to_string().contains(
-		"`CommentReleasedIssues` requires `[source].provider = \"github\"` configuration"
-	));
+	assert!(
+		error.to_string().contains(
+			"`CommentReleasedIssues` is not supported for `[source].provider = \"gitlab\"`"
+		)
+	);
+}
+
+#[test]
+fn execute_cli_command_comment_released_issues_requires_source_configuration() {
+	let root = fixture_path("monochange/release-base");
+	let mut configuration = load_workspace_configuration(&root)
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+	configuration.source = None;
+	let cli_command = monochange_core::CliCommandDefinition {
+		name: "release-comments".to_string(),
+		help_text: None,
+		inputs: Vec::new(),
+		steps: vec![
+			monochange_core::CliStepDefinition::PrepareRelease {
+				name: None,
+				when: None,
+				inputs: BTreeMap::new(),
+			},
+			monochange_core::CliStepDefinition::CommentReleasedIssues {
+				name: None,
+				when: None,
+				inputs: BTreeMap::new(),
+			},
+		],
+	};
+
+	let error =
+		crate::execute_cli_command(&root, &configuration, &cli_command, true, BTreeMap::new())
+			.err()
+			.unwrap_or_else(|| panic!("expected missing source configuration error"));
+
+	assert!(
+		error
+			.to_string()
+			.contains("`CommentReleasedIssues` requires `[source]` configuration")
+	);
 }
 
 #[test]

--- a/crates/monochange/src/changesets.rs
+++ b/crates/monochange/src/changesets.rs
@@ -28,12 +28,9 @@ pub(crate) fn diagnose_changesets(
 		.map(|path| load_changeset_file(path, &configuration, &discovery.packages))
 		.collect::<MonochangeResult<Vec<_>>>()?;
 	let mut changesets = build_prepared_changesets(root, &loaded_changesets);
-	if let Some(source) = configuration
-		.source
-		.as_ref()
-		.filter(|source| source.provider == SourceProvider::GitHub)
-	{
-		github_provider::enrich_changeset_context(source, &mut changesets);
+	if let Some(source) = configuration.source.as_ref() {
+		hosted_sources::configured_hosted_source_adapter(source)
+			.enrich_changeset_context(source, &mut changesets);
 	}
 
 	let requested_changesets = changeset_paths

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -27,7 +27,6 @@ use monochange_core::ShellConfig;
 use monochange_core::SourceChangeRequest;
 use monochange_core::SourceChangeRequestOutcome;
 use monochange_core::SourceConfiguration;
-use monochange_core::SourceProvider;
 use monochange_core::SourceReleaseOutcome;
 use monochange_core::SourceReleaseRequest;
 
@@ -365,8 +364,8 @@ fn build_release_request_result_for_source(
 
 pub(crate) fn build_issue_comment_results(
 	dry_run: bool,
-	plans: &[github_provider::GitHubIssueCommentPlan],
-	publish: impl FnOnce() -> MonochangeResult<Vec<github_provider::GitHubIssueCommentOutcome>>,
+	plans: &[HostedIssueCommentPlan],
+	publish: impl FnOnce() -> MonochangeResult<Vec<monochange_core::HostedIssueCommentOutcome>>,
 ) -> MonochangeResult<Vec<String>> {
 	if dry_run {
 		Ok(plans
@@ -382,8 +381,8 @@ pub(crate) fn build_issue_comment_results(
 					result.repository,
 					result.issue_id,
 					match result.operation {
-						monochange_github::GitHubIssueCommentOperation::Created => "created",
-						monochange_github::GitHubIssueCommentOperation::SkippedExisting => {
+						monochange_core::HostedIssueCommentOperation::Created => "created",
+						monochange_core::HostedIssueCommentOperation::SkippedExisting => {
 							"skipped_existing"
 						}
 					}
@@ -397,10 +396,11 @@ fn build_issue_comment_results_for_source(
 	dry_run: bool,
 	source: &SourceConfiguration,
 	manifest: &ReleaseManifest,
-	plans: &[github_provider::GitHubIssueCommentPlan],
+	plans: &[HostedIssueCommentPlan],
 ) -> MonochangeResult<Vec<String>> {
+	let adapter = hosted_sources::configured_hosted_source_adapter(source);
 	#[rustfmt::skip]
-	let result = build_issue_comment_results(dry_run, plans, || github_provider::comment_released_issues(source, manifest));
+	let result = build_issue_comment_results(dry_run, plans, || adapter.comment_released_issues(source, manifest));
 	result
 }
 
@@ -734,23 +734,25 @@ pub(crate) fn execute_cli_command_with_options(
 								.to_string(),
 						)
 					})?;
-					let source = configuration
-						.source
-						.clone()
-						.filter(|source| source.provider == SourceProvider::GitHub)
-						.ok_or_else(|| {
-							MonochangeError::Config(
-							"`CommentReleasedIssues` requires `[source].provider = \"github\"` configuration"
-								.to_string(),
+					let source = configuration.source.clone().ok_or_else(|| {
+						MonochangeError::Config(
+							"`CommentReleasedIssues` requires `[source]` configuration".to_string(),
 						)
-						})?;
+					})?;
+					let adapter = hosted_sources::configured_hosted_source_adapter(&source);
+					if !adapter.features().released_issue_comments {
+						return Err(MonochangeError::Config(format!(
+							"`CommentReleasedIssues` is not supported for `[source].provider = \"{}\"`",
+							source.provider
+						)));
+					}
 					let manifest = build_release_manifest(
 						cli_command,
 						prepared_release,
 						&context.command_logs,
 					);
 					context.issue_comment_plans =
-						github_provider::plan_released_issue_comments(&source, &manifest);
+						adapter.plan_released_issue_comments(&source, &manifest);
 					let dry_run = context.dry_run;
 					let plans = &context.issue_comment_plans;
 					let results =

--- a/crates/monochange/src/hosted_sources.rs
+++ b/crates/monochange/src/hosted_sources.rs
@@ -1,0 +1,17 @@
+use monochange_core::HostedSourceAdapter;
+use monochange_core::SourceConfiguration;
+use monochange_core::SourceProvider;
+
+pub(crate) fn hosted_source_adapter(provider: SourceProvider) -> &'static dyn HostedSourceAdapter {
+	match provider {
+		SourceProvider::GitHub => &monochange_github::HOSTED_SOURCE_ADAPTER,
+		SourceProvider::GitLab => &monochange_gitlab::HOSTED_SOURCE_ADAPTER,
+		SourceProvider::Gitea => &monochange_gitea::HOSTED_SOURCE_ADAPTER,
+	}
+}
+
+pub(crate) fn configured_hosted_source_adapter(
+	source: &SourceConfiguration,
+) -> &'static dyn HostedSourceAdapter {
+	hosted_source_adapter(source.provider)
+}

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -160,6 +160,7 @@ use monochange_core::GroupChangelogInclude;
 use monochange_core::HostedActorRef;
 use monochange_core::HostedActorSourceKind;
 use monochange_core::HostedCommitRef;
+use monochange_core::HostedIssueCommentPlan;
 use monochange_core::HostedIssueRef;
 use monochange_core::HostedIssueRelationshipKind;
 use monochange_core::HostedReviewRequestRef;
@@ -249,6 +250,7 @@ mod cli;
 mod cli_progress;
 mod cli_runtime;
 mod git_support;
+mod hosted_sources;
 mod interactive;
 mod mcp;
 mod prepared_release_cache;
@@ -502,7 +504,7 @@ struct CliContext {
 	release_request: Option<SourceChangeRequest>,
 	release_request_result: Option<String>,
 	release_commit_report: Option<CommitReleaseReport>,
-	issue_comment_plans: Vec<github_provider::GitHubIssueCommentPlan>,
+	issue_comment_plans: Vec<HostedIssueCommentPlan>,
 	issue_comment_results: Vec<String>,
 	changeset_policy_evaluation: Option<ChangesetPolicyEvaluation>,
 	changeset_diagnostics: Option<ChangesetDiagnosticsReport>,

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -1115,7 +1115,7 @@ pub(crate) fn render_release_cli_command_json(
 	manifest: &ReleaseManifest,
 	releases: &[SourceReleaseRequest],
 	release_request: Option<&SourceChangeRequest>,
-	issue_comments: &[github_provider::GitHubIssueCommentPlan],
+	issue_comments: &[HostedIssueCommentPlan],
 	release_commit: Option<&CommitReleaseReport>,
 	file_diffs: &[PreparedFileDiff],
 ) -> MonochangeResult<String> {

--- a/crates/monochange/src/release_record.rs
+++ b/crates/monochange/src/release_record.rs
@@ -23,7 +23,7 @@ use crate::git_support::push_git_tags;
 use crate::git_support::read_git_commit_message;
 use crate::git_support::resolve_git_commit_ref;
 use crate::git_support::resolve_git_tag_commit;
-use crate::github_provider;
+use crate::hosted_sources;
 
 pub(crate) fn render_release_record_discovery(
 	root: &Path,
@@ -137,31 +137,20 @@ pub fn plan_release_retarget(
 	let provider_updates = if sync_provider {
 		match provider {
 			Some(provider) => {
-				release_record_release_tag_names(&discovery.record)
+				let planned_provider_tags = release_record_release_tag_names(&discovery.record)
 					.into_iter()
 					.map(|tag_name| {
-						RetargetProviderResult {
-							provider,
+						RetargetTagResult {
 							tag_name,
-							target_commit: target_commit.clone(),
-							operation: match provider {
-								SourceProvider::GitHub => RetargetProviderOperation::Planned,
-								SourceProvider::GitLab | SourceProvider::Gitea => {
-									RetargetProviderOperation::Unsupported
-								}
-							},
-							url: None,
-							message: match provider {
-								SourceProvider::GitHub => None,
-								SourceProvider::GitLab | SourceProvider::Gitea => {
-									Some(format!(
-										"provider sync is not yet supported for {provider} release retargeting"
-									))
-								}
-							},
+							operation: RetargetOperation::Planned,
+							from_commit: discovery.record_commit.clone(),
+							to_commit: target_commit.clone(),
+							message: None,
 						}
 					})
-					.collect()
+					.collect::<Vec<_>>();
+				hosted_sources::hosted_source_adapter(provider)
+					.plan_retargeted_releases(&planned_provider_tags)
 			}
 			None => Vec::new(),
 		}
@@ -292,36 +281,11 @@ pub(crate) fn sync_retargeted_provider_releases(
 	tag_results: &[RetargetTagResult],
 	dry_run: bool,
 ) -> MonochangeResult<Vec<RetargetProviderResult>> {
-	match source.provider {
-		SourceProvider::GitHub => {
-			github_provider::sync_retargeted_releases(source, tag_results, dry_run)
-		}
-		SourceProvider::GitLab | SourceProvider::Gitea => {
-			if dry_run {
-				Ok(tag_results
-					.iter()
-					.map(|update| {
-						RetargetProviderResult {
-							provider: source.provider,
-							tag_name: update.tag_name.clone(),
-							target_commit: update.to_commit.clone(),
-							operation: RetargetProviderOperation::Unsupported,
-							url: None,
-							message: Some(format!(
-								"provider sync is not yet supported for {} release retargeting",
-								source.provider
-							)),
-						}
-					})
-					.collect())
-			} else {
-				Err(MonochangeError::Config(format!(
-					"provider sync is not yet supported for {} release retargeting",
-					source.provider
-				)))
-			}
-		}
-	}
+	hosted_sources::configured_hosted_source_adapter(source).sync_retargeted_releases(
+		source,
+		tag_results,
+		dry_run,
+	)
 }
 
 pub(crate) fn text_release_record_discovery(discovery: &ReleaseRecordDiscovery) -> String {

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -27,15 +27,11 @@ use monochange_core::PackageRecord;
 use monochange_core::PackageType;
 use monochange_core::ReleasePlan;
 use monochange_core::SourceConfiguration;
-use monochange_core::SourceProvider;
 use monochange_core::default_cli_commands;
 use monochange_dart::discover_dart_packages;
 use monochange_dart::load_configured_dart_package;
 use monochange_deno::discover_deno_packages;
 use monochange_deno::load_configured_deno_package;
-use monochange_gitea as gitea_provider;
-use monochange_github as github_provider;
-use monochange_gitlab as gitlab_provider;
 use monochange_npm::discover_npm_packages;
 use monochange_npm::load_configured_npm_package;
 use serde_json::json;
@@ -1695,28 +1691,11 @@ fn apply_source_changeset_context(
 	dry_run: bool,
 	changesets: &mut [PreparedChangeset],
 ) {
-	match source.provider {
-		SourceProvider::GitHub => {
-			if dry_run {
-				github_provider::annotate_changeset_context(source, changesets);
-			} else {
-				github_provider::enrich_changeset_context(source, changesets);
-			}
-		}
-		SourceProvider::GitLab => {
-			if dry_run {
-				gitlab_provider::annotate_changeset_context(source, changesets);
-			} else {
-				gitlab_provider::enrich_changeset_context(source, changesets);
-			}
-		}
-		SourceProvider::Gitea => {
-			if dry_run {
-				gitea_provider::annotate_changeset_context(source, changesets);
-			} else {
-				gitea_provider::enrich_changeset_context(source, changesets);
-			}
-		}
+	let adapter = hosted_sources::configured_hosted_source_adapter(source);
+	if dry_run {
+		adapter.annotate_changeset_context(source, changesets);
+	} else {
+		adapter.enrich_changeset_context(source, changesets);
 	}
 }
 

--- a/crates/monochange/tests/snapshots/source_providers__source_provider_diagnostics_match_snapshot@gitea.snap
+++ b/crates/monochange/tests/snapshots/source_providers__source_provider_diagnostics_match_snapshot@gitea.snap
@@ -1,0 +1,40 @@
+---
+source: crates/monochange/tests/source_providers.rs
+expression: json
+---
+{
+  "changesets": [
+    {
+      "context": {
+        "capabilities": {
+          "actorProfiles": false,
+          "commitWebUrls": true,
+          "issueComments": false,
+          "relatedIssues": false,
+          "reviewRequestLookup": false
+        },
+        "host": "codeberg.org",
+        "introduced": null,
+        "lastUpdated": null,
+        "provider": "gitea",
+        "relatedIssues": []
+      },
+      "details": null,
+      "path": ".changeset/feature.md",
+      "summary": "add gitea fixture coverage",
+      "targets": [
+        {
+          "bump": "patch",
+          "changeType": null,
+          "evidenceRefs": [],
+          "id": "core",
+          "kind": "package",
+          "origin": "direct-change"
+        }
+      ]
+    }
+  ],
+  "requestedChangesets": [
+    ".changeset/feature.md"
+  ]
+}

--- a/crates/monochange/tests/snapshots/source_providers__source_provider_diagnostics_match_snapshot@github.snap
+++ b/crates/monochange/tests/snapshots/source_providers__source_provider_diagnostics_match_snapshot@github.snap
@@ -1,0 +1,40 @@
+---
+source: crates/monochange/tests/source_providers.rs
+expression: json
+---
+{
+  "changesets": [
+    {
+      "context": {
+        "capabilities": {
+          "actorProfiles": true,
+          "commitWebUrls": true,
+          "issueComments": true,
+          "relatedIssues": true,
+          "reviewRequestLookup": true
+        },
+        "host": "github.com",
+        "introduced": null,
+        "lastUpdated": null,
+        "provider": "github",
+        "relatedIssues": []
+      },
+      "details": null,
+      "path": ".changeset/feature.md",
+      "summary": "add github fixture coverage",
+      "targets": [
+        {
+          "bump": "minor",
+          "changeType": null,
+          "evidenceRefs": [],
+          "id": "core",
+          "kind": "package",
+          "origin": "direct-change"
+        }
+      ]
+    }
+  ],
+  "requestedChangesets": [
+    ".changeset/feature.md"
+  ]
+}

--- a/crates/monochange/tests/snapshots/source_providers__source_provider_diagnostics_match_snapshot@gitlab.snap
+++ b/crates/monochange/tests/snapshots/source_providers__source_provider_diagnostics_match_snapshot@gitlab.snap
@@ -1,0 +1,40 @@
+---
+source: crates/monochange/tests/source_providers.rs
+expression: json
+---
+{
+  "changesets": [
+    {
+      "context": {
+        "capabilities": {
+          "actorProfiles": false,
+          "commitWebUrls": true,
+          "issueComments": false,
+          "relatedIssues": false,
+          "reviewRequestLookup": false
+        },
+        "host": "gitlab.com",
+        "introduced": null,
+        "lastUpdated": null,
+        "provider": "gitlab",
+        "relatedIssues": []
+      },
+      "details": null,
+      "path": ".changeset/feature.md",
+      "summary": "add gitlab fixture coverage",
+      "targets": [
+        {
+          "bump": "minor",
+          "changeType": null,
+          "evidenceRefs": [],
+          "id": "core",
+          "kind": "package",
+          "origin": "direct-change"
+        }
+      ]
+    }
+  ],
+  "requestedChangesets": [
+    ".changeset/feature.md"
+  ]
+}

--- a/crates/monochange/tests/source_providers.rs
+++ b/crates/monochange/tests/source_providers.rs
@@ -25,3 +25,17 @@ fn source_provider_scenarios_match_snapshot(
 	let json = run_json_command(tempdir.path(), command, Some("2026-04-06"));
 	assert_json_snapshot!(json);
 }
+
+#[rstest]
+#[case::github("source/github")]
+#[case::gitlab("source/gitlab")]
+#[case::gitea("source/gitea")]
+fn source_provider_diagnostics_match_snapshot(#[case] scenario_relative: &str) {
+	let mut settings = snapshot_settings();
+	settings.set_snapshot_suffix(current_test_name());
+	let _guard = settings.bind_to_scope();
+
+	let tempdir = setup_scenario_workspace(scenario_relative);
+	let json = run_json_command(tempdir.path(), "diagnostics", Some("2026-04-06"));
+	assert_json_snapshot!(json);
+}

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -19,18 +19,26 @@ use crate::Ecosystem;
 use crate::EcosystemSettings;
 use crate::GroupChangelogInclude;
 use crate::GroupDefinition;
+use crate::HostedIssueCommentPlan;
+use crate::HostedSourceAdapter;
+use crate::HostedSourceFeatures;
 use crate::HostingProviderKind;
 use crate::MonochangeError;
 use crate::PackageDefinition;
 use crate::PackageDependency;
 use crate::PackageRecord;
 use crate::PackageType;
+use crate::ProviderBotSettings;
+use crate::ProviderMergeRequestSettings;
+use crate::ProviderReleaseSettings;
 use crate::PublishState;
 use crate::RELEASE_RECORD_END_MARKER;
 use crate::RELEASE_RECORD_HEADING;
 use crate::RELEASE_RECORD_KIND;
 use crate::RELEASE_RECORD_SCHEMA_VERSION;
 use crate::RELEASE_RECORD_START_MARKER;
+use crate::ReleaseManifest;
+use crate::ReleaseManifestPlan;
 use crate::ReleaseNotesDocument;
 use crate::ReleaseNotesSection;
 use crate::ReleaseNotesSettings;
@@ -47,6 +55,7 @@ use crate::RetargetProviderResult;
 use crate::RetargetResult;
 use crate::RetargetTagResult;
 use crate::ShellConfig;
+use crate::SourceConfiguration;
 use crate::SourceProvider;
 use crate::VersionFormat;
 use crate::VersionedFileDefinition;
@@ -73,6 +82,104 @@ fn must_err<T, E>(result: Result<T, E>, context: &str) -> E {
 		Ok(_) => panic!("{context}"),
 		Err(error) => error,
 	}
+}
+
+#[derive(Clone)]
+struct TestHostedSourceAdapter {
+	provider: SourceProvider,
+	features: HostedSourceFeatures,
+	issue_comment_plans: Vec<HostedIssueCommentPlan>,
+}
+
+impl HostedSourceAdapter for TestHostedSourceAdapter {
+	fn provider(&self) -> SourceProvider {
+		self.provider
+	}
+
+	fn features(&self) -> HostedSourceFeatures {
+		self.features
+	}
+
+	fn annotate_changeset_context(
+		&self,
+		_source: &SourceConfiguration,
+		_changesets: &mut [crate::PreparedChangeset],
+	) {
+	}
+
+	fn plan_released_issue_comments(
+		&self,
+		_source: &SourceConfiguration,
+		_manifest: &ReleaseManifest,
+	) -> Vec<HostedIssueCommentPlan> {
+		self.issue_comment_plans.clone()
+	}
+}
+
+struct DefaultHostedSourceAdapter {
+	provider: SourceProvider,
+}
+
+impl HostedSourceAdapter for DefaultHostedSourceAdapter {
+	fn provider(&self) -> SourceProvider {
+		self.provider
+	}
+
+	fn annotate_changeset_context(
+		&self,
+		_source: &SourceConfiguration,
+		changesets: &mut [crate::PreparedChangeset],
+	) {
+		if let Some(first) = changesets.first_mut() {
+			first.summary = Some("annotated".to_string());
+		}
+	}
+}
+
+fn test_source_configuration(provider: SourceProvider) -> SourceConfiguration {
+	SourceConfiguration {
+		provider,
+		owner: "org".to_string(),
+		repo: "repo".to_string(),
+		host: None,
+		api_url: None,
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+		bot: ProviderBotSettings::default(),
+	}
+}
+
+fn test_release_manifest() -> ReleaseManifest {
+	ReleaseManifest {
+		command: "release".to_string(),
+		dry_run: true,
+		version: Some("1.2.3".to_string()),
+		group_version: Some("1.2.3".to_string()),
+		release_targets: Vec::new(),
+		released_packages: Vec::new(),
+		changed_files: Vec::new(),
+		changelogs: Vec::new(),
+		changesets: Vec::new(),
+		deleted_changesets: Vec::new(),
+		plan: ReleaseManifestPlan {
+			workspace_root: PathBuf::from("."),
+			decisions: Vec::new(),
+			groups: Vec::new(),
+			warnings: Vec::new(),
+			unresolved_items: Vec::new(),
+			compatibility_evidence: Vec::new(),
+		},
+	}
+}
+
+fn test_retarget_tags() -> Vec<RetargetTagResult> {
+	vec![RetargetTagResult {
+		tag_name: "v1.2.3".to_string(),
+		from_commit: "abc1234".to_string(),
+		to_commit: "def5678".to_string(),
+		operation: RetargetOperation::Planned,
+		message: None,
+	}]
 }
 
 fn init_git_repository(root: &Path) {
@@ -111,6 +218,142 @@ fn must_ok_panics_on_errors() {
 #[test]
 fn must_err_panics_on_ok_results() {
 	assert!(std::panic::catch_unwind(|| must_err(Ok::<(), &str>(()), "context")).is_err());
+}
+
+#[test]
+fn hosted_source_adapter_default_comment_publishing_returns_empty_when_no_plans_exist() {
+	let adapter = DefaultHostedSourceAdapter {
+		provider: SourceProvider::GitLab,
+	};
+	let source = test_source_configuration(SourceProvider::GitLab);
+	let manifest = test_release_manifest();
+
+	let outcomes = must_ok(
+		adapter.comment_released_issues(&source, &manifest),
+		"default comment publishing should allow empty plans",
+	);
+
+	assert!(outcomes.is_empty());
+}
+
+#[test]
+fn hosted_source_adapter_default_features_are_empty_and_comment_plans_are_empty() {
+	let adapter = DefaultHostedSourceAdapter {
+		provider: SourceProvider::GitLab,
+	};
+	let source = test_source_configuration(SourceProvider::GitLab);
+	let manifest = test_release_manifest();
+
+	assert_eq!(adapter.features(), HostedSourceFeatures::default());
+	assert!(
+		adapter
+			.plan_released_issue_comments(&source, &manifest)
+			.is_empty()
+	);
+}
+
+#[test]
+fn hosted_source_adapter_default_enrich_delegates_to_annotate() {
+	let adapter = DefaultHostedSourceAdapter {
+		provider: SourceProvider::GitLab,
+	};
+	let source = test_source_configuration(SourceProvider::GitLab);
+	let mut changesets = vec![crate::PreparedChangeset {
+		path: PathBuf::from(".changeset/example.md"),
+		summary: None,
+		details: None,
+		targets: Vec::new(),
+		context: None,
+	}];
+
+	adapter.enrich_changeset_context(&source, &mut changesets);
+
+	assert_eq!(
+		changesets
+			.first()
+			.and_then(|changeset| changeset.summary.as_deref()),
+		Some("annotated")
+	);
+}
+
+#[test]
+fn hosted_source_adapter_default_comment_publishing_errors_when_provider_lacks_support() {
+	let adapter = TestHostedSourceAdapter {
+		provider: SourceProvider::GitLab,
+		features: HostedSourceFeatures::default(),
+		issue_comment_plans: vec![HostedIssueCommentPlan {
+			repository: "org/repo".to_string(),
+			issue_id: "#7".to_string(),
+			issue_url: Some("https://gitlab.example.com/org/repo/-/issues/7".to_string()),
+			body: "Released in v1.2.3.".to_string(),
+		}],
+	};
+	let source = test_source_configuration(SourceProvider::GitLab);
+	let manifest = test_release_manifest();
+
+	let error = must_err(
+		adapter.comment_released_issues(&source, &manifest),
+		"default comment publishing should reject unsupported providers",
+	);
+
+	assert!(
+		error
+			.to_string()
+			.contains("released issue comments are not yet supported for gitlab")
+	);
+}
+
+#[test]
+fn hosted_source_adapter_default_retarget_planning_marks_unsupported_providers() {
+	let adapter = TestHostedSourceAdapter {
+		provider: SourceProvider::GitLab,
+		features: HostedSourceFeatures::default(),
+		issue_comment_plans: Vec::new(),
+	};
+
+	let plan = adapter.plan_retargeted_releases(&test_retarget_tags());
+
+	assert_eq!(plan.len(), 1);
+	assert_eq!(plan[0].provider, SourceProvider::GitLab);
+	assert_eq!(plan[0].operation, RetargetProviderOperation::Unsupported);
+	assert_eq!(
+		plan[0].message.as_deref(),
+		Some("provider sync is not yet supported for gitlab release retargeting")
+	);
+}
+
+#[test]
+fn hosted_source_adapter_default_retarget_sync_uses_dry_run_plans_and_blocks_real_runs() {
+	let adapter = TestHostedSourceAdapter {
+		provider: SourceProvider::GitHub,
+		features: HostedSourceFeatures {
+			batched_changeset_context_lookup: true,
+			released_issue_comments: true,
+			release_retarget_sync: true,
+		},
+		issue_comment_plans: Vec::new(),
+	};
+	let source = test_source_configuration(SourceProvider::GitHub);
+	let tags = test_retarget_tags();
+
+	let dry_run_plan = must_ok(
+		adapter.sync_retargeted_releases(&source, &tags, true),
+		"default retarget sync should reuse dry-run planning",
+	);
+	assert_eq!(
+		dry_run_plan[0].operation,
+		RetargetProviderOperation::Planned
+	);
+
+	let error = must_err(
+		adapter.sync_retargeted_releases(&source, &tags, false),
+		"default retarget sync should reject unsupported real runs",
+	);
+	assert!(
+		error
+			.to_string()
+			.contains("provider sync is not yet supported for github release retargeting")
+	);
 }
 
 #[test]

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -312,12 +312,15 @@ fn hosted_source_adapter_default_retarget_planning_marks_unsupported_providers()
 	};
 
 	let plan = adapter.plan_retargeted_releases(&test_retarget_tags());
+	let plan_entry = plan
+		.first()
+		.expect("default retarget planning should emit one entry");
 
 	assert_eq!(plan.len(), 1);
-	assert_eq!(plan[0].provider, SourceProvider::GitLab);
-	assert_eq!(plan[0].operation, RetargetProviderOperation::Unsupported);
+	assert_eq!(plan_entry.provider, SourceProvider::GitLab);
+	assert_eq!(plan_entry.operation, RetargetProviderOperation::Unsupported);
 	assert_eq!(
-		plan[0].message.as_deref(),
+		plan_entry.message.as_deref(),
 		Some("provider sync is not yet supported for gitlab release retargeting")
 	);
 }
@@ -340,10 +343,10 @@ fn hosted_source_adapter_default_retarget_sync_uses_dry_run_plans_and_blocks_rea
 		adapter.sync_retargeted_releases(&source, &tags, true),
 		"default retarget sync should reuse dry-run planning",
 	);
-	assert_eq!(
-		dry_run_plan[0].operation,
-		RetargetProviderOperation::Planned
-	);
+	let dry_run_entry = dry_run_plan
+		.first()
+		.expect("default retarget sync should emit one dry-run entry");
+	assert_eq!(dry_run_entry.operation, RetargetProviderOperation::Planned);
 
 	let error = must_err(
 		adapter.sync_retargeted_releases(&source, &tags, false),

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -2585,6 +2585,127 @@ pub struct SourceConfiguration {
 	pub bot: ProviderBotSettings,
 }
 
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct HostedSourceFeatures {
+	pub batched_changeset_context_lookup: bool,
+	pub released_issue_comments: bool,
+	pub release_retarget_sync: bool,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HostedIssueCommentPlan {
+	pub repository: String,
+	pub issue_id: String,
+	pub issue_url: Option<String>,
+	pub body: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HostedIssueCommentOperation {
+	Created,
+	SkippedExisting,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HostedIssueCommentOutcome {
+	pub repository: String,
+	pub issue_id: String,
+	pub operation: HostedIssueCommentOperation,
+	pub url: Option<String>,
+}
+
+pub trait HostedSourceAdapter: Sync {
+	fn provider(&self) -> SourceProvider;
+
+	fn features(&self) -> HostedSourceFeatures {
+		HostedSourceFeatures::default()
+	}
+
+	fn annotate_changeset_context(
+		&self,
+		source: &SourceConfiguration,
+		changesets: &mut [PreparedChangeset],
+	);
+
+	fn enrich_changeset_context(
+		&self,
+		source: &SourceConfiguration,
+		changesets: &mut [PreparedChangeset],
+	) {
+		self.annotate_changeset_context(source, changesets);
+	}
+
+	fn plan_released_issue_comments(
+		&self,
+		_source: &SourceConfiguration,
+		_manifest: &ReleaseManifest,
+	) -> Vec<HostedIssueCommentPlan> {
+		Vec::new()
+	}
+
+	fn comment_released_issues(
+		&self,
+		source: &SourceConfiguration,
+		manifest: &ReleaseManifest,
+	) -> MonochangeResult<Vec<HostedIssueCommentOutcome>> {
+		let plans = self.plan_released_issue_comments(source, manifest);
+		if plans.is_empty() {
+			return Ok(Vec::new());
+		}
+		Err(MonochangeError::Config(format!(
+			"released issue comments are not yet supported for {}",
+			self.provider()
+		)))
+	}
+
+	fn plan_retargeted_releases(
+		&self,
+		tag_results: &[RetargetTagResult],
+	) -> Vec<RetargetProviderResult> {
+		let provider = self.provider();
+		let supports_sync = self.features().release_retarget_sync;
+		tag_results
+			.iter()
+			.map(|update| {
+				RetargetProviderResult {
+					provider,
+					tag_name: update.tag_name.clone(),
+					target_commit: update.to_commit.clone(),
+					operation: if supports_sync {
+						RetargetProviderOperation::Planned
+					} else {
+						RetargetProviderOperation::Unsupported
+					},
+					url: None,
+					message: (!supports_sync).then_some(format!(
+						"provider sync is not yet supported for {provider} release retargeting"
+					)),
+				}
+			})
+			.collect()
+	}
+
+	fn sync_retargeted_releases(
+		&self,
+		source: &SourceConfiguration,
+		tag_results: &[RetargetTagResult],
+		dry_run: bool,
+	) -> MonochangeResult<Vec<RetargetProviderResult>> {
+		if dry_run {
+			return Ok(self.plan_retargeted_releases(tag_results));
+		}
+		Err(MonochangeError::Config(format!(
+			"provider sync is not yet supported for {} release retargeting",
+			source.provider
+		)))
+	}
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SourceReleaseRequest {

--- a/crates/monochange_gitea/src/lib.rs
+++ b/crates/monochange_gitea/src/lib.rs
@@ -6,6 +6,8 @@ use std::path::PathBuf;
 use std::thread;
 
 use monochange_core::CommitMessage;
+use monochange_core::HostedSourceAdapter;
+use monochange_core::HostedSourceFeatures;
 use monochange_core::HostingCapabilities;
 use monochange_core::HostingProviderKind;
 use monochange_core::MonochangeError;
@@ -51,6 +53,40 @@ pub const fn source_capabilities() -> SourceCapabilities {
 		auto_merge_change_requests: false,
 		released_issue_comments: false,
 		requires_host: true,
+	}
+}
+
+pub static HOSTED_SOURCE_ADAPTER: GiteaHostedSourceAdapter = GiteaHostedSourceAdapter;
+
+pub struct GiteaHostedSourceAdapter;
+
+impl HostedSourceAdapter for GiteaHostedSourceAdapter {
+	fn provider(&self) -> SourceProvider {
+		SourceProvider::Gitea
+	}
+
+	fn features(&self) -> HostedSourceFeatures {
+		HostedSourceFeatures {
+			batched_changeset_context_lookup: false,
+			released_issue_comments: false,
+			release_retarget_sync: false,
+		}
+	}
+
+	fn annotate_changeset_context(
+		&self,
+		source: &SourceConfiguration,
+		changesets: &mut [PreparedChangeset],
+	) {
+		annotate_changeset_context(source, changesets);
+	}
+
+	fn enrich_changeset_context(
+		&self,
+		source: &SourceConfiguration,
+		changesets: &mut [PreparedChangeset],
+	) {
+		enrich_changeset_context(source, changesets);
 	}
 }
 

--- a/crates/monochange_github/src/__tests.rs
+++ b/crates/monochange_github/src/__tests.rs
@@ -15,6 +15,7 @@ use monochange_core::HostedActorSourceKind;
 use monochange_core::HostedCommitRef;
 use monochange_core::HostedIssueRef;
 use monochange_core::HostedIssueRelationshipKind;
+use monochange_core::HostedSourceAdapter;
 use monochange_core::HostingCapabilities;
 use monochange_core::HostingProviderKind;
 use monochange_core::MonochangeError;
@@ -249,6 +250,77 @@ fn comment_released_issues_public_api_uses_source_configuration() {
 			.unwrap_or_else(|| panic!("expected one issue comment outcome"))
 			.issue_id,
 		"#7"
+	);
+}
+
+#[test]
+fn github_hosted_source_adapter_comments_released_issues() {
+	let server = MockServer::start();
+	let list_issue_comments = server.mock(|when, then| {
+		when.method(GET)
+			.path("/repos/ifiokjr/monochange/issues/7/comments");
+		then.status(200)
+			.header("content-type", "application/json")
+			.body("[]");
+	});
+	let create_issue_comment = server.mock(|when, then| {
+		when.method(POST)
+			.path("/repos/ifiokjr/monochange/issues/7/comments");
+		then.status(201)
+			.header("content-type", "application/json")
+			.body("{\"html_url\":\"https://example.com/issues/7#comment-1\"}");
+	});
+	let source = SourceConfiguration {
+		provider: SourceProvider::GitHub,
+		host: None,
+		api_url: Some(server.base_url()),
+		owner: "ifiokjr".to_string(),
+		repo: "monochange".to_string(),
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+		bot: ProviderBotSettings::default(),
+	};
+	let mut manifest = sample_manifest();
+	manifest.changesets = vec![PreparedChangeset {
+		path: PathBuf::from(".changeset/feature.md"),
+		summary: Some("add release context".to_string()),
+		details: None,
+		targets: Vec::new(),
+		context: Some(ChangesetContext {
+			provider: HostingProviderKind::GitHub,
+			host: Some("example.com".to_string()),
+			capabilities: github_hosting_capabilities(),
+			introduced: None,
+			last_updated: None,
+			related_issues: vec![HostedIssueRef {
+				provider: HostingProviderKind::GitHub,
+				host: Some("example.com".to_string()),
+				id: "#7".to_string(),
+				title: Some("Track release context".to_string()),
+				url: Some("https://example.com/issues/7".to_string()),
+				relationship: HostedIssueRelationshipKind::ClosedByReviewRequest,
+			}],
+		}),
+	}];
+
+	let outcomes = temp_env::with_vars(
+		[
+			("GITHUB_TOKEN", Some("token")),
+			("GITHUB_SERVER_URL", Some("https://example.com")),
+		],
+		|| HOSTED_SOURCE_ADAPTER.comment_released_issues(&source, &manifest),
+	)
+	.unwrap_or_else(|error| panic!("adapter issue comments: {error}"));
+
+	list_issue_comments.assert();
+	create_issue_comment.assert();
+	assert_eq!(outcomes.len(), 1);
+	assert_eq!(
+		outcomes
+			.first()
+			.unwrap_or_else(|| panic!("expected one issue comment outcome"))
+			.operation,
+		GitHubIssueCommentOperation::Created
 	);
 }
 

--- a/crates/monochange_github/src/lib.rs
+++ b/crates/monochange_github/src/lib.rs
@@ -100,10 +100,15 @@ use std::thread;
 use monochange_core::CommitMessage;
 use monochange_core::HostedActorRef;
 use monochange_core::HostedActorSourceKind;
+use monochange_core::HostedIssueCommentOperation;
+use monochange_core::HostedIssueCommentOutcome;
+use monochange_core::HostedIssueCommentPlan;
 use monochange_core::HostedIssueRef;
 use monochange_core::HostedIssueRelationshipKind;
 use monochange_core::HostedReviewRequestKind;
 use monochange_core::HostedReviewRequestRef;
+use monochange_core::HostedSourceAdapter;
+use monochange_core::HostedSourceFeatures;
 use monochange_core::HostingCapabilities;
 use monochange_core::HostingProviderKind;
 use monochange_core::MonochangeError;
@@ -175,29 +180,67 @@ pub fn validate_source_configuration(source: &SourceConfiguration) -> Monochange
 	Ok(())
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct GitHubIssueCommentPlan {
-	pub repository: String,
-	pub issue_id: String,
-	pub issue_url: Option<String>,
-	pub body: String,
-}
+pub type GitHubIssueCommentPlan = HostedIssueCommentPlan;
+pub type GitHubIssueCommentOperation = HostedIssueCommentOperation;
+pub type GitHubIssueCommentOutcome = HostedIssueCommentOutcome;
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum GitHubIssueCommentOperation {
-	Created,
-	SkippedExisting,
-}
+pub static HOSTED_SOURCE_ADAPTER: GitHubHostedSourceAdapter = GitHubHostedSourceAdapter;
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct GitHubIssueCommentOutcome {
-	pub repository: String,
-	pub issue_id: String,
-	pub operation: GitHubIssueCommentOperation,
-	pub url: Option<String>,
+pub struct GitHubHostedSourceAdapter;
+
+impl HostedSourceAdapter for GitHubHostedSourceAdapter {
+	fn provider(&self) -> SourceProvider {
+		SourceProvider::GitHub
+	}
+
+	fn features(&self) -> HostedSourceFeatures {
+		HostedSourceFeatures {
+			batched_changeset_context_lookup: true,
+			released_issue_comments: true,
+			release_retarget_sync: true,
+		}
+	}
+
+	fn annotate_changeset_context(
+		&self,
+		source: &SourceConfiguration,
+		changesets: &mut [PreparedChangeset],
+	) {
+		annotate_changeset_context(source, changesets);
+	}
+
+	fn enrich_changeset_context(
+		&self,
+		source: &SourceConfiguration,
+		changesets: &mut [PreparedChangeset],
+	) {
+		enrich_changeset_context(source, changesets);
+	}
+
+	fn plan_released_issue_comments(
+		&self,
+		source: &SourceConfiguration,
+		manifest: &ReleaseManifest,
+	) -> Vec<HostedIssueCommentPlan> {
+		plan_released_issue_comments(source, manifest)
+	}
+
+	fn comment_released_issues(
+		&self,
+		source: &SourceConfiguration,
+		manifest: &ReleaseManifest,
+	) -> MonochangeResult<Vec<HostedIssueCommentOutcome>> {
+		comment_released_issues(source, manifest)
+	}
+
+	fn sync_retargeted_releases(
+		&self,
+		source: &SourceConfiguration,
+		tag_results: &[RetargetTagResult],
+		dry_run: bool,
+	) -> MonochangeResult<Vec<RetargetProviderResult>> {
+		sync_retargeted_releases(source, tag_results, dry_run)
+	}
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/crates/monochange_gitlab/src/lib.rs
+++ b/crates/monochange_gitlab/src/lib.rs
@@ -6,6 +6,8 @@ use std::path::PathBuf;
 use std::thread;
 
 use monochange_core::CommitMessage;
+use monochange_core::HostedSourceAdapter;
+use monochange_core::HostedSourceFeatures;
 use monochange_core::HostingCapabilities;
 use monochange_core::HostingProviderKind;
 use monochange_core::MonochangeError;
@@ -50,6 +52,40 @@ pub const fn source_capabilities() -> SourceCapabilities {
 		auto_merge_change_requests: false,
 		released_issue_comments: false,
 		requires_host: false,
+	}
+}
+
+pub static HOSTED_SOURCE_ADAPTER: GitLabHostedSourceAdapter = GitLabHostedSourceAdapter;
+
+pub struct GitLabHostedSourceAdapter;
+
+impl HostedSourceAdapter for GitLabHostedSourceAdapter {
+	fn provider(&self) -> SourceProvider {
+		SourceProvider::GitLab
+	}
+
+	fn features(&self) -> HostedSourceFeatures {
+		HostedSourceFeatures {
+			batched_changeset_context_lookup: false,
+			released_issue_comments: false,
+			release_retarget_sync: false,
+		}
+	}
+
+	fn annotate_changeset_context(
+		&self,
+		source: &SourceConfiguration,
+		changesets: &mut [PreparedChangeset],
+	) {
+		annotate_changeset_context(source, changesets);
+	}
+
+	fn enrich_changeset_context(
+		&self,
+		source: &SourceConfiguration,
+		changesets: &mut [PreparedChangeset],
+	) {
+		enrich_changeset_context(source, changesets);
 	}
 }
 


### PR DESCRIPTION
Fixes #176

## Summary

- move hosted enrichment, released-issue comments, and release-retarget sync behind a provider-portable adapter boundary
- keep GitHub on the batched fast path while giving GitLab and Gitea the same orchestration surface with explicit capability flags
- add cross-provider integration coverage plus adapter default-behavior tests so the changed executable lines stay fully covered

## Validation

- `devenv shell cargo test -p monochange_core hosted_source_adapter_`
- `devenv shell cargo test -p monochange_github github_hosted_source_adapter_comments_released_issues`
- `devenv shell cargo test -p monochange execute_cli_command_comment_released_issues_requires_source_configuration`
- pre-push hooks: `lint`, `secrets`, `test`
- changed executable lines for touched production files: 100%