### PR TITLE
test: speed up suite execution and stabilize coverage

### DIFF
--- a/.changeset/test-suite-performance-signed.md
+++ b/.changeset/test-suite-performance-signed.md
@@ -1,0 +1,9 @@
+---
+"monochange": patch
+"monochange_config": patch
+"monochange_gitea": patch
+"monochange_github": patch
+"monochange_gitlab": patch
+---
+
+Improve test suite performance and stabilize coverage-focused integration tests.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: run cargo tests
-        run: test:cargo
+        run: test:cargo:expensive
         shell: devenv shell -- bash -e {0}
 
       - name: run doc tests

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -7648,27 +7648,21 @@ fn sample_group_definition(include: GroupChangelogInclude) -> monochange_core::G
 #[test]
 fn assistant_display_name_covers_all_variants() {
 	assert_eq!(
-		crate::assistant_display_name(crate::Assistant::Generic),
+		crate::assistant_display_name(Assistant::Generic),
 		"Generic MCP client"
 	);
+	assert_eq!(crate::assistant_display_name(Assistant::Claude), "Claude");
+	assert_eq!(crate::assistant_display_name(Assistant::Cursor), "Cursor");
 	assert_eq!(
-		crate::assistant_display_name(crate::Assistant::Claude),
-		"Claude"
-	);
-	assert_eq!(
-		crate::assistant_display_name(crate::Assistant::Cursor),
-		"Cursor"
-	);
-	assert_eq!(
-		crate::assistant_display_name(crate::Assistant::Copilot),
+		crate::assistant_display_name(Assistant::Copilot),
 		"GitHub Copilot"
 	);
-	assert_eq!(crate::assistant_display_name(crate::Assistant::Pi), "Pi");
+	assert_eq!(crate::assistant_display_name(Assistant::Pi), "Pi");
 }
 
 #[test]
 fn assistant_setup_payload_contains_mcp_config_and_guidance() {
-	let payload = crate::assistant_setup_payload(crate::Assistant::Pi);
+	let payload = crate::assistant_setup_payload(Assistant::Pi);
 	assert_eq!(payload["assistant"].as_str(), Some("Pi"));
 	assert_eq!(
 		payload["mcp_config"]["mcpServers"]["monochange"]["command"],
@@ -7690,14 +7684,11 @@ fn assistant_setup_payload_contains_mcp_config_and_guidance() {
 #[test]
 fn assistant_setup_payload_includes_variant_specific_notes() {
 	let cases = [
-		(crate::Assistant::Generic, "supports stdio MCP servers"),
-		(crate::Assistant::Claude, "Claude's MCP configuration"),
+		(Assistant::Generic, "supports stdio MCP servers"),
+		(Assistant::Claude, "Claude's MCP configuration"),
+		(Assistant::Cursor, "Configure the MCP server in Cursor"),
 		(
-			crate::Assistant::Cursor,
-			"Configure the MCP server in Cursor",
-		),
-		(
-			crate::Assistant::Copilot,
+			Assistant::Copilot,
 			"support MCP-compatible server definitions",
 		),
 	];
@@ -8190,12 +8181,12 @@ fn build_cli_command_subcommand_parses_supported_input_kinds() {
 
 #[test]
 fn run_assist_renders_json_and_text_outputs() {
-	let json_output = crate::run_assist(crate::Assistant::Cursor, crate::AssistOutputFormat::Json)
+	let json_output = crate::run_assist(Assistant::Cursor, AssistOutputFormat::Json)
 		.unwrap_or_else(|error| panic!("assist json: {error}"));
 	assert!(json_output.contains("\"assistant\": \"Cursor\""));
 	assert!(json_output.contains("\"mcp_config\""));
 
-	let text_output = crate::run_assist(crate::Assistant::Copilot, crate::AssistOutputFormat::Text)
+	let text_output = crate::run_assist(Assistant::Copilot, AssistOutputFormat::Text)
 		.unwrap_or_else(|error| panic!("assist text: {error}"));
 	assert!(text_output.contains("monochange assist"));
 	assert!(text_output.contains("Notes for GitHub Copilot:"));

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -4588,7 +4588,7 @@ fn quiet_builtin_commands_return_empty_output() {
 	)
 	.unwrap_or_else(|error| panic!("quiet init output: {error}"));
 	assert!(init_output.is_empty());
-	assert!(!root.join("monochange.toml").exists());
+	assert!(root.join("monochange.toml").exists());
 
 	let populate_output = run_cli(
 		root,

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -25,6 +25,8 @@ use monochange_test_helpers::snapshot_settings;
 use semver::Version;
 use tempfile::tempdir;
 
+use crate::AssistOutputFormat;
+use crate::Assistant;
 use crate::CliContext;
 use crate::PreparedFileDiff;
 use crate::add_change_file;
@@ -37,6 +39,8 @@ use crate::cli_runtime::should_execute_cli_step;
 use crate::discover_workspace;
 use crate::interactive::InteractiveChangeResult;
 use crate::interactive::InteractiveTarget;
+use crate::parse_assist_output_format_or_default;
+use crate::parse_assistant_or_default;
 use crate::parse_change_bump;
 use crate::plan_release;
 use crate::prepare_release_execution;
@@ -227,6 +231,104 @@ fn assist_command_supports_json_output() {
 	assert!(output.contains("\"mcp_config\""));
 	assert!(output.contains("\"install\""));
 	assert!(output.contains("@monochange/skill"));
+}
+
+#[test]
+fn assist_command_requires_assistant_and_valid_format() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+
+	let missing_assistant = run_cli(
+		tempdir.path(),
+		[OsString::from("mc"), OsString::from("assist")],
+	)
+	.expect_err("assist without assistant should fail");
+	assert!(
+		missing_assistant
+			.to_string()
+			.contains("required arguments were not provided")
+	);
+
+	let invalid_format = run_cli(
+		tempdir.path(),
+		[
+			OsString::from("mc"),
+			OsString::from("assist"),
+			OsString::from("pi"),
+			OsString::from("--format"),
+			OsString::from("yaml"),
+		],
+	)
+	.expect_err("invalid assist format should fail");
+	assert!(invalid_format.to_string().contains("invalid value 'yaml'"));
+}
+
+#[test]
+fn assist_parsing_helpers_cover_defaults_and_unknown_values() {
+	assert_eq!(parse_assistant_or_default(None), Assistant::Generic);
+	assert_eq!(
+		parse_assistant_or_default(Some(&"cursor".to_string())),
+		Assistant::Cursor
+	);
+	assert_eq!(
+		parse_assistant_or_default(Some(&"unknown".to_string())),
+		Assistant::Generic
+	);
+	assert_eq!(
+		parse_assist_output_format_or_default(None),
+		AssistOutputFormat::Text
+	);
+	assert_eq!(
+		parse_assist_output_format_or_default(Some(&"json".to_string())),
+		AssistOutputFormat::Json
+	);
+	assert_eq!(
+		parse_assist_output_format_or_default(Some(&"yaml".to_string())),
+		AssistOutputFormat::Text
+	);
+}
+
+#[test]
+fn mcp_and_root_command_support_quiet_and_missing_subcommands() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+
+	let quiet_output = run_cli(
+		tempdir.path(),
+		[
+			OsString::from("mc"),
+			OsString::from("mcp"),
+			OsString::from("--quiet"),
+		],
+	)
+	.unwrap_or_else(|error| panic!("quiet mcp output: {error}"));
+	assert!(quiet_output.is_empty());
+
+	let no_subcommand = run_cli(tempdir.path(), [OsString::from("mc")])
+		.expect_err("missing subcommand should fail");
+	assert!(no_subcommand.to_string().contains("Usage: mc"));
+}
+
+#[test]
+fn release_record_supports_json_output() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	write_blank_monochange_config(root);
+	create_release_record_history(root);
+	let output = run_cli(
+		root,
+		[
+			OsString::from("mc"),
+			OsString::from("release-record"),
+			OsString::from("--from"),
+			OsString::from("HEAD"),
+			OsString::from("--format"),
+			OsString::from("json"),
+		],
+	)
+	.unwrap_or_else(|error| panic!("release-record json output: {error}"));
+
+	assert!(output.contains("\"record\""));
+	assert!(output.contains("\"recordCommit\""));
+	assert!(output.contains("\"resolvedCommit\""));
 }
 
 #[test]
@@ -924,6 +1026,14 @@ fn parse_change_bump_supports_none() {
 		BumpSeverity::from(crate::ChangeBump::None),
 		BumpSeverity::None
 	);
+}
+
+#[test]
+fn parse_change_bump_rejects_unsupported_values() {
+	let error = parse_change_bump("prerelease")
+		.err()
+		.unwrap_or_else(|| panic!("expected invalid bump error"));
+	assert!(error.to_string().contains("unsupported bump `prerelease`"));
 }
 
 #[test]
@@ -3359,8 +3469,7 @@ fn text_release_record_discovery_omits_empty_sections() {
 fn commit_release_command_creates_local_commit_with_release_record() {
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	let root = tempdir.path();
-	copy_fixture("monochange/release-base", root);
-	copy_fixture("monochange/commit-release", root);
+	copy_fixture("prepared-release/source-github-follow-up/workspace", root);
 	init_git_repo(root);
 	git_in_temp_repo(root, &["add", "."]);
 	git_in_temp_repo(root, &["commit", "-m", "initial"]);
@@ -3389,8 +3498,7 @@ fn commit_release_command_creates_local_commit_with_release_record() {
 fn commit_release_command_reports_json_output() {
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	let root = tempdir.path();
-	copy_fixture("monochange/release-base", root);
-	copy_fixture("monochange/commit-release", root);
+	copy_fixture("prepared-release/source-github-follow-up/workspace", root);
 
 	let output = run_cli(
 		root,
@@ -3428,19 +3536,21 @@ fn repair_release_command_dry_run_reports_text_output() {
 	write_blank_monochange_config(root);
 	create_release_record_history(root);
 
-	let output = run_cli(
-		root,
-		[
-			OsString::from("mc"),
-			OsString::from("repair-release"),
-			OsString::from("--from"),
-			OsString::from("v1.2.3"),
-			OsString::from("--target"),
-			OsString::from("HEAD"),
-			OsString::from("--sync-provider=false"),
-			OsString::from("--dry-run"),
-		],
-	)
+	let output = temp_env::with_var("MONOCHANGE_PROGRESS_FORMAT", None::<&str>, || {
+		run_cli(
+			root,
+			[
+				OsString::from("mc"),
+				OsString::from("repair-release"),
+				OsString::from("--from"),
+				OsString::from("v1.2.3"),
+				OsString::from("--target"),
+				OsString::from("HEAD"),
+				OsString::from("--sync-provider=false"),
+				OsString::from("--dry-run"),
+			],
+		)
+	})
 	.unwrap_or_else(|error| panic!("repair-release output: {error}"));
 
 	assert!(output.contains("repair release:"));
@@ -3458,19 +3568,21 @@ fn repair_release_command_reports_json_output() {
 	write_blank_monochange_config(root);
 	create_release_record_history(root);
 
-	let output = run_cli(
-		root,
-		[
-			OsString::from("mc"),
-			OsString::from("repair-release"),
-			OsString::from("--from"),
-			OsString::from("v1.2.3"),
-			OsString::from("--sync-provider=false"),
-			OsString::from("--format"),
-			OsString::from("json"),
-			OsString::from("--dry-run"),
-		],
-	)
+	let output = temp_env::with_var("MONOCHANGE_PROGRESS_FORMAT", None::<&str>, || {
+		run_cli(
+			root,
+			[
+				OsString::from("mc"),
+				OsString::from("repair-release"),
+				OsString::from("--from"),
+				OsString::from("v1.2.3"),
+				OsString::from("--sync-provider=false"),
+				OsString::from("--format"),
+				OsString::from("json"),
+				OsString::from("--dry-run"),
+			],
+		)
+	})
 	.unwrap_or_else(|error| panic!("repair-release json output: {error}"));
 	let value: serde_json::Value =
 		serde_json::from_str(&output).unwrap_or_else(|error| panic!("parse json: {error}"));
@@ -3868,6 +3980,63 @@ fn render_cli_command_markdown_result_uses_markdown_sections_for_prepare_release
 	assert!(rendered.contains("```diff"));
 	assert!(rendered.contains("## Commands"));
 	assert!(rendered.contains("skipped command `cargo publish` (dry-run)"));
+}
+
+#[test]
+fn render_cli_command_markdown_result_renders_release_follow_up_sections() {
+	let cli_command = monochange_core::CliCommandDefinition {
+		name: "release".to_string(),
+		help_text: None,
+		inputs: Vec::new(),
+		steps: Vec::new(),
+	};
+	let context = CliContext {
+		root: PathBuf::from("."),
+		dry_run: false,
+		quiet: false,
+		show_diff: true,
+		inputs: BTreeMap::new(),
+		last_step_inputs: BTreeMap::new(),
+		prepared_release: Some(sample_prepared_release_for_cli_render()),
+		prepared_file_diffs: vec![PreparedFileDiff {
+			path: PathBuf::from("Cargo.toml"),
+			diff: "@@ -1 +1 @@".to_string(),
+			display_diff: "diff --git a/Cargo.toml b/Cargo.toml\n@@ -1 +1 @@".to_string(),
+		}],
+		release_manifest_path: Some(PathBuf::from("target/release-manifest.json")),
+		release_requests: Vec::new(),
+		release_results: vec!["published monochange v1.2.3".to_string()],
+		release_request: None,
+		release_request_result: Some("opened monochange/release".to_string()),
+		release_commit_report: Some(crate::CommitReleaseReport {
+			subject: "chore(release): prepare release".to_string(),
+			body: "## monochange Release Record".to_string(),
+			commit: Some("abcdef1234567890".to_string()),
+			tracked_paths: vec![PathBuf::from("Cargo.toml"), PathBuf::from("CHANGELOG.md")],
+			dry_run: false,
+			status: "completed".to_string(),
+		}),
+		issue_comment_plans: Vec::new(),
+		issue_comment_results: vec!["commented on #123".to_string()],
+		changeset_policy_evaluation: None,
+		changeset_diagnostics: None,
+		retarget_report: None,
+		step_outputs: BTreeMap::new(),
+		command_logs: vec!["executed release workflow".to_string()],
+	};
+
+	let rendered = crate::render_cli_command_markdown_result(&cli_command, &context);
+	assert!(rendered.contains("## Releases"));
+	assert!(rendered.contains("published monochange v1.2.3"));
+	assert!(rendered.contains("## Release commit"));
+	assert!(rendered.contains("abcdef1"));
+	assert!(rendered.contains("## Release request"));
+	assert!(rendered.contains("opened monochange/release"));
+	assert!(rendered.contains("## Issue comments"));
+	assert!(rendered.contains("commented on #123"));
+	assert!(rendered.contains("## Changed files"));
+	assert!(rendered.contains("abcdef1"));
+	assert!(rendered.contains("CHANGELOG.md"));
 }
 
 #[test]
@@ -4402,6 +4571,46 @@ fn parse_boolean_step_input_rejects_invalid_values() {
 			.to_string()
 			.contains("invalid boolean value `maybe` for `force`")
 	);
+}
+
+#[test]
+fn quiet_builtin_commands_return_empty_output() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+
+	let init_output = run_cli(
+		root,
+		[
+			OsString::from("mc"),
+			OsString::from("--quiet"),
+			OsString::from("init"),
+		],
+	)
+	.unwrap_or_else(|error| panic!("quiet init output: {error}"));
+	assert!(init_output.is_empty());
+	assert!(!root.join("monochange.toml").exists());
+
+	let populate_output = run_cli(
+		root,
+		[
+			OsString::from("mc"),
+			OsString::from("--quiet"),
+			OsString::from("populate"),
+		],
+	)
+	.unwrap_or_else(|error| panic!("quiet populate output: {error}"));
+	assert!(populate_output.is_empty());
+
+	let mcp_output = run_cli(
+		root,
+		[
+			OsString::from("mc"),
+			OsString::from("--quiet"),
+			OsString::from("mcp"),
+		],
+	)
+	.unwrap_or_else(|error| panic!("quiet mcp output: {error}"));
+	assert!(mcp_output.is_empty());
 }
 
 #[test]
@@ -8644,7 +8853,7 @@ fn sample_github_source_configuration(api_url: &str) -> monochange_core::SourceC
 }
 
 fn init_git_repo(root: &Path) {
-	git_in_temp_repo(root, &["init"]);
+	git_in_temp_repo(root, &["init", "-b", "main"]);
 	git_in_temp_repo(root, &["config", "user.name", "monochange Tests"]);
 	git_in_temp_repo(root, &["config", "user.email", "monochange@example.com"]);
 	git_in_temp_repo(root, &["config", "commit.gpgsign", "false"]);

--- a/crates/monochange/src/changelog.rs
+++ b/crates/monochange/src/changelog.rs
@@ -1458,7 +1458,7 @@ mod tests {
 			context: Some(ChangesetContext {
 				provider: HostingProviderKind::GitHub,
 				host: Some("github.com".to_string()),
-				capabilities: Default::default(),
+				capabilities: HostingCapabilities::default(),
 				introduced: Some(ChangesetRevision {
 					actor: Some(HostedActorRef {
 						provider: HostingProviderKind::GitHub,
@@ -1589,7 +1589,7 @@ mod tests {
 		let source_path = root_relative(tempdir.path(), &changeset.path);
 		let mapped = build_release_note_change(
 			&signal,
-			&[package.clone()],
+			std::slice::from_ref(&package),
 			tempdir.path(),
 			&BTreeMap::from([(source_path, rendered.clone())]),
 		)
@@ -1658,7 +1658,7 @@ mod tests {
 			render_markdown_link("linked", Some("https://example.com")),
 			"[linked](https://example.com)"
 		);
-		let issues = vec![
+		let issues = [
 			HostedIssueRef {
 				id: "#1".to_string(),
 				url: Some("https://example.com/issues/1".to_string()),
@@ -2087,7 +2087,7 @@ mod tests {
 					change_type: Some("note".to_string()),
 					..sample_change("pkg-a", "pkg-a", ".changeset/a.md")
 				},
-				&[selected.clone()],
+				std::slice::from_ref(&selected),
 			),
 			ResolvedReleaseSectionTarget::Builtin(BuiltinReleaseSection::Note)
 		);
@@ -2097,7 +2097,7 @@ mod tests {
 					change_type: Some("custom".to_string()),
 					..sample_change("pkg-a", "pkg-a", ".changeset/a.md")
 				},
-				&[selected.clone()],
+				std::slice::from_ref(&selected),
 			),
 			ResolvedReleaseSectionTarget::Extra(0)
 		);

--- a/crates/monochange/src/changelog.rs
+++ b/crates/monochange/src/changelog.rs
@@ -1182,3 +1182,933 @@ fn builtin_release_sections() -> [BuiltinReleaseSection; 4] {
 		BuiltinReleaseSection::Note,
 	]
 }
+
+#[cfg(test)]
+mod tests {
+	use std::collections::BTreeMap;
+	use std::collections::BTreeSet;
+	use std::fs;
+
+	use monochange_core::ChangeSignal;
+	use monochange_core::ChangelogFormat;
+	use monochange_core::ChangelogTarget;
+	use monochange_core::ChangesetContext;
+	use monochange_core::ChangesetRevision;
+	use monochange_core::ChangesetTargetKind;
+	use monochange_core::Ecosystem;
+	use monochange_core::ExtraChangelogSection;
+	use monochange_core::GroupChangelogInclude;
+	use monochange_core::GroupDefinition;
+	use monochange_core::HostedActorRef;
+	use monochange_core::HostedActorSourceKind;
+	use monochange_core::HostedCommitRef;
+	use monochange_core::HostedIssueRef;
+	use monochange_core::HostedIssueRelationshipKind;
+	use monochange_core::HostedReviewRequestKind;
+	use monochange_core::HostedReviewRequestRef;
+	use monochange_core::HostingProviderKind;
+	use monochange_core::PackageDefinition;
+	use monochange_core::PackageRecord;
+	use monochange_core::PackageType;
+	use monochange_core::PlannedVersionGroup;
+	use monochange_core::PreparedChangeset;
+	use monochange_core::PreparedChangesetTarget;
+	use monochange_core::PublishState;
+	use monochange_core::ReleaseDecision;
+	use monochange_core::ReleaseNotesSettings;
+	use monochange_core::VersionFormat;
+	use monochange_core::WorkspaceConfiguration;
+	use monochange_core::WorkspaceDefaults;
+	use semver::Version;
+	use tempfile::tempdir;
+
+	use super::*;
+
+	fn empty_configuration(root: &Path) -> WorkspaceConfiguration {
+		WorkspaceConfiguration {
+			root_path: root.to_path_buf(),
+			defaults: WorkspaceDefaults::default(),
+			release_notes: ReleaseNotesSettings::default(),
+			packages: Vec::new(),
+			groups: Vec::new(),
+			cli: Vec::new(),
+			changesets: monochange_core::ChangesetSettings::default(),
+			source: None,
+			cargo: monochange_core::EcosystemSettings::default(),
+			npm: monochange_core::EcosystemSettings::default(),
+			deno: monochange_core::EcosystemSettings::default(),
+			dart: monochange_core::EcosystemSettings::default(),
+		}
+	}
+
+	fn sample_package_record(root: &Path, config_id: &str, name: &str) -> PackageRecord {
+		let manifest_dir = root.join("packages").join(config_id);
+		fs::create_dir_all(&manifest_dir)
+			.unwrap_or_else(|error| panic!("create manifest dir: {error}"));
+		let manifest_path = manifest_dir.join("package.json");
+		fs::write(&manifest_path, "{}\n")
+			.unwrap_or_else(|error| panic!("write manifest file: {error}"));
+
+		let mut package = PackageRecord::new(
+			Ecosystem::Npm,
+			name,
+			manifest_path,
+			root.to_path_buf(),
+			Some(Version::new(1, 0, 0)),
+			PublishState::Public,
+		);
+		package
+			.metadata
+			.insert("config_id".to_string(), config_id.to_string());
+		package
+	}
+
+	fn sample_package_definition(config_id: &str) -> PackageDefinition {
+		PackageDefinition {
+			id: config_id.to_string(),
+			path: PathBuf::from(format!("packages/{config_id}")),
+			package_type: PackageType::Npm,
+			changelog: Some(ChangelogTarget {
+				path: PathBuf::from(format!("packages/{config_id}/CHANGELOG.md")),
+				format: ChangelogFormat::Monochange,
+			}),
+			extra_changelog_sections: Vec::new(),
+			empty_update_message: None,
+			release_title: None,
+			changelog_version_title: None,
+			versioned_files: Vec::new(),
+			ignore_ecosystem_versioned_files: false,
+			ignored_paths: Vec::new(),
+			additional_paths: Vec::new(),
+			tag: true,
+			release: true,
+			version_format: VersionFormat::Namespaced,
+		}
+	}
+
+	fn sample_group_definition(include: GroupChangelogInclude) -> GroupDefinition {
+		GroupDefinition {
+			id: "sdk".to_string(),
+			packages: vec!["pkg-a".to_string(), "pkg-b".to_string()],
+			changelog: Some(ChangelogTarget {
+				path: PathBuf::from("groups/sdk/CHANGELOG.md"),
+				format: ChangelogFormat::Monochange,
+			}),
+			changelog_include: include,
+			extra_changelog_sections: Vec::new(),
+			empty_update_message: None,
+			release_title: None,
+			changelog_version_title: None,
+			versioned_files: Vec::new(),
+			tag: true,
+			release: true,
+			version_format: VersionFormat::Namespaced,
+		}
+	}
+
+	fn sample_decision(package_id: &str, group_id: Option<&str>) -> ReleaseDecision {
+		ReleaseDecision {
+			package_id: package_id.to_string(),
+			trigger_type: "changeset".to_string(),
+			recommended_bump: BumpSeverity::Patch,
+			planned_version: Some(Version::new(1, 2, 3)),
+			group_id: group_id.map(ToString::to_string),
+			reasons: vec!["covered".to_string()],
+			upstream_sources: Vec::new(),
+			warnings: Vec::new(),
+		}
+	}
+
+	fn sample_group(member_ids: Vec<String>) -> PlannedVersionGroup {
+		PlannedVersionGroup {
+			group_id: "sdk".to_string(),
+			display_name: "SDK".to_string(),
+			members: member_ids,
+			mismatch_detected: false,
+			planned_version: Some(Version::new(2, 0, 0)),
+			recommended_bump: BumpSeverity::Minor,
+		}
+	}
+
+	fn sample_change(package_id: &str, package_name: &str, source_path: &str) -> ReleaseNoteChange {
+		ReleaseNoteChange {
+			package_id: package_id.to_string(),
+			package_name: package_name.to_string(),
+			package_labels: Vec::new(),
+			source_path: Some(source_path.to_string()),
+			summary: "Added release note support".to_string(),
+			details: Some("Detailed explanation".to_string()),
+			bump: BumpSeverity::Minor,
+			change_type: Some("note".to_string()),
+			context: Some("> _Owner:_ @octocat".to_string()),
+			changeset_path: Some(source_path.to_string()),
+			change_owner: Some("@octocat".to_string()),
+			change_owner_link: Some("[@octocat](https://example.com/octocat)".to_string()),
+			review_request: Some("PR 42".to_string()),
+			review_request_link: Some("[PR 42](https://example.com/pr/42)".to_string()),
+			introduced_commit: Some("abc1234".to_string()),
+			introduced_commit_link: Some(
+				"[`abc1234`](https://example.com/commit/abc1234)".to_string(),
+			),
+			last_updated_commit: Some("def5678".to_string()),
+			last_updated_commit_link: Some(
+				"[`def5678`](https://example.com/commit/def5678)".to_string(),
+			),
+			related_issues: Some("#10".to_string()),
+			related_issue_links: Some("[#10](https://example.com/issues/10)".to_string()),
+			closed_issues: Some("#20".to_string()),
+			closed_issue_links: Some("[#20](https://example.com/issues/20)".to_string()),
+		}
+	}
+
+	#[test]
+	fn changelog_file_helpers_append_and_deduplicate_updates() {
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let changelog_path = tempdir.path().join("CHANGELOG.md");
+
+		let first = append_changelog_section(&changelog_path, "## 1.0.0\n- initial")
+			.unwrap_or_else(|error| panic!("append first changelog section: {error}"));
+		assert_eq!(first, "## 1.0.0\n- initial\n");
+
+		fs::write(&changelog_path, "# Changelog\n\n## 0.9.0\n- older\n")
+			.unwrap_or_else(|error| panic!("write existing changelog: {error}"));
+		let appended = append_changelog_section(&changelog_path, "## 1.0.0\n- latest")
+			.unwrap_or_else(|error| panic!("append second changelog section: {error}"));
+		assert_eq!(
+			appended,
+			"# Changelog\n\n## 0.9.0\n- older\n\n## 1.0.0\n- latest\n"
+		);
+
+		let earlier = ChangelogUpdate {
+			file: FileUpdate {
+				path: changelog_path.clone(),
+				content: b"old".to_vec(),
+			},
+			owner_id: "pkg-a".to_string(),
+			owner_kind: ReleaseOwnerKind::Package,
+			format: ChangelogFormat::Monochange,
+			notes: ReleaseNotesDocument {
+				title: "0.9.0".to_string(),
+				summary: Vec::new(),
+				sections: Vec::new(),
+			},
+			rendered: "old".to_string(),
+		};
+		let latest = ChangelogUpdate {
+			file: FileUpdate {
+				path: changelog_path.clone(),
+				content: b"new".to_vec(),
+			},
+			owner_id: "pkg-a".to_string(),
+			owner_kind: ReleaseOwnerKind::Package,
+			format: ChangelogFormat::Monochange,
+			notes: ReleaseNotesDocument {
+				title: "1.0.0".to_string(),
+				summary: Vec::new(),
+				sections: Vec::new(),
+			},
+			rendered: "new".to_string(),
+		};
+		let unique_path = tempdir.path().join("OTHER.md");
+		let unique = ChangelogUpdate {
+			file: FileUpdate {
+				path: unique_path.clone(),
+				content: b"other".to_vec(),
+			},
+			owner_id: "pkg-b".to_string(),
+			owner_kind: ReleaseOwnerKind::Package,
+			format: ChangelogFormat::Monochange,
+			notes: ReleaseNotesDocument {
+				title: "1.0.0".to_string(),
+				summary: Vec::new(),
+				sections: Vec::new(),
+			},
+			rendered: "other".to_string(),
+		};
+
+		let deduped = dedup_changelog_updates(vec![earlier, latest.clone(), unique]);
+		assert_eq!(deduped.len(), 2);
+		assert!(deduped.iter().any(|update| update.file.path == unique_path));
+		assert!(deduped.iter().any(|update| {
+			update.file.path == changelog_path && update.file.content == latest.file.content
+		}));
+	}
+
+	#[test]
+	fn rendered_changeset_context_and_signal_mapping_cover_hosted_metadata() {
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let changeset_path = tempdir.path().join(".changeset/feature.md");
+		fs::create_dir_all(changeset_path.parent().unwrap_or_else(|| Path::new(".")))
+			.unwrap_or_else(|error| panic!("create changeset dir: {error}"));
+		fs::write(&changeset_path, "feature\n")
+			.unwrap_or_else(|error| panic!("write changeset file: {error}"));
+
+		let changeset = PreparedChangeset {
+			path: changeset_path.clone(),
+			summary: Some("summary".to_string()),
+			details: Some("details".to_string()),
+			targets: vec![PreparedChangesetTarget {
+				id: "pkg-a".to_string(),
+				kind: ChangesetTargetKind::Package,
+				bump: Some(BumpSeverity::Minor),
+				origin: "manual".to_string(),
+				evidence_refs: Vec::new(),
+				change_type: Some("note".to_string()),
+			}],
+			context: Some(ChangesetContext {
+				provider: HostingProviderKind::GitHub,
+				host: Some("github.com".to_string()),
+				capabilities: Default::default(),
+				introduced: Some(ChangesetRevision {
+					actor: Some(HostedActorRef {
+						provider: HostingProviderKind::GitHub,
+						host: Some("github.com".to_string()),
+						id: Some("1".to_string()),
+						login: Some("octocat".to_string()),
+						display_name: Some("Octo Cat".to_string()),
+						url: Some("https://example.com/octocat".to_string()),
+						source: HostedActorSourceKind::ReviewRequestAuthor,
+					}),
+					commit: Some(HostedCommitRef {
+						provider: HostingProviderKind::GitHub,
+						host: Some("github.com".to_string()),
+						sha: "abcdef123456".to_string(),
+						short_sha: "abcdef1".to_string(),
+						url: Some("https://example.com/commit/abcdef1".to_string()),
+						authored_at: None,
+						committed_at: None,
+						author_name: None,
+						author_email: None,
+					}),
+					review_request: Some(HostedReviewRequestRef {
+						provider: HostingProviderKind::GitHub,
+						host: Some("github.com".to_string()),
+						kind: HostedReviewRequestKind::PullRequest,
+						id: "42".to_string(),
+						title: Some("release notes".to_string()),
+						url: Some("https://example.com/pull/42".to_string()),
+						author: None,
+					}),
+				}),
+				last_updated: Some(ChangesetRevision {
+					actor: Some(HostedActorRef {
+						provider: HostingProviderKind::GitHub,
+						host: Some("github.com".to_string()),
+						id: None,
+						login: None,
+						display_name: Some("Release Bot".to_string()),
+						url: None,
+						source: HostedActorSourceKind::CommitAuthor,
+					}),
+					commit: Some(HostedCommitRef {
+						provider: HostingProviderKind::GitHub,
+						host: Some("github.com".to_string()),
+						sha: "9876543210ab".to_string(),
+						short_sha: "9876543".to_string(),
+						url: Some("https://example.com/commit/9876543".to_string()),
+						authored_at: None,
+						committed_at: None,
+						author_name: None,
+						author_email: None,
+					}),
+					review_request: Some(HostedReviewRequestRef {
+						provider: HostingProviderKind::GitHub,
+						host: Some("github.com".to_string()),
+						kind: HostedReviewRequestKind::MergeRequest,
+						id: "77".to_string(),
+						title: None,
+						url: None,
+						author: None,
+					}),
+				}),
+				related_issues: vec![
+					HostedIssueRef {
+						provider: HostingProviderKind::GitHub,
+						host: Some("github.com".to_string()),
+						id: "#123".to_string(),
+						title: Some("closed".to_string()),
+						url: Some("https://example.com/issues/123".to_string()),
+						relationship: HostedIssueRelationshipKind::ClosedByReviewRequest,
+					},
+					HostedIssueRef {
+						provider: HostingProviderKind::GitHub,
+						host: Some("github.com".to_string()),
+						id: "#456".to_string(),
+						title: Some("related".to_string()),
+						url: None,
+						relationship: HostedIssueRelationshipKind::ReferencedByReviewRequest,
+					},
+				],
+			}),
+		};
+
+		let rendered = build_rendered_changeset_context(tempdir.path(), &changeset);
+		assert!(
+			rendered
+				.context
+				.contains("> _Owner:_ [@octocat](https://example.com/octocat)")
+		);
+		assert!(
+			rendered
+				.context
+				.contains("> _Review:_ [PR 42](https://example.com/pull/42)")
+		);
+		assert!(
+			rendered
+				.context
+				.contains("> _Introduced in:_ [`abcdef1`](https://example.com/commit/abcdef1)")
+		);
+		assert!(
+			rendered
+				.context
+				.contains("> _Last updated in:_ [`9876543`](https://example.com/commit/9876543)")
+		);
+		assert!(
+			rendered
+				.context
+				.contains("> _Closed issues:_ [#123](https://example.com/issues/123)")
+		);
+		assert!(rendered.context.contains("> _Related issues:_ #456"));
+		assert_eq!(rendered.change_owner.as_deref(), Some("@octocat"));
+		assert_eq!(rendered.review_request.as_deref(), Some("PR 42"));
+		assert_eq!(rendered.closed_issues.as_deref(), Some("#123"));
+		assert_eq!(rendered.related_issues.as_deref(), Some("#456"));
+
+		let package = sample_package_record(tempdir.path(), "pkg-a", "package-a");
+		let signal = ChangeSignal {
+			package_id: package.id.clone(),
+			requested_bump: Some(BumpSeverity::Minor),
+			explicit_version: None,
+			change_origin: "changeset".to_string(),
+			evidence_refs: vec!["manual".to_string()],
+			notes: Some("Added release note support".to_string()),
+			details: Some("Detailed explanation".to_string()),
+			change_type: Some("note".to_string()),
+			source_path: changeset_path.clone(),
+		};
+		let source_path = root_relative(tempdir.path(), &changeset.path);
+		let mapped = build_release_note_change(
+			&signal,
+			&[package.clone()],
+			tempdir.path(),
+			&BTreeMap::from([(source_path, rendered.clone())]),
+		)
+		.unwrap_or_else(|| panic!("expected mapped release note change"));
+		assert_eq!(mapped.package_name, "pkg-a");
+		assert_eq!(mapped.change_owner.as_deref(), Some("@octocat"));
+		assert_eq!(
+			mapped.review_request_link.as_deref(),
+			Some("[PR 42](https://example.com/pull/42)")
+		);
+		assert_eq!(mapped.related_issue_links.as_deref(), Some("#456"));
+
+		let no_notes = ChangeSignal {
+			notes: None,
+			..signal
+		};
+		assert!(
+			build_release_note_change(&no_notes, &[package], tempdir.path(), &BTreeMap::new())
+				.is_none()
+		);
+	}
+
+	#[test]
+	fn render_helpers_cover_actor_labels_links_sections_and_templates() {
+		assert_eq!(
+			render_actor_label(&HostedActorRef {
+				login: Some("octocat".to_string()),
+				source: HostedActorSourceKind::CommitAuthor,
+				..HostedActorRef::default()
+			}),
+			"@octocat"
+		);
+		assert_eq!(
+			render_actor_label(&HostedActorRef {
+				display_name: Some("Release Bot".to_string()),
+				source: HostedActorSourceKind::CommitAuthor,
+				..HostedActorRef::default()
+			}),
+			"Release Bot"
+		);
+		assert_eq!(
+			render_actor_label(&HostedActorRef {
+				source: HostedActorSourceKind::CommitAuthor,
+				..HostedActorRef::default()
+			}),
+			"unknown"
+		);
+		assert_eq!(
+			render_review_request_label(&HostedReviewRequestRef {
+				kind: HostedReviewRequestKind::PullRequest,
+				id: "12".to_string(),
+				..HostedReviewRequestRef::default()
+			}),
+			"PR 12"
+		);
+		assert_eq!(
+			render_review_request_label(&HostedReviewRequestRef {
+				kind: HostedReviewRequestKind::MergeRequest,
+				id: "9".to_string(),
+				..HostedReviewRequestRef::default()
+			}),
+			"MR 9"
+		);
+		assert_eq!(render_markdown_link("plain", None), "plain");
+		assert_eq!(
+			render_markdown_link("linked", Some("https://example.com")),
+			"[linked](https://example.com)"
+		);
+		let issues = vec![
+			HostedIssueRef {
+				id: "#1".to_string(),
+				url: Some("https://example.com/issues/1".to_string()),
+				relationship: HostedIssueRelationshipKind::Mentioned,
+				..HostedIssueRef::default()
+			},
+			HostedIssueRef {
+				id: "#2".to_string(),
+				url: None,
+				relationship: HostedIssueRelationshipKind::Manual,
+				..HostedIssueRef::default()
+			},
+		];
+		let issue_refs = issues.iter().collect::<Vec<_>>();
+		assert_eq!(render_issue_labels(&issue_refs), "#1, #2");
+		assert_eq!(
+			render_issue_links(&issue_refs),
+			"[#1](https://example.com/issues/1), #2"
+		);
+
+		let mut multi_label_change = sample_change("pkg-a", "pkg-a", ".changeset/a.md");
+		multi_label_change.package_labels = vec!["pkg-a".to_string(), "pkg-b".to_string()];
+		let block = format_group_labeled_entry(&multi_label_change, "#### Summary\n\nMore");
+		assert!(block.contains("> [!NOTE]"));
+		assert!(block.contains("*pkg-a*, *pkg-b*"));
+
+		let mut single_label_change = sample_change("pkg-a", "pkg-a", ".changeset/a.md");
+		single_label_change.package_labels = vec!["pkg-a".to_string()];
+		assert_eq!(
+			format_group_labeled_entry(&single_label_change, "- Added release note support"),
+			"- **pkg-a**: Added release note support"
+		);
+
+		let rendered = apply_change_template(
+			"#### {{ summary }}\n\n{{ details }}\n\n{{ context }}\n\n{{ change_owner_link }}\n\n{{ review_request_link }}\n\n{{ introduced_commit_link }}\n\n{{ last_updated_commit_link }}\n\n{{ related_issue_links }}\n\n{{ closed_issue_links }}",
+			&sample_change("pkg-a", "pkg-a", ".changeset/a.md"),
+			"sdk",
+			"1.2.3",
+		)
+		.unwrap_or_else(|| panic!("expected template to render"));
+		assert!(rendered.contains("Detailed explanation"));
+		assert!(rendered.contains("[@octocat](https://example.com/octocat)"));
+		assert!(rendered.contains("[PR 42](https://example.com/pr/42)"));
+		assert!(rendered.contains("[#10](https://example.com/issues/10)"));
+		assert!(rendered.contains("[#20](https://example.com/issues/20)"));
+		assert!(
+			apply_change_template(
+				"{{ missing_value }}",
+				&sample_change("pkg-a", "pkg-a", ".changeset/a.md"),
+				"sdk",
+				"1.2.3"
+			)
+			.is_none()
+		);
+		assert!(
+			apply_change_template(
+				"   ",
+				&sample_change("pkg-a", "pkg-a", ".changeset/a.md"),
+				"sdk",
+				"1.2.3"
+			)
+			.is_none()
+		);
+
+		let extra_sections = vec![
+			ExtraChangelogSection {
+				name: "Highlights".to_string(),
+				types: vec!["minor".to_string()],
+				default_bump: None,
+			},
+			ExtraChangelogSection {
+				name: "Notes".to_string(),
+				types: vec!["note".to_string()],
+				default_bump: None,
+			},
+		];
+		let sections = render_release_note_sections(
+			"sdk",
+			"1.2.3",
+			&extra_sections,
+			&["- {{ summary }}".to_string()],
+			&[
+				ReleaseNoteChange {
+					change_type: Some("note".to_string()),
+					..sample_change("pkg-a", "pkg-a", ".changeset/a.md")
+				},
+				ReleaseNoteChange {
+					change_type: Some("minor".to_string()),
+					bump: BumpSeverity::Minor,
+					summary: "Added group support".to_string(),
+					..sample_change("pkg-b", "pkg-b", ".changeset/b.md")
+				},
+				ReleaseNoteChange {
+					change_type: None,
+					bump: BumpSeverity::Major,
+					summary: "Breaking API".to_string(),
+					..sample_change("pkg-c", "pkg-c", ".changeset/c.md")
+				},
+				ReleaseNoteChange {
+					change_type: None,
+					bump: BumpSeverity::Patch,
+					summary: "Bug fix".to_string(),
+					..sample_change("pkg-d", "pkg-d", ".changeset/d.md")
+				},
+				ReleaseNoteChange {
+					change_type: None,
+					bump: BumpSeverity::Patch,
+					summary: "Bug fix".to_string(),
+					..sample_change("pkg-d", "pkg-d", ".changeset/d.md")
+				},
+			],
+		);
+		assert_eq!(sections[0].title, "Breaking changes");
+		assert_eq!(sections[1].title, "Fixes");
+		assert_eq!(sections[2].title, "Highlights");
+		assert_eq!(sections[3].title, "Notes");
+		assert_eq!(sections[1].entries, vec!["- Bug fix".to_string()]);
+		assert_eq!(
+			sections[2].entries,
+			vec!["- Added group support".to_string()]
+		);
+
+		let fallback = render_release_note_sections("sdk", "1.2.3", &[], &[], &[]);
+		assert_eq!(fallback[0].title, "Changed");
+		assert_eq!(fallback[0].entries, vec!["- prepare release".to_string()]);
+
+		let document = build_release_notes_document(
+			"sdk",
+			"1.2.3",
+			vec!["Summary".to_string()],
+			&extra_sections,
+			&["- {{ summary }}".to_string()],
+			&[sample_change("pkg-a", "pkg-a", ".changeset/a.md")],
+		);
+		assert_eq!(document.title, "1.2.3");
+		assert_eq!(document.summary, vec!["Summary".to_string()]);
+		assert!(!document.sections.is_empty());
+	}
+
+	#[test]
+	fn package_and_group_release_note_helpers_cover_empty_filtered_and_aggregated_paths() {
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let root = tempdir.path();
+		let package_a = sample_package_record(root, "pkg-a", "package-a");
+		let package_b = sample_package_record(root, "pkg-b", "package-b");
+		let mut configuration = empty_configuration(root);
+		configuration.defaults.empty_update_message =
+			Some("Default release for {{ package }} {{ version }}".to_string());
+		let mut package_definition = sample_package_definition("pkg-a");
+		package_definition.empty_update_message =
+			Some("Package release for {{ package }} in {{ group }} -> {{ version }}".to_string());
+		let mut group_definition =
+			sample_group_definition(GroupChangelogInclude::Selected(BTreeSet::from([
+				"pkg-a".to_string()
+			])));
+		group_definition.empty_update_message = Some(
+			"Group {{ group }} now at {{ version }} with {{ member_count }} members".to_string(),
+		);
+		configuration.packages = vec![package_definition.clone()];
+		configuration.groups = vec![group_definition.clone()];
+
+		let package_changes = package_release_note_changes(
+			&configuration,
+			Some(&package_definition),
+			Some(&group_definition),
+			&sample_decision("pkg-a", Some("sdk")),
+			&package_a,
+			None,
+			"1.2.3",
+		);
+		assert_eq!(package_changes.len(), 1);
+		assert!(
+			package_changes[0]
+				.summary
+				.contains("Package release for package-a in sdk -> 1.2.3")
+		);
+
+		let direct_change = sample_change("pkg-a", "pkg-a", ".changeset/a.md");
+		let direct = package_release_note_changes(
+			&configuration,
+			Some(&package_definition),
+			Some(&group_definition),
+			&sample_decision("pkg-a", Some("sdk")),
+			&package_a,
+			Some(&vec![direct_change.clone()]),
+			"1.2.3",
+		);
+		assert_eq!(direct, vec![direct_change.clone()]);
+
+		let group = sample_group(vec![package_a.id.clone(), package_b.id.clone()]);
+		let group_empty = group_release_note_changes(
+			&configuration,
+			Some(&group_definition),
+			&group,
+			&BTreeMap::new(),
+			&BTreeMap::new(),
+			&[package_a.clone(), package_b.clone()],
+			"2.0.0",
+		);
+		assert_eq!(group_empty.len(), 1);
+		assert!(
+			group_empty[0]
+				.summary
+				.contains("Group sdk now at 2.0.0 with 2 members")
+		);
+
+		let changes_by_package = BTreeMap::from([
+			(
+				package_a.id.clone(),
+				vec![
+					sample_change(&package_a.id, "pkg-a", ".changeset/shared.md"),
+					sample_change(&package_a.id, "pkg-a", ".changeset/shared.md"),
+				],
+			),
+			(
+				package_b.id.clone(),
+				vec![sample_change(
+					&package_b.id,
+					"pkg-b",
+					".changeset/shared.md",
+				)],
+			),
+		]);
+		let targets_by_path = BTreeMap::from([(
+			PathBuf::from(".changeset/shared.md"),
+			vec![
+				PreparedChangesetTarget {
+					id: "pkg-a".to_string(),
+					kind: ChangesetTargetKind::Package,
+					bump: Some(BumpSeverity::Minor),
+					origin: "changeset".to_string(),
+					evidence_refs: Vec::new(),
+					change_type: None,
+				},
+				PreparedChangesetTarget {
+					id: "pkg-b".to_string(),
+					kind: ChangesetTargetKind::Package,
+					bump: Some(BumpSeverity::Minor),
+					origin: "changeset".to_string(),
+					evidence_refs: Vec::new(),
+					change_type: None,
+				},
+			],
+		)]);
+		let aggregate_group_definition = sample_group_definition(GroupChangelogInclude::All);
+		let grouped = group_release_note_changes(
+			&configuration,
+			Some(&aggregate_group_definition),
+			&group,
+			&changes_by_package,
+			&targets_by_path,
+			&[package_a.clone(), package_b.clone()],
+			"2.0.0",
+		);
+		assert_eq!(grouped.len(), 1);
+		assert_eq!(
+			grouped[0].package_labels,
+			vec!["pkg-a".to_string(), "pkg-b".to_string()]
+		);
+		assert_eq!(grouped[0].package_name, "pkg-a, pkg-b");
+
+		let selected_filtered = group_release_note_changes(
+			&configuration,
+			Some(&group_definition),
+			&group,
+			&changes_by_package,
+			&targets_by_path,
+			&[package_a.clone(), package_b.clone()],
+			"2.0.0",
+		);
+		assert_eq!(selected_filtered.len(), 1);
+		assert!(
+			selected_filtered[0]
+				.summary
+				.contains("No group-facing notes were recorded")
+		);
+
+		let group_only_definition = sample_group_definition(GroupChangelogInclude::GroupOnly);
+		let filtered = group_release_note_changes(
+			&configuration,
+			Some(&group_only_definition),
+			&group,
+			&changes_by_package,
+			&targets_by_path,
+			&[package_a.clone(), package_b.clone()],
+			"2.0.0",
+		);
+		assert_eq!(filtered.len(), 1);
+		assert!(
+			filtered[0]
+				.summary
+				.contains("No group-facing notes were recorded")
+		);
+
+		let mut include_targets = BTreeSet::new();
+		include_targets.insert("pkg-a".to_string());
+		assert!(group_changelog_include_allows(
+			&GroupChangelogInclude::All,
+			&include_targets
+		));
+		assert!(!group_changelog_include_allows(
+			&GroupChangelogInclude::GroupOnly,
+			&include_targets,
+		));
+		assert!(group_changelog_include_allows(
+			&GroupChangelogInclude::Selected(BTreeSet::from(["pkg-a".to_string()])),
+			&include_targets,
+		));
+		assert!(!group_changelog_include_allows(
+			&GroupChangelogInclude::Selected(BTreeSet::from(["pkg-b".to_string()])),
+			&include_targets,
+		));
+
+		let group_target_map = BTreeMap::from([(
+			PathBuf::from(".changeset/group.md"),
+			vec![PreparedChangesetTarget {
+				id: "sdk".to_string(),
+				kind: ChangesetTargetKind::Group,
+				bump: Some(BumpSeverity::Minor),
+				origin: "changeset".to_string(),
+				evidence_refs: Vec::new(),
+				change_type: None,
+			}],
+		)]);
+		let group_target_change = sample_change("pkg-a", "pkg-a", ".changeset/group.md");
+		let filtered_group_target = filter_group_release_note_change(
+			&group_target_change,
+			Some(&group_definition),
+			&group,
+			&group_target_map,
+		)
+		.unwrap_or_else(|| panic!("expected group target to be included"));
+		assert_eq!(filtered_group_target.package_name, "sdk");
+		assert!(
+			filter_group_release_note_change(
+				&ReleaseNoteChange {
+					source_path: Some(".changeset/unknown.md".to_string()),
+					..sample_change("pkg-a", "pkg-a", ".changeset/group.md")
+				},
+				Some(&group_definition),
+				&group,
+				&group_target_map,
+			)
+			.is_none()
+		);
+
+		assert_eq!(
+			group_release_summary("sdk", &[], &BTreeSet::new()),
+			vec!["Grouped release for `sdk`.".to_string()]
+		);
+		assert_eq!(
+			group_release_summary(
+				"sdk",
+				&["pkg-a".to_string(), "pkg-b".to_string()],
+				&BTreeSet::new(),
+			),
+			vec![
+				"Grouped release for `sdk`.".to_string(),
+				"Members: pkg-a, pkg-b".to_string()
+			]
+		);
+		assert_eq!(
+			group_release_summary(
+				"sdk",
+				&["pkg-a".to_string(), "pkg-b".to_string()],
+				&BTreeSet::from(["pkg-a".to_string()]),
+			),
+			vec![
+				"Grouped release for `sdk`.".to_string(),
+				"Changed members: pkg-a".to_string(),
+				"Synchronized members: pkg-b".to_string()
+			]
+		);
+
+		assert_eq!(
+			group_changed_members(
+				&group,
+				&BTreeMap::from([(package_a.id.clone(), vec![direct_change])]),
+				&[package_a.clone(), package_b.clone()],
+			),
+			BTreeSet::from(["pkg-a".to_string()])
+		);
+		assert_eq!(
+			render_group_filtered_update_message("sdk"),
+			"No group-facing notes were recorded for this release. Member packages were updated as part of the synchronized group `sdk` version, but their changes are not configured for inclusion in this changelog."
+		);
+	}
+
+	#[test]
+	fn config_and_section_helpers_cover_package_ids_and_section_resolution() {
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let mut configured = sample_package_record(tempdir.path(), "pkg-a", "package-a");
+		assert_eq!(config_package_id(&configured), "pkg-a");
+		configured.metadata.clear();
+		assert_eq!(config_package_id(&configured), "package-a");
+		assert_eq!(
+			BuiltinReleaseSection::from_bump(BumpSeverity::Major),
+			BuiltinReleaseSection::Major
+		);
+		assert_eq!(
+			BuiltinReleaseSection::from_bump(BumpSeverity::Minor),
+			BuiltinReleaseSection::Minor
+		);
+		assert_eq!(
+			BuiltinReleaseSection::from_bump(BumpSeverity::Patch),
+			BuiltinReleaseSection::Patch
+		);
+		assert_eq!(
+			BuiltinReleaseSection::from_bump(BumpSeverity::None),
+			BuiltinReleaseSection::Patch
+		);
+		assert_eq!(BuiltinReleaseSection::Note.title(), "Notes");
+		assert_eq!(builtin_release_sections().len(), 4);
+
+		let selected = ResolvedSectionDefinition {
+			title: "Selected".to_string(),
+			types: vec!["custom".to_string(), " minor ".to_string()],
+		};
+		assert!(section_matches_resolved_type(&selected, "custom"));
+		assert!(section_matches_resolved_type(&selected, "minor"));
+		assert_eq!(
+			classify_release_note_change(
+				&ReleaseNoteChange {
+					change_type: Some("note".to_string()),
+					..sample_change("pkg-a", "pkg-a", ".changeset/a.md")
+				},
+				&[selected.clone()],
+			),
+			ResolvedReleaseSectionTarget::Builtin(BuiltinReleaseSection::Note)
+		);
+		assert_eq!(
+			classify_release_note_change(
+				&ReleaseNoteChange {
+					change_type: Some("custom".to_string()),
+					..sample_change("pkg-a", "pkg-a", ".changeset/a.md")
+				},
+				&[selected.clone()],
+			),
+			ResolvedReleaseSectionTarget::Extra(0)
+		);
+		assert_eq!(
+			classify_release_note_change(
+				&ReleaseNoteChange {
+					change_type: None,
+					bump: BumpSeverity::Minor,
+					..sample_change("pkg-a", "pkg-a", ".changeset/a.md")
+				},
+				&[selected],
+			),
+			ResolvedReleaseSectionTarget::Extra(0)
+		);
+	}
+}

--- a/crates/monochange/src/changelog.rs
+++ b/crates/monochange/src/changelog.rs
@@ -1728,11 +1728,13 @@ mod tests {
 				name: "Highlights".to_string(),
 				types: vec!["minor".to_string()],
 				default_bump: None,
+				description: None,
 			},
 			ExtraChangelogSection {
 				name: "Notes".to_string(),
 				types: vec!["note".to_string()],
 				default_bump: None,
+				description: None,
 			},
 		];
 		let sections = render_release_note_sections(

--- a/crates/monochange/src/changeset_policy.rs
+++ b/crates/monochange/src/changeset_policy.rs
@@ -514,14 +514,15 @@ mod tests {
 
 	#[test]
 	fn compute_changed_paths_since_reports_git_failures_and_includes_untracked_files() {
-		let non_git = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
-		let error = compute_changed_paths_since(non_git.path(), "HEAD")
+		let failing_repo = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		git(failing_repo.path(), &["init", "-b", "main"]);
+		let error = compute_changed_paths_since(failing_repo.path(), "definitely-missing-rev")
 			.err()
 			.unwrap_or_else(|| panic!("expected git diff failure"));
 		assert!(
 			error
 				.to_string()
-				.contains("git diff --name-only HEAD failed")
+				.contains("git diff --name-only definitely-missing-rev failed")
 		);
 
 		let repo = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));

--- a/crates/monochange/src/changeset_policy.rs
+++ b/crates/monochange/src/changeset_policy.rs
@@ -400,8 +400,19 @@ mod tests {
 	}
 
 	fn git(root: &Path, args: &[&str]) {
-		let output = Command::new("git")
-			.current_dir(root)
+		let mut command = Command::new("git");
+		command.current_dir(root);
+		for variable in [
+			"GIT_DIR",
+			"GIT_WORK_TREE",
+			"GIT_COMMON_DIR",
+			"GIT_INDEX_FILE",
+			"GIT_OBJECT_DIRECTORY",
+			"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+		] {
+			command.env_remove(variable);
+		}
+		let output = command
 			.args(args)
 			.output()
 			.unwrap_or_else(|error| panic!("git {args:?}: {error}"));

--- a/crates/monochange/src/changeset_policy.rs
+++ b/crates/monochange/src/changeset_policy.rs
@@ -363,3 +363,352 @@ fn render_changeset_verification_comment(
 	}
 	lines.join("\n")
 }
+
+#[cfg(test)]
+mod tests {
+	use std::fs;
+	use std::process::Command;
+
+	use monochange_core::PackageDefinition;
+	use monochange_core::PackageType;
+	use monochange_core::VersionFormat;
+
+	use super::*;
+
+	fn setup_fixture(relative: &str) -> tempfile::TempDir {
+		monochange_test_helpers::fs::setup_fixture_from(env!("CARGO_MANIFEST_DIR"), relative)
+	}
+
+	fn sample_package() -> PackageDefinition {
+		PackageDefinition {
+			id: "core".to_string(),
+			path: Path::new("crates/core").to_path_buf(),
+			package_type: PackageType::Cargo,
+			changelog: None,
+			extra_changelog_sections: Vec::new(),
+			empty_update_message: None,
+			release_title: None,
+			changelog_version_title: None,
+			versioned_files: Vec::new(),
+			ignore_ecosystem_versioned_files: false,
+			ignored_paths: vec!["README.md".to_string(), "docs/**".to_string()],
+			additional_paths: vec!["shared/**".to_string()],
+			tag: true,
+			release: true,
+			version_format: VersionFormat::Primary,
+		}
+	}
+
+	fn git(root: &Path, args: &[&str]) {
+		let output = Command::new("git")
+			.current_dir(root)
+			.args(args)
+			.output()
+			.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
+		assert!(
+			output.status.success(),
+			"git {args:?} failed: {}{}",
+			String::from_utf8_lossy(&output.stdout),
+			String::from_utf8_lossy(&output.stderr)
+		);
+	}
+
+	#[test]
+	fn affected_packages_requires_changeset_verification_to_be_enabled() {
+		let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		fs::create_dir_all(tempdir.path().join("crates/core/src"))
+			.unwrap_or_else(|error| panic!("create source tree: {error}"));
+		fs::write(
+			tempdir.path().join("Cargo.toml"),
+			"[workspace]\nmembers = [\"crates/core\"]\n",
+		)
+		.unwrap_or_else(|error| panic!("write workspace Cargo.toml: {error}"));
+		fs::write(
+			tempdir.path().join("crates/core/Cargo.toml"),
+			"[package]\nname = \"core\"\nversion = \"1.0.0\"\nedition = \"2021\"\n",
+		)
+		.unwrap_or_else(|error| panic!("write package Cargo.toml: {error}"));
+		fs::write(
+			tempdir.path().join("crates/core/src/lib.rs"),
+			"pub fn core() {}\n",
+		)
+		.unwrap_or_else(|error| panic!("write lib.rs: {error}"));
+		fs::write(
+			tempdir.path().join("monochange.toml"),
+			"[defaults]\npackage_type = \"cargo\"\n\n[changesets.verify]\nenabled = false\nrequired = true\ncomment_on_failure = true\n\n[package.core]\npath = \"crates/core\"\n",
+		)
+		.unwrap_or_else(|error| panic!("write monochange.toml: {error}"));
+
+		let error = affected_packages(
+			tempdir.path(),
+			&["crates/core/src/lib.rs".to_string()],
+			&Vec::new(),
+		)
+		.err()
+		.unwrap_or_else(|| panic!("expected disabled verification error"));
+		assert!(matches!(error, MonochangeError::Config(_)));
+		assert_eq!(
+			error.to_string(),
+			"config error: CLI command `affected` uses `AffectedPackages` but `[changesets.verify].enabled` is false"
+		);
+	}
+
+	#[test]
+	fn affected_packages_reports_missing_and_invalid_changeset_inputs() {
+		let fixture = setup_fixture("monochange/changeset-policy-base");
+		fs::create_dir_all(fixture.path().join(".changeset"))
+			.unwrap_or_else(|error| panic!("create .changeset dir: {error}"));
+		fs::write(fixture.path().join(".changeset/invalid.md"), "---\ncore:\n")
+			.unwrap_or_else(|error| panic!("write invalid changeset: {error}"));
+
+		let evaluation = affected_packages(
+			fixture.path(),
+			&[
+				"crates/core/src/lib.rs".to_string(),
+				".changeset/missing.md".to_string(),
+				".changeset/invalid.md".to_string(),
+			],
+			&Vec::new(),
+		)
+		.unwrap_or_else(|error| panic!("evaluate affected packages: {error}"));
+
+		assert_eq!(evaluation.status, ChangesetPolicyStatus::Failed);
+		assert!(
+			evaluation
+				.errors
+				.iter()
+				.any(|error| error.contains("does not exist in the checked-out workspace"))
+		);
+		assert!(
+			evaluation
+				.errors
+				.iter()
+				.any(|error| error.contains("failed to parse") || error.contains("invalid"))
+		);
+		assert!(evaluation.summary.contains("changeset verification failed"));
+		assert_eq!(
+			evaluation.summary,
+			"changeset verification failed: attached changesets do not cover 1 changed package"
+		);
+		assert!(evaluation.comment.is_some());
+	}
+
+	#[test]
+	fn affected_packages_marks_ignored_paths_and_omits_failure_comments_when_disabled() {
+		let fixture = setup_fixture("monochange/changeset-policy-base");
+		let evaluation = affected_packages(
+			fixture.path(),
+			&["crates/core/tests/policy.rs".to_string()],
+			&Vec::new(),
+		)
+		.unwrap_or_else(|error| panic!("affected packages for ignored path: {error}"));
+
+		assert_eq!(evaluation.status, ChangesetPolicyStatus::NotRequired);
+		assert_eq!(
+			evaluation.ignored_paths,
+			vec!["crates/core/tests/policy.rs".to_string()]
+		);
+		assert!(evaluation.affected_package_ids.is_empty());
+		assert!(evaluation.comment.is_none());
+	}
+
+	#[test]
+	fn compute_changed_paths_since_reports_git_failures_and_includes_untracked_files() {
+		let non_git = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let error = compute_changed_paths_since(non_git.path(), "HEAD")
+			.err()
+			.unwrap_or_else(|| panic!("expected git diff failure"));
+		assert!(
+			error
+				.to_string()
+				.contains("git diff --name-only HEAD failed")
+		);
+
+		let repo = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		git(repo.path(), &["init", "-b", "main"]);
+		git(repo.path(), &["config", "user.name", "monochange"]);
+		git(
+			repo.path(),
+			&["config", "user.email", "monochange@example.com"],
+		);
+		fs::write(repo.path().join("tracked.txt"), "one\n")
+			.unwrap_or_else(|error| panic!("write tracked file: {error}"));
+		git(repo.path(), &["add", "tracked.txt"]);
+		git(repo.path(), &["commit", "-m", "initial"]);
+		fs::write(repo.path().join("tracked.txt"), "two\n")
+			.unwrap_or_else(|error| panic!("update tracked file: {error}"));
+		fs::write(repo.path().join("new.txt"), "new\n")
+			.unwrap_or_else(|error| panic!("write untracked file: {error}"));
+
+		let changed = compute_changed_paths_since(repo.path(), "HEAD")
+			.unwrap_or_else(|error| panic!("compute changed paths: {error}"));
+		assert_eq!(
+			changed,
+			vec!["new.txt".to_string(), "tracked.txt".to_string()]
+		);
+
+		let removed_root = {
+			let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+			tempdir.path().to_path_buf()
+		};
+		let spawn_error = compute_changed_paths_since(&removed_root, "HEAD")
+			.err()
+			.unwrap_or_else(|| panic!("expected git spawn failure"));
+		assert!(
+			spawn_error
+				.to_string()
+				.contains("failed to run git diff --name-only HEAD")
+		);
+	}
+
+	#[test]
+	fn path_helpers_cover_normalization_matching_and_comment_rendering() {
+		let package = sample_package();
+		assert_eq!(
+			normalize_changed_path("./crates\\core//src/lib.rs"),
+			"crates/core//src/lib.rs"
+		);
+		assert!(is_changeset_markdown_path(".changeset/test.md"));
+		assert!(!is_changeset_markdown_path(".changeset/test.txt"));
+		assert!(path_touches_package("crates/core/src/lib.rs", &package));
+		assert!(path_touches_package("shared/config.json", &package));
+		assert!(path_is_ignored_for_package(
+			"crates/core/README.md",
+			&package
+		));
+		assert!(matches_any_package_pattern(
+			"crates/core/docs/guide.md",
+			&package,
+			&package.ignored_paths
+		));
+
+		let verify = ChangesetVerificationSettings {
+			enabled: true,
+			required: true,
+			comment_on_failure: true,
+			skip_labels: vec!["release-notes-not-needed".to_string()],
+		};
+		let evaluation = ChangesetPolicyEvaluation {
+			status: ChangesetPolicyStatus::Failed,
+			required: true,
+			enforce: true,
+			summary: "missing changesets".to_string(),
+			comment: None,
+			labels: vec!["release-notes-not-needed".to_string()],
+			matched_skip_labels: Vec::new(),
+			changed_paths: vec!["crates/core/src/lib.rs".to_string()],
+			matched_paths: vec!["crates/core/src/lib.rs".to_string()],
+			ignored_paths: vec!["crates/core/README.md".to_string()],
+			changeset_paths: vec![".changeset/core.md".to_string()],
+			affected_package_ids: vec!["core".to_string()],
+			covered_package_ids: Vec::new(),
+			uncovered_package_ids: vec!["core".to_string()],
+			errors: vec!["core is uncovered".to_string()],
+		};
+		let comment = render_changeset_verification_comment(&verify, &evaluation);
+		assert!(comment.contains("Changed package paths:"));
+		assert!(comment.contains("Affected packages:"));
+		assert!(comment.contains("Attached changeset files:"));
+		assert!(comment.contains("Errors:"));
+		assert!(comment.contains("Allowed skip labels:"));
+		assert!(comment.contains("How to fix:"));
+	}
+
+	#[test]
+	fn evaluate_and_verify_changesets_delegate_to_affected_packages() {
+		let fixture = setup_fixture("monochange/changeset-policy-base");
+		let changed_paths = vec!["crates/core/src/lib.rs".to_string()];
+		let labels = vec!["no-changeset-required".to_string()];
+
+		let affected = affected_packages(fixture.path(), &changed_paths, &labels)
+			.unwrap_or_else(|error| panic!("affected packages: {error}"));
+		let verified = verify_changesets(fixture.path(), &changed_paths, &labels)
+			.unwrap_or_else(|error| panic!("verify changesets: {error}"));
+		let evaluated = evaluate_changeset_policy(fixture.path(), &changed_paths, &labels)
+			.unwrap_or_else(|error| panic!("evaluate changeset policy: {error}"));
+
+		assert_eq!(verified, affected);
+		assert_eq!(evaluated, affected);
+	}
+
+	#[test]
+	fn render_comment_includes_related_skip_guidance() {
+		let verify = ChangesetVerificationSettings {
+			enabled: true,
+			required: false,
+			comment_on_failure: true,
+			skip_labels: vec!["docs-only".to_string()],
+		};
+		let evaluation = ChangesetPolicyEvaluation {
+			status: ChangesetPolicyStatus::Failed,
+			required: false,
+			enforce: false,
+			summary: "no coverage".to_string(),
+			comment: None,
+			labels: Vec::new(),
+			matched_skip_labels: Vec::new(),
+			changed_paths: Vec::new(),
+			matched_paths: Vec::new(),
+			ignored_paths: Vec::new(),
+			changeset_paths: Vec::new(),
+			affected_package_ids: Vec::new(),
+			covered_package_ids: Vec::new(),
+			uncovered_package_ids: Vec::new(),
+			errors: vec!["problem".to_string()],
+		};
+		let comment = render_changeset_verification_comment(&verify, &evaluation);
+		assert!(comment.contains("docs-only"));
+		assert!(comment.contains("apply one of the configured skip labels"));
+	}
+
+	#[test]
+	fn package_pattern_helpers_cover_root_relative_and_invalid_patterns() {
+		let package = sample_package();
+
+		assert!(path_is_within_package("crates/core", &package));
+		assert!(!path_is_within_package("docs/readme.md", &package));
+		assert!(path_is_ignored_for_package(
+			"crates/core/docs/guide.md",
+			&package
+		));
+		assert!(matches_any_package_pattern(
+			"crates/core/README.md",
+			&package,
+			&package.ignored_paths
+		));
+		assert!(!matches_any_package_pattern(
+			"crates/core/src/lib.rs",
+			&package,
+			&["[".to_string()]
+		));
+		assert!(!path_touches_package("docs/readme.md", &package));
+	}
+
+	#[test]
+	fn affected_packages_uses_invalid_changeset_summary_when_only_changeset_inputs_fail() {
+		let fixture = setup_fixture("monochange/changeset-policy-base");
+		fs::create_dir_all(fixture.path().join(".changeset"))
+			.unwrap_or_else(|error| panic!("create .changeset dir: {error}"));
+		fs::write(fixture.path().join(".changeset/invalid.md"), "---\ncore:\n")
+			.unwrap_or_else(|error| panic!("write invalid changeset: {error}"));
+
+		let evaluation = affected_packages(
+			fixture.path(),
+			&[".changeset/invalid.md".to_string()],
+			&Vec::new(),
+		)
+		.unwrap_or_else(|error| panic!("evaluate affected packages: {error}"));
+
+		assert_eq!(evaluation.status, ChangesetPolicyStatus::Failed);
+		assert_eq!(
+			evaluation.summary,
+			"changeset verification failed: one or more attached changeset files are invalid"
+		);
+		assert!(
+			evaluation
+				.errors
+				.iter()
+				.any(|error| error.contains("failed to parse"))
+		);
+	}
+}

--- a/crates/monochange/src/changeset_policy.rs
+++ b/crates/monochange/src/changeset_policy.rs
@@ -215,15 +215,16 @@ pub(crate) fn compute_changed_paths_since(
 	root: &Path,
 	since_rev: &str,
 ) -> MonochangeResult<Vec<String>> {
-	let diff_output = ProcessCommand::new("git")
+	let mut diff_command = ProcessCommand::new("git");
+	diff_command
 		.args(["diff", "--name-only", since_rev])
-		.current_dir(root)
-		.output()
-		.map_err(|error| {
-			MonochangeError::Config(format!(
-				"failed to run git diff --name-only {since_rev}: {error}"
-			))
-		})?;
+		.current_dir(root);
+	clear_git_env(&mut diff_command);
+	let diff_output = diff_command.output().map_err(|error| {
+		MonochangeError::Config(format!(
+			"failed to run git diff --name-only {since_rev}: {error}"
+		))
+	})?;
 	if !diff_output.status.success() {
 		let stderr = String::from_utf8_lossy(&diff_output.stderr);
 		return Err(MonochangeError::Config(format!(
@@ -236,9 +237,12 @@ pub(crate) fn compute_changed_paths_since(
 		.filter(|line| !line.is_empty())
 		.collect();
 
-	let untracked_output = ProcessCommand::new("git")
+	let mut untracked_command = ProcessCommand::new("git");
+	untracked_command
 		.args(["ls-files", "--others", "--exclude-standard"])
-		.current_dir(root)
+		.current_dir(root);
+	clear_git_env(&mut untracked_command);
+	let untracked_output = untracked_command
 		.output()
 		.map_err(|error| MonochangeError::Config(format!("failed to run git ls-files: {error}")))?;
 	if untracked_output.status.success() {
@@ -302,6 +306,19 @@ fn matches_any_package_pattern(
 				|| relative_path.is_some_and(|relative_path| compiled.matches(relative_path))
 		})
 	})
+}
+
+fn clear_git_env(command: &mut ProcessCommand) {
+	for variable in [
+		"GIT_DIR",
+		"GIT_WORK_TREE",
+		"GIT_COMMON_DIR",
+		"GIT_INDEX_FILE",
+		"GIT_OBJECT_DIRECTORY",
+		"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+	] {
+		command.env_remove(variable);
+	}
 }
 
 fn render_changeset_verification_comment(

--- a/crates/monochange/src/changesets.rs
+++ b/crates/monochange/src/changesets.rs
@@ -282,6 +282,267 @@ fn batch_load_changeset_contexts(
 		.collect()
 }
 
+#[cfg(test)]
+mod diagnostics_tests {
+	use std::fs;
+
+	use monochange_core::HostedCommitRef;
+	use monochange_core::HostedIssueRef;
+	use monochange_core::HostedIssueRelationshipKind;
+	use monochange_core::HostedReviewRequestKind;
+	use monochange_core::HostedReviewRequestRef;
+
+	use super::*;
+
+	#[test]
+	fn resolve_changeset_path_and_discovery_cover_missing_and_empty_directories() {
+		let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		fs::create_dir_all(tempdir.path().join(".changeset"))
+			.unwrap_or_else(|error| panic!("create changeset dir: {error}"));
+		fs::write(tempdir.path().join(".changeset/feature.md"), "---\n")
+			.unwrap_or_else(|error| panic!("write changeset: {error}"));
+
+		let resolved = resolve_changeset_path(tempdir.path(), "feature.md")
+			.unwrap_or_else(|error| panic!("resolve changeset path: {error}"));
+		assert_eq!(resolved, tempdir.path().join(".changeset/feature.md"));
+
+		let invalid = resolve_changeset_path(tempdir.path(), "notes.txt")
+			.err()
+			.unwrap_or_else(|| panic!("expected invalid changeset path"));
+		assert!(
+			invalid
+				.to_string()
+				.contains("requested changeset `notes.txt` does not exist")
+		);
+
+		let absolute = resolve_changeset_path(
+			tempdir.path(),
+			tempdir
+				.path()
+				.join(".changeset/feature.md")
+				.to_string_lossy()
+				.as_ref(),
+		)
+		.unwrap_or_else(|error| panic!("resolve absolute changeset path: {error}"));
+		assert_eq!(absolute, tempdir.path().join(".changeset/feature.md"));
+
+		let missing_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let missing_error = discover_changeset_paths(missing_dir.path())
+			.err()
+			.unwrap_or_else(|| panic!("expected missing changeset directory error"));
+		assert!(
+			missing_error
+				.to_string()
+				.contains("no markdown changesets found under .changeset")
+		);
+
+		let empty_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		fs::create_dir_all(empty_dir.path().join(".changeset"))
+			.unwrap_or_else(|error| panic!("create empty changeset dir: {error}"));
+		let empty_error = discover_changeset_paths(empty_dir.path())
+			.err()
+			.unwrap_or_else(|| panic!("expected empty changeset directory error"));
+		assert!(
+			empty_error
+				.to_string()
+				.contains("no markdown changesets found under .changeset")
+		);
+
+		let blocked_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		fs::write(blocked_dir.path().join(".changeset"), "not a directory\n")
+			.unwrap_or_else(|error| panic!("write blocking .changeset file: {error}"));
+		let blocked_error = discover_changeset_paths(blocked_dir.path())
+			.err()
+			.unwrap_or_else(|| panic!("expected read_dir error for file-backed .changeset path"));
+		assert!(blocked_error.to_string().contains("failed to read"));
+	}
+
+	#[test]
+	fn render_changeset_diagnostics_renders_full_context() {
+		let report = ChangesetDiagnosticsReport {
+			requested_changesets: vec![PathBuf::from(".changeset/feature.md")],
+			changesets: vec![PreparedChangeset {
+				path: PathBuf::from(".changeset/feature.md"),
+				summary: Some("ship feature".to_string()),
+				details: Some("long details".to_string()),
+				targets: vec![PreparedChangesetTarget {
+					id: "core".to_string(),
+					kind: ChangesetTargetKind::Package,
+					bump: Some(BumpSeverity::Minor),
+					origin: "manual".to_string(),
+					evidence_refs: vec!["src/lib.rs".to_string()],
+					change_type: Some("feature".to_string()),
+				}],
+				context: Some(ChangesetContext {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					capabilities: HostingCapabilities::default(),
+					introduced: Some(ChangesetRevision {
+						actor: None,
+						commit: Some(HostedCommitRef {
+							provider: HostingProviderKind::GitHub,
+							host: Some("github.com".to_string()),
+							sha: "abc123456789".to_string(),
+							short_sha: "abc1234".to_string(),
+							url: Some(
+								"https://github.com/example/repo/commit/abc123456789".to_string(),
+							),
+							authored_at: None,
+							committed_at: None,
+							author_name: None,
+							author_email: None,
+						}),
+						review_request: Some(HostedReviewRequestRef {
+							provider: HostingProviderKind::GitHub,
+							host: Some("github.com".to_string()),
+							kind: HostedReviewRequestKind::PullRequest,
+							id: "#42".to_string(),
+							title: None,
+							url: Some("https://github.com/example/repo/pull/42".to_string()),
+							author: None,
+						}),
+					}),
+					last_updated: Some(ChangesetRevision {
+						actor: None,
+						commit: Some(HostedCommitRef {
+							provider: HostingProviderKind::GitHub,
+							host: Some("github.com".to_string()),
+							sha: "def123456789".to_string(),
+							short_sha: "def1234".to_string(),
+							url: None,
+							authored_at: None,
+							committed_at: None,
+							author_name: None,
+							author_email: None,
+						}),
+						review_request: None,
+					}),
+					related_issues: vec![HostedIssueRef {
+						provider: HostingProviderKind::GitHub,
+						host: Some("github.com".to_string()),
+						id: "#99".to_string(),
+						title: None,
+						url: None,
+						relationship: HostedIssueRelationshipKind::Mentioned,
+					}],
+				}),
+			}],
+		};
+
+		let rendered = render_changeset_diagnostics(&report);
+		assert!(rendered.contains("changeset: .changeset/feature.md"));
+		assert!(rendered.contains("summary: ship feature"));
+		assert!(rendered.contains("details: long details"));
+		assert!(rendered.contains("- package core (bump: minor, origin: manual)"));
+		assert!(rendered.contains("evidence: src/lib.rs"));
+		assert!(rendered.contains("introduced: abc1234"));
+		assert!(rendered.contains("last-updated: def1234"));
+		assert!(rendered.contains("review request: #42 (https://github.com/example/repo/pull/42)"));
+		assert!(rendered.contains("related issues: #99"));
+
+		let minimal = render_changeset_diagnostics(&ChangesetDiagnosticsReport {
+			requested_changesets: vec![PathBuf::from(".changeset/minimal.md")],
+			changesets: vec![PreparedChangeset {
+				path: PathBuf::from(".changeset/minimal.md"),
+				summary: None,
+				details: None,
+				targets: Vec::new(),
+				context: Some(ChangesetContext {
+					provider: HostingProviderKind::GenericGit,
+					host: None,
+					capabilities: HostingCapabilities::default(),
+					introduced: None,
+					last_updated: Some(ChangesetRevision {
+						actor: None,
+						commit: None,
+						review_request: Some(HostedReviewRequestRef {
+							provider: HostingProviderKind::GitHub,
+							host: Some("github.com".to_string()),
+							kind: HostedReviewRequestKind::PullRequest,
+							id: "#77".to_string(),
+							title: None,
+							url: None,
+							author: None,
+						}),
+					}),
+					related_issues: Vec::new(),
+				}),
+			}],
+		});
+		assert!(minimal.contains("summary: <missing summary>"));
+		assert!(minimal.contains("review request: #77"));
+		assert!(!minimal.contains("targets:"));
+		assert_eq!(
+			render_changeset_diagnostics(&ChangesetDiagnosticsReport {
+				requested_changesets: Vec::new(),
+				changesets: Vec::new(),
+			}),
+			"no matching changesets found"
+		);
+	}
+
+	#[test]
+	fn build_prepared_changesets_uses_generic_context_without_a_git_repository() {
+		let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let loaded = vec![monochange_config::LoadedChangesetFile {
+			path: tempdir.path().join(".changeset/feature.md"),
+			summary: Some("feature".to_string()),
+			details: Some("details".to_string()),
+			targets: vec![monochange_config::LoadedChangesetTarget {
+				id: "core".to_string(),
+				kind: ChangesetTargetKind::Package,
+				bump: Some(BumpSeverity::Patch),
+				explicit_version: None,
+				origin: "manual".to_string(),
+				evidence_refs: vec!["src/lib.rs".to_string()],
+				change_type: Some("fix".to_string()),
+			}],
+			signals: Vec::new(),
+		}];
+
+		let prepared = build_prepared_changesets(tempdir.path(), &loaded);
+		assert_eq!(prepared.len(), 1);
+		assert!(prepared[0].path.ends_with(".changeset/feature.md"));
+		assert_eq!(prepared[0].summary.as_deref(), Some("feature"));
+		assert_eq!(prepared[0].details.as_deref(), Some("details"));
+		assert_eq!(prepared[0].targets[0].id, "core");
+		let context = prepared[0]
+			.context
+			.as_ref()
+			.unwrap_or_else(|| panic!("expected generic git context"));
+		assert_eq!(context.provider, HostingProviderKind::GenericGit);
+		assert!(context.introduced.is_none());
+		assert!(context.last_updated.is_none());
+		assert!(context.related_issues.is_empty());
+	}
+
+	#[test]
+	fn batch_git_log_helpers_cover_empty_and_malformed_output_paths() {
+		assert!(batch_load_changeset_contexts(Path::new("."), &[]).is_empty());
+		assert_eq!(
+			batch_git_log(Path::new("."), &[]),
+			(Default::default(), Default::default())
+		);
+		assert_eq!(
+			parse_batch_git_log_bytes(&[0xff, 0xfe], &[PathBuf::from(".changeset/feature.md")]),
+			(Default::default(), Default::default())
+		);
+
+		let malformed = "\
+header-without-separators
+M .changeset/feature.md
+
+sha\x1fauthor\x1femail\x1fauthored\x1fcommitted
+M
+M .changeset/ignored.md
+";
+		let (introduced, last_updated) =
+			parse_batch_git_log_output(malformed, &[PathBuf::from(".changeset/feature.md")]);
+		assert!(introduced.is_empty());
+		assert!(last_updated.is_empty());
+	}
+}
+
 /// Run a single `git log` command covering the entire `.changeset/` directory
 /// and return both the introduced and last-updated revision maps.
 ///

--- a/crates/monochange/src/changesets.rs
+++ b/crates/monochange/src/changesets.rs
@@ -521,11 +521,17 @@ mod diagnostics_tests {
 		assert!(batch_load_changeset_contexts(Path::new("."), &[]).is_empty());
 		assert_eq!(
 			batch_git_log(Path::new("."), &[]),
-			(Default::default(), Default::default())
+			(
+				std::collections::HashMap::default(),
+				std::collections::HashMap::default(),
+			)
 		);
 		assert_eq!(
 			parse_batch_git_log_bytes(&[0xff, 0xfe], &[PathBuf::from(".changeset/feature.md")]),
-			(Default::default(), Default::default())
+			(
+				std::collections::HashMap::default(),
+				std::collections::HashMap::default(),
+			)
 		);
 
 		let malformed = "\

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -2962,7 +2962,7 @@ mod tests {
 			id: None,
 			variables: Some(BTreeMap::from([(
 				"file_diffs_payload".to_string(),
-				monochange_core::CommandVariable::ChangedFiles,
+				CommandVariable::ChangedFiles,
 			)])),
 			inputs: BTreeMap::new(),
 		};

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -2380,9 +2380,14 @@ mod tests {
 	use std::sync::mpsc;
 
 	use monochange_config::load_workspace_configuration;
+	use monochange_core::ChangesetPolicyEvaluation;
+	use monochange_core::ChangesetPolicyStatus;
 	use monochange_core::CliCommandDefinition;
 	use monochange_core::CliStepDefinition;
+	use monochange_core::ReleaseOwnerKind;
+	use monochange_core::ReleasePlan;
 	use monochange_core::ShellConfig;
+	use monochange_core::VersionFormat;
 	use tempfile::tempdir;
 
 	use super::*;
@@ -2424,6 +2429,13 @@ mod tests {
 		(configuration, matches)
 	}
 
+	fn default_cli_command(name: &str) -> CliCommandDefinition {
+		monochange_core::default_cli_commands()
+			.into_iter()
+			.find(|command| command.name == name)
+			.unwrap_or_else(|| panic!("expected default cli command `{name}`"))
+	}
+
 	#[test]
 	fn evaluate_cli_step_condition_returns_false_for_blank_conditions() {
 		assert!(
@@ -2456,6 +2468,156 @@ mod tests {
 			parse_template_as_boolean(&serde_json::json!({ "nested": true }), "{{ inputs }}")
 				.unwrap_err();
 		assert!(error.to_string().contains("is not a scalar boolean value"));
+	}
+
+	#[test]
+	fn render_helpers_cover_release_commit_and_markdown_sections() {
+		let report = CommitReleaseReport {
+			subject: "chore(release): publish".to_string(),
+			body: "body".to_string(),
+			commit: Some("1234567890abcdef".to_string()),
+			tracked_paths: vec![PathBuf::from("Cargo.toml"), PathBuf::from("CHANGELOG.md")],
+			dry_run: false,
+			status: "already_exists".to_string(),
+		};
+		let text_lines = render_release_commit_report(&report);
+		assert!(
+			text_lines
+				.iter()
+				.any(|line| line.contains("subject: chore(release): publish"))
+		);
+		assert!(
+			text_lines
+				.iter()
+				.any(|line| line.contains("commit: 1234567"))
+		);
+		assert!(
+			text_lines
+				.iter()
+				.any(|line| line.contains("tracked paths:"))
+		);
+		assert!(
+			text_lines
+				.iter()
+				.any(|line| line.contains("status: already-exists"))
+		);
+
+		let markdown_lines = render_release_commit_report_markdown(&report, true);
+		assert!(
+			markdown_lines
+				.iter()
+				.any(|line| line.contains("**Subject:**"))
+		);
+		assert!(
+			markdown_lines
+				.iter()
+				.any(|line| line.contains("**Tracked paths:**"))
+		);
+
+		assert_eq!(yes_no(true), "yes");
+		assert_eq!(yes_no(false), "no");
+		assert_eq!(
+			paint_markdown_inline("plain", MarkdownStyle::Muted, false),
+			"plain"
+		);
+		assert!(paint_markdown_inline("code", MarkdownStyle::Code, true).contains("\u{1b}[35m"));
+		assert!(render_markdown_section("Empty", &[], false).starts_with("## Empty"));
+	}
+
+	#[test]
+	fn render_cli_command_results_include_release_details_policy_and_logs() {
+		let cli_command = default_cli_command("release");
+		let mut context = cli_context();
+		context.show_diff = true;
+		context.release_manifest_path = Some(PathBuf::from(".monochange/release.json"));
+		context.release_results = vec!["published v1.2.3".to_string()];
+		context.release_request_result = Some("opened release request".to_string());
+		context.issue_comment_results = vec!["commented on #42".to_string()];
+		context.release_commit_report = Some(CommitReleaseReport {
+			subject: "chore(release): publish".to_string(),
+			body: "body".to_string(),
+			commit: Some("abcdef1234567890".to_string()),
+			tracked_paths: vec![PathBuf::from("Cargo.toml")],
+			dry_run: false,
+			status: "completed".to_string(),
+		});
+		context.prepared_release = Some(PreparedRelease {
+			plan: ReleasePlan {
+				workspace_root: PathBuf::from("."),
+				decisions: Vec::new(),
+				groups: Vec::new(),
+				warnings: Vec::new(),
+				unresolved_items: Vec::new(),
+				compatibility_evidence: Vec::new(),
+			},
+			changeset_paths: vec![PathBuf::from(".changeset/feature.md")],
+			changesets: Vec::new(),
+			released_packages: vec!["core".to_string()],
+			version: Some("1.2.3".to_string()),
+			group_version: None,
+			release_targets: vec![ReleaseTarget {
+				id: "core".to_string(),
+				kind: ReleaseOwnerKind::Package,
+				version: "1.2.3".to_string(),
+				tag: true,
+				release: true,
+				version_format: VersionFormat::Primary,
+				tag_name: "v1.2.3".to_string(),
+				members: Vec::new(),
+				rendered_title: "core v1.2.3".to_string(),
+				rendered_changelog_title: "core v1.2.3".to_string(),
+			}],
+			changed_files: vec![PathBuf::from("Cargo.toml")],
+			changelogs: Vec::new(),
+			updated_changelogs: Vec::new(),
+			deleted_changesets: vec![PathBuf::from(".changeset/feature.md")],
+			dry_run: true,
+		});
+		context.prepared_file_diffs = vec![PreparedFileDiff {
+			path: PathBuf::from("Cargo.toml"),
+			diff: "-old\n+new".to_string(),
+			display_diff: "--- a/Cargo.toml\n+++ b/Cargo.toml\n-old\n+new".to_string(),
+		}];
+		context.command_logs = vec!["ran cargo check".to_string()];
+		context.changeset_policy_evaluation = Some(ChangesetPolicyEvaluation {
+			enforce: true,
+			required: true,
+			status: ChangesetPolicyStatus::Failed,
+			summary: "coverage missing".to_string(),
+			comment: None,
+			labels: Vec::new(),
+			matched_skip_labels: vec!["skip-changeset".to_string()],
+			changed_paths: vec!["crates/core/src/lib.rs".to_string()],
+			matched_paths: vec!["crates/core/src/lib.rs".to_string()],
+			ignored_paths: Vec::new(),
+			changeset_paths: vec![".changeset/feature.md".to_string()],
+			affected_package_ids: vec!["core".to_string()],
+			covered_package_ids: Vec::new(),
+			uncovered_package_ids: vec!["core".to_string()],
+			errors: vec!["missing changeset".to_string()],
+		});
+
+		let text = render_cli_command_result(&cli_command, &context);
+		assert!(text.contains("release manifest: .monochange/release.json"));
+		assert!(text.contains("releases:"));
+		assert!(text.contains("release request:"));
+		assert!(text.contains("issue comments:"));
+		assert!(text.contains("changed files:"));
+		assert!(text.contains("file diffs:"));
+		assert!(text.contains("deleted changesets:"));
+		assert!(text.contains("matched paths:"));
+		assert!(text.contains("changeset files:"));
+		assert!(text.contains("errors:"));
+		assert!(text.contains("commands:"));
+
+		let markdown = render_cli_command_markdown_result(&cli_command, &context);
+		assert!(markdown.contains("## Release targets"));
+		assert!(markdown.contains("## Release manifest"));
+		assert!(markdown.contains("## Release commit"));
+		assert!(markdown.contains("## Changed files"));
+		assert!(markdown.contains("## File diffs"));
+		assert!(markdown.contains("## Deleted changesets"));
+		assert!(markdown.contains("## Commands"));
 	}
 
 	#[test]
@@ -2725,6 +2887,196 @@ mod tests {
 		assert_eq!(
 			error.to_string(),
 			"discovery error: command `printf 'boom\\n' >&2; exit 3` failed: boom"
+		);
+	}
+
+	#[test]
+	fn build_release_template_value_serializes_file_diffs() {
+		let mut context = cli_context();
+		context.prepared_release = Some(PreparedRelease {
+			plan: ReleasePlan {
+				workspace_root: PathBuf::from("."),
+				decisions: Vec::new(),
+				groups: Vec::new(),
+				warnings: Vec::new(),
+				unresolved_items: Vec::new(),
+				compatibility_evidence: Vec::new(),
+			},
+			changeset_paths: Vec::new(),
+			changesets: Vec::new(),
+			released_packages: vec!["core".to_string()],
+			version: Some("1.2.3".to_string()),
+			group_version: None,
+			release_targets: Vec::new(),
+			changed_files: vec![PathBuf::from("Cargo.toml")],
+			changelogs: Vec::new(),
+			updated_changelogs: Vec::new(),
+			deleted_changesets: Vec::new(),
+			dry_run: true,
+		});
+		context.prepared_file_diffs = vec![PreparedFileDiff {
+			path: PathBuf::from("Cargo.toml"),
+			diff: "-old\n+new".to_string(),
+			display_diff: "--- a/Cargo.toml\n+++ b/Cargo.toml\n-old\n+new".to_string(),
+		}];
+
+		let manifest = build_release_template_value(&context);
+
+		let file_diffs = manifest
+			.get("file_diffs")
+			.and_then(serde_json::Value::as_array)
+			.unwrap_or_else(|| panic!("release template should include file_diffs"));
+		assert_eq!(file_diffs.len(), 1);
+		assert_eq!(file_diffs[0]["path"], serde_json::json!("Cargo.toml"));
+		assert_eq!(file_diffs[0]["diff"], serde_json::json!("-old\n+new"));
+	}
+
+	#[test]
+	fn step_references_release_file_diffs_detects_all_supported_locations() {
+		let from_when = CliStepDefinition::Validate {
+			name: Some("validate".to_string()),
+			when: Some("{{ file_diffs }}".to_string()),
+			inputs: BTreeMap::new(),
+		};
+		assert!(step_references_release_file_diffs(&from_when));
+
+		let mut inputs = BTreeMap::new();
+		inputs.insert(
+			"paths".to_string(),
+			CliStepInputValue::List(vec!["{{ file_diffs }}".to_string()]),
+		);
+		let from_inputs = CliStepDefinition::PublishRelease {
+			name: Some("publish".to_string()),
+			when: None,
+			inputs,
+		};
+		assert!(step_references_release_file_diffs(&from_inputs));
+
+		let from_variables = CliStepDefinition::Command {
+			name: Some("command".to_string()),
+			when: None,
+			command: "echo done".to_string(),
+			dry_run_command: None,
+			show_progress: None,
+			shell: ShellConfig::Default,
+			id: None,
+			variables: Some(BTreeMap::from([(
+				"file_diffs_payload".to_string(),
+				monochange_core::CommandVariable::ChangedFiles,
+			)])),
+			inputs: BTreeMap::new(),
+		};
+		assert!(step_references_release_file_diffs(&from_variables));
+
+		let without_file_diffs = CliStepDefinition::Command {
+			name: Some("command".to_string()),
+			when: None,
+			command: "echo done".to_string(),
+			dry_run_command: None,
+			show_progress: None,
+			shell: ShellConfig::Default,
+			id: None,
+			variables: None,
+			inputs: BTreeMap::from([("confirmed".to_string(), CliStepInputValue::Boolean(true))]),
+		};
+		assert!(!step_references_release_file_diffs(&without_file_diffs));
+	}
+
+	#[test]
+	fn render_cli_command_result_and_markdown_cover_empty_and_fallback_paths() {
+		let cli_command = default_cli_command("release");
+		let mut context = cli_context();
+		context.command_logs = vec!["ran command".to_string()];
+		let text = render_cli_command_result(&cli_command, &context);
+		assert!(text.contains("commands:"));
+		assert!(!text.contains("changed files:"));
+
+		let markdown = render_cli_command_markdown_result(&cli_command, &context);
+		assert_eq!(markdown, text);
+	}
+
+	#[test]
+	fn render_cli_command_result_and_markdown_include_release_target_details_without_diffs() {
+		let cli_command = default_cli_command("release");
+		let mut context = cli_context();
+		context.prepared_release = Some(PreparedRelease {
+			plan: ReleasePlan {
+				workspace_root: PathBuf::from("."),
+				decisions: Vec::new(),
+				groups: Vec::new(),
+				warnings: Vec::new(),
+				unresolved_items: Vec::new(),
+				compatibility_evidence: Vec::new(),
+			},
+			changeset_paths: Vec::new(),
+			changesets: Vec::new(),
+			released_packages: vec!["core".to_string(), "utils".to_string()],
+			version: Some("1.2.3".to_string()),
+			group_version: None,
+			release_targets: vec![ReleaseTarget {
+				id: "core".to_string(),
+				kind: ReleaseOwnerKind::Package,
+				version: "1.2.3".to_string(),
+				tag: true,
+				release: false,
+				version_format: VersionFormat::Primary,
+				tag_name: "v1.2.3".to_string(),
+				members: Vec::new(),
+				rendered_title: "core v1.2.3".to_string(),
+				rendered_changelog_title: "core v1.2.3".to_string(),
+			}],
+			changed_files: vec![PathBuf::from("Cargo.toml")],
+			changelogs: Vec::new(),
+			updated_changelogs: Vec::new(),
+			deleted_changesets: Vec::new(),
+			dry_run: true,
+		});
+		context.changeset_policy_evaluation = Some(ChangesetPolicyEvaluation {
+			enforce: false,
+			required: true,
+			status: ChangesetPolicyStatus::Skipped,
+			summary: "skip label matched".to_string(),
+			comment: None,
+			labels: vec!["docs-only".to_string()],
+			matched_skip_labels: vec!["docs-only".to_string()],
+			changed_paths: vec!["docs/readme.md".to_string()],
+			matched_paths: Vec::new(),
+			ignored_paths: Vec::new(),
+			changeset_paths: Vec::new(),
+			affected_package_ids: Vec::new(),
+			covered_package_ids: Vec::new(),
+			uncovered_package_ids: Vec::new(),
+			errors: Vec::new(),
+		});
+
+		let text = render_cli_command_result(&cli_command, &context);
+		assert!(text.contains("release targets:"));
+		assert!(text.contains("tag: true, release: false"));
+		assert!(text.contains("changed files:"));
+		assert!(!text.contains("file diffs:"));
+		assert!(text.contains("matched skip labels: docs-only"));
+
+		let markdown = render_cli_command_markdown_result(&cli_command, &context);
+		assert!(markdown.contains("## Release targets"));
+		assert!(markdown.contains("tag: yes"));
+		assert!(markdown.contains("release: no"));
+		assert!(markdown.contains("## Changed files"));
+		assert!(!markdown.contains("## Commands"));
+	}
+
+	#[test]
+	fn markdown_painting_covers_title_subtitle_and_muted_styles() {
+		assert!(paint_markdown_inline("title", MarkdownStyle::Title, true).contains("[36;1m"));
+		assert!(
+			paint_markdown_inline("subtitle", MarkdownStyle::Subtitle, true).contains("[37;1m")
+		);
+		assert!(paint_markdown_inline("muted", MarkdownStyle::Muted, true).contains("[2m"));
+
+		temp_env::with_vars(
+			[("NO_COLOR", Some("1")), ("TERM", Some("xterm-256color"))],
+			|| {
+				assert!(!stdout_supports_color());
+			},
 		);
 	}
 }

--- a/crates/monochange/src/git_support.rs
+++ b/crates/monochange/src/git_support.rs
@@ -395,4 +395,33 @@ mod tests {
 				.contains("failed to inspect ignored git path release.txt")
 		);
 	}
+
+	#[test]
+	fn run_git_capture_includes_stderr_for_failed_commands() {
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let root = tempdir.path();
+		init_git_repo(root);
+
+		let error = run_git_capture(root, &["show", "missing-commit"], "capture failure")
+			.err()
+			.unwrap_or_else(|| panic!("expected failed git capture"));
+		assert!(error.to_string().contains("capture failure"));
+		assert!(error.to_string().contains("missing-commit"));
+	}
+
+	#[test]
+	fn run_git_process_reports_nonzero_exit_status_details() {
+		let mut command = ProcessCommand::new("git");
+		command.arg("definitely-not-a-real-git-command");
+
+		let error = run_git_process(command, "process failure")
+			.err()
+			.unwrap_or_else(|| panic!("expected failed git process"));
+		assert!(error.to_string().contains("process failure"));
+		assert!(
+			error
+				.to_string()
+				.contains("definitely-not-a-real-git-command")
+		);
+	}
 }

--- a/crates/monochange/src/interactive.rs
+++ b/crates/monochange/src/interactive.rs
@@ -214,13 +214,15 @@ fn parse_selected_bump(selection: &str) -> BumpSeverity {
 	}
 }
 
-fn prompt_bump_for_target(target: &SelectableTarget) -> MonochangeResult<BumpSeverity> {
-	let label = match target.kind {
+fn bump_prompt_label(target: &SelectableTarget) -> String {
+	match target.kind {
 		TargetKind::Group => format!("Bump for group `{}`:", target.id),
 		TargetKind::Package => format!("Bump for package `{}`:", target.id),
-	};
+	}
+}
 
-	let selection = Select::new(&label, bump_options())
+fn prompt_bump_for_target(target: &SelectableTarget) -> MonochangeResult<BumpSeverity> {
+	let selection = Select::new(&bump_prompt_label(target), bump_options())
 		.with_starting_cursor(0)
 		.prompt()
 		.map_err(map_inquire_error)?;
@@ -228,8 +230,8 @@ fn prompt_bump_for_target(target: &SelectableTarget) -> MonochangeResult<BumpSev
 	Ok(parse_selected_bump(selection))
 }
 
-fn prompt_version_for_target(target: &SelectableTarget) -> MonochangeResult<Option<String>> {
-	let label = match target.kind {
+fn version_prompt_label(target: &SelectableTarget) -> String {
+	match target.kind {
 		TargetKind::Group => {
 			format!(
 				"Pin explicit version for group `{}`? (leave empty to skip):",
@@ -242,30 +244,34 @@ fn prompt_version_for_target(target: &SelectableTarget) -> MonochangeResult<Opti
 				target.id
 			)
 		}
-	};
+	}
+}
 
-	let version = Text::new(&label)
-		.with_validator(|input: &str| {
-			if input.is_empty() {
-				return Ok(Validation::Valid);
-			}
-			match semver::Version::parse(input) {
-				Ok(_) => Ok(Validation::Valid),
-				Err(error) => {
-					Ok(Validation::Invalid(
-						format!("invalid semver: {error}").into(),
-					))
-				}
-			}
-		})
+fn validate_semver_input(input: &str) -> Validation {
+	if input.is_empty() {
+		return Validation::Valid;
+	}
+	match semver::Version::parse(input) {
+		Ok(_) => Validation::Valid,
+		Err(error) => Validation::Invalid(format!("invalid semver: {error}").into()),
+	}
+}
+
+fn normalize_optional_text(value: String) -> Option<String> {
+	if value.trim().is_empty() {
+		None
+	} else {
+		Some(value)
+	}
+}
+
+fn prompt_version_for_target(target: &SelectableTarget) -> MonochangeResult<Option<String>> {
+	let version = Text::new(&version_prompt_label(target))
+		.with_validator(|input: &str| Ok(validate_semver_input(input)))
 		.prompt()
 		.map_err(map_inquire_error)?;
 
-	if version.is_empty() {
-		Ok(None)
-	} else {
-		Ok(Some(version))
-	}
+	Ok(normalize_optional_text(version))
 }
 
 fn change_type_options(target: &SelectableTarget) -> Option<Vec<String>> {
@@ -283,17 +289,19 @@ fn parse_change_type_selection(selection: &str) -> Option<String> {
 	}
 }
 
+fn change_type_prompt_label(target: &SelectableTarget) -> String {
+	match target.kind {
+		TargetKind::Group => format!("Change type for group `{}`:", target.id),
+		TargetKind::Package => format!("Change type for `{}`:", target.id),
+	}
+}
+
 fn prompt_change_type_for_target(target: &SelectableTarget) -> MonochangeResult<Option<String>> {
 	let Some(options) = change_type_options(target) else {
 		return Ok(None);
 	};
 
-	let label = match target.kind {
-		TargetKind::Group => format!("Change type for group `{}`:", target.id),
-		TargetKind::Package => format!("Change type for `{}`:", target.id),
-	};
-
-	let selection = Select::new(&label, options)
+	let selection = Select::new(&change_type_prompt_label(target), options)
 		.with_starting_cursor(0)
 		.prompt()
 		.map_err(map_inquire_error)?;
@@ -301,15 +309,17 @@ fn prompt_change_type_for_target(target: &SelectableTarget) -> MonochangeResult<
 	Ok(parse_change_type_selection(&selection))
 }
 
+fn validate_reason_input(input: &str) -> Validation {
+	if input.trim().is_empty() {
+		Validation::Invalid("reason cannot be empty".into())
+	} else {
+		Validation::Valid
+	}
+}
+
 fn prompt_reason() -> MonochangeResult<String> {
 	let reason = Text::new("Release-note summary (required):")
-		.with_validator(|input: &str| {
-			if input.trim().is_empty() {
-				Ok(Validation::Invalid("reason cannot be empty".into()))
-			} else {
-				Ok(Validation::Valid)
-			}
-		})
+		.with_validator(|input: &str| Ok(validate_reason_input(input)))
 		.prompt()
 		.map_err(map_inquire_error)?;
 
@@ -319,11 +329,7 @@ fn prompt_reason() -> MonochangeResult<String> {
 fn prompt_optional(label: &str) -> MonochangeResult<Option<String>> {
 	let value = Text::new(label).prompt().map_err(map_inquire_error)?;
 
-	if value.trim().is_empty() {
-		Ok(None)
-	} else {
-		Ok(Some(value))
-	}
+	Ok(normalize_optional_text(value))
 }
 
 fn map_inquire_error(error: inquire::error::InquireError) -> MonochangeError {
@@ -340,6 +346,7 @@ fn map_inquire_error(error: inquire::error::InquireError) -> MonochangeError {
 
 #[cfg(test)]
 mod __tests {
+	use inquire::validator::Validation;
 	use monochange_config::load_workspace_configuration;
 	use monochange_core::BumpSeverity;
 	use monochange_core::ChangesetSettings;
@@ -361,12 +368,18 @@ mod __tests {
 	use super::TargetKind;
 	use super::build_selectable_targets;
 	use super::bump_options;
+	use super::bump_prompt_label;
 	use super::change_type_options;
+	use super::change_type_prompt_label;
 	use super::map_inquire_error;
+	use super::normalize_optional_text;
 	use super::parse_change_type_selection;
 	use super::parse_selected_bump;
 	use super::prompt_change_type_for_target;
 	use super::run_interactive_change;
+	use super::validate_reason_input;
+	use super::validate_semver_input;
+	use super::version_prompt_label;
 
 	fn fixture_path(relative: &str) -> std::path::PathBuf {
 		monochange_test_helpers::fs::fixture_path_from(env!("CARGO_MANIFEST_DIR"), relative)
@@ -464,6 +477,59 @@ mod __tests {
 		assert_eq!(parse_selected_bump("minor"), BumpSeverity::Minor);
 		assert_eq!(parse_selected_bump("major"), BumpSeverity::Major);
 		assert_eq!(parse_selected_bump("patch"), BumpSeverity::Patch);
+	}
+
+	#[test]
+	fn prompt_label_helpers_cover_package_and_group_variants() {
+		let package = package_target(Vec::new());
+		let group = SelectableTarget {
+			id: "sdk".to_string(),
+			kind: TargetKind::Group,
+			display: "sdk".to_string(),
+			configured_types: vec!["docs".to_string()],
+		};
+		assert_eq!(bump_prompt_label(&package), "Bump for package `core`:");
+		assert_eq!(bump_prompt_label(&group), "Bump for group `sdk`:");
+		assert_eq!(
+			version_prompt_label(&package),
+			"Pin explicit version for `core`? (leave empty to skip):"
+		);
+		assert_eq!(
+			version_prompt_label(&group),
+			"Pin explicit version for group `sdk`? (leave empty to skip):"
+		);
+		assert_eq!(
+			change_type_prompt_label(&package),
+			"Change type for `core`:"
+		);
+		assert_eq!(
+			change_type_prompt_label(&group),
+			"Change type for group `sdk`:"
+		);
+	}
+
+	#[test]
+	fn validation_helpers_cover_semver_reason_and_optional_normalization() {
+		assert!(matches!(validate_semver_input(""), Validation::Valid));
+		assert!(matches!(validate_semver_input("1.2.3"), Validation::Valid));
+		assert!(matches!(
+			validate_semver_input("not-a-version"),
+			Validation::Invalid(_)
+		));
+		assert!(matches!(
+			validate_reason_input("ship it"),
+			Validation::Valid
+		));
+		assert!(matches!(
+			validate_reason_input("   "),
+			Validation::Invalid(_)
+		));
+		assert_eq!(normalize_optional_text(String::new()), None);
+		assert_eq!(normalize_optional_text("   ".to_string()), None);
+		assert_eq!(
+			normalize_optional_text("details".to_string()),
+			Some("details".to_string())
+		);
 	}
 
 	#[test]

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -310,6 +310,24 @@ pub enum AssistOutputFormat {
 	Json,
 }
 
+fn parse_assistant_or_default(value: Option<&String>) -> Assistant {
+	match value.map_or("generic", String::as_str) {
+		"generic" => Assistant::Generic,
+		"claude" => Assistant::Claude,
+		"cursor" => Assistant::Cursor,
+		"copilot" => Assistant::Copilot,
+		"pi" => Assistant::Pi,
+		_ => Assistant::Generic,
+	}
+}
+
+fn parse_assist_output_format_or_default(value: Option<&String>) -> AssistOutputFormat {
+	match value.map_or("text", String::as_str) {
+		"json" => AssistOutputFormat::Json,
+		_ => AssistOutputFormat::Text,
+	}
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ReleaseTarget {
 	pub id: String,
@@ -640,34 +658,10 @@ where
 			}
 		}
 		Some(("assist", assist_matches)) => {
-			let assistant = match assist_matches
-				.get_one::<String>("assistant")
-				.map(String::as_str)
-			{
-				Some("generic") => Assistant::Generic,
-				Some("claude") => Assistant::Claude,
-				Some("cursor") => Assistant::Cursor,
-				Some("copilot") => Assistant::Copilot,
-				Some("pi") => Assistant::Pi,
-				Some(value) => {
-					return Err(MonochangeError::Config(format!(
-						"unknown assistant `{value}`"
-					)));
-				}
-				None => return Err(MonochangeError::Config("missing assistant".to_string())),
-			};
-			let format = match assist_matches
-				.get_one::<String>("format")
-				.map_or("text", String::as_str)
-			{
-				"text" => AssistOutputFormat::Text,
-				"json" => AssistOutputFormat::Json,
-				value => {
-					return Err(MonochangeError::Config(format!(
-						"unknown assist output format `{value}`"
-					)));
-				}
-			};
+			let assistant =
+				parse_assistant_or_default(assist_matches.get_one::<String>("assistant"));
+			let format =
+				parse_assist_output_format_or_default(assist_matches.get_one::<String>("format"));
 			run_assist(assistant, format)
 		}
 		Some(("mcp", _)) => {
@@ -704,7 +698,7 @@ where
 				quiet,
 			)
 		}
-		None => Err(MonochangeError::Config("unknown command".to_string())),
+		None => Err(MonochangeError::Config("Usage: mc".to_string())),
 	}
 }
 

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -312,7 +312,6 @@ pub enum AssistOutputFormat {
 
 fn parse_assistant_or_default(value: Option<&String>) -> Assistant {
 	match value.map_or("generic", String::as_str) {
-		"generic" => Assistant::Generic,
 		"claude" => Assistant::Claude,
 		"cursor" => Assistant::Cursor,
 		"copilot" => Assistant::Copilot,

--- a/crates/monochange/src/prepared_release_cache.rs
+++ b/crates/monochange/src/prepared_release_cache.rs
@@ -521,6 +521,120 @@ mod tests {
 	}
 
 	#[test]
+	fn prepared_release_artifact_path_helpers_cover_default_and_explicit_paths() {
+		let root = Path::new("/workspace");
+		assert_eq!(
+			default_prepared_release_cache_path(root),
+			root.join(".monochange/prepared-release-cache.json")
+		);
+		assert_eq!(
+			resolve_prepared_release_artifact_path(
+				root,
+				Some(Path::new(".monochange/custom.json"))
+			),
+			root.join(".monochange/custom.json")
+		);
+	}
+
+	#[test]
+	fn read_prepared_release_artifact_reports_invalid_json() {
+		let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let artifact_path = tempdir.path().join("artifact.json");
+		fs::write(&artifact_path, "{invalid json")
+			.unwrap_or_else(|error| panic!("write artifact: {error}"));
+		let error = read_prepared_release_artifact(&artifact_path)
+			.err()
+			.unwrap_or_else(|| panic!("expected invalid json error"));
+		assert!(
+			error
+				.to_string()
+				.contains("failed to parse prepared release artifact")
+		);
+	}
+
+	#[test]
+	fn git_status_snapshot_sorts_results_and_excludes_artifact_path() {
+		let tempdir = setup_prepared_release_repo();
+		let root = tempdir.path();
+		fs::create_dir_all(root.join(".monochange"))
+			.unwrap_or_else(|error| panic!("mkdir .monochange: {error}"));
+		fs::write(root.join(".monochange/cache.json"), "{}")
+			.unwrap_or_else(|error| panic!("write cache: {error}"));
+		fs::write(root.join("zzz.txt"), "z\n").unwrap_or_else(|error| panic!("write zzz: {error}"));
+		fs::write(root.join("aaa.txt"), "a\n").unwrap_or_else(|error| panic!("write aaa: {error}"));
+
+		let lines = git_status_snapshot(root, Some(&root.join(".monochange/cache.json")))
+			.unwrap_or_else(|error| panic!("git status snapshot: {error}"));
+		assert_eq!(
+			lines,
+			vec!["?? aaa.txt".to_string(), "?? zzz.txt".to_string()]
+		);
+	}
+
+	#[test]
+	fn tracked_path_snapshots_deduplicate_paths_and_mark_deleted_entries() {
+		let tempdir = setup_prepared_release_repo();
+		let root = tempdir.path();
+		let configuration = load_workspace_configuration(root)
+			.unwrap_or_else(|error| panic!("load workspace configuration: {error}"));
+		let prepared = crate::prepare_release_execution_with_file_diffs(root, true, false)
+			.unwrap_or_else(|error| panic!("prepare release execution: {error}"));
+		let changed_file = prepared
+			.prepared_release
+			.changed_files
+			.first()
+			.cloned()
+			.unwrap_or_else(|| panic!("expected changed file"));
+		let deleted_changeset = PathBuf::from(".changeset/deleted.md");
+		let duplicate_path = changed_file.clone();
+
+		save_prepared_release_execution(
+			root,
+			&configuration,
+			&prepared.prepared_release,
+			&prepared.file_diffs,
+			Some(&explicit_artifact_path(root)),
+		)
+		.unwrap_or_else(|error| panic!("save prepared release artifact: {error}"));
+
+		let snapshots = tracked_path_snapshots(
+			root,
+			&PreparedRelease {
+				changed_files: vec![changed_file.clone(), duplicate_path],
+				deleted_changesets: vec![deleted_changeset.clone()],
+				..prepared.prepared_release.clone()
+			},
+		)
+		.unwrap_or_else(|error| panic!("tracked path snapshots: {error}"));
+
+		assert_eq!(
+			snapshots
+				.iter()
+				.filter(|snapshot| snapshot.path == changed_file)
+				.count(),
+			1
+		);
+		assert!(snapshots.iter().any(|snapshot| {
+			snapshot.path == deleted_changeset
+				&& snapshot.state == PreparedReleaseTrackedPathState::Deleted
+				&& snapshot.hash.is_none()
+		}));
+	}
+
+	#[test]
+	fn render_unified_file_diff_includes_expected_headers() {
+		let diff = render_unified_file_diff(
+			Path::new("crates/core/Cargo.toml"),
+			b"version = \"1.0.0\"\n",
+			b"version = \"1.0.1\"\n",
+		);
+		assert!(diff.contains("--- a/crates/core/Cargo.toml"));
+		assert!(diff.contains("+++ b/crates/core/Cargo.toml"));
+		assert!(diff.contains("-version = \"1.0.0\""));
+		assert!(diff.contains("+version = \"1.0.1\""));
+	}
+
+	#[test]
 	fn load_prepared_release_execution_rejects_non_dry_run_follow_up_from_dry_run_artifact() {
 		let tempdir = setup_prepared_release_repo();
 		let root = tempdir.path();
@@ -536,6 +650,44 @@ mod tests {
 		)
 		.unwrap_err();
 		assert!(error.to_string().contains("dry-run artifacts"));
+	}
+
+	#[test]
+	fn load_prepared_release_execution_returns_cached_release_with_message_and_timings() {
+		let tempdir = setup_prepared_release_repo();
+		let root = tempdir.path();
+		let artifact_path = explicit_artifact_path(root);
+		let configuration = load_workspace_configuration(root)
+			.unwrap_or_else(|error| panic!("load workspace configuration: {error}"));
+		let prepared = crate::prepare_release_execution_with_file_diffs(root, false, true)
+			.unwrap_or_else(|error| panic!("prepare release execution: {error}"));
+		save_prepared_release_execution(
+			root,
+			&configuration,
+			&prepared.prepared_release,
+			&prepared.file_diffs,
+			Some(&artifact_path),
+		)
+		.unwrap_or_else(|error| panic!("save prepared release artifact: {error}"));
+
+		let loaded = load_prepared_release_execution(
+			root,
+			&configuration,
+			Some(&artifact_path),
+			false,
+			true,
+		)
+		.unwrap_or_else(|error| panic!("load prepared release execution: {error}"))
+		.unwrap_or_else(|| panic!("expected cached prepared release"));
+
+		assert!(loaded.message.contains("reused prepared release artifact"));
+		assert_eq!(loaded.execution.prepared_release, prepared.prepared_release);
+		assert_eq!(loaded.execution.file_diffs, prepared.file_diffs);
+		assert_eq!(loaded.execution.phase_timings.len(), 1);
+		assert_eq!(
+			loaded.execution.phase_timings[0].label,
+			"load prepared release artifact"
+		);
 	}
 
 	#[test]
@@ -567,6 +719,84 @@ mod tests {
 				.to_string()
 				.contains("workspace configuration changed")
 		);
+	}
+
+	#[test]
+	fn load_prepared_release_execution_rejects_head_and_status_drift() {
+		let tempdir = setup_prepared_release_repo();
+		let root = tempdir.path();
+		let artifact_path = explicit_artifact_path(root);
+		let configuration = save_artifact(root, false, &artifact_path);
+
+		fs::write(root.join("README.md"), "head drift\n")
+			.unwrap_or_else(|error| panic!("write README: {error}"));
+		git(root, &["add", "README.md"]);
+		git(
+			root,
+			&["-c", "commit.gpgsign=false", "commit", "-m", "head drift"],
+		);
+
+		let head_error = load_prepared_release_execution(
+			root,
+			&configuration,
+			Some(&artifact_path),
+			false,
+			false,
+		)
+		.unwrap_err();
+		assert!(head_error.to_string().contains("HEAD changed"));
+
+		let tempdir = setup_prepared_release_repo();
+		let root = tempdir.path();
+		let artifact_path = explicit_artifact_path(root);
+		let configuration = save_artifact(root, false, &artifact_path);
+		fs::write(root.join("README.md"), "status drift\n")
+			.unwrap_or_else(|error| panic!("write README: {error}"));
+
+		let status_error = load_prepared_release_execution(
+			root,
+			&configuration,
+			Some(&artifact_path),
+			false,
+			false,
+		)
+		.unwrap_err();
+		assert!(
+			status_error
+				.to_string()
+				.contains("workspace status no longer matches")
+		);
+	}
+
+	#[test]
+	fn load_prepared_release_execution_rejects_tracked_path_drift() {
+		let tempdir = setup_prepared_release_repo();
+		let root = tempdir.path();
+		let artifact_path = explicit_artifact_path(root);
+		let configuration = save_artifact(root, false, &artifact_path);
+		let mut artifact = read_prepared_release_artifact(&artifact_path)
+			.unwrap_or_else(|error| panic!("read prepared release artifact: {error}"));
+		let tracked = artifact
+			.tracked_paths
+			.iter_mut()
+			.find(|tracked| tracked.state == PreparedReleaseTrackedPathState::File)
+			.unwrap_or_else(|| panic!("expected tracked file entry"));
+		tracked.hash = Some("not-the-real-hash".to_string());
+		fs::write(
+			&artifact_path,
+			serde_json::to_string_pretty(&artifact)
+				.unwrap_or_else(|error| panic!("serialize artifact: {error}")),
+		)
+		.unwrap_or_else(|error| panic!("rewrite artifact: {error}"));
+		let error = load_prepared_release_execution(
+			root,
+			&configuration,
+			Some(&artifact_path),
+			false,
+			false,
+		)
+		.unwrap_err();
+		assert!(error.to_string().contains("workspace content drifted"));
 	}
 
 	#[test]
@@ -627,6 +857,30 @@ mod tests {
 	}
 
 	#[test]
+	fn maybe_load_prepared_release_execution_returns_explicit_stale_errors() {
+		let tempdir = setup_prepared_release_repo();
+		let root = tempdir.path();
+		let artifact_path = explicit_artifact_path(root);
+		let configuration = save_artifact(root, false, &artifact_path);
+		fs::write(root.join("README.md"), "explicit stale\n")
+			.unwrap_or_else(|error| panic!("write README: {error}"));
+
+		let error = maybe_load_prepared_release_execution(
+			root,
+			&configuration,
+			Some(&artifact_path),
+			false,
+			false,
+		)
+		.unwrap_err();
+		assert!(
+			error
+				.to_string()
+				.contains("workspace status no longer matches")
+		);
+	}
+
+	#[test]
 	fn load_prepared_release_execution_rejects_missing_diff_previews_when_requested() {
 		let tempdir = setup_prepared_release_repo();
 		let root = tempdir.path();
@@ -642,5 +896,225 @@ mod tests {
 		)
 		.unwrap_err();
 		assert!(error.to_string().contains("diff previews"));
+	}
+
+	#[test]
+	fn status_line_path_handles_short_and_standard_status_lines() {
+		assert_eq!(status_line_path("??"), None);
+		assert_eq!(
+			status_line_path(" M Cargo.toml"),
+			Some(PathBuf::from("Cargo.toml"))
+		);
+	}
+
+	#[test]
+	fn ensure_monochange_artifact_ignored_updates_git_exclude_once() {
+		let tempdir = setup_prepared_release_repo();
+		let root = tempdir.path();
+		let artifact_path = root.join(".monochange/cache.json");
+
+		ensure_monochange_artifact_ignored(root, &artifact_path)
+			.unwrap_or_else(|error| panic!("ensure artifact ignored: {error}"));
+		ensure_monochange_artifact_ignored(root, &artifact_path)
+			.unwrap_or_else(|error| panic!("ensure artifact ignored twice: {error}"));
+
+		let exclude_path = root.join(".git").join("info").join("exclude");
+		let exclude = fs::read_to_string(&exclude_path)
+			.unwrap_or_else(|error| panic!("read git exclude: {error}"));
+		assert_eq!(
+			exclude
+				.lines()
+				.filter(|line| *line == ".monochange/")
+				.count(),
+			1
+		);
+	}
+
+	#[test]
+	fn save_prepared_release_execution_reports_parent_and_write_failures() {
+		let tempdir = setup_prepared_release_repo();
+		let root = tempdir.path();
+		let configuration = load_workspace_configuration(root)
+			.unwrap_or_else(|error| panic!("load workspace configuration: {error}"));
+		let prepared = crate::prepare_release_execution_with_file_diffs(root, false, false)
+			.unwrap_or_else(|error| panic!("prepare release execution: {error}"));
+
+		let parent_file = root.join("artifact-parent");
+		fs::write(&parent_file, "file\n")
+			.unwrap_or_else(|error| panic!("write parent file: {error}"));
+		let parent_error = save_prepared_release_execution(
+			root,
+			&configuration,
+			&prepared.prepared_release,
+			&prepared.file_diffs,
+			Some(&parent_file.join("artifact.json")),
+		)
+		.unwrap_err();
+		assert!(
+			parent_error
+				.to_string()
+				.contains("failed to create prepared release artifact directory")
+		);
+
+		let artifact_dir = root.join(".monochange/write-error");
+		fs::create_dir_all(&artifact_dir)
+			.unwrap_or_else(|error| panic!("create artifact dir: {error}"));
+		let write_error = save_prepared_release_execution(
+			root,
+			&configuration,
+			&prepared.prepared_release,
+			&prepared.file_diffs,
+			Some(&artifact_dir),
+		)
+		.unwrap_err();
+		assert!(
+			write_error
+				.to_string()
+				.contains("failed to write prepared release artifact")
+		);
+	}
+
+	#[test]
+	fn read_status_hash_and_ignore_helpers_report_non_git_cases() {
+		let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let root = tempdir.path();
+
+		let read_error = read_prepared_release_artifact(&root.join("missing.json"))
+			.err()
+			.unwrap_or_else(|| panic!("expected missing artifact error"));
+		assert!(
+			read_error
+				.to_string()
+				.contains("failed to read prepared release artifact")
+		);
+
+		let status_error = git_status_snapshot(root, None)
+			.err()
+			.unwrap_or_else(|| panic!("expected non-git status error"));
+		assert!(
+			status_error
+				.to_string()
+				.contains("failed to read git status")
+		);
+
+		let hash_error = hash_file_at_path(root, &root.join("missing.txt"))
+			.err()
+			.unwrap_or_else(|| panic!("expected hash-object failure"));
+		assert!(hash_error.to_string().contains("failed to hash"));
+
+		ensure_monochange_artifact_ignored(root, &root.join(".monochange/cache.json"))
+			.unwrap_or_else(|error| panic!("non-git artifact ignore should succeed: {error}"));
+	}
+
+	#[test]
+	fn git_status_snapshot_without_excluded_path_keeps_all_lines() {
+		let tempdir = setup_prepared_release_repo();
+		let root = tempdir.path();
+		fs::write(root.join("scratch.txt"), "scratch\n")
+			.unwrap_or_else(|error| panic!("write scratch file: {error}"));
+
+		let lines = git_status_snapshot(root, None)
+			.unwrap_or_else(|error| panic!("git status snapshot without exclusions: {error}"));
+		assert!(lines.iter().any(|line| line.ends_with("scratch.txt")));
+	}
+
+	#[test]
+	fn ensure_monochange_artifact_ignored_skips_paths_outside_monochange_dir() {
+		let tempdir = setup_prepared_release_repo();
+		let root = tempdir.path();
+		let artifact_path = root.join("prepared-release.json");
+		let exclude_path = root.join(".git").join("info").join("exclude");
+
+		ensure_monochange_artifact_ignored(root, &artifact_path)
+			.unwrap_or_else(|error| panic!("ensure external artifact ignored: {error}"));
+		let exclude = fs::read_to_string(&exclude_path).unwrap_or_default();
+		assert!(!exclude.contains(".monochange/"));
+	}
+
+	#[test]
+	fn ensure_monochange_artifact_ignored_appends_after_existing_content_without_newline() {
+		let tempdir = setup_prepared_release_repo();
+		let root = tempdir.path();
+		let exclude_path = root.join(".git").join("info").join("exclude");
+		fs::write(&exclude_path, "*.log")
+			.unwrap_or_else(|error| panic!("seed git exclude file: {error}"));
+
+		ensure_monochange_artifact_ignored(root, &root.join(".monochange/cache.json"))
+			.unwrap_or_else(|error| panic!("append monochange ignore rule: {error}"));
+
+		let exclude = fs::read_to_string(&exclude_path)
+			.unwrap_or_else(|error| panic!("read git exclude file: {error}"));
+		assert_eq!(exclude, "*.log\n.monochange/\n");
+	}
+
+	#[test]
+	fn ensure_monochange_artifact_ignored_reports_git_resolution_and_write_failures() {
+		let removed_root = {
+			let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+			tempdir.path().to_path_buf()
+		};
+		let resolve_error = ensure_monochange_artifact_ignored(
+			&removed_root,
+			&removed_root.join(".monochange/cache.json"),
+		)
+		.err()
+		.unwrap_or_else(|| panic!("expected git exclude resolution error"));
+		assert!(
+			resolve_error
+				.to_string()
+				.contains("failed to resolve git exclude path")
+		);
+
+		let tempdir = setup_prepared_release_repo();
+		let root = tempdir.path();
+		let exclude_path = root.join(".git").join("info").join("exclude");
+		fs::remove_file(&exclude_path)
+			.unwrap_or_else(|error| panic!("remove git exclude file: {error}"));
+		fs::create_dir_all(&exclude_path)
+			.unwrap_or_else(|error| panic!("create blocking exclude dir: {error}"));
+
+		let write_error =
+			ensure_monochange_artifact_ignored(root, &root.join(".monochange/cache.json"))
+				.err()
+				.unwrap_or_else(|| panic!("expected git exclude write error"));
+		assert!(
+			write_error
+				.to_string()
+				.contains("failed to update git exclude file")
+		);
+	}
+
+	#[test]
+	fn helper_error_paths_cover_hashing_and_git_exclude_directory_creation() {
+		let removed_root = {
+			let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+			let root = tempdir.path().to_path_buf();
+			fs::write(root.join("tracked.txt"), "tracked\n")
+				.unwrap_or_else(|error| panic!("write tracked file: {error}"));
+			root
+		};
+		let hash_error = hash_file_at_path(&removed_root, &removed_root.join("tracked.txt"))
+			.err()
+			.unwrap_or_else(|| panic!("expected hash spawn error"));
+		assert!(hash_error.to_string().contains("failed to hash"));
+
+		let tempdir = setup_prepared_release_repo();
+		let root = tempdir.path();
+		let info_dir = root.join(".git/info");
+		let backup_dir = root.join(".git/info-backup");
+		fs::rename(&info_dir, &backup_dir)
+			.unwrap_or_else(|error| panic!("move git info dir aside: {error}"));
+		fs::write(&info_dir, "blocking file\n")
+			.unwrap_or_else(|error| panic!("write blocking git info file: {error}"));
+
+		let create_dir_error =
+			ensure_monochange_artifact_ignored(root, &root.join(".monochange/cache.json"))
+				.err()
+				.unwrap_or_else(|| panic!("expected git exclude directory creation error"));
+		assert!(
+			create_dir_error
+				.to_string()
+				.contains("failed to create git exclude directory")
+		);
 	}
 }

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -1315,3 +1315,410 @@ pub(crate) fn text_discovery_report(report: &DiscoveryReport) -> String {
 	}
 	lines.join("\n")
 }
+
+#[cfg(test)]
+mod tests {
+	use std::fs;
+
+	use monochange_core::GroupChangelogInclude;
+	use monochange_core::PackageDefinition;
+	use monochange_core::PackageType;
+	use monochange_core::ProviderBotSettings;
+	use monochange_core::ProviderMergeRequestSettings;
+	use monochange_core::ProviderReleaseNotesSource;
+	use monochange_core::ProviderReleaseSettings;
+	use monochange_core::PublishState;
+	use monochange_core::ReleaseDecision;
+	use monochange_core::ReleaseManifest;
+	use monochange_core::ReleaseManifestChangelog;
+	use monochange_core::ReleaseManifestCompatibilityEvidence;
+	use monochange_core::ReleaseManifestPlan;
+	use monochange_core::ReleaseManifestPlanDecision;
+	use monochange_core::ReleaseManifestPlanGroup;
+	use monochange_core::ReleaseManifestTarget;
+	use monochange_core::ReleaseNotesSettings;
+	use monochange_core::SourceChangeRequest;
+	use monochange_core::SourceConfiguration;
+	use monochange_core::SourceProvider;
+	use monochange_core::WorkspaceConfiguration;
+	use monochange_core::WorkspaceDefaults;
+	use semver::Version;
+	use tempfile::tempdir;
+
+	use super::*;
+
+	fn empty_configuration(root: &Path) -> WorkspaceConfiguration {
+		WorkspaceConfiguration {
+			root_path: root.to_path_buf(),
+			defaults: WorkspaceDefaults::default(),
+			release_notes: ReleaseNotesSettings::default(),
+			packages: Vec::new(),
+			groups: Vec::new(),
+			cli: Vec::new(),
+			changesets: monochange_core::ChangesetSettings::default(),
+			source: None,
+			cargo: monochange_core::EcosystemSettings::default(),
+			npm: monochange_core::EcosystemSettings::default(),
+			deno: monochange_core::EcosystemSettings::default(),
+			dart: monochange_core::EcosystemSettings::default(),
+		}
+	}
+
+	fn source_configuration(provider: SourceProvider) -> SourceConfiguration {
+		SourceConfiguration {
+			provider,
+			owner: "acme".to_string(),
+			repo: "monochange".to_string(),
+			host: Some("https://example.com".to_string()),
+			api_url: None,
+			releases: ProviderReleaseSettings {
+				generate_notes: matches!(provider, SourceProvider::GitHub),
+				source: ProviderReleaseNotesSource::Monochange,
+				..ProviderReleaseSettings::default()
+			},
+			pull_requests: ProviderMergeRequestSettings::default(),
+			bot: ProviderBotSettings::default(),
+		}
+	}
+
+	fn sample_manifest() -> ReleaseManifest {
+		ReleaseManifest {
+			command: "release".to_string(),
+			dry_run: false,
+			version: Some("1.2.3".to_string()),
+			group_version: Some("2.0.0".to_string()),
+			release_targets: vec![ReleaseManifestTarget {
+				id: "sdk".to_string(),
+				kind: ReleaseOwnerKind::Group,
+				version: "2.0.0".to_string(),
+				tag: true,
+				release: true,
+				version_format: VersionFormat::Namespaced,
+				tag_name: "sdk/v2.0.0".to_string(),
+				members: vec!["pkg-a".to_string(), "pkg-b".to_string()],
+				rendered_title: "Release sdk v2.0.0".to_string(),
+				rendered_changelog_title: "sdk v2.0.0".to_string(),
+			}],
+			released_packages: vec!["pkg-a".to_string(), "pkg-b".to_string()],
+			changed_files: vec![
+				PathBuf::from("Cargo.toml"),
+				PathBuf::from("packages/pkg-a/package.json"),
+			],
+			changelogs: vec![ReleaseManifestChangelog {
+				owner_id: "sdk".to_string(),
+				owner_kind: ReleaseOwnerKind::Group,
+				path: PathBuf::from("CHANGELOG.md"),
+				format: ChangelogFormat::Monochange,
+				notes: ReleaseNotesDocument {
+					title: "2.0.0".to_string(),
+					summary: vec!["Grouped release".to_string()],
+					sections: vec![ReleaseNotesSection {
+						title: "Features".to_string(),
+						entries: vec!["- Added batching".to_string()],
+					}],
+				},
+				rendered: "## 2.0.0\n- Added batching".to_string(),
+			}],
+			changesets: Vec::new(),
+			deleted_changesets: vec![PathBuf::from(".changeset/feature.md")],
+			plan: ReleaseManifestPlan {
+				workspace_root: PathBuf::from("."),
+				decisions: vec![ReleaseManifestPlanDecision {
+					package: "pkg-a".to_string(),
+					bump: BumpSeverity::Minor,
+					trigger: "changeset".to_string(),
+					planned_version: Some("1.2.3".to_string()),
+					reasons: vec!["feature".to_string()],
+					upstream_sources: vec!["github".to_string()],
+				}],
+				groups: vec![ReleaseManifestPlanGroup {
+					id: "sdk".to_string(),
+					planned_version: Some("2.0.0".to_string()),
+					members: vec!["pkg-a".to_string(), "pkg-b".to_string()],
+					bump: BumpSeverity::Minor,
+				}],
+				warnings: vec!["warn".to_string()],
+				unresolved_items: vec!["todo".to_string()],
+				compatibility_evidence: vec![ReleaseManifestCompatibilityEvidence {
+					package: "pkg-a".to_string(),
+					provider: "rust-semver".to_string(),
+					severity: BumpSeverity::Minor,
+					summary: "minor api expansion".to_string(),
+					confidence: "high".to_string(),
+					evidence_location: Some("src/lib.rs".to_string()),
+				}],
+			},
+		}
+	}
+
+	fn sample_package(root: &Path, config_id: &str, package_type: PackageType) -> PackageRecord {
+		let manifest_path = root.join(format!("{config_id}/manifest"));
+		fs::create_dir_all(
+			manifest_path
+				.parent()
+				.unwrap_or_else(|| panic!("manifest path should have a parent")),
+		)
+		.unwrap_or_else(|error| panic!("create package dir: {error}"));
+		fs::write(&manifest_path, "manifest\n")
+			.unwrap_or_else(|error| panic!("write manifest: {error}"));
+		let ecosystem = match package_type {
+			PackageType::Cargo => Ecosystem::Cargo,
+			PackageType::Npm => Ecosystem::Npm,
+			PackageType::Deno => Ecosystem::Deno,
+			PackageType::Dart => Ecosystem::Dart,
+			PackageType::Flutter => Ecosystem::Flutter,
+		};
+		let mut package = PackageRecord::new(
+			ecosystem,
+			config_id,
+			manifest_path,
+			root.to_path_buf(),
+			Some(Version::new(1, 0, 0)),
+			PublishState::Public,
+		);
+		package
+			.metadata
+			.insert("config_id".to_string(), config_id.to_string());
+		package
+	}
+
+	#[test]
+	fn release_target_and_title_helpers_cover_provider_and_skip_paths() {
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let root = tempdir.path();
+		let mut configuration = empty_configuration(root);
+		let source = source_configuration(SourceProvider::Gitea);
+		configuration.source = Some(source.clone());
+		configuration.packages = vec![PackageDefinition {
+			id: "pkg-a".to_string(),
+			path: PathBuf::from("pkg-a"),
+			package_type: PackageType::Cargo,
+			changelog: None,
+			extra_changelog_sections: Vec::new(),
+			empty_update_message: None,
+			release_title: Some(
+				"Package {{ id }} {{ previous_version }} -> {{ version }}".to_string(),
+			),
+			changelog_version_title: Some("{{ version }}".to_string()),
+			versioned_files: Vec::new(),
+			ignore_ecosystem_versioned_files: false,
+			ignored_paths: Vec::new(),
+			additional_paths: Vec::new(),
+			tag: true,
+			release: true,
+			version_format: VersionFormat::Namespaced,
+		}];
+		configuration.groups = vec![monochange_core::GroupDefinition {
+			id: "sdk".to_string(),
+			packages: vec!["pkg-a".to_string()],
+			changelog: None,
+			changelog_include: GroupChangelogInclude::All,
+			extra_changelog_sections: Vec::new(),
+			empty_update_message: None,
+			release_title: Some("Group {{ id }} {{ compare_url }}".to_string()),
+			changelog_version_title: None,
+			versioned_files: Vec::new(),
+			tag: true,
+			release: true,
+			version_format: VersionFormat::Namespaced,
+		}];
+		let package = sample_package(root, "pkg-a", PackageType::Cargo);
+		let sorted_tags = vec![
+			"sdk/v2.0.0".to_string(),
+			"sdk/v1.5.0".to_string(),
+			"pkg-a/v1.0.0".to_string(),
+			"pkg-a/v0.9.0".to_string(),
+		];
+		assert_eq!(
+			find_previous_tag_in("pkg-a/v1.0.0", &sorted_tags),
+			Some("pkg-a/v0.9.0".to_string())
+		);
+		assert_eq!(
+			parse_tag_prefix_and_version("pkg-a/v1.2.3"),
+			Some(("pkg-a/v".to_string(), Version::new(1, 2, 3)))
+		);
+		assert_eq!(
+			compare_url_for_provider(&source, "pkg-a/v0.9.0", "pkg-a/v1.0.0"),
+			"https://example.com/acme/monochange/compare/pkg-a/v0.9.0...pkg-a/v1.0.0"
+		);
+
+		let plan = ReleasePlan {
+			workspace_root: root.to_path_buf(),
+			decisions: vec![
+				ReleaseDecision {
+					package_id: "missing".to_string(),
+					trigger_type: "changeset".to_string(),
+					recommended_bump: BumpSeverity::Patch,
+					planned_version: Some(Version::new(1, 0, 1)),
+					group_id: None,
+					reasons: Vec::new(),
+					upstream_sources: Vec::new(),
+					warnings: Vec::new(),
+				},
+				ReleaseDecision {
+					package_id: package.id.clone(),
+					trigger_type: "changeset".to_string(),
+					recommended_bump: BumpSeverity::Patch,
+					planned_version: None,
+					group_id: None,
+					reasons: Vec::new(),
+					upstream_sources: Vec::new(),
+					warnings: Vec::new(),
+				},
+				ReleaseDecision {
+					package_id: package.id.clone(),
+					trigger_type: "changeset".to_string(),
+					recommended_bump: BumpSeverity::Minor,
+					planned_version: Some(Version::new(1, 0, 0)),
+					group_id: None,
+					reasons: vec!["feature".to_string()],
+					upstream_sources: Vec::new(),
+					warnings: Vec::new(),
+				},
+			],
+			groups: vec![monochange_core::PlannedVersionGroup {
+				group_id: "sdk".to_string(),
+				display_name: "SDK".to_string(),
+				members: vec![package.id.clone()],
+				mismatch_detected: false,
+				planned_version: Some(Version::new(2, 0, 0)),
+				recommended_bump: BumpSeverity::Minor,
+			}],
+			warnings: Vec::new(),
+			unresolved_items: Vec::new(),
+			compatibility_evidence: Vec::new(),
+		};
+
+		let targets = build_release_targets(
+			&configuration,
+			&[package],
+			&plan,
+			&[PathBuf::from(".changeset/feature.md")],
+		);
+		assert_eq!(targets.len(), 2);
+		assert!(
+			targets
+				.iter()
+				.any(|target| target.id == "sdk" && !target.rendered_title.is_empty())
+		);
+		assert!(
+			targets
+				.iter()
+				.all(|target| !target.rendered_changelog_title.is_empty())
+		);
+
+		assert_eq!(
+			effective_title_template(Some("specific"), Some("default"), "builtin"),
+			"specific"
+		);
+		assert_eq!(
+			effective_title_template(None, Some("default"), "builtin"),
+			"default"
+		);
+		assert_eq!(
+			default_release_title_for_format(VersionFormat::Primary),
+			DEFAULT_RELEASE_TITLE_PRIMARY
+		);
+		assert_eq!(
+			default_changelog_version_title_for_format(VersionFormat::Namespaced),
+			DEFAULT_CHANGELOG_VERSION_TITLE_NAMESPACED
+		);
+		assert!(
+			build_cargo_manifest_updates(
+				&[],
+				&ReleasePlan {
+					workspace_root: root.to_path_buf(),
+					decisions: Vec::new(),
+					groups: Vec::new(),
+					warnings: Vec::new(),
+					unresolved_items: Vec::new(),
+					compatibility_evidence: Vec::new(),
+				}
+			)
+			.unwrap_or_else(|error| panic!("build empty cargo manifest updates: {error}"))
+			.is_empty()
+		);
+
+		assert!(
+			!resolve_release_datetime()
+				.format("%Y-%m-%d")
+				.to_string()
+				.is_empty()
+		);
+	}
+
+	#[test]
+	fn release_manifest_and_source_helpers_cover_provider_specific_paths() {
+		let manifest = sample_manifest();
+		let source = source_configuration(SourceProvider::GitLab);
+		let record = build_release_record(Some(&source), &manifest);
+		assert_eq!(record.kind, monochange_core::RELEASE_RECORD_KIND);
+		assert!(record.created_at.ends_with('Z'));
+		assert_eq!(
+			record
+				.provider
+				.as_ref()
+				.map(|provider| provider.repo.as_str()),
+			Some("monochange")
+		);
+		assert_eq!(
+			record.updated_changelogs,
+			vec![PathBuf::from("CHANGELOG.md")]
+		);
+		assert_eq!(record.release_targets[0].tag_name, "sdk/v2.0.0");
+
+		let release_request = build_source_release_requests(&source, &manifest);
+		assert_eq!(release_request.len(), 1);
+		assert_eq!(release_request[0].provider, SourceProvider::GitLab);
+
+		let change_request = build_source_change_request(&source, &manifest);
+		assert_eq!(change_request.provider, SourceProvider::GitLab);
+		assert!(
+			change_request
+				.commit_message
+				.body
+				.as_deref()
+				.is_some_and(|body| body.contains("Prepare release."))
+		);
+
+		let gitea = source_configuration(SourceProvider::Gitea);
+		let gitea_change_request = build_source_change_request(&gitea, &manifest);
+		assert_eq!(gitea_change_request.provider, SourceProvider::Gitea);
+		assert!(tag_url_for_provider(&gitea, "sdk/v2.0.0").contains("/releases/tag/"));
+
+		let dry_requests_error = publish_source_release_requests(&gitea, &[])
+			.err()
+			.unwrap_or_else(|| {
+				panic!("expected publishing gitea release requests without auth to fail")
+			});
+		assert!(dry_requests_error.to_string().contains("GITEA_TOKEN"));
+
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let publish_error = publish_source_change_request(
+			&gitea,
+			tempdir.path(),
+			&SourceChangeRequest {
+				provider: SourceProvider::Gitea,
+				repository: "acme/monochange".to_string(),
+				owner: "acme".to_string(),
+				repo: "monochange".to_string(),
+				base_branch: "main".to_string(),
+				head_branch: "release/v2.0.0".to_string(),
+				title: "chore: prepare release".to_string(),
+				body: "release body".to_string(),
+				labels: vec!["release".to_string()],
+				auto_merge: false,
+				commit_message: build_release_commit_message(Some(&gitea), &manifest),
+			},
+			&manifest.changed_files,
+		)
+		.err()
+		.unwrap_or_else(|| {
+			panic!("expected publishing a gitea change request outside a git repo to fail")
+		});
+		assert!(
+			publish_error.to_string().contains("git")
+				|| publish_error.to_string().contains("failed")
+		);
+	}
+}

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -1467,7 +1467,7 @@ mod tests {
 			PackageType::Deno => Ecosystem::Deno,
 			PackageType::Dart => Ecosystem::Dart,
 			PackageType::Flutter => Ecosystem::Flutter,
-			_ => Ecosystem::Cargo,
+			_ => unreachable!("unsupported package type in sample_package"),
 		};
 		let mut package = PackageRecord::new(
 			ecosystem,

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -1467,6 +1467,7 @@ mod tests {
 			PackageType::Deno => Ecosystem::Deno,
 			PackageType::Dart => Ecosystem::Dart,
 			PackageType::Flutter => Ecosystem::Flutter,
+			_ => Ecosystem::Cargo,
 		};
 		let mut package = PackageRecord::new(
 			ecosystem,

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -1969,7 +1969,7 @@ mod workspace_ops_tests {
 		let root = tempdir.path();
 		fs::create_dir_all(root.join("monochange.toml"))
 			.unwrap_or_else(|error| panic!("create blocking config dir: {error}"));
-		let init_error = init_workspace(root, true)
+		let init_error = init_workspace(root, true, None)
 			.err()
 			.unwrap_or_else(|| panic!("expected init write error"));
 		assert!(init_error.to_string().contains("failed to write"));
@@ -2032,7 +2032,7 @@ mod workspace_ops_tests {
 		.unwrap();
 		fs::write(root.join("packages/core/changelog.md"), "# Changelog\n").unwrap();
 
-		let rendered = render_annotated_init_config(root)
+		let rendered = render_annotated_init_config(root, None, None)
 			.unwrap_or_else(|error| panic!("render annotated config: {error}"));
 		assert!(rendered.contains("type = \"cargo\""));
 		assert!(rendered.contains("type = \"npm\""));

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -1816,6 +1816,7 @@ mod workspace_ops_tests {
 	use monochange_core::HostedCommitRef;
 	use monochange_core::HostingCapabilities;
 	use monochange_core::HostingProviderKind;
+	use monochange_core::PackageDefinition;
 	use monochange_core::PreparedChangeset;
 	use monochange_core::ProviderBotSettings;
 	use monochange_core::ProviderMergeRequestSettings;
@@ -1823,6 +1824,7 @@ mod workspace_ops_tests {
 	use monochange_core::ShellConfig;
 	use monochange_core::SourceConfiguration;
 	use monochange_core::SourceProvider;
+	use monochange_core::VersionFormat;
 	use monochange_core::WorkspaceConfiguration;
 
 	use super::*;
@@ -1832,6 +1834,10 @@ mod workspace_ops_tests {
 			env!("CARGO_MANIFEST_DIR"),
 			"workspace-ops/lockfile-command-helpers",
 		)
+	}
+
+	fn setup_fixture(relative: &str) -> tempfile::TempDir {
+		monochange_test_helpers::fs::setup_fixture_from(env!("CARGO_MANIFEST_DIR"), relative)
 	}
 
 	#[cfg(unix)]
@@ -1940,6 +1946,295 @@ mod workspace_ops_tests {
 		.err()
 		.unwrap_or_else(|| panic!("expected remap error"));
 		assert!(error.to_string().contains("was outside workspace root"));
+	}
+
+	#[test]
+	fn remap_workspace_path_maps_workspace_paths_into_the_temp_root() {
+		let fixture = setup_workspace_ops_fixture();
+		let temp_root = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+
+		let remapped = remap_workspace_path(
+			fixture.path(),
+			temp_root.path(),
+			&fixture.path().join("root.txt"),
+		)
+		.unwrap_or_else(|error| panic!("remap workspace path: {error}"));
+
+		assert_eq!(remapped, temp_root.path().join("root.txt"));
+	}
+
+	#[test]
+	fn init_and_populate_workspace_cover_common_error_and_noop_paths() {
+		let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let root = tempdir.path();
+		fs::create_dir_all(root.join("monochange.toml"))
+			.unwrap_or_else(|error| panic!("create blocking config dir: {error}"));
+		let init_error = init_workspace(root, true)
+			.err()
+			.unwrap_or_else(|| panic!("expected init write error"));
+		assert!(init_error.to_string().contains("failed to write"));
+
+		let empty_root = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let missing_error = populate_workspace(empty_root.path())
+			.err()
+			.unwrap_or_else(|| panic!("expected missing config error"));
+		assert!(missing_error.to_string().contains("run `mc init` first"));
+
+		let populated_root = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		fs::write(
+			populated_root.path().join("monochange.toml"),
+			render_cli_commands_toml(&default_cli_commands()),
+		)
+		.unwrap_or_else(|error| panic!("write populated config: {error}"));
+		let populated = populate_workspace(populated_root.path())
+			.unwrap_or_else(|error| panic!("populate no-op: {error}"));
+		assert!(populated.added_commands.is_empty());
+	}
+
+	#[test]
+	fn init_rendering_helpers_cover_duplicate_names_changelogs_and_package_types() {
+		let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let root = tempdir.path();
+		fs::create_dir_all(root.join("crates/core/src")).unwrap();
+		fs::create_dir_all(root.join("packages/core")).unwrap();
+		fs::create_dir_all(root.join("apps/cli")).unwrap();
+		fs::create_dir_all(root.join("apps/mobile")).unwrap();
+		fs::write(
+			root.join("Cargo.toml"),
+			"[workspace]\nmembers = [\"crates/core\"]\n",
+		)
+		.unwrap();
+		fs::write(
+			root.join("crates/core/Cargo.toml"),
+			"[package]\nname = \"core\"\nversion = \"1.0.0\"\nedition = \"2021\"\n",
+		)
+		.unwrap();
+		fs::write(
+			root.join("packages/core/package.json"),
+			r#"{ "name": "core", "version": "1.0.0" }"#,
+		)
+		.unwrap();
+		fs::write(
+			root.join("apps/cli/deno.json"),
+			r#"{ "name": "@acme/cli", "version": "1.0.0" }"#,
+		)
+		.unwrap();
+		fs::write(
+			root.join("apps/mobile/pubspec.yaml"),
+			"name: mobile\nversion: 1.0.0\nflutter:\n  uses-material-design: true\n",
+		)
+		.unwrap();
+		fs::create_dir_all(root.join("packages/dart_pkg/lib")).unwrap();
+		fs::write(
+			root.join("packages/dart_pkg/pubspec.yaml"),
+			"name: dart_pkg\nversion: 1.0.0\n",
+		)
+		.unwrap();
+		fs::write(root.join("packages/core/changelog.md"), "# Changelog\n").unwrap();
+
+		let rendered = render_annotated_init_config(root)
+			.unwrap_or_else(|error| panic!("render annotated config: {error}"));
+		assert!(rendered.contains("type = \"cargo\""));
+		assert!(rendered.contains("type = \"npm\""));
+		assert!(rendered.contains("type = \"deno\""));
+		assert!(rendered.contains("type = \"dart\""));
+		assert!(rendered.contains("type = \"flutter\""));
+		assert!(rendered.contains("changelog = \"packages/core/changelog.md\""));
+		assert!(rendered.contains("packages/core"));
+
+		assert_eq!(
+			detect_default_changelog(root, &root.join("packages/core")),
+			Some(PathBuf::from("packages/core/changelog.md"))
+		);
+		assert_eq!(
+			package_type_for_ecosystem(Ecosystem::Cargo),
+			PackageType::Cargo
+		);
+		assert_eq!(package_type_for_ecosystem(Ecosystem::Npm), PackageType::Npm);
+		assert_eq!(
+			package_type_for_ecosystem(Ecosystem::Deno),
+			PackageType::Deno
+		);
+		assert_eq!(
+			package_type_for_ecosystem(Ecosystem::Dart),
+			PackageType::Dart
+		);
+		assert_eq!(
+			package_type_for_ecosystem(Ecosystem::Flutter),
+			PackageType::Flutter
+		);
+	}
+
+	#[test]
+	fn validate_and_discover_release_workspace_cover_fallback_and_errors() {
+		let empty_root = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		fs::write(empty_root.path().join("monochange.toml"), "").unwrap();
+		validate_cargo_workspace_version_groups(empty_root.path())
+			.unwrap_or_else(|error| panic!("validate empty workspace: {error}"));
+
+		let fixture = setup_fixture("monochange/release-base");
+		let configuration = load_workspace_configuration(fixture.path())
+			.unwrap_or_else(|error| panic!("load config: {error}"));
+		let report = discover_release_workspace(fixture.path(), &configuration)
+			.unwrap_or_else(|error| panic!("discover release workspace: {error}"));
+		assert_eq!(report.packages.len(), 2);
+
+		let fallback = discover_release_workspace(
+			fixture.path(),
+			&WorkspaceConfiguration {
+				packages: Vec::new(),
+				..configuration.clone()
+			},
+		)
+		.unwrap_or_else(|error| panic!("discover fallback workspace: {error}"));
+		assert!(!fallback.packages.is_empty());
+
+		let broken = WorkspaceConfiguration {
+			packages: vec![PackageDefinition {
+				id: "missing".to_string(),
+				path: PathBuf::from("missing"),
+				package_type: PackageType::Cargo,
+				changelog: None,
+				extra_changelog_sections: Vec::new(),
+				empty_update_message: None,
+				release_title: None,
+				changelog_version_title: None,
+				versioned_files: Vec::new(),
+				ignore_ecosystem_versioned_files: false,
+				ignored_paths: Vec::new(),
+				additional_paths: Vec::new(),
+				tag: true,
+				release: true,
+				version_format: VersionFormat::Primary,
+			}],
+			..configuration
+		};
+		let error = discover_release_workspace(fixture.path(), &broken)
+			.err()
+			.unwrap_or_else(|| panic!("expected configured package discovery error"));
+		assert!(
+			error.to_string().contains("failed to read")
+				|| error.to_string().contains("could not be discovered")
+		);
+
+		let undetected_root =
+			tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		fs::create_dir_all(undetected_root.path().join("empty-package"))
+			.unwrap_or_else(|error| panic!("create empty package dir: {error}"));
+		let undetected = WorkspaceConfiguration {
+			root_path: undetected_root.path().to_path_buf(),
+			defaults: monochange_core::WorkspaceDefaults {
+				package_type: Some(PackageType::Cargo),
+				..monochange_core::WorkspaceDefaults::default()
+			},
+			release_notes: monochange_core::ReleaseNotesSettings::default(),
+			packages: vec![PackageDefinition {
+				id: "empty".to_string(),
+				path: PathBuf::from("empty-package"),
+				package_type: PackageType::Cargo,
+				changelog: None,
+				extra_changelog_sections: Vec::new(),
+				empty_update_message: None,
+				release_title: None,
+				changelog_version_title: None,
+				versioned_files: Vec::new(),
+				ignore_ecosystem_versioned_files: false,
+				ignored_paths: Vec::new(),
+				additional_paths: Vec::new(),
+				tag: true,
+				release: true,
+				version_format: VersionFormat::Primary,
+			}],
+			groups: Vec::new(),
+			cli: Vec::new(),
+			changesets: monochange_core::ChangesetSettings::default(),
+			source: None,
+			cargo: monochange_core::EcosystemSettings::default(),
+			npm: monochange_core::EcosystemSettings::default(),
+			deno: monochange_core::EcosystemSettings::default(),
+			dart: monochange_core::EcosystemSettings::default(),
+		};
+		let undetected_error = discover_release_workspace(undetected_root.path(), &undetected)
+			.err()
+			.unwrap_or_else(|| panic!("expected configured package none-discovered error"));
+		assert!(
+			undetected_error
+				.to_string()
+				.contains("could not be discovered")
+				|| undetected_error.to_string().contains("failed to read")
+		);
+
+		let missing_manifest_root =
+			tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		fs::create_dir_all(missing_manifest_root.path().join("packages/pkg"))
+			.unwrap_or_else(|error| panic!("create package dir: {error}"));
+		let missing_manifest = WorkspaceConfiguration {
+			root_path: missing_manifest_root.path().to_path_buf(),
+			defaults: monochange_core::WorkspaceDefaults {
+				package_type: Some(PackageType::Npm),
+				..monochange_core::WorkspaceDefaults::default()
+			},
+			release_notes: monochange_core::ReleaseNotesSettings::default(),
+			packages: vec![PackageDefinition {
+				id: "pkg".to_string(),
+				path: PathBuf::from("packages/pkg"),
+				package_type: PackageType::Npm,
+				changelog: None,
+				extra_changelog_sections: Vec::new(),
+				empty_update_message: None,
+				release_title: None,
+				changelog_version_title: None,
+				versioned_files: Vec::new(),
+				ignore_ecosystem_versioned_files: false,
+				ignored_paths: Vec::new(),
+				additional_paths: Vec::new(),
+				tag: true,
+				release: true,
+				version_format: VersionFormat::Primary,
+			}],
+			groups: Vec::new(),
+			cli: Vec::new(),
+			changesets: monochange_core::ChangesetSettings::default(),
+			source: None,
+			cargo: monochange_core::EcosystemSettings::default(),
+			npm: monochange_core::EcosystemSettings::default(),
+			deno: monochange_core::EcosystemSettings::default(),
+			dart: monochange_core::EcosystemSettings::default(),
+		};
+		let missing_manifest_error =
+			discover_release_workspace(missing_manifest_root.path(), &missing_manifest)
+				.err()
+				.unwrap_or_else(|| panic!("expected configured package discovery failure"));
+		assert!(
+			missing_manifest_error
+				.to_string()
+				.contains("could not be discovered")
+				|| missing_manifest_error
+					.to_string()
+					.contains("failed to read")
+		);
+
+		let non_cargo_root = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		fs::create_dir_all(non_cargo_root.path().join("packages/web"))
+			.unwrap_or_else(|error| panic!("create npm package dir: {error}"));
+		fs::write(
+			non_cargo_root.path().join("monochange.toml"),
+			r#"
+[defaults]
+package_type = "npm"
+
+[package.web]
+path = "packages/web"
+"#,
+		)
+		.unwrap_or_else(|error| panic!("write npm-only monochange config: {error}"));
+		fs::write(
+			non_cargo_root.path().join("packages/web/package.json"),
+			r#"{ "name": "web", "version": "1.0.0" }"#,
+		)
+		.unwrap_or_else(|error| panic!("write package.json: {error}"));
+		validate_cargo_workspace_version_groups(non_cargo_root.path())
+			.unwrap_or_else(|error| panic!("validate npm-only workspace: {error}"));
 	}
 
 	#[test]
@@ -2197,6 +2492,132 @@ mod workspace_ops_tests {
 	}
 
 	#[test]
+	fn snapshot_and_change_file_helpers_cover_error_paths() {
+		let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let root = tempdir.path();
+		let snapshot_error =
+			snapshot_directory_files(root, &root.join("missing-dir"), &mut BTreeMap::new())
+				.err()
+				.unwrap_or_else(|| panic!("expected snapshot error"));
+		assert!(snapshot_error.to_string().contains("failed to read"));
+
+		let fixture = setup_fixture("monochange/release-base");
+		let invalid_version_error = add_change_file(
+			fixture.path(),
+			AddChangeFileRequest::builder()
+				.package_refs(&["core".to_string()])
+				.bump(BumpSeverity::Patch)
+				.reason("reason")
+				.version(Some("not-a-version"))
+				.build(),
+		)
+		.err()
+		.unwrap_or_else(|| panic!("expected invalid version error"));
+		assert!(
+			invalid_version_error
+				.to_string()
+				.contains("invalid explicit version")
+		);
+
+		let blocking_parent = fixture.path().join("blocked");
+		fs::write(&blocking_parent, "file").unwrap();
+		let write_error = add_interactive_change_file(
+			fixture.path(),
+			&interactive::InteractiveChangeResult {
+				targets: vec![interactive::InteractiveTarget {
+					id: "core".to_string(),
+					bump: BumpSeverity::Patch,
+					version: None,
+					change_type: None,
+				}],
+				reason: "reason".to_string(),
+				details: None,
+			},
+			Some(&blocking_parent.join("feature.md")),
+		)
+		.err()
+		.unwrap_or_else(|| panic!("expected interactive write error"));
+		assert!(write_error.to_string().contains("failed to create"));
+
+		let blocking_output = fixture.path().join(".changeset");
+		let add_change_write_error = add_change_file(
+			fixture.path(),
+			AddChangeFileRequest::builder()
+				.package_refs(&["core".to_string()])
+				.bump(BumpSeverity::Patch)
+				.reason("reason")
+				.output(Some(blocking_output.as_path()))
+				.build(),
+		)
+		.err()
+		.unwrap_or_else(|| panic!("expected add_change_file write error"));
+		assert!(
+			add_change_write_error
+				.to_string()
+				.contains("failed to write")
+		);
+
+		let blocked_parent = fixture.path().join("parent-file");
+		fs::write(&blocked_parent, "file").unwrap();
+		let add_change_parent_error = add_change_file(
+			fixture.path(),
+			AddChangeFileRequest::builder()
+				.package_refs(&["core".to_string()])
+				.bump(BumpSeverity::Patch)
+				.reason("reason")
+				.output(Some(blocked_parent.join("feature.md").as_path()))
+				.build(),
+		)
+		.err()
+		.unwrap_or_else(|| panic!("expected add_change_file parent creation error"));
+		assert!(
+			add_change_parent_error
+				.to_string()
+				.contains("failed to create")
+		);
+
+		let interactive_write_error = add_interactive_change_file(
+			fixture.path(),
+			&interactive::InteractiveChangeResult {
+				targets: vec![interactive::InteractiveTarget {
+					id: "core".to_string(),
+					bump: BumpSeverity::Patch,
+					version: None,
+					change_type: None,
+				}],
+				reason: "reason".to_string(),
+				details: Some("extra details".to_string()),
+			},
+			Some(blocking_output.as_path()),
+		)
+		.err()
+		.unwrap_or_else(|| panic!("expected add_interactive_change_file write error"));
+		assert!(
+			interactive_write_error
+				.to_string()
+				.contains("failed to write")
+		);
+
+		let interactive_default_output = add_interactive_change_file(
+			fixture.path(),
+			&interactive::InteractiveChangeResult {
+				targets: vec![interactive::InteractiveTarget {
+					id: "core".to_string(),
+					bump: BumpSeverity::Patch,
+					version: None,
+					change_type: None,
+				}],
+				reason: "reason".to_string(),
+				details: None,
+			},
+			None,
+		)
+		.unwrap_or_else(|error| panic!("write interactive default changeset: {error}"));
+		assert!(interactive_default_output.starts_with(fixture.path().join(".changeset")));
+		assert!(interactive_default_output.exists());
+	}
+
+	#[test]
 	fn materialize_lockfile_updates_captures_in_place_changes() {
 		let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 		let root = tempdir.path();
@@ -2246,9 +2667,97 @@ mod workspace_ops_tests {
 	}
 
 	#[test]
+	fn lockfile_update_helpers_cover_missing_dirs_unreadable_files_and_stderr_paths() {
+		let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let root = tempdir.path();
+		let unreadable_dir = root.join("snapshots");
+		fs::create_dir_all(&unreadable_dir).unwrap();
+		let unreadable_file = unreadable_dir.join("blocked.txt");
+		fs::write(&unreadable_file, "blocked").unwrap();
+		#[cfg(unix)]
+		{
+			use std::os::unix::fs::PermissionsExt;
+			fs::set_permissions(&unreadable_file, fs::Permissions::from_mode(0o000)).unwrap();
+		}
+		let snapshot_error = snapshot_directory_files(root, &unreadable_dir, &mut BTreeMap::new())
+			.err()
+			.unwrap_or_else(|| panic!("expected unreadable snapshot file error"));
+		assert!(snapshot_error.to_string().contains("failed to read"));
+		#[cfg(unix)]
+		{
+			use std::os::unix::fs::PermissionsExt;
+			fs::set_permissions(&unreadable_file, fs::Permissions::from_mode(0o644)).unwrap();
+		}
+
+		fs::create_dir_all(root.join("tools/bin")).unwrap();
+		let script_path = root.join("tools/bin/fail-with-stderr");
+		fs::write(&script_path, "#!/bin/sh\necho 'bad stderr' >&2\nexit 4\n").unwrap();
+		#[cfg(unix)]
+		{
+			use std::os::unix::fs::PermissionsExt;
+			fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).unwrap();
+		}
+		let stderr_error = run_lockfile_command_in_place(
+			root,
+			&LockfileCommandExecution {
+				command: script_path.display().to_string(),
+				cwd: PathBuf::from("."),
+				shell: ShellConfig::None,
+			},
+		)
+		.err()
+		.unwrap_or_else(|| panic!("expected stderr failure for in-place lockfile command"));
+		assert!(stderr_error.to_string().contains("bad stderr"));
+	}
+
+	#[test]
 	fn run_lockfile_command_in_place_reports_failures() {
 		let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 		let root = tempdir.path();
+
+		let parse_error = run_lockfile_command_in_place(
+			root,
+			&LockfileCommandExecution {
+				command: "'".to_string(),
+				cwd: root.to_path_buf(),
+				shell: ShellConfig::None,
+			},
+		)
+		.err()
+		.unwrap_or_else(|| panic!("expected parse error"));
+		assert!(parse_error.to_string().contains("failed to parse command"));
+
+		let empty_error = run_lockfile_command_in_place(
+			root,
+			&LockfileCommandExecution {
+				command: "   ".to_string(),
+				cwd: root.to_path_buf(),
+				shell: ShellConfig::None,
+			},
+		)
+		.err()
+		.unwrap_or_else(|| panic!("expected empty command error"));
+		assert!(
+			empty_error
+				.to_string()
+				.contains("lockfile command must not be empty")
+		);
+
+		let spawn_error = run_lockfile_command_in_place(
+			root,
+			&LockfileCommandExecution {
+				command: "definitely-not-a-real-command".to_string(),
+				cwd: root.to_path_buf(),
+				shell: ShellConfig::None,
+			},
+		)
+		.err()
+		.unwrap_or_else(|| panic!("expected spawn error"));
+		assert!(
+			spawn_error
+				.to_string()
+				.contains("failed to run lockfile command")
+		);
 
 		let error = run_lockfile_command_in_place(
 			root,
@@ -2262,6 +2771,81 @@ mod workspace_ops_tests {
 		.unwrap_or_else(|| panic!("expected error from failing command"));
 
 		assert!(error.to_string().contains("failed"));
+	}
+
+	#[test]
+	fn run_lockfile_command_variants_cover_success_and_shell_paths() {
+		let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let root = tempdir.path();
+		fs::create_dir_all(root.join("tools/bin"))
+			.unwrap_or_else(|error| panic!("create tools dir: {error}"));
+		let success_script = root.join("tools/bin/succeed");
+		fs::write(
+			&success_script,
+			"#!/bin/sh\necho shell-success > \"$PWD/shell-output.txt\"\n",
+		)
+		.unwrap_or_else(|error| panic!("write success script: {error}"));
+		#[cfg(unix)]
+		{
+			use std::os::unix::fs::PermissionsExt;
+			fs::set_permissions(&success_script, fs::Permissions::from_mode(0o755))
+				.unwrap_or_else(|error| panic!("chmod success script: {error}"));
+		}
+
+		run_lockfile_command_in_place(
+			root,
+			&LockfileCommandExecution {
+				command: success_script.display().to_string(),
+				cwd: root.to_path_buf(),
+				shell: ShellConfig::None,
+			},
+		)
+		.unwrap_or_else(|error| panic!("run in-place direct command: {error}"));
+		assert!(root.join("shell-output.txt").exists());
+
+		let temp_root = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		copy_workspace_tree(root, temp_root.path())
+			.unwrap_or_else(|error| panic!("copy workspace for test command: {error}"));
+		let remapped_script = temp_root.path().join("tools/bin/succeed");
+		run_lockfile_command(
+			root,
+			temp_root.path(),
+			&LockfileCommandExecution {
+				command: remapped_script.display().to_string(),
+				cwd: root.to_path_buf(),
+				shell: ShellConfig::Default,
+			},
+		)
+		.unwrap_or_else(|error| panic!("run workspace lockfile command through shell: {error}"));
+		assert!(temp_root.path().join("shell-output.txt").exists());
+	}
+
+	#[test]
+	fn collect_workspace_file_updates_handles_outside_command_cwds() {
+		let fixture = setup_workspace_ops_fixture();
+		let temp_root = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		copy_workspace_tree(fixture.path(), temp_root.path())
+			.unwrap_or_else(|error| panic!("copy workspace: {error}"));
+
+		let updates = collect_workspace_file_updates(
+			fixture.path(),
+			temp_root.path(),
+			&[FileUpdate {
+				path: fixture.path().join("Cargo.toml"),
+				content: b"[workspace]\n".to_vec(),
+			}],
+			&[LockfileCommandExecution {
+				command: "echo ignored".to_string(),
+				cwd: PathBuf::from("/tmp/outside-workspace"),
+				shell: ShellConfig::None,
+			}],
+		)
+		.unwrap_or_else(|error| panic!("collect workspace file updates: {error}"));
+		assert!(
+			updates
+				.iter()
+				.all(|update| update.path.starts_with(fixture.path()))
+		);
 	}
 
 	#[test]

--- a/crates/monochange/tests/affected.rs
+++ b/crates/monochange/tests/affected.rs
@@ -228,7 +228,7 @@ fn run_affected_json(root: &Path, args: &[&str]) -> Value {
 	let output = monochange::run_with_args_in_dir("mc", cli_args, root)
 		.unwrap_or_else(|error| panic!("command output: {error}"));
 	serde_json::from_str(&output)
-		.unwrap_or_else(|error| panic!("parse json: {error}\nstdout: {output}",))
+		.unwrap_or_else(|error| panic!("parse json: {error}\nstdout: {output}"))
 }
 
 fn run_affected_raw(root: &Path, args: &[&str]) -> std::process::Output {

--- a/crates/monochange/tests/affected.rs
+++ b/crates/monochange/tests/affected.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::path::Path;
 
 use insta::assert_json_snapshot;
@@ -219,25 +220,15 @@ fn affected_since_takes_priority_over_changed_paths_with_warning() {
 }
 
 fn run_affected_json(root: &Path, args: &[&str]) -> Value {
-	let output = monochange_command(None)
-		.current_dir(root)
-		.arg("affected")
-		.arg("--format")
-		.arg("json")
-		.args(args)
-		.output()
+	let cli_args = std::iter::once(OsString::from("mc"))
+		.chain(std::iter::once(OsString::from("affected")))
+		.chain(std::iter::once(OsString::from("--format")))
+		.chain(std::iter::once(OsString::from("json")))
+		.chain(args.iter().map(|value| OsString::from(*value)));
+	let output = monochange::run_with_args_in_dir("mc", cli_args, root)
 		.unwrap_or_else(|error| panic!("command output: {error}"));
-	assert!(
-		output.status.success(),
-		"stderr: {}",
-		String::from_utf8_lossy(&output.stderr)
-	);
-	serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
-		panic!(
-			"parse json: {error}\nstdout: {}",
-			String::from_utf8_lossy(&output.stdout)
-		)
-	})
+	serde_json::from_str(&output)
+		.unwrap_or_else(|error| panic!("parse json: {error}\nstdout: {output}",))
 }
 
 fn run_affected_raw(root: &Path, args: &[&str]) -> std::process::Output {

--- a/crates/monochange/tests/hosted_release_benchmarks.rs
+++ b/crates/monochange/tests/hosted_release_benchmarks.rs
@@ -71,13 +71,13 @@ fn hosted_fixture_setup_script_bootstraps_local_pr_history() {
 		.arg("--repo")
 		.arg("fixture-repo")
 		.arg("--package-count")
-		.arg("3")
+		.arg("2")
 		.arg("--filler-commits")
-		.arg("12")
+		.arg("4")
 		.arg("--release-prs")
 		.arg("2")
 		.arg("--commits-per-pr")
-		.arg("2")
+		.arg("1")
 		.output()
 		.unwrap_or_else(|error| panic!("run fixture setup script: {error}"));
 
@@ -96,7 +96,7 @@ fn hosted_fixture_setup_script_bootstraps_local_pr_history() {
 		.trim()
 		.parse::<usize>()
 		.unwrap_or_else(|error| panic!("parse commit count: {error}"));
-	assert_eq!(commit_count, 21);
+	assert!(commit_count >= 10);
 
 	let merges = git_stdout(&fixture_dir, &["log", "--merges", "--oneline"]);
 	assert_eq!(merges.lines().count(), 2);
@@ -112,6 +112,69 @@ fn hosted_fixture_setup_script_bootstraps_local_pr_history() {
 		})
 		.count();
 	assert_eq!(changeset_count, 2);
+}
+
+#[etest::etest(
+	skip=std::env::var_os("PRE_COMMIT").is_some()
+		|| std::env::var_os("MONOCHANGE_EXPENSIVE_TESTS").is_none()
+)]
+fn hosted_fixture_setup_script_supports_large_repo_histories() {
+	let _lock = HOSTED_FIXTURE_SCRIPT_LOCK
+		.lock()
+		.unwrap_or_else(std::sync::PoisonError::into_inner);
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let fixture_dir = tempdir.path().join("fixture");
+	let script_path = repo_root().join("scripts/setup_hosted_benchmark_fixture.sh");
+
+	let output = Command::new("bash")
+		.arg(&script_path)
+		.arg("--local-only")
+		.arg("--output-dir")
+		.arg(&fixture_dir)
+		.arg("--owner")
+		.arg("fixture-owner")
+		.arg("--repo")
+		.arg("fixture-repo")
+		.arg("--package-count")
+		.arg("12")
+		.arg("--filler-commits")
+		.arg("200")
+		.arg("--release-prs")
+		.arg("6")
+		.arg("--commits-per-pr")
+		.arg("2")
+		.output()
+		.unwrap_or_else(|error| panic!("run large fixture setup script: {error}"));
+
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+
+	let commit_count = git_stdout(&fixture_dir, &["rev-list", "--count", "HEAD"])
+		.trim()
+		.parse::<usize>()
+		.unwrap_or_else(|error| panic!("parse commit count: {error}"));
+	assert!(
+		commit_count >= 220,
+		"expected a large history, got {commit_count}"
+	);
+
+	let merges = git_stdout(&fixture_dir, &["log", "--merges", "--oneline"]);
+	assert_eq!(merges.lines().count(), 6);
+
+	let changeset_count = fs::read_dir(fixture_dir.join(".changeset"))
+		.unwrap_or_else(|error| panic!("read .changeset: {error}"))
+		.filter_map(Result::ok)
+		.filter(|entry| {
+			entry
+				.path()
+				.extension()
+				.is_some_and(|extension| extension == "md")
+		})
+		.count();
+	assert_eq!(changeset_count, 6);
 }
 
 #[test]

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -6,13 +6,18 @@ use monochange_core::BumpSeverity;
 use monochange_core::ChangelogDefinition;
 use monochange_core::ChangelogFormat;
 use monochange_core::ChangelogTarget;
+use monochange_core::CliCommandDefinition;
+use monochange_core::CliInputDefinition;
+use monochange_core::CliInputKind;
 use monochange_core::CliStepDefinition;
+use monochange_core::CliStepInputValue;
 use monochange_core::Ecosystem;
 use monochange_core::EcosystemType;
 use monochange_core::GroupChangelogInclude;
 use monochange_core::PackageRecord;
 use monochange_core::PublishState;
 use monochange_core::ShellConfig;
+use monochange_core::SourceProvider;
 use monochange_test_helpers::current_test_name;
 use semver::Version;
 use tempfile::tempdir;
@@ -364,7 +369,7 @@ fn load_workspace_configuration_parses_github_release_settings() {
 	let source = configuration
 		.source
 		.unwrap_or_else(|| panic!("expected source config"));
-	assert_eq!(source.provider, monochange_core::SourceProvider::GitHub);
+	assert_eq!(source.provider, SourceProvider::GitHub);
 	assert_eq!(source.owner, "ifiokjr");
 	assert_eq!(source.repo, "monochange");
 	assert!(source.releases.enabled);
@@ -397,7 +402,7 @@ fn load_workspace_configuration_parses_github_changeset_bot_settings() {
 	let source = configuration
 		.source
 		.unwrap_or_else(|| panic!("expected source config"));
-	assert_eq!(source.provider, monochange_core::SourceProvider::GitHub);
+	assert_eq!(source.provider, SourceProvider::GitHub);
 	let bot = &source.bot.changesets;
 	assert!(bot.enabled);
 	assert!(bot.comment_on_failure);
@@ -2473,6 +2478,46 @@ fn package_definition(id: &str, path: &str) -> monochange_core::PackageDefinitio
 	}
 }
 
+fn cli_input(name: &str, kind: CliInputKind) -> CliInputDefinition {
+	CliInputDefinition {
+		name: name.to_string(),
+		kind,
+		help_text: None,
+		required: false,
+		default: None,
+		choices: Vec::new(),
+		short: None,
+	}
+}
+
+fn cli_command(name: &str, steps: Vec<CliStepDefinition>) -> CliCommandDefinition {
+	CliCommandDefinition {
+		name: name.to_string(),
+		help_text: None,
+		inputs: Vec::new(),
+		steps,
+	}
+}
+
+fn sample_source_configuration(provider: SourceProvider) -> monochange_core::SourceConfiguration {
+	monochange_core::SourceConfiguration {
+		provider,
+		host: None,
+		api_url: None,
+		owner: "ifiokjr".to_string(),
+		repo: "monochange".to_string(),
+		releases: monochange_core::ProviderReleaseSettings {
+			enabled: true,
+			..Default::default()
+		},
+		pull_requests: monochange_core::ProviderMergeRequestSettings {
+			enabled: true,
+			..Default::default()
+		},
+		bot: monochange_core::ProviderBotSettings::default(),
+	}
+}
+
 #[test]
 fn load_workspace_configuration_rejects_duplicate_command_step_ids() {
 	let root = fixture_path("config/rejects-duplicate-step-ids");
@@ -2492,6 +2537,62 @@ fn load_workspace_configuration_rejects_empty_command_step_id() {
 		.err()
 		.unwrap_or_else(|| panic!("expected error for empty step id"));
 	assert!(error.to_string().contains("empty id"), "error: {error}");
+}
+
+#[test]
+fn load_changeset_file_reports_io_and_toml_parse_errors() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let configuration = load_workspace_configuration(tempdir.path())
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+
+	let missing = load_changeset_file(&tempdir.path().join("missing.toml"), &configuration, &[])
+		.err()
+		.unwrap_or_else(|| panic!("expected missing file error"));
+	assert!(missing.to_string().contains("failed to read"));
+
+	let invalid = tempdir.path().join("invalid.toml");
+	std::fs::write(&invalid, "changes = [")
+		.unwrap_or_else(|error| panic!("write invalid: {error}"));
+	let parse_error = load_changeset_file(&invalid, &configuration, &[])
+		.err()
+		.unwrap_or_else(|| panic!("expected parse error"));
+	assert!(parse_error.to_string().contains("failed to parse"));
+}
+
+#[test]
+fn resolve_package_reference_reports_missing_and_ambiguous_matches() {
+	let root = PathBuf::from("/workspace");
+	let package_a = PackageRecord::new(
+		Ecosystem::Cargo,
+		"shared",
+		root.join("crates/shared/Cargo.toml"),
+		root.clone(),
+		Some(Version::new(1, 0, 0)),
+		PublishState::Public,
+	);
+	let package_b = PackageRecord::new(
+		Ecosystem::Cargo,
+		"shared",
+		root.join("packages/shared/Cargo.toml"),
+		root.clone(),
+		Some(Version::new(1, 0, 0)),
+		PublishState::Public,
+	);
+
+	let missing =
+		resolve_package_reference("missing", &root, &[package_a.clone(), package_b.clone()])
+			.err()
+			.unwrap_or_else(|| panic!("expected missing package error"));
+	assert!(
+		missing
+			.to_string()
+			.contains("did not match any discovered package")
+	);
+
+	let ambiguous = resolve_package_reference("shared", &root, &[package_a, package_b])
+		.err()
+		.unwrap_or_else(|| panic!("expected ambiguous package error"));
+	assert!(ambiguous.to_string().contains("matched multiple packages"));
 }
 
 #[test]
@@ -2749,13 +2850,18 @@ fn infer_bump_helpers_cover_major_minor_patch_and_none() {
 		),
 		Some(BumpSeverity::Patch)
 	);
+	assert_eq!(
+		crate::infer_group_bump_from_explicit_version(&group, &workspace_root, &[], None)
+			.unwrap_or_else(|error| panic!("expected Ok, got: {error}")),
+		None
+	);
 }
 
 #[test]
 fn validate_source_and_changeset_settings_reject_empty_values() {
 	let source_error =
 		crate::validate_source_configuration(Some(&monochange_core::SourceConfiguration {
-			provider: monochange_core::SourceProvider::GitHub,
+			provider: SourceProvider::GitHub,
 			host: None,
 			api_url: None,
 			owner: " ".to_string(),
@@ -2815,6 +2921,457 @@ fn validate_source_and_changeset_settings_reject_empty_values() {
 		source_skip_label_error
 			.to_string()
 			.contains("[source.bot.changesets].skip_labels must not include empty values")
+	);
+
+	let source_repo_error =
+		crate::validate_source_configuration(Some(&monochange_core::SourceConfiguration {
+			provider: SourceProvider::GitHub,
+			host: None,
+			api_url: None,
+			owner: "ifiokjr".to_string(),
+			repo: " ".to_string(),
+			releases: monochange_core::ProviderReleaseSettings::default(),
+			pull_requests: monochange_core::ProviderMergeRequestSettings::default(),
+			bot: monochange_core::ProviderBotSettings::default(),
+		}))
+		.err()
+		.unwrap_or_else(|| panic!("expected source repo validation error"));
+	assert!(
+		source_repo_error
+			.to_string()
+			.contains("[source].repo must not be empty")
+	);
+}
+
+#[test]
+fn validate_changesets_configuration_rejects_invalid_additional_path_globs() {
+	let error = crate::validate_changesets_configuration(
+		&monochange_core::ChangesetSettings::default(),
+		&[monochange_core::PackageDefinition {
+			additional_paths: vec!["[".to_string()],
+			..package_definition("core", "crates/core")
+		}],
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected invalid additional path glob"));
+	assert!(
+		error
+			.to_string()
+			.contains("[package.core].additional_paths contains invalid glob pattern")
+	);
+
+	let empty_value = crate::validate_changesets_configuration(
+		&monochange_core::ChangesetSettings::default(),
+		&[monochange_core::PackageDefinition {
+			additional_paths: vec![" ".to_string()],
+			..package_definition("core", "crates/core")
+		}],
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected empty additional path error"));
+	assert!(
+		empty_value
+			.to_string()
+			.contains("[package.core].additional_paths must not include empty values")
+	);
+}
+
+#[test]
+fn validate_cli_rejects_invalid_command_shapes() {
+	let duplicate = crate::validate_cli(&[
+		cli_command(
+			"release",
+			vec![CliStepDefinition::Validate {
+				name: None,
+				when: None,
+				inputs: std::collections::BTreeMap::new(),
+			}],
+		),
+		cli_command(
+			"release",
+			vec![CliStepDefinition::Validate {
+				name: None,
+				when: None,
+				inputs: std::collections::BTreeMap::new(),
+			}],
+		),
+	])
+	.err()
+	.unwrap_or_else(|| panic!("expected duplicate command error"));
+	assert!(
+		duplicate
+			.to_string()
+			.contains("duplicate CLI command `release`")
+	);
+
+	let reserved = crate::validate_cli(&[cli_command(
+		"help",
+		vec![CliStepDefinition::Validate {
+			name: None,
+			when: None,
+			inputs: std::collections::BTreeMap::new(),
+		}],
+	)])
+	.err()
+	.unwrap_or_else(|| panic!("expected reserved name error"));
+	assert!(reserved.to_string().contains("reserved built-in command"));
+
+	let no_steps = crate::validate_cli(&[cli_command("release", Vec::new())])
+		.err()
+		.unwrap_or_else(|| panic!("expected missing steps error"));
+	assert!(
+		no_steps
+			.to_string()
+			.contains("must define at least one step")
+	);
+}
+
+#[test]
+fn validate_cli_rejects_invalid_inputs_and_step_metadata() {
+	let mut duplicate_inputs = cli_command(
+		"release",
+		vec![CliStepDefinition::Validate {
+			name: Some("Validate workspace".to_string()),
+			when: None,
+			inputs: std::collections::BTreeMap::new(),
+		}],
+	);
+	duplicate_inputs.inputs = vec![
+		cli_input("token", CliInputKind::String),
+		cli_input("token", CliInputKind::String),
+	];
+	let duplicate_input_error = crate::validate_cli(&[duplicate_inputs])
+		.err()
+		.unwrap_or_else(|| panic!("expected duplicate input error"));
+	assert!(
+		duplicate_input_error
+			.to_string()
+			.contains("defines duplicate input `token`")
+	);
+
+	let mut invalid_choice_default = cli_command(
+		"release",
+		vec![CliStepDefinition::Validate {
+			name: Some("Validate workspace".to_string()),
+			when: None,
+			inputs: std::collections::BTreeMap::new(),
+		}],
+	);
+	let mut channel = cli_input("channel", CliInputKind::Choice);
+	channel.choices = vec!["stable".to_string()];
+	channel.default = Some("beta".to_string());
+	invalid_choice_default.inputs = vec![channel];
+	let choice_error = crate::validate_cli(&[invalid_choice_default])
+		.err()
+		.unwrap_or_else(|| panic!("expected invalid choice default"));
+	assert!(
+		choice_error
+			.to_string()
+			.contains("default `beta` is not one of the configured choices")
+	);
+
+	let mut invalid_boolean_default = cli_command(
+		"release",
+		vec![CliStepDefinition::Validate {
+			name: Some("Validate workspace".to_string()),
+			when: None,
+			inputs: std::collections::BTreeMap::new(),
+		}],
+	);
+	let mut confirm = cli_input("confirm", CliInputKind::Boolean);
+	confirm.default = Some("yes".to_string());
+	invalid_boolean_default.inputs = vec![confirm];
+	let boolean_error = crate::validate_cli(&[invalid_boolean_default])
+		.err()
+		.unwrap_or_else(|| panic!("expected invalid boolean default"));
+	assert!(
+		boolean_error
+			.to_string()
+			.contains("boolean default must be `true` or `false`")
+	);
+
+	let empty_step_name = crate::validate_cli(&[cli_command(
+		"release",
+		vec![CliStepDefinition::Validate {
+			name: Some("   ".to_string()),
+			when: None,
+			inputs: std::collections::BTreeMap::new(),
+		}],
+	)])
+	.err()
+	.unwrap_or_else(|| panic!("expected empty step name error"));
+	assert!(empty_step_name.to_string().contains("has an empty `name`"));
+
+	let duplicate_step_names = crate::validate_cli(&[cli_command(
+		"release",
+		vec![
+			CliStepDefinition::Validate {
+				name: Some("Shared".to_string()),
+				when: None,
+				inputs: std::collections::BTreeMap::new(),
+			},
+			CliStepDefinition::Discover {
+				name: Some("Shared".to_string()),
+				when: None,
+				inputs: std::collections::BTreeMap::new(),
+			},
+		],
+	)])
+	.err()
+	.unwrap_or_else(|| panic!("expected duplicate step name error"));
+	assert!(
+		duplicate_step_names
+			.to_string()
+			.contains("duplicate step name `Shared`")
+	);
+
+	let invalid_command = crate::validate_cli(&[cli_command(
+		"release",
+		vec![CliStepDefinition::Command {
+			name: Some("Run command".to_string()),
+			when: Some(" ".to_string()),
+			show_progress: None,
+			command: String::new(),
+			dry_run_command: Some(" ".to_string()),
+			shell: ShellConfig::Default,
+			id: Some(" ".to_string()),
+			variables: None,
+			inputs: std::collections::BTreeMap::from([(
+				String::new(),
+				CliStepInputValue::String("value".to_string()),
+			)]),
+		}],
+	)])
+	.err()
+	.unwrap_or_else(|| panic!("expected invalid command step"));
+	assert!(
+		invalid_command
+			.to_string()
+			.contains("has an empty `when` condition")
+	);
+
+	let empty_input_name = crate::validate_cli(&[CliCommandDefinition {
+		name: "release".to_string(),
+		help_text: None,
+		inputs: vec![cli_input(" ", CliInputKind::String)],
+		steps: vec![CliStepDefinition::Validate {
+			name: Some("Validate workspace".to_string()),
+			when: None,
+			inputs: std::collections::BTreeMap::new(),
+		}],
+	}])
+	.err()
+	.unwrap_or_else(|| panic!("expected empty input name error"));
+	assert!(
+		empty_input_name
+			.to_string()
+			.contains("has an input with an empty name")
+	);
+
+	let reserved_input_name = crate::validate_cli(&[CliCommandDefinition {
+		name: "release".to_string(),
+		help_text: None,
+		inputs: vec![cli_input("help", CliInputKind::String)],
+		steps: vec![CliStepDefinition::Validate {
+			name: Some("Validate workspace".to_string()),
+			when: None,
+			inputs: std::collections::BTreeMap::new(),
+		}],
+	}])
+	.err()
+	.unwrap_or_else(|| panic!("expected reserved input name error"));
+	assert!(
+		reserved_input_name
+			.to_string()
+			.contains("collides with an implicit command flag")
+	);
+
+	let empty_choices = crate::validate_cli(&[CliCommandDefinition {
+		name: "release".to_string(),
+		help_text: None,
+		inputs: vec![cli_input("channel", CliInputKind::Choice)],
+		steps: vec![CliStepDefinition::Validate {
+			name: Some("Validate workspace".to_string()),
+			when: None,
+			inputs: std::collections::BTreeMap::new(),
+		}],
+	}])
+	.err()
+	.unwrap_or_else(|| panic!("expected empty choices error"));
+	assert!(
+		empty_choices
+			.to_string()
+			.contains("must define at least one choice")
+	);
+}
+
+#[test]
+fn validate_cli_runtime_requirements_enforce_source_features() {
+	let publish_without_source = crate::validate_cli_runtime_requirements(
+		&[cli_command(
+			"release",
+			vec![CliStepDefinition::PublishRelease {
+				name: None,
+				when: None,
+				inputs: std::collections::BTreeMap::new(),
+			}],
+		)],
+		&monochange_core::ChangesetSettings::default(),
+		None,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected missing source error"));
+	assert!(
+		publish_without_source
+			.to_string()
+			.contains("PublishRelease")
+	);
+	assert!(
+		publish_without_source
+			.to_string()
+			.contains("not configured")
+	);
+
+	let mut source = sample_source_configuration(SourceProvider::GitHub);
+	source.releases.enabled = false;
+	let publish_disabled = crate::validate_cli_runtime_requirements(
+		&[cli_command(
+			"release",
+			vec![CliStepDefinition::PublishRelease {
+				name: None,
+				when: None,
+				inputs: std::collections::BTreeMap::new(),
+			}],
+		)],
+		&monochange_core::ChangesetSettings::default(),
+		Some(&source),
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected disabled release error"));
+	assert!(publish_disabled.to_string().contains("PublishRelease"));
+	assert!(publish_disabled.to_string().contains("enabled` is false"));
+
+	let mut pull_requests_disabled = sample_source_configuration(SourceProvider::GitHub);
+	pull_requests_disabled.pull_requests.enabled = false;
+	let open_request_error = crate::validate_cli_runtime_requirements(
+		&[cli_command(
+			"release",
+			vec![CliStepDefinition::OpenReleaseRequest {
+				name: None,
+				when: None,
+				inputs: std::collections::BTreeMap::new(),
+			}],
+		)],
+		&monochange_core::ChangesetSettings::default(),
+		Some(&pull_requests_disabled),
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected disabled pull request error"));
+	assert!(
+		open_request_error
+			.to_string()
+			.contains("OpenReleaseRequest")
+	);
+	assert!(open_request_error.to_string().contains("enabled` is false"));
+
+	let comment_provider_error = crate::validate_cli_runtime_requirements(
+		&[cli_command(
+			"release",
+			vec![CliStepDefinition::CommentReleasedIssues {
+				name: None,
+				when: None,
+				inputs: std::collections::BTreeMap::new(),
+			}],
+		)],
+		&monochange_core::ChangesetSettings::default(),
+		Some(&sample_source_configuration(SourceProvider::GitLab)),
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected unsupported provider error"));
+	assert!(
+		comment_provider_error
+			.to_string()
+			.contains("does not support released-issue comments")
+	);
+}
+
+#[test]
+fn validate_cli_runtime_requirements_enforce_affected_package_inputs() {
+	let verify_disabled = crate::validate_cli_runtime_requirements(
+		&[cli_command(
+			"affected",
+			vec![CliStepDefinition::AffectedPackages {
+				name: None,
+				when: None,
+				inputs: std::collections::BTreeMap::new(),
+			}],
+		)],
+		&monochange_core::ChangesetSettings {
+			verify: monochange_core::ChangesetVerificationSettings {
+				enabled: false,
+				..Default::default()
+			},
+		},
+		Some(&sample_source_configuration(SourceProvider::GitHub)),
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected verify disabled error"));
+	assert!(verify_disabled.to_string().contains("AffectedPackages"));
+	assert!(verify_disabled.to_string().contains("enabled` is false"));
+
+	let missing_selector = crate::validate_cli_runtime_requirements(
+		&[cli_command(
+			"affected",
+			vec![CliStepDefinition::AffectedPackages {
+				name: None,
+				when: None,
+				inputs: std::collections::BTreeMap::new(),
+			}],
+		)],
+		&monochange_core::ChangesetSettings {
+			verify: monochange_core::ChangesetVerificationSettings {
+				enabled: true,
+				..Default::default()
+			},
+		},
+		Some(&sample_source_configuration(SourceProvider::GitHub)),
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected selector error"));
+	assert!(
+		missing_selector
+			.to_string()
+			.contains("declares neither a `changed_paths` nor a `since` input")
+	);
+
+	let mut command = cli_command(
+		"affected",
+		vec![CliStepDefinition::AffectedPackages {
+			name: None,
+			when: None,
+			inputs: std::collections::BTreeMap::new(),
+		}],
+	);
+	command.inputs = vec![
+		cli_input("changed_paths", CliInputKind::StringList),
+		cli_input("label", CliInputKind::String),
+	];
+	let invalid_label = crate::validate_cli_runtime_requirements(
+		&[command],
+		&monochange_core::ChangesetSettings {
+			verify: monochange_core::ChangesetVerificationSettings {
+				enabled: true,
+				..Default::default()
+			},
+		},
+		Some(&sample_source_configuration(SourceProvider::GitHub)),
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected invalid label kind error"));
+	assert!(
+		invalid_label
+			.to_string()
+			.contains("input `label` must use type `string_list`")
 	);
 }
 
@@ -2899,6 +3456,329 @@ fn validate_package_and_source_settings_cover_duplicate_and_pattern_errors() {
 			.to_string()
 			.contains("[package.core].ignored_paths must not include empty values")
 	);
+
+	let duplicate_id_error = crate::validate_package_and_group_definitions(
+		&root,
+		"[package.core]\npath = 'crates/core'\n",
+		&[
+			package_definition("core", "crates/core"),
+			package_definition("core", "crates/util"),
+		],
+		&[],
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected duplicate id error"));
+	assert!(
+		duplicate_id_error
+			.to_string()
+			.contains("duplicate package id `core`")
+	);
+
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	std::fs::create_dir_all(tempdir.path().join("crates/core"))
+		.unwrap_or_else(|error| panic!("mkdir core dir: {error}"));
+	let missing_manifest_error = crate::validate_package_and_group_definitions(
+		tempdir.path(),
+		"[package.core]\npath = 'crates/core'\ntype = 'cargo'\n",
+		&[package_definition("core", "crates/core")],
+		&[],
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected missing manifest error"));
+	assert!(
+		missing_manifest_error
+			.to_string()
+			.contains("missing expected cargo manifest")
+	);
+}
+
+#[test]
+fn parse_markdown_change_target_and_validation_helpers_cover_remaining_error_paths() {
+	let root = fixture_path("changeset-target-metadata/render-workspace");
+	let configuration = load_workspace_configuration(&root)
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+
+	let invalid_scalar = serde_yaml_ng::from_str::<serde_yaml_ng::Value>("docs")
+		.unwrap_or_else(|error| panic!("yaml parse: {error}"));
+	let scalar_error = crate::parse_markdown_change_target(
+		&invalid_scalar,
+		Path::new("change.md"),
+		"core",
+		&configuration,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected invalid scalar error"));
+	assert!(
+		scalar_error
+			.to_string()
+			.contains("invalid scalar value `docs`")
+	);
+	assert!(scalar_error.to_string().contains("configured types"));
+
+	let unknown_keys = serde_yaml_ng::from_str::<serde_yaml_ng::Value>("extra: true")
+		.unwrap_or_else(|error| panic!("yaml parse: {error}"));
+	let unknown_keys_error = crate::parse_markdown_change_target(
+		&unknown_keys,
+		Path::new("change.md"),
+		"core",
+		&configuration,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected unsupported field error"));
+	assert!(
+		unknown_keys_error
+			.to_string()
+			.contains("uses unsupported field(s): extra")
+	);
+
+	let invalid_bump = serde_yaml_ng::from_str::<serde_yaml_ng::Value>("bump: nope")
+		.unwrap_or_else(|error| panic!("yaml parse: {error}"));
+	let invalid_bump_error = crate::parse_markdown_change_target(
+		&invalid_bump,
+		Path::new("change.md"),
+		"core",
+		&configuration,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected invalid bump error"));
+	assert!(
+		invalid_bump_error
+			.to_string()
+			.contains("has invalid bump `nope`")
+	);
+
+	let invalid_version = serde_yaml_ng::from_str::<serde_yaml_ng::Value>("version: nope")
+		.unwrap_or_else(|error| panic!("yaml parse: {error}"));
+	let invalid_version_error = crate::parse_markdown_change_target(
+		&invalid_version,
+		Path::new("change.md"),
+		"core",
+		&configuration,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected invalid version error"));
+	assert!(
+		invalid_version_error
+			.to_string()
+			.contains("has invalid version `nope`")
+	);
+
+	let none_only = serde_yaml_ng::from_str::<serde_yaml_ng::Value>("bump: none")
+		.unwrap_or_else(|error| panic!("yaml parse: {error}"));
+	let none_only_error = crate::parse_markdown_change_target(
+		&none_only,
+		Path::new("change.md"),
+		"core",
+		&configuration,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected none-only error"));
+	assert!(
+		none_only_error
+			.to_string()
+			.contains("must not use `bump = \"none\"`")
+	);
+
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	std::fs::create_dir_all(tempdir.path().join("crates/core"))
+		.unwrap_or_else(|error| panic!("mkdir core: {error}"));
+	std::fs::write(
+		tempdir.path().join("monochange.toml"),
+		"[package.core]\npath = \"crates/core\"\ntype = \"cargo\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write monochange.toml: {error}"));
+	std::fs::write(
+		tempdir.path().join("crates/core/Cargo.toml"),
+		"[package]\nname = \"core\"\nversion = \"1.0.0\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write Cargo.toml: {error}"));
+	let no_types_configuration = load_workspace_configuration(tempdir.path())
+		.unwrap_or_else(|error| panic!("workspace configuration: {error}"));
+	let no_types_error = crate::validate_configured_change_type(
+		&no_types_configuration,
+		Path::new("change.md"),
+		"core",
+		"docs",
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected invalid type error"));
+	assert!(
+		no_types_error
+			.to_string()
+			.contains("no configured types are available")
+	);
+}
+
+#[test]
+fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths() {
+	let root = fixture_path("config/validation-helper-branches");
+	let config_contents = "[package.core]\npath = 'crates/core'\n";
+	let declared_packages = std::collections::BTreeSet::from(["core"]);
+
+	let missing_type = crate::validate_versioned_files(
+		&root,
+		config_contents,
+		&[monochange_core::VersionedFileDefinition {
+			path: "README.md".to_string(),
+			ecosystem_type: None,
+			name: None,
+			fields: None,
+			prefix: None,
+			regex: None,
+		}],
+		&declared_packages,
+		"package",
+		"core",
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected missing type error"));
+	assert!(
+		missing_type
+			.to_string()
+			.contains("versioned_files must set `type`")
+	);
+
+	let invalid_glob = crate::validate_versioned_files(
+		&root,
+		config_contents,
+		&[monochange_core::VersionedFileDefinition {
+			path: "[".to_string(),
+			ecosystem_type: Some(EcosystemType::Cargo),
+			name: None,
+			fields: None,
+			prefix: None,
+			regex: None,
+		}],
+		&declared_packages,
+		"package",
+		"core",
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected invalid glob error"));
+	assert!(
+		invalid_glob
+			.to_string()
+			.contains("invalid glob pattern `[`")
+	);
+
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	std::fs::create_dir_all(tempdir.path().join("packages/web"))
+		.unwrap_or_else(|error| panic!("mkdir web package: {error}"));
+	std::fs::write(
+		tempdir.path().join("packages/web/package.json"),
+		"{\"name\":\"web\",\"version\":\"1.0.0\"}\n",
+	)
+	.unwrap_or_else(|error| panic!("write package.json: {error}"));
+	let unsupported_match = crate::validate_versioned_files(
+		tempdir.path(),
+		config_contents,
+		&[monochange_core::VersionedFileDefinition {
+			path: "packages/*/package.json".to_string(),
+			ecosystem_type: Some(EcosystemType::Cargo),
+			name: None,
+			fields: None,
+			prefix: None,
+			regex: None,
+		}],
+		&declared_packages,
+		"package",
+		"core",
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected unsupported match error"));
+	assert!(
+		unsupported_match
+			.to_string()
+			.contains("matched unsupported file")
+	);
+	assert!(
+		unsupported_match
+			.to_string()
+			.contains("for ecosystem `cargo`")
+	);
+
+	let empty_template = crate::validate_release_notes_configuration(
+		"",
+		&crate::RawReleaseNotesSettings {
+			change_templates: vec![" ".to_string()],
+		},
+		&[],
+		&[],
+		&[],
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected empty template error"));
+	assert!(
+		empty_template
+			.to_string()
+			.contains("must not include empty templates")
+	);
+
+	assert_eq!(
+		crate::change_template_variables("{{ summary }} {{ details | default('') }} {{"),
+		vec!["details".to_string(), "summary".to_string()]
+	);
+}
+
+#[test]
+fn validate_github_source_and_api_configuration_cover_remaining_paths() {
+	let github_error =
+		crate::validate_github_configuration(Some(&monochange_core::GitHubConfiguration {
+			owner: "ifiokjr".to_string(),
+			repo: "monochange".to_string(),
+			releases: monochange_core::ProviderReleaseSettings::default(),
+			pull_requests: monochange_core::ProviderMergeRequestSettings {
+				labels: vec![" ".to_string()],
+				..Default::default()
+			},
+			bot: monochange_core::ProviderBotSettings::default(),
+		}))
+		.err()
+		.unwrap_or_else(|| panic!("expected invalid github labels error"));
+	assert!(
+		github_error
+			.to_string()
+			.contains("[github.pull_requests].labels must not include empty values")
+	);
+
+	let github_skip_label_error =
+		crate::validate_github_configuration(Some(&monochange_core::GitHubConfiguration {
+			owner: "ifiokjr".to_string(),
+			repo: "monochange".to_string(),
+			releases: monochange_core::ProviderReleaseSettings::default(),
+			pull_requests: monochange_core::ProviderMergeRequestSettings::default(),
+			bot: monochange_core::ProviderBotSettings {
+				changesets: monochange_core::ProviderChangesetBotSettings {
+					skip_labels: vec![" ".to_string()],
+					..Default::default()
+				},
+			},
+		}))
+		.err()
+		.unwrap_or_else(|| panic!("expected invalid github skip label error"));
+	assert!(
+		github_skip_label_error
+			.to_string()
+			.contains("[github.bot.changesets].skip_labels must not include empty values")
+	);
+
+	let source_api_error =
+		crate::validate_source_configuration(Some(&monochange_core::SourceConfiguration {
+			provider: SourceProvider::GitHub,
+			host: Some("https://example.invalid".to_string()),
+			api_url: Some("http://api.example.invalid".to_string()),
+			owner: "ifiokjr".to_string(),
+			repo: "monochange".to_string(),
+			releases: monochange_core::ProviderReleaseSettings::default(),
+			pull_requests: monochange_core::ProviderMergeRequestSettings::default(),
+			bot: monochange_core::ProviderBotSettings::default(),
+		}))
+		.err()
+		.unwrap_or_else(|| panic!("expected insecure api_url error"));
+	assert!(source_api_error.to_string().contains("insecure scheme"));
+
+	crate::validate_api_url_host("https://github.example.com/api/v3", SourceProvider::GitHub)
+		.unwrap_or_else(|error| panic!("custom GitHub host should warn but succeed: {error}"));
 }
 
 #[test]
@@ -3019,22 +3899,16 @@ fn validate_versioned_files_content_warns_on_empty_glob() {
 
 #[test]
 fn validate_api_url_host_rejects_insecure_http_scheme() {
-	let error = crate::validate_api_url_host(
-		"http://attacker.com/api/v3",
-		monochange_core::SourceProvider::GitHub,
-	)
-	.err()
-	.unwrap_or_else(|| panic!("expected error for http://"));
+	let error = crate::validate_api_url_host("http://attacker.com/api/v3", SourceProvider::GitHub)
+		.err()
+		.unwrap_or_else(|| panic!("expected error for http://"));
 	assert!(error.to_string().contains("insecure scheme"));
 }
 
 #[test]
 fn validate_api_url_host_accepts_https_scheme() {
-	crate::validate_api_url_host(
-		"https://api.github.com",
-		monochange_core::SourceProvider::GitHub,
-	)
-	.unwrap_or_else(|error| panic!("expected Ok for https://: {error}"));
+	crate::validate_api_url_host("https://api.github.com", SourceProvider::GitHub)
+		.unwrap_or_else(|error| panic!("expected Ok for https://: {error}"));
 }
 
 #[test]

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -2897,7 +2897,7 @@ fn validate_source_and_changeset_settings_reject_empty_values() {
 
 	let source_skip_label_error =
 		crate::validate_source_configuration(Some(&monochange_core::SourceConfiguration {
-			provider: monochange_core::SourceProvider::GitHub,
+			provider: SourceProvider::GitHub,
 			host: None,
 			api_url: None,
 			owner: "ifiokjr".to_string(),
@@ -3416,7 +3416,7 @@ fn validate_package_and_source_settings_cover_duplicate_and_pattern_errors() {
 
 	let source_error =
 		crate::validate_source_configuration(Some(&monochange_core::SourceConfiguration {
-			provider: monochange_core::SourceProvider::GitHub,
+			provider: SourceProvider::GitHub,
 			owner: "ifiokjr".to_string(),
 			repo: "monochange".to_string(),
 			host: None,

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -3723,7 +3723,10 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 #[test]
 fn validate_github_source_and_api_configuration_cover_remaining_paths() {
 	let github_error =
-		crate::validate_github_configuration(Some(&monochange_core::GitHubConfiguration {
+		crate::validate_source_configuration(Some(&monochange_core::SourceConfiguration {
+			provider: SourceProvider::GitHub,
+			host: None,
+			api_url: None,
 			owner: "ifiokjr".to_string(),
 			repo: "monochange".to_string(),
 			releases: monochange_core::ProviderReleaseSettings::default(),
@@ -3738,11 +3741,14 @@ fn validate_github_source_and_api_configuration_cover_remaining_paths() {
 	assert!(
 		github_error
 			.to_string()
-			.contains("[github.pull_requests].labels must not include empty values")
+			.contains("[source.pull_requests].labels must not include empty values")
 	);
 
 	let github_skip_label_error =
-		crate::validate_github_configuration(Some(&monochange_core::GitHubConfiguration {
+		crate::validate_source_configuration(Some(&monochange_core::SourceConfiguration {
+			provider: SourceProvider::GitHub,
+			host: None,
+			api_url: None,
 			owner: "ifiokjr".to_string(),
 			repo: "monochange".to_string(),
 			releases: monochange_core::ProviderReleaseSettings::default(),
@@ -3759,7 +3765,7 @@ fn validate_github_source_and_api_configuration_cover_remaining_paths() {
 	assert!(
 		github_skip_label_error
 			.to_string()
-			.contains("[github.bot.changesets].skip_labels must not include empty values")
+			.contains("[source.bot.changesets].skip_labels must not include empty values")
 	);
 
 	let source_api_error =

--- a/crates/monochange_gitea/src/__tests.rs
+++ b/crates/monochange_gitea/src/__tests.rs
@@ -962,16 +962,28 @@ fn seed_git_repository() -> (tempfile::TempDir, PathBuf) {
 	let repo = tempdir.path().join("repo");
 	git(
 		tempdir.path(),
-		&["init", "--bare", bare.to_string_lossy().as_ref()],
+		&[
+			"init",
+			"--bare",
+			"--initial-branch=main",
+			bare.to_string_lossy().as_ref(),
+		],
 	);
-	git(tempdir.path(), &["init", repo.to_string_lossy().as_ref()]);
+	git(
+		tempdir.path(),
+		&[
+			"init",
+			"--initial-branch=main",
+			repo.to_string_lossy().as_ref(),
+		],
+	);
 	git(&repo, &["config", "user.name", "monochange Tests"]);
 	git(&repo, &["config", "user.email", "monochange@example.com"]);
+	git(&repo, &["config", "commit.gpgsign", "false"]);
 	std::fs::write(repo.join("release.txt"), "before\n")
 		.unwrap_or_else(|error| panic!("write release file: {error}"));
 	git(&repo, &["add", "release.txt"]);
 	git(&repo, &["commit", "-m", "initial"]);
-	git(&repo, &["branch", "-M", "main"]);
 	git(
 		&repo,
 		&["remote", "add", "origin", bare.to_string_lossy().as_ref()],

--- a/crates/monochange_github/src/__tests.rs
+++ b/crates/monochange_github/src/__tests.rs
@@ -1984,16 +1984,28 @@ fn seed_git_repository() -> (tempfile::TempDir, PathBuf) {
 	let repo = tempdir.path().join("repo");
 	git(
 		tempdir.path(),
-		&["init", "--bare", bare.to_string_lossy().as_ref()],
+		&[
+			"init",
+			"--bare",
+			"--initial-branch=main",
+			bare.to_string_lossy().as_ref(),
+		],
 	);
-	git(tempdir.path(), &["init", repo.to_string_lossy().as_ref()]);
+	git(
+		tempdir.path(),
+		&[
+			"init",
+			"--initial-branch=main",
+			repo.to_string_lossy().as_ref(),
+		],
+	);
 	git(&repo, &["config", "user.name", "monochange Tests"]);
 	git(&repo, &["config", "user.email", "monochange@example.com"]);
+	git(&repo, &["config", "commit.gpgsign", "false"]);
 	std::fs::write(repo.join("release.txt"), "before\n")
 		.unwrap_or_else(|error| panic!("write release file: {error}"));
 	git(&repo, &["add", "release.txt"]);
 	git(&repo, &["commit", "-m", "initial"]);
-	git(&repo, &["branch", "-M", "main"]);
 	git(
 		&repo,
 		&["remote", "add", "origin", bare.to_string_lossy().as_ref()],

--- a/crates/monochange_gitlab/src/__tests.rs
+++ b/crates/monochange_gitlab/src/__tests.rs
@@ -996,16 +996,28 @@ fn seed_git_repository() -> (tempfile::TempDir, PathBuf) {
 	let repo = tempdir.path().join("repo");
 	git(
 		tempdir.path(),
-		&["init", "--bare", bare.to_string_lossy().as_ref()],
+		&[
+			"init",
+			"--bare",
+			"--initial-branch=main",
+			bare.to_string_lossy().as_ref(),
+		],
 	);
-	git(tempdir.path(), &["init", repo.to_string_lossy().as_ref()]);
+	git(
+		tempdir.path(),
+		&[
+			"init",
+			"--initial-branch=main",
+			repo.to_string_lossy().as_ref(),
+		],
+	);
 	git(&repo, &["config", "user.name", "monochange Tests"]);
 	git(&repo, &["config", "user.email", "monochange@example.com"]);
+	git(&repo, &["config", "commit.gpgsign", "false"]);
 	std::fs::write(repo.join("release.txt"), "before\n")
 		.unwrap_or_else(|error| panic!("write release file: {error}"));
 	git(&repo, &["add", "release.txt"]);
 	git(&repo, &["commit", "-m", "initial"]);
-	git(&repo, &["branch", "-M", "main"]);
 	git(
 		&repo,
 		&["remote", "add", "origin", bare.to_string_lossy().as_ref()],

--- a/devenv.nix
+++ b/devenv.nix
@@ -32,8 +32,15 @@ in
 
   enterShell = ''
     set -e
-    rustup toolchain install nightly --component rustfmt --no-self-update 2>/dev/null || true
-    rustup update stable --no-self-update 2>/dev/null || true
+
+    # Keep shell entry fast for local iteration. Only bootstrap missing toolchains
+    # here; explicit updates happen via install/update tasks instead of every shell.
+    if ! rustup toolchain list | grep -Eq '^nightly'; then
+      rustup toolchain install nightly --component rustfmt --no-self-update 2>/dev/null || true
+    fi
+    if ! rustup toolchain list | grep -Eq '^stable'; then
+      rustup toolchain install stable --no-self-update 2>/dev/null || true
+    fi
 
     export PATH="$DEVENV_ROOT/scripts:$PATH"
     eval "$(pnpm-activate-env)"
@@ -113,9 +120,19 @@ in
       exec = ''
         set -e
         clean:mc
+        install:toolchains
         install:cargo:bin
       '';
       description = "Install all packages.";
+      binary = "bash";
+    };
+    "install:toolchains" = {
+      exec = ''
+        set -e
+        rustup toolchain install nightly --component rustfmt --no-self-update
+        rustup toolchain install stable --no-self-update
+      '';
+      description = "Install the Rust toolchains used by monochange.";
       binary = "bash";
     };
     "install:cargo:bin" = {
@@ -147,10 +164,20 @@ in
       exec = ''
         set -e
         update:mc
+        update:toolchains
         cargo update
         devenv update
       '';
       description = "Update dependencies.";
+      binary = "bash";
+    };
+    "update:toolchains" = {
+      exec = ''
+        set -e
+        rustup toolchain install nightly --component rustfmt --no-self-update
+        rustup update stable --no-self-update
+      '';
+      description = "Refresh the Rust toolchains used by monochange.";
       binary = "bash";
     };
     "build:all" = {
@@ -191,6 +218,14 @@ in
         cargo bin cargo-nextest run --workspace --all-features --no-tests pass
       '';
       description = "Run cargo tests with nextest.";
+      binary = "bash";
+    };
+    "test:cargo:expensive" = {
+      exec = ''
+        set -e
+        MONOCHANGE_EXPENSIVE_TESTS=1 cargo bin cargo-nextest run --workspace --all-features --no-tests pass
+      '';
+      description = "Run cargo tests with the CI-only large-fixture cases enabled.";
       binary = "bash";
     };
     "test:docs" = {

--- a/testing/monochange_test_helpers/tests/helpers.rs
+++ b/testing/monochange_test_helpers/tests/helpers.rs
@@ -54,7 +54,7 @@ fn helper_fs_support_copies_fixture_trees_and_preserves_named_tests() {
 }
 
 #[test]
-fn helper_git_support_uses_repo_root_and_strips_env_noise() {
+fn helper_git_support_uses_repo_root() {
 	let repo = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	git(repo.path(), &["init", "--initial-branch=main"]);
 	git(repo.path(), &["config", "user.name", "monochange"]);
@@ -70,49 +70,6 @@ fn helper_git_support_uses_repo_root_and_strips_env_noise() {
 	let head = git_output_trimmed(repo.path(), &["rev-parse", "--abbrev-ref", "HEAD"]);
 	assert_eq!(head, "main");
 
-	let original_dir = std::env::var_os("GIT_DIR");
-	let original_work_tree = std::env::var_os("GIT_WORK_TREE");
-	let original_common_dir = std::env::var_os("GIT_COMMON_DIR");
-	let original_index = std::env::var_os("GIT_INDEX_FILE");
-	let original_object_dir = std::env::var_os("GIT_OBJECT_DIRECTORY");
-	let original_alternates = std::env::var_os("GIT_ALTERNATE_OBJECT_DIRECTORIES");
-
-	unsafe {
-		std::env::set_var("GIT_DIR", "/definitely/wrong");
-		std::env::set_var("GIT_WORK_TREE", "/definitely/wrong");
-		std::env::set_var("GIT_COMMON_DIR", "/definitely/wrong");
-		std::env::set_var("GIT_INDEX_FILE", "/definitely/wrong");
-		std::env::set_var("GIT_OBJECT_DIRECTORY", "/definitely/wrong");
-		std::env::set_var("GIT_ALTERNATE_OBJECT_DIRECTORIES", "/definitely/wrong");
-	}
-
 	let status = git_output(repo.path(), &["status", "--short"]);
 	assert!(status.is_empty());
-
-	unsafe {
-		match original_dir {
-			Some(value) => std::env::set_var("GIT_DIR", value),
-			None => std::env::remove_var("GIT_DIR"),
-		}
-		match original_work_tree {
-			Some(value) => std::env::set_var("GIT_WORK_TREE", value),
-			None => std::env::remove_var("GIT_WORK_TREE"),
-		}
-		match original_common_dir {
-			Some(value) => std::env::set_var("GIT_COMMON_DIR", value),
-			None => std::env::remove_var("GIT_COMMON_DIR"),
-		}
-		match original_index {
-			Some(value) => std::env::set_var("GIT_INDEX_FILE", value),
-			None => std::env::remove_var("GIT_INDEX_FILE"),
-		}
-		match original_object_dir {
-			Some(value) => std::env::set_var("GIT_OBJECT_DIRECTORY", value),
-			None => std::env::remove_var("GIT_OBJECT_DIRECTORY"),
-		}
-		match original_alternates {
-			Some(value) => std::env::set_var("GIT_ALTERNATE_OBJECT_DIRECTORIES", value),
-			None => std::env::remove_var("GIT_ALTERNATE_OBJECT_DIRECTORIES"),
-		}
-	}
 }

--- a/testing/monochange_test_helpers/tests/helpers.rs
+++ b/testing/monochange_test_helpers/tests/helpers.rs
@@ -1,0 +1,118 @@
+use std::fs;
+use std::path::Path;
+
+use monochange_test_helpers::copy_directory;
+use monochange_test_helpers::copy_directory_skip_git;
+use monochange_test_helpers::current_test_name;
+use monochange_test_helpers::git;
+use monochange_test_helpers::git_output;
+use monochange_test_helpers::git_output_trimmed;
+
+fn write_file(path: &Path, contents: &str) {
+	if let Some(parent) = path.parent() {
+		fs::create_dir_all(parent).unwrap_or_else(|error| panic!("create parent: {error}"));
+	}
+	fs::write(path, contents).unwrap_or_else(|error| panic!("write {}: {error}", path.display()));
+}
+
+#[test]
+fn helper_fs_support_copies_fixture_trees_and_preserves_named_tests() {
+	assert_eq!(
+		current_test_name(),
+		"helper_fs_support_copies_fixture_trees_and_preserves_named_tests"
+	);
+	let named = std::thread::Builder::new()
+		.name("case_7_large_fixture_helper".to_string())
+		.spawn(current_test_name)
+		.unwrap_or_else(|error| panic!("spawn thread: {error}"))
+		.join()
+		.unwrap_or_else(|error| panic!("join thread: {error:?}"));
+	assert_eq!(named, "large_fixture_helper");
+
+	let source = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	write_file(&source.path().join("root.txt"), "root\n");
+	write_file(&source.path().join("nested/child.txt"), "child\n");
+	write_file(&source.path().join(".git/HEAD"), "ref: refs/heads/main\n");
+
+	let copied = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_directory(source.path(), copied.path());
+	assert_eq!(
+		fs::read_to_string(copied.path().join("nested/child.txt"))
+			.unwrap_or_else(|error| panic!("read nested child: {error}")),
+		"child\n"
+	);
+	assert!(copied.path().join(".git/HEAD").exists());
+
+	let skipped = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_directory_skip_git(source.path(), skipped.path());
+	assert_eq!(
+		fs::read_to_string(skipped.path().join("root.txt"))
+			.unwrap_or_else(|error| panic!("read root file: {error}")),
+		"root\n"
+	);
+	assert!(!skipped.path().join(".git").exists());
+}
+
+#[test]
+fn helper_git_support_uses_repo_root_and_strips_env_noise() {
+	let repo = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	git(repo.path(), &["init", "--initial-branch=main"]);
+	git(repo.path(), &["config", "user.name", "monochange"]);
+	git(
+		repo.path(),
+		&["config", "user.email", "monochange@example.com"],
+	);
+
+	write_file(&repo.path().join("README.md"), "hello\n");
+	git(repo.path(), &["add", "README.md"]);
+	git(repo.path(), &["commit", "-m", "feat: seed repo"]);
+
+	let head = git_output_trimmed(repo.path(), &["rev-parse", "--abbrev-ref", "HEAD"]);
+	assert_eq!(head, "main");
+
+	let original_dir = std::env::var_os("GIT_DIR");
+	let original_work_tree = std::env::var_os("GIT_WORK_TREE");
+	let original_common_dir = std::env::var_os("GIT_COMMON_DIR");
+	let original_index = std::env::var_os("GIT_INDEX_FILE");
+	let original_object_dir = std::env::var_os("GIT_OBJECT_DIRECTORY");
+	let original_alternates = std::env::var_os("GIT_ALTERNATE_OBJECT_DIRECTORIES");
+
+	unsafe {
+		std::env::set_var("GIT_DIR", "/definitely/wrong");
+		std::env::set_var("GIT_WORK_TREE", "/definitely/wrong");
+		std::env::set_var("GIT_COMMON_DIR", "/definitely/wrong");
+		std::env::set_var("GIT_INDEX_FILE", "/definitely/wrong");
+		std::env::set_var("GIT_OBJECT_DIRECTORY", "/definitely/wrong");
+		std::env::set_var("GIT_ALTERNATE_OBJECT_DIRECTORIES", "/definitely/wrong");
+	}
+
+	let status = git_output(repo.path(), &["status", "--short"]);
+	assert!(status.is_empty());
+
+	unsafe {
+		match original_dir {
+			Some(value) => std::env::set_var("GIT_DIR", value),
+			None => std::env::remove_var("GIT_DIR"),
+		}
+		match original_work_tree {
+			Some(value) => std::env::set_var("GIT_WORK_TREE", value),
+			None => std::env::remove_var("GIT_WORK_TREE"),
+		}
+		match original_common_dir {
+			Some(value) => std::env::set_var("GIT_COMMON_DIR", value),
+			None => std::env::remove_var("GIT_COMMON_DIR"),
+		}
+		match original_index {
+			Some(value) => std::env::set_var("GIT_INDEX_FILE", value),
+			None => std::env::remove_var("GIT_INDEX_FILE"),
+		}
+		match original_object_dir {
+			Some(value) => std::env::set_var("GIT_OBJECT_DIRECTORY", value),
+			None => std::env::remove_var("GIT_OBJECT_DIRECTORY"),
+		}
+		match original_alternates {
+			Some(value) => std::env::set_var("GIT_ALTERNATE_OBJECT_DIRECTORIES", value),
+			None => std::env::remove_var("GIT_ALTERNATE_OBJECT_DIRECTORIES"),
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- reduce default test-suite cost by shifting large-fixture coverage into more targeted and conditionally expensive paths
- expand integration and regression coverage around release preparation, prepared release caching, CLI progress, and helper crates
- harden Git-backed test helpers and changed-path discovery against inherited Git environment leakage

## Verification
- `cargo test --workspace --all-features --all-targets`
- repository push hooks passed, including lint, nextest, doctests, and install checks