### PR TITLE
feat: add skill multi-package publishing guide

### DIFF
--- a/.changeset/skill-multi-package-publishing-guide.md
+++ b/.changeset/skill-multi-package-publishing-guide.md
@@ -1,0 +1,16 @@
+---
+"@monochange/skill": patch
+---
+
+#### add a multi-package publishing guide to the packaged skill
+
+The packaged skill now includes a dedicated `MULTI-PACKAGE-PUBLISHING.md` guide for repositories that publish multiple public packages from one workspace.
+
+It explains:
+
+- when one shared post-merge `mc publish` job is a good fit
+- when package-specific jobs or fully external workflows are clearer
+- how to keep tags, workflows, environments, and working directories aligned per package
+- when to use package-level publishing overrides in `monochange.toml`
+
+The skill `README.md`, `SKILL.md`, `REFERENCE.md`, and `skills/configuration.md` now point agents to the new guide when publishing strategy depends on monorepo shape rather than only on per-registry trusted-publishing setup.

--- a/packages/monochange__skill/MULTI-PACKAGE-PUBLISHING.md
+++ b/packages/monochange__skill/MULTI-PACKAGE-PUBLISHING.md
@@ -1,0 +1,235 @@
+# Multi-package publishing patterns
+
+Use this guide when one repository publishes more than one public package and the publish workflow cannot be explained by a single generic `mc publish` example.
+
+This is the practical companion to [TRUSTED-PUBLISHING.md](./TRUSTED-PUBLISHING.md).
+
+## Core idea
+
+For multi-package repositories, keep one distinction clear:
+
+- monochange plans releases at the workspace level
+- registries authorize publishing at the package level
+
+That means one release commit can describe the whole workspace while publish automation still needs to stay package-specific.
+
+A good default rollout is:
+
+1. let monochange prepare one release commit for the workspace
+2. decide which packages use built-in publishing and which use `mode = "external"`
+3. keep each registry's trusted-publishing enrollment aligned with the exact workflow, tag pattern, and working directory that will publish that package
+
+## Pattern 1: one post-merge `mc publish` job
+
+Use this when most packages can stay on monochange's built-in publishing path.
+
+```yaml
+name: publish-packages
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: detect monochange release commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! devenv shell -- mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then
+            echo "HEAD is not a monochange release commit; skipping publish"
+            exit 0
+          fi
+
+      - name: publish packages
+        run: devenv shell -- mc publish
+```
+
+This is the best fit when:
+
+- multiple npm packages publish from the same workflow
+- multiple packages share the same built-in post-merge flow
+- you do not need package-specific tag triggers to satisfy the registry
+
+## Pattern 2: package-specific external workflows
+
+Use this when the registry expects each package to have its own tag trigger, working directory, or workflow.
+
+This is often the clearest fit for:
+
+- `pub.dev`
+- some `crates.io` setups
+- mixed workspaces where one package needs registry-native steps that do not match `mc publish`
+
+Example tag naming scheme:
+
+- `web-v{{version}}`
+- `cli-v{{version}}`
+- `dart_client-v{{version}}`
+
+Example config:
+
+```toml
+[ecosystems.cargo.publish]
+enabled = true
+mode = "external"
+trusted_publishing = true
+
+[ecosystems.dart.publish]
+enabled = true
+mode = "external"
+trusted_publishing = true
+registry = "pub.dev"
+```
+
+Example workflow shape:
+
+```yaml
+name: publish-dart-client
+
+on:
+  push:
+    tags:
+      - "dart_client-v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  publish:
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      working-directory: packages/dart_client
+      # environment: pub.dev
+```
+
+Choose this pattern when a tag for one package must never authorize publishing a different package.
+
+## Pattern 3: one workflow, multiple package-specific jobs
+
+Use this when you want one workflow file but separate jobs per package.
+
+That gives you:
+
+- one place to manage permissions and branch or tag triggers
+- package-specific working directories
+- package-specific environments
+- package-specific failure visibility
+
+Example shape:
+
+```yaml
+jobs:
+  publish-crate-a:
+    environment: crates-a
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - run: cargo publish --package crate_a
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+  publish-crate-b:
+    environment: crates-b
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - run: cargo publish --package crate_b
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+```
+
+This pattern is especially useful when multiple packages live in the same ecosystem but should not share the same trusted-publishing enrollment.
+
+## Registry-specific recommendations
+
+| Registry  | Recommended multi-package pattern                                    | Why                                                                   |
+| --------- | -------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| npm       | one post-merge `mc publish` job when possible                        | monochange can automate npm trusted-publishing setup on GitHub        |
+| crates.io | one job per crate when using external OIDC auth                      | trusted publishing is enrolled per crate and workflow context matters |
+| jsr       | built-in `mc publish` is often fine, but keep setup package-specific | registry linking is still manual today                                |
+| pub.dev   | package-specific tags and often one workflow per package             | automated publishing is tag-driven and package-specific               |
+
+## Keep config, tags, and workflows aligned
+
+For each published package, keep these values aligned:
+
+- package id in `monochange.toml`
+- registry package name
+- trusted-publishing repository, workflow, and environment values
+- workflow trigger
+- tag pattern, when the registry uses tags
+- working directory, when the registry workflow publishes from a subdirectory
+
+If those drift apart, trusted-publishing validation will be confusing even when release planning is correct.
+
+## When to use package-level overrides
+
+Use package-level publishing config when one package differs from the ecosystem default.
+
+```toml
+[ecosystems.dart.publish]
+enabled = true
+mode = "external"
+trusted_publishing = true
+registry = "pub.dev"
+
+[package.dart_client.publish.trusted_publishing]
+workflow = "publish-dart-client.yml"
+environment = "pub.dev"
+
+[package.example_app.publish]
+enabled = false
+```
+
+This is the right move when:
+
+- one package publishes from a different workflow file
+- one package needs a protected environment but others do not
+- one package is internal and should not publish publicly
+- one ecosystem default is correct for most packages, but not all of them
+
+## Practical rollout
+
+1. decide which packages are public and which stay unpublished
+2. choose `builtin` or `external` per ecosystem or package
+3. register trusted publishing for each package at the registry
+4. prefer package-specific tags where a registry is tag-authorized
+5. run `mc publish --dry-run` after registry enrollment changes
+6. keep the workflow filename and environment stable once a registry record is enrolled
+
+## Common mistakes
+
+Avoid these failure modes:
+
+- using one broad tag pattern that lets a tag for package A publish package B
+- reusing one trusted-publishing record across packages that actually publish from different workflows
+- changing a workflow filename after registry enrollment without updating the registry record
+- keeping `mode = "builtin"` for packages that really need registry-native external publish steps
+- forgetting that `pub.dev` automated publishing is tag-triggered
+
+## Related references
+
+- [TRUSTED-PUBLISHING.md](./TRUSTED-PUBLISHING.md) — registry-side trusted-publishing setup details
+- [skills/configuration.md](./skills/configuration.md) — publishing config and per-package overrides
+- [REFERENCE.md](./REFERENCE.md) — broader publishing and release workflow reference

--- a/packages/monochange__skill/README.md
+++ b/packages/monochange__skill/README.md
@@ -12,6 +12,7 @@ This package bundles:
 - `skills/linting.md` — `mc check`, `[ecosystems.<name>].lints`, and manifest-focused rule explanations with examples
 - `REFERENCE.md` — high-context reference with broader examples
 - `TRUSTED-PUBLISHING.md` — GitHub/OIDC setup guidance for `npm`, `crates.io`, `jsr`, and `pub.dev`
+- `MULTI-PACKAGE-PUBLISHING.md` — monorepo-oriented publishing patterns for multiple public packages
 - `monochange-skill` — helper executable for printing or copying the bundled skill
 
 ## Install
@@ -28,7 +29,7 @@ monochange-skill --print-skill
 monochange-skill --copy ~/.pi/agent/skills/monochange
 ```
 
-`monochange-skill --copy` copies the full skill bundle, including `SKILL.md`, `REFERENCE.md`, `TRUSTED-PUBLISHING.md`, and the `skills/` deep-dive folder.
+`monochange-skill --copy` copies the full skill bundle, including `SKILL.md`, `REFERENCE.md`, `TRUSTED-PUBLISHING.md`, `MULTI-PACKAGE-PUBLISHING.md`, and the `skills/` deep-dive folder.
 
 ## What the skill teaches
 
@@ -41,5 +42,6 @@ The bundled skill explains how to:
 - inspect durable release history with `mc release-record`
 - understand groups, package ids, changelogs, linting policy, package publishing, and source-provider release flows
 - set up trusted publishing / OIDC-backed package publishing for the registries that monochange supports
+- choose sane multi-package publish patterns when one repository ships multiple public packages
 
-Open [SKILL.md](./SKILL.md) first, then use [skills/README.md](./skills/README.md), [REFERENCE.md](./REFERENCE.md), and [TRUSTED-PUBLISHING.md](./TRUSTED-PUBLISHING.md) for the deeper sections.
+Open [SKILL.md](./SKILL.md) first, then use [skills/README.md](./skills/README.md), [REFERENCE.md](./REFERENCE.md), [TRUSTED-PUBLISHING.md](./TRUSTED-PUBLISHING.md), and [MULTI-PACKAGE-PUBLISHING.md](./MULTI-PACKAGE-PUBLISHING.md) for the deeper sections.

--- a/packages/monochange__skill/REFERENCE.md
+++ b/packages/monochange__skill/REFERENCE.md
@@ -472,6 +472,7 @@ Placeholder README content can come from:
 - npm trusted publishing can be configured automatically from GitHub Actions context; monochange verifies the current state first, then runs `npm trust github <package> --repo <owner/repo> --file <workflow> [--env <environment>] --yes` or the `pnpm exec npm trust ...` equivalent for pnpm workspaces
 - Cargo, `jsr`, and `pub.dev` currently require manual trusted-publishing setup; monochange reports the setup URL and blocks the next built-in release publish until trust is configured
 - See [TRUSTED-PUBLISHING.md](TRUSTED-PUBLISHING.md) for a GitHub-focused setup guide covering the exact registry fields and commands for `npm`, `crates.io`, `jsr`, and `pub.dev`
+- See [MULTI-PACKAGE-PUBLISHING.md](MULTI-PACKAGE-PUBLISHING.md) when one repository publishes multiple public packages and you need to choose between shared built-in flows and package-specific external workflows
 - Built-in publishing does not yet manage registry rate-limit retries or delayed requeues; use `mode = "external"` when your workflow needs custom scheduling
 
 ### Lint rules

--- a/packages/monochange__skill/SKILL.md
+++ b/packages/monochange__skill/SKILL.md
@@ -56,6 +56,7 @@ Release-oriented commands default to markdown output. Use `--format json` for au
 - [skills/commands.md](skills/commands.md) — built-in commands and workflow selection
 - [skills/configuration.md](skills/configuration.md) — creating and extending `monochange.toml`
 - [skills/linting.md](skills/linting.md) — `mc check`, `[ecosystems.<name>.lints]`, and manifest-focused rule explanations with examples
+- [MULTI-PACKAGE-PUBLISHING.md](MULTI-PACKAGE-PUBLISHING.md) — patterns for publishing multiple public packages from one repository
 - [CHANGESET-GUIDE.md](CHANGESET-GUIDE.md) — full lifecycle guidance
 - [ARTIFACT-TYPES.md](ARTIFACT-TYPES.md) — package-type-specific release-note guidance
 
@@ -159,6 +160,7 @@ Lockfile refresh is command-driven via `[ecosystems.<name>].lockfile_commands`. 
 - Cargo, `jsr`, and `pub.dev` currently require manual trusted-publishing setup. monochange reports the setup URL and blocks the next built-in release publish until trust is configured.
 - Prefer the official GitHub publishing workflows for manual registries when they exist: `rust-lang/crates-io-auth-action@v1` for `crates.io` and `dart-lang/setup-dart/.github/workflows/publish.yml@v1` for `pub.dev`.
 - See [TRUSTED-PUBLISHING.md](TRUSTED-PUBLISHING.md) for the exact registry fields, commands, official workflow preferences, and GitHub Actions requirements across `npm`, `crates.io`, `jsr`, and `pub.dev`.
+- See [MULTI-PACKAGE-PUBLISHING.md](MULTI-PACKAGE-PUBLISHING.md) when one repository publishes multiple packages and you need to choose between shared `mc publish` flows, package-specific jobs, or external workflows.
 - Built-in publishing does not yet manage registry rate-limit retries or delayed requeues. Use `mode = "external"` if your workflow needs custom scheduling.
 
 ### Release titles
@@ -247,3 +249,5 @@ Start with [REFERENCE.md](REFERENCE.md) for the broad reference.
 Open [skills/README.md](skills/README.md) when you need the focused deep dives for changesets, commands, configuration, or linting.
 
 See [TRUSTED-PUBLISHING.md](TRUSTED-PUBLISHING.md) for GitHub/OIDC trusted-publishing setup details across the registries that monochange supports.
+
+See [MULTI-PACKAGE-PUBLISHING.md](MULTI-PACKAGE-PUBLISHING.md) for monorepo publishing patterns when one repository ships multiple public packages.

--- a/packages/monochange__skill/package.json
+++ b/packages/monochange__skill/package.json
@@ -17,6 +17,7 @@
 		"CHANGESET-GUIDE.md",
 		"ARTIFACT-TYPES.md",
 		"TRUSTED-PUBLISHING.md",
+		"MULTI-PACKAGE-PUBLISHING.md",
 		"skills",
 		"README.md",
 		"LICENSE",

--- a/packages/monochange__skill/skills/README.md
+++ b/packages/monochange__skill/skills/README.md
@@ -5,7 +5,8 @@ Use these focused guides when the top-level [SKILL.md](../SKILL.md) is not enoug
 - [changesets.md](./changesets.md) — creating, updating, replacing, and removing `.changeset/*.md` files
 - [commands.md](./commands.md) — the built-in `mc` commands, when to run them, and how they fit together
 - [configuration.md](./configuration.md) — creating and evolving `monochange.toml`
-- [linting.md](./linting.md) — `mc check`, `[ecosystems.<name>.lints]`, and manifest-focused rule explanations with examples
+- [linting.md](./linting.md) — `mc check`, `[ecosystems.<name>].lints`, and manifest-focused rule explanations with examples
+- [../MULTI-PACKAGE-PUBLISHING.md](../MULTI-PACKAGE-PUBLISHING.md) — publishing patterns for repositories that ship multiple public packages
 
 Keep [REFERENCE.md](../REFERENCE.md) open when you want a single high-context document with broader examples and copy-paste snippets.
 

--- a/packages/monochange__skill/skills/configuration.md
+++ b/packages/monochange__skill/skills/configuration.md
@@ -172,6 +172,7 @@ Preference rules for trusted publishing:
 - for `crates.io`, prefer `rust-lang/crates-io-auth-action@v1` when you want a registry-native GitHub Actions publish workflow
 - for `pub.dev`, prefer `dart-lang/setup-dart/.github/workflows/publish.yml@v1` when you want the workflow shape recommended by the Dart team
 - for `crates.io` and `pub.dev`, `mode = "external"` is often the clearest fit when the registry-maintained workflow should own the publish command directly
+- if one repository publishes multiple public packages, use [MULTI-PACKAGE-PUBLISHING.md](../MULTI-PACKAGE-PUBLISHING.md) to decide between one shared `mc publish` job, package-specific jobs, or fully external workflows
 
 ## Release titles and changelog headings
 


### PR DESCRIPTION
## Summary

- add a dedicated `MULTI-PACKAGE-PUBLISHING.md` guide to the packaged `@monochange/skill`
- mirror the new mdBook guidance into the skill bundle so agents get monorepo publishing strategy help alongside the trusted-publishing guide
- link the new guide from the skill entrypoint, README, reference doc, and configuration deep dive

## Testing

- `devenv shell docs:check`
- `devenv shell fix:all`
