### PR TITLE
feat: prefer official publishing workflows

### DIFF
--- a/.changeset/prefer-official-publishing-workflows.md
+++ b/.changeset/prefer-official-publishing-workflows.md
@@ -1,0 +1,15 @@
+---
+"@monochange/skill": patch
+---
+
+#### prefer official trusted-publishing workflows in the packaged skill
+
+The packaged skill now explicitly recommends the registry-maintained GitHub publishing workflows for manual trusted-publishing registries.
+
+**Updated guidance:**
+
+- prefers `rust-lang/crates-io-auth-action@v1` for `crates.io`
+- prefers `dart-lang/setup-dart/.github/workflows/publish.yml@v1` for `pub.dev`
+- clarifies that `mode = "external"` is often the clearest fit when those workflows should own the publish command directly
+
+These recommendations were added to the main skill entrypoint, the configuration deep dive, and the packaged trusted-publishing guide.

--- a/packages/monochange__skill/SKILL.md
+++ b/packages/monochange__skill/SKILL.md
@@ -157,7 +157,8 @@ Lockfile refresh is command-driven via `[ecosystems.<name>].lockfile_commands`. 
 - `publish.trusted_publishing = true` tells monochange to manage or verify trusted publishing for that package when supported.
 - npm trusted publishing can be configured automatically from GitHub Actions context. pnpm workspaces use `pnpm exec npm trust ...` and `pnpm publish`, and monochange verifies the trust state before changing it.
 - Cargo, `jsr`, and `pub.dev` currently require manual trusted-publishing setup. monochange reports the setup URL and blocks the next built-in release publish until trust is configured.
-- See [TRUSTED-PUBLISHING.md](TRUSTED-PUBLISHING.md) for the exact registry fields, commands, and GitHub Actions requirements across `npm`, `crates.io`, `jsr`, and `pub.dev`.
+- Prefer the official GitHub publishing workflows for manual registries when they exist: `rust-lang/crates-io-auth-action@v1` for `crates.io` and `dart-lang/setup-dart/.github/workflows/publish.yml@v1` for `pub.dev`.
+- See [TRUSTED-PUBLISHING.md](TRUSTED-PUBLISHING.md) for the exact registry fields, commands, official workflow preferences, and GitHub Actions requirements across `npm`, `crates.io`, `jsr`, and `pub.dev`.
 - Built-in publishing does not yet manage registry rate-limit retries or delayed requeues. Use `mode = "external"` if your workflow needs custom scheduling.
 
 ### Release titles

--- a/packages/monochange__skill/TRUSTED-PUBLISHING.md
+++ b/packages/monochange__skill/TRUSTED-PUBLISHING.md
@@ -234,6 +234,8 @@ If you configure an environment on crates.io, the GitHub job must use the same e
 - Once the registry-side configuration exists, monochange can publish with the temporary token exposed by `rust-lang/crates-io-auth-action@v1`.
 - crates.io issues a short-lived publish token; the current docs describe these tokens as expiring after 30 minutes.
 - Use a specific workflow filename and, when needed, a protected GitHub environment to reduce the publish attack surface.
+- If you want the most registry-native GitHub workflow, prefer `rust-lang/crates-io-auth-action@v1` and let it own the token exchange explicitly.
+- When you want that workflow to own the publish command directly, `mode = "external"` is usually the clearest monochange configuration.
 - The current monochange GitHub publish workflow already includes this pattern.
 
 Useful references:
@@ -391,6 +393,8 @@ flutter pub publish --force
 - monochange reports the package admin URL so you can finish the setup manually.
 - pub.dev is stricter than the others here because the workflow must be tag-triggered, not just manually dispatched or branch-triggered.
 - The reusable workflow from `dart-lang/setup-dart` is the officially recommended path and is worth preferring unless you need custom pre-publish steps.
+- If you want the workflow shape recommended by the Dart team, prefer `dart-lang/setup-dart/.github/workflows/publish.yml@v1`.
+- When that reusable workflow should own the publish command directly, `mode = "external"` is usually the clearest monochange configuration.
 - Keep the Git tag, `pubspec.yaml` version, and tag pattern aligned.
 - Protect matching tags, and use GitHub environment protection rules when you need an approval gate before publishing.
 

--- a/packages/monochange__skill/skills/configuration.md
+++ b/packages/monochange__skill/skills/configuration.md
@@ -166,6 +166,13 @@ Use:
 - `mc publish` for package-registry publishing
 - `mc publish-release` for hosted/provider releases
 
+Preference rules for trusted publishing:
+
+- for npm on GitHub, `mode = "builtin"` is the preferred path because monochange can verify and configure trust itself
+- for `crates.io`, prefer `rust-lang/crates-io-auth-action@v1` when you want a registry-native GitHub Actions publish workflow
+- for `pub.dev`, prefer `dart-lang/setup-dart/.github/workflows/publish.yml@v1` when you want the workflow shape recommended by the Dart team
+- for `crates.io` and `pub.dev`, `mode = "external"` is often the clearest fit when the registry-maintained workflow should own the publish command directly
+
 ## Release titles and changelog headings
 
 Customize outward release text with these fields:


### PR DESCRIPTION
## Summary

- update the packaged skill to explicitly prefer the official GitHub publishing workflows for manual trusted-publishing registries
- recommend `rust-lang/crates-io-auth-action@v1` for `crates.io`
- recommend `dart-lang/setup-dart/.github/workflows/publish.yml@v1` for `pub.dev`
- clarify that `mode = "external"` is often the clearest fit when those workflows should own the publish command directly

## Testing

- `devenv shell docs:check`
- `devenv shell fix:all`
