### PR TITLE
feat: improve manual trust guidance

### DIFF
--- a/.changeset/trusted-publishing-manual-guidance.md
+++ b/.changeset/trusted-publishing-manual-guidance.md
@@ -1,0 +1,13 @@
+---
+monochange: patch
+---
+
+#### make manual trusted-publishing guidance more actionable
+
+Improves CLI guidance for registries that still require manual trusted-publishing setup.
+
+**Updated behavior:**
+
+- manual trusted-publishing messages now point users to open the registry setup URL and match repository, workflow, and environment to the current GitHub context
+- package-publish text and markdown output now include a concrete next step telling users to finish registry setup and rerun `mc publish`
+- built-in publish prerequisite failures now tell users to complete registry setup and rerun the publish command

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -1732,6 +1732,7 @@ fn render_package_publish_report(report: &package_publish::PackagePublishReport)
 		}
 		if let Some(setup_url) = &package.trusted_publishing.setup_url {
 			lines.push(format!("  setup: {setup_url}"));
+			lines.push("  next: open the setup URL, configure trusted publishing for this package, then rerun `mc publish`".to_string());
 		}
 	}
 
@@ -1805,6 +1806,10 @@ fn render_package_publish_report_markdown(
 				"- **Setup:** {}",
 				paint_markdown_inline(&format!("`{setup_url}`"), MarkdownStyle::Code, color,)
 			));
+			lines.push(
+				"- **Next:** open the setup URL, configure trusted publishing for this package, then rerun `mc publish`"
+					.to_string(),
+			);
 		}
 	}
 
@@ -3100,6 +3105,7 @@ path = "crates/core"
 		assert!(text.contains("trusted publishing: manual-action-required"));
 		assert!(text.contains("trust message: configure trusted publishing manually for `pkg`"));
 		assert!(text.contains("setup: https://crates.io/crates/pkg"));
+		assert!(text.contains("next: open the setup URL, configure trusted publishing for this package, then rerun `mc publish`"));
 
 		let markdown = render_package_publish_report_markdown(&report, false).join("\n");
 		assert!(markdown.contains("**Trusted publishing:** manual-action-required"));
@@ -3107,6 +3113,7 @@ path = "crates/core"
 			markdown.contains("**Trust message:** configure trusted publishing manually for `pkg`")
 		);
 		assert!(markdown.contains("**Setup:** `https://crates.io/crates/pkg`"));
+		assert!(markdown.contains("**Next:** open the setup URL, configure trusted publishing for this package, then rerun `mc publish`"));
 	}
 
 	#[test]

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -547,18 +547,14 @@ fn enforce_release_trust_prerequisites(
 		return Ok(());
 	}
 
-	match request.registry {
-		RegistryKind::Npm => {
-			resolve_github_trust_context(root, source, &request.trusted_publishing, env_map)
-				.map(|_| ())
-		}
-		_ => {
-			Err(MonochangeError::Config(format!(
-				"`{}` requires manual trusted publishing setup before built-in release publishing can continue: {}",
-				request.package_id,
-				manual_setup_url(request)
-			)))
-		}
+	if request.registry == RegistryKind::Npm {
+		resolve_github_trust_context(root, source, &request.trusted_publishing, env_map).map(|_| ())
+	} else {
+		let setup_url = manual_setup_url(request);
+		Err(MonochangeError::Config(format!(
+			"`{}` requires manual trusted publishing setup before built-in release publishing can continue: {}. Configure the registry entry there, then rerun `mc publish`.",
+			request.package_id, setup_url,
+		)))
 	}
 }
 
@@ -1347,15 +1343,16 @@ fn disabled_trust_outcome() -> TrustedPublishingOutcome {
 }
 
 fn manual_trust_outcome(request: &PublishRequest) -> TrustedPublishingOutcome {
+	let setup_url = manual_setup_url(request);
 	TrustedPublishingOutcome {
 		status: TrustedPublishingStatus::ManualActionRequired,
 		repository: request.trusted_publishing.repository.clone(),
 		workflow: request.trusted_publishing.workflow.clone(),
 		environment: request.trusted_publishing.environment.clone(),
-		setup_url: Some(manual_setup_url(request)),
+		setup_url: Some(setup_url.clone()),
 		message: format!(
-			"configure trusted publishing manually for `{}` before the next built-in release publish",
-			request.package_name
+			"configure trusted publishing manually for `{}` before the next built-in release publish; open {} and match repository/workflow/environment to the current GitHub context",
+			request.package_name, setup_url
 		),
 	}
 }
@@ -2751,6 +2748,11 @@ jobs:
 			outcome
 				.message
 				.contains("configure trusted publishing manually for `pkg`")
+		);
+		assert!(
+			outcome
+				.message
+				.contains("match repository/workflow/environment to the current GitHub context")
 		);
 	}
 


### PR DESCRIPTION
## Summary

- make manual trusted-publishing CLI guidance more actionable for registries that still require registry-side setup
- tell users to open the registry setup URL, configure trusted publishing there, and rerun `mc publish`
- include repository/workflow/environment matching guidance in manual trusted-publishing messages
- improve both prerequisite failure messages and package-publish report rendering

## Testing

- `devenv shell docs:check`
- `devenv shell -- cargo test -p monochange render_package_publish_reports_include_manual_registry_guidance --lib`
- `devenv shell -- cargo test -p monochange manual_trust_outcome_preserves_explicit_context_and_registry_setup_url --lib`
- `devenv shell fix:all`
