### PR TITLE
test: replace python tty harnesses

### DIFF
--- a/.changeset/test-remove-python-harnesses.md
+++ b/.changeset/test-remove-python-harnesses.md
@@ -1,0 +1,25 @@
+---
+"monochange": patch
+---
+
+#### replace Python-based CLI test harnesses with Rust PTY helpers
+
+monochange no longer relies on `python3` for the interactive CLI integration tests that exercise TTY progress output and `mc change --interactive` flows.
+
+This matters for contributors and CI environments because the test suite can now run without a Python runtime installed just to drive terminal interactions.
+
+**Before:** the Rust tests spawned inline Python scripts that opened a PTY and sent interactive input.
+
+```bash
+cargo test -p monochange --test cli_progress --test changeset_target_metadata
+```
+
+Those tests required a working `python3` binary in `PATH`.
+
+**After:** the same test commands use a Rust-native PTY helper instead.
+
+```bash
+cargo test -p monochange --test cli_progress --test changeset_target_metadata
+```
+
+No Python interpreter is required for those integration tests anymore.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,12 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -297,6 +303,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -546,7 +558,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -737,6 +749,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,6 +929,17 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1552,7 +1581,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6654738b8024300cf062d04a1c13c10c8e2cea598ec1c47dc9b6641159429756"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "crossterm",
  "dyn-clone",
  "fuzzy-matcher",
@@ -1874,6 +1903,7 @@ dependencies = [
  "monochange_npm",
  "monochange_semver",
  "monochange_test_helpers",
+ "portable-pty",
  "rayon",
  "regex",
  "rmcp",
@@ -2119,6 +2149,18 @@ dependencies = [
  "insta",
  "rmcp",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
 ]
 
 [[package]]
@@ -2437,6 +2479,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2504,7 +2567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -2545,7 +2608,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -2659,7 +2722,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2888,7 +2951,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3062,7 +3125,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3199,6 +3262,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e66ab7ee258c6456796c6098e1b53a5baa1a5e0637347de59ddb44ee8e20be6e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3228,6 +3302,22 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -3434,7 +3524,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -3720,7 +3810,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -4050,7 +4140,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4419,6 +4509,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4476,7 +4575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ insta-cmd = { version = "^0.6", default-features = false }
 miette = { version = "^7", default-features = false }
 minijinja = { version = "^2", default-features = false }
 octocrab = { version = "^0.49", default-features = false, features = ["default-client", "follow-redirect", "jwt-rust-crypto", "retry", "rustls", "rustls-aws-lc-rs", "timeout", "tracing"] }
+portable-pty = { version = "^0.9", default-features = false }
 rayon = { version = "^1.10", default-features = false }
 regex = { version = "^1", default-features = false, features = ["std", "unicode-perl"] }
 reqwest = { version = "^0.13", default-features = false, features = ["blocking", "json", "rustls"] }

--- a/crates/monochange/Cargo.toml
+++ b/crates/monochange/Cargo.toml
@@ -58,6 +58,7 @@ insta = { workspace = true, default-features = true }
 insta-cmd = { workspace = true, default-features = true }
 monochange_config = { workspace = true }
 monochange_test_helpers = { version = "0.0.0", path = "../../testing/monochange_test_helpers" }
+portable-pty = { workspace = true, default-features = true }
 rstest = { workspace = true, default-features = true }
 similar-asserts = { workspace = true, default-features = true }
 temp-env = { workspace = true, default-features = true }

--- a/crates/monochange/tests/changeset_target_metadata.rs
+++ b/crates/monochange/tests/changeset_target_metadata.rs
@@ -4,7 +4,9 @@ use std::path::Path;
 use serde_json::Value;
 
 mod test_support;
+use test_support::TtyAction;
 use test_support::monochange_command;
+use test_support::run_in_tty;
 use test_support::setup_scenario_workspace;
 
 fn cli() -> std::process::Command {
@@ -12,75 +14,50 @@ fn cli() -> std::process::Command {
 }
 
 #[cfg(unix)]
-fn run_interactive_change_cli(workspace: &Path, output_path: &Path) -> std::process::Output {
-	const SCRIPT: &str = r"
-import os
-import pty
-import select
-import subprocess
-import time
-import sys
-
-workspace = os.environ['MC_WORKSPACE']
-output_path = os.environ['MC_OUTPUT']
-mc_bin = os.environ['MC_BIN']
-master, slave = pty.openpty()
-proc = subprocess.Popen(
-    [mc_bin, 'change', '--interactive', '--reason', 'interactive reason', '--details', 'interactive details', '--output', output_path],
-    cwd=workspace,
-    stdin=slave,
-    stdout=slave,
-    stderr=slave,
-    text=False,
-    close_fds=True,
-)
-os.close(slave)
-
-transcript = bytearray()
-
-def drain(seconds):
-    end = time.time() + seconds
-    while time.time() < end:
-        ready, _, _ = select.select([master], [], [], 0.05)
-        if master in ready:
-            try:
-                data = os.read(master, 4096)
-            except OSError:
-                break
-            if not data:
-                break
-            transcript.extend(data)
-        if proc.poll() is not None:
-            break
-
-drain(0.5)
-os.write(master, b' ')
-time.sleep(0.1)
-os.write(master, b'\r')
-drain(0.5)
-os.write(master, b'\x1b[B')
-time.sleep(0.1)
-os.write(master, b'\r')
-drain(0.5)
-os.write(master, b'\r')
-drain(0.5)
-os.write(master, b'\r')
-drain(0.5)
-proc.wait(timeout=10)
-drain(0.2)
-os.close(master)
-sys.stdout.buffer.write(transcript)
-sys.exit(proc.returncode)
-";
-
-	std::process::Command::new("python3")
-		.arg("-c")
-		.arg(SCRIPT)
-		.env("MC_BIN", insta_cmd::get_cargo_bin("mc"))
-		.env("MC_WORKSPACE", workspace)
-		.env("MC_OUTPUT", output_path)
-		.output()
-		.unwrap_or_else(|error| panic!("interactive python harness: {error}"))
+fn run_interactive_change_cli(workspace: &Path, output_path: &Path) -> (i32, String) {
+	let actions = [
+		TtyAction::Sleep(std::time::Duration::from_millis(500)),
+		TtyAction::Send {
+			bytes: b" ",
+			pause_after: std::time::Duration::from_millis(100),
+		},
+		TtyAction::Send {
+			bytes: b"\r",
+			pause_after: std::time::Duration::from_millis(500),
+		},
+		TtyAction::Send {
+			bytes: b"\x1b[B",
+			pause_after: std::time::Duration::from_millis(100),
+		},
+		TtyAction::Send {
+			bytes: b"\r",
+			pause_after: std::time::Duration::from_millis(500),
+		},
+		TtyAction::Send {
+			bytes: b"\r",
+			pause_after: std::time::Duration::from_millis(500),
+		},
+		TtyAction::Send {
+			bytes: b"\r",
+			pause_after: std::time::Duration::from_millis(500),
+		},
+	];
+	let output = output_path.display().to_string();
+	run_in_tty(
+		workspace,
+		&[
+			"change",
+			"--interactive",
+			"--reason",
+			"interactive reason",
+			"--details",
+			"interactive details",
+			"--output",
+			output.as_str(),
+		],
+		Some("2026-04-06"),
+		&actions,
+	)
 }
 
 #[test]
@@ -193,13 +170,9 @@ fn interactive_change_cli_writes_selected_bump() {
 	let tempdir = setup_scenario_workspace("changeset-target-metadata/render-workspace");
 	let output_path = tempdir.path().join("interactive.md");
 
-	let output = run_interactive_change_cli(tempdir.path(), &output_path);
-	assert!(
-		output.status.success(),
-		"{}",
-		String::from_utf8_lossy(&output.stdout)
-	);
-	assert!(String::from_utf8_lossy(&output.stdout).contains("wrote change file interactive.md"));
+	let (status, transcript) = run_interactive_change_cli(tempdir.path(), &output_path);
+	assert!(status == 0, "{transcript}");
+	assert!(transcript.contains("wrote change file interactive.md"));
 
 	let contents = fs::read_to_string(output_path).unwrap_or_else(|error| panic!("read: {error}"));
 	assert!(contents.contains("sdk: patch"));

--- a/crates/monochange/tests/cli_progress.rs
+++ b/crates/monochange/tests/cli_progress.rs
@@ -8,12 +8,12 @@ use regex::Regex;
 use serde_json::Value;
 
 mod test_support;
+use test_support::TtyAction;
 use test_support::current_test_name;
 use test_support::monochange_command;
+use test_support::run_in_tty;
 use test_support::setup_fixture;
 use test_support::snapshot_settings;
-
-const EXIT_STATUS_MARKER: &str = "__MC_EXIT_STATUS__=";
 
 fn append_progress_command(workspace: &Path, command_name: &str, body: &str) {
 	let config_path = workspace.join("monochange.toml");
@@ -149,84 +149,8 @@ fn normalize_terminal_transcript(text: &str) -> String {
 
 #[cfg(unix)]
 fn run_tty_command_result(workspace: &Path, command_name: &str) -> (i32, String) {
-	const SCRIPT: &str = r"
-import os
-import pty
-import select
-import subprocess
-import sys
-
-workspace = os.environ['MC_WORKSPACE']
-command_name = os.environ['MC_COMMAND']
-mc_bin = os.environ['MC_BIN']
-master, slave = pty.openpty()
-proc = subprocess.Popen(
-    [mc_bin, command_name],
-    cwd=workspace,
-    stdin=slave,
-    stdout=slave,
-    stderr=slave,
-    text=False,
-    close_fds=True,
-    env={**os.environ, 'NO_COLOR': '1'},
-)
-os.close(slave)
-transcript = bytearray()
-
-def drain(timeout=0.01):
-    ready, _, _ = select.select([master], [], [], timeout)
-    if master not in ready:
-        return False
-    try:
-        data = os.read(master, 4096)
-    except OSError:
-        return False
-    if not data:
-        return False
-    transcript.extend(data)
-    return True
-
-while True:
-    saw_output = drain(0.01)
-    if proc.poll() is not None and not saw_output:
-        break
-proc.wait(timeout=10)
-idle_polls = 0
-while idle_polls < 5:
-    if drain(0.05):
-        idle_polls = 0
-    else:
-        idle_polls += 1
-os.close(master)
-sys.stdout.buffer.write(transcript)
-sys.stderr.write(f'__MC_EXIT_STATUS__={proc.returncode}\n')
-sys.exit(0)
-";
-
-	let output = std::process::Command::new("python3")
-		.arg("-c")
-		.arg(SCRIPT)
-		.env("MC_BIN", insta_cmd::get_cargo_bin("mc"))
-		.env("MC_WORKSPACE", workspace)
-		.env("MC_COMMAND", command_name)
-		.output()
-		.unwrap_or_else(|error| panic!("tty python harness: {error}"));
-	assert!(
-		output.status.success(),
-		"tty python harness failed:\n{}",
-		String::from_utf8_lossy(&output.stderr)
-	);
-	let stderr =
-		String::from_utf8(output.stderr).unwrap_or_else(|error| panic!("tty stderr utf8: {error}"));
-	let status_code = stderr
-		.lines()
-		.find_map(|line| line.strip_prefix(EXIT_STATUS_MARKER))
-		.unwrap_or_else(|| panic!("missing tty exit status marker:\n{stderr}"))
-		.parse::<i32>()
-		.unwrap_or_else(|error| panic!("parse tty exit status: {error}\n{stderr}"));
-	let transcript =
-		String::from_utf8(output.stdout).unwrap_or_else(|error| panic!("tty output utf8: {error}"));
-	(status_code, normalize_terminal_transcript(&transcript))
+	let (status, transcript) = run_in_tty(workspace, &[command_name], None, &[]);
+	(status, normalize_terminal_transcript(&transcript))
 }
 
 #[cfg(unix)]
@@ -238,98 +162,50 @@ fn run_tty_command(workspace: &Path, command_name: &str) -> String {
 
 #[cfg(unix)]
 fn run_tty_interactive_change(workspace: &Path, output_path: &Path) -> (i32, String) {
-	const SCRIPT: &str = r"
-import os
-import pty
-import select
-import subprocess
-import sys
-import time
-
-workspace = os.environ['MC_WORKSPACE']
-output_path = os.environ['MC_OUTPUT']
-mc_bin = os.environ['MC_BIN']
-master, slave = pty.openpty()
-proc = subprocess.Popen(
-    [mc_bin, 'change', '--interactive', '--reason', 'interactive reason', '--details', 'interactive details', '--output', output_path],
-    cwd=workspace,
-    stdin=slave,
-    stdout=slave,
-    stderr=slave,
-    text=False,
-    close_fds=True,
-    env={**os.environ, 'NO_COLOR': '1'},
-)
-os.close(slave)
-transcript = bytearray()
-
-def drain(seconds):
-    end = time.time() + seconds
-    while time.time() < end:
-        ready, _, _ = select.select([master], [], [], 0.05)
-        if master in ready:
-            try:
-                data = os.read(master, 4096)
-            except OSError:
-                break
-            if not data:
-                break
-            transcript.extend(data)
-        if proc.poll() is not None:
-            break
-
-def send(data, pause=0.0):
-    try:
-        os.write(master, data)
-    except OSError:
-        return False
-    if pause:
-        time.sleep(pause)
-    return True
-
-drain(0.5)
-if send(b' ', 0.1):
-    send(b'\r')
-drain(0.5)
-if send(b'\x1b[B', 0.1):
-    send(b'\r')
-drain(0.5)
-send(b'\r')
-drain(0.5)
-send(b'\r')
-drain(0.5)
-proc.wait(timeout=10)
-drain(0.2)
-os.close(master)
-sys.stdout.buffer.write(transcript)
-sys.stderr.write(f'__MC_EXIT_STATUS__={proc.returncode}\n')
-sys.exit(0)
-";
-
-	let output = std::process::Command::new("python3")
-		.arg("-c")
-		.arg(SCRIPT)
-		.env("MC_BIN", insta_cmd::get_cargo_bin("mc"))
-		.env("MC_WORKSPACE", workspace)
-		.env("MC_OUTPUT", output_path)
-		.output()
-		.unwrap_or_else(|error| panic!("interactive tty python harness: {error}"));
-	assert!(
-		output.status.success(),
-		"interactive tty python harness failed:\n{}",
-		String::from_utf8_lossy(&output.stderr)
+	let actions = [
+		TtyAction::Sleep(std::time::Duration::from_millis(500)),
+		TtyAction::Send {
+			bytes: b" ",
+			pause_after: std::time::Duration::from_millis(100),
+		},
+		TtyAction::Send {
+			bytes: b"\r",
+			pause_after: std::time::Duration::from_millis(500),
+		},
+		TtyAction::Send {
+			bytes: b"\x1b[B",
+			pause_after: std::time::Duration::from_millis(100),
+		},
+		TtyAction::Send {
+			bytes: b"\r",
+			pause_after: std::time::Duration::from_millis(500),
+		},
+		TtyAction::Send {
+			bytes: b"\r",
+			pause_after: std::time::Duration::from_millis(500),
+		},
+		TtyAction::Send {
+			bytes: b"\r",
+			pause_after: std::time::Duration::from_millis(500),
+		},
+	];
+	let output = output_path.display().to_string();
+	let (status, transcript) = run_in_tty(
+		workspace,
+		&[
+			"change",
+			"--interactive",
+			"--reason",
+			"interactive reason",
+			"--details",
+			"interactive details",
+			"--output",
+			output.as_str(),
+		],
+		None,
+		&actions,
 	);
-	let stderr =
-		String::from_utf8(output.stderr).unwrap_or_else(|error| panic!("tty stderr utf8: {error}"));
-	let status_code = stderr
-		.lines()
-		.find_map(|line| line.strip_prefix(EXIT_STATUS_MARKER))
-		.unwrap_or_else(|| panic!("missing tty exit status marker:\n{stderr}"))
-		.parse::<i32>()
-		.unwrap_or_else(|error| panic!("parse tty exit status: {error}\n{stderr}"));
-	let transcript = String::from_utf8(output.stdout)
-		.unwrap_or_else(|error| panic!("interactive tty output utf8: {error}"));
-	(status_code, normalize_terminal_transcript(&transcript))
+	(status, normalize_terminal_transcript(&transcript))
 }
 
 #[cfg(not(unix))]

--- a/crates/monochange/tests/test_support.rs
+++ b/crates/monochange/tests/test_support.rs
@@ -8,6 +8,12 @@ pub use monochange_test_helpers::copy_directory;
 pub use monochange_test_helpers::current_test_name;
 #[allow(unused_imports)]
 pub use monochange_test_helpers::snapshot_settings;
+#[cfg(unix)]
+use portable_pty::CommandBuilder;
+#[cfg(unix)]
+use portable_pty::PtySize;
+#[cfg(unix)]
+use portable_pty::native_pty_system;
 use serde_json::Map;
 use serde_json::Value;
 
@@ -35,6 +41,104 @@ pub fn monochange_command(release_date: Option<&str>) -> Command {
 		command.env("MONOCHANGE_RELEASE_DATE", release_date);
 	}
 	command
+}
+
+#[cfg(unix)]
+#[allow(dead_code)]
+pub enum TtyAction<'a> {
+	Sleep(std::time::Duration),
+	Send {
+		bytes: &'a [u8],
+		pause_after: std::time::Duration,
+	},
+}
+
+#[cfg(unix)]
+#[allow(dead_code)]
+pub fn run_in_tty(
+	workspace: &Path,
+	args: &[&str],
+	release_date: Option<&str>,
+	actions: &[TtyAction<'_>],
+) -> (i32, String) {
+	use std::io::Read as _;
+	use std::io::Write as _;
+	use std::thread;
+
+	let pty_system = native_pty_system();
+	let pair = pty_system
+		.openpty(PtySize {
+			rows: 24,
+			cols: 80,
+			pixel_width: 0,
+			pixel_height: 0,
+		})
+		.unwrap_or_else(|error| panic!("open pty: {error}"));
+	let mut command = CommandBuilder::new(get_cargo_bin("mc"));
+	command.cwd(workspace);
+	command.env("NO_COLOR", "1");
+	command.env_remove("RUST_LOG");
+	if let Some(release_date) = release_date {
+		command.env("MONOCHANGE_RELEASE_DATE", release_date);
+	}
+	for arg in args {
+		command.arg(arg);
+	}
+	let mut child = pair
+		.slave
+		.spawn_command(command)
+		.unwrap_or_else(|error| panic!("spawn tty command: {error}"));
+	drop(pair.slave);
+
+	let mut reader = pair
+		.master
+		.try_clone_reader()
+		.unwrap_or_else(|error| panic!("clone tty reader: {error}"));
+	let reader_thread = thread::spawn(move || {
+		let mut transcript = Vec::new();
+		reader
+			.read_to_end(&mut transcript)
+			.unwrap_or_else(|error| panic!("read tty transcript: {error}"));
+		transcript
+	});
+	let mut writer = pair
+		.master
+		.take_writer()
+		.unwrap_or_else(|error| panic!("take tty writer: {error}"));
+	for action in actions {
+		match action {
+			TtyAction::Sleep(duration) => thread::sleep(*duration),
+			TtyAction::Send { bytes, pause_after } => {
+				match writer.write_all(bytes) {
+					Ok(()) => {
+						writer
+							.flush()
+							.unwrap_or_else(|error| panic!("flush tty input: {error}"));
+						thread::sleep(*pause_after);
+					}
+					Err(error) if error.raw_os_error() == Some(5) => break,
+					Err(error) => panic!("write tty input: {error}"),
+				}
+			}
+		}
+	}
+	drop(writer);
+	let status = child
+		.wait()
+		.unwrap_or_else(|error| panic!("wait for tty command: {error}"));
+	drop(pair.master);
+	let transcript = reader_thread
+		.join()
+		.unwrap_or_else(|_| panic!("tty reader thread panicked"));
+	let status_code = status
+		.exit_code()
+		.try_into()
+		.unwrap_or_else(|error| panic!("tty exit status conversion: {error}"));
+	(
+		status_code,
+		String::from_utf8(transcript)
+			.unwrap_or_else(|error| panic!("tty transcript utf8: {error}")),
+	)
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
## Summary
- replace python3-based PTY test harnesses with a Rust-native helper
- share the TTY helper across the CLI interaction integration tests
- add a changeset covering the test runtime dependency removal

## Validation
- cargo test -p monochange --test cli_progress --test changeset_target_metadata
- cargo run -q -p monochange --bin mc -- affected --changed-paths Cargo.toml --changed-paths Cargo.lock --changed-paths crates/monochange/Cargo.toml --changed-paths crates/monochange/tests/test_support.rs --changed-paths crates/monochange/tests/cli_progress.rs --changed-paths crates/monochange/tests/changeset_target_metadata.rs --changed-paths .changeset/test-remove-python-harnesses.md
- devenv shell fix:all