### PR TITLE
style: apply coding style guide for improved code readability

### DIFF
--- a/.changeset/style-refactor-code-readability.md
+++ b/.changeset/style-refactor-code-readability.md
@@ -1,0 +1,27 @@
+---
+monochange: patch
+monochange_cargo: patch
+monochange_config: patch
+monochange_core: patch
+monochange_dart: patch
+monochange_deno: patch
+monochange_gitea: patch
+monochange_github: patch
+monochange_gitlab: patch
+monochange_graph: patch
+monochange_hosting: patch
+monochange_npm: patch
+monochange_semver: patch
+---
+
+# Apply coding style guide for improved code readability
+
+Applied the @ifi/coding-style-guide style principles across the entire Rust codebase:
+
+- Added visual breathing room with blank lines before control flow statements
+- Converted nested conditionals to early returns for flatter structure
+- Grouped related variable declarations with section comments
+- Improved guard clauses to reduce indentation levels
+- Enhanced code organization with logical grouping separators
+
+This is a pure refactoring with no functional changes - all behavior is preserved.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,4 +36,5 @@
 - [Documentation workflow](docs/agents/documentation.md)
 - [Product and architecture rules](docs/agents/product-rules.md)
 - [Rust quality and safety](docs/agents/rust-quality.md)
+- [Coding style](docs/agents/coding-style.md)
 - [Changeset quality](docs/agents/changeset-quality.md)

--- a/crates/monochange/src/assist.rs
+++ b/crates/monochange/src/assist.rs
@@ -84,16 +84,19 @@ pub(crate) fn run_assist(
 	format: AssistOutputFormat,
 ) -> MonochangeResult<String> {
 	let payload = assistant_setup_payload(assistant);
+
 	match format {
 		AssistOutputFormat::Json => {
 			serde_json::to_string_pretty(&payload)
 				.map_err(|error| MonochangeError::Config(error.to_string()))
 		}
+
 		AssistOutputFormat::Text => {
 			let mcp_config = serde_json::to_string_pretty(&payload["mcp_config"])
 				.map_err(|error| MonochangeError::Config(error.to_string()))?;
 			let install = serde_json::to_string_pretty(&payload["install"])
 				.map_err(|error| MonochangeError::Config(error.to_string()))?;
+
 			let mut output = String::new();
 			let _ = writeln!(output, "monochange assist");
 			let _ = writeln!(output);
@@ -115,18 +118,22 @@ pub(crate) fn run_assist(
 			let _ = writeln!(output, "{mcp_config}");
 			let _ = writeln!(output);
 			let _ = writeln!(output, "Suggested repo-local guidance:");
+
 			for item in payload["repo_guidance"].as_array().into_iter().flatten() {
 				if let Some(text) = item.as_str() {
 					let _ = writeln!(output, "- {text}");
 				}
 			}
+
 			let _ = writeln!(output);
 			let _ = writeln!(output, "Notes for {}:", assistant_display_name(assistant));
+
 			for item in payload["notes"].as_array().into_iter().flatten() {
 				if let Some(text) = item.as_str() {
 					let _ = writeln!(output, "- {text}");
 				}
 			}
+
 			Ok(output.trim_end().to_string())
 		}
 	}

--- a/crates/monochange/src/bin/mc.rs
+++ b/crates/monochange/src/bin/mc.rs
@@ -1,9 +1,14 @@
 fn main() {
 	let quiet = std::env::args_os().any(|arg| matches!(arg.to_str(), Some("--quiet" | "-q")));
-	if let Err(error) = monochange::run_from_env("mc") {
-		if !quiet {
-			eprintln!("{}", error.render());
-		}
-		std::process::exit(1);
+
+	let result = monochange::run_from_env("mc");
+	let Err(error) = result else {
+		return;
+	};
+
+	if !quiet {
+		eprintln!("{}", error.render());
 	}
+
+	std::process::exit(1);
 }

--- a/crates/monochange/src/changelog.rs
+++ b/crates/monochange/src/changelog.rs
@@ -221,12 +221,16 @@ fn append_changelog_section(path: &Path, section: &str) -> MonochangeResult<Stri
 	} else {
 		String::new()
 	};
+
 	let mut content = current.trim_end().to_string();
+
 	if !content.is_empty() {
 		content.push_str("\n\n");
 	}
+
 	content.push_str(section);
 	content.push('\n');
+
 	Ok(content)
 }
 

--- a/crates/monochange/src/changeset_policy.rs
+++ b/crates/monochange/src/changeset_policy.rs
@@ -20,15 +20,19 @@ pub fn affected_packages(
 	changed_paths: &[String],
 	labels: &[String],
 ) -> MonochangeResult<ChangesetPolicyEvaluation> {
+	// Load and validate configuration
 	let configuration = load_workspace_configuration(root)?;
 	let verify = &configuration.changesets.verify;
+
 	if !verify.enabled {
 		return Err(MonochangeError::Config(
 			"changeset verification requires `[changesets.verify].enabled = true`".to_string(),
 		));
 	}
 
+	// Discover workspace and normalize inputs
 	let discovery = discover_workspace(root)?;
+	// Normalize labels and changed paths
 	let labels = labels
 		.iter()
 		.map(|label| label.trim().to_string())
@@ -39,6 +43,8 @@ pub fn affected_packages(
 		.map(|path| normalize_changed_path(path))
 		.filter(|path| !path.is_empty())
 		.collect::<Vec<_>>();
+
+	// Identify skip labels and changeset paths
 	let matched_skip_labels = labels
 		.iter()
 		.filter(|label| {
@@ -54,6 +60,8 @@ pub fn affected_packages(
 		.filter(|path| is_changeset_markdown_path(path))
 		.cloned()
 		.collect::<Vec<_>>();
+
+	// Build package ID mapping
 	let config_ids_by_package_id = configuration
 		.packages
 		.iter()
@@ -63,6 +71,7 @@ pub fn affected_packages(
 		})
 		.collect::<MonochangeResult<BTreeMap<_, _>>>()?;
 
+	// Classify changed paths against package definitions
 	let mut matched_paths = Vec::new();
 	let mut ignored_paths = Vec::new();
 	let mut affected_package_ids = BTreeSet::new();

--- a/crates/monochange/src/changesets.rs
+++ b/crates/monochange/src/changesets.rs
@@ -8,6 +8,7 @@ pub(crate) fn diagnose_changesets(
 ) -> MonochangeResult<ChangesetDiagnosticsReport> {
 	let configuration = load_workspace_configuration(root)?;
 	let discovery = discover_workspace(root)?;
+
 	let changeset_paths = if requested.is_empty() {
 		discover_changeset_paths(root)?
 			.into_iter()
@@ -15,9 +16,11 @@ pub(crate) fn diagnose_changesets(
 			.collect::<Vec<_>>()
 	} else {
 		let mut resolved = Vec::new();
+
 		for path in requested {
 			resolved.push(resolve_changeset_path(root, path)?);
 		}
+
 		resolved.sort();
 		resolved.dedup();
 		resolved
@@ -27,7 +30,9 @@ pub(crate) fn diagnose_changesets(
 		.iter()
 		.map(|path| load_changeset_file(path, &configuration, &discovery.packages))
 		.collect::<MonochangeResult<Vec<_>>>()?;
+
 	let mut changesets = build_prepared_changesets(root, &loaded_changesets);
+
 	if let Some(source) = configuration.source.as_ref() {
 		hosted_sources::configured_hosted_source_adapter(source)
 			.enrich_changeset_context(source, &mut changesets);
@@ -37,6 +42,7 @@ pub(crate) fn diagnose_changesets(
 		.iter()
 		.map(|path| root_relative(root, path))
 		.collect();
+
 	Ok(ChangesetDiagnosticsReport {
 		requested_changesets,
 		changesets,
@@ -46,11 +52,13 @@ pub(crate) fn diagnose_changesets(
 #[must_use = "the changeset path result must be checked"]
 pub(crate) fn resolve_changeset_path(root: &Path, requested: &str) -> MonochangeResult<PathBuf> {
 	let requested_is_absolute = Path::new(requested).is_absolute();
+
 	let normalized = if requested_is_absolute {
 		requested.to_string()
 	} else {
 		normalize_changed_path(requested)
 	};
+
 	if normalized.is_empty() {
 		return Err(MonochangeError::Config(
 			"changeset path cannot be empty".to_string(),
@@ -62,13 +70,16 @@ pub(crate) fn resolve_changeset_path(root: &Path, requested: &str) -> Monochange
 	} else {
 		Path::new(&normalized)
 	};
+
 	let candidates = if candidate.is_absolute() {
 		vec![candidate.to_path_buf()]
 	} else {
 		let mut candidates = vec![root.join(candidate)];
+
 		if !normalized.starts_with(CHANGESET_DIR) {
 			candidates.push(root.join(CHANGESET_DIR).join(candidate));
 		}
+
 		candidates
 	};
 
@@ -76,13 +87,16 @@ pub(crate) fn resolve_changeset_path(root: &Path, requested: &str) -> Monochange
 		let Some(relative_candidate) = relative_to_root(root, &candidate) else {
 			continue;
 		};
+
 		if !is_changeset_markdown_path(&relative_candidate.to_string_lossy()) {
 			continue;
 		}
+
 		if candidate.exists() {
 			return Ok(candidate);
 		}
 	}
+
 	Err(MonochangeError::Config(format!(
 		"requested changeset `{requested}` does not exist"
 	)))
@@ -94,15 +108,20 @@ pub(crate) fn render_changeset_diagnostics(report: &ChangesetDiagnosticsReport) 
 	}
 
 	let mut lines = Vec::new();
+
 	for changeset in &report.changesets {
 		let change_summary = changeset.summary.as_deref().unwrap_or("<missing summary>");
+
 		lines.push(format!("changeset: {}", changeset.path.display()));
 		lines.push(format!("  summary: {change_summary}"));
+
 		if let Some(details) = &changeset.details {
 			lines.push(format!("  details: {details}"));
 		}
+
 		if !changeset.targets.is_empty() {
 			lines.push("  targets:".to_string());
+
 			for target in &changeset.targets {
 				let bump = target
 					.bump
@@ -111,11 +130,13 @@ pub(crate) fn render_changeset_diagnostics(report: &ChangesetDiagnosticsReport) 
 					"  - {} {} (bump: {}, origin: {})",
 					target.kind, target.id, bump, target.origin,
 				));
+
 				if !target.evidence_refs.is_empty() {
 					lines.push(format!("    evidence: {}", target.evidence_refs.join(", ")));
 				}
 			}
 		}
+
 		if let Some(context) = &changeset.context {
 			if let Some(introduced) = context
 				.introduced
@@ -124,6 +145,7 @@ pub(crate) fn render_changeset_diagnostics(report: &ChangesetDiagnosticsReport) 
 			{
 				lines.push(format!("  introduced: {}", introduced.short_sha));
 			}
+
 			if let Some(last_updated) = context
 				.last_updated
 				.as_ref()
@@ -131,6 +153,7 @@ pub(crate) fn render_changeset_diagnostics(report: &ChangesetDiagnosticsReport) 
 			{
 				lines.push(format!("  last-updated: {}", last_updated.short_sha));
 			}
+
 			let review_request = context
 				.introduced
 				.as_ref()
@@ -141,6 +164,7 @@ pub(crate) fn render_changeset_diagnostics(report: &ChangesetDiagnosticsReport) 
 						.as_ref()
 						.and_then(|revision| revision.review_request.as_ref())
 				});
+
 			if let Some(review_request) = review_request {
 				if let Some(url) = &review_request.url {
 					lines.push(format!("  review request: {} ({})", review_request.id, url));
@@ -148,6 +172,7 @@ pub(crate) fn render_changeset_diagnostics(report: &ChangesetDiagnosticsReport) 
 					lines.push(format!("  review request: {}", review_request.id));
 				}
 			}
+
 			if !context.related_issues.is_empty() {
 				let issues = context
 					.related_issues
@@ -158,8 +183,10 @@ pub(crate) fn render_changeset_diagnostics(report: &ChangesetDiagnosticsReport) 
 				lines.push(format!("  related issues: {issues}"));
 			}
 		}
+
 		lines.push(String::new());
 	}
+
 	lines.pop();
 	lines.join("\n")
 }
@@ -167,6 +194,7 @@ pub(crate) fn render_changeset_diagnostics(report: &ChangesetDiagnosticsReport) 
 #[must_use = "the discovery result must be checked"]
 pub(crate) fn discover_changeset_paths(root: &Path) -> MonochangeResult<Vec<PathBuf>> {
 	let changeset_dir = root.join(CHANGESET_DIR);
+
 	if !changeset_dir.exists() {
 		return Err(MonochangeError::Config(format!(
 			"no markdown changesets found under {CHANGESET_DIR}"
@@ -184,12 +212,15 @@ pub(crate) fn discover_changeset_paths(root: &Path) -> MonochangeResult<Vec<Path
 		.map(|entry| entry.path())
 		.filter(|path| path.extension().and_then(|value| value.to_str()) == Some("md"))
 		.collect::<Vec<_>>();
+
 	changeset_paths.sort();
+
 	if changeset_paths.is_empty() {
 		return Err(MonochangeError::Config(format!(
 			"no markdown changesets found under {CHANGESET_DIR}"
 		)));
 	}
+
 	Ok(changeset_paths)
 }
 
@@ -270,6 +301,7 @@ fn batch_load_changeset_contexts(
 		.iter()
 		.map(|path| {
 			let path_str = path.to_string_lossy();
+
 			ChangesetContext {
 				provider: HostingProviderKind::GenericGit,
 				host: None,

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -19,7 +19,7 @@ pub fn build_command(bin_name: &'static str) -> Command {
 pub(crate) fn configured_change_type_choices(
 	configuration: &monochange_core::WorkspaceConfiguration,
 ) -> Vec<String> {
-	configuration
+	let all_sections = configuration
 		.packages
 		.iter()
 		.flat_map(|package| package.extra_changelog_sections.iter())
@@ -28,7 +28,9 @@ pub(crate) fn configured_change_type_choices(
 				.groups
 				.iter()
 				.flat_map(|group| group.extra_changelog_sections.iter()),
-		)
+		);
+
+	all_sections
 		.flat_map(|section| section.types.iter())
 		.map(|value| value.trim().to_string())
 		.filter(|value| !value.is_empty())
@@ -42,18 +44,24 @@ pub(crate) fn apply_runtime_change_type_choices(
 	configuration: &monochange_core::WorkspaceConfiguration,
 ) {
 	let choices = configured_change_type_choices(configuration);
+
 	if choices.is_empty() {
 		return;
 	}
-	if let Some(change_command) = cli.iter_mut().find(|command| command.name == "change")
-		&& let Some(change_type_input) = change_command
-			.inputs
-			.iter_mut()
-			.find(|input| input.name == "type" && input.choices.is_empty())
-	{
-		change_type_input.kind = CliInputKind::Choice;
-		change_type_input.choices = choices;
-	}
+
+	let Some(change_command) = cli.iter_mut().find(|command| command.name == "change") else {
+		return;
+	};
+	let Some(change_type_input) = change_command
+		.inputs
+		.iter_mut()
+		.find(|input| input.name == "type" && input.choices.is_empty())
+	else {
+		return;
+	};
+
+	change_type_input.kind = CliInputKind::Choice;
+	change_type_input.choices = choices;
 }
 
 pub(crate) fn cli_commands_for_root(root: &Path) -> Vec<CliCommandDefinition> {
@@ -69,15 +77,15 @@ pub(crate) fn cli_commands_from_config(
 		monochange_core::MonochangeError,
 	>,
 ) -> Vec<CliCommandDefinition> {
-	match configuration {
-		Ok(configuration) => {
-			let mut cli = configuration.cli.clone();
-			apply_runtime_change_type_choices(&mut cli, configuration);
-			apply_runtime_prepare_release_markdown_defaults(&mut cli);
-			cli
-		}
-		Err(_) => default_cli_commands(),
-	}
+	let Ok(configuration) = configuration else {
+		return default_cli_commands();
+	};
+
+	let mut cli = configuration.cli.clone();
+	apply_runtime_change_type_choices(&mut cli, configuration);
+	apply_runtime_prepare_release_markdown_defaults(&mut cli);
+
+	cli
 }
 
 pub(crate) fn apply_runtime_prepare_release_markdown_defaults(cli: &mut [CliCommandDefinition]) {
@@ -85,6 +93,7 @@ pub(crate) fn apply_runtime_prepare_release_markdown_defaults(cli: &mut [CliComm
 		if !command_supports_release_diff_preview(cli_command) {
 			continue;
 		}
+
 		let Some(format_input) = cli_command
 			.inputs
 			.iter_mut()
@@ -92,13 +101,15 @@ pub(crate) fn apply_runtime_prepare_release_markdown_defaults(cli: &mut [CliComm
 		else {
 			continue;
 		};
-		if !format_input
+
+		let has_markdown = format_input
 			.choices
 			.iter()
-			.any(|choice| choice == "markdown")
-		{
+			.any(|choice| choice == "markdown");
+		if !has_markdown {
 			format_input.choices.insert(0, "markdown".to_string());
 		}
+
 		if format_input.default.as_deref() == Some("text") {
 			format_input.default = Some("markdown".to_string());
 		}
@@ -244,13 +255,13 @@ pub(crate) fn command_supports_release_diff_preview(cli_command: &CliCommandDefi
 }
 
 pub(crate) fn build_cli_command_subcommand(cli_command: &CliCommandDefinition) -> Command {
+	let help_text = cli_command
+		.help_text
+		.clone()
+		.unwrap_or_else(|| format!("Run the `{}` command", cli_command.name));
+
 	let mut command = Command::new(leak_string(cli_command.name.clone()))
-		.about(
-			cli_command
-				.help_text
-				.clone()
-				.unwrap_or_else(|| format!("Run the `{}` command", cli_command.name)),
-		)
+		.about(help_text)
 		.arg(
 			Arg::new("dry-run")
 				.long("dry-run")
@@ -373,15 +384,18 @@ Repair notes:
 fn build_cli_command_input_arg(input: &CliInputDefinition) -> Arg {
 	let long_name = leak_string(input.name.replace('_', "-"));
 	let value_name = leak_string(input.name.to_uppercase());
+	let help_text = input.help_text.clone().unwrap_or_default();
+
 	let mut arg = Arg::new(leak_string(input.name.clone()))
 		.long(long_name)
 		.required(input.required)
-		.help(input.help_text.clone().unwrap_or_default());
+		.help(help_text);
 
 	arg = match input.kind {
 		CliInputKind::String => arg.value_name(value_name),
 		CliInputKind::StringList => arg.value_name(value_name).action(ArgAction::Append),
 		CliInputKind::Path => arg.value_name("PATH"),
+
 		CliInputKind::Boolean => {
 			if input.default.as_deref() == Some("true") {
 				arg.value_name(value_name)
@@ -393,16 +407,12 @@ fn build_cli_command_input_arg(input: &CliInputDefinition) -> Arg {
 				arg.action(ArgAction::SetTrue)
 			}
 		}
+
 		CliInputKind::Choice => {
+			let possible_values: Vec<_> = input.choices.iter().cloned().map(leak_string).collect();
+
 			arg.value_name(value_name)
-				.value_parser(clap::builder::PossibleValuesParser::new(
-					input
-						.choices
-						.iter()
-						.cloned()
-						.map(leak_string)
-						.collect::<Vec<_>>(),
-				))
+				.value_parser(clap::builder::PossibleValuesParser::new(possible_values))
 		}
 	};
 
@@ -410,10 +420,13 @@ fn build_cli_command_input_arg(input: &CliInputDefinition) -> Arg {
 		arg = arg.short(short);
 	}
 
-	if let Some(default) = &input.default
-		&& (!matches!(input.kind, CliInputKind::Boolean) || default == "true")
-	{
-		arg = arg.default_value(leak_string(default.clone()));
+	let should_apply_default = input
+		.default
+		.as_ref()
+		.is_some_and(|default| !matches!(input.kind, CliInputKind::Boolean) || default == "true");
+
+	if should_apply_default {
+		arg = arg.default_value(leak_string(input.default.clone().unwrap()));
 	}
 
 	arg

--- a/crates/monochange/src/cli_progress.rs
+++ b/crates/monochange/src/cli_progress.rs
@@ -170,10 +170,12 @@ impl CliProgressReporter {
 	}
 
 	pub(crate) fn command_started(&mut self) {
+		// Guard: skip if disabled or already started
 		if !self.enabled || self.command_started {
 			return;
 		}
 		self.command_started = true;
+
 		if self.render_mode == ProgressRenderMode::Json {
 			let sequence = self.next_sequence();
 			self.emit_json_event(&serde_json::json!({
@@ -185,6 +187,7 @@ impl CliProgressReporter {
 			}));
 			return;
 		}
+
 		let suffix = if self.dry_run { " (dry-run)" } else { "" };
 		self.print_line(&format!(
 			"{} {}{}",

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -119,6 +119,7 @@ pub(crate) fn collect_cli_command_inputs(
 	matches: &ArgMatches,
 ) -> BTreeMap<String, Vec<String>> {
 	let mut inputs = BTreeMap::new();
+
 	for input in &cli_command.inputs {
 		let value_source = matches.value_source(input.name.as_str());
 		let values = match input.kind {
@@ -141,6 +142,7 @@ pub(crate) fn collect_cli_command_inputs(
 				}
 			}
 			CliInputKind::String | CliInputKind::Path | CliInputKind::Choice => {
+				// Special case: `change` command with `bump` default value
 				if cli_command.name == "change"
 					&& input.name == "bump"
 					&& value_source == Some(ValueSource::DefaultValue)
@@ -156,6 +158,7 @@ pub(crate) fn collect_cli_command_inputs(
 		};
 		inputs.insert(input.name.clone(), values);
 	}
+
 	inputs
 }
 
@@ -1278,6 +1281,7 @@ pub(crate) fn build_cli_template_context(
 ) -> serde_json::Map<String, serde_json::Value> {
 	let mut template_context = serde_json::Map::new();
 
+	// Core release variables
 	template_context.insert(
 		"version".to_string(),
 		serde_json::Value::String(cli_command_variable_value(
@@ -1314,6 +1318,7 @@ pub(crate) fn build_cli_template_context(
 		)),
 	);
 
+	// Released packages list (structured)
 	if let Some(prepared) = &context.prepared_release {
 		template_context.insert(
 			"released_packages_list".to_string(),
@@ -1395,12 +1400,14 @@ pub(crate) fn build_cli_template_context(
 		template_context.insert("steps".to_string(), serde_json::Value::Object(steps_map));
 	}
 
+	// User-provided inputs
 	let input_context = cli_inputs_template_value(inputs);
 	template_context.insert(
 		"inputs".to_string(),
 		serde_json::Value::Object(input_context),
 	);
 
+	// Custom template variables
 	if let Some(variables) = variables {
 		for (needle, variable) in variables {
 			template_context.insert(

--- a/crates/monochange/src/git_support.rs
+++ b/crates/monochange/src/git_support.rs
@@ -34,6 +34,7 @@ pub(crate) fn git_is_ancestor(
 		.map_err(|error| {
 		MonochangeError::Discovery(format!("failed to compare commit ancestry: {error}"))
 	})?;
+
 	match output.status.code() {
 		Some(0) => Ok(true),
 		Some(1) => Ok(false),
@@ -56,13 +57,16 @@ pub(crate) fn move_git_tag(
 #[must_use = "the push result must be checked"]
 pub(crate) fn push_git_tags(root: &Path, tags: &[&str]) -> MonochangeResult<()> {
 	let mut args = vec!["push", "--force", "origin"];
-	let tag_refs = tags
+
+	let tag_refs: Vec<String> = tags
 		.iter()
 		.map(|tag| format!("refs/tags/{tag}:refs/tags/{tag}"))
-		.collect::<Vec<_>>();
+		.collect();
+
 	for tag_ref in &tag_refs {
 		args.push(tag_ref.as_str());
 	}
+
 	run_git_status(root, &args, "failed to push retargeted release tags")
 }
 
@@ -84,6 +88,7 @@ pub(crate) fn first_parent_commits(root: &Path, commit: &str) -> MonochangeResul
 		&["rev-list", "--first-parent", commit],
 		"failed to read first-parent commit ancestry",
 	)?;
+
 	Ok(output
 		.lines()
 		.map(str::to_string)
@@ -108,16 +113,20 @@ pub(crate) fn run_git_capture(
 ) -> MonochangeResult<String> {
 	let output = git_command_output(root, args)
 		.map_err(|error| MonochangeError::Discovery(format!("{error_message}: {error}")))?;
+
 	if !output.status.success() {
 		let stderr = git_stderr_trimmed(&output);
 		tracing::warn!(args = ?args, %stderr, "git command failed");
+
 		let detail = [error_message, stderr.as_str()]
 			.into_iter()
 			.filter(|part| !part.is_empty())
 			.collect::<Vec<_>>()
 			.join(": ");
+
 		return Err(MonochangeError::Discovery(detail));
 	}
+
 	Ok(git_stdout_trimmed(&output))
 }
 
@@ -132,20 +141,24 @@ pub(crate) fn run_git_status(
 #[must_use = "the staging result must be checked"]
 pub(crate) fn git_stage_paths(root: &Path, tracked_paths: &[PathBuf]) -> MonochangeResult<()> {
 	let stageable_paths = resolve_stageable_release_paths(root, tracked_paths)?;
+
 	if stageable_paths.is_empty() {
 		let skipped_count = tracked_paths.len();
 		tracing::debug!(
 			count = skipped_count,
 			"no release commit paths required staging"
 		);
+
 		return Ok(());
 	}
+
 	let stageable_count = stageable_paths.len();
 	tracing::debug!(
 		count = stageable_count,
 		?stageable_paths,
 		"staging release commit paths"
 	);
+
 	run_git_process(
 		git_stage_paths_command(root, &stageable_paths),
 		"failed to stage release commit files",
@@ -157,6 +170,7 @@ fn resolve_stageable_release_paths(
 	tracked_paths: &[PathBuf],
 ) -> MonochangeResult<Vec<PathBuf>> {
 	let mut stageable_paths = Vec::with_capacity(tracked_paths.len());
+
 	for path in tracked_paths {
 		if release_path_requires_staging(root, path)? {
 			stageable_paths.push(path.clone());
@@ -164,18 +178,22 @@ fn resolve_stageable_release_paths(
 			tracing::debug!(path = %path.display(), "skipping non-stageable release path");
 		}
 	}
+
 	Ok(stageable_paths)
 }
 
 fn release_path_requires_staging(root: &Path, path: &Path) -> MonochangeResult<bool> {
 	let absolute_path = root.join(path);
-	if absolute_path.exists() {
-		if git_path_is_tracked(root, path)? {
-			return Ok(true);
-		}
-		return Ok(!git_path_is_ignored(root, path)?);
+
+	if !absolute_path.exists() {
+		return git_path_is_tracked(root, path);
 	}
-	git_path_is_tracked(root, path)
+
+	if git_path_is_tracked(root, path)? {
+		return Ok(true);
+	}
+
+	Ok(!git_path_is_ignored(root, path)?)
 }
 
 #[must_use = "the tracked status result must be checked"]
@@ -188,6 +206,7 @@ fn git_path_is_tracked(root: &Path, path: &Path) -> MonochangeResult<bool> {
 				path.display()
 			))
 		})?;
+
 	match output.status.code() {
 		Some(0) => Ok(true),
 		Some(1) => Ok(false),
@@ -211,6 +230,7 @@ fn git_path_is_ignored(root: &Path, path: &Path) -> MonochangeResult<bool> {
 				path.display()
 			))
 		})?;
+
 	match output.status.code() {
 		Some(0) => Ok(true),
 		Some(1) => Ok(false),

--- a/crates/monochange/src/hosted_sources.rs
+++ b/crates/monochange/src/hosted_sources.rs
@@ -2,6 +2,11 @@ use monochange_core::HostedSourceAdapter;
 use monochange_core::SourceConfiguration;
 use monochange_core::SourceProvider;
 
+/// Returns the appropriate hosted source adapter for the given provider.
+///
+/// # Panics
+///
+/// Panics if the provider feature is not enabled at compile time.
 pub(crate) fn hosted_source_adapter(provider: SourceProvider) -> &'static dyn HostedSourceAdapter {
 	match provider {
 		#[cfg(feature = "github")]

--- a/crates/monochange/src/interactive.rs
+++ b/crates/monochange/src/interactive.rs
@@ -64,6 +64,7 @@ pub fn run_interactive_change(
 	options: &InteractiveOptions,
 ) -> MonochangeResult<InteractiveChangeResult> {
 	let targets = build_selectable_targets(configuration);
+
 	if targets.is_empty() {
 		return Err(MonochangeError::Config(
 			"no packages or groups found in workspace configuration".to_string(),
@@ -72,6 +73,7 @@ pub fn run_interactive_change(
 
 	// Step 1: Select packages/groups
 	let selected = prompt_select_targets(&targets)?;
+
 	if selected.is_empty() {
 		return Err(MonochangeError::Config(
 			"no packages or groups selected".to_string(),
@@ -80,10 +82,12 @@ pub fn run_interactive_change(
 
 	// Step 2: For each selected target, choose bump, optional version, and optional change type
 	let mut interactive_targets = Vec::new();
+
 	for target in &selected {
 		let bump = prompt_bump_for_target(target)?;
 		let version = prompt_version_for_target(target)?;
 		let change_type = prompt_change_type_for_target(target)?;
+
 		interactive_targets.push(InteractiveTarget {
 			id: target.id.clone(),
 			bump,

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -561,14 +561,17 @@ where
 	I: IntoIterator<Item = String>,
 {
 	let mut args = args.into_iter();
+
 	while let Some(arg) = args.next() {
 		if arg == "--log-level" {
 			return args.next();
 		}
+
 		if let Some(value) = arg.strip_prefix("--log-level=") {
 			return Some(value.to_string());
 		}
 	}
+
 	None
 }
 

--- a/crates/monochange/src/main.rs
+++ b/crates/monochange/src/main.rs
@@ -1,6 +1,8 @@
 fn main() {
 	let quiet = std::env::args_os().any(|arg| matches!(arg.to_str(), Some("--quiet" | "-q")));
-	if let Err(error) = monochange::run_from_env("monochange") {
+	let result = monochange::run_from_env("monochange");
+
+	if let Err(error) = result {
 		if !quiet {
 			eprintln!("{}", error.render());
 		}

--- a/crates/monochange/src/mcp.rs
+++ b/crates/monochange/src/mcp.rs
@@ -90,10 +90,11 @@ impl ServerHandler for MonochangeMcpServer {
 }
 
 fn resolve_root(path: Option<&str>) -> PathBuf {
-	path.map_or_else(
-		|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-		PathBuf::from,
-	)
+	let Some(path_str) = path else {
+		return std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+	};
+
+	PathBuf::from(path_str)
 }
 
 fn json_result(value: serde_json::Value) -> CallToolResult {
@@ -154,25 +155,23 @@ impl MonochangeMcpServer {
 		Parameters(params): Parameters<PathParam>,
 	) -> Result<CallToolResult, McpError> {
 		let root = resolve_root(params.path.as_deref());
-		match validate_workspace(&root) {
-			Ok(()) => {
-				Ok(json_result(json!({
-					"ok": true,
-					"action": "validate",
-					"root": root,
-					"summary": "workspace validation passed"
-				})))
-			}
-			Err(error) => {
-				Ok(json_error_result(json!({
-					"ok": false,
-					"action": "validate",
-					"root": root,
-					"summary": error.render(),
-					"error": error.render()
-				})))
-			}
+
+		if let Err(error) = validate_workspace(&root) {
+			return Ok(json_error_result(json!({
+				"ok": false,
+				"action": "validate",
+				"root": root,
+				"summary": error.render(),
+				"error": error.render()
+			})));
 		}
+
+		Ok(json_result(json!({
+			"ok": true,
+			"action": "validate",
+			"root": root,
+			"summary": "workspace validation passed"
+		})))
 	}
 
 	#[tool(
@@ -184,29 +183,30 @@ impl MonochangeMcpServer {
 		Parameters(params): Parameters<PathParam>,
 	) -> Result<CallToolResult, McpError> {
 		let root = resolve_root(params.path.as_deref());
-		match crate::discover_workspace(&root) {
-			Ok(report) => {
-				Ok(json_result(json!({
-					"ok": true,
-					"action": "discover",
-					"summary": format!(
-						"Discovered {} package(s) and {} dependency edge(s).",
-						report.packages.len(),
-						report.dependencies.len()
-					),
-					"report": report,
-				})))
-			}
+
+		let report = match crate::discover_workspace(&root) {
+			Ok(report) => report,
 			Err(error) => {
-				Ok(json_error_result(json!({
+				return Ok(json_error_result(json!({
 					"ok": false,
 					"action": "discover",
 					"root": root,
 					"summary": error.render(),
 					"error": error.render()
-				})))
+				})));
 			}
-		}
+		};
+
+		Ok(json_result(json!({
+			"ok": true,
+			"action": "discover",
+			"summary": format!(
+				"Discovered {} package(s) and {} dependency edge(s).",
+				report.packages.len(),
+				report.dependencies.len()
+			),
+			"report": report,
+		})))
 	}
 
 	#[tool(
@@ -220,37 +220,37 @@ impl MonochangeMcpServer {
 		let root = resolve_root(params.path.as_deref());
 		let output = params.output.as_deref().map(Path::new);
 		let bump = ChangeBump::from(params.bump);
-		match crate::add_change_file(
-			&root,
-			crate::AddChangeFileRequest::builder()
-				.package_refs(&params.package)
-				.bump(bump.into())
-				.reason(&params.reason)
-				.version(params.version.as_deref())
-				.change_type(params.change_type.as_deref())
-				.details(params.details.as_deref())
-				.output(output)
-				.build(),
-		) {
-			Ok(path) => {
-				Ok(json_result(json!({
-					"ok": true,
-					"action": "change",
-					"root": root,
-					"path": path,
-					"summary": format!("Wrote change file {}", path.display())
-				})))
-			}
+
+		let request = crate::AddChangeFileRequest::builder()
+			.package_refs(&params.package)
+			.bump(bump.into())
+			.reason(&params.reason)
+			.version(params.version.as_deref())
+			.change_type(params.change_type.as_deref())
+			.details(params.details.as_deref())
+			.output(output)
+			.build();
+
+		let path = match crate::add_change_file(&root, request) {
+			Ok(path) => path,
 			Err(error) => {
-				Ok(json_error_result(json!({
+				return Ok(json_error_result(json!({
 					"ok": false,
 					"action": "change",
 					"root": root,
 					"summary": error.render(),
 					"error": error.render()
-				})))
+				})));
 			}
-		}
+		};
+
+		Ok(json_result(json!({
+			"ok": true,
+			"action": "change",
+			"root": root,
+			"path": path,
+			"summary": format!("Wrote change file {}", path.display())
+		})))
 	}
 
 	#[tool(
@@ -262,28 +262,29 @@ impl MonochangeMcpServer {
 		Parameters(params): Parameters<PathParam>,
 	) -> Result<CallToolResult, McpError> {
 		let root = resolve_root(params.path.as_deref());
-		match crate::prepare_release(&root, true) {
-			Ok(prepared_release) => {
-				Ok(json_result(json!({
-					"ok": true,
-					"action": "release_preview",
-					"summary": format!(
-						"Prepared dry-run release preview with {} release target(s).",
-						prepared_release.release_targets.len()
-					),
-					"release": prepared_release_value(&prepared_release)
-				})))
-			}
+
+		let prepared_release = match crate::prepare_release(&root, true) {
+			Ok(release) => release,
 			Err(error) => {
-				Ok(json_error_result(json!({
+				return Ok(json_error_result(json!({
 					"ok": false,
 					"action": "release_preview",
 					"root": root,
 					"summary": error.render(),
 					"error": error.render()
-				})))
+				})));
 			}
-		}
+		};
+
+		Ok(json_result(json!({
+			"ok": true,
+			"action": "release_preview",
+			"summary": format!(
+				"Prepared dry-run release preview with {} release target(s).",
+				prepared_release.release_targets.len()
+			),
+			"release": prepared_release_value(&prepared_release)
+		})))
 	}
 
 	#[tool(
@@ -295,29 +296,31 @@ impl MonochangeMcpServer {
 		Parameters(params): Parameters<PathParam>,
 	) -> Result<CallToolResult, McpError> {
 		let root = resolve_root(params.path.as_deref());
-		match crate::prepare_release(&root, true) {
-			Ok(prepared_release) => {
-				let manifest = manifest_for_prepared_release(&prepared_release);
-				Ok(json_result(json!({
-					"ok": true,
-					"action": "release_manifest",
-					"summary": format!(
-						"Generated dry-run release manifest with {} release target(s).",
-						manifest.release_targets.len()
-					),
-					"manifest": manifest,
-				})))
-			}
+
+		let prepared_release = match crate::prepare_release(&root, true) {
+			Ok(release) => release,
 			Err(error) => {
-				Ok(json_error_result(json!({
+				return Ok(json_error_result(json!({
 					"ok": false,
 					"action": "release_manifest",
 					"root": root,
 					"summary": error.render(),
 					"error": error.render()
-				})))
+				})));
 			}
-		}
+		};
+
+		let manifest = manifest_for_prepared_release(&prepared_release);
+
+		Ok(json_result(json!({
+			"ok": true,
+			"action": "release_manifest",
+			"summary": format!(
+				"Generated dry-run release manifest with {} release target(s).",
+				manifest.release_targets.len()
+			),
+			"manifest": manifest,
+		})))
 	}
 
 	#[tool(
@@ -329,25 +332,27 @@ impl MonochangeMcpServer {
 		Parameters(params): Parameters<AffectedParam>,
 	) -> Result<CallToolResult, McpError> {
 		let root = resolve_root(params.path.as_deref());
-		match crate::affected_packages(&root, &params.changed_paths, &params.labels) {
-			Ok(evaluation) => {
-				Ok(json_result(json!({
-					"ok": evaluation.status != monochange_core::ChangesetPolicyStatus::Failed,
-					"action": "affected_packages",
-					"summary": evaluation.summary,
-					"evaluation": evaluation,
-				})))
-			}
-			Err(error) => {
-				Ok(json_error_result(json!({
-					"ok": false,
-					"action": "affected_packages",
-					"root": root,
-					"summary": error.render(),
-					"error": error.render()
-				})))
-			}
-		}
+
+		let evaluation =
+			match crate::affected_packages(&root, &params.changed_paths, &params.labels) {
+				Ok(eval) => eval,
+				Err(error) => {
+					return Ok(json_error_result(json!({
+						"ok": false,
+						"action": "affected_packages",
+						"root": root,
+						"summary": error.render(),
+						"error": error.render()
+					})));
+				}
+			};
+
+		Ok(json_result(json!({
+			"ok": evaluation.status != monochange_core::ChangesetPolicyStatus::Failed,
+			"action": "affected_packages",
+			"summary": evaluation.summary,
+			"evaluation": evaluation,
+		})))
 	}
 }
 
@@ -355,14 +360,15 @@ pub async fn run_server() {
 	let server = MonochangeMcpServer::new();
 	let transport = rmcp::transport::io::stdio();
 
-	match server.serve(transport).await {
-		Ok(running) => {
-			let _ = running.waiting().await;
-		}
+	let running = match server.serve(transport).await {
+		Ok(running) => running,
 		Err(error) => {
 			eprintln!("monochange-mcp: failed to start server: {error}");
+			return;
 		}
-	}
+	};
+
+	let _ = running.waiting().await;
 }
 
 #[cfg(test)]

--- a/crates/monochange/src/prepared_release_cache.rs
+++ b/crates/monochange/src/prepared_release_cache.rs
@@ -87,10 +87,12 @@ pub(crate) fn load_prepared_release_execution(
 	build_file_diffs: bool,
 ) -> MonochangeResult<Option<LoadedPreparedReleaseExecution>> {
 	let artifact_path = resolve_prepared_release_artifact_path(root, explicit_path);
+
 	if !artifact_path.exists() {
 		return Ok(None);
 	}
 
+	// Load and validate the artifact
 	let artifact = read_prepared_release_artifact(&artifact_path)?;
 	validate_prepared_release_artifact(
 		root,
@@ -101,6 +103,7 @@ pub(crate) fn load_prepared_release_execution(
 		build_file_diffs,
 	)?;
 
+	// Transform persisted diffs into runtime format
 	let load_started_at = Instant::now();
 	let file_diffs = artifact
 		.file_diffs
@@ -113,6 +116,7 @@ pub(crate) fn load_prepared_release_execution(
 			}
 		})
 		.collect();
+
 	let execution = PreparedReleaseExecution {
 		prepared_release: artifact.prepared_release,
 		file_diffs,
@@ -125,6 +129,7 @@ pub(crate) fn load_prepared_release_execution(
 		"reused prepared release artifact `{}`",
 		root_relative(root, &artifact_path).display()
 	);
+
 	Ok(Some(LoadedPreparedReleaseExecution { execution, message }))
 }
 

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -25,6 +25,7 @@ pub(crate) fn build_release_targets(
 	let source = configuration.source.as_ref();
 	let defaults_release_title = configuration.defaults.release_title.as_deref();
 	let defaults_changelog_title = configuration.defaults.changelog_version_title.as_deref();
+
 	// Cache the sorted tag list once for the whole command.
 	//
 	// Performance note:

--- a/crates/monochange/src/release_record.rs
+++ b/crates/monochange/src/release_record.rs
@@ -101,6 +101,7 @@ pub fn plan_release_retarget(
 ) -> MonochangeResult<RetargetPlan> {
 	let target_commit = resolve_git_commit_ref(root, target)?;
 	let is_descendant = git_is_ancestor(root, &discovery.record_commit, &target_commit)?;
+
 	if !is_descendant && !force {
 		return Err(MonochangeError::Config(format!(
 			"target commit {} is not a descendant of release-record commit {}; rerun with --force to override",
@@ -108,12 +109,14 @@ pub fn plan_release_retarget(
 			crate::short_commit_sha(&discovery.record_commit)
 		)));
 	}
+
 	validate_retarget_provider(discovery, source)?;
 
 	let git_tag_updates = release_record_tag_names(&discovery.record)
 		.into_iter()
 		.map(|tag_name| {
 			let from_commit = resolve_git_tag_commit(root, &tag_name)?;
+
 			Ok(RetargetTagResult {
 				tag_name,
 				operation: if from_commit == target_commit {
@@ -134,6 +137,7 @@ pub fn plan_release_retarget(
 			.as_ref()
 			.map(|provider| provider.kind)
 	});
+
 	let provider_updates = if sync_provider {
 		match provider {
 			Some(provider) => {
@@ -149,6 +153,7 @@ pub fn plan_release_retarget(
 						}
 					})
 					.collect::<Vec<_>>();
+
 				hosted_sources::hosted_source_adapter(provider)
 					.plan_retargeted_releases(&planned_provider_tags)
 			}
@@ -176,6 +181,7 @@ pub fn execute_release_retarget(
 	plan: &RetargetPlan,
 ) -> MonochangeResult<RetargetResult> {
 	let mut git_tag_results = plan.git_tag_updates.clone();
+
 	if !plan.dry_run {
 		for update in &mut git_tag_results {
 			if update.from_commit == update.to_commit {
@@ -185,11 +191,13 @@ pub fn execute_release_retarget(
 			move_git_tag(root, &update.tag_name, &update.to_commit)?;
 			update.operation = RetargetOperation::Moved;
 		}
+
 		let moved_tags = git_tag_results
 			.iter()
 			.filter(|update| update.operation == RetargetOperation::Moved)
 			.map(|update| update.tag_name.as_str())
 			.collect::<Vec<_>>();
+
 		if !moved_tags.is_empty() {
 			push_git_tags(root, &moved_tags)?;
 		}
@@ -209,6 +217,7 @@ pub fn execute_release_retarget(
 				.provider_updates
 				.first()
 				.map_or(SourceProvider::GitHub, |result| result.provider);
+
 			return Err(MonochangeError::Config(format!(
 				"provider sync is not yet supported for {provider} release retargeting"
 			)));
@@ -261,18 +270,21 @@ fn validate_retarget_provider(
 	let Some(provider) = &discovery.record.provider else {
 		return Ok(());
 	};
+
 	if provider.kind != source.provider {
 		return Err(MonochangeError::Config(format!(
 			"release record provider `{}` does not match configured source provider `{}`",
 			provider.kind, source.provider
 		)));
 	}
+
 	if provider.owner != source.owner || provider.repo != source.repo {
 		return Err(MonochangeError::Config(format!(
 			"release record repository `{}/{}` does not match configured source repository `{}/{}`",
 			provider.owner, provider.repo, source.owner, source.repo
 		)));
 	}
+
 	Ok(())
 }
 

--- a/crates/monochange/src/tracing_setup.rs
+++ b/crates/monochange/src/tracing_setup.rs
@@ -9,6 +9,7 @@ use tracing_subscriber::fmt::format::FmtSpan;
 /// 2. `log_level` parameter from `--log-level` CLI flag
 /// 3. No subscriber installed (silent, near-zero overhead)
 pub(crate) fn init_tracing(log_level: Option<&str>) {
+	// Try environment variable first, then fall back to CLI parameter
 	let filter = match EnvFilter::try_from_default_env() {
 		Ok(env_filter) => env_filter,
 		Err(_) => {

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -94,7 +94,9 @@ pub(crate) fn build_versioned_file_updates(
 	if configuration.packages.is_empty() && configuration.groups.is_empty() {
 		return Ok(Vec::new());
 	}
+
 	let released_versions_by_record_id = released_versions_by_record_id(plan);
+
 	let package_by_config_id = packages
 		.iter()
 		.filter_map(|package| {
@@ -104,10 +106,12 @@ pub(crate) fn build_versioned_file_updates(
 				.map(|config_id| (config_id.as_str(), package))
 		})
 		.collect::<BTreeMap<_, _>>();
+
 	let package_by_native_name = packages
 		.iter()
 		.map(|package| (package.name.as_str(), package))
 		.collect::<BTreeMap<_, _>>();
+
 	let current_versions_by_native_name = packages
 		.iter()
 		.filter_map(|package| {
@@ -117,6 +121,7 @@ pub(crate) fn build_versioned_file_updates(
 				.map(|version| (package.name.clone(), version.to_string()))
 		})
 		.collect::<BTreeMap<_, _>>();
+
 	let released_versions_by_config_id = packages
 		.iter()
 		.filter_map(|package| {
@@ -127,6 +132,7 @@ pub(crate) fn build_versioned_file_updates(
 			})
 		})
 		.collect::<BTreeMap<_, _>>();
+
 	let released_versions_by_native_name = packages
 		.iter()
 		.filter_map(|package| {
@@ -135,7 +141,9 @@ pub(crate) fn build_versioned_file_updates(
 				.map(|version| (package.name.clone(), version.clone()))
 		})
 		.collect::<BTreeMap<_, _>>();
+
 	let shared_release_version = shared_release_version(plan);
+
 	let context = VersionedFileUpdateContext {
 		package_by_config_id,
 		package_by_native_name,
@@ -143,27 +151,33 @@ pub(crate) fn build_versioned_file_updates(
 		released_versions_by_native_name,
 		configuration,
 	};
+
 	let mut updates = BTreeMap::<PathBuf, CachedDocument>::new();
 
 	for package_definition in &configuration.packages {
 		let Some(version) = released_versions_by_config_id.get(&package_definition.id) else {
 			continue;
 		};
+
 		let matched_package = context
 			.package_by_config_id
 			.get(package_definition.id.as_str());
+
 		let dep_names = if let Some(name) = matched_package.map(|package| package.name.clone()) {
 			vec![name]
 		} else {
 			vec![package_definition.id.clone()]
 		};
+
 		let effective_versioned_files = package_definition.versioned_files.clone();
+
 		for versioned_file in dedup_versioned_file_definitions(effective_versioned_files) {
 			let effective_dep_names = if let Some(override_name) = &versioned_file.name {
 				vec![override_name.clone()]
 			} else {
 				dep_names.clone()
 			};
+
 			apply_versioned_file_definition(
 				root,
 				&mut updates,
@@ -186,6 +200,7 @@ pub(crate) fn build_versioned_file_updates(
 		else {
 			continue;
 		};
+
 		// For groups, collect all member native names
 		let group_dep_names = group_definition
 			.packages
@@ -197,6 +212,7 @@ pub(crate) fn build_versioned_file_updates(
 					.map_or_else(|| member_id.clone(), |package| package.name.clone())
 			})
 			.collect::<Vec<_>>();
+
 		for versioned_file in &group_definition.versioned_files {
 			apply_versioned_file_definition(
 				root,
@@ -248,6 +264,7 @@ fn apply_inferred_lockfile_updates(
 		else {
 			continue;
 		};
+
 		for lockfile_path in inferred_lockfile_paths(package) {
 			let relative_lockfile = root_relative(root, &lockfile_path);
 			let (_, dep_names) = dep_names_by_lockfile
@@ -266,6 +283,7 @@ fn apply_inferred_lockfile_updates(
 			name: None,
 			regex: None,
 		};
+
 		// Supported lockfiles can be rewritten directly from the release plan.
 		// That keeps normal `mc release` runs on the fast path instead of paying
 		// package-manager startup and dependency-resolution costs for every bump.
@@ -333,12 +351,15 @@ fn render_cached_document_bytes(
 			rendered.push('\n');
 			Ok(rendered.into_bytes())
 		}
+
 		CachedDocument::Yaml(mapping) => {
 			serde_yaml_ng::to_string(&mapping)
 				.map(String::into_bytes)
 				.map_err(|error| MonochangeError::Config(error.to_string()))
 		}
+
 		CachedDocument::Text(contents) => Ok(contents.into_bytes()),
+
 		CachedDocument::Bytes(contents) => Ok(contents),
 	}
 }
@@ -391,6 +412,7 @@ pub(crate) fn read_cached_document(
 	if let Some(cached) = updates.remove(path) {
 		return Ok(cached);
 	}
+
 	let Some(kind) = versioned_file_kind(ecosystem_type, path) else {
 		return Err(MonochangeError::Config(format!(
 			"unsupported versioned file `{}` for ecosystem `{}`",
@@ -404,9 +426,11 @@ pub(crate) fn read_cached_document(
 			},
 		)));
 	};
+
 	let contents = fs::read(path).map_err(|error| {
 		MonochangeError::Io(format!("failed to read {}: {error}", path.display()))
 	})?;
+
 	let text_contents = String::from_utf8(contents.clone())
 		.map_err(|error| {
 			MonochangeError::Config(format!(
@@ -415,6 +439,7 @@ pub(crate) fn read_cached_document(
 			))
 		})
 		.ok();
+
 	match kind {
 		#[cfg(feature = "cargo")]
 		VersionedFileKind::Cargo(kind) => {

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -93,6 +93,7 @@ pub(crate) fn init_workspace(
 	provider: Option<&str>,
 ) -> MonochangeResult<InitWorkspaceResult> {
 	let path = monochange_config::config_path(root);
+
 	if path.exists() && !force {
 		return Err(MonochangeError::Config(format!(
 			"{} already exists; rerun with --force to overwrite it",
@@ -102,6 +103,7 @@ pub(crate) fn init_workspace(
 
 	let remote = provider.and_then(|_| detect_remote_owner_repo(root));
 	let content = render_annotated_init_config(root, provider, remote.as_ref())?;
+
 	fs::write(&path, &content).map_err(|error| {
 		MonochangeError::Io(format!("failed to write {}: {error}", path.display()))
 	})?;
@@ -209,6 +211,7 @@ pub(crate) struct PopulateWorkspaceResult {
 #[must_use = "the population result must be checked"]
 pub(crate) fn populate_workspace(root: &Path) -> MonochangeResult<PopulateWorkspaceResult> {
 	let path = monochange_config::config_path(root);
+
 	if !path.exists() {
 		return Err(MonochangeError::Config(format!(
 			"{} does not exist; run `mc init` first or create a monochange.toml before running `mc populate`",
@@ -225,6 +228,7 @@ pub(crate) fn populate_workspace(root: &Path) -> MonochangeResult<PopulateWorksp
 			)));
 		}
 	};
+
 	let existing = existing_cli_command_names(&contents, &path)?;
 	let missing = default_cli_commands()
 		.into_iter()
@@ -244,6 +248,7 @@ pub(crate) fn populate_workspace(root: &Path) -> MonochangeResult<PopulateWorksp
 	}
 	updated.push_str(&render_cli_commands_toml(&missing));
 	updated.push('\n');
+
 	if let Err(error) = fs::write(&path, updated) {
 		return Err(MonochangeError::Io(format!(
 			"failed to write {}: {error}",
@@ -261,9 +266,11 @@ fn existing_cli_command_names(contents: &str, path: &Path) -> MonochangeResult<B
 	if contents.trim().is_empty() {
 		return Ok(BTreeSet::new());
 	}
+
 	let document = toml::from_str::<toml::Value>(contents).map_err(|error| {
 		MonochangeError::Config(format!("failed to parse {}: {error}", path.display()))
 	})?;
+
 	Ok(document
 		.get("cli")
 		.and_then(toml::Value::as_table)
@@ -512,6 +519,7 @@ fn render_annotated_init_config(
 			format!("{}-{}", package.name, package.ecosystem.as_str())
 		};
 		package_ids.push(id.clone());
+
 		let manifest_dir = package.manifest_path.parent().unwrap_or(root).to_path_buf();
 		let relative_dir = root_relative(root, &manifest_dir);
 		let pkg_type = package_type_for_ecosystem(package.ecosystem);
@@ -524,13 +532,16 @@ fn render_annotated_init_config(
 			PackageType::Flutter => "flutter",
 			_ => unreachable!(),
 		};
+
 		let mut entry = BTreeMap::new();
 		entry.insert("id", json!(id));
 		entry.insert("path", json!(relative_dir.display().to_string()));
 		entry.insert("type", json!(type_str));
+
 		if let Some(cl) = changelog {
 			entry.insert("changelog", json!(cl.display().to_string()));
 		}
+
 		template_packages.push(json!(entry));
 	}
 
@@ -566,6 +577,7 @@ fn render_annotated_init_config(
 	// Collapse runs of 3+ blank lines down to 2 (one visual blank line)
 	let mut collapsed = String::with_capacity(rendered.len());
 	let mut consecutive_blanks = 0u32;
+
 	for line in rendered.lines() {
 		if line.trim().is_empty() {
 			consecutive_blanks += 1;
@@ -584,6 +596,7 @@ fn render_annotated_init_config(
 
 fn discover_packages(root: &Path) -> MonochangeResult<Vec<PackageRecord>> {
 	let mut packages = Vec::new();
+
 	#[cfg(feature = "cargo")]
 	packages.extend(discover_cargo_packages(root)?.packages);
 	#[cfg(feature = "npm")]
@@ -592,33 +605,39 @@ fn discover_packages(root: &Path) -> MonochangeResult<Vec<PackageRecord>> {
 	packages.extend(discover_deno_packages(root)?.packages);
 	#[cfg(feature = "dart")]
 	packages.extend(discover_dart_packages(root)?.packages);
+
 	normalize_package_ids(root, &mut packages);
 	packages.sort_by(|left, right| left.id.cmp(&right.id));
 	packages.dedup_by(|left, right| left.id == right.id);
+
 	Ok(packages)
 }
 
 fn normalize_package_ids(root: &Path, packages: &mut [PackageRecord]) {
 	for package in packages {
-		if let Some(relative_manifest) = relative_to_root(root, &package.manifest_path) {
-			package.id = format!(
-				"{}:{}",
-				package.ecosystem.as_str(),
-				relative_manifest.display()
-			);
-		}
+		let Some(relative_manifest) = relative_to_root(root, &package.manifest_path) else {
+			continue;
+		};
+		package.id = format!(
+			"{}:{}",
+			package.ecosystem.as_str(),
+			relative_manifest.display()
+		);
 	}
 }
 
 fn detect_default_changelog(root: &Path, manifest_dir: &Path) -> Option<PathBuf> {
-	for candidate in [
+	let candidates = [
 		manifest_dir.join("CHANGELOG.md"),
 		manifest_dir.join("changelog.md"),
-	] {
+	];
+
+	for candidate in candidates {
 		if candidate.exists() {
 			return Some(root_relative(root, &candidate));
 		}
 	}
+
 	None
 }
 
@@ -743,6 +762,7 @@ fn dedup_lockfile_command_executions(
 ) -> Vec<LockfileCommandExecution> {
 	let mut seen = BTreeSet::new();
 	let mut deduped = Vec::new();
+
 	for execution in executions {
 		let key = format!(
 			"{}::{:?}::{}",
@@ -750,10 +770,12 @@ fn dedup_lockfile_command_executions(
 			execution.shell,
 			execution.command,
 		);
+
 		if seen.insert(key) {
 			deduped.push(execution);
 		}
 	}
+
 	deduped
 }
 
@@ -761,16 +783,19 @@ fn dedup_lockfile_command_executions(
 #[cfg(feature = "cargo")]
 pub(crate) fn validate_cargo_workspace_version_groups(root: &Path) -> MonochangeResult<()> {
 	let configuration = load_workspace_configuration(root)?;
+
 	if configuration.packages.is_empty() {
 		return Ok(());
 	}
 
 	let mut packages = discover_cargo_packages(root)?.packages;
+
 	if packages.is_empty() {
 		return Ok(());
 	}
 
 	apply_version_groups(&mut packages, &configuration)?;
+
 	monochange_cargo::validate_workspace_version_groups(&packages)
 }
 
@@ -976,9 +1001,11 @@ pub fn add_change_file(
 		&configuration,
 		&discovery.packages,
 	)?;
+
 	let output_path = request
 		.output
 		.map_or_else(|| default_change_path(root, &packages), Path::to_path_buf);
+
 	if let Some(parent) = output_path.parent() {
 		fs::create_dir_all(parent).map_err(|error| {
 			MonochangeError::Io(format!("failed to create {}: {error}", parent.display()))
@@ -1002,12 +1029,14 @@ pub fn add_change_file(
 		request.change_type,
 		request.details,
 	)?;
+
 	fs::write(&output_path, content).map_err(|error| {
 		MonochangeError::Io(format!(
 			"failed to write {}: {error}",
 			output_path.display()
 		))
 	})?;
+
 	Ok(output_path)
 }
 
@@ -1021,10 +1050,12 @@ pub(crate) fn add_interactive_change_file(
 		.iter()
 		.map(|target| target.id.clone())
 		.collect::<Vec<_>>();
+
 	let output_path = output.map_or_else(
 		|| default_change_path(root, &package_refs),
 		Path::to_path_buf,
 	);
+
 	if let Some(parent) = output_path.parent() {
 		fs::create_dir_all(parent).map_err(|error| {
 			MonochangeError::Io(format!("failed to create {}: {error}", parent.display()))
@@ -1033,12 +1064,14 @@ pub(crate) fn add_interactive_change_file(
 
 	let configuration = load_workspace_configuration(root)?;
 	let content = render_interactive_changeset_markdown(&configuration, result)?;
+
 	fs::write(&output_path, content).map_err(|error| {
 		MonochangeError::Io(format!(
 			"failed to write {}: {error}",
 			output_path.display()
 		))
 	})?;
+
 	Ok(output_path)
 }
 
@@ -1055,6 +1088,7 @@ pub(crate) fn change_type_default_bump(
 				.group_by_id(target_id)
 				.map(|group| group.extra_changelog_sections.as_slice())
 		})?;
+
 	sections.iter().find_map(|section| {
 		section
 			.types
@@ -1090,8 +1124,11 @@ pub(crate) fn render_change_target_markdown(
 			"target `{target_id}` must not use a `none` bump without also declaring `type` or `version`"
 		)));
 	}
+
 	let mut lines = Vec::new();
 	let target_key = render_changeset_target_key(target_id);
+
+	// Handle explicit change type
 	if let Some(change_type) = change_type.filter(|value| !value.trim().is_empty()) {
 		let default_bump = change_type_default_bump(configuration, target_id, change_type)
 			.ok_or_else(|| {
@@ -1099,10 +1136,12 @@ pub(crate) fn render_change_target_markdown(
 					"target `{target_id}` uses unknown change type `{change_type}`"
 				))
 			})?;
+
 		if version.is_none() && bump == default_bump {
 			lines.push(format!("{target_key}: {change_type}"));
 			return Ok(lines);
 		}
+
 		lines.push(format!("{target_key}:"));
 		if bump != BumpSeverity::None {
 			lines.push(format!("  bump: {bump}"));
@@ -1113,6 +1152,8 @@ pub(crate) fn render_change_target_markdown(
 		}
 		return Ok(lines);
 	}
+
+	// Handle explicit version
 	if let Some(version) = version {
 		lines.push(format!("{target_key}:"));
 		if bump != BumpSeverity::None {
@@ -1121,7 +1162,9 @@ pub(crate) fn render_change_target_markdown(
 		lines.push(format!("  version: \"{version}\""));
 		return Ok(lines);
 	}
+
 	lines.push(format!("{target_key}: {bump}"));
+
 	Ok(lines)
 }
 
@@ -1130,6 +1173,7 @@ pub(crate) fn render_interactive_changeset_markdown(
 	result: &interactive::InteractiveChangeResult,
 ) -> MonochangeResult<String> {
 	let mut lines = vec!["---".to_string()];
+
 	for target in &result.targets {
 		let id = &target.id;
 		let version = target.version.as_deref();
@@ -1138,9 +1182,11 @@ pub(crate) fn render_interactive_changeset_markdown(
 			render_change_target_markdown(configuration, id, target.bump, version, change_type)?;
 		lines.extend(target_lines);
 	}
+
 	lines.push("---".to_string());
 	lines.push(String::new());
 	lines.push(format!("# {}", result.reason));
+
 	if let Some(details) = result
 		.details
 		.as_deref()
@@ -1149,7 +1195,9 @@ pub(crate) fn render_interactive_changeset_markdown(
 		lines.push(String::new());
 		lines.push(details.trim().to_string());
 	}
+
 	lines.push(String::new());
+
 	Ok(lines.join("\n"))
 }
 
@@ -1222,10 +1270,12 @@ fn snapshot_directory_files(
 	let entries = fs::read_dir(dir).map_err(|error| {
 		MonochangeError::Io(format!("failed to read {}: {error}", dir.display()))
 	})?;
+
 	for entry in entries {
 		let entry = entry
 			.map_err(|error| MonochangeError::Io(format!("directory entry error: {error}")))?;
 		let path = entry.path();
+
 		if path.is_file() {
 			let relative = path.strip_prefix(root).unwrap_or(&path).to_path_buf();
 			let content = fs::read(&path).map_err(|error| {
@@ -1234,6 +1284,7 @@ fn snapshot_directory_files(
 			snapshots.insert(relative, content);
 		}
 	}
+
 	Ok(())
 }
 
@@ -1263,6 +1314,7 @@ fn run_lockfile_command_in_place(
 			.current_dir(&cwd)
 			.output()
 	};
+
 	let output = output.map_err(|error| {
 		MonochangeError::Io(format!(
 			"failed to run lockfile command `{}` in {}: {error}",
@@ -1270,15 +1322,18 @@ fn run_lockfile_command_in_place(
 			root_relative(root, &command.cwd).display(),
 		))
 	})?;
+
 	if output.status.success() {
 		return Ok(());
 	}
+
 	let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
 	let details = if stderr.is_empty() {
 		format!("exit status {}", output.status)
 	} else {
 		stderr
 	};
+
 	Err(MonochangeError::Config(format!(
 		"lockfile command `{}` failed in {}: {details}",
 		command.command,
@@ -1312,6 +1367,7 @@ fn collect_workspace_file_updates(
 ) -> MonochangeResult<Vec<FileUpdate>> {
 	let normalized_root = monochange_core::normalize_path(root);
 	let mut dirs_to_scan = BTreeSet::new();
+
 	for update in base_updates {
 		if let Some(parent) = update.path.parent() {
 			let normalized = monochange_core::normalize_path(parent);
@@ -1320,6 +1376,7 @@ fn collect_workspace_file_updates(
 			}
 		}
 	}
+
 	for command in lockfile_commands {
 		let normalized = monochange_core::normalize_path(&command.cwd);
 		if let Ok(relative) = normalized.strip_prefix(&normalized_root) {
@@ -1328,10 +1385,12 @@ fn collect_workspace_file_updates(
 			dirs_to_scan.insert(command.cwd.clone());
 		}
 	}
+
 	// Always scan the changeset directory (files are deleted during release).
 	dirs_to_scan.insert(PathBuf::from(".changeset"));
 
 	let mut relative_paths = BTreeSet::new();
+
 	for dir in &dirs_to_scan {
 		let original_dir = root.join(dir);
 		let temp_dir = temp_root.join(dir);
@@ -1344,6 +1403,7 @@ fn collect_workspace_file_updates(
 	}
 
 	let mut updates = Vec::new();
+
 	for relative in relative_paths {
 		let before = read_optional_file(&root.join(&relative))?;
 		let after = read_optional_file(&temp_root.join(&relative))?;
@@ -1354,7 +1414,9 @@ fn collect_workspace_file_updates(
 			});
 		}
 	}
+
 	updates.sort_by(|left, right| left.path.cmp(&right.path));
+
 	Ok(updates)
 }
 

--- a/crates/monochange/tests/test_support.rs
+++ b/crates/monochange/tests/test_support.rs
@@ -37,9 +37,11 @@ pub fn monochange_command(release_date: Option<&str>) -> Command {
 	let mut command = Command::new(get_cargo_bin("mc"));
 	command.env("NO_COLOR", "1");
 	command.env_remove("RUST_LOG");
+
 	if let Some(release_date) = release_date {
 		command.env("MONOCHANGE_RELEASE_DATE", release_date);
 	}
+
 	command
 }
 

--- a/crates/monochange_cargo/src/lib.rs
+++ b/crates/monochange_cargo/src/lib.rs
@@ -155,6 +155,7 @@ pub fn lockfile_requires_command_refresh(lockfile: &Path, packages: &[&PackageRe
 	let Ok(document) = toml::from_str::<Value>(&contents) else {
 		return true;
 	};
+
 	let locked_package_names = document
 		.get("package")
 		.and_then(Value::as_array)
@@ -162,13 +163,16 @@ pub fn lockfile_requires_command_refresh(lockfile: &Path, packages: &[&PackageRe
 		.flatten()
 		.filter_map(|package| package.get("name").and_then(Value::as_str))
 		.collect::<HashSet<_>>();
+
 	if locked_package_names.is_empty() {
 		return true;
 	}
+
 	let workspace_package_names = packages
 		.iter()
 		.map(|package| package.name.as_str())
 		.collect::<HashSet<_>>();
+
 	packages.iter().any(|package| {
 		package
 			.declared_dependencies
@@ -184,6 +188,7 @@ pub fn lockfile_requires_command_refresh(lockfile: &Path, packages: &[&PackageRe
 #[must_use = "the validation result must be checked"]
 pub fn validate_workspace_version_groups(packages: &[PackageRecord]) -> MonochangeResult<()> {
 	let mut workspace_versioned = BTreeMap::<PathBuf, Vec<&PackageRecord>>::new();
+
 	for package in packages {
 		if package.ecosystem == Ecosystem::Cargo
 			&& package.metadata.contains_key("config_id")
@@ -204,10 +209,12 @@ pub fn validate_workspace_version_groups(packages: &[PackageRecord]) -> Monochan
 		if packages.len() < 2 {
 			continue;
 		}
+
 		let group_ids = packages
 			.iter()
 			.map(|package| package.version_group_id.as_deref())
 			.collect::<BTreeSet<_>>();
+
 		if group_ids.len() > 1 || group_ids.contains(&None) {
 			let details = packages
 				.iter()
@@ -218,6 +225,7 @@ pub fn validate_workspace_version_groups(packages: &[PackageRecord]) -> Monochan
 					}
 				})
 				.collect::<Vec<_>>();
+
 			return Err(MonochangeError::Config(format!(
 				"cargo packages using `version.workspace = true` must belong to the same version group, but found mismatched assignments: {}",
 				details.join(", ")

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -425,6 +425,7 @@ fn default_warn_on_group_mismatch() -> bool {
 
 fn merge_cli_commands(cli: BTreeMap<String, RawCliCommandDefinition>) -> Vec<CliCommandDefinition> {
 	let mut merged = default_cli_commands();
+
 	for (name, definition) in cli {
 		let command = CliCommandDefinition {
 			name: name.clone(),
@@ -432,6 +433,7 @@ fn merge_cli_commands(cli: BTreeMap<String, RawCliCommandDefinition>) -> Vec<Cli
 			inputs: definition.inputs,
 			steps: definition.steps,
 		};
+
 		if let Some(existing) = merged
 			.iter_mut()
 			.find(|cli_command| cli_command.name == name)
@@ -441,13 +443,16 @@ fn merge_cli_commands(cli: BTreeMap<String, RawCliCommandDefinition>) -> Vec<Cli
 			merged.push(command);
 		}
 	}
+
 	merged
 }
 
 fn render_changelog_path_template(template: &str, package_path: &Path) -> String {
 	let package_path_str = package_path.to_string_lossy();
 	let mut env = Environment::new();
+
 	env.set_undefined_behavior(UndefinedBehavior::Lenient);
+
 	let context = minijinja::context! { path => package_path_str.as_ref() };
 	env.render_str(template, context)
 		.unwrap_or_else(|_| template.replace("{{ path }}", &package_path_str))

--- a/crates/monochange_core/src/git.rs
+++ b/crates/monochange_core/src/git.rs
@@ -11,6 +11,7 @@ use crate::MonochangeResult;
 pub fn git_command(root: &Path) -> Command {
 	let mut command = Command::new("git");
 	command.current_dir(root);
+
 	for variable in [
 		"GIT_DIR",
 		"GIT_WORK_TREE",
@@ -21,6 +22,7 @@ pub fn git_command(root: &Path) -> Command {
 	] {
 		command.env_remove(variable);
 	}
+
 	command
 }
 
@@ -68,12 +70,14 @@ pub fn git_current_branch(root: &Path) -> MonochangeResult<String> {
 		git_command_output(root, &["symbolic-ref", "--short", "HEAD"]).map_err(|error| {
 			MonochangeError::Io(format!("failed to read current git branch: {error}"))
 		})?;
+
 	if !output.status.success() {
 		return Err(MonochangeError::Config(format!(
 			"failed to read current git branch: {}",
 			git_error_detail(&output)
 		)));
 	}
+
 	Ok(git_stdout_trimmed(&output))
 }
 
@@ -81,12 +85,14 @@ pub fn git_current_branch(root: &Path) -> MonochangeResult<String> {
 pub fn git_head_commit(root: &Path) -> MonochangeResult<String> {
 	let output = git_command_output(root, &["rev-parse", "HEAD"])
 		.map_err(|error| MonochangeError::Io(format!("failed to read HEAD commit: {error}")))?;
+
 	if !output.status.success() {
 		return Err(MonochangeError::Config(format!(
 			"failed to read HEAD commit: {}",
 			git_error_detail(&output)
 		)));
 	}
+
 	Ok(git_stdout_trimmed(&output))
 }
 
@@ -126,12 +132,14 @@ pub fn run_command(mut command: Command, action: &str) -> MonochangeResult<()> {
 	let output = command
 		.output()
 		.map_err(|error| MonochangeError::Io(format!("failed to {action}: {error}")))?;
+
 	if !output.status.success() {
 		return Err(MonochangeError::Config(format!(
 			"failed to {action}: {}",
 			git_error_detail(&output)
 		)));
 	}
+
 	Ok(())
 }
 
@@ -143,9 +151,11 @@ pub fn run_commit_command_allow_nothing_to_commit(
 	let output = command
 		.output()
 		.map_err(|error| MonochangeError::Io(format!("failed to {action}: {error}")))?;
+
 	if output.status.success() || git_reports_nothing_to_commit(&output) {
 		return Ok(());
 	}
+
 	Err(MonochangeError::Config(format!(
 		"failed to {action}: {}",
 		git_error_detail(&output)

--- a/crates/monochange_dart/src/lib.rs
+++ b/crates/monochange_dart/src/lib.rs
@@ -92,10 +92,12 @@ pub fn discover_lockfiles(package: &PackageRecord) -> Vec<PathBuf> {
 	} else {
 		package.workspace_root.clone()
 	};
+
 	let mut discovered = [scope.join("pubspec.lock")]
 		.into_iter()
 		.filter(|path| path.exists())
 		.collect::<Vec<_>>();
+
 	if discovered.is_empty() && scope != manifest_dir {
 		discovered.extend(
 			[manifest_dir.join("pubspec.lock")]
@@ -103,6 +105,7 @@ pub fn discover_lockfiles(package: &PackageRecord) -> Vec<PathBuf> {
 				.filter(|path| path.exists()),
 		);
 	}
+
 	discovered
 }
 
@@ -112,6 +115,7 @@ pub fn default_lockfile_commands(package: &PackageRecord) -> Vec<LockfileCommand
 		Ecosystem::Dart => "dart pub get",
 		_ => return Vec::new(),
 	};
+
 	discover_lockfiles(package)
 		.into_iter()
 		.map(|lockfile| {
@@ -133,12 +137,16 @@ pub fn update_dependency_fields(
 	versioned_deps: &std::collections::BTreeMap<String, String>,
 ) {
 	for field in fields {
-		if let Some(Value::Mapping(section)) = mapping.get_mut(Value::String(field.to_string())) {
-			for (dep_name, dep_version) in versioned_deps {
-				let key = Value::String(dep_name.clone());
-				if section.contains_key(&key) {
-					section.insert(key, Value::String(dep_version.clone()));
-				}
+		let Some(Value::Mapping(section)) = mapping.get_mut(Value::String(field.to_string()))
+		else {
+			continue;
+		};
+
+		for (dep_name, dep_version) in versioned_deps {
+			let key = Value::String(dep_name.clone());
+
+			if section.contains_key(&key) {
+				section.insert(key, Value::String(dep_version.clone()));
 			}
 		}
 	}
@@ -154,8 +162,10 @@ pub fn update_manifest_text(
 	serde_yaml_ng::from_str::<Mapping>(contents).map_err(|error| {
 		MonochangeError::Config(format!("failed to parse pubspec yaml: {error}"))
 	})?;
+
 	let line_ranges = yaml_line_ranges(contents);
 	let mut replacements = Vec::<((usize, usize), String)>::new();
+
 	if let Some(owner_version) = owner_version
 		&& let Some(span) = find_yaml_scalar_for_key(contents, &line_ranges, 0, "version")
 	{
@@ -164,10 +174,12 @@ pub fn update_manifest_text(
 			render_yaml_scalar(&contents[span.0..span.1], owner_version),
 		));
 	}
+
 	for field in fields {
 		let Some(section_index) = find_yaml_key_line(contents, &line_ranges, 0, field) else {
 			continue;
 		};
+
 		for (dep_name, dep_version) in versioned_deps {
 			if let Some(span) =
 				find_yaml_dependency_scalar(contents, &line_ranges, section_index, dep_name)
@@ -179,11 +191,14 @@ pub fn update_manifest_text(
 			}
 		}
 	}
+
 	replacements.sort_by_key(|right| std::cmp::Reverse(right.0.0));
+
 	let mut updated = contents.to_string();
 	for ((start, end), replacement) in replacements {
 		updated.replace_range(start..end, &replacement);
 	}
+
 	Ok(updated)
 }
 

--- a/crates/monochange_deno/src/lib.rs
+++ b/crates/monochange_deno/src/lib.rs
@@ -82,8 +82,10 @@ pub fn supported_versioned_file_kind(path: &Path) -> Option<DenoVersionedFileKin
 
 fn rewrite_dependency_reference(text: &str, package_name: &str, version: &str) -> String {
 	let mut updated = text.to_string();
+
 	for prefix in [format!("npm:{package_name}@"), format!("{package_name}@")] {
 		let mut cursor = 0usize;
+
 		while let Some(found) = updated[cursor..].find(&prefix) {
 			let start = cursor + found + prefix.len();
 			let end = updated[start..]
@@ -93,10 +95,12 @@ fn rewrite_dependency_reference(text: &str, package_name: &str, version: &str) -
 						.then_some(start + index)
 				})
 				.unwrap_or(updated.len());
+
 			updated.replace_range(start..end, version);
 			cursor = start + version.len();
 		}
 	}
+
 	updated
 }
 
@@ -104,9 +108,11 @@ pub fn update_lockfile(value: &mut Value, raw_versions: &BTreeMap<String, String
 	let Ok(mut rendered) = serde_json::to_string(value) else {
 		return;
 	};
+
 	for (package_name, version) in raw_versions {
 		rendered = rewrite_dependency_reference(&rendered, package_name, version);
 	}
+
 	if let Ok(updated) = serde_json::from_str::<Value>(&rendered) {
 		*value = updated;
 	}
@@ -122,10 +128,12 @@ pub fn discover_lockfiles(package: &PackageRecord) -> Vec<PathBuf> {
 	} else {
 		package.workspace_root.clone()
 	};
+
 	let mut discovered = [scope.join("deno.lock")]
 		.into_iter()
 		.filter(|path| path.exists())
 		.collect::<Vec<_>>();
+
 	if discovered.is_empty() && scope != manifest_dir {
 		discovered.extend(
 			[manifest_dir.join("deno.lock")]
@@ -133,10 +141,12 @@ pub fn discover_lockfiles(package: &PackageRecord) -> Vec<PathBuf> {
 				.filter(|path| path.exists()),
 		);
 	}
+
 	discovered
 }
 
 pub fn default_lockfile_commands(_package: &PackageRecord) -> Vec<LockfileCommandExecution> {
+	// Deno does not require lockfile commands for version updates.
 	Vec::new()
 }
 

--- a/crates/monochange_gitea/src/lib.rs
+++ b/crates/monochange_gitea/src/lib.rs
@@ -135,22 +135,27 @@ pub fn annotate_changeset_context(
 ) {
 	let host = gitea_host_name(source);
 	let capabilities = gitea_hosting_capabilities();
+
 	for changeset in changesets {
 		let Some(context) = changeset.context.as_mut() else {
 			continue;
 		};
+
 		context.provider = HostingProviderKind::Gitea;
 		context.host.clone_from(&host);
 		context.capabilities = capabilities.clone();
+
 		for revision in [&mut context.introduced, &mut context.last_updated] {
 			let Some(revision) = revision.as_mut() else {
 				continue;
 			};
+
 			if let Some(commit) = revision.commit.as_mut() {
 				commit.provider = HostingProviderKind::Gitea;
 				commit.host.clone_from(&host);
 				commit.url = Some(gitea_commit_url(source, &commit.sha));
 			}
+
 			if let Some(actor) = revision.actor.as_mut() {
 				actor.provider = HostingProviderKind::Gitea;
 				actor.host.clone_from(&host);

--- a/crates/monochange_github/src/lib.rs
+++ b/crates/monochange_github/src/lib.rs
@@ -182,6 +182,7 @@ pub fn validate_source_configuration(source: &SourceConfiguration) -> Monochange
 				.to_string(),
 		));
 	}
+
 	Ok(())
 }
 
@@ -614,18 +615,23 @@ async fn enrich_changeset_context_with_client(
 				tracing::warn!(commits = review_request_lookup_shas.len(), %error, "failed to batch load GitHub review requests; continuing with commit annotations only");
 				std::collections::BTreeMap::new()
 			});
+
 	for changeset in changesets.iter_mut() {
 		let Some(context) = changeset.context.as_mut() else {
 			continue;
 		};
+
 		let mut issues_by_id = std::collections::BTreeMap::<String, HostedIssueRef>::new();
+
 		for revision in [&mut context.introduced, &mut context.last_updated] {
 			let Some(revision) = revision.as_mut() else {
 				continue;
 			};
+
 			let Some(commit) = revision.commit.as_ref() else {
 				continue;
 			};
+
 			if let Some(related_review_request) = review_requests_by_sha
 				.get(&commit.sha)
 				.and_then(Clone::clone)
@@ -638,11 +644,13 @@ async fn enrich_changeset_context_with_client(
 					revision.actor = Some(author);
 				}
 			}
+
 			if let Some(actor) = revision.actor.as_mut() {
 				actor.provider = HostingProviderKind::GitHub;
 				actor.host.clone_from(&host);
 			}
 		}
+
 		context.related_issues = issues_by_id.into_values().collect();
 	}
 }
@@ -656,8 +664,10 @@ fn collect_review_request_lookup_shas(changesets: &[PreparedChangeset]) -> Vec<S
 		.filter_map(|revision| revision.commit.as_ref())
 		.map(|commit| commit.sha.clone())
 		.collect::<Vec<_>>();
+
 	shas.sort();
 	shas.dedup();
+
 	shas
 }
 
@@ -669,16 +679,21 @@ async fn load_review_requests_for_commits_with_client(
 	if shas.is_empty() {
 		return Ok(std::collections::BTreeMap::new());
 	}
+
 	#[rustfmt::skip]
 	tracing::info!(commits = shas.len(), requests = 1, "loading GitHub review requests");
+
 	let review_requests_by_sha =
 		load_review_request_batch_with_client(client, source, shas).await?;
+
 	let review_requests_found = review_requests_by_sha
 		.values()
 		.filter(|review_request| review_request.is_some())
 		.count();
+
 	#[rustfmt::skip]
 	tracing::debug!(commits = shas.len(), review_requests = review_requests_found, "resolved GitHub review requests");
+
 	Ok(review_requests_by_sha)
 }
 
@@ -688,6 +703,7 @@ async fn load_review_request_batch_with_client(
 	shas: &[String],
 ) -> MonochangeResult<std::collections::BTreeMap<String, Option<GitHubRelatedReviewRequest>>> {
 	let query = build_review_request_batch_query(&source.owner, &source.repo, shas);
+
 	let response = client
 		.graphql::<serde_json::Value>(&json!({ "query": query }))
 		.await
@@ -697,6 +713,7 @@ async fn load_review_request_batch_with_client(
 				shas.len()
 			))
 		})?;
+
 	let repository = response
 		.get("repository")
 		.or_else(|| response.get("data").and_then(|data| data.get("repository")))
@@ -706,8 +723,10 @@ async fn load_review_request_batch_with_client(
 				"GitHub review-request lookup returned no repository payload".to_string(),
 			)
 		})?;
+
 	let mut review_requests_by_sha =
 		std::collections::BTreeMap::<String, Option<GitHubRelatedReviewRequest>>::new();
+
 	for (index, sha) in shas.iter().enumerate() {
 		let alias = format!("commit_{index}");
 		let review_request = repository
@@ -722,6 +741,7 @@ async fn load_review_request_batch_with_client(
 			.and_then(|pull_request| parse_review_request_from_graphql(source, pull_request));
 		review_requests_by_sha.insert(sha.clone(), review_request);
 	}
+
 	Ok(review_requests_by_sha)
 }
 

--- a/crates/monochange_gitlab/src/lib.rs
+++ b/crates/monochange_gitlab/src/lib.rs
@@ -135,22 +135,27 @@ pub fn annotate_changeset_context(
 ) {
 	let host = gitlab_host_name(source);
 	let capabilities = gitlab_hosting_capabilities();
+
 	for changeset in changesets {
 		let Some(context) = changeset.context.as_mut() else {
 			continue;
 		};
+
 		context.provider = HostingProviderKind::GitLab;
 		context.host.clone_from(&host);
 		context.capabilities = capabilities.clone();
+
 		for revision in [&mut context.introduced, &mut context.last_updated] {
 			let Some(revision) = revision.as_mut() else {
 				continue;
 			};
+
 			if let Some(commit) = revision.commit.as_mut() {
 				commit.provider = HostingProviderKind::GitLab;
 				commit.host.clone_from(&host);
 				commit.url = Some(gitlab_commit_url(source, &commit.sha));
 			}
+
 			if let Some(actor) = revision.actor.as_mut() {
 				actor.provider = HostingProviderKind::GitLab;
 				actor.host.clone_from(&host);

--- a/crates/monochange_graph/src/lib.rs
+++ b/crates/monochange_graph/src/lib.rs
@@ -158,12 +158,14 @@ pub fn build_release_plan(
 		.iter()
 		.map(|group| (group.group_id.as_str(), group))
 		.collect::<BTreeMap<_, _>>();
+
 	let (explicit_package_versions, explicit_group_versions, warnings) = resolve_explicit_versions(
 		&package_by_id,
 		&group_by_id,
 		change_signals,
 		strict_version_conflicts,
 	)?;
+
 	let mut states = packages
 		.iter()
 		.map(|package| {
@@ -178,6 +180,7 @@ pub fn build_release_plan(
 		.collect::<BTreeMap<&str, _>>();
 	let mut queue: VecDeque<&str> = VecDeque::new();
 
+	// Process all change signals to establish initial decisions.
 	for change_signal in change_signals {
 		let assessment =
 			strongest_assessment_for_package(compatibility_evidence, &change_signal.package_id);
@@ -188,6 +191,7 @@ pub fn build_release_plan(
 			.clone()
 			.unwrap_or_else(|| "explicit change input".to_string());
 		let upstream_sources = BTreeSet::from([change_signal.package_id.clone()]);
+
 		apply_decision(
 			&mut states,
 			&mut queue,
@@ -199,12 +203,14 @@ pub fn build_release_plan(
 		);
 	}
 
+	// Propagate decisions through the dependency graph.
 	while let Some(source_package_id) = queue.pop_front() {
 		let source_state = if let Some(state) = states.get(source_package_id) {
 			state.clone()
 		} else {
 			continue;
 		};
+
 		if !source_state.severity.is_release() {
 			continue;
 		}
@@ -229,43 +235,45 @@ pub fn build_release_plan(
 			}
 		}
 
-		if let Some(group_id) = package_by_id
+		let group_id = package_by_id
 			.get(source_package_id)
-			.and_then(|package| package.version_group_id.as_deref())
-		{
-			let Some(group) = group_by_id.get(group_id) else {
-				continue;
-			};
-			let group_max = group
-				.members
-				.iter()
-				.map(|member| {
-					states.get(member.as_str()).map_or_else(
-						|| {
-							eprintln!(
-								"warning: version group `{group_id}` member `{member}` was not found in discovered packages"
-							);
-							BumpSeverity::None
-						},
-						|state| state.severity,
-					)
-				})
-				.max()
-				.unwrap_or(BumpSeverity::None);
+			.and_then(|package| package.version_group_id.as_deref());
+		let Some(group_id) = group_id else {
+			continue;
+		};
+		let Some(group) = group_by_id.get(group_id) else {
+			continue;
+		};
 
-			if group_max.is_release() {
-				let reason = format!("shares version group `{group_id}`");
-				for member_id in &group.members {
-					apply_decision(
-						&mut states,
-						&mut queue,
-						member_id,
-						group_max,
-						"version-group-synchronization",
-						&reason,
-						&source_state.upstream_sources,
-					);
-				}
+		let group_max = group
+			.members
+			.iter()
+			.map(|member| {
+				states.get(member.as_str()).map_or_else(
+					|| {
+						eprintln!(
+							"warning: version group `{group_id}` member `{member}` was not found in discovered packages"
+						);
+						BumpSeverity::None
+					},
+					|state| state.severity,
+				)
+			})
+			.max()
+			.unwrap_or(BumpSeverity::None);
+
+		if group_max.is_release() {
+			let reason = format!("shares version group `{group_id}`");
+			for member_id in &group.members {
+				apply_decision(
+					&mut states,
+					&mut queue,
+					member_id,
+					group_max,
+					"version-group-synchronization",
+					&reason,
+					&source_state.upstream_sources,
+				);
 			}
 		}
 	}

--- a/crates/monochange_hosting/src/lib.rs
+++ b/crates/monochange_hosting/src/lib.rs
@@ -26,6 +26,7 @@ use serde::de::DeserializeOwned;
 pub fn push_body_entries(lines: &mut Vec<String>, entries: &[String]) {
 	for (index, entry) in entries.iter().enumerate() {
 		let trimmed = entry.trim();
+
 		if trimmed.contains('\n') {
 			lines.extend(trimmed.lines().map(ToString::to_string));
 			if index + 1 < entries.len() {
@@ -33,6 +34,7 @@ pub fn push_body_entries(lines: &mut Vec<String>, entries: &[String]) {
 			}
 			continue;
 		}
+
 		if trimmed.starts_with("- ") || trimmed.starts_with("* ") || trimmed.starts_with('#') {
 			lines.push(trimmed.to_string());
 		} else {
@@ -43,10 +45,12 @@ pub fn push_body_entries(lines: &mut Vec<String>, entries: &[String]) {
 
 pub fn minimal_release_body(manifest: &ReleaseManifest, target: &ReleaseManifestTarget) -> String {
 	let mut lines = vec![format!("Release target `{}`", target.id), String::new()];
+
 	if !target.members.is_empty() {
 		lines.push(format!("Members: {}", target.members.join(", ")));
 		lines.push(String::new());
 	}
+
 	let reasons = manifest
 		.plan
 		.decisions
@@ -56,6 +60,7 @@ pub fn minimal_release_body(manifest: &ReleaseManifest, target: &ReleaseManifest
 		})
 		.flat_map(|decision| decision.reasons.iter().cloned())
 		.collect::<Vec<_>>();
+
 	if reasons.is_empty() {
 		lines.push("- prepare release".to_string());
 	} else {
@@ -63,6 +68,7 @@ pub fn minimal_release_body(manifest: &ReleaseManifest, target: &ReleaseManifest
 			lines.push(format!("- {reason}"));
 		}
 	}
+
 	lines.join("\n")
 }
 
@@ -79,17 +85,20 @@ pub fn release_pull_request_branch(branch_prefix: &str, command: &str) -> String
 		.collect::<String>()
 		.trim_matches('-')
 		.to_string();
+
 	let command = if command.is_empty() {
 		"release".to_string()
 	} else {
 		command
 	};
+
 	format!("{}/{}", branch_prefix.trim_end_matches('/'), command)
 }
 
 pub fn release_pull_request_body(manifest: &ReleaseManifest) -> String {
 	let mut lines = vec!["## Prepared release".to_string(), String::new()];
 	lines.push(format!("- command: `{}`", manifest.command));
+
 	for target in manifest
 		.release_targets
 		.iter()
@@ -100,11 +109,14 @@ pub fn release_pull_request_body(manifest: &ReleaseManifest) -> String {
 			target.kind, target.id, target.tag_name
 		));
 	}
+
 	if !manifest.release_targets.iter().any(|target| target.release) {
 		lines.push("- no outward release targets".to_string());
 	}
+
 	lines.push(String::new());
 	lines.push("## Release notes".to_string());
+
 	for target in manifest
 		.release_targets
 		.iter()
@@ -112,6 +124,7 @@ pub fn release_pull_request_body(manifest: &ReleaseManifest) -> String {
 	{
 		lines.push(String::new());
 		lines.push(format!("### {} {}", target.id, target.version));
+
 		if let Some(changelog) = manifest.changelogs.iter().find(|changelog| {
 			changelog.owner_id == target.id && changelog.owner_kind == target.kind
 		}) {
@@ -119,6 +132,7 @@ pub fn release_pull_request_body(manifest: &ReleaseManifest) -> String {
 				lines.push(String::new());
 				lines.push(paragraph.clone());
 			}
+
 			for section in &changelog.notes.sections {
 				if section.entries.is_empty() {
 					continue;
@@ -133,14 +147,17 @@ pub fn release_pull_request_body(manifest: &ReleaseManifest) -> String {
 			lines.push(minimal_release_body(manifest, target));
 		}
 	}
+
 	if !manifest.changed_files.is_empty() {
 		lines.push(String::new());
 		lines.push("## Changed files".to_string());
 		lines.push(String::new());
+
 		for path in &manifest.changed_files {
 			lines.push(format!("- {}", path.display()));
 		}
 	}
+
 	lines.join("\n")
 }
 

--- a/crates/monochange_npm/src/lib.rs
+++ b/crates/monochange_npm/src/lib.rs
@@ -98,17 +98,20 @@ pub fn discover_lockfiles(package: &PackageRecord) -> Vec<PathBuf> {
 	} else {
 		package.workspace_root.clone()
 	};
+
 	let candidate_names = [
 		"pnpm-lock.yaml",
 		"package-lock.json",
 		"bun.lock",
 		"bun.lockb",
 	];
+
 	let mut discovered = candidate_names
 		.iter()
 		.map(|name| scope.join(name))
 		.filter(|path| path.exists())
 		.collect::<Vec<_>>();
+
 	if discovered.is_empty() && scope != manifest_dir {
 		discovered.extend(
 			candidate_names
@@ -117,6 +120,7 @@ pub fn discover_lockfiles(package: &PackageRecord) -> Vec<PathBuf> {
 				.filter(|path| path.exists()),
 		);
 	}
+
 	discovered
 }
 
@@ -135,6 +139,7 @@ pub fn default_lockfile_commands(package: &PackageRecord) -> Vec<LockfileCommand
 			} else {
 				"bun install --lockfile-only"
 			};
+
 			LockfileCommandExecution {
 				command: command.to_string(),
 				cwd: lockfile

--- a/crates/monochange_semver/src/lib.rs
+++ b/crates/monochange_semver/src/lib.rs
@@ -78,11 +78,13 @@ pub fn collect_assessments(
 		.collect()
 }
 
+/// Merge two bump severities and return the higher one.
 #[must_use]
 pub fn merge_severities(left: BumpSeverity, right: BumpSeverity) -> BumpSeverity {
 	left.max(right)
 }
 
+/// Return the strongest assessment from a list.
 #[must_use]
 pub fn strongest_assessment(
 	assessments: &[CompatibilityAssessment],
@@ -93,6 +95,7 @@ pub fn strongest_assessment(
 		.max_by_key(|assessment| assessment.severity)
 }
 
+/// Return the strongest assessment for a specific package.
 #[must_use]
 pub fn strongest_assessment_for_package(
 	assessments: &[CompatibilityAssessment],
@@ -103,6 +106,7 @@ pub fn strongest_assessment_for_package(
 		.filter(|assessment| assessment.package_id == package_id)
 		.cloned()
 		.collect::<Vec<_>>();
+
 	strongest_assessment(&matching)
 }
 

--- a/docs/agents/coding-style.md
+++ b/docs/agents/coding-style.md
@@ -1,0 +1,321 @@
+# Coding style
+
+This guide defines the code aesthetics and layout standards for the monochange codebase. It focuses on **how code looks** rather than what it does—whitespace placement, comment positioning, code simplification patterns, and visual organization to maximize readability.
+
+> **Note**: This guide does not dictate which functions, methods, or language features to use. Those decisions are documented in other guides (e.g., [Rust quality and safety](rust-quality.md), [Architecture rules](architecture.md)). This guide is purely about the _visual presentation_ of code.
+
+## Philosophy
+
+**Simple code is better than complex code.**
+
+Given two implementations that achieve the same goal, choose the one that:
+
+- Has fewer lines
+- Has less nesting
+- Requires less mental effort to follow
+- Is easier to explain in words
+
+> **Exception**: When security or performance requires complexity
+
+When you must introduce complexity for security or performance reasons, **always add a comment explaining why**:
+
+```rust
+// Security: We must validate the signature before parsing
+// to prevent malformed input from causing panic or undefined behavior
+if !is_valid_signature(input) {
+    return Err(Error::InvalidSignature);
+}
+```
+
+## Core principles
+
+### Whitespace is semantics
+
+Blank lines are not just for decoration—they separate concepts and give the reader time to breathe.
+
+**Where to place blank lines:**
+
+1. **Before control flow statements**: Add blank lines before `if`, `match`, `for`, `while`, etc.
+2. **Between logical groups**: Group related operations, then separate groups with blank lines
+3. **After complex declarations**: Long variable declarations deserve breathing room
+4. **Before return statements**: Unless it's the very next line after a short operation
+
+```rust
+// Good: Whitespace separates concerns
+fn process_order(order: Order) -> Result<Receipt, Error> {
+	// Group 1: Validation
+	if order.items.is_empty() {
+		return Err(Error::EmptyOrder);
+	}
+
+	if !order.payment_method.is_valid() {
+		return Err(Error::InvalidPayment);
+	}
+
+	// Group 2: Calculation
+	let subtotal = calculate_subtotal(&order.items);
+	let tax = calculate_tax(subtotal, order.region);
+	let total = subtotal + tax;
+
+	// Group 3: Payment processing
+	let payment_result = process_payment(order.payment_method, total)?;
+
+	if !payment_result.success {
+		return Err(Error::PaymentFailed);
+	}
+
+	// Group 4: Finalization
+	let receipt = Receipt {
+		order_id: order.id,
+		total,
+		transaction_id: payment_result.id,
+	};
+
+	Ok(receipt)
+}
+```
+
+### Variables at the top
+
+Declare variables and constants at the start of functions or at the top of files when possible. This establishes the "state" for what's about to happen.
+
+```rust
+// Good: State is established upfront
+fn configure_server(config: &Config) -> Server {
+	// Configuration extraction
+	let port = config.port;
+	let timeout = config.timeout_secs;
+	let max_connections = config.max_connections;
+
+	// Security settings
+	let require_tls = config.environment == Environment::Production;
+
+	// Build and return
+	Server::builder()
+		.port(port)
+		.timeout(timeout)
+		.max_connections(max_connections)
+		.tls(require_tls)
+		.build()
+}
+```
+
+**Exception**: When a variable's value depends on a prior computation, declare it near where it's computed.
+
+### Early returns over deep nesting
+
+**Indentation is an orange flag.** Treat deeply nested code as a code smell.
+
+**The rule**: If you find yourself more than 2-3 levels deep, refactor.
+
+**Strategy**: Guard clauses and early returns
+
+```rust
+// Avoid: Deep nesting
+fn handle_request(req: Request) -> Response {
+	if let Some(user) = req.user {
+		if user.is_active {
+			if user.has_permission("read") {
+				if let Some(data) = fetch_data() {
+					Response::ok(data)
+				} else {
+					Response::not_found()
+				}
+			} else {
+				Response::forbidden()
+			}
+		} else {
+			Response::unauthorized()
+		}
+	} else {
+		Response::unauthorized()
+	}
+}
+
+// Prefer: Early returns
+fn handle_request(req: Request) -> Response {
+	let user = req.user.ok_or_else(|| Response::unauthorized())?;
+
+	if !user.is_active {
+		return Response::unauthorized();
+	}
+
+	if !user.has_permission("read") {
+		return Response::forbidden();
+	}
+
+	let data = fetch_data().ok_or_else(|| Response::not_found())?;
+
+	Response::ok(data)
+}
+```
+
+### Extraction over nesting
+
+When you can't avoid complex logic, extract it into smaller functions.
+
+```rust
+// Avoid: Complex nested logic
+fn process_data(data: Data) -> Result {
+	if let Some(items) = data.items {
+		for item in items {
+			if item.is_active {
+				if let Some(value) = item.value {
+					if value > threshold {
+						// 20 lines of complex processing...
+					}
+				}
+			}
+		}
+	}
+}
+
+// Prefer: Extract into focused functions
+fn process_data(data: Data) -> Result {
+	let active_items = data.active_items()?;
+
+	for item in active_items {
+		if let Some(value) = item.significant_value(threshold) {
+			process_significant_item(item, value)?;
+		}
+	}
+
+	Ok(())
+}
+
+fn process_significant_item(item: &Item, value: Value) -> Result {
+	// 20 lines of focused processing...
+}
+```
+
+### Comments explain why, not what
+
+Comments should explain **why** code exists, not **what** it does (the code itself should be clear).
+
+**Exception**: When security or performance requires non-obvious code, explain both what and why:
+
+```rust
+// Security: Constant-time comparison to prevent timing attacks
+// We compare every byte regardless of mismatches to ensure
+// the operation takes the same time regardless of where the
+// first difference occurs
+if !constant_time_eq(provided_hash, stored_hash) {
+    return Err(Error::InvalidCredentials);
+}
+```
+
+```rust
+// Performance: Pre-allocate array to avoid reallocations
+// This reduces GC pressure when processing large datasets
+const results = new Array(estimatedSize);
+```
+
+### Documentation blocks
+
+Every function, class, and module should have a documentation block explaining:
+
+- **Purpose**: What does this do?
+- **Why**: Why does this exist? What problem does it solve?
+
+```rust
+/// Validates a user session.
+///
+/// # Why this exists
+/// Session validation is required before any privileged operation
+/// to ensure the user is authenticated and their session hasn't expired.
+///
+/// # Security considerations
+/// - This check must happen before any data access
+/// - Session tokens are validated cryptographically
+/// - Expired sessions are logged for security monitoring
+fn validate_session(token: &str) -> Result<Session, Error> {
+	// ...
+}
+```
+
+## Language-specific guidelines
+
+### Rust
+
+For Rust code, the following patterns are encouraged:
+
+- **Whitespace**: Add blank lines before control flow, between logical groups, after complex declarations
+- **Early returns**: Use `let-else` syntax or `?` operator for flat structure
+- **Variable grouping**: Group related `let` statements, separate from usage with blank lines
+- **Section comments**: Use comments like `// === Configuration loading ===` to mark logical sections
+
+**Always run the formatter and linter after editing:**
+
+```bash
+# 1. Format
+rustfmt ./crates/monochange/src/lib.rs
+
+# 2. Auto-fix what clippy can
+rustclippy --fix -- ./crates/monochange/src/lib.rs
+
+# 3. Check remaining issues
+rustclippy -- ./crates/monochange/src/lib.rs
+```
+
+### TypeScript and JavaScript
+
+- Use `prettier` for formatting
+- Apply the same whitespace principles: blank lines before control flow, between logical groups
+- Prefer early returns over deep nesting
+
+### Markdown
+
+- Use `dprint` for formatting documentation
+- Add blank lines between sections
+- Keep lines reasonably short for readability
+
+## Integration with formatters
+
+This style guide **complements**, not replaces, automated formatters:
+
+- **Always use**: `rustfmt`, `prettier`, `dprint`, etc.
+- **This guide covers**: Blank line placement, grouping, early return patterns, comment positioning
+- **Formatters cover**: Indentation, trailing commas, spacing around operators, line length
+
+Never fight the formatter on mechanical details. This guide addresses aesthetic choices that formatters don't make.
+
+### Always run the formatter after editing
+
+**Rule**: After editing any code file or markdown file, always run the project's formatter.
+
+For this project:
+
+- **dprint** - Universal formatter for many languages
+- **rustfmt** - Rust code
+
+Run the formatter on the specific files you edited. Auto-formatted code is essential for consistent codebases.
+
+### Always run the linter and fix all issues
+
+**Rule**: Run the project's linter after editing files.
+
+**Warnings are errors**: Treat all linter warnings as errors.
+
+- If a warning shouldn't exist, remove it from the lint settings
+- Don't leave warnings in the codebase
+
+**Auto-fix what you can**:
+
+- Formatters auto-correct their own formatting issues
+- Linters often have auto-fix for some issues: run the auto-fix first
+- For remaining issues that require reasoning: fix them manually
+
+## Summary
+
+| Principle              | Rule                                            | Exception                                            |
+| ---------------------- | ----------------------------------------------- | ---------------------------------------------------- |
+| **Simplicity**         | Choose the simpler solution                     | When security or performance requires complexity     |
+| **Whitespace**         | Blank lines before control flow, between groups | Short, tightly-coupled operations                    |
+| **Variable placement** | Declare at top when possible                    | When value depends on prior computation              |
+| **Nesting**            | Avoid more than 2-3 levels deep                 | When language idioms require it                      |
+| **Comments**           | Explain why, not what                           | Security and performance require explanation of what |
+| **Extraction**         | Break complex logic into small functions        | When it hurts performance                            |
+| **Formatting**         | Run formatter after every edit                  | N/A - Always run it                                  |
+| **Linting**            | Run linter after edits, fix all issues          | Only skip if linter is very slow                     |
+
+**Remember**: Code is read far more often than it is written. Optimize for the reader.

--- a/testing/monochange_test_helpers/src/fs.rs
+++ b/testing/monochange_test_helpers/src/fs.rs
@@ -13,6 +13,7 @@ pub fn current_test_name() -> String {
 		.split("::")
 		.last()
 		.unwrap_or("unknown");
+
 	if let Some(rest) = name.strip_prefix("case_")
 		&& let Some((index, suffix)) = rest.split_once('_')
 		&& index.chars().all(|ch| ch.is_ascii_digit())
@@ -20,6 +21,7 @@ pub fn current_test_name() -> String {
 	{
 		return suffix.to_string();
 	}
+
 	name.to_string()
 }
 
@@ -50,35 +52,45 @@ pub fn setup_fixture_from(manifest_dir: &str, relative: &str) -> TempDir {
 pub fn setup_scenario_workspace_from(manifest_dir: &str, scenario_relative: &str) -> TempDir {
 	let scenario_root = fixture_path_from(manifest_dir, scenario_relative);
 	let workspace_root = scenario_root.join("workspace");
+
 	let source_root = if workspace_root.is_dir() {
 		workspace_root
 	} else {
 		scenario_root
 	};
+
 	let tempdir = TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	copy_directory_filtered(&source_root, tempdir.path(), &|path| {
 		path.file_name().is_some_and(|name| name == "expected")
 	});
+
 	tempdir
 }
 
 fn copy_directory_filtered(source: &Path, destination: &Path, skipped: &dyn Fn(&Path) -> bool) {
 	fs::create_dir_all(destination)
 		.unwrap_or_else(|error| panic!("create destination {}: {error}", destination.display()));
+
 	for entry in fs::read_dir(source)
 		.unwrap_or_else(|error| panic!("read dir {}: {error}", source.display()))
 	{
 		let entry = entry.unwrap_or_else(|error| panic!("dir entry: {error}"));
+
 		let source_path = entry.path();
 		if skipped(&source_path) {
 			continue;
 		}
+
 		let destination_path = destination.join(entry.file_name());
 		let metadata = fs::metadata(&source_path)
 			.unwrap_or_else(|error| panic!("metadata {}: {error}", source_path.display()));
+
 		if metadata.is_dir() {
 			copy_directory_filtered(&source_path, &destination_path, skipped);
-		} else if metadata.is_file() {
+			continue;
+		}
+
+		if metadata.is_file() {
 			if let Some(parent) = destination_path.parent() {
 				fs::create_dir_all(parent)
 					.unwrap_or_else(|error| panic!("create parent {}: {error}", parent.display()));

--- a/testing/monochange_test_helpers/src/git.rs
+++ b/testing/monochange_test_helpers/src/git.rs
@@ -5,6 +5,7 @@ pub fn git(root: &Path, args: &[&str]) {
 	let output = git_command(root, args)
 		.output()
 		.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
+
 	assert!(
 		output.status.success(),
 		"git {args:?} failed: {}{}",
@@ -17,12 +18,14 @@ pub fn git_output(root: &Path, args: &[&str]) -> String {
 	let output = git_command(root, args)
 		.output()
 		.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
+
 	assert!(
 		output.status.success(),
 		"git {args:?} failed: {}{}",
 		String::from_utf8_lossy(&output.stdout),
 		String::from_utf8_lossy(&output.stderr)
 	);
+
 	String::from_utf8(output.stdout).unwrap_or_else(|error| panic!("git output utf8: {error}"))
 }
 

--- a/testing/monochange_test_helpers/src/insta.rs
+++ b/testing/monochange_test_helpers/src/insta.rs
@@ -1,17 +1,24 @@
 pub fn snapshot_settings() -> insta::Settings {
 	let mut settings = insta::Settings::clone_current();
+
+	// Path filters - normalize temporary directories across platforms
 	settings.add_filter(r"/private/var/folders/[^\s]+?/T/[^/\s]+", "[ROOT]");
 	settings.add_filter(r"/var/folders/[^\s]+?/T/[^/\s]+", "[ROOT]");
 	settings.add_filter(r"/private/tmp/[^/\s]+", "[ROOT]");
 	settings.add_filter(r"/tmp/[^/\s]+", "[ROOT]");
 	settings.add_filter(r"/home/runner/work/_temp/[^/\s]+", "[ROOT]");
 	settings.add_filter(r"\b[A-Z]:\\[^\s]+?\\Temp\\[^\\\s]+", "[ROOT]");
+
+	// Position filters
 	settings.add_filter(r"near position \d+", "near position [POS]");
 	settings.add_filter(r"SourceOffset\(\d+\)", "SourceOffset([OFFSET])");
 	settings.add_filter(r"length: \d+", "length: [LEN]");
 	settings.add_filter(r"@ bytes \d+\.\.\d+", "@ bytes [OFFSET]..[END]");
+
+	// Hash and date filters
 	settings.add_filter(r"\b[0-9a-f]{7,40}\b", "[SHA]");
 	settings.add_filter(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}", "[DATETIME]");
 	settings.add_filter(r"\d{4}-\d{2}-\d{2}", "[DATE]");
+
 	settings
 }

--- a/testing/monochange_test_helpers/src/rmcp.rs
+++ b/testing/monochange_test_helpers/src/rmcp.rs
@@ -1,12 +1,10 @@
 pub fn content_text(result: &rmcp::model::CallToolResult) -> String {
-	result
-		.content
-		.first()
-		.and_then(|content| {
-			match &content.raw {
-				rmcp::model::RawContent::Text(text) => Some(text.text.clone()),
-				_ => None,
-			}
-		})
-		.unwrap_or_default()
+	let Some(content) = result.content.first() else {
+		return String::new();
+	};
+
+	match &content.raw {
+		rmcp::model::RawContent::Text(text) => text.text.clone(),
+		_ => String::new(),
+	}
 }

--- a/testing/monochange_test_helpers/src/workspace_ops.rs
+++ b/testing/monochange_test_helpers/src/workspace_ops.rs
@@ -11,6 +11,7 @@ use monochange_core::MonochangeResult;
 fn root_relative(root: &Path, path: &Path) -> PathBuf {
 	let relative =
 		monochange_core::relative_to_root(root, path).unwrap_or_else(|| path.to_path_buf());
+
 	if relative.as_os_str().is_empty() {
 		PathBuf::from(".")
 	} else {
@@ -43,6 +44,7 @@ pub fn run_lockfile_command(
 	command: &LockfileCommandExecution,
 ) -> MonochangeResult<()> {
 	let cwd = remap_workspace_path(root, temp_root, &command.cwd)?;
+
 	let output = if let Some(shell_binary) = command.shell.shell_binary() {
 		Command::new(shell_binary)
 			.arg("-c")
@@ -60,6 +62,7 @@ pub fn run_lockfile_command(
 		};
 		Command::new(program).args(args).current_dir(&cwd).output()
 	};
+
 	let output = output.map_err(|error| {
 		MonochangeError::Io(format!(
 			"failed to run lockfile command `{}` in {}: {error}",
@@ -67,15 +70,18 @@ pub fn run_lockfile_command(
 			root_relative(root, &command.cwd).display(),
 		))
 	})?;
+
 	if output.status.success() {
 		return Ok(());
 	}
+
 	let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
 	let details = if stderr.is_empty() {
 		format!("exit status {}", output.status)
 	} else {
 		stderr
 	};
+
 	Err(MonochangeError::Discovery(format!(
 		"lockfile command `{}` failed in {}: {details}",
 		command.command,
@@ -86,6 +92,7 @@ pub fn run_lockfile_command(
 pub fn read_optional_file(path: &Path) -> MonochangeResult<Option<Vec<u8>>> {
 	match fs::read(path) {
 		Ok(contents) => Ok(Some(contents)),
+
 		Err(error)
 			if matches!(
 				error.kind(),
@@ -94,6 +101,7 @@ pub fn read_optional_file(path: &Path) -> MonochangeResult<Option<Vec<u8>>> {
 		{
 			Ok(None)
 		}
+
 		Err(error) => {
 			Err(MonochangeError::Io(format!(
 				"failed to read {}: {error}",
@@ -149,19 +157,24 @@ pub fn collect_workspace_files(
 	})? {
 		let entry = entry
 			.map_err(|error| MonochangeError::Io(format!("directory entry error: {error}")))?;
+
 		let path = entry.path();
 		if path.file_name().is_some_and(|name| name == ".git") {
 			continue;
 		}
+
 		let file_type = entry_file_type(&entry, &path)?;
+
 		if file_type.is_dir() {
 			collect_workspace_files(root, &path, relative_paths)?;
 			continue;
 		}
+
 		if file_type.is_file() {
 			relative_paths.insert(strip_workspace_prefix(&path, root)?.to_path_buf());
 		}
 	}
+
 	Ok(())
 }
 
@@ -172,25 +185,31 @@ pub fn copy_workspace_tree(source: &Path, destination: &Path) -> MonochangeResul
 			destination.display()
 		))
 	})?;
+
 	for entry in fs::read_dir(source).map_err(|error| {
 		MonochangeError::Io(format!("failed to read {}: {error}", source.display()))
 	})? {
 		let entry = entry
 			.map_err(|error| MonochangeError::Io(format!("directory entry error: {error}")))?;
+
 		let source_path = entry.path();
 		if source_path.file_name().is_some_and(|name| name == ".git") {
 			continue;
 		}
+
 		let destination_path = destination.join(entry.file_name());
 		let file_type = entry_file_type(&entry, &source_path)?;
+
 		if file_type.is_dir() {
 			copy_workspace_tree(&source_path, &destination_path)?;
 			continue;
 		}
+
 		if file_type.is_file() {
 			ensure_parent_directory(&destination_path)?;
 			copy_workspace_file(&source_path, &destination_path)?;
 		}
 	}
+
 	Ok(())
 }


### PR DESCRIPTION
## Summary

Applied the @ifi/coding-style-guide style principles across the entire Rust codebase to improve readability and maintainability.

## Changes

### Style improvements applied:

1. **Whitespace and Visual Breathing Room**
   - Added blank lines before control flow statements (`if`, `match`, `for`, `while`)
   - Added blank lines between logical groups of code
   - Added blank lines after complex variable declarations
   - Added blank lines before return statements

2. **Early Returns and Flat Structure**
   - Converted nested if-let chains to early returns using `let-else` syntax
   - Used guard clauses at function start to handle edge cases upfront
   - Reduced indentation levels across multiple functions

3. **Variable Declaration and Grouping**
   - Grouped related variable declarations at start of functions where possible
   - Separated variable declarations from usage with blank lines
   - Added section comments for logical groups

4. **Extraction Patterns**
   - Broke complex nested logic into smaller, named functions
   - Kept functions focused and under ~30-40 lines where possible

5. **Documentation**
   - Added `docs/agents/coding-style.md` documenting the style guide
   - Updated `AGENTS.md` to reference the new coding style documentation
   - Added changeset for this refactor

### Files modified:

- **Core crates**: 21 files with style improvements
- **Test helpers**: 5 files with improved readability
- **Documentation**: Added `docs/agents/coding-style.md`

## Verification

- ✅ `cargo fmt` - All files formatted
- ✅ `cargo clippy --all-features` - No warnings
- ✅ `cargo test --lib` - All library tests pass
- ✅ `mc validate` - Workspace validation passes

## Notes

This is a pure refactoring PR with **no functional changes** - all existing behavior is preserved. The changes are purely aesthetic improvements to enhance code readability following the established style guide.