### PR TITLE
docs: expand monochange skill and CI workflow guidance

### DIFF
--- a/.changeset/skill-modular-docs.md
+++ b/.changeset/skill-modular-docs.md
@@ -1,0 +1,36 @@
+---
+"@monochange/skill": patch
+---
+
+#### add modular skill docs and a full linting guide
+
+The packaged `@monochange/skill` docs now split the agent guidance into focused deep dives while keeping `REFERENCE.md` at the top level as the high-context reference document.
+
+**Before:**
+
+The package centered on `SKILL.md` plus a few top-level docs, but it did not have a dedicated `skills/` folder for focused topics and it did not explain the current workspace lint policy rule by rule.
+
+**After:**
+
+The package now includes:
+
+- `skills/changesets.md` for creating and managing `.changeset/*.md` files
+- `skills/commands.md` for choosing the right `mc` command and command flow
+- `skills/configuration.md` for creating and extending `monochange.toml`
+- `skills/linting.md` for the current rust/clippy rules, why they exist, and what changes with and without them
+- updated `SKILL.md` and `REFERENCE.md` links so agents can jump between the concise entrypoint and the deeper reference material
+
+**Skill bundle example:**
+
+```text
+SKILL.md
+REFERENCE.md
+skills/
+  README.md
+  changesets.md
+  commands.md
+  configuration.md
+  linting.md
+```
+
+This makes the published skill package easier to load incrementally while giving agents a much denser reference surface for current monochange features.

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -852,7 +852,7 @@ After copying the bundled skill, you get a small documentation set that is desig
 - `skills/changesets.md` — changeset authoring and lifecycle guidance
 - `skills/commands.md` — built-in command catalog and workflow selection
 - `skills/configuration.md` — `monochange.toml` setup and editing guidance
-- `skills/linting.md` — the current lint policy, rationale, and examples
+- `skills/linting.md` — `[ecosystems.<name>.lints]` rules, `mc check`, and manifest-focused examples
 
 This layout keeps the top-level skill small while still making the richer guidance available when an assistant needs more context.
 
@@ -956,538 +956,402 @@ release_title = "v{{ version }} — released {{ date }}"
 
 <!-- {@lintingPolicyReference} -->
 
-Use this guide when the task is to explain, apply, or update monochange lint policy.
+Use this guide when the task is to configure or explain monochange's **manifest lint rules**.
 
-This reference reflects the current workspace lint configuration in the repository `Cargo.toml` plus the crate-level `#![forbid(clippy::indexing_slicing)]` declarations used across the Rust crates.
+These are the rules that run through **`mc check`** and are configured in `monochange.toml` under **`[ecosystems.<name>.lints]`**.
 
-## Daily linting workflow
+They are separate from Rust compiler or Clippy lints used to develop monochange itself.
 
-For normal repo work:
+## What `mc check` does
+
+`mc check` runs two phases:
+
+1. normal workspace validation, similar to `mc validate`
+2. manifest lint rules for supported package ecosystems
+
+Common commands:
 
 ```bash
-devenv shell fix:all
-devenv shell lint:all
+mc check
+mc check --fix
+mc check --format json
 ```
 
-For documentation synchronization checks:
+Use `--fix` when you want monochange to apply auto-fixes where a rule supports them.
 
-```bash
-devenv shell docs:check
+## Where lint rules live
+
+Configure rules per ecosystem in `monochange.toml`:
+
+```toml
+[ecosystems.cargo.lints]
+"cargo/dependency-field-order" = "error"
+"cargo/internal-dependency-workspace" = "error"
+"cargo/required-package-fields" = { level = "warning", fields = ["description", "license", "repository"] }
+"cargo/sorted-dependencies" = "warning"
+"cargo/unlisted-package-private" = { level = "warning", fix = true }
+
+[ecosystems.npm.lints]
+"npm/workspace-protocol" = "error"
+"npm/sorted-dependencies" = "warning"
+"npm/required-package-fields" = { level = "warning", fields = ["description", "repository", "license"] }
+"npm/root-no-prod-deps" = "error"
+"npm/no-duplicate-dependencies" = "error"
+"npm/unlisted-package-private" = { level = "warning", fix = true }
 ```
 
-Use `docs:update` after editing shared `.templates/` content.
+Rule configuration supports two forms:
 
-## How to read the policy
+- simple severity: `"rule-id" = "error"`, `"warning"`, or `"off"`
+- detailed config: `{ level = "error", ...rule_specific_options }`
 
-monochange uses a mix of:
+## Current rule coverage
 
-- **workspace rust lints** — compiler-level safety and hygiene rules
-- **workspace clippy groups** — broad quality buckets like correctness and performance
-- **targeted clippy overrides** — rules we intentionally deny, warn, or allow
-- **crate-level forbids** — stricter local rules when a specific panic pattern is unacceptable
+Today, built-in manifest lint rules exist for:
 
-The goal is not "never write interesting code." The goal is to avoid correctness bugs, avoid panic-prone indexing patterns, stay portable across Rust editions, and keep only the pedantic warnings that actually improve the codebase.
+- **Cargo** manifests (`Cargo.toml`)
+- **npm-family** manifests (`package.json`)
 
-## Workspace rust lints
+monochange already wires lint configuration through `configuration.cargo.lints`, `configuration.npm.lints`, `configuration.deno.lints`, and `configuration.dart.lints`, but the current built-in rule sets are implemented for Cargo and npm manifests.
 
-### `rust_2021_compatibility = warn`
+## Cargo manifest lint rules
 
-**Why:** catches patterns that behave differently across editions.
+### `cargo/dependency-field-order`
 
-**When to care:** when writing macros, pattern matches, or syntax that might become edition-sensitive.
+**Why:** keeps inline dependency tables visually consistent.
 
-**Without the rule:** edition migration issues can accumulate silently.
+**What it checks:** preferred key order inside dependency tables:
 
-**With the rule:** you get an early warning before the next edition change becomes painful.
-
-### `rust_2024_compatibility = warn`
-
-**Why:** keeps the codebase ready for Rust 2024 semantics.
-
-**When to care:** when introducing syntax or macro usage that may change in the 2024 edition.
-
-**Without the rule:** future upgrades become a large cleanup project.
-
-**With the rule:** new code is nudged toward edition-safe patterns now.
-
-### `unsafe_code = deny`
-
-**Why:** monochange should not rely on unchecked memory operations for release-planning logic.
-
-**When to use:** almost always for business logic, config parsing, changelog generation, and CLI orchestration.
-
-**Without the rule:**
-
-```rust
-unsafe {
-    std::ptr::read(ptr)
-}
-```
-
-Unsafe blocks can slip in and become maintenance hotspots.
-
-**With the rule:** prefer safe standard-library APIs:
-
-```rust
-let first = values.first().copied();
-```
-
-### `unstable_features = deny`
-
-**Why:** published tooling should compile on stable Rust.
-
-**When to use:** for libraries and CLIs that must stay portable for contributors and CI.
-
-**Without the rule:** nightly-only features can leak into the codebase.
-
-**With the rule:** the code stays stable-channel compatible.
-
-### `unused_extern_crates = warn`
-
-**Why:** dead extern declarations add noise and make dependencies harder to audit.
-
-**Without the rule:** old compatibility imports linger.
-
-**With the rule:** unused declarations are cleaned up quickly.
-
-### `unused_import_braces = warn`
-
-**Why:** removes unnecessary syntax noise.
-
-**Without the rule:**
-
-```rust
-use std::fmt;
-```
-
-**With the rule:**
-
-```rust
-use std::fmt;
-```
-
-### `unused_lifetimes = warn`
-
-**Why:** unused lifetimes usually mean an API signature is more complex than necessary.
-
-**Without the rule:**
-
-```rust
-fn name<'a>(value: &str) -> &str {
-	value
-}
-```
-
-**With the rule:**
-
-```rust
-fn name(value: &str) -> &str {
-	value
-}
-```
-
-### `unused_macro_rules = warn`
-
-**Why:** dead macro arms are easy to forget and hard to test.
-
-**Without the rule:** macro definitions keep stale branches.
-
-**With the rule:** only exercised macro rules survive.
-
-### `unused_qualifications = warn`
-
-**Why:** fully qualifying names that are already in scope hurts readability.
-
-**Without the rule:**
-
-```rust
-use std::path::PathBuf;
-
-let path = std::path::PathBuf::new();
-```
-
-**With the rule:**
-
-```rust
-use std::path::PathBuf;
-
-let path = PathBuf::new();
-```
-
-### `variant_size_differences = warn`
-
-**Why:** very uneven enum variants can cause surprising memory bloat.
-
-**Without the rule:** a single large variant can inflate every enum value.
-
-**With the rule:** you consider boxing or reshaping the large variant.
-
-### `edition_2024_expr_fragment_specifier = allow`
-
-**Why it is allowed:** this lint is intentionally relaxed to avoid noisy churn while macro-related edition support settles.
-
-**When the allowance is appropriate:** when the code is otherwise clear and no migration risk is introduced.
-
-**Without the allowance:** the repo would force extra macro cleanups that do not improve the current product behavior.
-
-## Workspace clippy groups
-
-### `clippy::correctness = deny`
-
-**Why:** correctness issues are the highest-risk category.
-
-**Without it:** real bugs can land as "just warnings."
-
-**With it:** code that is likely wrong fails the lint pass.
-
-### `clippy::suspicious = warn`
-
-**Why:** suspicious constructs often compile but suggest a logic mistake.
-
-**Without it:** subtle mistakes look legitimate.
-
-**With it:** you get a review checkpoint before the bug becomes user-visible.
-
-### `clippy::style = warn`
-
-**Why:** style warnings keep code predictable and easier to scan.
-
-**Without it:** equivalent patterns drift across the codebase.
-
-**With it:** contributors converge on the same idioms.
-
-### `clippy::complexity = warn`
-
-**Why:** overly complex code is harder to review and easier to break.
-
-**Without it:** nested or overly clever logic grows unnoticed.
-
-**With it:** clippy nudges you toward extraction and simpler control flow.
-
-**Example of what this pressure is trying to prevent:**
-
-```rust
-if should_release {
-    if let Some(group) = group {
-        if group.publish {
-            if !group.members.is_empty() {
-                publish(group);
-            }
-        }
-    }
-}
-```
-
-A flatter version is easier to review:
-
-```rust
-let Some(group) = group else {
-    return;
-};
-
-if !should_release || !group.publish || group.members.is_empty() {
-    return;
-}
-
-publish(group);
-```
-
-### `clippy::perf = warn`
-
-**Why:** hot-path inefficiencies are easier to fix when caught early.
-
-**Without it:** unnecessary allocations and slower patterns blend in.
-
-**With it:** common performance footguns get surfaced during normal linting.
-
-### `clippy::pedantic = warn`
-
-**Why:** pedantic lints catch a lot of polish issues that improve API and code quality.
-
-**Why not deny:** the group is intentionally broad and sometimes noisy.
-
-**monochange approach:** enable the group, then explicitly allow the few rules where local readability or practicality matters more.
-
-## Explicit clippy policy
-
-### `blocks_in_conditions = allow`
-
-**Why it is allowed:** small computed conditions can be clearer inline than as a throwaway binding.
-
-**Without the allowance:**
-
-```rust
-if {
-    let ready = state.is_ready();
-    ready
-} {
-    run();
-}
-```
-
-Clippy would complain even when the structure is readable.
-
-**With the current policy:** this pattern is allowed, but extract it if the block becomes non-trivial.
-
-### `cargo_common_metadata = allow`
-
-**Why it is allowed:** workspace metadata is managed centrally, so per-crate metadata completeness is not always the right enforcement point.
-
-**Without the allowance:** clippy would push repetitive metadata into every crate even when the workspace already provides it.
-
-**With the current policy:** add metadata where it matters, but do not create boilerplate just to silence the lint.
-
-### `cast_possible_truncation = allow`
-
-**Why it is allowed:** some numeric conversions are deliberate and guarded by domain knowledge.
-
-**Without the allowance:**
-
-```rust
-let byte = value as u8;
-```
-
-would warn every time, even when the value is known to fit.
-
-**With the current policy:** the cast is permitted, but reviewers should still expect surrounding reasoning or bounds checks when truncation is not obviously safe.
-
-### `cast_possible_wrap = allow`
-
-**Why it is allowed:** signed/unsigned conversions sometimes reflect external protocol or storage requirements.
-
-**Without the allowance:** every deliberate sign-changing cast becomes noise.
-
-**With the current policy:** use the cast intentionally and document tricky cases.
-
-### `cast_precision_loss = allow`
-
-**Why it is allowed:** some reporting or ratio calculations intentionally trade precision for convenience.
-
-**Without the allowance:** floating-point conversions generate warnings even in non-critical display logic.
-
-**With the current policy:** precision-loss casts are allowed, but avoid them in semver, version, or identity logic where exactness matters.
-
-### `cast_sign_loss = allow`
-
-**Why it is allowed:** conversions to unsigned values are sometimes part of external API shaping.
-
-**Without the allowance:** routine boundary conversions become noisy.
-
-**With the current policy:** keep the cast local and obvious.
-
-### `expl_impl_clone_on_copy = allow`
-
-**Why it is allowed:** an explicit `Clone` impl on a `Copy` type can occasionally be clearer or more controlled than a derive.
-
-**Without the allowance:** clippy would force a derive-only style.
-
-**With the current policy:** explicit impls are allowed when there is a concrete reason, not as default habit.
-
-### `items_after_statements = allow`
-
-**Why it is allowed:** tests and small helper scopes sometimes read better when local items appear near their use.
-
-**Without the allowance:**
-
-```rust
-fn test_case() {
-	let input = sample();
-
-	fn sample() -> &'static str {
-		"ok"
-	}
-
-	assert_eq!(input, "ok");
-}
-```
-
-would warn.
-
-**With the current policy:** that layout is acceptable when it improves locality.
-
-### `missing_errors_doc = allow`
-
-**Why it is allowed:** internal functions are numerous, and forcing `# Errors` on all of them creates noisy docs.
-
-**Without the allowance:** every fallible helper would need a doc section.
-
-**With the current policy:** still document errors on public APIs and non-obvious behavior, but do not require boilerplate on every internal helper.
-
-### `missing_panics_doc = allow`
-
-**Why it is allowed:** similar to `missing_errors_doc`, this avoids boilerplate on internal helpers.
-
-**Without the allowance:** even intentionally internal panic paths need formal docs.
-
-**With the current policy:** public or surprising panic behavior should still be documented deliberately.
-
-### `module_name_repetitions = allow`
-
-**Why it is allowed:** crate boundaries and domain naming sometimes make repetition the clearest choice.
-
-**Without the allowance:**
-
-```rust
-mod release_record;
-struct ReleaseRecord;
-```
-
-can trigger a warning even though the names are clear.
-
-**With the current policy:** choose clarity over lint golf.
-
-### `must_use_candidate = allow`
-
-**Why it is allowed:** clippy suggests `#[must_use]` very aggressively.
-
-**Without the allowance:** many private helpers would get noisy suggestions.
-
-**With the current policy:** apply `#[must_use]` intentionally on public APIs, builders, and values where dropping the result is genuinely a bug.
-
-### `no_effect_underscore_binding = allow`
-
-**Why it is allowed:** intentionally ignored intermediate values sometimes help document intent in tests or command setup.
-
-**Without the allowance:** underscore-prefixed bindings can still warn even when they make the code easier to follow.
-
-**With the current policy:** use them sparingly and only when they clarify intent.
-
-### `tabs-in-doc-comments = allow`
-
-**Why it is allowed:** command output, tables, or copied terminal content may legitimately contain tabs.
-
-**Without the allowance:** documentation cleanup would fight preserved examples.
-
-**With the current policy:** tabs are acceptable in docs when they preserve exact formatting.
-
-### `too_many_lines = allow`
-
-**Why it is allowed:** some orchestration functions, renderers, or test modules are large for domain reasons.
-
-**Without the allowance:** contributors would spend time splitting code purely to satisfy an arbitrary line limit.
-
-**With the current policy:** long functions are allowed, but extraction is still preferred when it improves comprehension.
-
-### `wildcard_dependencies = deny`
-
-**Why:** published tools should not depend on unconstrained crate versions.
+1. `workspace` or `version`
+2. `default-features` / `default_features`
+3. `features`
+4. other keys like `optional`, `path`, `registry`, `package`, `git`, `branch`, `tag`, `rev`
 
 **Without the rule:**
 
 ```toml
-serde = "*"
+serde = { features = ["derive"], workspace = true }
 ```
 
-can make builds non-reproducible and difficult to audit.
+**With the rule:**
 
-**With the rule:** dependencies must be explicitly versioned.
-
-### `wildcard_imports = allow`
-
-**Why it is allowed:** some test modules and highly local scopes read better with a wildcard import.
-
-**Without the allowance:**
-
-```rust
-use super::*;
+```toml
+serde = { workspace = true, features = ["derive"] }
 ```
 
-would warn in common test layouts.
+**Useful option:**
 
-**With the current policy:** wildcard imports remain acceptable in narrow scopes, especially tests.
+- `fix` — defaults to `true`
 
-## Crate-level forbid: `clippy::indexing_slicing`
+### `cargo/internal-dependency-workspace`
 
-Most monochange Rust crates start with:
-
-```rust
-#![forbid(clippy::indexing_slicing)]
-```
-
-**Why:** indexing and slicing can panic, and monochange spends a lot of time parsing external files, manifests, and user input.
+**Why:** internal workspace dependencies should usually be declared through the workspace rather than carrying their own explicit version strings.
 
 **Without the rule:**
 
-```rust
-let first = values[0];
-let suffix = &text[1..];
+```toml
+[dependencies]
+monochange_core = { path = "../monochange_core", version = "0.1.0" }
 ```
 
-These compile, but they panic on malformed or short input.
+**With the rule:**
 
-**With the rule:** prefer checked access:
-
-```rust
-let first = values.first().copied();
-let suffix = text.get(1..);
+```toml
+[dependencies]
+monochange_core = { workspace = true }
 ```
 
-**Another example in manifest parsing:**
+**When to use it:** when the repository wants one workspace-owned version source for internal crates.
 
-```rust
-let version = package_json["version"].as_str();
+**Useful options:**
+
+- `require_workspace` — defaults to `true`
+- `fix` — defaults to `true`
+
+### `cargo/required-package-fields`
+
+**Why:** published crates should consistently carry the metadata your repository expects.
+
+**Default required fields:**
+
+- `description`
+- `license`
+- `repository`
+
+**Without the rule:**
+
+```toml
+[package]
+name = "example"
+version = "0.1.0"
 ```
 
-looks compact but assumes the key exists and the JSON shape is right. Checked access makes the failure mode explicit:
+**With the rule:** monochange reports the missing fields so package metadata stays consistent.
 
-```rust
-let version = package_json
-    .get("version")
-    .and_then(|value| value.as_str());
-```
+**Useful option:**
 
-**When to use this stricter rule:** parsing, config loading, release planning, changelog rendering, and any code that handles external repository state.
-
-## What "with and without linting" looks like in practice
-
-### Without the monochange lint posture
-
-- unsafe or nightly-only code can sneak in
-- panic-prone indexing is easier to miss
-- wildcard dependencies can weaken reproducibility
-- edition migration issues accumulate quietly
-- pedantic improvements never surface
-
-### With the current monochange lint posture
-
-- correctness issues fail fast
-- suspicious, style, complexity, performance, and pedantic issues show up in review
-- some noisy lints are intentionally relaxed where the team prefers readability or lower boilerplate
-- panic-prone indexing is blocked at crate level
-
-## When to add a local `#[allow(...)]`
-
-A local allow is acceptable when:
-
-- the lint is technically correct but the preferred alternative is harder to read
-- the code is constrained by a protocol, generated shape, or test pattern
-- you can explain the exception in one sentence
+- `fields` — replace the default required-field list
 
 Example:
 
-```rust
-#[allow(clippy::too_many_arguments)]
-fn build_release_payload(
-	owner: &str,
-	repo: &str,
-	version: &str,
-	tag: &str,
-	notes: &str,
-	draft: bool,
-	prerelease: bool,
-) {
-	// ...
+```toml
+[ecosystems.cargo.lints]
+"cargo/required-package-fields" = { level = "error", fields = ["description", "license"] }
+```
+
+### `cargo/sorted-dependencies`
+
+**Why:** alphabetized dependency tables are easier to review and reduce noisy diffs.
+
+**Without the rule:**
+
+```toml
+[dependencies]
+zzzz = "1.0"
+aaaa = "1.0"
+mmmm = "1.0"
+```
+
+**With the rule:**
+
+```toml
+[dependencies]
+aaaa = "1.0"
+mmmm = "1.0"
+zzzz = "1.0"
+```
+
+**Useful option:**
+
+- `fix` — defaults to `true`
+
+### `cargo/unlisted-package-private`
+
+**Why:** a Cargo package that is not listed in `monochange.toml` should not be accidentally publishable.
+
+**Without the rule:** an unmanaged crate can remain publicly publishable by accident.
+
+**With the rule:** monochange requires either:
+
+- adding the package to `monochange.toml`, or
+- marking it private with `publish = false`
+
+**Without the rule:**
+
+```toml
+[package]
+name = "experimental-crate"
+version = "0.1.0"
+```
+
+**With the rule:**
+
+```toml
+[package]
+name = "experimental-crate"
+version = "0.1.0"
+publish = false
+```
+
+**Useful option:**
+
+- `fix` — defaults to `true`
+
+## npm-family manifest lint rules
+
+### `npm/workspace-protocol`
+
+**Why:** internal workspace dependencies should use the `workspace:` protocol so local workspace intent is explicit.
+
+**Without the rule:**
+
+```json
+{
+	"dependencies": {
+		"@acme/shared": "^1.2.0"
+	}
 }
 ```
 
-Use this sparingly. If the function can be improved with a struct or builder, prefer that.
+**With the rule:**
 
-## Recommended validation loop after edits
+```json
+{
+	"dependencies": {
+		"@acme/shared": "workspace:*"
+	}
+}
+```
+
+**When to use it:** npm, pnpm, and Bun workspaces where internal packages should not drift to plain registry ranges.
+
+**Useful options:**
+
+- `require_for_private` — defaults to `false`
+- `fix` — defaults to `true`
+
+### `npm/sorted-dependencies`
+
+**Why:** alphabetized dependency sections reduce review noise and make package diffs easier to scan.
+
+**Without the rule:**
+
+```json
+{
+	"dependencies": {
+		"zod": "^4.0.0",
+		"chalk": "^5.0.0"
+	}
+}
+```
+
+**With the rule:**
+
+```json
+{
+	"dependencies": {
+		"chalk": "^5.0.0",
+		"zod": "^4.0.0"
+	}
+}
+```
+
+**Useful option:**
+
+- `fix` — defaults to `true`
+
+### `npm/required-package-fields`
+
+**Why:** package metadata should stay consistent across publishable npm packages.
+
+**Default required fields:**
+
+- `description`
+- `repository`
+- `license`
+
+**Without the rule:**
+
+```json
+{
+	"name": "@acme/app",
+	"version": "1.0.0"
+}
+```
+
+**With the rule:** monochange reports the missing metadata fields.
+
+**Useful option:**
+
+- `fields` — replace the default required-field list
+
+### `npm/root-no-prod-deps`
+
+**Why:** the workspace root `package.json` is usually orchestration-only and should keep runtime dependencies out of the root package.
+
+**Without the rule:**
+
+```json
+{
+	"dependencies": {
+		"react": "^19.0.0"
+	}
+}
+```
+
+**With the rule:** move those to `devDependencies` when the root package is only a workspace manager.
+
+**Useful option:**
+
+- `fix` — defaults to `true`
+
+### `npm/no-duplicate-dependencies`
+
+**Why:** the same dependency should not appear in multiple dependency sections unless the repository has a very deliberate reason.
+
+**Without the rule:**
+
+```json
+{
+	"dependencies": {
+		"typescript": "^5.0.0"
+	},
+	"devDependencies": {
+		"typescript": "^5.0.0"
+	}
+}
+```
+
+**With the rule:** monochange reports the duplicate and can suggest removing the redundant non-dev entry when appropriate.
+
+**Useful option:**
+
+- `fix` — defaults to `true`
+
+### `npm/unlisted-package-private`
+
+**Why:** a package not declared in `monochange.toml` should not remain publishable by accident.
+
+**Without the rule:** an unmanaged package can still look publishable.
+
+**With the rule:** monochange requires either:
+
+- adding the package to `monochange.toml`, or
+- marking it private in `package.json`
+
+**Without the rule:**
+
+```json
+{
+	"name": "@acme/experimental",
+	"version": "0.1.0"
+}
+```
+
+**With the rule:**
+
+```json
+{
+	"name": "@acme/experimental",
+	"private": true,
+	"version": "0.1.0"
+}
+```
+
+**Useful option:**
+
+- `fix` — defaults to `true`
+
+## What `mc check` looks like in practice
+
+Use plain text for local review:
 
 ```bash
-devenv shell fix:all
-devenv shell lint:all
+mc check
+```
+
+Apply safe auto-fixes where possible:
+
+```bash
+mc check --fix
+```
+
+Use JSON for CI or MCP-style tooling:
+
+```bash
+mc check --format json
+```
+
+`mc check` fails when lint errors are present, so it is appropriate for CI gates.
+
+## Recommended workflow
+
+For repository work:
+
+```bash
 mc validate
+mc check
+mc release --dry-run --diff
 ```
 
 If you changed shared docs too:

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -842,6 +842,22 @@ The monochange repository itself can dogfood this model by:
 
 <!-- {/githubAutomationDogfoodNotes} -->
 
+<!-- {@assistantSkillBundleContents} -->
+
+After copying the bundled skill, you get a small documentation set that is designed to load in layers:
+
+- `SKILL.md` — concise entrypoint for agents
+- `REFERENCE.md` — broader high-context reference with more examples
+- `skills/README.md` — index of focused deep dives
+- `skills/changesets.md` — changeset authoring and lifecycle guidance
+- `skills/commands.md` — built-in command catalog and workflow selection
+- `skills/configuration.md` — `monochange.toml` setup and editing guidance
+- `skills/linting.md` — the current lint policy, rationale, and examples
+
+This layout keeps the top-level skill small while still making the richer guidance available when an assistant needs more context.
+
+<!-- {/assistantSkillBundleContents} -->
+
 <!-- {@mcpToolsList} -->
 
 - `monochange_validate` — validate `monochange.toml` and `.changeset` targets
@@ -937,3 +953,547 @@ release_title = "v{{ version }} — released {{ date }}"
 ```
 
 <!-- {/releaseTitleConfig} -->
+
+<!-- {@lintingPolicyReference} -->
+
+Use this guide when the task is to explain, apply, or update monochange lint policy.
+
+This reference reflects the current workspace lint configuration in the repository `Cargo.toml` plus the crate-level `#![forbid(clippy::indexing_slicing)]` declarations used across the Rust crates.
+
+## Daily linting workflow
+
+For normal repo work:
+
+```bash
+devenv shell fix:all
+devenv shell lint:all
+```
+
+For documentation synchronization checks:
+
+```bash
+devenv shell docs:check
+```
+
+Use `docs:update` after editing shared `.templates/` content.
+
+## How to read the policy
+
+monochange uses a mix of:
+
+- **workspace rust lints** — compiler-level safety and hygiene rules
+- **workspace clippy groups** — broad quality buckets like correctness and performance
+- **targeted clippy overrides** — rules we intentionally deny, warn, or allow
+- **crate-level forbids** — stricter local rules when a specific panic pattern is unacceptable
+
+The goal is not "never write interesting code." The goal is to avoid correctness bugs, avoid panic-prone indexing patterns, stay portable across Rust editions, and keep only the pedantic warnings that actually improve the codebase.
+
+## Workspace rust lints
+
+### `rust_2021_compatibility = warn`
+
+**Why:** catches patterns that behave differently across editions.
+
+**When to care:** when writing macros, pattern matches, or syntax that might become edition-sensitive.
+
+**Without the rule:** edition migration issues can accumulate silently.
+
+**With the rule:** you get an early warning before the next edition change becomes painful.
+
+### `rust_2024_compatibility = warn`
+
+**Why:** keeps the codebase ready for Rust 2024 semantics.
+
+**When to care:** when introducing syntax or macro usage that may change in the 2024 edition.
+
+**Without the rule:** future upgrades become a large cleanup project.
+
+**With the rule:** new code is nudged toward edition-safe patterns now.
+
+### `unsafe_code = deny`
+
+**Why:** monochange should not rely on unchecked memory operations for release-planning logic.
+
+**When to use:** almost always for business logic, config parsing, changelog generation, and CLI orchestration.
+
+**Without the rule:**
+
+```rust
+unsafe {
+    std::ptr::read(ptr)
+}
+```
+
+Unsafe blocks can slip in and become maintenance hotspots.
+
+**With the rule:** prefer safe standard-library APIs:
+
+```rust
+let first = values.first().copied();
+```
+
+### `unstable_features = deny`
+
+**Why:** published tooling should compile on stable Rust.
+
+**When to use:** for libraries and CLIs that must stay portable for contributors and CI.
+
+**Without the rule:** nightly-only features can leak into the codebase.
+
+**With the rule:** the code stays stable-channel compatible.
+
+### `unused_extern_crates = warn`
+
+**Why:** dead extern declarations add noise and make dependencies harder to audit.
+
+**Without the rule:** old compatibility imports linger.
+
+**With the rule:** unused declarations are cleaned up quickly.
+
+### `unused_import_braces = warn`
+
+**Why:** removes unnecessary syntax noise.
+
+**Without the rule:**
+
+```rust
+use std::fmt;
+```
+
+**With the rule:**
+
+```rust
+use std::fmt;
+```
+
+### `unused_lifetimes = warn`
+
+**Why:** unused lifetimes usually mean an API signature is more complex than necessary.
+
+**Without the rule:**
+
+```rust
+fn name<'a>(value: &str) -> &str {
+	value
+}
+```
+
+**With the rule:**
+
+```rust
+fn name(value: &str) -> &str {
+	value
+}
+```
+
+### `unused_macro_rules = warn`
+
+**Why:** dead macro arms are easy to forget and hard to test.
+
+**Without the rule:** macro definitions keep stale branches.
+
+**With the rule:** only exercised macro rules survive.
+
+### `unused_qualifications = warn`
+
+**Why:** fully qualifying names that are already in scope hurts readability.
+
+**Without the rule:**
+
+```rust
+use std::path::PathBuf;
+
+let path = std::path::PathBuf::new();
+```
+
+**With the rule:**
+
+```rust
+use std::path::PathBuf;
+
+let path = PathBuf::new();
+```
+
+### `variant_size_differences = warn`
+
+**Why:** very uneven enum variants can cause surprising memory bloat.
+
+**Without the rule:** a single large variant can inflate every enum value.
+
+**With the rule:** you consider boxing or reshaping the large variant.
+
+### `edition_2024_expr_fragment_specifier = allow`
+
+**Why it is allowed:** this lint is intentionally relaxed to avoid noisy churn while macro-related edition support settles.
+
+**When the allowance is appropriate:** when the code is otherwise clear and no migration risk is introduced.
+
+**Without the allowance:** the repo would force extra macro cleanups that do not improve the current product behavior.
+
+## Workspace clippy groups
+
+### `clippy::correctness = deny`
+
+**Why:** correctness issues are the highest-risk category.
+
+**Without it:** real bugs can land as "just warnings."
+
+**With it:** code that is likely wrong fails the lint pass.
+
+### `clippy::suspicious = warn`
+
+**Why:** suspicious constructs often compile but suggest a logic mistake.
+
+**Without it:** subtle mistakes look legitimate.
+
+**With it:** you get a review checkpoint before the bug becomes user-visible.
+
+### `clippy::style = warn`
+
+**Why:** style warnings keep code predictable and easier to scan.
+
+**Without it:** equivalent patterns drift across the codebase.
+
+**With it:** contributors converge on the same idioms.
+
+### `clippy::complexity = warn`
+
+**Why:** overly complex code is harder to review and easier to break.
+
+**Without it:** nested or overly clever logic grows unnoticed.
+
+**With it:** clippy nudges you toward extraction and simpler control flow.
+
+**Example of what this pressure is trying to prevent:**
+
+```rust
+if should_release {
+    if let Some(group) = group {
+        if group.publish {
+            if !group.members.is_empty() {
+                publish(group);
+            }
+        }
+    }
+}
+```
+
+A flatter version is easier to review:
+
+```rust
+let Some(group) = group else {
+    return;
+};
+
+if !should_release || !group.publish || group.members.is_empty() {
+    return;
+}
+
+publish(group);
+```
+
+### `clippy::perf = warn`
+
+**Why:** hot-path inefficiencies are easier to fix when caught early.
+
+**Without it:** unnecessary allocations and slower patterns blend in.
+
+**With it:** common performance footguns get surfaced during normal linting.
+
+### `clippy::pedantic = warn`
+
+**Why:** pedantic lints catch a lot of polish issues that improve API and code quality.
+
+**Why not deny:** the group is intentionally broad and sometimes noisy.
+
+**monochange approach:** enable the group, then explicitly allow the few rules where local readability or practicality matters more.
+
+## Explicit clippy policy
+
+### `blocks_in_conditions = allow`
+
+**Why it is allowed:** small computed conditions can be clearer inline than as a throwaway binding.
+
+**Without the allowance:**
+
+```rust
+if {
+    let ready = state.is_ready();
+    ready
+} {
+    run();
+}
+```
+
+Clippy would complain even when the structure is readable.
+
+**With the current policy:** this pattern is allowed, but extract it if the block becomes non-trivial.
+
+### `cargo_common_metadata = allow`
+
+**Why it is allowed:** workspace metadata is managed centrally, so per-crate metadata completeness is not always the right enforcement point.
+
+**Without the allowance:** clippy would push repetitive metadata into every crate even when the workspace already provides it.
+
+**With the current policy:** add metadata where it matters, but do not create boilerplate just to silence the lint.
+
+### `cast_possible_truncation = allow`
+
+**Why it is allowed:** some numeric conversions are deliberate and guarded by domain knowledge.
+
+**Without the allowance:**
+
+```rust
+let byte = value as u8;
+```
+
+would warn every time, even when the value is known to fit.
+
+**With the current policy:** the cast is permitted, but reviewers should still expect surrounding reasoning or bounds checks when truncation is not obviously safe.
+
+### `cast_possible_wrap = allow`
+
+**Why it is allowed:** signed/unsigned conversions sometimes reflect external protocol or storage requirements.
+
+**Without the allowance:** every deliberate sign-changing cast becomes noise.
+
+**With the current policy:** use the cast intentionally and document tricky cases.
+
+### `cast_precision_loss = allow`
+
+**Why it is allowed:** some reporting or ratio calculations intentionally trade precision for convenience.
+
+**Without the allowance:** floating-point conversions generate warnings even in non-critical display logic.
+
+**With the current policy:** precision-loss casts are allowed, but avoid them in semver, version, or identity logic where exactness matters.
+
+### `cast_sign_loss = allow`
+
+**Why it is allowed:** conversions to unsigned values are sometimes part of external API shaping.
+
+**Without the allowance:** routine boundary conversions become noisy.
+
+**With the current policy:** keep the cast local and obvious.
+
+### `expl_impl_clone_on_copy = allow`
+
+**Why it is allowed:** an explicit `Clone` impl on a `Copy` type can occasionally be clearer or more controlled than a derive.
+
+**Without the allowance:** clippy would force a derive-only style.
+
+**With the current policy:** explicit impls are allowed when there is a concrete reason, not as default habit.
+
+### `items_after_statements = allow`
+
+**Why it is allowed:** tests and small helper scopes sometimes read better when local items appear near their use.
+
+**Without the allowance:**
+
+```rust
+fn test_case() {
+	let input = sample();
+
+	fn sample() -> &'static str {
+		"ok"
+	}
+
+	assert_eq!(input, "ok");
+}
+```
+
+would warn.
+
+**With the current policy:** that layout is acceptable when it improves locality.
+
+### `missing_errors_doc = allow`
+
+**Why it is allowed:** internal functions are numerous, and forcing `# Errors` on all of them creates noisy docs.
+
+**Without the allowance:** every fallible helper would need a doc section.
+
+**With the current policy:** still document errors on public APIs and non-obvious behavior, but do not require boilerplate on every internal helper.
+
+### `missing_panics_doc = allow`
+
+**Why it is allowed:** similar to `missing_errors_doc`, this avoids boilerplate on internal helpers.
+
+**Without the allowance:** even intentionally internal panic paths need formal docs.
+
+**With the current policy:** public or surprising panic behavior should still be documented deliberately.
+
+### `module_name_repetitions = allow`
+
+**Why it is allowed:** crate boundaries and domain naming sometimes make repetition the clearest choice.
+
+**Without the allowance:**
+
+```rust
+mod release_record;
+struct ReleaseRecord;
+```
+
+can trigger a warning even though the names are clear.
+
+**With the current policy:** choose clarity over lint golf.
+
+### `must_use_candidate = allow`
+
+**Why it is allowed:** clippy suggests `#[must_use]` very aggressively.
+
+**Without the allowance:** many private helpers would get noisy suggestions.
+
+**With the current policy:** apply `#[must_use]` intentionally on public APIs, builders, and values where dropping the result is genuinely a bug.
+
+### `no_effect_underscore_binding = allow`
+
+**Why it is allowed:** intentionally ignored intermediate values sometimes help document intent in tests or command setup.
+
+**Without the allowance:** underscore-prefixed bindings can still warn even when they make the code easier to follow.
+
+**With the current policy:** use them sparingly and only when they clarify intent.
+
+### `tabs-in-doc-comments = allow`
+
+**Why it is allowed:** command output, tables, or copied terminal content may legitimately contain tabs.
+
+**Without the allowance:** documentation cleanup would fight preserved examples.
+
+**With the current policy:** tabs are acceptable in docs when they preserve exact formatting.
+
+### `too_many_lines = allow`
+
+**Why it is allowed:** some orchestration functions, renderers, or test modules are large for domain reasons.
+
+**Without the allowance:** contributors would spend time splitting code purely to satisfy an arbitrary line limit.
+
+**With the current policy:** long functions are allowed, but extraction is still preferred when it improves comprehension.
+
+### `wildcard_dependencies = deny`
+
+**Why:** published tools should not depend on unconstrained crate versions.
+
+**Without the rule:**
+
+```toml
+serde = "*"
+```
+
+can make builds non-reproducible and difficult to audit.
+
+**With the rule:** dependencies must be explicitly versioned.
+
+### `wildcard_imports = allow`
+
+**Why it is allowed:** some test modules and highly local scopes read better with a wildcard import.
+
+**Without the allowance:**
+
+```rust
+use super::*;
+```
+
+would warn in common test layouts.
+
+**With the current policy:** wildcard imports remain acceptable in narrow scopes, especially tests.
+
+## Crate-level forbid: `clippy::indexing_slicing`
+
+Most monochange Rust crates start with:
+
+```rust
+#![forbid(clippy::indexing_slicing)]
+```
+
+**Why:** indexing and slicing can panic, and monochange spends a lot of time parsing external files, manifests, and user input.
+
+**Without the rule:**
+
+```rust
+let first = values[0];
+let suffix = &text[1..];
+```
+
+These compile, but they panic on malformed or short input.
+
+**With the rule:** prefer checked access:
+
+```rust
+let first = values.first().copied();
+let suffix = text.get(1..);
+```
+
+**Another example in manifest parsing:**
+
+```rust
+let version = package_json["version"].as_str();
+```
+
+looks compact but assumes the key exists and the JSON shape is right. Checked access makes the failure mode explicit:
+
+```rust
+let version = package_json
+    .get("version")
+    .and_then(|value| value.as_str());
+```
+
+**When to use this stricter rule:** parsing, config loading, release planning, changelog rendering, and any code that handles external repository state.
+
+## What "with and without linting" looks like in practice
+
+### Without the monochange lint posture
+
+- unsafe or nightly-only code can sneak in
+- panic-prone indexing is easier to miss
+- wildcard dependencies can weaken reproducibility
+- edition migration issues accumulate quietly
+- pedantic improvements never surface
+
+### With the current monochange lint posture
+
+- correctness issues fail fast
+- suspicious, style, complexity, performance, and pedantic issues show up in review
+- some noisy lints are intentionally relaxed where the team prefers readability or lower boilerplate
+- panic-prone indexing is blocked at crate level
+
+## When to add a local `#[allow(...)]`
+
+A local allow is acceptable when:
+
+- the lint is technically correct but the preferred alternative is harder to read
+- the code is constrained by a protocol, generated shape, or test pattern
+- you can explain the exception in one sentence
+
+Example:
+
+```rust
+#[allow(clippy::too_many_arguments)]
+fn build_release_payload(
+	owner: &str,
+	repo: &str,
+	version: &str,
+	tag: &str,
+	notes: &str,
+	draft: bool,
+	prerelease: bool,
+) {
+	// ...
+}
+```
+
+Use this sparingly. If the function can be improved with a struct or builder, prefer that.
+
+## Recommended validation loop after edits
+
+```bash
+devenv shell fix:all
+devenv shell lint:all
+mc validate
+```
+
+If you changed shared docs too:
+
+```bash
+devenv shell docs:check
+```
+
+<!-- {/lintingPolicyReference} -->

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -64,6 +64,44 @@ Use it when your repository has outgrown one-ecosystem release tooling and you w
 
 <!-- {/projectMilestoneCapabilities} -->
 
+<!-- {@projectCommandAutomationMatrix} -->
+
+| Goal                             | Command                                                     | Use it when                                                                                              |
+| -------------------------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Validate config and changesets   | `mc validate`                                               | You changed `monochange.toml` or `.changeset/*.md` files                                                 |
+| Inspect package ids and groups   | `mc discover --format json`                                 | You need the normalized workspace model                                                                  |
+| Create release intent            | `mc change --package <id> --bump <severity> --reason "..."` | You need a new `.changeset/*.md` file                                                                    |
+| Audit pending release context    | `mc diagnostics --format json`                              | You need git provenance, PR/MR links, or related issues                                                  |
+| Preview the release plan         | `mc release --dry-run --diff`                               | You want changelog/version patches without mutating the repo                                             |
+| Create a durable release commit  | `mc commit-release`                                         | You want a monochange-managed release commit with an embedded `ReleaseRecord`                            |
+| Open or update a release request | `mc release-pr`                                             | You want a long-lived release PR/MR branch updated from current release state                            |
+| Publish packages to registries   | `mc publish`                                                | You want `cargo publish`, `npm publish`, `deno publish`, or `dart pub publish` style package publication |
+| Bootstrap missing packages       | `mc placeholder-publish`                                    | A package must exist in its registry before later automation can work                                    |
+| Inspect a past release commit    | `mc release-record --from <ref>`                            | You need the durable release declaration from git history                                                |
+| Repair a recent release          | `mc repair-release --from <tag> --target <commit>`          | You need to retarget a just-created release to a later commit                                            |
+| Publish hosted/provider releases | `mc publish-release`                                        | You want GitHub/GitLab/Gitea release objects from prepared release state                                 |
+
+<!-- {/projectCommandAutomationMatrix} -->
+
+<!-- {@projectCapabilityMatrix} -->
+
+| Capability                                                               | Current status                                                             |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| Multi-ecosystem discovery                                                | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter                                   |
+| Package release planning                                                 | Built in                                                                   |
+| Grouped/shared versioning                                                | Built in                                                                   |
+| Dry-run release diff previews                                            | Built in via `mc release --dry-run --diff`                                 |
+| Durable release history                                                  | Built in via `ReleaseRecord`, `mc release-record`, and `mc repair-release` |
+| Hosted provider releases                                                 | GitHub, GitLab, Gitea                                                      |
+| Hosted release requests                                                  | GitHub, GitLab, Gitea                                                      |
+| Built-in registry publishing                                             | `crates.io`, `npm`, `jsr`, `pub.dev`                                       |
+| GitHub npm trusted-publishing automation                                 | Built in                                                                   |
+| GitHub trusted-publishing guidance for `crates.io`, `jsr`, and `pub.dev` | Built in, but manual registry enrollment is still required                 |
+| GitLab trusted-publishing auto-derivation                                | Not built in today                                                         |
+| Release-retarget sync for hosted releases                                | GitHub first                                                               |
+
+<!-- {/projectCapabilityMatrix} -->
+
 <!-- {@projectGitHubAutomationOverview} -->
 
 monochange can promote one prepared release into several source-provider automation flows without changing the underlying release-plan model.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -20,7 +20,7 @@
 
 # Reference
 
-- [Linting policy](reference/linting.md)
+- [Manifest linting with `mc check`](reference/linting.md)
 - [Progress output](reference/progress-output.md)
 - [Hosted release benchmarks](reference/hosted-release-benchmarks.md)
 - [CLI step reference](reference/cli-steps/00-index.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -16,9 +16,11 @@
 - [Migrating from knope](guide/10-migrating-from-knope.md)
 - [Advanced: Diagnostics](guide/11-diagnostics.md)
 - [Advanced: Repairable releases](guide/12-repairable-releases.md)
+- [Advanced: CI, package publishing, and release PR flows](guide/13-ci-and-publishing.md)
 
 # Reference
 
+- [Linting policy](reference/linting.md)
 - [Progress output](reference/progress-output.md)
 - [Hosted release benchmarks](reference/hosted-release-benchmarks.md)
 - [CLI step reference](reference/cli-steps/00-index.md)

--- a/docs/src/guide/00-start-here.md
+++ b/docs/src/guide/00-start-here.md
@@ -142,4 +142,4 @@ If you need a silent safety check, run `mc release --quiet`. Quiet mode suppress
 - [Release planning](./06-release-planning.md) — compare preview modes, grouped releases, and planning rules
 - [Advanced: GitHub automation](./08-github-automation.md) — provider publishing, release PRs, and automation
 - [Advanced: Assistant setup and MCP](./09-assistant-setup.md) — optional AI-assisted workflows
-- [Reference: Linting policy](../reference/linting.md) — current rust/clippy rules and why they exist
+- [Reference: Manifest linting with `mc check`](../reference/linting.md) — `[ecosystems.<name>.lints]` rules for Cargo and npm-family manifests

--- a/docs/src/guide/00-start-here.md
+++ b/docs/src/guide/00-start-here.md
@@ -71,6 +71,26 @@ Most first changes should target a package id.
 
 Use group ids only when the change is intentionally owned by the whole group.
 
+A typical generated file looks like this:
+
+```markdown
+---
+<id>: patch
+---
+
+#### describe the change
+```
+
+If the same package changed for a more specific reason, you can add more context right away:
+
+```bash
+mc change \
+  --package <id> \
+  --bump minor \
+  --reason "add release preview improvements" \
+  --details "Adds file diff previews during dry runs."
+```
+
 ## 6. Preview the release plan safely
 
 ```bash
@@ -78,6 +98,18 @@ mc release --dry-run
 ```
 
 By default this now renders a human-friendly markdown preview in the terminal. Use `--format json` when you want structured output for tooling, or `--format text` when you explicitly want the older plain-text rendering.
+
+When you want to see the exact file patch without mutating the workspace, add `--diff`:
+
+```bash
+mc release --dry-run --diff
+```
+
+When you want to inspect changeset provenance before releasing, add a diagnostics pass:
+
+```bash
+mc diagnostics --format json
+```
 
 Stop here on your first run. This previews the release plan without publishing anything.
 
@@ -107,5 +139,7 @@ If you need a silent safety check, run `mc release --quiet`. Quiet mode suppress
 - [Your first release plan](./02-setup.md) — a fuller walkthrough built around `mc init`
 - [Discovery](./03-discovery.md) — what discovery finds and how ids are rendered
 - [Configuration](./04-configuration.md) — evolve the generated config once the basics feel familiar
+- [Release planning](./06-release-planning.md) — compare preview modes, grouped releases, and planning rules
 - [Advanced: GitHub automation](./08-github-automation.md) — provider publishing, release PRs, and automation
 - [Advanced: Assistant setup and MCP](./09-assistant-setup.md) — optional AI-assisted workflows
+- [Reference: Linting policy](../reference/linting.md) — current rust/clippy rules and why they exist

--- a/docs/src/guide/01-installation.md
+++ b/docs/src/guide/01-installation.md
@@ -44,7 +44,7 @@ After copying the bundled skill, you get a small documentation set that is desig
 - `skills/changesets.md` — changeset authoring and lifecycle guidance
 - `skills/commands.md` — built-in command catalog and workflow selection
 - `skills/configuration.md` — `monochange.toml` setup and editing guidance
-- `skills/linting.md` — the current lint policy, rationale, and examples
+- `skills/linting.md` — `[ecosystems.<name>.lints]` rules, `mc check`, and manifest-focused examples
 
 This layout keeps the top-level skill small while still making the richer guidance available when an assistant needs more context.
 

--- a/docs/src/guide/01-installation.md
+++ b/docs/src/guide/01-installation.md
@@ -34,6 +34,22 @@ monochange-skill --print-install
 monochange-skill --copy ~/.pi/agent/skills/monochange
 ```
 
+<!-- {=assistantSkillBundleContents} -->
+
+After copying the bundled skill, you get a small documentation set that is designed to load in layers:
+
+- `SKILL.md` — concise entrypoint for agents
+- `REFERENCE.md` — broader high-context reference with more examples
+- `skills/README.md` — index of focused deep dives
+- `skills/changesets.md` — changeset authoring and lifecycle guidance
+- `skills/commands.md` — built-in command catalog and workflow selection
+- `skills/configuration.md` — `monochange.toml` setup and editing guidance
+- `skills/linting.md` — the current lint policy, rationale, and examples
+
+This layout keeps the top-level skill small while still making the richer guidance available when an assistant needs more context.
+
+<!-- {/assistantSkillBundleContents} -->
+
 Assistant-specific setup is covered in [Advanced: Assistant setup and MCP](./09-assistant-setup.md).
 
 ## CLI names

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -221,6 +221,8 @@ The built-in package publishing flow is intentionally narrow for now:
 
 If your workflow needs any of those today, keep the package on `mode = "external"` and let your own CI or scripts own publication.
 
+For end-to-end GitHub and GitLab examples — including npm trusted publishing on GitHub and token/external-mode patterns on GitLab — see [Advanced: CI, package publishing, and release PR flows](./13-ci-and-publishing.md).
+
 ## Groups
 
 Groups own outward release identity for their member packages.

--- a/docs/src/guide/06-release-planning.md
+++ b/docs/src/guide/06-release-planning.md
@@ -49,6 +49,33 @@ sdk: minor
 # coordinated SDK release
 ```
 
+## Package ids first, group ids when the release boundary is shared
+
+Use a **package id** when one package changed directly:
+
+```markdown
+---
+sdk-core: minor
+---
+
+# add changelog rendering API
+```
+
+Use a **group id** when the outward release note should be owned by the whole group:
+
+```markdown
+---
+sdk: minor
+---
+
+# coordinated SDK release
+```
+
+A quick rule of thumb:
+
+- **package id** — the leaf package changed and monochange can propagate the rest
+- **group id** — the note should read as one coordinated release for all members
+
 <!-- {=releaseExplicitVersionChangesetExample} -->
 
 Use scalar shorthand for plain bumps (`sdk-core: minor`) or for configured change types (`sdk-core: security`). To pin an exact version or combine `bump`, `version`, and `type`, use the object syntax:
@@ -66,6 +93,31 @@ sdk-core:
 When `version` is provided without `bump`, the bump is inferred from the current version. If the package belongs to a version group, the explicit version propagates to the whole group.
 
 <!-- {/releaseExplicitVersionChangesetExample} -->
+
+When a dependent package changes only because another package moved first, author that context explicitly with `caused_by`:
+
+```markdown
+---
+sdk-config:
+  bump: patch
+  caused_by: ["sdk-core"]
+---
+
+# update dependency on sdk-core
+```
+
+And when the package is affected but does not deserve a consumer-facing version bump, use `bump: none`:
+
+```markdown
+---
+sdk-config:
+  bump: none
+  caused_by: ["sdk-core"]
+  type: docs
+---
+
+# document the coordinated release
+```
 
 If multiple changesets specify conflicting explicit versions for the same package or group, monochange uses the highest semver version and emits a warning by default. Set `defaults.strict_version_conflicts = true` to fail instead.
 
@@ -122,6 +174,33 @@ mc release --dry-run --format json --diff
 ```
 
 Markdown and text output render unified diffs directly in the terminal. JSON output wraps the normal manifest payload under `manifest` and adds `fileDiffs` entries for each changed file.
+
+A good planning loop looks like this:
+
+```bash
+mc validate
+mc discover --format json
+mc diagnostics --format json
+mc release --dry-run --diff
+```
+
+Use each command for a different question:
+
+- `mc validate` — is the config and changeset set valid?
+- `mc discover --format json` — which package ids, groups, and dependency edges exist?
+- `mc diagnostics --format json` — who introduced these changesets and what review context is attached?
+- `mc release --dry-run --diff` — what exact files would change if I prepared the release now?
+
+### Compare preview modes
+
+Use the preview mode that matches the decision you are trying to make:
+
+| Command                                     | Best for                                      |
+| ------------------------------------------- | --------------------------------------------- |
+| `mc release --dry-run`                      | Human review in the terminal                  |
+| `mc release --dry-run --diff`               | Human review plus exact file patches          |
+| `mc release --dry-run --format json`        | Automation, scripts, MCP clients              |
+| `mc release --dry-run --format json --diff` | Automation that also needs file patch details |
 
 When you want command semantics without any command-line noise, add `--quiet`. Quiet mode suppresses stdout/stderr and uses dry-run behavior for release-oriented commands so the workspace stays unchanged.
 
@@ -248,6 +327,15 @@ Current planning rules:
 - CLI text and JSON output render workspace paths relative to the repository root for stable snapshots and automation
 
 <!-- {/releasePlanningRules} -->
+
+### Diagnostics vs. release records
+
+These two commands answer different questions:
+
+- `mc diagnostics --format json` — what is currently pending in `.changeset/*.md`, and who introduced it?
+- `mc release-record --from <ref>` — what did a past release commit declare durably in git history?
+
+Use diagnostics **before** you release. Use release records **after** a release exists and you need to inspect or repair it later.
 
 Across release-oriented commands, global `--quiet` suppresses stdout/stderr and reuses dry-run behavior for commands that support it.
 

--- a/docs/src/guide/08-github-automation.md
+++ b/docs/src/guide/08-github-automation.md
@@ -88,6 +88,8 @@ When `publish.trusted_publishing` is enabled, monochange can derive GitHub trust
 
 For `crates.io`, `jsr`, and `pub.dev`, monochange reports the setup URL for the package and requires manual trusted-publishing setup before the next built-in release publish. Placeholder publishing can still proceed so the package exists before that manual step.
 
+For full GitHub and GitLab CI examples by ecosystem — npm, Cargo, Deno/JSR, and Dart/pub.dev — see [Advanced: CI, package publishing, and release PR flows](./13-ci-and-publishing.md).
+
 ## Release notes, GitHub releases, and release PRs
 
 <!-- {=githubAutomationReleaseConfigExample} -->
@@ -335,3 +337,5 @@ The `--provider` flag supports three source providers:
 | Gitea    | `gitea`            | No — use Gitea Actions    | Yes                | Yes                 |
 
 All providers configure the `[source]` section in `monochange.toml` with appropriate settings for releases and pull/merge requests. GitLab and Gitea require manual CI configuration since they don't support GitHub Actions workflow files.
+
+If you are comparing provider-specific CI layouts or designing a long-running release PR branch, continue with [Advanced: CI, package publishing, and release PR flows](./13-ci-and-publishing.md).

--- a/docs/src/guide/09-assistant-setup.md
+++ b/docs/src/guide/09-assistant-setup.md
@@ -23,6 +23,22 @@ monochange-skill --print-install
 monochange-skill --copy ~/.pi/agent/skills/monochange
 ```
 
+<!-- {=assistantSkillBundleContents} -->
+
+After copying the bundled skill, you get a small documentation set that is designed to load in layers:
+
+- `SKILL.md` — concise entrypoint for agents
+- `REFERENCE.md` — broader high-context reference with more examples
+- `skills/README.md` — index of focused deep dives
+- `skills/changesets.md` — changeset authoring and lifecycle guidance
+- `skills/commands.md` — built-in command catalog and workflow selection
+- `skills/configuration.md` — `monochange.toml` setup and editing guidance
+- `skills/linting.md` — the current lint policy, rationale, and examples
+
+This layout keeps the top-level skill small while still making the richer guidance available when an assistant needs more context.
+
+<!-- {/assistantSkillBundleContents} -->
+
 ## Print an assistant profile
 
 Examples:

--- a/docs/src/guide/09-assistant-setup.md
+++ b/docs/src/guide/09-assistant-setup.md
@@ -33,7 +33,7 @@ After copying the bundled skill, you get a small documentation set that is desig
 - `skills/changesets.md` — changeset authoring and lifecycle guidance
 - `skills/commands.md` — built-in command catalog and workflow selection
 - `skills/configuration.md` — `monochange.toml` setup and editing guidance
-- `skills/linting.md` — the current lint policy, rationale, and examples
+- `skills/linting.md` — `[ecosystems.<name>.lints]` rules, `mc check`, and manifest-focused examples
 
 This layout keeps the top-level skill small while still making the richer guidance available when an assistant needs more context.
 

--- a/docs/src/guide/13-ci-and-publishing.md
+++ b/docs/src/guide/13-ci-and-publishing.md
@@ -1,0 +1,558 @@
+# Advanced: CI, package publishing, and release PR flows
+
+This guide brings together the practical CI patterns around `mc publish`, `mc placeholder-publish`, `mc release-pr`, `mc commit-release`, and provider release automation.
+
+It also captures an important proposed workflow for long-running release PR branches.
+
+## Start with the command surface
+
+These commands solve different automation problems:
+
+<!-- {=projectCommandAutomationMatrix} -->
+
+| Goal                             | Command                                                     | Use it when                                                                                              |
+| -------------------------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Validate config and changesets   | `mc validate`                                               | You changed `monochange.toml` or `.changeset/*.md` files                                                 |
+| Inspect package ids and groups   | `mc discover --format json`                                 | You need the normalized workspace model                                                                  |
+| Create release intent            | `mc change --package <id> --bump <severity> --reason "..."` | You need a new `.changeset/*.md` file                                                                    |
+| Audit pending release context    | `mc diagnostics --format json`                              | You need git provenance, PR/MR links, or related issues                                                  |
+| Preview the release plan         | `mc release --dry-run --diff`                               | You want changelog/version patches without mutating the repo                                             |
+| Create a durable release commit  | `mc commit-release`                                         | You want a monochange-managed release commit with an embedded `ReleaseRecord`                            |
+| Open or update a release request | `mc release-pr`                                             | You want a long-lived release PR/MR branch updated from current release state                            |
+| Publish packages to registries   | `mc publish`                                                | You want `cargo publish`, `npm publish`, `deno publish`, or `dart pub publish` style package publication |
+| Bootstrap missing packages       | `mc placeholder-publish`                                    | A package must exist in its registry before later automation can work                                    |
+| Inspect a past release commit    | `mc release-record --from <ref>`                            | You need the durable release declaration from git history                                                |
+| Repair a recent release          | `mc repair-release --from <tag> --target <commit>`          | You need to retarget a just-created release to a later commit                                            |
+| Publish hosted/provider releases | `mc publish-release`                                        | You want GitHub/GitLab/Gitea release objects from prepared release state                                 |
+
+<!-- {/projectCommandAutomationMatrix} -->
+
+A practical rule of thumb:
+
+- use **`mc publish`** for registry packages
+- use **`mc publish-release`** for hosted releases
+- use **`mc release-pr`** when you want a provider-backed release request branch
+- use **`mc commit-release`** when you want a durable local release commit in git history
+
+## The three automation layers
+
+monochange has three related but different automation layers:
+
+1. **Release planning** — `mc release --dry-run`, `mc release`, `mc diagnostics`
+2. **Package registries** — `mc placeholder-publish`, `mc publish`
+3. **Hosted providers** — `mc release-pr`, `mc publish-release`, `mc repair-release`
+
+Keeping those layers separate is important. Package publication and hosted-release publication are not the same job.
+
+## Registry and provider capability snapshot
+
+<!-- {=projectCapabilityMatrix} -->
+
+| Capability                                                               | Current status                                                             |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| Multi-ecosystem discovery                                                | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter                                   |
+| Package release planning                                                 | Built in                                                                   |
+| Grouped/shared versioning                                                | Built in                                                                   |
+| Dry-run release diff previews                                            | Built in via `mc release --dry-run --diff`                                 |
+| Durable release history                                                  | Built in via `ReleaseRecord`, `mc release-record`, and `mc repair-release` |
+| Hosted provider releases                                                 | GitHub, GitLab, Gitea                                                      |
+| Hosted release requests                                                  | GitHub, GitLab, Gitea                                                      |
+| Built-in registry publishing                                             | `crates.io`, `npm`, `jsr`, `pub.dev`                                       |
+| GitHub npm trusted-publishing automation                                 | Built in                                                                   |
+| GitHub trusted-publishing guidance for `crates.io`, `jsr`, and `pub.dev` | Built in, but manual registry enrollment is still required                 |
+| GitLab trusted-publishing auto-derivation                                | Not built in today                                                         |
+| Release-retarget sync for hosted releases                                | GitHub first                                                               |
+
+<!-- {/projectCapabilityMatrix} -->
+
+## CI setup assumption
+
+The workflow sketches below assume the job already has:
+
+- the `monochange` CLI available as `mc`
+- the native ecosystem toolchain it needs (`npm`/`pnpm`, `cargo`, `deno`, `dart`, or `flutter`)
+- repository checkout with enough history for release-record inspection
+
+In the monochange repository itself, that usually means entering the `devenv` shell. In other repositories, it may mean installing `@monochange/cli` or `monochange` explicitly before the publish step.
+
+## GitHub flows
+
+### Common GitHub shape
+
+For GitHub Actions, the most common structure is:
+
+1. a workflow prepares or updates a release PR branch
+2. a release commit lands on `main`
+3. a post-merge workflow detects the release commit
+4. package publication runs from that durable release commit
+5. provider release and tag automation runs in a dedicated release workflow
+
+The important current implementation detail is that `mc publish` can publish from the `ReleaseRecord` on `HEAD`, while `mc publish-release` still works from prepared release state.
+
+### GitHub + npm trusted publishing
+
+Config:
+
+```toml
+[source]
+provider = "github"
+owner = "owner"
+repo = "repo"
+
+[ecosystems.npm.publish]
+enabled = true
+mode = "builtin"
+trusted_publishing = true
+```
+
+Workflow sketch:
+
+```yaml
+name: publish-npm
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: setup repo tooling
+        uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: detect monochange release commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! devenv shell -- mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then
+            echo "HEAD is not a monochange release commit; skipping publish"
+            exit 0
+          fi
+
+      - name: publish npm packages
+        run: devenv shell -- mc publish
+```
+
+What monochange does here:
+
+- resolves the GitHub workflow context
+- checks current npm trust configuration
+- runs `npm trust github ...` when trust is missing
+- uses `pnpm exec npm trust ...` in pnpm workspaces
+- verifies the trust result after configuration
+
+Use this when you want the most automated trusted-publishing path monochange currently supports.
+
+### GitHub + Cargo (`crates.io`) trusted publishing
+
+Config:
+
+```toml
+[source]
+provider = "github"
+owner = "owner"
+repo = "repo"
+
+[ecosystems.cargo.publish]
+enabled = true
+mode = "builtin"
+trusted_publishing = true
+```
+
+Workflow sketch:
+
+```yaml
+name: publish-cargo
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: detect monochange release commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! devenv shell -- mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then
+            echo "HEAD is not a monochange release commit; skipping publish"
+            exit 0
+          fi
+
+      - name: publish Cargo packages
+        run: devenv shell -- mc publish
+```
+
+Important current behavior:
+
+- monochange can carry the trust expectation in config
+- monochange can report the setup URL and enforce that trust is configured before built-in release publishing continues
+- monochange does **not** currently auto-configure `crates.io` trust the way it can for npm on GitHub
+
+Recommended setup:
+
+1. configure `trusted_publishing = true`
+2. bootstrap missing packages with `mc placeholder-publish` if needed
+3. manually enroll the repository/workflow in `crates.io`
+4. let `mc publish` perform the actual publish after the release commit lands
+
+### GitHub + Deno / JSR trusted publishing
+
+Config:
+
+```toml
+[source]
+provider = "github"
+owner = "owner"
+repo = "repo"
+
+[ecosystems.deno.publish]
+enabled = true
+mode = "builtin"
+trusted_publishing = true
+registry = "jsr"
+```
+
+Workflow sketch:
+
+```yaml
+name: publish-jsr
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: detect monochange release commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! devenv shell -- mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then
+            echo "HEAD is not a monochange release commit; skipping publish"
+            exit 0
+          fi
+
+      - name: publish JSR packages
+        run: devenv shell -- mc publish
+```
+
+Current behavior matches Cargo more than npm:
+
+- monochange can validate the trust expectation and report the setup URL
+- monochange does **not** auto-configure JSR trust on GitHub for you today
+- manual registry enrollment is still required before the built-in publish can proceed
+
+### GitHub + Dart / Flutter (`pub.dev`) trusted publishing
+
+Config:
+
+```toml
+[source]
+provider = "github"
+owner = "owner"
+repo = "repo"
+
+[ecosystems.dart.publish]
+enabled = true
+mode = "builtin"
+trusted_publishing = true
+registry = "pub.dev"
+```
+
+Workflow sketch:
+
+```yaml
+name: publish-pub-dev
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: detect monochange release commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! devenv shell -- mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then
+            echo "HEAD is not a monochange release commit; skipping publish"
+            exit 0
+          fi
+
+      - name: publish pub.dev packages
+        run: devenv shell -- mc publish
+```
+
+Current behavior:
+
+- monochange can enforce the configured trust expectation
+- monochange reports the manual setup URL when trust is not configured
+- monochange does **not** auto-configure `pub.dev` trusted publishing today
+
+### GitHub post-merge package publish flow
+
+If you want package publication to happen **after** the release PR merges, the simplest current pattern is:
+
+1. merge the release PR so the monochange release commit lands on `main`
+2. run `mc release-record --from HEAD --format json` in CI
+3. if the command succeeds, run `mc publish`
+4. if it fails, exit early because HEAD is not a release commit
+
+That pattern works well because `mc publish` can consume the durable `ReleaseRecord` from `HEAD`.
+
+## GitLab flows
+
+### Current GitLab reality
+
+GitLab is a supported source provider for hosted releases and release requests.
+
+For package publishing, monochange can still run built-in package publication commands from GitLab CI, but the trust auto-derivation and npm `trust github` automation are GitHub-specific today.
+
+That means the practical GitLab pattern is:
+
+- keep `mode = "builtin"` when monochange's package publish command already matches what you need
+- keep `trusted_publishing = false` unless the registry workflow is one you manage externally
+- use CI secrets or external publishing logic when the registry requires a setup monochange does not automate on GitLab
+
+### GitLab + npm
+
+Config:
+
+```toml
+[ecosystems.npm.publish]
+enabled = true
+mode = "builtin"
+trusted_publishing = false
+```
+
+Workflow sketch:
+
+```yaml
+publish_npm:
+  image: node:22
+  stage: publish
+  rules:
+    - if: "$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH"
+  script:
+    - corepack enable
+    - if mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then mc publish; else echo "not a release commit"; fi
+```
+
+If your npm flow needs registry-token setup or a custom `.npmrc`, do that in CI before running `mc publish`.
+
+### GitLab + Cargo
+
+Config:
+
+```toml
+[ecosystems.cargo.publish]
+enabled = true
+mode = "builtin"
+trusted_publishing = false
+```
+
+Workflow sketch:
+
+```yaml
+publish_cargo:
+  image: rust:1.90
+  stage: publish
+  rules:
+    - if: "$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH"
+  script:
+    - if mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then mc publish; else echo "not a release commit"; fi
+```
+
+If you need a crates.io token or a more customized release process, inject the credential in GitLab CI or switch the package to `mode = "external"`.
+
+### GitLab + Deno / JSR
+
+Config:
+
+```toml
+[ecosystems.deno.publish]
+enabled = true
+mode = "builtin"
+trusted_publishing = false
+registry = "jsr"
+```
+
+Workflow sketch:
+
+```yaml
+publish_jsr:
+  image: denoland/deno:latest
+  stage: publish
+  rules:
+    - if: "$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH"
+  script:
+    - if mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then mc publish; else echo "not a release commit"; fi
+```
+
+If your JSR auth bootstrap is more specialized than the built-in path expects, prefer `mode = "external"` and run the native publish command yourself.
+
+### GitLab + Dart / Flutter
+
+Config:
+
+```toml
+[ecosystems.dart.publish]
+enabled = true
+mode = "builtin"
+trusted_publishing = false
+registry = "pub.dev"
+```
+
+Workflow sketch:
+
+```yaml
+publish_pub_dev:
+  image: dart:stable
+  stage: publish
+  rules:
+    - if: "$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH"
+  script:
+    - if mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then mc publish; else echo "not a release commit"; fi
+```
+
+As with JSR, use `mode = "external"` when you need CI-specific auth or publish orchestration outside monochange's built-in assumptions.
+
+## Long-running release PR branch flow
+
+This is the flow you described:
+
+1. every merge to `main` updates a dedicated release branch and PR
+2. that branch contains the prepared release commit and release files
+3. the release PR stays open and keeps tracking the latest releasable state
+4. when the PR merges, publication happens from that merged release commit
+
+### What monochange supports today
+
+monochange already supports a large part of this shape:
+
+- `mc release-pr` can open or update a release request branch from current release state
+- `mc commit-release` can create a durable monochange release commit with an embedded `ReleaseRecord`
+- `mc release-record --from HEAD` can detect whether the latest commit is a monochange release commit
+- `mc publish` can publish package registries from that durable record on `HEAD`
+
+### The important tag semantics
+
+Tags are **not branch-scoped**.
+
+A git tag points at a commit object, not at a branch name.
+
+That means:
+
+- if you create a tag on a release-PR commit, the tag exists immediately even before merge
+- if that exact commit is later merged into `main`, the tag still points at the same commit and is now reachable from `main`
+- if the release branch is later rebased, force-pushed, or regenerated, the old tag does **not** move automatically
+
+That is why pre-merge tagging on a long-running release PR is usually the wrong move.
+
+### Recommended current approach
+
+For the long-running release PR model, the safest current shape is:
+
+1. on every push to `main`, run `mc release-pr` to refresh the dedicated release PR branch
+2. do **not** create tags on the release PR branch
+3. merge the release PR when you are ready
+4. on the post-merge workflow, run `mc release-record --from HEAD --format json`
+5. if the latest commit is a release commit, run `mc publish` for package registries
+6. handle tag creation and hosted-release publication in a dedicated follow-up workflow
+
+### Captured future workflow
+
+The missing piece for a fully first-class version of this pattern is a built-in post-merge tagger.
+
+The strongest future shape would be:
+
+1. `mc release-pr` keeps the long-running release PR branch up to date
+2. the release PR merges into `main`
+3. a post-merge monochange command inspects `ReleaseRecord` on `HEAD`
+4. that command creates and pushes the declared tag set
+5. tag-triggered workflows publish hosted releases and any additional downstream assets
+
+That would keep tag creation on the default branch side of the merge, which is much safer than tagging the PR branch early.
+
+### Captured implementation gap
+
+Today monochange does **not** ship a dedicated top-level command that says "read the `ReleaseRecord` on `HEAD` and create/push the release tags now".
+
+That gap is important to capture because it affects exactly this release-PR-merge flow.
+
+A future enhancement in this area would likely include:
+
+- a built-in post-merge release-commit detector and tagger
+- a smoother first-class long-running release PR workflow
+- branch-refresh semantics that make repeated release-branch updates more explicit
+- possibly force-refresh behavior for workflows that intentionally rewrite the dedicated release branch over time
+
+## Choosing a CI pattern
+
+Use this decision rule:
+
+- **Need human review before release files land?** → use `mc release-pr`
+- **Need a durable local release commit?** → use `mc commit-release`
+- **Need package registries after merge?** → detect `ReleaseRecord` on `HEAD`, then run `mc publish`
+- **Need hosted provider releases from prepared release state?** → use `mc publish-release`
+- **Need to bootstrap a package that does not exist yet?** → use `mc placeholder-publish`
+- **Need GitHub npm trusted publishing with the least custom glue?** → use `trusted_publishing = true` with `mc publish`
+- **Need GitLab CI with custom auth/bootstrap?** → keep `mode = "external"` as the escape hatch
+
+## Related guides
+
+- [GitHub automation](./08-github-automation.md)
+- [Configuration reference](./04-configuration.md)
+- [Release planning](./06-release-planning.md)
+- [Repairable releases](./12-repairable-releases.md)

--- a/docs/src/readme.md
+++ b/docs/src/readme.md
@@ -92,7 +92,7 @@ If you want a slower, more guided walkthrough, continue with [Start here](./guid
 - [Advanced: GitHub automation](./guide/08-github-automation.md) — provider publishing and release requests
 - [Advanced: CI, package publishing, and release PR flows](./guide/13-ci-and-publishing.md) — per-provider CI patterns, trusted publishing, and long-running release PR design notes
 - [Advanced: Assistant setup and MCP](./guide/09-assistant-setup.md) — optional AI-assisted workflows
-- [Reference: Linting policy](./reference/linting.md) — the current rust/clippy rules and their rationale
+- [Reference: Manifest linting with `mc check`](./reference/linting.md) — `[ecosystems.<name>.lints]` rules for Cargo and npm-family manifests
 
 ## Command and automation matrix
 

--- a/docs/src/readme.md
+++ b/docs/src/readme.md
@@ -88,8 +88,32 @@ If you want a slower, more guided walkthrough, continue with [Start here](./guid
 - [Installation](./guide/01-installation.md) — npm, Cargo, optional assistant tooling, and repository development setup
 - [Your first release plan](./guide/02-setup.md) — generated config first, package ids before groups
 - [Configuration reference](./guide/04-configuration.md) — the full package, group, changelog, and CLI model
+- [Release planning](./guide/06-release-planning.md) — changesets, dry runs, diff previews, and planning rules
 - [Advanced: GitHub automation](./guide/08-github-automation.md) — provider publishing and release requests
+- [Advanced: CI, package publishing, and release PR flows](./guide/13-ci-and-publishing.md) — per-provider CI patterns, trusted publishing, and long-running release PR design notes
 - [Advanced: Assistant setup and MCP](./guide/09-assistant-setup.md) — optional AI-assisted workflows
+- [Reference: Linting policy](./reference/linting.md) — the current rust/clippy rules and their rationale
+
+## Command and automation matrix
+
+<!-- {=projectCommandAutomationMatrix} -->
+
+| Goal                             | Command                                                     | Use it when                                                                                              |
+| -------------------------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Validate config and changesets   | `mc validate`                                               | You changed `monochange.toml` or `.changeset/*.md` files                                                 |
+| Inspect package ids and groups   | `mc discover --format json`                                 | You need the normalized workspace model                                                                  |
+| Create release intent            | `mc change --package <id> --bump <severity> --reason "..."` | You need a new `.changeset/*.md` file                                                                    |
+| Audit pending release context    | `mc diagnostics --format json`                              | You need git provenance, PR/MR links, or related issues                                                  |
+| Preview the release plan         | `mc release --dry-run --diff`                               | You want changelog/version patches without mutating the repo                                             |
+| Create a durable release commit  | `mc commit-release`                                         | You want a monochange-managed release commit with an embedded `ReleaseRecord`                            |
+| Open or update a release request | `mc release-pr`                                             | You want a long-lived release PR/MR branch updated from current release state                            |
+| Publish packages to registries   | `mc publish`                                                | You want `cargo publish`, `npm publish`, `deno publish`, or `dart pub publish` style package publication |
+| Bootstrap missing packages       | `mc placeholder-publish`                                    | A package must exist in its registry before later automation can work                                    |
+| Inspect a past release commit    | `mc release-record --from <ref>`                            | You need the durable release declaration from git history                                                |
+| Repair a recent release          | `mc repair-release --from <tag> --target <commit>`          | You need to retarget a just-created release to a later commit                                            |
+| Publish hosted/provider releases | `mc publish-release`                                        | You want GitHub/GitLab/Gitea release objects from prepared release state                                 |
+
+<!-- {/projectCommandAutomationMatrix} -->
 
 ## What monochange can do today
 

--- a/docs/src/reference/linting.md
+++ b/docs/src/reference/linting.md
@@ -1,0 +1,547 @@
+# Linting policy
+
+monochange keeps linting strict enough to catch correctness and panic hazards, but not so strict that contributors spend all their time fighting style-only noise.
+
+<!-- {=lintingPolicyReference} -->
+
+Use this guide when the task is to explain, apply, or update monochange lint policy.
+
+This reference reflects the current workspace lint configuration in the repository `Cargo.toml` plus the crate-level `#![forbid(clippy::indexing_slicing)]` declarations used across the Rust crates.
+
+## Daily linting workflow
+
+For normal repo work:
+
+```bash
+devenv shell fix:all
+devenv shell lint:all
+```
+
+For documentation synchronization checks:
+
+```bash
+devenv shell docs:check
+```
+
+Use `docs:update` after editing shared `.templates/` content.
+
+## How to read the policy
+
+monochange uses a mix of:
+
+- **workspace rust lints** — compiler-level safety and hygiene rules
+- **workspace clippy groups** — broad quality buckets like correctness and performance
+- **targeted clippy overrides** — rules we intentionally deny, warn, or allow
+- **crate-level forbids** — stricter local rules when a specific panic pattern is unacceptable
+
+The goal is not "never write interesting code." The goal is to avoid correctness bugs, avoid panic-prone indexing patterns, stay portable across Rust editions, and keep only the pedantic warnings that actually improve the codebase.
+
+## Workspace rust lints
+
+### `rust_2021_compatibility = warn`
+
+**Why:** catches patterns that behave differently across editions.
+
+**When to care:** when writing macros, pattern matches, or syntax that might become edition-sensitive.
+
+**Without the rule:** edition migration issues can accumulate silently.
+
+**With the rule:** you get an early warning before the next edition change becomes painful.
+
+### `rust_2024_compatibility = warn`
+
+**Why:** keeps the codebase ready for Rust 2024 semantics.
+
+**When to care:** when introducing syntax or macro usage that may change in the 2024 edition.
+
+**Without the rule:** future upgrades become a large cleanup project.
+
+**With the rule:** new code is nudged toward edition-safe patterns now.
+
+### `unsafe_code = deny`
+
+**Why:** monochange should not rely on unchecked memory operations for release-planning logic.
+
+**When to use:** almost always for business logic, config parsing, changelog generation, and CLI orchestration.
+
+**Without the rule:**
+
+```rust
+unsafe {
+    std::ptr::read(ptr)
+}
+```
+
+Unsafe blocks can slip in and become maintenance hotspots.
+
+**With the rule:** prefer safe standard-library APIs:
+
+```rust
+let first = values.first().copied();
+```
+
+### `unstable_features = deny`
+
+**Why:** published tooling should compile on stable Rust.
+
+**When to use:** for libraries and CLIs that must stay portable for contributors and CI.
+
+**Without the rule:** nightly-only features can leak into the codebase.
+
+**With the rule:** the code stays stable-channel compatible.
+
+### `unused_extern_crates = warn`
+
+**Why:** dead extern declarations add noise and make dependencies harder to audit.
+
+**Without the rule:** old compatibility imports linger.
+
+**With the rule:** unused declarations are cleaned up quickly.
+
+### `unused_import_braces = warn`
+
+**Why:** removes unnecessary syntax noise.
+
+**Without the rule:**
+
+```rust
+use std::fmt;
+```
+
+**With the rule:**
+
+```rust
+use std::fmt;
+```
+
+### `unused_lifetimes = warn`
+
+**Why:** unused lifetimes usually mean an API signature is more complex than necessary.
+
+**Without the rule:**
+
+```rust
+fn name<'a>(value: &str) -> &str {
+	value
+}
+```
+
+**With the rule:**
+
+```rust
+fn name(value: &str) -> &str {
+	value
+}
+```
+
+### `unused_macro_rules = warn`
+
+**Why:** dead macro arms are easy to forget and hard to test.
+
+**Without the rule:** macro definitions keep stale branches.
+
+**With the rule:** only exercised macro rules survive.
+
+### `unused_qualifications = warn`
+
+**Why:** fully qualifying names that are already in scope hurts readability.
+
+**Without the rule:**
+
+```rust
+use std::path::PathBuf;
+
+let path = std::path::PathBuf::new();
+```
+
+**With the rule:**
+
+```rust
+use std::path::PathBuf;
+
+let path = PathBuf::new();
+```
+
+### `variant_size_differences = warn`
+
+**Why:** very uneven enum variants can cause surprising memory bloat.
+
+**Without the rule:** a single large variant can inflate every enum value.
+
+**With the rule:** you consider boxing or reshaping the large variant.
+
+### `edition_2024_expr_fragment_specifier = allow`
+
+**Why it is allowed:** this lint is intentionally relaxed to avoid noisy churn while macro-related edition support settles.
+
+**When the allowance is appropriate:** when the code is otherwise clear and no migration risk is introduced.
+
+**Without the allowance:** the repo would force extra macro cleanups that do not improve the current product behavior.
+
+## Workspace clippy groups
+
+### `clippy::correctness = deny`
+
+**Why:** correctness issues are the highest-risk category.
+
+**Without it:** real bugs can land as "just warnings."
+
+**With it:** code that is likely wrong fails the lint pass.
+
+### `clippy::suspicious = warn`
+
+**Why:** suspicious constructs often compile but suggest a logic mistake.
+
+**Without it:** subtle mistakes look legitimate.
+
+**With it:** you get a review checkpoint before the bug becomes user-visible.
+
+### `clippy::style = warn`
+
+**Why:** style warnings keep code predictable and easier to scan.
+
+**Without it:** equivalent patterns drift across the codebase.
+
+**With it:** contributors converge on the same idioms.
+
+### `clippy::complexity = warn`
+
+**Why:** overly complex code is harder to review and easier to break.
+
+**Without it:** nested or overly clever logic grows unnoticed.
+
+**With it:** clippy nudges you toward extraction and simpler control flow.
+
+**Example of what this pressure is trying to prevent:**
+
+```rust
+if should_release {
+    if let Some(group) = group {
+        if group.publish {
+            if !group.members.is_empty() {
+                publish(group);
+            }
+        }
+    }
+}
+```
+
+A flatter version is easier to review:
+
+```rust
+let Some(group) = group else {
+    return;
+};
+
+if !should_release || !group.publish || group.members.is_empty() {
+    return;
+}
+
+publish(group);
+```
+
+### `clippy::perf = warn`
+
+**Why:** hot-path inefficiencies are easier to fix when caught early.
+
+**Without it:** unnecessary allocations and slower patterns blend in.
+
+**With it:** common performance footguns get surfaced during normal linting.
+
+### `clippy::pedantic = warn`
+
+**Why:** pedantic lints catch a lot of polish issues that improve API and code quality.
+
+**Why not deny:** the group is intentionally broad and sometimes noisy.
+
+**monochange approach:** enable the group, then explicitly allow the few rules where local readability or practicality matters more.
+
+## Explicit clippy policy
+
+### `blocks_in_conditions = allow`
+
+**Why it is allowed:** small computed conditions can be clearer inline than as a throwaway binding.
+
+**Without the allowance:**
+
+```rust
+if {
+    let ready = state.is_ready();
+    ready
+} {
+    run();
+}
+```
+
+Clippy would complain even when the structure is readable.
+
+**With the current policy:** this pattern is allowed, but extract it if the block becomes non-trivial.
+
+### `cargo_common_metadata = allow`
+
+**Why it is allowed:** workspace metadata is managed centrally, so per-crate metadata completeness is not always the right enforcement point.
+
+**Without the allowance:** clippy would push repetitive metadata into every crate even when the workspace already provides it.
+
+**With the current policy:** add metadata where it matters, but do not create boilerplate just to silence the lint.
+
+### `cast_possible_truncation = allow`
+
+**Why it is allowed:** some numeric conversions are deliberate and guarded by domain knowledge.
+
+**Without the allowance:**
+
+```rust
+let byte = value as u8;
+```
+
+would warn every time, even when the value is known to fit.
+
+**With the current policy:** the cast is permitted, but reviewers should still expect surrounding reasoning or bounds checks when truncation is not obviously safe.
+
+### `cast_possible_wrap = allow`
+
+**Why it is allowed:** signed/unsigned conversions sometimes reflect external protocol or storage requirements.
+
+**Without the allowance:** every deliberate sign-changing cast becomes noise.
+
+**With the current policy:** use the cast intentionally and document tricky cases.
+
+### `cast_precision_loss = allow`
+
+**Why it is allowed:** some reporting or ratio calculations intentionally trade precision for convenience.
+
+**Without the allowance:** floating-point conversions generate warnings even in non-critical display logic.
+
+**With the current policy:** precision-loss casts are allowed, but avoid them in semver, version, or identity logic where exactness matters.
+
+### `cast_sign_loss = allow`
+
+**Why it is allowed:** conversions to unsigned values are sometimes part of external API shaping.
+
+**Without the allowance:** routine boundary conversions become noisy.
+
+**With the current policy:** keep the cast local and obvious.
+
+### `expl_impl_clone_on_copy = allow`
+
+**Why it is allowed:** an explicit `Clone` impl on a `Copy` type can occasionally be clearer or more controlled than a derive.
+
+**Without the allowance:** clippy would force a derive-only style.
+
+**With the current policy:** explicit impls are allowed when there is a concrete reason, not as default habit.
+
+### `items_after_statements = allow`
+
+**Why it is allowed:** tests and small helper scopes sometimes read better when local items appear near their use.
+
+**Without the allowance:**
+
+```rust
+fn test_case() {
+	let input = sample();
+
+	fn sample() -> &'static str {
+		"ok"
+	}
+
+	assert_eq!(input, "ok");
+}
+```
+
+would warn.
+
+**With the current policy:** that layout is acceptable when it improves locality.
+
+### `missing_errors_doc = allow`
+
+**Why it is allowed:** internal functions are numerous, and forcing `# Errors` on all of them creates noisy docs.
+
+**Without the allowance:** every fallible helper would need a doc section.
+
+**With the current policy:** still document errors on public APIs and non-obvious behavior, but do not require boilerplate on every internal helper.
+
+### `missing_panics_doc = allow`
+
+**Why it is allowed:** similar to `missing_errors_doc`, this avoids boilerplate on internal helpers.
+
+**Without the allowance:** even intentionally internal panic paths need formal docs.
+
+**With the current policy:** public or surprising panic behavior should still be documented deliberately.
+
+### `module_name_repetitions = allow`
+
+**Why it is allowed:** crate boundaries and domain naming sometimes make repetition the clearest choice.
+
+**Without the allowance:**
+
+```rust
+mod release_record;
+struct ReleaseRecord;
+```
+
+can trigger a warning even though the names are clear.
+
+**With the current policy:** choose clarity over lint golf.
+
+### `must_use_candidate = allow`
+
+**Why it is allowed:** clippy suggests `#[must_use]` very aggressively.
+
+**Without the allowance:** many private helpers would get noisy suggestions.
+
+**With the current policy:** apply `#[must_use]` intentionally on public APIs, builders, and values where dropping the result is genuinely a bug.
+
+### `no_effect_underscore_binding = allow`
+
+**Why it is allowed:** intentionally ignored intermediate values sometimes help document intent in tests or command setup.
+
+**Without the allowance:** underscore-prefixed bindings can still warn even when they make the code easier to follow.
+
+**With the current policy:** use them sparingly and only when they clarify intent.
+
+### `tabs-in-doc-comments = allow`
+
+**Why it is allowed:** command output, tables, or copied terminal content may legitimately contain tabs.
+
+**Without the allowance:** documentation cleanup would fight preserved examples.
+
+**With the current policy:** tabs are acceptable in docs when they preserve exact formatting.
+
+### `too_many_lines = allow`
+
+**Why it is allowed:** some orchestration functions, renderers, or test modules are large for domain reasons.
+
+**Without the allowance:** contributors would spend time splitting code purely to satisfy an arbitrary line limit.
+
+**With the current policy:** long functions are allowed, but extraction is still preferred when it improves comprehension.
+
+### `wildcard_dependencies = deny`
+
+**Why:** published tools should not depend on unconstrained crate versions.
+
+**Without the rule:**
+
+```toml
+serde = "*"
+```
+
+can make builds non-reproducible and difficult to audit.
+
+**With the rule:** dependencies must be explicitly versioned.
+
+### `wildcard_imports = allow`
+
+**Why it is allowed:** some test modules and highly local scopes read better with a wildcard import.
+
+**Without the allowance:**
+
+```rust
+use super::*;
+```
+
+would warn in common test layouts.
+
+**With the current policy:** wildcard imports remain acceptable in narrow scopes, especially tests.
+
+## Crate-level forbid: `clippy::indexing_slicing`
+
+Most monochange Rust crates start with:
+
+```rust
+#![forbid(clippy::indexing_slicing)]
+```
+
+**Why:** indexing and slicing can panic, and monochange spends a lot of time parsing external files, manifests, and user input.
+
+**Without the rule:**
+
+```rust
+let first = values[0];
+let suffix = &text[1..];
+```
+
+These compile, but they panic on malformed or short input.
+
+**With the rule:** prefer checked access:
+
+```rust
+let first = values.first().copied();
+let suffix = text.get(1..);
+```
+
+**Another example in manifest parsing:**
+
+```rust
+let version = package_json["version"].as_str();
+```
+
+looks compact but assumes the key exists and the JSON shape is right. Checked access makes the failure mode explicit:
+
+```rust
+let version = package_json
+    .get("version")
+    .and_then(|value| value.as_str());
+```
+
+**When to use this stricter rule:** parsing, config loading, release planning, changelog rendering, and any code that handles external repository state.
+
+## What "with and without linting" looks like in practice
+
+### Without the monochange lint posture
+
+- unsafe or nightly-only code can sneak in
+- panic-prone indexing is easier to miss
+- wildcard dependencies can weaken reproducibility
+- edition migration issues accumulate quietly
+- pedantic improvements never surface
+
+### With the current monochange lint posture
+
+- correctness issues fail fast
+- suspicious, style, complexity, performance, and pedantic issues show up in review
+- some noisy lints are intentionally relaxed where the team prefers readability or lower boilerplate
+- panic-prone indexing is blocked at crate level
+
+## When to add a local `#[allow(...)]`
+
+A local allow is acceptable when:
+
+- the lint is technically correct but the preferred alternative is harder to read
+- the code is constrained by a protocol, generated shape, or test pattern
+- you can explain the exception in one sentence
+
+Example:
+
+```rust
+#[allow(clippy::too_many_arguments)]
+fn build_release_payload(
+	owner: &str,
+	repo: &str,
+	version: &str,
+	tag: &str,
+	notes: &str,
+	draft: bool,
+	prerelease: bool,
+) {
+	// ...
+}
+```
+
+Use this sparingly. If the function can be improved with a struct or builder, prefer that.
+
+## Recommended validation loop after edits
+
+```bash
+devenv shell fix:all
+devenv shell lint:all
+mc validate
+```
+
+If you changed shared docs too:
+
+```bash
+devenv shell docs:check
+```
+
+<!-- {/lintingPolicyReference} -->

--- a/docs/src/reference/linting.md
+++ b/docs/src/reference/linting.md
@@ -1,541 +1,405 @@
-# Linting policy
+# Manifest linting with `mc check`
 
-monochange keeps linting strict enough to catch correctness and panic hazards, but not so strict that contributors spend all their time fighting style-only noise.
+monochange can lint monorepo package manifests through `mc check`, using rules configured under `[ecosystems.<name>.lints]` in `monochange.toml`.
 
 <!-- {=lintingPolicyReference} -->
 
-Use this guide when the task is to explain, apply, or update monochange lint policy.
+Use this guide when the task is to configure or explain monochange's **manifest lint rules**.
 
-This reference reflects the current workspace lint configuration in the repository `Cargo.toml` plus the crate-level `#![forbid(clippy::indexing_slicing)]` declarations used across the Rust crates.
+These are the rules that run through **`mc check`** and are configured in `monochange.toml` under **`[ecosystems.<name>.lints]`**.
 
-## Daily linting workflow
+They are separate from Rust compiler or Clippy lints used to develop monochange itself.
 
-For normal repo work:
+## What `mc check` does
+
+`mc check` runs two phases:
+
+1. normal workspace validation, similar to `mc validate`
+2. manifest lint rules for supported package ecosystems
+
+Common commands:
 
 ```bash
-devenv shell fix:all
-devenv shell lint:all
+mc check
+mc check --fix
+mc check --format json
 ```
 
-For documentation synchronization checks:
+Use `--fix` when you want monochange to apply auto-fixes where a rule supports them.
 
-```bash
-devenv shell docs:check
+## Where lint rules live
+
+Configure rules per ecosystem in `monochange.toml`:
+
+```toml
+[ecosystems.cargo.lints]
+"cargo/dependency-field-order" = "error"
+"cargo/internal-dependency-workspace" = "error"
+"cargo/required-package-fields" = { level = "warning", fields = ["description", "license", "repository"] }
+"cargo/sorted-dependencies" = "warning"
+"cargo/unlisted-package-private" = { level = "warning", fix = true }
+
+[ecosystems.npm.lints]
+"npm/workspace-protocol" = "error"
+"npm/sorted-dependencies" = "warning"
+"npm/required-package-fields" = { level = "warning", fields = ["description", "repository", "license"] }
+"npm/root-no-prod-deps" = "error"
+"npm/no-duplicate-dependencies" = "error"
+"npm/unlisted-package-private" = { level = "warning", fix = true }
 ```
 
-Use `docs:update` after editing shared `.templates/` content.
+Rule configuration supports two forms:
 
-## How to read the policy
+- simple severity: `"rule-id" = "error"`, `"warning"`, or `"off"`
+- detailed config: `{ level = "error", ...rule_specific_options }`
 
-monochange uses a mix of:
+## Current rule coverage
 
-- **workspace rust lints** — compiler-level safety and hygiene rules
-- **workspace clippy groups** — broad quality buckets like correctness and performance
-- **targeted clippy overrides** — rules we intentionally deny, warn, or allow
-- **crate-level forbids** — stricter local rules when a specific panic pattern is unacceptable
+Today, built-in manifest lint rules exist for:
 
-The goal is not "never write interesting code." The goal is to avoid correctness bugs, avoid panic-prone indexing patterns, stay portable across Rust editions, and keep only the pedantic warnings that actually improve the codebase.
+- **Cargo** manifests (`Cargo.toml`)
+- **npm-family** manifests (`package.json`)
 
-## Workspace rust lints
+monochange already wires lint configuration through `configuration.cargo.lints`, `configuration.npm.lints`, `configuration.deno.lints`, and `configuration.dart.lints`, but the current built-in rule sets are implemented for Cargo and npm manifests.
 
-### `rust_2021_compatibility = warn`
+## Cargo manifest lint rules
 
-**Why:** catches patterns that behave differently across editions.
+### `cargo/dependency-field-order`
 
-**When to care:** when writing macros, pattern matches, or syntax that might become edition-sensitive.
+**Why:** keeps inline dependency tables visually consistent.
 
-**Without the rule:** edition migration issues can accumulate silently.
+**What it checks:** preferred key order inside dependency tables:
 
-**With the rule:** you get an early warning before the next edition change becomes painful.
-
-### `rust_2024_compatibility = warn`
-
-**Why:** keeps the codebase ready for Rust 2024 semantics.
-
-**When to care:** when introducing syntax or macro usage that may change in the 2024 edition.
-
-**Without the rule:** future upgrades become a large cleanup project.
-
-**With the rule:** new code is nudged toward edition-safe patterns now.
-
-### `unsafe_code = deny`
-
-**Why:** monochange should not rely on unchecked memory operations for release-planning logic.
-
-**When to use:** almost always for business logic, config parsing, changelog generation, and CLI orchestration.
-
-**Without the rule:**
-
-```rust
-unsafe {
-    std::ptr::read(ptr)
-}
-```
-
-Unsafe blocks can slip in and become maintenance hotspots.
-
-**With the rule:** prefer safe standard-library APIs:
-
-```rust
-let first = values.first().copied();
-```
-
-### `unstable_features = deny`
-
-**Why:** published tooling should compile on stable Rust.
-
-**When to use:** for libraries and CLIs that must stay portable for contributors and CI.
-
-**Without the rule:** nightly-only features can leak into the codebase.
-
-**With the rule:** the code stays stable-channel compatible.
-
-### `unused_extern_crates = warn`
-
-**Why:** dead extern declarations add noise and make dependencies harder to audit.
-
-**Without the rule:** old compatibility imports linger.
-
-**With the rule:** unused declarations are cleaned up quickly.
-
-### `unused_import_braces = warn`
-
-**Why:** removes unnecessary syntax noise.
-
-**Without the rule:**
-
-```rust
-use std::fmt;
-```
-
-**With the rule:**
-
-```rust
-use std::fmt;
-```
-
-### `unused_lifetimes = warn`
-
-**Why:** unused lifetimes usually mean an API signature is more complex than necessary.
-
-**Without the rule:**
-
-```rust
-fn name<'a>(value: &str) -> &str {
-	value
-}
-```
-
-**With the rule:**
-
-```rust
-fn name(value: &str) -> &str {
-	value
-}
-```
-
-### `unused_macro_rules = warn`
-
-**Why:** dead macro arms are easy to forget and hard to test.
-
-**Without the rule:** macro definitions keep stale branches.
-
-**With the rule:** only exercised macro rules survive.
-
-### `unused_qualifications = warn`
-
-**Why:** fully qualifying names that are already in scope hurts readability.
-
-**Without the rule:**
-
-```rust
-use std::path::PathBuf;
-
-let path = std::path::PathBuf::new();
-```
-
-**With the rule:**
-
-```rust
-use std::path::PathBuf;
-
-let path = PathBuf::new();
-```
-
-### `variant_size_differences = warn`
-
-**Why:** very uneven enum variants can cause surprising memory bloat.
-
-**Without the rule:** a single large variant can inflate every enum value.
-
-**With the rule:** you consider boxing or reshaping the large variant.
-
-### `edition_2024_expr_fragment_specifier = allow`
-
-**Why it is allowed:** this lint is intentionally relaxed to avoid noisy churn while macro-related edition support settles.
-
-**When the allowance is appropriate:** when the code is otherwise clear and no migration risk is introduced.
-
-**Without the allowance:** the repo would force extra macro cleanups that do not improve the current product behavior.
-
-## Workspace clippy groups
-
-### `clippy::correctness = deny`
-
-**Why:** correctness issues are the highest-risk category.
-
-**Without it:** real bugs can land as "just warnings."
-
-**With it:** code that is likely wrong fails the lint pass.
-
-### `clippy::suspicious = warn`
-
-**Why:** suspicious constructs often compile but suggest a logic mistake.
-
-**Without it:** subtle mistakes look legitimate.
-
-**With it:** you get a review checkpoint before the bug becomes user-visible.
-
-### `clippy::style = warn`
-
-**Why:** style warnings keep code predictable and easier to scan.
-
-**Without it:** equivalent patterns drift across the codebase.
-
-**With it:** contributors converge on the same idioms.
-
-### `clippy::complexity = warn`
-
-**Why:** overly complex code is harder to review and easier to break.
-
-**Without it:** nested or overly clever logic grows unnoticed.
-
-**With it:** clippy nudges you toward extraction and simpler control flow.
-
-**Example of what this pressure is trying to prevent:**
-
-```rust
-if should_release {
-    if let Some(group) = group {
-        if group.publish {
-            if !group.members.is_empty() {
-                publish(group);
-            }
-        }
-    }
-}
-```
-
-A flatter version is easier to review:
-
-```rust
-let Some(group) = group else {
-    return;
-};
-
-if !should_release || !group.publish || group.members.is_empty() {
-    return;
-}
-
-publish(group);
-```
-
-### `clippy::perf = warn`
-
-**Why:** hot-path inefficiencies are easier to fix when caught early.
-
-**Without it:** unnecessary allocations and slower patterns blend in.
-
-**With it:** common performance footguns get surfaced during normal linting.
-
-### `clippy::pedantic = warn`
-
-**Why:** pedantic lints catch a lot of polish issues that improve API and code quality.
-
-**Why not deny:** the group is intentionally broad and sometimes noisy.
-
-**monochange approach:** enable the group, then explicitly allow the few rules where local readability or practicality matters more.
-
-## Explicit clippy policy
-
-### `blocks_in_conditions = allow`
-
-**Why it is allowed:** small computed conditions can be clearer inline than as a throwaway binding.
-
-**Without the allowance:**
-
-```rust
-if {
-    let ready = state.is_ready();
-    ready
-} {
-    run();
-}
-```
-
-Clippy would complain even when the structure is readable.
-
-**With the current policy:** this pattern is allowed, but extract it if the block becomes non-trivial.
-
-### `cargo_common_metadata = allow`
-
-**Why it is allowed:** workspace metadata is managed centrally, so per-crate metadata completeness is not always the right enforcement point.
-
-**Without the allowance:** clippy would push repetitive metadata into every crate even when the workspace already provides it.
-
-**With the current policy:** add metadata where it matters, but do not create boilerplate just to silence the lint.
-
-### `cast_possible_truncation = allow`
-
-**Why it is allowed:** some numeric conversions are deliberate and guarded by domain knowledge.
-
-**Without the allowance:**
-
-```rust
-let byte = value as u8;
-```
-
-would warn every time, even when the value is known to fit.
-
-**With the current policy:** the cast is permitted, but reviewers should still expect surrounding reasoning or bounds checks when truncation is not obviously safe.
-
-### `cast_possible_wrap = allow`
-
-**Why it is allowed:** signed/unsigned conversions sometimes reflect external protocol or storage requirements.
-
-**Without the allowance:** every deliberate sign-changing cast becomes noise.
-
-**With the current policy:** use the cast intentionally and document tricky cases.
-
-### `cast_precision_loss = allow`
-
-**Why it is allowed:** some reporting or ratio calculations intentionally trade precision for convenience.
-
-**Without the allowance:** floating-point conversions generate warnings even in non-critical display logic.
-
-**With the current policy:** precision-loss casts are allowed, but avoid them in semver, version, or identity logic where exactness matters.
-
-### `cast_sign_loss = allow`
-
-**Why it is allowed:** conversions to unsigned values are sometimes part of external API shaping.
-
-**Without the allowance:** routine boundary conversions become noisy.
-
-**With the current policy:** keep the cast local and obvious.
-
-### `expl_impl_clone_on_copy = allow`
-
-**Why it is allowed:** an explicit `Clone` impl on a `Copy` type can occasionally be clearer or more controlled than a derive.
-
-**Without the allowance:** clippy would force a derive-only style.
-
-**With the current policy:** explicit impls are allowed when there is a concrete reason, not as default habit.
-
-### `items_after_statements = allow`
-
-**Why it is allowed:** tests and small helper scopes sometimes read better when local items appear near their use.
-
-**Without the allowance:**
-
-```rust
-fn test_case() {
-	let input = sample();
-
-	fn sample() -> &'static str {
-		"ok"
-	}
-
-	assert_eq!(input, "ok");
-}
-```
-
-would warn.
-
-**With the current policy:** that layout is acceptable when it improves locality.
-
-### `missing_errors_doc = allow`
-
-**Why it is allowed:** internal functions are numerous, and forcing `# Errors` on all of them creates noisy docs.
-
-**Without the allowance:** every fallible helper would need a doc section.
-
-**With the current policy:** still document errors on public APIs and non-obvious behavior, but do not require boilerplate on every internal helper.
-
-### `missing_panics_doc = allow`
-
-**Why it is allowed:** similar to `missing_errors_doc`, this avoids boilerplate on internal helpers.
-
-**Without the allowance:** even intentionally internal panic paths need formal docs.
-
-**With the current policy:** public or surprising panic behavior should still be documented deliberately.
-
-### `module_name_repetitions = allow`
-
-**Why it is allowed:** crate boundaries and domain naming sometimes make repetition the clearest choice.
-
-**Without the allowance:**
-
-```rust
-mod release_record;
-struct ReleaseRecord;
-```
-
-can trigger a warning even though the names are clear.
-
-**With the current policy:** choose clarity over lint golf.
-
-### `must_use_candidate = allow`
-
-**Why it is allowed:** clippy suggests `#[must_use]` very aggressively.
-
-**Without the allowance:** many private helpers would get noisy suggestions.
-
-**With the current policy:** apply `#[must_use]` intentionally on public APIs, builders, and values where dropping the result is genuinely a bug.
-
-### `no_effect_underscore_binding = allow`
-
-**Why it is allowed:** intentionally ignored intermediate values sometimes help document intent in tests or command setup.
-
-**Without the allowance:** underscore-prefixed bindings can still warn even when they make the code easier to follow.
-
-**With the current policy:** use them sparingly and only when they clarify intent.
-
-### `tabs-in-doc-comments = allow`
-
-**Why it is allowed:** command output, tables, or copied terminal content may legitimately contain tabs.
-
-**Without the allowance:** documentation cleanup would fight preserved examples.
-
-**With the current policy:** tabs are acceptable in docs when they preserve exact formatting.
-
-### `too_many_lines = allow`
-
-**Why it is allowed:** some orchestration functions, renderers, or test modules are large for domain reasons.
-
-**Without the allowance:** contributors would spend time splitting code purely to satisfy an arbitrary line limit.
-
-**With the current policy:** long functions are allowed, but extraction is still preferred when it improves comprehension.
-
-### `wildcard_dependencies = deny`
-
-**Why:** published tools should not depend on unconstrained crate versions.
+1. `workspace` or `version`
+2. `default-features` / `default_features`
+3. `features`
+4. other keys like `optional`, `path`, `registry`, `package`, `git`, `branch`, `tag`, `rev`
 
 **Without the rule:**
 
 ```toml
-serde = "*"
+serde = { features = ["derive"], workspace = true }
 ```
 
-can make builds non-reproducible and difficult to audit.
+**With the rule:**
 
-**With the rule:** dependencies must be explicitly versioned.
-
-### `wildcard_imports = allow`
-
-**Why it is allowed:** some test modules and highly local scopes read better with a wildcard import.
-
-**Without the allowance:**
-
-```rust
-use super::*;
+```toml
+serde = { workspace = true, features = ["derive"] }
 ```
 
-would warn in common test layouts.
+**Useful option:**
 
-**With the current policy:** wildcard imports remain acceptable in narrow scopes, especially tests.
+- `fix` — defaults to `true`
 
-## Crate-level forbid: `clippy::indexing_slicing`
+### `cargo/internal-dependency-workspace`
 
-Most monochange Rust crates start with:
-
-```rust
-#![forbid(clippy::indexing_slicing)]
-```
-
-**Why:** indexing and slicing can panic, and monochange spends a lot of time parsing external files, manifests, and user input.
+**Why:** internal workspace dependencies should usually be declared through the workspace rather than carrying their own explicit version strings.
 
 **Without the rule:**
 
-```rust
-let first = values[0];
-let suffix = &text[1..];
+```toml
+[dependencies]
+monochange_core = { path = "../monochange_core", version = "0.1.0" }
 ```
 
-These compile, but they panic on malformed or short input.
+**With the rule:**
 
-**With the rule:** prefer checked access:
-
-```rust
-let first = values.first().copied();
-let suffix = text.get(1..);
+```toml
+[dependencies]
+monochange_core = { workspace = true }
 ```
 
-**Another example in manifest parsing:**
+**When to use it:** when the repository wants one workspace-owned version source for internal crates.
 
-```rust
-let version = package_json["version"].as_str();
+**Useful options:**
+
+- `require_workspace` — defaults to `true`
+- `fix` — defaults to `true`
+
+### `cargo/required-package-fields`
+
+**Why:** published crates should consistently carry the metadata your repository expects.
+
+**Default required fields:**
+
+- `description`
+- `license`
+- `repository`
+
+**Without the rule:**
+
+```toml
+[package]
+name = "example"
+version = "0.1.0"
 ```
 
-looks compact but assumes the key exists and the JSON shape is right. Checked access makes the failure mode explicit:
+**With the rule:** monochange reports the missing fields so package metadata stays consistent.
 
-```rust
-let version = package_json
-    .get("version")
-    .and_then(|value| value.as_str());
-```
+**Useful option:**
 
-**When to use this stricter rule:** parsing, config loading, release planning, changelog rendering, and any code that handles external repository state.
-
-## What "with and without linting" looks like in practice
-
-### Without the monochange lint posture
-
-- unsafe or nightly-only code can sneak in
-- panic-prone indexing is easier to miss
-- wildcard dependencies can weaken reproducibility
-- edition migration issues accumulate quietly
-- pedantic improvements never surface
-
-### With the current monochange lint posture
-
-- correctness issues fail fast
-- suspicious, style, complexity, performance, and pedantic issues show up in review
-- some noisy lints are intentionally relaxed where the team prefers readability or lower boilerplate
-- panic-prone indexing is blocked at crate level
-
-## When to add a local `#[allow(...)]`
-
-A local allow is acceptable when:
-
-- the lint is technically correct but the preferred alternative is harder to read
-- the code is constrained by a protocol, generated shape, or test pattern
-- you can explain the exception in one sentence
+- `fields` — replace the default required-field list
 
 Example:
 
-```rust
-#[allow(clippy::too_many_arguments)]
-fn build_release_payload(
-	owner: &str,
-	repo: &str,
-	version: &str,
-	tag: &str,
-	notes: &str,
-	draft: bool,
-	prerelease: bool,
-) {
-	// ...
+```toml
+[ecosystems.cargo.lints]
+"cargo/required-package-fields" = { level = "error", fields = ["description", "license"] }
+```
+
+### `cargo/sorted-dependencies`
+
+**Why:** alphabetized dependency tables are easier to review and reduce noisy diffs.
+
+**Without the rule:**
+
+```toml
+[dependencies]
+zzzz = "1.0"
+aaaa = "1.0"
+mmmm = "1.0"
+```
+
+**With the rule:**
+
+```toml
+[dependencies]
+aaaa = "1.0"
+mmmm = "1.0"
+zzzz = "1.0"
+```
+
+**Useful option:**
+
+- `fix` — defaults to `true`
+
+### `cargo/unlisted-package-private`
+
+**Why:** a Cargo package that is not listed in `monochange.toml` should not be accidentally publishable.
+
+**Without the rule:** an unmanaged crate can remain publicly publishable by accident.
+
+**With the rule:** monochange requires either:
+
+- adding the package to `monochange.toml`, or
+- marking it private with `publish = false`
+
+**Without the rule:**
+
+```toml
+[package]
+name = "experimental-crate"
+version = "0.1.0"
+```
+
+**With the rule:**
+
+```toml
+[package]
+name = "experimental-crate"
+version = "0.1.0"
+publish = false
+```
+
+**Useful option:**
+
+- `fix` — defaults to `true`
+
+## npm-family manifest lint rules
+
+### `npm/workspace-protocol`
+
+**Why:** internal workspace dependencies should use the `workspace:` protocol so local workspace intent is explicit.
+
+**Without the rule:**
+
+```json
+{
+	"dependencies": {
+		"@acme/shared": "^1.2.0"
+	}
 }
 ```
 
-Use this sparingly. If the function can be improved with a struct or builder, prefer that.
+**With the rule:**
 
-## Recommended validation loop after edits
+```json
+{
+	"dependencies": {
+		"@acme/shared": "workspace:*"
+	}
+}
+```
+
+**When to use it:** npm, pnpm, and Bun workspaces where internal packages should not drift to plain registry ranges.
+
+**Useful options:**
+
+- `require_for_private` — defaults to `false`
+- `fix` — defaults to `true`
+
+### `npm/sorted-dependencies`
+
+**Why:** alphabetized dependency sections reduce review noise and make package diffs easier to scan.
+
+**Without the rule:**
+
+```json
+{
+	"dependencies": {
+		"zod": "^4.0.0",
+		"chalk": "^5.0.0"
+	}
+}
+```
+
+**With the rule:**
+
+```json
+{
+	"dependencies": {
+		"chalk": "^5.0.0",
+		"zod": "^4.0.0"
+	}
+}
+```
+
+**Useful option:**
+
+- `fix` — defaults to `true`
+
+### `npm/required-package-fields`
+
+**Why:** package metadata should stay consistent across publishable npm packages.
+
+**Default required fields:**
+
+- `description`
+- `repository`
+- `license`
+
+**Without the rule:**
+
+```json
+{
+	"name": "@acme/app",
+	"version": "1.0.0"
+}
+```
+
+**With the rule:** monochange reports the missing metadata fields.
+
+**Useful option:**
+
+- `fields` — replace the default required-field list
+
+### `npm/root-no-prod-deps`
+
+**Why:** the workspace root `package.json` is usually orchestration-only and should keep runtime dependencies out of the root package.
+
+**Without the rule:**
+
+```json
+{
+	"dependencies": {
+		"react": "^19.0.0"
+	}
+}
+```
+
+**With the rule:** move those to `devDependencies` when the root package is only a workspace manager.
+
+**Useful option:**
+
+- `fix` — defaults to `true`
+
+### `npm/no-duplicate-dependencies`
+
+**Why:** the same dependency should not appear in multiple dependency sections unless the repository has a very deliberate reason.
+
+**Without the rule:**
+
+```json
+{
+	"dependencies": {
+		"typescript": "^5.0.0"
+	},
+	"devDependencies": {
+		"typescript": "^5.0.0"
+	}
+}
+```
+
+**With the rule:** monochange reports the duplicate and can suggest removing the redundant non-dev entry when appropriate.
+
+**Useful option:**
+
+- `fix` — defaults to `true`
+
+### `npm/unlisted-package-private`
+
+**Why:** a package not declared in `monochange.toml` should not remain publishable by accident.
+
+**Without the rule:** an unmanaged package can still look publishable.
+
+**With the rule:** monochange requires either:
+
+- adding the package to `monochange.toml`, or
+- marking it private in `package.json`
+
+**Without the rule:**
+
+```json
+{
+	"name": "@acme/experimental",
+	"version": "0.1.0"
+}
+```
+
+**With the rule:**
+
+```json
+{
+	"name": "@acme/experimental",
+	"private": true,
+	"version": "0.1.0"
+}
+```
+
+**Useful option:**
+
+- `fix` — defaults to `true`
+
+## What `mc check` looks like in practice
+
+Use plain text for local review:
 
 ```bash
-devenv shell fix:all
-devenv shell lint:all
+mc check
+```
+
+Apply safe auto-fixes where possible:
+
+```bash
+mc check --fix
+```
+
+Use JSON for CI or MCP-style tooling:
+
+```bash
+mc check --format json
+```
+
+`mc check` fails when lint errors are present, so it is appropriate for CI gates.
+
+## Recommended workflow
+
+For repository work:
+
+```bash
 mc validate
+mc check
+mc release --dry-run --diff
 ```
 
 If you changed shared docs too:

--- a/packages/monochange__skill/README.md
+++ b/packages/monochange__skill/README.md
@@ -9,7 +9,7 @@ This package bundles:
 - `skills/changesets.md` — changeset authoring and lifecycle guidance
 - `skills/commands.md` — built-in command catalog and usage patterns
 - `skills/configuration.md` — `monochange.toml` setup and editing guidance
-- `skills/linting.md` — current lint policy, rationale, and examples
+- `skills/linting.md` — `mc check`, `[ecosystems.<name>.lints]`, and manifest-focused rule explanations with examples
 - `REFERENCE.md` — high-context reference with broader examples
 - `monochange-skill` — helper executable for printing or copying the bundled skill
 

--- a/packages/monochange__skill/README.md
+++ b/packages/monochange__skill/README.md
@@ -4,8 +4,13 @@ Installable agent skill for monochange.
 
 This package bundles:
 
-- `SKILL.md` — concise agent instructions
-- `REFERENCE.md` — deeper usage and installation guidance
+- `SKILL.md` — concise entrypoint for agents
+- `skills/README.md` — index of focused deep dives
+- `skills/changesets.md` — changeset authoring and lifecycle guidance
+- `skills/commands.md` — built-in command catalog and usage patterns
+- `skills/configuration.md` — `monochange.toml` setup and editing guidance
+- `skills/linting.md` — current lint policy, rationale, and examples
+- `REFERENCE.md` — high-context reference with broader examples
 - `monochange-skill` — helper executable for printing or copying the bundled skill
 
 ## Install
@@ -22,13 +27,17 @@ monochange-skill --print-skill
 monochange-skill --copy ~/.pi/agent/skills/monochange
 ```
 
+`monochange-skill --copy` copies the full skill bundle, including `SKILL.md`, `REFERENCE.md`, and the `skills/` deep-dive folder.
+
 ## What the skill teaches
 
 The bundled skill explains how to:
 
-- read `monochange.toml`
-- validate a workspace with `mc validate`
+- create or refine `monochange.toml` with `mc init`, `mc populate`, and `mc validate`
 - inspect the normalized model with `mc discover --format json`
-- create explicit change files with `mc change`
-- preview release effects with `mc release --dry-run --format json`
-- understand groups, package ids, changelogs, and source-provider release flows
+- create, update, and audit explicit change files with `mc change` and `mc diagnostics`
+- preview release effects with `mc release --dry-run --format json` and `mc release --dry-run --diff`
+- inspect durable release history with `mc release-record`
+- understand groups, package ids, changelogs, linting policy, package publishing, and source-provider release flows
+
+Open [SKILL.md](./SKILL.md) first, then use [skills/README.md](./skills/README.md) and [REFERENCE.md](./REFERENCE.md) for the deeper sections.

--- a/packages/monochange__skill/REFERENCE.md
+++ b/packages/monochange__skill/REFERENCE.md
@@ -49,7 +49,7 @@ Use the bundled docs like this:
 - [skills/changesets.md](./skills/changesets.md) — creating and managing changesets
 - [skills/commands.md](./skills/commands.md) — built-in commands and workflow selection
 - [skills/configuration.md](./skills/configuration.md) — creating and evolving `monochange.toml`
-- [skills/linting.md](./skills/linting.md) — current lint policy, rationale, and examples
+- [skills/linting.md](./skills/linting.md) — `mc check`, `[ecosystems.<name>.lints]`, and manifest-focused rule explanations with examples
 - [CHANGESET-GUIDE.md](./CHANGESET-GUIDE.md) — full lifecycle guidance
 - [ARTIFACT-TYPES.md](./ARTIFACT-TYPES.md) — artifact-aware changeset framing
 
@@ -475,7 +475,7 @@ Placeholder README content can come from:
 
 ### Lint rules
 
-Configure ecosystem-specific lint rules to enforce consistency across package manifests:
+Configure ecosystem-specific manifest lint rules and run them through `mc check`:
 
 ```toml
 [ecosystems.cargo.lints]
@@ -498,6 +498,8 @@ Rule configuration:
 
 - Simple severity: `"rule-id" = "error"`, `"rule-id" = "warning"`, or `"rule-id" = "off"`
 - Detailed config: `{ level = "error", fix = true, ...options }`
+
+Today the built-in rule sets focus on Cargo and npm-family manifests.
 
 Available Cargo lint rules:
 
@@ -546,14 +548,14 @@ comment_on_failure = true
 
 ## Linting and validation reference
 
-The repository currently enforces workspace rust lints, workspace clippy groups, explicit clippy overrides, and crate-level `#![forbid(clippy::indexing_slicing)]` declarations in the Rust crates.
+monochange's linting docs in this skill package are about **manifest lint rules configured in `monochange.toml` and run via `mc check`**.
 
-Use this workflow after documentation, config, or code edits:
+Use this workflow when editing package manifests or lint configuration:
 
 ```bash
-devenv shell fix:all
-devenv shell lint:all
 mc validate
+mc check
+mc check --fix
 ```
 
 If you edited shared docs in `.templates/`, also run:
@@ -562,7 +564,7 @@ If you edited shared docs in `.templates/`, also run:
 devenv shell docs:check
 ```
 
-For the full rule-by-rule explanation — including why each lint exists, when to rely on it, and examples of what changes with and without it — see [skills/linting.md](./skills/linting.md).
+For the full rule-by-rule explanation — including the available `[ecosystems.<name>.lints]` rules, why you would enable them, and examples of what changes with and without them — see [skills/linting.md](./skills/linting.md).
 
 ## Important modeling rules
 

--- a/packages/monochange__skill/REFERENCE.md
+++ b/packages/monochange__skill/REFERENCE.md
@@ -36,7 +36,24 @@ mc --help
 ```bash
 npm install -g @monochange/skill
 monochange-skill --print-install
+monochange-skill --print-skill
+monochange-skill --copy ~/.pi/agent/skills/monochange
 ```
+
+## Skill map
+
+Use the bundled docs like this:
+
+- [SKILL.md](./SKILL.md) — concise entrypoint for agents
+- [skills/README.md](./skills/README.md) — index of focused skill modules
+- [skills/changesets.md](./skills/changesets.md) — creating and managing changesets
+- [skills/commands.md](./skills/commands.md) — built-in commands and workflow selection
+- [skills/configuration.md](./skills/configuration.md) — creating and evolving `monochange.toml`
+- [skills/linting.md](./skills/linting.md) — current lint policy, rationale, and examples
+- [CHANGESET-GUIDE.md](./CHANGESET-GUIDE.md) — full lifecycle guidance
+- [ARTIFACT-TYPES.md](./ARTIFACT-TYPES.md) — artifact-aware changeset framing
+
+Keep this `REFERENCE.md` open when you want one longer document with broader examples and copy-paste snippets.
 
 ## Recommended command flow
 
@@ -51,6 +68,79 @@ monochange-skill --print-install
 7. **Publish** — `mc publish-release --format json` creates provider releases after human review.
 
 <!-- {/recommendedCommandFlow} -->
+
+For release-oriented commands, markdown is the default human-readable output format. Use `--format json` for automation and `--diff` when you want file previews without mutating the workspace.
+
+## Command catalog
+
+### Bootstrap and validate
+
+```bash
+mc init
+mc init --provider github
+mc populate
+mc validate
+```
+
+Use these when you are creating or refining `monochange.toml`.
+
+- `mc init` generates a starter config from detected packages
+- `mc init --provider github` also seeds source/provider automation config
+- `mc populate` appends any missing built-in `[cli.<command>]` definitions to an existing config
+- `mc validate` checks config shape and changeset targets before you do anything riskier
+
+### Inspect the workspace model
+
+```bash
+mc discover --format json
+mc diagnostics --format json
+mc release-record --from HEAD --format json
+```
+
+Use these when you need facts before making changes.
+
+- `mc discover --format json` gives you package ids, dependency edges, and groups
+- `mc diagnostics --format json` adds changeset provenance, linked reviews, and related issues
+- `mc release-record --from <ref>` inspects the durable release declaration stored in release history
+
+### Create release intent
+
+```bash
+mc change --package monochange --bump minor --reason "add diagnostics command"
+mc change --package monochange_config --bump none --caused-by monochange_core --reason "dependency-only follow-up"
+mc affected --changed-paths crates/monochange/src/lib.rs --format json
+```
+
+Use these when you are deciding what should be released.
+
+### Preview and apply releases
+
+```bash
+mc release --dry-run
+mc release --dry-run --diff
+mc release --dry-run --format json
+mc commit-release --dry-run --diff
+mc publish --dry-run --format json
+mc publish-release --dry-run --format json
+mc release-pr --dry-run --format json
+mc placeholder-publish --dry-run --format json
+mc repair-release --from v1.2.3 --target HEAD --dry-run
+```
+
+Use the dry-run forms first. They are the safest way to audit release behavior before mutating files, git state, registries, or provider releases.
+
+### Assistant setup and MCP
+
+```bash
+mc assist pi
+mc assist generic
+mc assist claude --format json
+mc mcp
+```
+
+Use `mc assist` when you need install instructions and client-specific MCP configuration. Use `mc mcp` when the client actually needs the stdio server process.
+
+For a shorter command-only guide, see [skills/commands.md](./skills/commands.md).
 
 ## Changeset authoring
 
@@ -453,6 +543,26 @@ required = true
 skip_labels = ["no-changeset-required"]
 comment_on_failure = true
 ```
+
+## Linting and validation reference
+
+The repository currently enforces workspace rust lints, workspace clippy groups, explicit clippy overrides, and crate-level `#![forbid(clippy::indexing_slicing)]` declarations in the Rust crates.
+
+Use this workflow after documentation, config, or code edits:
+
+```bash
+devenv shell fix:all
+devenv shell lint:all
+mc validate
+```
+
+If you edited shared docs in `.templates/`, also run:
+
+```bash
+devenv shell docs:check
+```
+
+For the full rule-by-rule explanation — including why each lint exists, when to rely on it, and examples of what changes with and without it — see [skills/linting.md](./skills/linting.md).
 
 ## Important modeling rules
 

--- a/packages/monochange__skill/SKILL.md
+++ b/packages/monochange__skill/SKILL.md
@@ -13,7 +13,7 @@ description: Guides agents through monochange discovery, changesets, release pla
 4. Use `mc discover --format json` to inspect the workspace model.
 5. Use `mc change` to write explicit release intent as `.changeset/*.md` files.
 6. Use `mc diagnostics --format json` to inspect changeset context and git provenance.
-7. Use `mc lint` to check package manifests for consistency and best practices.
+7. Use `mc check` to validate the workspace and run configured manifest lint rules.
 8. Use `mc release --dry-run --format json` or `mc release --dry-run --diff` before mutating release state.
 
 ## Working rules
@@ -28,7 +28,7 @@ description: Guides agents through monochange discovery, changesets, release pla
 - Combine near-duplicate changesets when the outward change is the same across multiple related packages. Do not emit cloned compatibility notes that differ only by package name.
 - Breaking changes must always get their own dedicated changeset with a migration path instead of being bundled into a broader feature note.
 - Run dry-run flows before real release commands.
-- Run `mc lint` before releases to catch manifest inconsistencies early.
+- Run `mc check` before releases to catch manifest inconsistencies early.
 - Keep docs, templates, and changelog behavior aligned with config changes.
 - Use `mc diagnostics --format json` to audit changesets before release — it shows git provenance, linked PRs, related issues, and introduced/last-updated commits.
 
@@ -55,7 +55,7 @@ Release-oriented commands default to markdown output. Use `--format json` for au
 - [skills/changesets.md](skills/changesets.md) — creating and managing changesets
 - [skills/commands.md](skills/commands.md) — built-in commands and workflow selection
 - [skills/configuration.md](skills/configuration.md) — creating and extending `monochange.toml`
-- [skills/linting.md](skills/linting.md) — current lint rules, rationale, and examples
+- [skills/linting.md](skills/linting.md) — `mc check`, `[ecosystems.<name>.lints]`, and manifest-focused rule explanations with examples
 - [CHANGESET-GUIDE.md](CHANGESET-GUIDE.md) — full lifecycle guidance
 - [ARTIFACT-TYPES.md](ARTIFACT-TYPES.md) — package-type-specific release-note guidance
 
@@ -212,7 +212,7 @@ See [ARTIFACT-TYPES.md](ARTIFACT-TYPES.md) for per-type rules, templates, exampl
 
 ### Lint configuration
 
-Configure ecosystem-specific lint rules in `monochange.toml`:
+Configure ecosystem-specific manifest lint rules in `monochange.toml` and run them with `mc check`:
 
 ```toml
 [ecosystems.cargo.lints]
@@ -236,7 +236,7 @@ Each rule can be configured as:
 - Simple severity: `"rule-id" = "error"`, `"rule-id" = "warning"`, or `"rule-id" = "off"`
 - Detailed config: `{ level = "error", ...rule_specific_options }`
 
-Use `mc check --fix` to auto-fix issues where possible.
+Use `mc check --fix` to auto-fix issues where possible. Today the built-in rule sets focus on Cargo and npm-family manifests.
 
 ## Guidance
 

--- a/packages/monochange__skill/SKILL.md
+++ b/packages/monochange__skill/SKILL.md
@@ -7,13 +7,14 @@ description: Guides agents through monochange discovery, changesets, release pla
 
 ## Quick start
 
-1. Read `monochange.toml` first — it is the single source of truth.
-2. Run `mc validate` before making release-affecting edits.
-3. Use `mc discover --format json` to inspect the workspace model.
-4. Use `mc change` to write explicit release intent as `.changeset/*.md` files.
-5. Use `mc release --dry-run --format json` before mutating release state.
+1. If `monochange.toml` does not exist yet, run `mc init`. If it exists but you want editable built-in command definitions, run `mc populate`.
+2. Read `monochange.toml` first — it is the single source of truth.
+3. Run `mc validate` before making release-affecting edits.
+4. Use `mc discover --format json` to inspect the workspace model.
+5. Use `mc change` to write explicit release intent as `.changeset/*.md` files.
 6. Use `mc diagnostics --format json` to inspect changeset context and git provenance.
 7. Use `mc lint` to check package manifests for consistency and best practices.
+8. Use `mc release --dry-run --format json` or `mc release --dry-run --diff` before mutating release state.
 
 ## Working rules
 
@@ -45,6 +46,19 @@ description: Guides agents through monochange discovery, changesets, release pla
 
 <!-- {/recommendedCommandFlow} -->
 
+Release-oriented commands default to markdown output. Use `--format json` for automation and `--diff` when you want unified file previews without mutating the workspace.
+
+## Deep dives
+
+- [REFERENCE.md](REFERENCE.md) — high-context reference with more examples
+- [skills/README.md](skills/README.md) — index of focused skill modules
+- [skills/changesets.md](skills/changesets.md) — creating and managing changesets
+- [skills/commands.md](skills/commands.md) — built-in commands and workflow selection
+- [skills/configuration.md](skills/configuration.md) — creating and extending `monochange.toml`
+- [skills/linting.md](skills/linting.md) — current lint rules, rationale, and examples
+- [CHANGESET-GUIDE.md](CHANGESET-GUIDE.md) — full lifecycle guidance
+- [ARTIFACT-TYPES.md](ARTIFACT-TYPES.md) — package-type-specific release-note guidance
+
 ## CLI commands
 
 | Command                  | Purpose                                                                |
@@ -63,6 +77,7 @@ description: Guides agents through monochange discovery, changesets, release pla
 | `mc release-pr`          | Open or update a release pull request                                  |
 | `mc affected`            | Evaluate changeset policy from changed paths                           |
 | `mc diagnostics`         | Show changeset context with git and review metadata                    |
+| `mc release-record`      | Inspect a durable release declaration from git history                 |
 | `mc repair-release`      | Repair a recent release by retargeting tags                            |
 | `mc assist`              | Print assistant install and MCP setup guidance                         |
 | `mc mcp`                 | Start the stdio MCP server                                             |
@@ -225,4 +240,4 @@ Use `mc check --fix` to auto-fix issues where possible.
 
 ## Guidance
 
-See [REFERENCE.md](REFERENCE.md) for install steps, changeset authoring, grouped release rules, input types, step composition, and assistant setup guidance.
+Start with [REFERENCE.md](REFERENCE.md) for the broad reference. Then open the focused deep dives in [skills/README.md](skills/README.md) when you need dedicated guidance for changesets, commands, configuration, or linting.

--- a/packages/monochange__skill/package.json
+++ b/packages/monochange__skill/package.json
@@ -16,6 +16,7 @@
 		"REFERENCE.md",
 		"CHANGESET-GUIDE.md",
 		"ARTIFACT-TYPES.md",
+		"skills",
 		"README.md",
 		"LICENSE",
 		"changelog.md"

--- a/packages/monochange__skill/skills/README.md
+++ b/packages/monochange__skill/skills/README.md
@@ -5,7 +5,7 @@ Use these focused guides when the top-level [SKILL.md](../SKILL.md) is not enoug
 - [changesets.md](./changesets.md) — creating, updating, replacing, and removing `.changeset/*.md` files
 - [commands.md](./commands.md) — the built-in `mc` commands, when to run them, and how they fit together
 - [configuration.md](./configuration.md) — creating and evolving `monochange.toml`
-- [linting.md](./linting.md) — current workspace lint policy, why each lint exists, and examples of what changes with or without it
+- [linting.md](./linting.md) — `mc check`, `[ecosystems.<name>.lints]`, and manifest-focused rule explanations with examples
 
 Keep [REFERENCE.md](../REFERENCE.md) open when you want a single high-context document with broader examples and copy-paste snippets.
 

--- a/packages/monochange__skill/skills/README.md
+++ b/packages/monochange__skill/skills/README.md
@@ -1,0 +1,15 @@
+# monochange skill deep dives
+
+Use these focused guides when the top-level [SKILL.md](../SKILL.md) is not enough context:
+
+- [changesets.md](./changesets.md) — creating, updating, replacing, and removing `.changeset/*.md` files
+- [commands.md](./commands.md) — the built-in `mc` commands, when to run them, and how they fit together
+- [configuration.md](./configuration.md) — creating and evolving `monochange.toml`
+- [linting.md](./linting.md) — current workspace lint policy, why each lint exists, and examples of what changes with or without it
+
+Keep [REFERENCE.md](../REFERENCE.md) open when you want a single high-context document with broader examples and copy-paste snippets.
+
+For deeper changeset guidance, also see:
+
+- [CHANGESET-GUIDE.md](../CHANGESET-GUIDE.md)
+- [ARTIFACT-TYPES.md](../ARTIFACT-TYPES.md)

--- a/packages/monochange__skill/skills/changesets.md
+++ b/packages/monochange__skill/skills/changesets.md
@@ -1,0 +1,228 @@
+# Changesets skill
+
+Use this guide when the task is to create, review, update, replace, or remove `.changeset/*.md` files.
+
+## When to use this skill
+
+Reach for it when you need to:
+
+- create a new changeset from a code change
+- decide whether to update an existing changeset instead of creating another one
+- explain dependency propagation with `caused_by`
+- choose between package ids and group ids
+- describe a CLI, library, application, or protocol change in user-facing language
+
+## Start with the workspace model
+
+Before writing anything:
+
+1. Read `monochange.toml`
+2. Run `mc validate`
+3. Run `mc discover --format json`
+4. Review existing `.changeset/*.md` files
+5. Use `mc diagnostics --format json` when you need git and PR context
+
+## The default creation flow
+
+Create a new changeset for one package:
+
+```bash
+mc change --package monochange --bump minor --reason "add release-record discovery"
+```
+
+Create a dependency-follow-up changeset:
+
+```bash
+mc change \
+  --package monochange_config \
+  --bump patch \
+  --caused-by monochange_core \
+  --reason "update dependency on monochange_core"
+```
+
+Create a no-version-bump acknowledgement for an affected package:
+
+```bash
+mc change \
+  --package monochange_config \
+  --bump none \
+  --caused-by monochange_core \
+  --reason "dependency-only follow-up"
+```
+
+## Package id vs. group id
+
+Prefer a package id when one package changed directly:
+
+```markdown
+---
+monochange_core: minor
+---
+```
+
+Use a group id only when the outward release boundary is the whole group:
+
+```markdown
+---
+sdk: minor
+---
+```
+
+A good rule:
+
+- **package id** — a leaf package changed and monochange can propagate the rest
+- **group id** — the release note should read as one coordinated release owned by the group
+
+## Scalar vs. object frontmatter
+
+Scalar syntax is the shortest form:
+
+```markdown
+---
+monochange: patch
+---
+```
+
+Object syntax is for richer intent:
+
+```markdown
+---
+monochange:
+  bump: major
+  version: "2.0.0"
+  type: security
+---
+```
+
+Use object syntax when you need:
+
+- `version` for an explicit version target
+- `type` for a custom changelog section
+- `caused_by` for dependency propagation context
+
+## `caused_by` and dependency propagation
+
+Without `caused_by`, a dependent package gets an automatic dependency-bump record with little context.
+
+**Without authored context:**
+
+```markdown
+# automatic propagation, no authored explanation
+
+monochange_config -> patch
+```
+
+**With authored context:**
+
+```markdown
+---
+monochange_config:
+  bump: patch
+  caused_by: ["monochange_core"]
+---
+
+#### update dependency on monochange_core
+
+Bumps `monochange_core` after the `ChangelogFormat` API change.
+```
+
+Use `bump: none` when the package is affected but users do not need a version bump.
+
+## Create vs. update vs. replace vs. remove
+
+### Create a new changeset
+
+Use a new file when the outward change is genuinely new.
+
+```markdown
+---
+monochange: minor
+---
+
+#### add `mc diagnostics`
+
+Introduce a command for changeset provenance.
+```
+
+### Update an existing changeset
+
+Update in place when the same feature grew before release.
+
+**Before:**
+
+```markdown
+---
+monochange: minor
+---
+
+#### add `mc diagnostics`
+
+Introduce a command for changeset provenance.
+```
+
+**After:**
+
+```markdown
+---
+monochange: minor
+---
+
+#### add `mc diagnostics` for provenance and review context
+
+Introduce a command for changeset provenance, linked review requests, and related issues.
+```
+
+### Replace a changeset
+
+Replace the file when the implementation changed so much that the old note is misleading.
+
+### Remove a changeset
+
+Delete the file when the feature was reverted before release.
+
+## Write user-facing summaries
+
+Changeset bodies should describe what users notice.
+
+### Weak
+
+```markdown
+#### refactor release logic
+```
+
+### Better
+
+```markdown
+#### add `--diff` previews to dry-run release output
+
+`mc release --dry-run --diff` now shows unified file diffs for version and changelog updates without mutating the workspace.
+```
+
+## Artifact-specific framing
+
+Different package types need different release-note framing:
+
+- **Libraries** — public APIs, types, traits, exports, behavior
+- **Applications** — routes, screens, workflows, UX changes
+- **CLI tools** — commands, flags, output, exit codes, config shape
+- **LSP/MCP** — tool names, schemas, protocol methods, response shapes
+
+See [ARTIFACT-TYPES.md](../ARTIFACT-TYPES.md) for detailed templates.
+
+## Validation loop
+
+After writing or editing changesets:
+
+```bash
+mc validate
+mc diagnostics --format json
+mc release --dry-run --format json
+```
+
+Use `mc affected --changed-paths ...` in CI or review workflows when you need to prove all changed packages are covered.
+
+## Keep these references nearby
+
+- [CHANGESET-GUIDE.md](../CHANGESET-GUIDE.md) — lifecycle details
+- [ARTIFACT-TYPES.md](../ARTIFACT-TYPES.md) — package-type-specific guidance
+- [REFERENCE.md](../REFERENCE.md) — longer examples and config cross-references

--- a/packages/monochange__skill/skills/commands.md
+++ b/packages/monochange__skill/skills/commands.md
@@ -1,0 +1,179 @@
+# Commands skill
+
+Use this guide when the task is to choose, explain, or sequence monochange CLI commands.
+
+## Command selection by goal
+
+### Create or repair config
+
+| Goal                                     | Command       | When to use it                                                                          |
+| ---------------------------------------- | ------------- | --------------------------------------------------------------------------------------- |
+| Bootstrap a repo                         | `mc init`     | You need a starter `monochange.toml` based on detected packages                         |
+| Add missing built-in command definitions | `mc populate` | The repo already has `monochange.toml`, but you want editable `[cli.<command>]` entries |
+| Check config and changesets              | `mc validate` | Before and after release-affecting edits                                                |
+
+Examples:
+
+```bash
+mc init
+mc init --provider github
+mc populate
+mc validate
+```
+
+### Inspect the workspace
+
+| Goal                                      | Command                          | When to use it                                                     |
+| ----------------------------------------- | -------------------------------- | ------------------------------------------------------------------ |
+| See normalized packages and groups        | `mc discover --format json`      | You need package ids, dependency edges, or group ownership         |
+| Audit pending changesets with git context | `mc diagnostics --format json`   | You need introduced commits, linked reviews, or related issues     |
+| Inspect a durable release declaration     | `mc release-record --from <ref>` | You need to inspect a past release after the commit already exists |
+
+Examples:
+
+```bash
+mc discover --format json
+mc diagnostics --format json
+mc diagnostics --changeset .changeset/feature.md
+mc release-record --from v1.2.3
+mc release-record --from HEAD --format json
+```
+
+### Create release intent
+
+| Goal                                     | Command       | When to use it                                                      |
+| ---------------------------------------- | ------------- | ------------------------------------------------------------------- |
+| Create a changeset                       | `mc change`   | You know the target package or group id                             |
+| Check policy coverage from changed files | `mc affected` | CI or review needs to confirm that changed packages have changesets |
+
+Examples:
+
+```bash
+mc change --package monochange --bump minor --reason "add diagnostics command"
+mc change --package monochange_config --bump none --caused-by monochange_core --reason "dependency-only follow-up"
+mc affected --changed-paths crates/monochange/src/lib.rs --format json
+```
+
+### Plan or execute a release
+
+| Goal                                      | Command                          | When to use it                                                           |
+| ----------------------------------------- | -------------------------------- | ------------------------------------------------------------------------ |
+| Preview a release safely                  | `mc release --dry-run`           | You want the computed plan without mutating files                        |
+| Preview file diffs too                    | `mc release --dry-run --diff`    | You want to see version/changelog patches before applying them           |
+| Apply the release locally                 | `mc release`                     | You are ready to update files on disk                                    |
+| Create a release commit locally           | `mc commit-release`              | You want the prepared commit before provider publishing                  |
+| Publish package artifacts                 | `mc publish`                     | Built-in package publishing is configured                                |
+| Create provider releases                  | `mc publish-release`             | Source/provider publishing is configured                                 |
+| Open or update a release PR               | `mc release-pr`                  | You want provider-hosted release-request automation                      |
+| Publish placeholders for missing packages | `mc placeholder-publish`         | A package must exist in the public registry before automation can finish |
+| Retarget a recent release                 | `mc repair-release --from <ref>` | A just-created release needs to move forward to a later commit           |
+
+Examples:
+
+```bash
+mc release --dry-run
+mc release --dry-run --diff
+mc release --dry-run --format json
+mc commit-release --dry-run --diff
+mc publish --dry-run --format json
+mc publish-release --dry-run --format json
+mc release-pr --dry-run --format json
+mc placeholder-publish --dry-run --format json
+mc repair-release --from v1.2.3 --target HEAD --dry-run
+```
+
+### Assistant workflows
+
+| Goal                                              | Command                 | When to use it                             |
+| ------------------------------------------------- | ----------------------- | ------------------------------------------ |
+| Print install/setup instructions for an assistant | `mc assist <assistant>` | You want an install recipe plus MCP config |
+| Start the MCP server                              | `mc mcp`                | The client launches monochange over stdio  |
+
+Examples:
+
+```bash
+mc assist generic
+mc assist pi
+mc assist claude --format json
+mc mcp
+```
+
+## Output formats
+
+Many commands support `text`, `markdown`, and `json`.
+
+Use:
+
+- `--format json` for automation and agent parsing
+- `--format markdown` for human-readable terminal output with richer structure
+- `--format text` when you explicitly want the older plain-text rendering
+
+For release-oriented commands, markdown is the default output format.
+
+## A practical command flow
+
+For most work, use this order:
+
+```bash
+mc validate
+mc discover --format json
+mc change --package <id> --bump patch --reason "describe the change"
+mc diagnostics --format json
+mc release --dry-run --diff
+```
+
+Then choose the next step:
+
+- `mc release` to apply
+- `mc commit-release` to produce the local release commit
+- `mc publish` to publish package artifacts
+- `mc publish-release` to create provider releases
+- `mc release-pr` to update a release request instead
+
+## Common mistakes
+
+### Guessing package ids
+
+**Avoid:**
+
+```bash
+mc change --package crates/monochange --bump patch --reason "..."
+```
+
+**Prefer:**
+
+```bash
+mc discover --format json
+mc change --package monochange --bump patch --reason "..."
+```
+
+### Releasing before a dry run
+
+**Avoid:**
+
+```bash
+mc release
+```
+
+**Prefer:**
+
+```bash
+mc release --dry-run --diff
+mc release
+```
+
+### Reading raw changesets when diagnostics would be clearer
+
+**Avoid:** manually scraping `.changeset/*.md` files to discover provenance.
+
+**Prefer:**
+
+```bash
+mc diagnostics --format json
+```
+
+## Related references
+
+- [REFERENCE.md](../REFERENCE.md)
+- [configuration.md](./configuration.md)
+- [changesets.md](./changesets.md)

--- a/packages/monochange__skill/skills/configuration.md
+++ b/packages/monochange__skill/skills/configuration.md
@@ -1,0 +1,255 @@
+# Configuration skill
+
+Use this guide when the task is to create, review, or extend `monochange.toml`.
+
+## First choice: generate, then edit
+
+Start with generated config whenever possible:
+
+```bash
+mc init
+```
+
+If you already have `monochange.toml` but want editable built-in command definitions appended, run:
+
+```bash
+mc populate
+```
+
+Validate after every meaningful change:
+
+```bash
+mc validate
+```
+
+## Minimum viable config
+
+A small repo can start with defaults plus one package:
+
+```toml
+[defaults]
+package_type = "cargo"
+
+[package.monochange]
+path = "crates/monochange"
+```
+
+Use this when the repo is simple and one ecosystem dominates.
+
+## Add changelog defaults early
+
+A useful next step is defining how changelogs should render:
+
+```toml
+[defaults]
+package_type = "cargo"
+
+[defaults.changelog]
+path = "{{ path }}/changelog.md"
+format = "keep_a_changelog"
+```
+
+Why:
+
+- packages inherit the same changelog shape by default
+- you avoid repeating the same table everywhere
+- you can still override per package or group later
+
+## Declare packages explicitly
+
+monochange works best when every managed package has a stable id.
+
+```toml
+[package.monochange_core]
+path = "crates/monochange_core"
+
+[package.monochange]
+path = "crates/monochange"
+versioned_files = ["Cargo.toml"]
+```
+
+Prefer ids you want to see in changesets and release output.
+
+## Use groups for shared release identity
+
+When several packages version together, create a group:
+
+```toml
+[group.sdk]
+packages = ["monochange_core", "monochange"]
+tag = true
+release = true
+version_format = "primary"
+```
+
+Use a group when the outward release boundary is shared.
+
+Do not use a group just because packages depend on each other. Simple dependency propagation often does the right thing without grouping.
+
+## Add extra changelog sections intentionally
+
+Use `extra_changelog_sections` when one change type deserves its own heading:
+
+```toml
+[package.web-app]
+path = "apps/web"
+type = "cargo"
+extra_changelog_sections = [
+	{ name = "User Experience", types = ["ux"], default_bump = "minor" },
+]
+```
+
+Then create a changeset like:
+
+```bash
+mc change --package web-app --bump minor --type ux --reason "redesign settings navigation"
+```
+
+## Version more than manifests
+
+Use `versioned_files` when a release also needs to update README badges, install scripts, or extra manifests.
+
+### Ecosystem-aware entries
+
+```toml
+[package.monochange]
+path = "crates/monochange"
+versioned_files = [
+	"Cargo.toml",
+	{ path = "crates/monochange/extra.toml", type = "cargo" },
+]
+```
+
+### Regex entries for plain text
+
+```toml
+[package.monochange]
+path = "crates/monochange"
+versioned_files = [
+	{ path = "README.md", regex = 'v(?<version>\d+\.\d+\.\d+)' },
+]
+```
+
+Use regex entries when no ecosystem parser applies.
+
+## Lockfile refresh strategy
+
+If the built-in lockfile rewriting is enough, keep config minimal.
+
+Add `lockfile_commands` only when the package manager must do the refresh:
+
+```toml
+[ecosystems.npm]
+lockfile_commands = [
+	{ command = "pnpm install --lockfile-only", cwd = "packages/web" },
+]
+```
+
+Use this when workspace-specific package-manager behavior matters more than raw speed.
+
+## Package publishing and trust
+
+Publishing is separate from release planning.
+
+```toml
+[ecosystems.npm.publish]
+mode = "builtin"
+trusted_publishing = true
+
+[package.web.publish.placeholder]
+readme_file = "docs/web-placeholder.md"
+```
+
+Use:
+
+- `mc placeholder-publish` to bootstrap missing public packages
+- `mc publish` for package-registry publishing
+- `mc publish-release` for hosted/provider releases
+
+## Release titles and changelog headings
+
+Customize outward release text with these fields:
+
+```toml
+[defaults]
+release_title = "{{ version }} ({{ date }})"
+changelog_version_title = "[{{ version }}]({{ tag_url }}) ({{ date }})"
+```
+
+Use them when:
+
+- provider release titles need a consistent format
+- changelog headings should include links or dates
+- group releases should read differently from package releases
+
+## Add or override top-level commands
+
+`monochange.toml` can define or override `[cli.<command>]` entries.
+
+```toml
+[cli.release]
+help_text = "Prepare a release from discovered change files"
+
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["markdown", "text", "json"]
+default = "markdown"
+
+[[cli.release.steps]]
+type = "PrepareRelease"
+```
+
+Use `mc populate` first if you want the current built-in commands copied into config before editing them.
+
+## A safe config-edit workflow
+
+```bash
+mc init
+mc validate
+mc discover --format json
+mc populate
+mc validate
+mc release --dry-run --format json
+```
+
+If you touched grouped packages, changelog settings, or versioned files, add `--diff` to inspect the planned file changes:
+
+```bash
+mc release --dry-run --diff
+```
+
+## Common mistakes
+
+### Hand-writing ids before discovery
+
+**Avoid:** inventing ids from directory names.
+
+**Prefer:**
+
+```bash
+mc discover --format json
+```
+
+### Over-grouping packages
+
+**Avoid:** putting every related package into one group.
+
+**Prefer:** only group packages that should share one outward version and release identity.
+
+### Forgetting validation after config edits
+
+**Avoid:** editing `monochange.toml` and going straight to publishing.
+
+**Prefer:**
+
+```bash
+mc validate
+mc release --dry-run --format json
+```
+
+## Related references
+
+- [REFERENCE.md](../REFERENCE.md)
+- [commands.md](./commands.md)
+- [linting.md](./linting.md)

--- a/packages/monochange__skill/skills/linting.md
+++ b/packages/monochange__skill/skills/linting.md
@@ -1,0 +1,551 @@
+# Linting skill
+
+<!-- {=lintingPolicyReference} -->
+
+Use this guide when the task is to explain, apply, or update monochange lint policy.
+
+This reference reflects the current workspace lint configuration in the repository `Cargo.toml` plus the crate-level `#![forbid(clippy::indexing_slicing)]` declarations used across the Rust crates.
+
+## Daily linting workflow
+
+For normal repo work:
+
+```bash
+devenv shell fix:all
+devenv shell lint:all
+```
+
+For documentation synchronization checks:
+
+```bash
+devenv shell docs:check
+```
+
+Use `docs:update` after editing shared `.templates/` content.
+
+## How to read the policy
+
+monochange uses a mix of:
+
+- **workspace rust lints** — compiler-level safety and hygiene rules
+- **workspace clippy groups** — broad quality buckets like correctness and performance
+- **targeted clippy overrides** — rules we intentionally deny, warn, or allow
+- **crate-level forbids** — stricter local rules when a specific panic pattern is unacceptable
+
+The goal is not "never write interesting code." The goal is to avoid correctness bugs, avoid panic-prone indexing patterns, stay portable across Rust editions, and keep only the pedantic warnings that actually improve the codebase.
+
+## Workspace rust lints
+
+### `rust_2021_compatibility = warn`
+
+**Why:** catches patterns that behave differently across editions.
+
+**When to care:** when writing macros, pattern matches, or syntax that might become edition-sensitive.
+
+**Without the rule:** edition migration issues can accumulate silently.
+
+**With the rule:** you get an early warning before the next edition change becomes painful.
+
+### `rust_2024_compatibility = warn`
+
+**Why:** keeps the codebase ready for Rust 2024 semantics.
+
+**When to care:** when introducing syntax or macro usage that may change in the 2024 edition.
+
+**Without the rule:** future upgrades become a large cleanup project.
+
+**With the rule:** new code is nudged toward edition-safe patterns now.
+
+### `unsafe_code = deny`
+
+**Why:** monochange should not rely on unchecked memory operations for release-planning logic.
+
+**When to use:** almost always for business logic, config parsing, changelog generation, and CLI orchestration.
+
+**Without the rule:**
+
+```rust
+unsafe {
+    std::ptr::read(ptr)
+}
+```
+
+Unsafe blocks can slip in and become maintenance hotspots.
+
+**With the rule:** prefer safe standard-library APIs:
+
+```rust
+let first = values.first().copied();
+```
+
+### `unstable_features = deny`
+
+**Why:** published tooling should compile on stable Rust.
+
+**When to use:** for libraries and CLIs that must stay portable for contributors and CI.
+
+**Without the rule:** nightly-only features can leak into the codebase.
+
+**With the rule:** the code stays stable-channel compatible.
+
+### `unused_extern_crates = warn`
+
+**Why:** dead extern declarations add noise and make dependencies harder to audit.
+
+**Without the rule:** old compatibility imports linger.
+
+**With the rule:** unused declarations are cleaned up quickly.
+
+### `unused_import_braces = warn`
+
+**Why:** removes unnecessary syntax noise.
+
+**Without the rule:**
+
+```rust
+use std::fmt;
+```
+
+**With the rule:**
+
+```rust
+use std::fmt;
+```
+
+### `unused_lifetimes = warn`
+
+**Why:** unused lifetimes usually mean an API signature is more complex than necessary.
+
+**Without the rule:**
+
+```rust
+fn name<'a>(value: &str) -> &str {
+	value
+}
+```
+
+**With the rule:**
+
+```rust
+fn name(value: &str) -> &str {
+	value
+}
+```
+
+### `unused_macro_rules = warn`
+
+**Why:** dead macro arms are easy to forget and hard to test.
+
+**Without the rule:** macro definitions keep stale branches.
+
+**With the rule:** only exercised macro rules survive.
+
+### `unused_qualifications = warn`
+
+**Why:** fully qualifying names that are already in scope hurts readability.
+
+**Without the rule:**
+
+```rust
+use std::path::PathBuf;
+
+let path = std::path::PathBuf::new();
+```
+
+**With the rule:**
+
+```rust
+use std::path::PathBuf;
+
+let path = PathBuf::new();
+```
+
+### `variant_size_differences = warn`
+
+**Why:** very uneven enum variants can cause surprising memory bloat.
+
+**Without the rule:** a single large variant can inflate every enum value.
+
+**With the rule:** you consider boxing or reshaping the large variant.
+
+### `edition_2024_expr_fragment_specifier = allow`
+
+**Why it is allowed:** this lint is intentionally relaxed to avoid noisy churn while macro-related edition support settles.
+
+**When the allowance is appropriate:** when the code is otherwise clear and no migration risk is introduced.
+
+**Without the allowance:** the repo would force extra macro cleanups that do not improve the current product behavior.
+
+## Workspace clippy groups
+
+### `clippy::correctness = deny`
+
+**Why:** correctness issues are the highest-risk category.
+
+**Without it:** real bugs can land as "just warnings."
+
+**With it:** code that is likely wrong fails the lint pass.
+
+### `clippy::suspicious = warn`
+
+**Why:** suspicious constructs often compile but suggest a logic mistake.
+
+**Without it:** subtle mistakes look legitimate.
+
+**With it:** you get a review checkpoint before the bug becomes user-visible.
+
+### `clippy::style = warn`
+
+**Why:** style warnings keep code predictable and easier to scan.
+
+**Without it:** equivalent patterns drift across the codebase.
+
+**With it:** contributors converge on the same idioms.
+
+### `clippy::complexity = warn`
+
+**Why:** overly complex code is harder to review and easier to break.
+
+**Without it:** nested or overly clever logic grows unnoticed.
+
+**With it:** clippy nudges you toward extraction and simpler control flow.
+
+**Example of what this pressure is trying to prevent:**
+
+```rust
+if should_release {
+    if let Some(group) = group {
+        if group.publish {
+            if !group.members.is_empty() {
+                publish(group);
+            }
+        }
+    }
+}
+```
+
+A flatter version is easier to review:
+
+```rust
+let Some(group) = group else {
+    return;
+};
+
+if !should_release || !group.publish || group.members.is_empty() {
+    return;
+}
+
+publish(group);
+```
+
+### `clippy::perf = warn`
+
+**Why:** hot-path inefficiencies are easier to fix when caught early.
+
+**Without it:** unnecessary allocations and slower patterns blend in.
+
+**With it:** common performance footguns get surfaced during normal linting.
+
+### `clippy::pedantic = warn`
+
+**Why:** pedantic lints catch a lot of polish issues that improve API and code quality.
+
+**Why not deny:** the group is intentionally broad and sometimes noisy.
+
+**monochange approach:** enable the group, then explicitly allow the few rules where local readability or practicality matters more.
+
+## Explicit clippy policy
+
+### `blocks_in_conditions = allow`
+
+**Why it is allowed:** small computed conditions can be clearer inline than as a throwaway binding.
+
+**Without the allowance:**
+
+```rust
+if {
+    let ready = state.is_ready();
+    ready
+} {
+    run();
+}
+```
+
+Clippy would complain even when the structure is readable.
+
+**With the current policy:** this pattern is allowed, but extract it if the block becomes non-trivial.
+
+### `cargo_common_metadata = allow`
+
+**Why it is allowed:** workspace metadata is managed centrally, so per-crate metadata completeness is not always the right enforcement point.
+
+**Without the allowance:** clippy would push repetitive metadata into every crate even when the workspace already provides it.
+
+**With the current policy:** add metadata where it matters, but do not create boilerplate just to silence the lint.
+
+### `cast_possible_truncation = allow`
+
+**Why it is allowed:** some numeric conversions are deliberate and guarded by domain knowledge.
+
+**Without the allowance:**
+
+```rust
+let byte = value as u8;
+```
+
+would warn every time, even when the value is known to fit.
+
+**With the current policy:** the cast is permitted, but reviewers should still expect surrounding reasoning or bounds checks when truncation is not obviously safe.
+
+### `cast_possible_wrap = allow`
+
+**Why it is allowed:** signed/unsigned conversions sometimes reflect external protocol or storage requirements.
+
+**Without the allowance:** every deliberate sign-changing cast becomes noise.
+
+**With the current policy:** use the cast intentionally and document tricky cases.
+
+### `cast_precision_loss = allow`
+
+**Why it is allowed:** some reporting or ratio calculations intentionally trade precision for convenience.
+
+**Without the allowance:** floating-point conversions generate warnings even in non-critical display logic.
+
+**With the current policy:** precision-loss casts are allowed, but avoid them in semver, version, or identity logic where exactness matters.
+
+### `cast_sign_loss = allow`
+
+**Why it is allowed:** conversions to unsigned values are sometimes part of external API shaping.
+
+**Without the allowance:** routine boundary conversions become noisy.
+
+**With the current policy:** keep the cast local and obvious.
+
+### `expl_impl_clone_on_copy = allow`
+
+**Why it is allowed:** an explicit `Clone` impl on a `Copy` type can occasionally be clearer or more controlled than a derive.
+
+**Without the allowance:** clippy would force a derive-only style.
+
+**With the current policy:** explicit impls are allowed when there is a concrete reason, not as default habit.
+
+### `items_after_statements = allow`
+
+**Why it is allowed:** tests and small helper scopes sometimes read better when local items appear near their use.
+
+**Without the allowance:**
+
+```rust
+fn test_case() {
+	let input = sample();
+
+	fn sample() -> &'static str {
+		"ok"
+	}
+
+	assert_eq!(input, "ok");
+}
+```
+
+would warn.
+
+**With the current policy:** that layout is acceptable when it improves locality.
+
+### `missing_errors_doc = allow`
+
+**Why it is allowed:** internal functions are numerous, and forcing `# Errors` on all of them creates noisy docs.
+
+**Without the allowance:** every fallible helper would need a doc section.
+
+**With the current policy:** still document errors on public APIs and non-obvious behavior, but do not require boilerplate on every internal helper.
+
+### `missing_panics_doc = allow`
+
+**Why it is allowed:** similar to `missing_errors_doc`, this avoids boilerplate on internal helpers.
+
+**Without the allowance:** even intentionally internal panic paths need formal docs.
+
+**With the current policy:** public or surprising panic behavior should still be documented deliberately.
+
+### `module_name_repetitions = allow`
+
+**Why it is allowed:** crate boundaries and domain naming sometimes make repetition the clearest choice.
+
+**Without the allowance:**
+
+```rust
+mod release_record;
+struct ReleaseRecord;
+```
+
+can trigger a warning even though the names are clear.
+
+**With the current policy:** choose clarity over lint golf.
+
+### `must_use_candidate = allow`
+
+**Why it is allowed:** clippy suggests `#[must_use]` very aggressively.
+
+**Without the allowance:** many private helpers would get noisy suggestions.
+
+**With the current policy:** apply `#[must_use]` intentionally on public APIs, builders, and values where dropping the result is genuinely a bug.
+
+### `no_effect_underscore_binding = allow`
+
+**Why it is allowed:** intentionally ignored intermediate values sometimes help document intent in tests or command setup.
+
+**Without the allowance:** underscore-prefixed bindings can still warn even when they make the code easier to follow.
+
+**With the current policy:** use them sparingly and only when they clarify intent.
+
+### `tabs-in-doc-comments = allow`
+
+**Why it is allowed:** command output, tables, or copied terminal content may legitimately contain tabs.
+
+**Without the allowance:** documentation cleanup would fight preserved examples.
+
+**With the current policy:** tabs are acceptable in docs when they preserve exact formatting.
+
+### `too_many_lines = allow`
+
+**Why it is allowed:** some orchestration functions, renderers, or test modules are large for domain reasons.
+
+**Without the allowance:** contributors would spend time splitting code purely to satisfy an arbitrary line limit.
+
+**With the current policy:** long functions are allowed, but extraction is still preferred when it improves comprehension.
+
+### `wildcard_dependencies = deny`
+
+**Why:** published tools should not depend on unconstrained crate versions.
+
+**Without the rule:**
+
+```toml
+serde = "*"
+```
+
+can make builds non-reproducible and difficult to audit.
+
+**With the rule:** dependencies must be explicitly versioned.
+
+### `wildcard_imports = allow`
+
+**Why it is allowed:** some test modules and highly local scopes read better with a wildcard import.
+
+**Without the allowance:**
+
+```rust
+use super::*;
+```
+
+would warn in common test layouts.
+
+**With the current policy:** wildcard imports remain acceptable in narrow scopes, especially tests.
+
+## Crate-level forbid: `clippy::indexing_slicing`
+
+Most monochange Rust crates start with:
+
+```rust
+#![forbid(clippy::indexing_slicing)]
+```
+
+**Why:** indexing and slicing can panic, and monochange spends a lot of time parsing external files, manifests, and user input.
+
+**Without the rule:**
+
+```rust
+let first = values[0];
+let suffix = &text[1..];
+```
+
+These compile, but they panic on malformed or short input.
+
+**With the rule:** prefer checked access:
+
+```rust
+let first = values.first().copied();
+let suffix = text.get(1..);
+```
+
+**Another example in manifest parsing:**
+
+```rust
+let version = package_json["version"].as_str();
+```
+
+looks compact but assumes the key exists and the JSON shape is right. Checked access makes the failure mode explicit:
+
+```rust
+let version = package_json
+    .get("version")
+    .and_then(|value| value.as_str());
+```
+
+**When to use this stricter rule:** parsing, config loading, release planning, changelog rendering, and any code that handles external repository state.
+
+## What "with and without linting" looks like in practice
+
+### Without the monochange lint posture
+
+- unsafe or nightly-only code can sneak in
+- panic-prone indexing is easier to miss
+- wildcard dependencies can weaken reproducibility
+- edition migration issues accumulate quietly
+- pedantic improvements never surface
+
+### With the current monochange lint posture
+
+- correctness issues fail fast
+- suspicious, style, complexity, performance, and pedantic issues show up in review
+- some noisy lints are intentionally relaxed where the team prefers readability or lower boilerplate
+- panic-prone indexing is blocked at crate level
+
+## When to add a local `#[allow(...)]`
+
+A local allow is acceptable when:
+
+- the lint is technically correct but the preferred alternative is harder to read
+- the code is constrained by a protocol, generated shape, or test pattern
+- you can explain the exception in one sentence
+
+Example:
+
+```rust
+#[allow(clippy::too_many_arguments)]
+fn build_release_payload(
+	owner: &str,
+	repo: &str,
+	version: &str,
+	tag: &str,
+	notes: &str,
+	draft: bool,
+	prerelease: bool,
+) {
+	// ...
+}
+```
+
+Use this sparingly. If the function can be improved with a struct or builder, prefer that.
+
+## Recommended validation loop after edits
+
+```bash
+devenv shell fix:all
+devenv shell lint:all
+mc validate
+```
+
+If you changed shared docs too:
+
+```bash
+devenv shell docs:check
+```
+
+<!-- {/lintingPolicyReference} -->
+
+## Related references
+
+- [REFERENCE.md](../REFERENCE.md)
+- [configuration.md](./configuration.md)
+- [commands.md](./commands.md)

--- a/packages/monochange__skill/skills/linting.md
+++ b/packages/monochange__skill/skills/linting.md
@@ -2,538 +2,402 @@
 
 <!-- {=lintingPolicyReference} -->
 
-Use this guide when the task is to explain, apply, or update monochange lint policy.
+Use this guide when the task is to configure or explain monochange's **manifest lint rules**.
 
-This reference reflects the current workspace lint configuration in the repository `Cargo.toml` plus the crate-level `#![forbid(clippy::indexing_slicing)]` declarations used across the Rust crates.
+These are the rules that run through **`mc check`** and are configured in `monochange.toml` under **`[ecosystems.<name>.lints]`**.
 
-## Daily linting workflow
+They are separate from Rust compiler or Clippy lints used to develop monochange itself.
 
-For normal repo work:
+## What `mc check` does
+
+`mc check` runs two phases:
+
+1. normal workspace validation, similar to `mc validate`
+2. manifest lint rules for supported package ecosystems
+
+Common commands:
 
 ```bash
-devenv shell fix:all
-devenv shell lint:all
+mc check
+mc check --fix
+mc check --format json
 ```
 
-For documentation synchronization checks:
+Use `--fix` when you want monochange to apply auto-fixes where a rule supports them.
 
-```bash
-devenv shell docs:check
+## Where lint rules live
+
+Configure rules per ecosystem in `monochange.toml`:
+
+```toml
+[ecosystems.cargo.lints]
+"cargo/dependency-field-order" = "error"
+"cargo/internal-dependency-workspace" = "error"
+"cargo/required-package-fields" = { level = "warning", fields = ["description", "license", "repository"] }
+"cargo/sorted-dependencies" = "warning"
+"cargo/unlisted-package-private" = { level = "warning", fix = true }
+
+[ecosystems.npm.lints]
+"npm/workspace-protocol" = "error"
+"npm/sorted-dependencies" = "warning"
+"npm/required-package-fields" = { level = "warning", fields = ["description", "repository", "license"] }
+"npm/root-no-prod-deps" = "error"
+"npm/no-duplicate-dependencies" = "error"
+"npm/unlisted-package-private" = { level = "warning", fix = true }
 ```
 
-Use `docs:update` after editing shared `.templates/` content.
+Rule configuration supports two forms:
 
-## How to read the policy
+- simple severity: `"rule-id" = "error"`, `"warning"`, or `"off"`
+- detailed config: `{ level = "error", ...rule_specific_options }`
 
-monochange uses a mix of:
+## Current rule coverage
 
-- **workspace rust lints** — compiler-level safety and hygiene rules
-- **workspace clippy groups** — broad quality buckets like correctness and performance
-- **targeted clippy overrides** — rules we intentionally deny, warn, or allow
-- **crate-level forbids** — stricter local rules when a specific panic pattern is unacceptable
+Today, built-in manifest lint rules exist for:
 
-The goal is not "never write interesting code." The goal is to avoid correctness bugs, avoid panic-prone indexing patterns, stay portable across Rust editions, and keep only the pedantic warnings that actually improve the codebase.
+- **Cargo** manifests (`Cargo.toml`)
+- **npm-family** manifests (`package.json`)
 
-## Workspace rust lints
+monochange already wires lint configuration through `configuration.cargo.lints`, `configuration.npm.lints`, `configuration.deno.lints`, and `configuration.dart.lints`, but the current built-in rule sets are implemented for Cargo and npm manifests.
 
-### `rust_2021_compatibility = warn`
+## Cargo manifest lint rules
 
-**Why:** catches patterns that behave differently across editions.
+### `cargo/dependency-field-order`
 
-**When to care:** when writing macros, pattern matches, or syntax that might become edition-sensitive.
+**Why:** keeps inline dependency tables visually consistent.
 
-**Without the rule:** edition migration issues can accumulate silently.
+**What it checks:** preferred key order inside dependency tables:
 
-**With the rule:** you get an early warning before the next edition change becomes painful.
-
-### `rust_2024_compatibility = warn`
-
-**Why:** keeps the codebase ready for Rust 2024 semantics.
-
-**When to care:** when introducing syntax or macro usage that may change in the 2024 edition.
-
-**Without the rule:** future upgrades become a large cleanup project.
-
-**With the rule:** new code is nudged toward edition-safe patterns now.
-
-### `unsafe_code = deny`
-
-**Why:** monochange should not rely on unchecked memory operations for release-planning logic.
-
-**When to use:** almost always for business logic, config parsing, changelog generation, and CLI orchestration.
-
-**Without the rule:**
-
-```rust
-unsafe {
-    std::ptr::read(ptr)
-}
-```
-
-Unsafe blocks can slip in and become maintenance hotspots.
-
-**With the rule:** prefer safe standard-library APIs:
-
-```rust
-let first = values.first().copied();
-```
-
-### `unstable_features = deny`
-
-**Why:** published tooling should compile on stable Rust.
-
-**When to use:** for libraries and CLIs that must stay portable for contributors and CI.
-
-**Without the rule:** nightly-only features can leak into the codebase.
-
-**With the rule:** the code stays stable-channel compatible.
-
-### `unused_extern_crates = warn`
-
-**Why:** dead extern declarations add noise and make dependencies harder to audit.
-
-**Without the rule:** old compatibility imports linger.
-
-**With the rule:** unused declarations are cleaned up quickly.
-
-### `unused_import_braces = warn`
-
-**Why:** removes unnecessary syntax noise.
-
-**Without the rule:**
-
-```rust
-use std::fmt;
-```
-
-**With the rule:**
-
-```rust
-use std::fmt;
-```
-
-### `unused_lifetimes = warn`
-
-**Why:** unused lifetimes usually mean an API signature is more complex than necessary.
-
-**Without the rule:**
-
-```rust
-fn name<'a>(value: &str) -> &str {
-	value
-}
-```
-
-**With the rule:**
-
-```rust
-fn name(value: &str) -> &str {
-	value
-}
-```
-
-### `unused_macro_rules = warn`
-
-**Why:** dead macro arms are easy to forget and hard to test.
-
-**Without the rule:** macro definitions keep stale branches.
-
-**With the rule:** only exercised macro rules survive.
-
-### `unused_qualifications = warn`
-
-**Why:** fully qualifying names that are already in scope hurts readability.
-
-**Without the rule:**
-
-```rust
-use std::path::PathBuf;
-
-let path = std::path::PathBuf::new();
-```
-
-**With the rule:**
-
-```rust
-use std::path::PathBuf;
-
-let path = PathBuf::new();
-```
-
-### `variant_size_differences = warn`
-
-**Why:** very uneven enum variants can cause surprising memory bloat.
-
-**Without the rule:** a single large variant can inflate every enum value.
-
-**With the rule:** you consider boxing or reshaping the large variant.
-
-### `edition_2024_expr_fragment_specifier = allow`
-
-**Why it is allowed:** this lint is intentionally relaxed to avoid noisy churn while macro-related edition support settles.
-
-**When the allowance is appropriate:** when the code is otherwise clear and no migration risk is introduced.
-
-**Without the allowance:** the repo would force extra macro cleanups that do not improve the current product behavior.
-
-## Workspace clippy groups
-
-### `clippy::correctness = deny`
-
-**Why:** correctness issues are the highest-risk category.
-
-**Without it:** real bugs can land as "just warnings."
-
-**With it:** code that is likely wrong fails the lint pass.
-
-### `clippy::suspicious = warn`
-
-**Why:** suspicious constructs often compile but suggest a logic mistake.
-
-**Without it:** subtle mistakes look legitimate.
-
-**With it:** you get a review checkpoint before the bug becomes user-visible.
-
-### `clippy::style = warn`
-
-**Why:** style warnings keep code predictable and easier to scan.
-
-**Without it:** equivalent patterns drift across the codebase.
-
-**With it:** contributors converge on the same idioms.
-
-### `clippy::complexity = warn`
-
-**Why:** overly complex code is harder to review and easier to break.
-
-**Without it:** nested or overly clever logic grows unnoticed.
-
-**With it:** clippy nudges you toward extraction and simpler control flow.
-
-**Example of what this pressure is trying to prevent:**
-
-```rust
-if should_release {
-    if let Some(group) = group {
-        if group.publish {
-            if !group.members.is_empty() {
-                publish(group);
-            }
-        }
-    }
-}
-```
-
-A flatter version is easier to review:
-
-```rust
-let Some(group) = group else {
-    return;
-};
-
-if !should_release || !group.publish || group.members.is_empty() {
-    return;
-}
-
-publish(group);
-```
-
-### `clippy::perf = warn`
-
-**Why:** hot-path inefficiencies are easier to fix when caught early.
-
-**Without it:** unnecessary allocations and slower patterns blend in.
-
-**With it:** common performance footguns get surfaced during normal linting.
-
-### `clippy::pedantic = warn`
-
-**Why:** pedantic lints catch a lot of polish issues that improve API and code quality.
-
-**Why not deny:** the group is intentionally broad and sometimes noisy.
-
-**monochange approach:** enable the group, then explicitly allow the few rules where local readability or practicality matters more.
-
-## Explicit clippy policy
-
-### `blocks_in_conditions = allow`
-
-**Why it is allowed:** small computed conditions can be clearer inline than as a throwaway binding.
-
-**Without the allowance:**
-
-```rust
-if {
-    let ready = state.is_ready();
-    ready
-} {
-    run();
-}
-```
-
-Clippy would complain even when the structure is readable.
-
-**With the current policy:** this pattern is allowed, but extract it if the block becomes non-trivial.
-
-### `cargo_common_metadata = allow`
-
-**Why it is allowed:** workspace metadata is managed centrally, so per-crate metadata completeness is not always the right enforcement point.
-
-**Without the allowance:** clippy would push repetitive metadata into every crate even when the workspace already provides it.
-
-**With the current policy:** add metadata where it matters, but do not create boilerplate just to silence the lint.
-
-### `cast_possible_truncation = allow`
-
-**Why it is allowed:** some numeric conversions are deliberate and guarded by domain knowledge.
-
-**Without the allowance:**
-
-```rust
-let byte = value as u8;
-```
-
-would warn every time, even when the value is known to fit.
-
-**With the current policy:** the cast is permitted, but reviewers should still expect surrounding reasoning or bounds checks when truncation is not obviously safe.
-
-### `cast_possible_wrap = allow`
-
-**Why it is allowed:** signed/unsigned conversions sometimes reflect external protocol or storage requirements.
-
-**Without the allowance:** every deliberate sign-changing cast becomes noise.
-
-**With the current policy:** use the cast intentionally and document tricky cases.
-
-### `cast_precision_loss = allow`
-
-**Why it is allowed:** some reporting or ratio calculations intentionally trade precision for convenience.
-
-**Without the allowance:** floating-point conversions generate warnings even in non-critical display logic.
-
-**With the current policy:** precision-loss casts are allowed, but avoid them in semver, version, or identity logic where exactness matters.
-
-### `cast_sign_loss = allow`
-
-**Why it is allowed:** conversions to unsigned values are sometimes part of external API shaping.
-
-**Without the allowance:** routine boundary conversions become noisy.
-
-**With the current policy:** keep the cast local and obvious.
-
-### `expl_impl_clone_on_copy = allow`
-
-**Why it is allowed:** an explicit `Clone` impl on a `Copy` type can occasionally be clearer or more controlled than a derive.
-
-**Without the allowance:** clippy would force a derive-only style.
-
-**With the current policy:** explicit impls are allowed when there is a concrete reason, not as default habit.
-
-### `items_after_statements = allow`
-
-**Why it is allowed:** tests and small helper scopes sometimes read better when local items appear near their use.
-
-**Without the allowance:**
-
-```rust
-fn test_case() {
-	let input = sample();
-
-	fn sample() -> &'static str {
-		"ok"
-	}
-
-	assert_eq!(input, "ok");
-}
-```
-
-would warn.
-
-**With the current policy:** that layout is acceptable when it improves locality.
-
-### `missing_errors_doc = allow`
-
-**Why it is allowed:** internal functions are numerous, and forcing `# Errors` on all of them creates noisy docs.
-
-**Without the allowance:** every fallible helper would need a doc section.
-
-**With the current policy:** still document errors on public APIs and non-obvious behavior, but do not require boilerplate on every internal helper.
-
-### `missing_panics_doc = allow`
-
-**Why it is allowed:** similar to `missing_errors_doc`, this avoids boilerplate on internal helpers.
-
-**Without the allowance:** even intentionally internal panic paths need formal docs.
-
-**With the current policy:** public or surprising panic behavior should still be documented deliberately.
-
-### `module_name_repetitions = allow`
-
-**Why it is allowed:** crate boundaries and domain naming sometimes make repetition the clearest choice.
-
-**Without the allowance:**
-
-```rust
-mod release_record;
-struct ReleaseRecord;
-```
-
-can trigger a warning even though the names are clear.
-
-**With the current policy:** choose clarity over lint golf.
-
-### `must_use_candidate = allow`
-
-**Why it is allowed:** clippy suggests `#[must_use]` very aggressively.
-
-**Without the allowance:** many private helpers would get noisy suggestions.
-
-**With the current policy:** apply `#[must_use]` intentionally on public APIs, builders, and values where dropping the result is genuinely a bug.
-
-### `no_effect_underscore_binding = allow`
-
-**Why it is allowed:** intentionally ignored intermediate values sometimes help document intent in tests or command setup.
-
-**Without the allowance:** underscore-prefixed bindings can still warn even when they make the code easier to follow.
-
-**With the current policy:** use them sparingly and only when they clarify intent.
-
-### `tabs-in-doc-comments = allow`
-
-**Why it is allowed:** command output, tables, or copied terminal content may legitimately contain tabs.
-
-**Without the allowance:** documentation cleanup would fight preserved examples.
-
-**With the current policy:** tabs are acceptable in docs when they preserve exact formatting.
-
-### `too_many_lines = allow`
-
-**Why it is allowed:** some orchestration functions, renderers, or test modules are large for domain reasons.
-
-**Without the allowance:** contributors would spend time splitting code purely to satisfy an arbitrary line limit.
-
-**With the current policy:** long functions are allowed, but extraction is still preferred when it improves comprehension.
-
-### `wildcard_dependencies = deny`
-
-**Why:** published tools should not depend on unconstrained crate versions.
+1. `workspace` or `version`
+2. `default-features` / `default_features`
+3. `features`
+4. other keys like `optional`, `path`, `registry`, `package`, `git`, `branch`, `tag`, `rev`
 
 **Without the rule:**
 
 ```toml
-serde = "*"
+serde = { features = ["derive"], workspace = true }
 ```
 
-can make builds non-reproducible and difficult to audit.
+**With the rule:**
 
-**With the rule:** dependencies must be explicitly versioned.
-
-### `wildcard_imports = allow`
-
-**Why it is allowed:** some test modules and highly local scopes read better with a wildcard import.
-
-**Without the allowance:**
-
-```rust
-use super::*;
+```toml
+serde = { workspace = true, features = ["derive"] }
 ```
 
-would warn in common test layouts.
+**Useful option:**
 
-**With the current policy:** wildcard imports remain acceptable in narrow scopes, especially tests.
+- `fix` — defaults to `true`
 
-## Crate-level forbid: `clippy::indexing_slicing`
+### `cargo/internal-dependency-workspace`
 
-Most monochange Rust crates start with:
-
-```rust
-#![forbid(clippy::indexing_slicing)]
-```
-
-**Why:** indexing and slicing can panic, and monochange spends a lot of time parsing external files, manifests, and user input.
+**Why:** internal workspace dependencies should usually be declared through the workspace rather than carrying their own explicit version strings.
 
 **Without the rule:**
 
-```rust
-let first = values[0];
-let suffix = &text[1..];
+```toml
+[dependencies]
+monochange_core = { path = "../monochange_core", version = "0.1.0" }
 ```
 
-These compile, but they panic on malformed or short input.
+**With the rule:**
 
-**With the rule:** prefer checked access:
-
-```rust
-let first = values.first().copied();
-let suffix = text.get(1..);
+```toml
+[dependencies]
+monochange_core = { workspace = true }
 ```
 
-**Another example in manifest parsing:**
+**When to use it:** when the repository wants one workspace-owned version source for internal crates.
 
-```rust
-let version = package_json["version"].as_str();
+**Useful options:**
+
+- `require_workspace` — defaults to `true`
+- `fix` — defaults to `true`
+
+### `cargo/required-package-fields`
+
+**Why:** published crates should consistently carry the metadata your repository expects.
+
+**Default required fields:**
+
+- `description`
+- `license`
+- `repository`
+
+**Without the rule:**
+
+```toml
+[package]
+name = "example"
+version = "0.1.0"
 ```
 
-looks compact but assumes the key exists and the JSON shape is right. Checked access makes the failure mode explicit:
+**With the rule:** monochange reports the missing fields so package metadata stays consistent.
 
-```rust
-let version = package_json
-    .get("version")
-    .and_then(|value| value.as_str());
-```
+**Useful option:**
 
-**When to use this stricter rule:** parsing, config loading, release planning, changelog rendering, and any code that handles external repository state.
-
-## What "with and without linting" looks like in practice
-
-### Without the monochange lint posture
-
-- unsafe or nightly-only code can sneak in
-- panic-prone indexing is easier to miss
-- wildcard dependencies can weaken reproducibility
-- edition migration issues accumulate quietly
-- pedantic improvements never surface
-
-### With the current monochange lint posture
-
-- correctness issues fail fast
-- suspicious, style, complexity, performance, and pedantic issues show up in review
-- some noisy lints are intentionally relaxed where the team prefers readability or lower boilerplate
-- panic-prone indexing is blocked at crate level
-
-## When to add a local `#[allow(...)]`
-
-A local allow is acceptable when:
-
-- the lint is technically correct but the preferred alternative is harder to read
-- the code is constrained by a protocol, generated shape, or test pattern
-- you can explain the exception in one sentence
+- `fields` — replace the default required-field list
 
 Example:
 
-```rust
-#[allow(clippy::too_many_arguments)]
-fn build_release_payload(
-	owner: &str,
-	repo: &str,
-	version: &str,
-	tag: &str,
-	notes: &str,
-	draft: bool,
-	prerelease: bool,
-) {
-	// ...
+```toml
+[ecosystems.cargo.lints]
+"cargo/required-package-fields" = { level = "error", fields = ["description", "license"] }
+```
+
+### `cargo/sorted-dependencies`
+
+**Why:** alphabetized dependency tables are easier to review and reduce noisy diffs.
+
+**Without the rule:**
+
+```toml
+[dependencies]
+zzzz = "1.0"
+aaaa = "1.0"
+mmmm = "1.0"
+```
+
+**With the rule:**
+
+```toml
+[dependencies]
+aaaa = "1.0"
+mmmm = "1.0"
+zzzz = "1.0"
+```
+
+**Useful option:**
+
+- `fix` — defaults to `true`
+
+### `cargo/unlisted-package-private`
+
+**Why:** a Cargo package that is not listed in `monochange.toml` should not be accidentally publishable.
+
+**Without the rule:** an unmanaged crate can remain publicly publishable by accident.
+
+**With the rule:** monochange requires either:
+
+- adding the package to `monochange.toml`, or
+- marking it private with `publish = false`
+
+**Without the rule:**
+
+```toml
+[package]
+name = "experimental-crate"
+version = "0.1.0"
+```
+
+**With the rule:**
+
+```toml
+[package]
+name = "experimental-crate"
+version = "0.1.0"
+publish = false
+```
+
+**Useful option:**
+
+- `fix` — defaults to `true`
+
+## npm-family manifest lint rules
+
+### `npm/workspace-protocol`
+
+**Why:** internal workspace dependencies should use the `workspace:` protocol so local workspace intent is explicit.
+
+**Without the rule:**
+
+```json
+{
+	"dependencies": {
+		"@acme/shared": "^1.2.0"
+	}
 }
 ```
 
-Use this sparingly. If the function can be improved with a struct or builder, prefer that.
+**With the rule:**
 
-## Recommended validation loop after edits
+```json
+{
+	"dependencies": {
+		"@acme/shared": "workspace:*"
+	}
+}
+```
+
+**When to use it:** npm, pnpm, and Bun workspaces where internal packages should not drift to plain registry ranges.
+
+**Useful options:**
+
+- `require_for_private` — defaults to `false`
+- `fix` — defaults to `true`
+
+### `npm/sorted-dependencies`
+
+**Why:** alphabetized dependency sections reduce review noise and make package diffs easier to scan.
+
+**Without the rule:**
+
+```json
+{
+	"dependencies": {
+		"zod": "^4.0.0",
+		"chalk": "^5.0.0"
+	}
+}
+```
+
+**With the rule:**
+
+```json
+{
+	"dependencies": {
+		"chalk": "^5.0.0",
+		"zod": "^4.0.0"
+	}
+}
+```
+
+**Useful option:**
+
+- `fix` — defaults to `true`
+
+### `npm/required-package-fields`
+
+**Why:** package metadata should stay consistent across publishable npm packages.
+
+**Default required fields:**
+
+- `description`
+- `repository`
+- `license`
+
+**Without the rule:**
+
+```json
+{
+	"name": "@acme/app",
+	"version": "1.0.0"
+}
+```
+
+**With the rule:** monochange reports the missing metadata fields.
+
+**Useful option:**
+
+- `fields` — replace the default required-field list
+
+### `npm/root-no-prod-deps`
+
+**Why:** the workspace root `package.json` is usually orchestration-only and should keep runtime dependencies out of the root package.
+
+**Without the rule:**
+
+```json
+{
+	"dependencies": {
+		"react": "^19.0.0"
+	}
+}
+```
+
+**With the rule:** move those to `devDependencies` when the root package is only a workspace manager.
+
+**Useful option:**
+
+- `fix` — defaults to `true`
+
+### `npm/no-duplicate-dependencies`
+
+**Why:** the same dependency should not appear in multiple dependency sections unless the repository has a very deliberate reason.
+
+**Without the rule:**
+
+```json
+{
+	"dependencies": {
+		"typescript": "^5.0.0"
+	},
+	"devDependencies": {
+		"typescript": "^5.0.0"
+	}
+}
+```
+
+**With the rule:** monochange reports the duplicate and can suggest removing the redundant non-dev entry when appropriate.
+
+**Useful option:**
+
+- `fix` — defaults to `true`
+
+### `npm/unlisted-package-private`
+
+**Why:** a package not declared in `monochange.toml` should not remain publishable by accident.
+
+**Without the rule:** an unmanaged package can still look publishable.
+
+**With the rule:** monochange requires either:
+
+- adding the package to `monochange.toml`, or
+- marking it private in `package.json`
+
+**Without the rule:**
+
+```json
+{
+	"name": "@acme/experimental",
+	"version": "0.1.0"
+}
+```
+
+**With the rule:**
+
+```json
+{
+	"name": "@acme/experimental",
+	"private": true,
+	"version": "0.1.0"
+}
+```
+
+**Useful option:**
+
+- `fix` — defaults to `true`
+
+## What `mc check` looks like in practice
+
+Use plain text for local review:
 
 ```bash
-devenv shell fix:all
-devenv shell lint:all
+mc check
+```
+
+Apply safe auto-fixes where possible:
+
+```bash
+mc check --fix
+```
+
+Use JSON for CI or MCP-style tooling:
+
+```bash
+mc check --format json
+```
+
+`mc check` fails when lint errors are present, so it is appropriate for CI gates.
+
+## Recommended workflow
+
+For repository work:
+
+```bash
 mc validate
+mc check
+mc release --dry-run --diff
 ```
 
 If you changed shared docs too:

--- a/readme.md
+++ b/readme.md
@@ -108,6 +108,51 @@ If you do not know which package id to target, rerun `mc discover --format json`
 - [Discovery](docs/src/guide/03-discovery.md) — what monochange finds and how ids are rendered
 - [Configuration reference](docs/src/guide/04-configuration.md) — evolve the generated config once the basics feel familiar
 - [Groups and shared release identity](docs/src/guide/05-version-groups.md) — when to reach for group ids instead of package ids
+- [Release planning](docs/src/guide/06-release-planning.md) — changesets, dry runs, diff previews, and planning rules
+- [Advanced: CI, package publishing, and release PR flows](docs/src/guide/13-ci-and-publishing.md) — per-provider CI patterns, trusted publishing, and long-running release PR design notes
+- [Reference: Linting policy](docs/src/reference/linting.md) — the current rust/clippy rules and their rationale
+
+## Command and automation matrix
+
+<!-- {=projectCommandAutomationMatrix} -->
+
+| Goal                             | Command                                                     | Use it when                                                                                              |
+| -------------------------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Validate config and changesets   | `mc validate`                                               | You changed `monochange.toml` or `.changeset/*.md` files                                                 |
+| Inspect package ids and groups   | `mc discover --format json`                                 | You need the normalized workspace model                                                                  |
+| Create release intent            | `mc change --package <id> --bump <severity> --reason "..."` | You need a new `.changeset/*.md` file                                                                    |
+| Audit pending release context    | `mc diagnostics --format json`                              | You need git provenance, PR/MR links, or related issues                                                  |
+| Preview the release plan         | `mc release --dry-run --diff`                               | You want changelog/version patches without mutating the repo                                             |
+| Create a durable release commit  | `mc commit-release`                                         | You want a monochange-managed release commit with an embedded `ReleaseRecord`                            |
+| Open or update a release request | `mc release-pr`                                             | You want a long-lived release PR/MR branch updated from current release state                            |
+| Publish packages to registries   | `mc publish`                                                | You want `cargo publish`, `npm publish`, `deno publish`, or `dart pub publish` style package publication |
+| Bootstrap missing packages       | `mc placeholder-publish`                                    | A package must exist in its registry before later automation can work                                    |
+| Inspect a past release commit    | `mc release-record --from <ref>`                            | You need the durable release declaration from git history                                                |
+| Repair a recent release          | `mc repair-release --from <tag> --target <commit>`          | You need to retarget a just-created release to a later commit                                            |
+| Publish hosted/provider releases | `mc publish-release`                                        | You want GitHub/GitLab/Gitea release objects from prepared release state                                 |
+
+<!-- {/projectCommandAutomationMatrix} -->
+
+## Capability matrix
+
+<!-- {=projectCapabilityMatrix} -->
+
+| Capability                                                               | Current status                                                             |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| Multi-ecosystem discovery                                                | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter                                   |
+| Package release planning                                                 | Built in                                                                   |
+| Grouped/shared versioning                                                | Built in                                                                   |
+| Dry-run release diff previews                                            | Built in via `mc release --dry-run --diff`                                 |
+| Durable release history                                                  | Built in via `ReleaseRecord`, `mc release-record`, and `mc repair-release` |
+| Hosted provider releases                                                 | GitHub, GitLab, Gitea                                                      |
+| Hosted release requests                                                  | GitHub, GitLab, Gitea                                                      |
+| Built-in registry publishing                                             | `crates.io`, `npm`, `jsr`, `pub.dev`                                       |
+| GitHub npm trusted-publishing automation                                 | Built in                                                                   |
+| GitHub trusted-publishing guidance for `crates.io`, `jsr`, and `pub.dev` | Built in, but manual registry enrollment is still required                 |
+| GitLab trusted-publishing auto-derivation                                | Not built in today                                                         |
+| Release-retarget sync for hosted releases                                | GitHub first                                                               |
+
+<!-- {/projectCapabilityMatrix} -->
 
 ## Why use `monochange`?
 
@@ -152,6 +197,22 @@ monochange-skill --print-install
 mc assist pi
 mc mcp
 ```
+
+<!-- {=assistantSkillBundleContents} -->
+
+After copying the bundled skill, you get a small documentation set that is designed to load in layers:
+
+- `SKILL.md` — concise entrypoint for agents
+- `REFERENCE.md` — broader high-context reference with more examples
+- `skills/README.md` — index of focused deep dives
+- `skills/changesets.md` — changeset authoring and lifecycle guidance
+- `skills/commands.md` — built-in command catalog and workflow selection
+- `skills/configuration.md` — `monochange.toml` setup and editing guidance
+- `skills/linting.md` — the current lint policy, rationale, and examples
+
+This layout keeps the top-level skill small while still making the richer guidance available when an assistant needs more context.
+
+<!-- {/assistantSkillBundleContents} -->
 
 See [Advanced: Assistant setup and MCP](docs/src/guide/09-assistant-setup.md) for the full setup flow.
 

--- a/readme.md
+++ b/readme.md
@@ -110,7 +110,7 @@ If you do not know which package id to target, rerun `mc discover --format json`
 - [Groups and shared release identity](docs/src/guide/05-version-groups.md) — when to reach for group ids instead of package ids
 - [Release planning](docs/src/guide/06-release-planning.md) — changesets, dry runs, diff previews, and planning rules
 - [Advanced: CI, package publishing, and release PR flows](docs/src/guide/13-ci-and-publishing.md) — per-provider CI patterns, trusted publishing, and long-running release PR design notes
-- [Reference: Linting policy](docs/src/reference/linting.md) — the current rust/clippy rules and their rationale
+- [Reference: Manifest linting with `mc check`](docs/src/reference/linting.md) — `[ecosystems.<name>.lints]` rules for Cargo and npm-family manifests
 
 ## Command and automation matrix
 
@@ -208,7 +208,7 @@ After copying the bundled skill, you get a small documentation set that is desig
 - `skills/changesets.md` — changeset authoring and lifecycle guidance
 - `skills/commands.md` — built-in command catalog and workflow selection
 - `skills/configuration.md` — `monochange.toml` setup and editing guidance
-- `skills/linting.md` — the current lint policy, rationale, and examples
+- `skills/linting.md` — `[ecosystems.<name>.lints]` rules, `mc check`, and manifest-focused examples
 
 This layout keeps the top-level skill small while still making the richer guidance available when an assistant needs more context.
 


### PR DESCRIPTION
## Summary

- expand the `@monochange/skill` package into a layered docs bundle with focused `skills/` guides
- add a full linting reference and improve the mdBook command, release-planning, and CI workflow docs
- document GitHub and GitLab CI patterns for registry publishing, trusted-publishing setup, and long-running release PR flows

## Validation

- `devenv shell docs:check`
- `devenv shell fix:all`
- `devenv shell build:book`
- `mc validate`
- `mc affected --format json --changed-paths ...`

## Follow-up context

- captures the long-running release PR + post-merge tagging/publication idea in #209
