### PR TITLE
perf: trim github enrichment issue lookups

### DIFF
--- a/.changeset/hosted-github-issue-lookup-trim.md
+++ b/.changeset/hosted-github-issue-lookup-trim.md
@@ -1,0 +1,5 @@
+---
+monochange_github: patch
+---
+
+Trim the hosted GitHub review-request payload by deriving closing and referenced issue numbers from pull request bodies instead of requesting `closingIssuesReferences` from GraphQL. This keeps provider batching in place while shaving work from the real non-dry-run `mc release` enrichment path, and also hardens the hosted benchmark fixture helper for machines with `commit.gpgsign=true`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2072,6 +2072,7 @@ dependencies = [
  "monochange_core",
  "monochange_test_helpers",
  "octocrab",
+ "regex",
  "serde",
  "serde_json",
  "temp-env",

--- a/crates/monochange_github/Cargo.toml
+++ b/crates/monochange_github/Cargo.toml
@@ -15,6 +15,7 @@ description = "GitHub release payload rendering and publishing for monochange"
 [dependencies]
 monochange_core = { workspace = true }
 octocrab = { workspace = true, default-features = false }
+regex = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
 thiserror = { workspace = true, default-features = true }

--- a/crates/monochange_github/src/__tests.rs
+++ b/crates/monochange_github/src/__tests.rs
@@ -1273,7 +1273,7 @@ fn enrich_changeset_context_resolves_pull_requests_and_related_issues() {
 		then.status(200)
 			.header("content-type", "application/json")
 			.body(
-				r#"{"repository":{"commit_0":{"associatedPullRequests":{"nodes":[{"number":42,"title":"Add release context","url":"https://example.com/pulls/42","body":"Closes #7\nRefs #8","author":{"login":"ifiokjr","url":"https://example.com/users/1"},"closingIssuesReferences":{"nodes":[{"number":7,"title":"Track release context","url":"https://example.com/issues/7"}]}}]}}}}"#,
+				r#"{"repository":{"commit_0":{"associatedPullRequests":{"nodes":[{"number":42,"title":"Add release context","url":"https://example.com/pulls/42","body":"Closes #7\nRefs #8","author":{"login":"ifiokjr","url":"https://example.com/users/1"}}]}}}}"#,
 			);
 	});
 	let github = SourceConfiguration {
@@ -1372,6 +1372,16 @@ fn enrich_changeset_context_resolves_pull_requests_and_related_issues() {
 			.and_then(|commit| commit.url.as_deref()),
 		Some("https://example.com/ifiokjr/monochange/commit/abc1234567890")
 	);
+}
+
+#[test]
+fn review_request_query_uses_lean_pull_request_payload() {
+	let query =
+		build_review_request_batch_query("ifiokjr", "monochange", &["abc1234567890".to_string()]);
+
+	assert!(query.contains("associatedPullRequests(first: 1)"));
+	assert!(query.contains("body"));
+	assert!(!query.contains("closingIssuesReferences"));
 }
 
 #[test]
@@ -1522,7 +1532,7 @@ fn enrich_changeset_context_falls_back_to_commit_annotations_when_batch_lookup_f
 }
 
 #[test]
-fn batch_review_request_lookup_reports_missing_repository_payload_and_skips_malformed_issues() {
+fn batch_review_request_lookup_reports_missing_repository_payload_and_parses_body_issue_refs() {
 	let server = MockServer::start();
 	let missing_repository = server.mock(|when, then| {
 		when.method(POST)
@@ -1562,19 +1572,19 @@ fn batch_review_request_lookup_reports_missing_repository_payload_and_skips_malf
 		});
 	missing_repository.assert();
 
-	let malformed_server = MockServer::start();
-	let malformed_issues = malformed_server.mock(|when, then| {
+	let parsing_server = MockServer::start();
+	let parsing_issues = parsing_server.mock(|when, then| {
 		when.method(POST).path("/graphql");
 		then.status(200)
 			.header("content-type", "application/json")
 			.body(
-				r#"{"repository":{"commit_0":{"associatedPullRequests":{"nodes":[{"number":42,"title":"Add release context","url":"https://example.com/pulls/42","body":"","author":{"login":"ifiokjr","url":"https://example.com/users/1"},"closingIssuesReferences":{"nodes":[{"title":"missing number"},{"number":7,"title":"Track release context","url":"https://example.com/issues/7"}]}}]}}}}"#,
+				r#"{"repository":{"commit_0":{"associatedPullRequests":{"nodes":[{"number":42,"title":"Add release context","url":"https://example.com/pulls/42","body":"Closes #7, #9 and owner/repo#11\nRefs #8","author":{"login":"ifiokjr","url":"https://example.com/users/1"}}]}}}}"#,
 			);
 	});
 	github_runtime()
 		.unwrap_or_else(|error| panic!("runtime: {error}"))
 		.block_on(async {
-			let client = build_test_client(&malformed_server);
+			let client = build_test_client(&parsing_server);
 			let review_requests = load_review_request_batch_with_client(
 				&client,
 				&github,
@@ -1587,10 +1597,41 @@ fn batch_review_request_lookup_reports_missing_repository_payload_and_skips_malf
 				.and_then(|value| value.as_ref())
 				.map(|related| related.issues.clone())
 				.unwrap_or_default();
-			assert_eq!(issues.len(), 1);
-			assert_eq!(issues.first().map(|issue| issue.id.as_str()), Some("#7"));
+			assert_eq!(issues.len(), 4);
+			assert!(issues.iter().any(|issue| {
+				issue.id == "#7"
+					&& issue.relationship == HostedIssueRelationshipKind::ClosedByReviewRequest
+			}));
+			assert!(issues.iter().any(|issue| {
+				issue.id == "#9"
+					&& issue.relationship == HostedIssueRelationshipKind::ClosedByReviewRequest
+			}));
+			assert!(issues.iter().any(|issue| {
+				issue.id == "#11"
+					&& issue.relationship == HostedIssueRelationshipKind::ClosedByReviewRequest
+			}));
+			assert!(issues.iter().any(|issue| {
+				issue.id == "#8"
+					&& issue.relationship == HostedIssueRelationshipKind::ReferencedByReviewRequest
+			}));
 		});
-	malformed_issues.assert();
+	parsing_issues.assert();
+}
+
+#[test]
+fn extract_closing_issue_numbers_only_marks_closing_keywords() {
+	let body = "Closes #7, #9 and owner/repo#11\nRefs #8\nFixed #10 and refs #12";
+
+	assert_eq!(
+		extract_issue_numbers(body).into_iter().collect::<Vec<_>>(),
+		vec![7, 8, 9, 10, 11, 12]
+	);
+	assert_eq!(
+		extract_closing_issue_numbers(body)
+			.into_iter()
+			.collect::<Vec<_>>(),
+		vec![7, 9, 10, 11]
+	);
 }
 
 #[test]

--- a/crates/monochange_github/src/lib.rs
+++ b/crates/monochange_github/src/lib.rs
@@ -95,6 +95,7 @@ use std::env;
 use std::fmt::Write as _;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::OnceLock;
 use std::thread;
 
 use monochange_core::CommitMessage;
@@ -140,6 +141,7 @@ use monochange_core::git::git_stage_paths_command;
 use monochange_core::git::run_command;
 use monochange_core::git::run_commit_command_allow_nothing_to_commit;
 use octocrab::Octocrab;
+use regex::Regex;
 use serde::Deserialize;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -726,7 +728,7 @@ fn build_review_request_batch_query(owner: &str, repo: &str, shas: &[String]) ->
 		let alias = format!("commit_{index}");
 		let _ = write!(
 			query,
-			" {alias}: object(expression: \"{sha}\") {{ ... on Commit {{ associatedPullRequests(first: 1) {{ nodes {{ number title url body author {{ login url }} closingIssuesReferences(first: 50) {{ nodes {{ number title url }} }} }} }} }} }}"
+			" {alias}: object(expression: \"{sha}\") {{ ... on Commit {{ associatedPullRequests(first: 1) {{ nodes {{ number title url body author {{ login url }} }} }} }} }}"
 		);
 	}
 	query.push_str(" } }");
@@ -783,30 +785,19 @@ fn parse_review_request_from_graphql(
 		author,
 	};
 	let mut issues_by_id = std::collections::BTreeMap::<String, HostedIssueRef>::new();
-	for issue in pull_request
-		.get("closingIssuesReferences")
-		.and_then(|issues| issues.get("nodes"))
-		.and_then(serde_json::Value::as_array)
-		.into_iter()
-		.flatten()
+	for issue_number in body
+		.as_deref()
+		.map(extract_closing_issue_numbers)
+		.unwrap_or_default()
 	{
-		let Some(number) = issue.get("number").and_then(serde_json::Value::as_u64) else {
-			continue;
-		};
 		issues_by_id.insert(
-			format!("#{number}"),
+			format!("#{issue_number}"),
 			HostedIssueRef {
 				provider: HostingProviderKind::GitHub,
 				host: github_host(),
-				id: format!("#{number}"),
-				title: issue
-					.get("title")
-					.and_then(serde_json::Value::as_str)
-					.map(str::to_string),
-				url: issue
-					.get("url")
-					.and_then(serde_json::Value::as_str)
-					.map(str::to_string),
+				id: format!("#{issue_number}"),
+				title: None,
+				url: Some(github_issue_url(source, issue_number)),
 				relationship: HostedIssueRelationshipKind::ClosedByReviewRequest,
 			},
 		);
@@ -835,30 +826,39 @@ fn parse_review_request_from_graphql(
 	})
 }
 
-fn extract_issue_numbers(text: &str) -> std::collections::BTreeSet<u64> {
+fn issue_reference_regex() -> &'static Regex {
+	static ISSUE_REFERENCE_RE: OnceLock<Regex> = OnceLock::new();
+	ISSUE_REFERENCE_RE.get_or_init(|| {
+		Regex::new(r"(?:[\w.-]+/[\w.-]+)?#(?P<number>\d+)")
+			.unwrap_or_else(|error| panic!("issue reference regex should compile: {error}"))
+	})
+}
+
+fn closing_issue_reference_regex() -> &'static Regex {
+	static CLOSING_ISSUE_REFERENCE_RE: OnceLock<Regex> = OnceLock::new();
+	CLOSING_ISSUE_REFERENCE_RE.get_or_init(|| {
+		Regex::new(r"(?i)\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\b[:\s]*(?P<refs>(?:[\w.-]+/[\w.-]+)?#\d+(?:\s*(?:,|and)\s*(?:[\w.-]+/[\w.-]+)?#\d+)*)")
+		.unwrap_or_else(|error| panic!("closing issue regex should compile: {error}"))
+	})
+}
+
+fn extract_closing_issue_numbers(text: &str) -> std::collections::BTreeSet<u64> {
 	let mut issue_numbers = std::collections::BTreeSet::new();
-	let bytes = text.as_bytes();
-	let mut index = 0;
-	while let Some(byte) = bytes.get(index) {
-		if *byte != b'#' {
-			index += 1;
+	for captures in closing_issue_reference_regex().captures_iter(text) {
+		let Some(references) = captures.name("refs") else {
 			continue;
-		}
-		let mut digits = String::new();
-		let mut cursor = index + 1;
-		while let Some(next) = bytes.get(cursor) {
-			if !next.is_ascii_digit() {
-				break;
-			}
-			digits.push(char::from(*next));
-			cursor += 1;
-		}
-		if let Ok(number) = digits.parse::<u64>() {
-			issue_numbers.insert(number);
-		}
-		index = cursor;
+		};
+		issue_numbers.extend(extract_issue_numbers(references.as_str()));
 	}
 	issue_numbers
+}
+
+fn extract_issue_numbers(text: &str) -> std::collections::BTreeSet<u64> {
+	issue_reference_regex()
+		.captures_iter(text)
+		.filter_map(|captures| captures.name("number"))
+		.filter_map(|number| number.as_str().parse::<u64>().ok())
+		.collect()
 }
 
 #[must_use]

--- a/scripts/setup_hosted_benchmark_fixture.sh
+++ b/scripts/setup_hosted_benchmark_fixture.sh
@@ -45,6 +45,7 @@ git_commit() {
 		-u GIT_COMMON_DIR \
 		git -C "$root" \
 		-c core.hooksPath=/dev/null \
+		-c commit.gpgsign=false \
 		-c user.name=fixture \
 		-c user.email=fixture@example.com \
 		commit -m "$message" >/dev/null
@@ -61,6 +62,7 @@ run_git() {
 		-u GIT_COMMON_DIR \
 		git -C "$root" \
 		-c core.hooksPath=/dev/null \
+		-c commit.gpgsign=false \
 		-c user.name=fixture \
 		-c user.email=fixture@example.com \
 		"$@"


### PR DESCRIPTION
## Summary
- trim the GitHub review-request GraphQL payload so hosted enrichment stops requesting `closingIssuesReferences`
- derive closing and referenced issues locally from pull request bodies
- harden the hosted benchmark fixture helper by disabling disposable repo GPG signing and setting explicit fixture git identity

## Why
Hosted `mc release` was already down to a single batched GitHub request, but the request still asked GitHub to resolve issue-closing references server-side. That field was the obvious remaining expensive payload in the hot path.

## Impact
- keeps the provider batching architecture intact
- reduces the hosted GitHub enrichment phase in the real `mc release` path
- makes the synthetic hosted fixture setup more robust on machines with `commit.gpgsign=true`

## Benchmark
Hosted GitHub fixture: 8 packages, 227 commits, 6 merged release PRs

- `mc release --dry-run`: `489.4 ms -> 473.2 ms`
- `mc release`: `1062.9 ms -> 1056.7 ms`
- `prepare release total`: `785 ms -> 727 ms`
- `enrich changeset context via github`: `736 ms -> 681 ms`

Fixes #171

## Validation
- `devenv shell cargo test -p monochange_github`
- `devenv shell cargo clippy -p monochange_github --tests -- -D warnings`
- `devenv shell cargo test -p monochange --test hosted_release_benchmarks`
- `devenv shell cargo build --release --bin mc`
- `.github/scripts/benchmark_cli.sh run-fixture ...`
