### PR TITLE
fix: handle deleted changeset files in CommitRelease step

### DIFF
--- a/.changeset/hosted-release-benchmark-fixture.md
+++ b/.changeset/hosted-release-benchmark-fixture.md
@@ -1,0 +1,9 @@
+---
+monochange: patch
+---
+
+#### add hosted release benchmark fixture tooling and docs
+
+The benchmark script can now run against an existing repository checkout with `run-fixture`, which makes it practical to compare `main` and PR binaries against a real hosted benchmark repository instead of only the synthetic CI fixtures.
+
+This release also adds `scripts/setup_hosted_benchmark_fixture.sh`, a repeatable way to seed a monochange benchmark repository with multiple packages, more than 200 commits, and release changesets introduced from PR-shaped branches, plus documentation for using that fixture when investigating hosted-provider latency.

--- a/.changeset/test-speed-up-slow-tests.md
+++ b/.changeset/test-speed-up-slow-tests.md
@@ -1,0 +1,14 @@
+---
+"monochange": patch
+---
+
+Improve the CLI progress integration test harness to reduce unnecessary waiting during TTY transcript collection.
+
+Before:
+
+- contributor test runs spent extra time waiting after streamed progress output finished
+
+After:
+
+- the TTY progress integration harness drains output as soon as the subprocess exits
+- the streamed progress fixture uses a shorter delay while still exercising live output rendering

--- a/.github/scripts/benchmark_cli.sh
+++ b/.github/scripts/benchmark_cli.sh
@@ -12,6 +12,7 @@ PHASE_COMMAND_ARGS=(
 	"release"
 )
 PHASE_BUDGETS_FILE="$(cd "$(dirname "$0")" && pwd)/benchmark_phase_budgets.json"
+HYPERFINE_BIN="${MONOCHANGE_HYPERFINE_BIN:-hyperfine}"
 
 SCENARIO_IDS=(baseline history_x10)
 SCENARIO_NAMES=("Baseline fixture" "Large history fixture")
@@ -420,7 +421,7 @@ run_scenario() {
 
 	(
 		cd "$fixture_dir"
-		hyperfine \
+		"$HYPERFINE_BIN" \
 			--prepare "git reset --hard HEAD >/dev/null && git clean -fd >/dev/null" \
 			--style basic \
 			--warmup "$WARMUP_RUNS" \
@@ -429,6 +430,92 @@ run_scenario() {
 			--export-markdown "$table_path" \
 			"${hyperfine_args[@]}"
 	)
+}
+
+run_fixture_mode() {
+	local main_bin=""
+	local pr_bin=""
+	local fixture_dir=""
+	local scenario_id=""
+	local scenario_name=""
+	local scenario_description=""
+	local output_path=""
+	local violations_output=""
+
+	while [ "$#" -gt 0 ]; do
+		case "$1" in
+		--main-bin)
+			main_bin="$2"
+			shift 2
+			;;
+		--pr-bin)
+			pr_bin="$2"
+			shift 2
+			;;
+		--fixture-dir)
+			fixture_dir="$2"
+			shift 2
+			;;
+		--scenario-id)
+			scenario_id="$2"
+			shift 2
+			;;
+		--scenario-name)
+			scenario_name="$2"
+			shift 2
+			;;
+		--scenario-description)
+			scenario_description="$2"
+			shift 2
+			;;
+		--output)
+			output_path="$2"
+			shift 2
+			;;
+		--violations-output)
+			violations_output="$2"
+			shift 2
+			;;
+		*)
+			echo "unknown argument: $1" >&2
+			exit 1
+			;;
+		esac
+	done
+
+	if [ -z "$main_bin" ] || [ -z "$pr_bin" ] || [ -z "$fixture_dir" ] || [ -z "$scenario_id" ] || [ -z "$scenario_name" ] || [ -z "$scenario_description" ] || [ -z "$output_path" ]; then
+		echo "run-fixture requires --main-bin, --pr-bin, --fixture-dir, --scenario-id, --scenario-name, --scenario-description, and --output" >&2
+		exit 1
+	fi
+
+	local table_path
+	local phase_path
+	local scenario_violations_path
+	table_path="$(mktemp -t monochange-bench-table.XXXXXX.md)"
+	phase_path="$(mktemp -t monochange-bench-phases.XXXXXX.md)"
+	scenario_violations_path="$(mktemp -t monochange-bench-violations.XXXXXX.txt)"
+
+	run_scenario \
+		"$main_bin" \
+		"$pr_bin" \
+		"$fixture_dir" \
+		"$table_path"
+	collect_phase_markdown \
+		"$scenario_id" \
+		"$fixture_dir" \
+		"$main_bin" \
+		"$pr_bin" \
+		"$phase_path" \
+		"$scenario_violations_path"
+	render_comment \
+		"$output_path" \
+		"$scenario_name" \
+		"$scenario_description" \
+		"$table_path" \
+		"$phase_path"
+	if [ -n "$violations_output" ]; then
+		cat "$scenario_violations_path" >"$violations_output"
+	fi
 }
 
 run_mode() {
@@ -546,9 +633,10 @@ main() {
 
 	case "$mode" in
 	run) run_mode "$@" ;;
+	run-fixture) run_fixture_mode "$@" ;;
 	render-fixture) render_fixture_mode "$@" ;;
 	*)
-		echo "usage: $0 <run|render-fixture> [args...]" >&2
+		echo "usage: $0 <run|run-fixture|render-fixture> [args...]" >&2
 		exit 1
 		;;
 	esac

--- a/crates/monochange/tests/cli_progress.rs
+++ b/crates/monochange/tests/cli_progress.rs
@@ -155,7 +155,6 @@ import pty
 import select
 import subprocess
 import sys
-import time
 
 workspace = os.environ['MC_WORKSPACE']
 command_name = os.environ['MC_COMMAND']
@@ -173,31 +172,31 @@ proc = subprocess.Popen(
 )
 os.close(slave)
 transcript = bytearray()
-while True:
-    ready, _, _ = select.select([master], [], [], 0.05)
-    if master in ready:
-        try:
-            data = os.read(master, 4096)
-        except OSError:
-            break
-        if not data:
-            break
-        transcript.extend(data)
-    if proc.poll() is not None and not ready:
-        break
-proc.wait(timeout=10)
-time.sleep(0.1)
-while True:
-    ready, _, _ = select.select([master], [], [], 0.01)
+
+def drain(timeout=0.01):
+    ready, _, _ = select.select([master], [], [], timeout)
     if master not in ready:
-        break
+        return False
     try:
         data = os.read(master, 4096)
     except OSError:
-        break
+        return False
     if not data:
-        break
+        return False
     transcript.extend(data)
+    return True
+
+while True:
+    saw_output = drain(0.01)
+    if proc.poll() is not None and not saw_output:
+        break
+proc.wait(timeout=10)
+idle_polls = 0
+while idle_polls < 5:
+    if drain(0.05):
+        idle_polls = 0
+    else:
+        idle_polls += 1
 os.close(master)
 sys.stdout.buffer.write(transcript)
 sys.stderr.write(f'__MC_EXIT_STATUS__={proc.returncode}\n')
@@ -348,7 +347,7 @@ fn release_progress_streams_named_steps_on_tty() {
 		r#"
 steps = [
 	{ type = "PrepareRelease", name = "plan release" },
-	{ type = "Command", name = "stream summary", shell = true, command = "printf 'streamed line 1\n'; sleep 0.1; printf 'streamed line 2\n'" },
+	{ type = "Command", name = "stream summary", shell = true, command = "printf 'streamed line 1\n'; sleep 0.01; printf 'streamed line 2\n'" },
 ]
 	"#,
 	);

--- a/crates/monochange/tests/hosted_release_benchmarks.rs
+++ b/crates/monochange/tests/hosted_release_benchmarks.rs
@@ -1,0 +1,267 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
+use std::sync::Mutex;
+
+use insta::assert_snapshot;
+
+mod test_support;
+use test_support::current_test_name;
+use test_support::snapshot_settings;
+
+static HOSTED_FIXTURE_SCRIPT_LOCK: Mutex<()> = Mutex::new(());
+
+fn repo_root() -> std::path::PathBuf {
+	Path::new(env!("CARGO_MANIFEST_DIR"))
+		.join("../..")
+		.canonicalize()
+		.unwrap_or_else(|error| panic!("repo root: {error}"))
+}
+
+fn write_executable(path: &Path, contents: &str) {
+	let display = path.display();
+	fs::write(path, contents).unwrap_or_else(|error| panic!("write {display}: {error}"));
+	let mut permissions = fs::metadata(path)
+		.unwrap_or_else(|error| panic!("metadata {display}: {error}"))
+		.permissions();
+	permissions.set_mode(0o755);
+	fs::set_permissions(path, permissions)
+		.unwrap_or_else(|error| panic!("chmod {display}: {error}"));
+}
+
+fn git_stdout(root: &Path, args: &[&str]) -> String {
+	let output = Command::new("git")
+		.env_remove("GIT_DIR")
+		.env_remove("GIT_WORK_TREE")
+		.env_remove("GIT_INDEX_FILE")
+		.env_remove("GIT_OBJECT_DIRECTORY")
+		.env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES")
+		.env_remove("GIT_COMMON_DIR")
+		.arg("-C")
+		.arg(root)
+		.args(args)
+		.output()
+		.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
+	assert!(
+		output.status.success(),
+		"git {:?} failed: {}",
+		args,
+		String::from_utf8_lossy(&output.stderr)
+	);
+	String::from_utf8(output.stdout).unwrap_or_else(|error| panic!("utf8 git stdout: {error}"))
+}
+
+#[test]
+fn hosted_fixture_setup_script_bootstraps_local_pr_history() {
+	let _lock = HOSTED_FIXTURE_SCRIPT_LOCK
+		.lock()
+		.unwrap_or_else(std::sync::PoisonError::into_inner);
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let fixture_dir = tempdir.path().join("fixture");
+	let script_path = repo_root().join("scripts/setup_hosted_benchmark_fixture.sh");
+
+	let output = Command::new("bash")
+		.arg(&script_path)
+		.arg("--local-only")
+		.arg("--output-dir")
+		.arg(&fixture_dir)
+		.arg("--owner")
+		.arg("fixture-owner")
+		.arg("--repo")
+		.arg("fixture-repo")
+		.arg("--package-count")
+		.arg("3")
+		.arg("--filler-commits")
+		.arg("12")
+		.arg("--release-prs")
+		.arg("2")
+		.arg("--commits-per-pr")
+		.arg("2")
+		.output()
+		.unwrap_or_else(|error| panic!("run fixture setup script: {error}"));
+
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+
+	let monochange_toml = fs::read_to_string(fixture_dir.join("monochange.toml"))
+		.unwrap_or_else(|error| panic!("read monochange.toml: {error}"));
+	assert!(monochange_toml.contains("owner = \"fixture-owner\""));
+	assert!(monochange_toml.contains("repo = \"fixture-repo\""));
+
+	let commit_count = git_stdout(&fixture_dir, &["rev-list", "--count", "HEAD"])
+		.trim()
+		.parse::<usize>()
+		.unwrap_or_else(|error| panic!("parse commit count: {error}"));
+	assert_eq!(commit_count, 21);
+
+	let merges = git_stdout(&fixture_dir, &["log", "--merges", "--oneline"]);
+	assert_eq!(merges.lines().count(), 2);
+
+	let changeset_count = fs::read_dir(fixture_dir.join(".changeset"))
+		.unwrap_or_else(|error| panic!("read .changeset: {error}"))
+		.filter_map(Result::ok)
+		.filter(|entry| {
+			entry
+				.path()
+				.extension()
+				.is_some_and(|extension| extension == "md")
+		})
+		.count();
+	assert_eq!(changeset_count, 2);
+}
+
+#[test]
+fn benchmark_cli_run_fixture_supports_hosted_fixture_metadata() {
+	let _lock = HOSTED_FIXTURE_SCRIPT_LOCK
+		.lock()
+		.unwrap_or_else(std::sync::PoisonError::into_inner);
+	let mut settings = snapshot_settings();
+	settings.set_snapshot_suffix(current_test_name());
+	let _guard = settings.bind_to_scope();
+
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let fixture_dir = tempdir.path().join("fixture");
+	let setup_script = repo_root().join("scripts/setup_hosted_benchmark_fixture.sh");
+
+	let setup_output = Command::new("bash")
+		.arg(&setup_script)
+		.arg("--local-only")
+		.arg("--output-dir")
+		.arg(&fixture_dir)
+		.arg("--package-count")
+		.arg("2")
+		.arg("--filler-commits")
+		.arg("3")
+		.arg("--release-prs")
+		.arg("1")
+		.arg("--commits-per-pr")
+		.arg("1")
+		.output()
+		.unwrap_or_else(|error| panic!("seed local hosted fixture: {error}"));
+	assert!(
+		setup_output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&setup_output.stderr)
+	);
+
+	let bin_dir = tempdir.path().join("bin");
+	fs::create_dir_all(&bin_dir).unwrap_or_else(|error| panic!("mkdir bin: {error}"));
+	let fake_main = bin_dir.join("mc-main");
+	let fake_pr = bin_dir.join("mc-pr");
+	let fake_hyperfine = bin_dir.join("hyperfine");
+	let output_path = tempdir.path().join("comment.md");
+	let violations_path = tempdir.path().join("violations.txt");
+
+	let fake_main_script = r#"#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "--help" ]; then
+  echo "--progress-format"
+  exit 0
+fi
+if [ "${1:-}" = "--progress-format" ]; then
+  shift 2
+fi
+if [ "${1:-}" = "release" ]; then
+  duration=150
+  phase=80
+  if [ "${2:-}" = "--dry-run" ]; then
+    duration=120
+    phase=60
+  fi
+  printf '{"event":"step_finished","stepKind":"PrepareRelease","durationMs":%s,"phaseTimings":[{"label":"enrich changeset context via github","durationMs":%s}]}\n' "$duration" "$phase" >&2
+fi
+"#;
+	let fake_pr_script = r#"#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "--help" ]; then
+  echo "--progress-format"
+  exit 0
+fi
+if [ "${1:-}" = "--progress-format" ]; then
+  shift 2
+fi
+if [ "${1:-}" = "release" ]; then
+  duration=140
+  phase=70
+  if [ "${2:-}" = "--dry-run" ]; then
+    duration=110
+    phase=55
+  fi
+  printf '{"event":"step_finished","stepKind":"PrepareRelease","durationMs":%s,"phaseTimings":[{"label":"enrich changeset context via github","durationMs":%s}]}\n' "$duration" "$phase" >&2
+fi
+"#;
+	let fake_hyperfine_script = r#"#!/usr/bin/env bash
+set -euo pipefail
+export_markdown=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --export-markdown)
+      export_markdown="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+cat >"$export_markdown" <<'EOF'
+| Command | Mean [ms] | Min [ms] | Max [ms] |
+|:---|---:|---:|---:|
+| main · mc validate | 10.0 | 9.0 | 11.0 |
+| pr · mc validate | 11.0 | 10.0 | 12.0 |
+| main · mc discover --format json | 12.0 | 11.0 | 13.0 |
+| pr · mc discover --format json | 13.0 | 12.0 | 14.0 |
+| main · mc release --dry-run | 50.0 | 49.0 | 51.0 |
+| pr · mc release --dry-run | 48.0 | 47.0 | 49.0 |
+| main · mc release | 60.0 | 59.0 | 61.0 |
+| pr · mc release | 57.0 | 56.0 | 58.0 |
+EOF
+"#;
+	write_executable(&fake_main, fake_main_script);
+	write_executable(&fake_pr, fake_pr_script);
+	write_executable(&fake_hyperfine, fake_hyperfine_script);
+
+	let benchmark_script = repo_root().join(".github/scripts/benchmark_cli.sh");
+	let output = Command::new("bash")
+		.arg(&benchmark_script)
+		.arg("run-fixture")
+		.arg("--main-bin")
+		.arg(&fake_main)
+		.arg("--pr-bin")
+		.arg(&fake_pr)
+		.arg("--fixture-dir")
+		.arg(&fixture_dir)
+		.arg("--scenario-id")
+		.arg("hosted_github")
+		.arg("--scenario-name")
+		.arg("Hosted GitHub fixture")
+		.arg("--scenario-description")
+		.arg("2 packages, local clone of the hosted fixture repo")
+		.arg("--output")
+		.arg(&output_path)
+		.arg("--violations-output")
+		.arg(&violations_path)
+		.env("MONOCHANGE_HYPERFINE_BIN", &fake_hyperfine)
+		.output()
+		.unwrap_or_else(|error| panic!("run benchmark fixture mode: {error}"));
+
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+
+	let rendered = fs::read_to_string(&output_path)
+		.unwrap_or_else(|error| panic!("read hosted benchmark comment: {error}"));
+	assert_snapshot!(rendered);
+	assert_eq!(
+		fs::read_to_string(&violations_path)
+			.unwrap_or_else(|error| panic!("read violations: {error}"))
+			.trim(),
+		"0"
+	);
+}

--- a/crates/monochange/tests/snapshots/hosted_release_benchmarks__benchmark_cli_run_fixture_supports_hosted_fixture_metadata@benchmark_cli_run_fixture_supports_hosted_fixture_metadata.snap
+++ b/crates/monochange/tests/snapshots/hosted_release_benchmarks__benchmark_cli_run_fixture_supports_hosted_fixture_metadata@benchmark_cli_run_fixture_supports_hosted_fixture_metadata.snap
@@ -1,0 +1,44 @@
+---
+source: crates/monochange/tests/hosted_release_benchmarks.rs
+expression: rendered
+---
+## Binary Benchmark: main vs PR
+
+Measured with `hyperfine --warmup 1 --runs 6`.
+
+Commands:
+- `mc validate`
+- `mc discover --format json`
+- `mc release --dry-run`
+- `mc release`
+
+### Hosted GitHub fixture
+
+Fixture: 2 packages, local clone of the hosted fixture repo
+
+| Command | Mean [ms] | Min [ms] | Max [ms] |
+|:---|---:|---:|---:|
+| main · mc validate | 10.0 | 9.0 | 11.0 |
+| pr · mc validate | 11.0 | 10.0 | 12.0 |
+| main · mc discover --format json | 12.0 | 11.0 | 13.0 |
+| pr · mc discover --format json | 13.0 | 12.0 | 14.0 |
+| main · mc release --dry-run | 50.0 | 49.0 | 51.0 |
+| pr · mc release --dry-run | 48.0 | 47.0 | 49.0 |
+| main · mc release | 60.0 | 59.0 | 61.0 |
+| pr · mc release | 57.0 | 56.0 | 58.0 |
+
+#### Phase timings
+
+##### `mc release --dry-run`
+
+| Phase | Budget [ms] | main [ms] | pr [ms] | Δ pr-main [ms] | Status |
+|:---|---:|---:|---:|---:|:---|
+| `prepare release total` | n/a | 120 | 110 | -10 | improved |
+| `enrich changeset context via github` | n/a | 60 | 55 | -5 | improved |
+
+##### `mc release`
+
+| Phase | Budget [ms] | main [ms] | pr [ms] | Δ pr-main [ms] | Status |
+|:---|---:|---:|---:|---:|:---|
+| `prepare release total` | n/a | 150 | 140 | -10 | improved |
+| `enrich changeset context via github` | n/a | 80 | 70 | -10 | improved |

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -21,6 +21,7 @@
 # Reference
 
 - [Progress output](reference/progress-output.md)
+- [Hosted release benchmarks](reference/hosted-release-benchmarks.md)
 - [CLI step reference](reference/cli-steps/00-index.md)
   - [Validate](reference/cli-steps/01-validate.md)
   - [Discover](reference/cli-steps/02-discover.md)

--- a/docs/src/reference/hosted-release-benchmarks.md
+++ b/docs/src/reference/hosted-release-benchmarks.md
@@ -1,0 +1,69 @@
+# Hosted release benchmarks
+
+The default binary benchmark workflow uses synthetic local fixtures so every pull request can run quickly in CI.
+
+When you need to measure hosted-provider overhead for the real `mc release` path, use a dedicated hosted fixture repository instead. That lets the benchmark include GitHub request cost, realistic history shape, and changesets that actually arrived through pull requests.
+
+## Create the fixture repository
+
+Use the helper script in this repository to create a repeatable fixture with:
+
+- multiple Cargo packages
+- more than 200 commits by default
+- release changesets introduced from PR-shaped branches
+
+Local dry run:
+
+```bash
+scripts/setup_hosted_benchmark_fixture.sh \
+  --local-only \
+  --output-dir /tmp/monochange-release-benchmark-fixture \
+  --owner ifiokjr \
+  --repo monochange-release-benchmark-fixture
+```
+
+Hosted GitHub repo:
+
+```bash
+scripts/setup_hosted_benchmark_fixture.sh \
+  --output-dir /tmp/monochange-release-benchmark-fixture \
+  --owner ifiokjr \
+  --repo monochange-release-benchmark-fixture
+```
+
+The hosted mode requires:
+
+- `gh auth status` to succeed with `repo` scope
+- permission to create repositories under the chosen owner
+
+The generator stores an authenticated HTTPS remote in the disposable fixture clone so it can push the seeded PR branches without depending on SSH agent state. Use a temporary output directory for hosted runs.
+
+## Benchmark the hosted fixture
+
+Build the `main` and PR binaries first, then run the benchmark script against a clone of the hosted fixture repository:
+
+```bash
+gh repo clone ifiokjr/monochange-release-benchmark-fixture /tmp/monochange-release-benchmark-fixture
+
+.github/scripts/benchmark_cli.sh run-fixture \
+  --main-bin /tmp/mc-main \
+  --pr-bin /tmp/mc-pr \
+  --fixture-dir /tmp/monochange-release-benchmark-fixture \
+  --scenario-id hosted_github \
+  --scenario-name "Hosted GitHub fixture" \
+  --scenario-description "8 packages, >200 commits, PR-originated changesets" \
+  --output /tmp/hosted-benchmark.md \
+  --violations-output /tmp/hosted-benchmark-violations.txt
+```
+
+This produces the same markdown summary format as the CI benchmark comment, but it benchmarks a real hosted repository checkout instead of a synthetic local fixture.
+
+## Reading the result
+
+Focus on:
+
+- the overall `mc release` delta between `main` and the PR binary
+- the `prepare release total` row in the phase table
+- hosted-specific phases such as `enrich changeset context via github`
+
+If the hosted run still shows a regression or an unexpectedly large absolute cost, capture a trace against the same fixture checkout and attach both the benchmark markdown and trace notes to the relevant issue or pull request.

--- a/docs/src/reference/progress-output.md
+++ b/docs/src/reference/progress-output.md
@@ -72,3 +72,5 @@ Example:
 The binary benchmark workflow uses `--progress-format json` to extract `PrepareRelease` phase timings for both `mc release --dry-run` and `mc release`.
 
 Those timings are summarized and compared against `.github/scripts/benchmark_phase_budgets.json`, which lets pull requests fail when real release-path regressions exceed the configured budget.
+
+For hosted-provider analysis outside CI, `.github/scripts/benchmark_cli.sh run-fixture` can benchmark an existing repository checkout and render the same markdown summary against a real hosted fixture. See [Hosted release benchmarks](./hosted-release-benchmarks.md).

--- a/monochange.toml
+++ b/monochange.toml
@@ -514,9 +514,9 @@ steps = [
 	# inspect immediately, so we only pay for clippy/docs/validation right before
 	# creating and publishing the release commit.
 	{ type = "Command", name = "refresh shared markdown", command = "mdt update", when = "{{ inputs.commit }}" },
-	# { type = "Command", name = "stage release changes", command = "git add --all", when = "{{ inputs.commit }}" },
+	{ type = "Command", name = "stage release changes", command = "git add --all", when = "{{ inputs.commit }}" },
 	{ type = "CommitRelease", name = "create release commit", when = "{{ inputs.commit }}" },
-	{ type = "Command", name = "push release commit", command = "git push --no-verify", when = "{{ inputs.commit }}" },
+	{ type = "Command", name = "push release commit", command = "git push", when = "{{ inputs.commit }}" },
 	{ type = "PublishRelease", name = "publish hosted releases", when = "{{ inputs.commit }}" },
 	{ type = "CommentReleasedIssues", name = "comment on released issues", when = "{{ inputs.commit }}" },
 ]

--- a/monochange.toml
+++ b/monochange.toml
@@ -514,9 +514,9 @@ steps = [
 	# inspect immediately, so we only pay for clippy/docs/validation right before
 	# creating and publishing the release commit.
 	{ type = "Command", name = "refresh shared markdown", command = "mdt update", when = "{{ inputs.commit }}" },
-	{ type = "Command", name = "stage release changes", command = "git add --all", when = "{{ inputs.commit }}" },
+	# { type = "Command", name = "stage release changes", command = "git add --all", when = "{{ inputs.commit }}" },
 	{ type = "CommitRelease", name = "create release commit", when = "{{ inputs.commit }}" },
-	{ type = "Command", name = "push release commit", command = "git push", when = "{{ inputs.commit }}" },
+	{ type = "Command", name = "push release commit", command = "git push --no-verify", when = "{{ inputs.commit }}" },
 	{ type = "PublishRelease", name = "publish hosted releases", when = "{{ inputs.commit }}" },
 	{ type = "CommentReleasedIssues", name = "comment on released issues", when = "{{ inputs.commit }}" },
 ]

--- a/scripts/setup_hosted_benchmark_fixture.sh
+++ b/scripts/setup_hosted_benchmark_fixture.sh
@@ -1,0 +1,339 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PACKAGE_COUNT=8
+FILLER_COMMITS=220
+RELEASE_PRS=6
+COMMITS_PER_PR=2
+LOCAL_ONLY=false
+VISIBILITY="public"
+OUTPUT_DIR=""
+OWNER="fixture"
+REPO="monochange-release-benchmark-fixture"
+
+usage() {
+	cat <<'EOF' >&2
+usage: scripts/setup_hosted_benchmark_fixture.sh [args...]
+
+Creates a repeatable monochange benchmark fixture repository with:
+- multiple cargo workspace packages
+- more than 200 commits by default
+- release changesets introduced through pull-request-like branches
+
+Options:
+  --output-dir <dir>        required destination directory
+  --owner <owner>           hosted repo owner (default: fixture)
+  --repo <repo>             hosted repo name (default: monochange-release-benchmark-fixture)
+  --package-count <count>   workspace package count (default: 8)
+  --filler-commits <count>  direct-history commits before release PRs (default: 220)
+  --release-prs <count>     number of release PR branches to seed (default: 6)
+  --commits-per-pr <count>  non-changeset commits per PR branch (default: 2)
+  --local-only              build the fixture locally without GitHub repo creation
+  --private                 create the hosted repo as private instead of public
+EOF
+	exit 1
+}
+
+git_commit() {
+	local root="$1"
+	local message="$2"
+	env -u GIT_DIR \
+		-u GIT_WORK_TREE \
+		-u GIT_INDEX_FILE \
+		-u GIT_OBJECT_DIRECTORY \
+		-u GIT_ALTERNATE_OBJECT_DIRECTORIES \
+		-u GIT_COMMON_DIR \
+		git -C "$root" \
+		-c core.hooksPath=/dev/null \
+		-c user.name=fixture \
+		-c user.email=fixture@example.com \
+		commit -m "$message" >/dev/null
+}
+
+run_git() {
+	local root="$1"
+	shift
+	env -u GIT_DIR \
+		-u GIT_WORK_TREE \
+		-u GIT_INDEX_FILE \
+		-u GIT_OBJECT_DIRECTORY \
+		-u GIT_ALTERNATE_OBJECT_DIRECTORIES \
+		-u GIT_COMMON_DIR \
+		git -C "$root" \
+		-c core.hooksPath=/dev/null \
+		-c user.name=fixture \
+		-c user.email=fixture@example.com \
+		"$@"
+}
+
+remote_push_url() {
+	local owner="$1"
+	local repo="$2"
+	printf 'https://x-access-token:%s@github.com/%s/%s.git\n' \
+		"$(gh auth token)" \
+		"$owner" \
+		"$repo"
+}
+
+create_workspace() {
+	local root="$1"
+	local owner="$2"
+	local repo="$3"
+
+	mkdir -p "$root/.changeset" "$root/crates"
+
+	{
+		echo '[workspace]'
+		echo 'members = ['
+		local package_index
+		for package_index in $(seq 0 $((PACKAGE_COUNT - 1))); do
+			echo "  \"crates/pkg-${package_index}\","
+		done
+		echo ']'
+		echo 'resolver = "2"'
+	} >"$root/Cargo.toml"
+
+	{
+		echo '[defaults]'
+		echo 'package_type = "cargo"'
+		echo
+		echo '[source]'
+		echo 'provider = "github"'
+		echo "owner = \"${owner}\""
+		echo "repo = \"${repo}\""
+		echo
+		local package_index
+		for package_index in $(seq 0 $((PACKAGE_COUNT - 1))); do
+			echo "[package.pkg-${package_index}]"
+			echo "path = \"crates/pkg-${package_index}\""
+			echo
+			mkdir -p "$root/crates/pkg-${package_index}/src"
+			{
+				echo '[package]'
+				echo "name = \"pkg-${package_index}\""
+				echo 'version = "1.0.0"'
+				echo 'edition = "2021"'
+				echo
+				echo '[lib]'
+				echo 'path = "src/lib.rs"'
+			} >"$root/crates/pkg-${package_index}/Cargo.toml"
+			cat >"$root/crates/pkg-${package_index}/src/lib.rs" <<EOF
+pub fn package_${package_index}_version() -> &'static str {
+	"1.0.0"
+}
+EOF
+		done
+		echo '[ecosystems.cargo]'
+		echo 'enabled = true'
+	} >"$root/monochange.toml"
+
+	cat >"$root/README.md" <<EOF
+# monochange hosted benchmark fixture
+
+This repository is generated for hosted \`mc release\` performance benchmarking.
+
+- owner: ${owner}
+- repo: ${repo}
+- packages: ${PACKAGE_COUNT}
+- filler commits: ${FILLER_COMMITS}
+- release pull requests: ${RELEASE_PRS}
+EOF
+}
+
+append_package_change() {
+	local root="$1"
+	local package_index="$2"
+	local label="$3"
+	cat >>"$root/crates/pkg-${package_index}/src/lib.rs" <<EOF
+
+pub fn ${label}_${package_index}() -> &'static str {
+	"${label}"
+}
+EOF
+}
+
+seed_filler_history() {
+	local root="$1"
+	local commit_index
+	for commit_index in $(seq 1 "$FILLER_COMMITS"); do
+		local package_index=$(((commit_index - 1) % PACKAGE_COUNT))
+		append_package_change "$root" "$package_index" "history_commit_${commit_index}"
+		run_git "$root" add .
+		git_commit "$root" "chore: history commit ${commit_index}"
+	done
+}
+
+merge_local_release_pr() {
+	local root="$1"
+	local pr_index="$2"
+	local branch_name="$3"
+	run_git "$root" checkout main >/dev/null
+	run_git "$root" merge --no-ff "$branch_name" -m "Merge pull request #${pr_index} from fixture/${branch_name}" >/dev/null
+	run_git "$root" branch -D "$branch_name" >/dev/null
+}
+
+merge_hosted_release_pr() {
+	local root="$1"
+	local owner="$2"
+	local repo="$3"
+	local pr_index="$4"
+	local branch_name="$5"
+	local pr_url
+
+	run_git "$root" push -u origin "$branch_name" >/dev/null
+	pr_url="$(
+		gh pr create \
+			--repo "${owner}/${repo}" \
+			--base main \
+			--head "$branch_name" \
+			--title "fixture: seed release PR ${pr_index}" \
+			--body "Seed hosted release benchmark fixture PR ${pr_index}."
+	)"
+	gh pr merge \
+		"$pr_url" \
+		--squash \
+		--delete-branch \
+		--admin >/dev/null 2>&1 || gh pr merge \
+		"$pr_url" \
+		--squash \
+		--delete-branch >/dev/null
+	run_git "$root" checkout main >/dev/null
+	run_git "$root" pull --ff-only origin main >/dev/null
+}
+
+seed_release_prs() {
+	local root="$1"
+	local owner="$2"
+	local repo="$3"
+	local pr_index
+	for pr_index in $(seq 1 "$RELEASE_PRS"); do
+		local branch_name
+		branch_name="fixture/release-pr-${pr_index}"
+		local package_index=$(((pr_index - 1) % PACKAGE_COUNT))
+		run_git "$root" checkout -b "$branch_name" main >/dev/null
+
+		local commit_index
+		for commit_index in $(seq 1 "$COMMITS_PER_PR"); do
+			append_package_change "$root" "$package_index" "release_pr_${pr_index}_commit_${commit_index}"
+			run_git "$root" add .
+			git_commit "$root" "feat: release fixture commit ${pr_index}.${commit_index}"
+		done
+
+		cat >"$root/.changeset/release-pr-$(printf '%02d' "$pr_index").md" <<EOF
+---
+pkg-${package_index}: patch
+---
+
+Release fixture PR ${pr_index}.
+EOF
+		run_git "$root" add .
+		git_commit "$root" "docs: add release changeset ${pr_index}"
+
+		if [ "$LOCAL_ONLY" = true ]; then
+			merge_local_release_pr "$root" "$pr_index" "$branch_name"
+		else
+			merge_hosted_release_pr "$root" "$owner" "$repo" "$pr_index" "$branch_name"
+		fi
+	done
+}
+
+ensure_remote_repo() {
+	local owner="$1"
+	local repo="$2"
+
+	if gh repo view "${owner}/${repo}" >/dev/null 2>&1; then
+		return
+	fi
+
+	gh repo create \
+		"${owner}/${repo}" \
+		"--${VISIBILITY}" \
+		--description "Hosted benchmark fixture for monochange release performance" \
+		--disable-issues \
+		--clone=false >/dev/null
+}
+
+parse_args() {
+	while [ "$#" -gt 0 ]; do
+		case "$1" in
+		--output-dir)
+			OUTPUT_DIR="$2"
+			shift 2
+			;;
+		--owner)
+			OWNER="$2"
+			shift 2
+			;;
+		--repo)
+			REPO="$2"
+			shift 2
+			;;
+		--package-count)
+			PACKAGE_COUNT="$2"
+			shift 2
+			;;
+		--filler-commits)
+			FILLER_COMMITS="$2"
+			shift 2
+			;;
+		--release-prs)
+			RELEASE_PRS="$2"
+			shift 2
+			;;
+		--commits-per-pr)
+			COMMITS_PER_PR="$2"
+			shift 2
+			;;
+		--local-only)
+			LOCAL_ONLY=true
+			shift
+			;;
+		--private)
+			VISIBILITY="private"
+			shift
+			;;
+		-h | --help)
+			usage
+			;;
+		*)
+			echo "unknown argument: $1" >&2
+			usage
+			;;
+		esac
+	done
+
+	if [ -z "$OUTPUT_DIR" ]; then
+		echo "--output-dir is required" >&2
+		usage
+	fi
+}
+
+main() {
+	parse_args "$@"
+
+	rm -rf "$OUTPUT_DIR"
+	mkdir -p "$OUTPUT_DIR"
+
+	create_workspace "$OUTPUT_DIR" "$OWNER" "$REPO"
+	run_git "$OUTPUT_DIR" init -b main >/dev/null
+	run_git "$OUTPUT_DIR" add .
+	git_commit "$OUTPUT_DIR" "chore: initialize hosted benchmark fixture"
+
+	seed_filler_history "$OUTPUT_DIR"
+
+	if [ "$LOCAL_ONLY" = false ]; then
+		ensure_remote_repo "$OWNER" "$REPO"
+		run_git "$OUTPUT_DIR" remote add origin "$(remote_push_url "$OWNER" "$REPO")"
+		run_git "$OUTPUT_DIR" push -u origin main >/dev/null
+	fi
+
+	seed_release_prs "$OUTPUT_DIR" "$OWNER" "$REPO"
+
+	printf 'fixture directory: %s\n' "$OUTPUT_DIR"
+	printf 'commit count: %s\n' "$(run_git "$OUTPUT_DIR" rev-list --count HEAD)"
+	if [ "$LOCAL_ONLY" = false ]; then
+		printf 'repository url: https://github.com/%s/%s\n' "$OWNER" "$REPO"
+	fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Add `git_rm_paths` to stage deleted files via `git rm --cached`
- Skip staging manifest file (in `.gitignore`)
- Handle already-deleted files gracefully (skip non-existent)

## Fixes
Fixes failure when staging deleted changeset files and ignored manifest in the `CommitRelease` CLI step.