### PR TITLE
test: cover trusted publishing messaging

### DIFF
--- a/.changeset/trusted-publishing-messaging-tests.md
+++ b/.changeset/trusted-publishing-messaging-tests.md
@@ -1,0 +1,12 @@
+---
+monochange: patch
+---
+
+#### add trusted-publishing messaging test coverage
+
+Adds regression coverage for trusted-publishing messaging in the `monochange` CLI and package-publish reporting.
+
+The new tests cover:
+
+- manual registry setup guidance rendering in text and markdown output
+- preservation of explicit trusted-publishing context in manual-action outcomes

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -3071,6 +3071,45 @@ path = "crates/core"
 	}
 
 	#[test]
+	fn render_package_publish_reports_include_manual_registry_guidance() {
+		let report = package_publish::PackagePublishReport {
+			mode: package_publish::PackagePublishRunMode::Release,
+			dry_run: false,
+			packages: vec![package_publish::PackagePublishOutcome {
+				package: "pkg".to_string(),
+				ecosystem: Ecosystem::Cargo,
+				registry: "crates_io".to_string(),
+				version: "1.2.3".to_string(),
+				status: package_publish::PackagePublishStatus::SkippedExternal,
+				message: "skipped built-in publish".to_string(),
+				placeholder: false,
+				trusted_publishing: package_publish::TrustedPublishingOutcome {
+					status: package_publish::TrustedPublishingStatus::ManualActionRequired,
+					repository: Some("ifiokjr/monochange".to_string()),
+					workflow: Some("publish.yml".to_string()),
+					environment: Some("release".to_string()),
+					setup_url: Some("https://crates.io/crates/pkg".to_string()),
+					message:
+						"configure trusted publishing manually for `pkg` before the next built-in release publish"
+							.to_string(),
+				},
+			}],
+		};
+
+		let text = render_package_publish_report(&report).join("\n");
+		assert!(text.contains("trusted publishing: manual-action-required"));
+		assert!(text.contains("trust message: configure trusted publishing manually for `pkg`"));
+		assert!(text.contains("setup: https://crates.io/crates/pkg"));
+
+		let markdown = render_package_publish_report_markdown(&report, false).join("\n");
+		assert!(markdown.contains("**Trusted publishing:** manual-action-required"));
+		assert!(
+			markdown.contains("**Trust message:** configure trusted publishing manually for `pkg`")
+		);
+		assert!(markdown.contains("**Setup:** `https://crates.io/crates/pkg`"));
+	}
+
+	#[test]
 	fn package_publish_status_labels_cover_all_variants() {
 		assert_eq!(
 			package_publish_status_label(package_publish::PackagePublishStatus::Planned),

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -2728,6 +2728,33 @@ jobs:
 	}
 
 	#[test]
+	fn manual_trust_outcome_preserves_explicit_context_and_registry_setup_url() {
+		let mut request = trusted_request(RegistryKind::PubDev);
+		request.trusted_publishing.repository = Some("ifiokjr/monochange".to_string());
+		request.trusted_publishing.workflow = Some("publish.yml".to_string());
+		request.trusted_publishing.environment = Some("pub.dev".to_string());
+
+		let outcome = manual_trust_outcome(&request);
+
+		assert_eq!(
+			outcome.status,
+			TrustedPublishingStatus::ManualActionRequired
+		);
+		assert_eq!(outcome.repository.as_deref(), Some("ifiokjr/monochange"));
+		assert_eq!(outcome.workflow.as_deref(), Some("publish.yml"));
+		assert_eq!(outcome.environment.as_deref(), Some("pub.dev"));
+		assert_eq!(
+			outcome.setup_url.as_deref(),
+			Some("https://pub.dev/packages/pkg/admin")
+		);
+		assert!(
+			outcome
+				.message
+				.contains("configure trusted publishing manually for `pkg`")
+		);
+	}
+
+	#[test]
 	fn planned_trust_outcome_returns_disabled_when_trust_is_off() {
 		let outcome = planned_trust_outcome(
 			&sample_request(RegistryKind::Npm),


### PR DESCRIPTION
## Summary

- add regression coverage for trusted-publishing messaging in `monochange`
- test manual-action outcome rendering in CLI text and markdown output
- test that manual trusted-publishing outcomes preserve explicit repository/workflow/environment context and registry setup URLs

## Testing

- `devenv shell docs:check`
- `devenv shell -- cargo test -p monochange render_package_publish_reports_include_manual_registry_guidance --lib`
- `devenv shell -- cargo test -p monochange manual_trust_outcome_preserves_explicit_context_and_registry_setup_url --lib`
- `devenv shell fix:all`
