### PR TITLE
feat: add trusted publishing setup guide

### DIFF
--- a/.changeset/skill-trusted-publishing-guide.md
+++ b/.changeset/skill-trusted-publishing-guide.md
@@ -1,0 +1,20 @@
+---
+"@monochange/skill": minor
+---
+
+#### add trusted publishing setup guidance for supported registries
+
+The packaged skill now ships a dedicated `TRUSTED-PUBLISHING.md` guide for setting up GitHub-based trusted publishing / OIDC flows across the registries that monochange supports.
+
+**Before:** The skill explained that `publish.trusted_publishing = true` existed, but it did not show the exact registry fields or commands needed to finish setup.
+
+**After:** The package now includes step-by-step guidance for:
+
+- `npm` trusted publishing, including the exact `npm trust github ...` and `pnpm exec npm trust ...` commands that monochange models
+- `crates.io` trusted publishing fields and the `rust-lang/crates-io-auth-action@v1` workflow pattern
+- `jsr` repository linking and GitHub Actions publishing
+- `pub.dev` automated publishing with repository and tag-pattern requirements
+
+The skill README, `SKILL.md`, and `REFERENCE.md` also point agents to the new guide when they need secure package-publishing setup details.
+
+The mdBook user guide now mirrors that content in a dedicated trusted-publishing chapter so the same setup guidance is available in both the packaged skill and the docs site.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -11,6 +11,7 @@
 - [Configuration reference](guide/04-configuration.md)
 - [Groups and shared release identity](guide/05-version-groups.md)
 - [Release planning](guide/06-release-planning.md)
+- [Advanced: Trusted publishing and OIDC](guide/07-trusted-publishing.md)
 - [Advanced: GitHub automation](guide/08-github-automation.md)
 - [Advanced: Assistant setup and MCP](guide/09-assistant-setup.md)
 - [Migrating from knope](guide/10-migrating-from-knope.md)

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -203,6 +203,8 @@ When `trusted_publishing` is enabled:
 - pnpm workspaces use `pnpm exec npm trust ...` and `pnpm publish`, so workspace protocol and catalog dependency handling stays aligned with the workspace manager
 - Cargo, `jsr`, and `pub.dev` currently require manual trusted-publishing setup; monochange reports the setup URL and blocks built-in release publishing until trust is configured
 
+For a GitHub-focused setup guide with exact registry fields, commands, and workflow requirements, see [Trusted publishing and OIDC](./07-trusted-publishing.md).
+
 monochange resolves the GitHub trust context from:
 
 - explicit `repository`, `workflow`, and `environment` values in config

--- a/docs/src/guide/07-trusted-publishing.md
+++ b/docs/src/guide/07-trusted-publishing.md
@@ -1,0 +1,378 @@
+# Trusted publishing and OIDC
+
+monochange supports built-in package publishing for the canonical public registries of the ecosystems it manages:
+
+- Cargo → `crates.io`
+- npm packages → `npm`
+- Deno packages → `jsr`
+- Dart / Flutter packages → `pub.dev`
+
+For those registries, monochange can also manage or verify **trusted publishing** when the registry supports publishing directly from a verified GitHub Actions identity.
+
+Different registries use different names for the same general pattern:
+
+- **trusted publishing**
+- **OIDC publishing**
+- **automated publishing**
+- **trusted publishers**
+
+The goal is the same in every case:
+
+- publish from CI instead of local machines
+- avoid long-lived registry tokens where possible
+- restrict publish rights to a specific repository, workflow, and sometimes environment
+
+## What monochange can automate today
+
+| Ecosystem      | Registry  | Registry term             | GitHub-based OIDC available | What monochange can automate                                                          |
+| -------------- | --------- | ------------------------- | --------------------------- | ------------------------------------------------------------------------------------- |
+| npm            | npm       | Trusted publishing        | Yes                         | Can verify existing trust and run `npm trust github ...` or `pnpm exec npm trust ...` |
+| cargo          | crates.io | Trusted Publishing        | Yes                         | Can publish with a temporary token after you finish registry-side setup               |
+| deno           | jsr       | GitHub Actions publishing | Yes                         | Reports the setup URL; repository linking is still manual                             |
+| dart / flutter | pub.dev   | Automated publishing      | Yes                         | Reports the setup URL; admin-page setup is still manual                               |
+
+npm is currently the only ecosystem where monochange performs bulk trusted-publishing setup itself.
+
+For `crates.io`, `jsr`, and `pub.dev`, monochange reports the setup URL for each package and blocks the next built-in registry publish until the trust configuration has been completed manually.
+
+## monochange configuration
+
+Start by enabling trusted publishing for the relevant ecosystem or package.
+
+```toml
+[source]
+provider = "github"
+owner = "ifiokjr"
+repo = "monochange"
+
+[ecosystems.npm.publish]
+trusted_publishing = true
+
+[ecosystems.cargo.publish]
+trusted_publishing = true
+
+[ecosystems.deno.publish]
+trusted_publishing = true
+
+[ecosystems.dart.publish]
+trusted_publishing = true
+
+[package.cli.publish.trusted_publishing]
+workflow = "publish.yml"
+environment = "publisher"
+```
+
+monochange resolves the GitHub trust context from:
+
+- `publish.trusted_publishing.repository`
+- `publish.trusted_publishing.workflow`
+- `publish.trusted_publishing.environment`
+- otherwise `[source]`
+- otherwise GitHub Actions runtime values such as `GITHUB_REPOSITORY`, `GITHUB_WORKFLOW_REF`, and `GITHUB_JOB`
+
+If your workflow filename or environment cannot be inferred reliably, set them explicitly in `monochange.toml`.
+
+## GitHub Actions baseline
+
+Most registries require the publish job to request an OIDC token.
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+```
+
+If you use a protected deployment environment, keep the workflow and registry settings aligned:
+
+```yaml
+jobs:
+  publish:
+    environment: publisher
+```
+
+Use the same environment name in GitHub Actions and in the registry configuration.
+
+## Recommended rollout
+
+Use this sequence when adopting trusted publishing for an existing workspace:
+
+1. Set `publish.trusted_publishing = true` for the target ecosystem or package.
+2. Run `mc placeholder-publish --dry-run` to see which packages do not exist yet.
+3. If needed, run `mc placeholder-publish` so the package exists in the registry first.
+4. Complete the registry-side trusted-publishing setup for each package.
+5. Run `mc publish --dry-run` to confirm monochange now sees the expected trust configuration.
+6. Publish from CI with `mc publish`.
+
+Placeholder publishing is especially useful when the package name must exist in the registry before trusted publishing can be configured.
+
+## npm
+
+### Registry-side setup
+
+On npm, trusted publishing can be configured from the package settings page or through the CLI.
+
+**UI path**
+
+- `npmjs.com` → package → **Settings** → **Trusted publishing**
+
+**Fields to enter for GitHub Actions**
+
+- **Organization or user** — GitHub owner
+- **Repository** — GitHub repository name
+- **Workflow filename** — for example `publish.yml`
+- **Environment name** — optional, for example `publisher`
+
+Only the workflow filename is required, not the full `.github/workflows/...` path.
+
+### CLI setup commands
+
+These are the same commands monochange models for npm trusted publishing.
+
+List the current trusted publishers for a package:
+
+```bash
+npm trust list <package-name> --json
+```
+
+Configure a package for a GitHub workflow:
+
+```bash
+npm trust github <package-name> \
+  --repo owner/repo \
+  --file publish.yml \
+  --yes
+```
+
+Add an environment restriction:
+
+```bash
+npm trust github <package-name> \
+  --repo owner/repo \
+  --file publish.yml \
+  --env publisher \
+  --yes
+```
+
+If the workspace uses pnpm, use the pnpm-wrapped form:
+
+```bash
+pnpm exec npm trust github <package-name> \
+  --repo owner/repo \
+  --file publish.yml \
+  --env publisher \
+  --yes
+```
+
+### Workflow requirements
+
+At minimum, the publish workflow should have:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+```
+
+### monochange notes
+
+- monochange verifies the current trust configuration first.
+- If trust is missing, monochange can run the trust command automatically before `npm publish` or `pnpm publish`.
+- If approval is still required in the browser, npm's own flow may still require human confirmation.
+- pnpm workspaces stay on `pnpm exec npm trust ...` and `pnpm publish` so workspace protocol and catalog dependency handling stay aligned with the workspace manager.
+
+## crates.io
+
+### Registry-side setup
+
+crates.io supports trusted publishing for GitHub Actions.
+
+**Important:** the crate must already exist on `crates.io` before you can finish trusted-publishing setup. If it does not exist yet, bootstrap it first with a real initial release or `mc placeholder-publish`.
+
+**UI path**
+
+- crate page → **Settings** → **Trusted Publishing**
+
+**Fields to enter for GitHub Actions**
+
+- **Repository owner** — GitHub owner
+- **Repository name** — GitHub repository name
+- **Workflow filename** — for example `publish.yml`
+- **Environment** — optional, for example `publisher`
+
+### Workflow setup
+
+A GitHub Actions job can use the official token-exchange action:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+
+steps:
+  - uses: actions/checkout@v6
+
+  - uses: rust-lang/crates-io-auth-action@v1
+    id: auth
+
+  - run: cargo publish
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+```
+
+### monochange notes
+
+- monochange does not create the `crates.io` trusted-publisher record for you yet.
+- Once the registry-side configuration exists, monochange can publish with the temporary token exposed by `rust-lang/crates-io-auth-action@v1`.
+- The current monochange GitHub publish workflow already uses this pattern.
+
+Useful references:
+
+- `https://crates.io/docs/trusted-publishing`
+- `https://rust-lang.github.io/rfcs/3691-trusted-publishing-cratesio.html`
+
+## jsr
+
+### Registry-side setup
+
+JSR supports tokenless publishing from GitHub Actions.
+
+**Manual setup step**
+
+- go to the package on `jsr.io`
+- open **Settings**
+- link the package to the GitHub repository that is allowed to publish it
+
+monochange currently reports the package URL and expects this repository-linking step to be completed manually.
+
+### Workflow setup
+
+A minimal GitHub Actions job looks like this:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+
+steps:
+  - uses: actions/checkout@v6
+  - run: npx jsr publish
+```
+
+You can also publish with:
+
+```bash
+deno publish
+```
+
+### monochange notes
+
+- JSR's tokenless publishing is currently GitHub Actions focused.
+- Other CI providers still need token-based publishing.
+- monochange does not yet link the package to the repository for you.
+- If the package does not exist yet, placeholder publishing can bootstrap the registry entry before you finish the repository-link step.
+
+Useful references:
+
+- `https://jsr.io/docs/publishing-packages`
+- `https://jsr.io/docs/trust`
+
+## pub.dev
+
+### Registry-side setup
+
+pub.dev calls this **automated publishing**.
+
+**Important:** the package must already exist before you can enable automated publishing. If the package does not exist yet, publish it once first or use `mc placeholder-publish`.
+
+**UI path**
+
+- `https://pub.dev/packages/<package>/admin`
+- find the **Automated publishing** section
+- click **Enable publishing from GitHub Actions**
+
+**Fields to enter**
+
+- **Repository** — `owner/repo`
+- **Tag pattern** — a string containing `{{version}}`
+
+Examples:
+
+- single-package repo: `v{{version}}`
+- monorepo package-specific tag: `my_package-v{{version}}`
+
+For a monorepo, give each package its own tag pattern so a tag for one package cannot publish another package by accident.
+
+### Workflow requirements
+
+pub.dev only accepts GitHub Actions automated publishing when the workflow was triggered by a **tag push**.
+
+That means the GitHub workflow trigger must align with the configured tag pattern.
+
+Example tag trigger for `v{{version}}`:
+
+```yaml
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: read
+  id-token: write
+```
+
+The publish step can then run:
+
+```bash
+dart pub publish --force
+```
+
+For Flutter packages, the equivalent publish command is:
+
+```bash
+flutter pub publish --force
+```
+
+### monochange notes
+
+- monochange does not configure pub.dev automated publishing for you yet.
+- monochange reports the package admin URL so you can finish the setup manually.
+- pub.dev is stricter than the others here because the workflow must be tag-triggered, not just manually dispatched or branch-triggered.
+- Keep the Git tag, `pubspec.yaml` version, and tag pattern aligned.
+
+Useful references:
+
+- `https://dart.dev/tools/pub/automated-publishing`
+- `https://pub.dev/packages/<package>/admin`
+
+## Mapping monochange config to registry values
+
+Use this cheat sheet when a registry asks for workflow details.
+
+| Registry field                              | Value to use                                                                                                  |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| repository owner / organization / namespace | GitHub owner from `[source]` or `publish.trusted_publishing.repository`                                       |
+| repository name / project                   | repository part of `owner/repo`                                                                               |
+| workflow filename                           | `publish.trusted_publishing.workflow`, for example `publish.yml`                                              |
+| environment                                 | `publish.trusted_publishing.environment`, for example `publisher`                                             |
+| pub.dev tag pattern                         | choose a tag rule that matches your release workflow, for example `v{{version}}` or `my_package-v{{version}}` |
+
+If monochange cannot infer the GitHub repository or workflow for a package, set them explicitly in `monochange.toml`.
+
+## Security recommendations
+
+- prefer trusted publishing over long-lived registry tokens whenever the registry supports it
+- keep `id-token: write` only on the publish job instead of the entire workflow when possible
+- use a protected GitHub environment such as `publisher` for high-value publish jobs
+- restrict tag creation and release workflows to trusted maintainers
+- use package-specific tags in monorepos when a registry supports tag-based publish authorization
+
+## When to keep `mode = "external"`
+
+Keep a package on `mode = "external"` when:
+
+- the registry is private or custom
+- you need retry or delayed requeue behavior that monochange does not manage yet
+- your registry requires a CI pattern that differs substantially from monochange's built-in publish flow
+
+In those cases, you can still use the same registry-side trusted-publishing setup while letting your own workflow own the actual publish command.

--- a/docs/src/guide/08-github-automation.md
+++ b/docs/src/guide/08-github-automation.md
@@ -88,6 +88,8 @@ When `publish.trusted_publishing` is enabled, monochange can derive GitHub trust
 
 For `crates.io`, `jsr`, and `pub.dev`, monochange reports the setup URL for the package and requires manual trusted-publishing setup before the next built-in release publish. Placeholder publishing can still proceed so the package exists before that manual step.
 
+For exact registry-side setup steps and field mappings, see [Trusted publishing and OIDC](./07-trusted-publishing.md).
+
 For full GitHub and GitLab CI examples by ecosystem — npm, Cargo, Deno/JSR, and Dart/pub.dev — see [Advanced: CI, package publishing, and release PR flows](./13-ci-and-publishing.md).
 
 ## Release notes, GitHub releases, and release PRs

--- a/packages/monochange__skill/README.md
+++ b/packages/monochange__skill/README.md
@@ -9,8 +9,9 @@ This package bundles:
 - `skills/changesets.md` — changeset authoring and lifecycle guidance
 - `skills/commands.md` — built-in command catalog and usage patterns
 - `skills/configuration.md` — `monochange.toml` setup and editing guidance
-- `skills/linting.md` — `mc check`, `[ecosystems.<name>.lints]`, and manifest-focused rule explanations with examples
+- `skills/linting.md` — `mc check`, `[ecosystems.<name>].lints`, and manifest-focused rule explanations with examples
 - `REFERENCE.md` — high-context reference with broader examples
+- `TRUSTED-PUBLISHING.md` — GitHub/OIDC setup guidance for `npm`, `crates.io`, `jsr`, and `pub.dev`
 - `monochange-skill` — helper executable for printing or copying the bundled skill
 
 ## Install
@@ -27,7 +28,7 @@ monochange-skill --print-skill
 monochange-skill --copy ~/.pi/agent/skills/monochange
 ```
 
-`monochange-skill --copy` copies the full skill bundle, including `SKILL.md`, `REFERENCE.md`, and the `skills/` deep-dive folder.
+`monochange-skill --copy` copies the full skill bundle, including `SKILL.md`, `REFERENCE.md`, `TRUSTED-PUBLISHING.md`, and the `skills/` deep-dive folder.
 
 ## What the skill teaches
 
@@ -39,5 +40,6 @@ The bundled skill explains how to:
 - preview release effects with `mc release --dry-run --format json` and `mc release --dry-run --diff`
 - inspect durable release history with `mc release-record`
 - understand groups, package ids, changelogs, linting policy, package publishing, and source-provider release flows
+- set up trusted publishing / OIDC-backed package publishing for the registries that monochange supports
 
-Open [SKILL.md](./SKILL.md) first, then use [skills/README.md](./skills/README.md) and [REFERENCE.md](./REFERENCE.md) for the deeper sections.
+Open [SKILL.md](./SKILL.md) first, then use [skills/README.md](./skills/README.md), [REFERENCE.md](./REFERENCE.md), and [TRUSTED-PUBLISHING.md](./TRUSTED-PUBLISHING.md) for the deeper sections.

--- a/packages/monochange__skill/REFERENCE.md
+++ b/packages/monochange__skill/REFERENCE.md
@@ -469,8 +469,9 @@ Placeholder README content can come from:
 
 `trusted_publishing = true` tells monochange to manage or verify trusted publishing when supported.
 
-- npm trusted publishing can be configured automatically from GitHub Actions context
+- npm trusted publishing can be configured automatically from GitHub Actions context; monochange verifies the current state first, then runs `npm trust github <package> --repo <owner/repo> --file <workflow> [--env <environment>] --yes` or the `pnpm exec npm trust ...` equivalent for pnpm workspaces
 - Cargo, `jsr`, and `pub.dev` currently require manual trusted-publishing setup; monochange reports the setup URL and blocks the next built-in release publish until trust is configured
+- See [TRUSTED-PUBLISHING.md](TRUSTED-PUBLISHING.md) for a GitHub-focused setup guide covering the exact registry fields and commands for `npm`, `crates.io`, `jsr`, and `pub.dev`
 - Built-in publishing does not yet manage registry rate-limit retries or delayed requeues; use `mode = "external"` when your workflow needs custom scheduling
 
 ### Lint rules

--- a/packages/monochange__skill/SKILL.md
+++ b/packages/monochange__skill/SKILL.md
@@ -155,8 +155,9 @@ Lockfile refresh is command-driven via `[ecosystems.<name>].lockfile_commands`. 
 - `mc placeholder-publish` exists for first-release bootstrap. It checks whether each managed package already exists in its registry and publishes a placeholder `0.0.0` version only for the missing ones.
 - Placeholder README content can come from `publish.placeholder.readme` or `publish.placeholder.readme_file`.
 - `publish.trusted_publishing = true` tells monochange to manage or verify trusted publishing for that package when supported.
-- npm trusted publishing can be configured automatically from GitHub Actions context. pnpm workspaces use `pnpm exec npm trust ...` and `pnpm publish`.
+- npm trusted publishing can be configured automatically from GitHub Actions context. pnpm workspaces use `pnpm exec npm trust ...` and `pnpm publish`, and monochange verifies the trust state before changing it.
 - Cargo, `jsr`, and `pub.dev` currently require manual trusted-publishing setup. monochange reports the setup URL and blocks the next built-in release publish until trust is configured.
+- See [TRUSTED-PUBLISHING.md](TRUSTED-PUBLISHING.md) for the exact registry fields, commands, and GitHub Actions requirements across `npm`, `crates.io`, `jsr`, and `pub.dev`.
 - Built-in publishing does not yet manage registry rate-limit retries or delayed requeues. Use `mode = "external"` if your workflow needs custom scheduling.
 
 ### Release titles
@@ -240,4 +241,8 @@ Use `mc check --fix` to auto-fix issues where possible. Today the built-in rule 
 
 ## Guidance
 
-Start with [REFERENCE.md](REFERENCE.md) for the broad reference. Then open the focused deep dives in [skills/README.md](skills/README.md) when you need dedicated guidance for changesets, commands, configuration, or linting.
+Start with [REFERENCE.md](REFERENCE.md) for the broad reference.
+
+Open [skills/README.md](skills/README.md) when you need the focused deep dives for changesets, commands, configuration, or linting.
+
+See [TRUSTED-PUBLISHING.md](TRUSTED-PUBLISHING.md) for GitHub/OIDC trusted-publishing setup details across the registries that monochange supports.

--- a/packages/monochange__skill/TRUSTED-PUBLISHING.md
+++ b/packages/monochange__skill/TRUSTED-PUBLISHING.md
@@ -1,0 +1,375 @@
+# Trusted publishing with GitHub Actions
+
+This guide explains how to set up secure package publishing for the registries that monochange supports.
+
+monochange uses the term **trusted publishing**. Other registries may call the same idea **OIDC publishing**, **automated publishing**, or **trusted publishers**.
+
+The common goal is the same:
+
+- publish directly from CI
+- avoid long-lived registry tokens where possible
+- restrict publish rights to a specific repository, workflow, and sometimes environment
+
+## What monochange can do today
+
+| Ecosystem      | Registry  | Registry term             | GitHub-based OIDC available | What monochange can automate                                                          |
+| -------------- | --------- | ------------------------- | --------------------------- | ------------------------------------------------------------------------------------- |
+| npm            | npm       | Trusted publishing        | Yes                         | Can verify existing trust and run `npm trust github ...` or `pnpm exec npm trust ...` |
+| cargo          | crates.io | Trusted Publishing        | Yes                         | Can publish with a temporary token after you finish registry-side setup               |
+| deno           | jsr       | GitHub Actions publishing | Yes                         | Reports the setup URL; repository linking is still manual                             |
+| dart / flutter | pub.dev   | Automated publishing      | Yes                         | Reports the setup URL; admin-page setup is still manual                               |
+
+## Monochange prerequisites
+
+Start by telling monochange that these packages are expected to publish from GitHub Actions.
+
+```toml
+[source]
+provider = "github"
+owner = "ifiokjr"
+repo = "monochange"
+
+[ecosystems.npm.publish]
+trusted_publishing = true
+
+[ecosystems.cargo.publish]
+trusted_publishing = true
+
+[ecosystems.deno.publish]
+trusted_publishing = true
+
+[ecosystems.dart.publish]
+trusted_publishing = true
+
+[package.cli.publish.trusted_publishing]
+workflow = "publish.yml"
+environment = "publisher"
+```
+
+monochange resolves the GitHub trust context from:
+
+- `publish.trusted_publishing.repository`
+- `publish.trusted_publishing.workflow`
+- `publish.trusted_publishing.environment`
+- otherwise `[source]`
+- otherwise GitHub Actions runtime values such as `GITHUB_REPOSITORY`, `GITHUB_WORKFLOW_REF`, and `GITHUB_JOB`
+
+If your workflow filename or environment cannot be inferred reliably, set them explicitly in config.
+
+## GitHub Actions baseline
+
+Most registries need the publish job to request an OIDC token.
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+```
+
+If you use a protected deployment environment, keep the workflow and registry settings aligned:
+
+```yaml
+jobs:
+  publish:
+    environment: publisher
+```
+
+Use the same environment name in both places.
+
+## Recommended monochange rollout
+
+Use this sequence when adopting trusted publishing across an existing workspace:
+
+1. Set `publish.trusted_publishing = true` for the target ecosystem or package.
+2. Run `mc placeholder-publish --dry-run` to see which packages do not exist yet.
+3. If needed, run `mc placeholder-publish` so the package exists in the registry first.
+4. Complete the registry-side trusted-publishing setup for each package.
+5. Run `mc publish --dry-run` to confirm monochange now sees the trust configuration it expects.
+6. Publish from CI with `mc publish`.
+
+Placeholder publishing is especially useful when the package name is reserved but the real release is not ready yet.
+
+---
+
+## npm
+
+### Registry-side setup
+
+On npm, trusted publishing can be configured from the package settings page or through the CLI.
+
+**UI path**
+
+- `npmjs.com` → package → **Settings** → **Trusted publishing**
+
+**Fields to enter for GitHub Actions**
+
+- **Organization or user** — GitHub owner
+- **Repository** — GitHub repository name
+- **Workflow filename** — for example `publish.yml`
+- **Environment name** — optional, for example `publisher`
+
+Only the workflow filename is required, not the full `.github/workflows/...` path.
+
+### CLI setup commands
+
+These are the exact commands monochange models for npm trusted publishing.
+
+List the current trusted publishers for a package:
+
+```bash
+npm trust list <package-name> --json
+```
+
+Configure a package for a GitHub workflow:
+
+```bash
+npm trust github <package-name> \
+  --repo owner/repo \
+  --file publish.yml \
+  --yes
+```
+
+Add an environment restriction:
+
+```bash
+npm trust github <package-name> \
+  --repo owner/repo \
+  --file publish.yml \
+  --env publisher \
+  --yes
+```
+
+If the workspace uses pnpm, use the pnpm-wrapped form:
+
+```bash
+pnpm exec npm trust github <package-name> \
+  --repo owner/repo \
+  --file publish.yml \
+  --env publisher \
+  --yes
+```
+
+### Workflow requirements
+
+At minimum, the publish workflow should have:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+```
+
+monochange can verify existing npm trust configuration and, when needed, run the trust command automatically before `pnpm publish` or `npm publish`.
+
+### Monochange notes
+
+- npm is the only ecosystem where monochange currently performs bulk trusted-publishing setup itself.
+- If approval is required in the browser, npm's own flow may still require human confirmation.
+- pnpm workspaces stay on `pnpm exec npm trust ...` and `pnpm publish` so the workspace manager stays consistent.
+
+---
+
+## crates.io
+
+### Registry-side setup
+
+crates.io supports trusted publishing for GitHub Actions.
+
+**Important:** the crate must already exist on crates.io before you can finish trusted-publishing setup. If it does not exist yet, bootstrap it first with a real initial release or `mc placeholder-publish`.
+
+**UI path**
+
+- crate page → **Settings** → **Trusted Publishing**
+
+**Fields to enter for GitHub Actions**
+
+- **Repository owner** — GitHub owner
+- **Repository name** — GitHub repository name
+- **Workflow filename** — for example `publish.yml`
+- **Environment** — optional, for example `publisher`
+
+These fields match the crates.io trusted-publisher form and are also reflected in the crates.io documentation and UI templates.
+
+### Workflow setup
+
+A GitHub Actions job can use the official token-exchange action:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+
+steps:
+  - uses: actions/checkout@v6
+
+  - uses: rust-lang/crates-io-auth-action@v1
+    id: auth
+
+  - run: cargo publish
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+```
+
+### Monochange notes
+
+- monochange does **not** create the crates.io trusted-publisher record for you yet.
+- Once the registry-side configuration exists, monochange can publish with the temporary token exposed by `rust-lang/crates-io-auth-action@v1`.
+- The current monochange GitHub publish workflow already includes this pattern.
+
+Useful references:
+
+- `https://crates.io/docs/trusted-publishing`
+- `https://rust-lang.github.io/rfcs/3691-trusted-publishing-cratesio.html`
+
+---
+
+## jsr
+
+### Registry-side setup
+
+JSR supports tokenless publishing from GitHub Actions.
+
+**Manual setup step**
+
+- go to your package on `jsr.io`
+- open **Settings**
+- link the package to the GitHub repository that is allowed to publish it
+
+monochange currently reports the package URL and expects this repository-linking step to be completed manually.
+
+### Workflow setup
+
+A minimal GitHub Actions job looks like this:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+
+steps:
+  - uses: actions/checkout@v6
+  - run: npx jsr publish
+```
+
+You can also use:
+
+```bash
+deno publish
+```
+
+### Monochange notes
+
+- JSR's tokenless publishing is currently GitHub Actions focused.
+- Other CI providers still need token-based publishing.
+- monochange does not yet link the package to the repository for you.
+- If the package does not exist yet, a placeholder release can bootstrap the registry entry before you finish the repository-link step.
+
+Useful references:
+
+- `https://jsr.io/docs/publishing-packages`
+- `https://jsr.io/docs/trust`
+
+---
+
+## pub.dev
+
+### Registry-side setup
+
+pub.dev calls this **automated publishing**.
+
+**Important:** the package must already exist before you can enable automated publishing. If the package does not exist yet, publish it once first or use `mc placeholder-publish`.
+
+**UI path**
+
+- `https://pub.dev/packages/<package>/admin`
+- find the **Automated publishing** section
+- click **Enable publishing from GitHub Actions**
+
+**Fields to enter**
+
+- **Repository** — `owner/repo`
+- **Tag pattern** — a string containing `{{version}}`
+
+Examples:
+
+- single-package repo: `v{{version}}`
+- monorepo package-specific tag: `my_package-v{{version}}`
+
+For a monorepo, give each package its own tag pattern so a tag for one package cannot publish another package by accident.
+
+### Workflow requirements
+
+pub.dev only accepts GitHub Actions automated publishing when the workflow was triggered by a **tag push**.
+
+That means the GitHub workflow trigger must align with the configured tag pattern.
+
+Example tag trigger for `v{{version}}`:
+
+```yaml
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: read
+  id-token: write
+```
+
+The publish step can then run:
+
+```bash
+dart pub publish --force
+```
+
+For Flutter packages, the equivalent publish command is:
+
+```bash
+flutter pub publish --force
+```
+
+### Monochange notes
+
+- monochange does **not** configure pub.dev automated publishing for you yet.
+- monochange reports the package admin URL so you can finish the setup manually.
+- pub.dev is stricter than the others here because the workflow must be tag-triggered, not just manually dispatched or branch-triggered.
+- Keep the Git tag, `pubspec.yaml` version, and tag pattern aligned.
+
+Useful references:
+
+- `https://dart.dev/tools/pub/automated-publishing`
+- `https://pub.dev/packages/<package>/admin`
+
+---
+
+## Mapping monochange config to registry values
+
+Use this cheat sheet when a registry asks for workflow details.
+
+| Registry field                              | Value to use                                                                                                  |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| repository owner / organization / namespace | GitHub owner from `[source]` or `publish.trusted_publishing.repository`                                       |
+| repository name / project                   | repository part of `owner/repo`                                                                               |
+| workflow filename                           | `publish.trusted_publishing.workflow`, for example `publish.yml`                                              |
+| environment                                 | `publish.trusted_publishing.environment`, for example `publisher`                                             |
+| pub.dev tag pattern                         | choose a tag rule that matches your release workflow, for example `v{{version}}` or `my_package-v{{version}}` |
+
+If monochange cannot infer the GitHub repository or workflow for a package, set them explicitly in `monochange.toml`.
+
+## Security recommendations
+
+- prefer trusted publishing over long-lived registry tokens whenever the registry supports it
+- keep `id-token: write` only on the publish job, not the entire workflow if you can avoid it
+- use a protected GitHub environment such as `publisher` for high-value publish jobs
+- restrict tag creation and release workflows to trusted maintainers
+- use package-specific tags in monorepos when a registry supports tag-based publish authorization
+
+## When to keep `mode = "external"`
+
+Keep a package on `mode = "external"` when:
+
+- the registry is private or custom
+- you need retry or delayed requeue behavior that monochange does not manage yet
+- your registry requires a CI pattern that differs substantially from monochange's built-in publish flow
+
+In those cases, you can still use this guide for the registry-side OIDC setup while letting your own workflow own the actual publish command.

--- a/packages/monochange__skill/package.json
+++ b/packages/monochange__skill/package.json
@@ -16,6 +16,7 @@
 		"REFERENCE.md",
 		"CHANGESET-GUIDE.md",
 		"ARTIFACT-TYPES.md",
+		"TRUSTED-PUBLISHING.md",
 		"skills",
 		"README.md",
 		"LICENSE",


### PR DESCRIPTION
## Summary

- add a dedicated trusted publishing / OIDC setup guide to `@monochange/skill`
- mirror that guidance into the mdBook as `docs/src/guide/07-trusted-publishing.md`
- link the new guide from the configuration and GitHub automation docs
- document exact GitHub-focused setup details for `npm`, `crates.io`, `jsr`, and `pub.dev`

## Testing

- `devenv shell docs:check`
- `devenv shell fix:all`
