### PR TITLE
feat: add post-merge release tagging workflow

### DIFF
--- a/.changeset/release-pr-post-merge-tagging.md
+++ b/.changeset/release-pr-post-merge-tagging.md
@@ -1,0 +1,58 @@
+---
+monochange: minor
+"@monochange/cli": patch
+---
+
+#### add `mc tag-release` for post-merge release PR workflows
+
+monochange now ships a first-class `mc tag-release` command for the long-running release PR flow.
+
+**Before:**
+
+```bash
+mc release-record --from HEAD --format json
+mc publish
+```
+
+That let CI detect a merged monochange release commit and publish package registries from the durable `ReleaseRecord`, but monochange did not have a built-in command to create and push the release tag set after merge.
+
+**After:**
+
+```bash
+mc release-record --from HEAD --format json
+mc tag-release --from HEAD
+mc publish
+```
+
+`mc tag-release` reads the durable `ReleaseRecord` on the merged release commit, creates the declared tag set on that commit, and pushes those tags to `origin`.
+
+**Before (generated GitHub Actions `release.yml`):**
+
+```yaml
+- name: prepare and open release PR
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  run: mc commit-release
+```
+
+**After:**
+
+```yaml
+- name: refresh release PR
+  if: steps.release_record.outputs.is_release_commit != 'true'
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  run: mc release-pr
+
+- name: create release tags
+  if: steps.release_record.outputs.is_release_commit == 'true'
+  run: mc tag-release --from HEAD
+
+- name: publish packages
+  if: steps.release_record.outputs.is_release_commit == 'true'
+  run: mc publish
+```
+
+The generated GitHub workflow now refreshes the release PR on normal `main` pushes, then switches into post-merge tagging and package publication when `HEAD` is already the merged monochange release commit.
+
+The bundled `@monochange/cli` documentation now describes this post-merge tagging flow as part of the recommended release PR workflow.

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -76,7 +76,7 @@ name = "open release PR"
 
 The GitHub Actions workflows enable:
 
-- **Release automation** — `release.yml` builds binaries and creates GitHub releases from tags
+- **Release automation** — `release.yml` refreshes the release PR on normal `main` pushes, then tags and publishes when the merged release commit lands on `main`
 - **Changeset policy enforcement** — `changeset-policy.yml` validates PRs have required changeset coverage
 
 For GitLab and Gitea, the `[source]` section is configured but workflows are not generated (use their respective CI configuration files).

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -55,6 +55,7 @@ Use it when your repository has outgrown one-ecosystem release tooling and you w
 - emit stable release-manifest JSON for downstream automation
 - preview or publish provider releases and release requests from typed command steps and shared release data
 - inspect durable release records from tags or descendant commits with `mc release-record`
+- create post-merge release tags from a merged release commit with `mc tag-release --from HEAD`
 - repair a recent source/provider release by retargeting its release tags with `mc repair-release`
 - inspect changeset context and review metadata with `mc diagnostics` for both human and automation workflows
 - apply Rust semver evidence when provided
@@ -78,6 +79,7 @@ Use it when your repository has outgrown one-ecosystem release tooling and you w
 | Publish packages to registries   | `mc publish`                                                | You want `cargo publish`, `npm publish`, `deno publish`, or `dart pub publish` style package publication |
 | Bootstrap missing packages       | `mc placeholder-publish`                                    | A package must exist in its registry before later automation can work                                    |
 | Inspect a past release commit    | `mc release-record --from <ref>`                            | You need the durable release declaration from git history                                                |
+| Create post-merge release tags   | `mc tag-release --from HEAD`                                | You merged a monochange release commit and now need to create and push its declared tag set              |
 | Repair a recent release          | `mc repair-release --from <tag> --target <commit>`          | You need to retarget a just-created release to a later commit                                            |
 | Publish hosted/provider releases | `mc publish-release`                                        | You want GitHub/GitLab/Gitea release objects from prepared release state                                 |
 
@@ -85,20 +87,20 @@ Use it when your repository has outgrown one-ecosystem release tooling and you w
 
 <!-- {@projectCapabilityMatrix} -->
 
-| Capability                                                               | Current status                                                             |
-| ------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
-| Multi-ecosystem discovery                                                | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter                                   |
-| Package release planning                                                 | Built in                                                                   |
-| Grouped/shared versioning                                                | Built in                                                                   |
-| Dry-run release diff previews                                            | Built in via `mc release --dry-run --diff`                                 |
-| Durable release history                                                  | Built in via `ReleaseRecord`, `mc release-record`, and `mc repair-release` |
-| Hosted provider releases                                                 | GitHub, GitLab, Gitea                                                      |
-| Hosted release requests                                                  | GitHub, GitLab, Gitea                                                      |
-| Built-in registry publishing                                             | `crates.io`, `npm`, `jsr`, `pub.dev`                                       |
-| GitHub npm trusted-publishing automation                                 | Built in                                                                   |
-| GitHub trusted-publishing guidance for `crates.io`, `jsr`, and `pub.dev` | Built in, but manual registry enrollment is still required                 |
-| GitLab trusted-publishing auto-derivation                                | Not built in today                                                         |
-| Release-retarget sync for hosted releases                                | GitHub first                                                               |
+| Capability                                                               | Current status                                                                               |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| Multi-ecosystem discovery                                                | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter                                                     |
+| Package release planning                                                 | Built in                                                                                     |
+| Grouped/shared versioning                                                | Built in                                                                                     |
+| Dry-run release diff previews                                            | Built in via `mc release --dry-run --diff`                                                   |
+| Durable release history and post-merge tagging                           | Built in via `ReleaseRecord`, `mc release-record`, `mc tag-release`, and `mc repair-release` |
+| Hosted provider releases                                                 | GitHub, GitLab, Gitea                                                                        |
+| Hosted release requests                                                  | GitHub, GitLab, Gitea                                                                        |
+| Built-in registry publishing                                             | `crates.io`, `npm`, `jsr`, `pub.dev`                                                         |
+| GitHub npm trusted-publishing automation                                 | Built in                                                                                     |
+| GitHub trusted-publishing guidance for `crates.io`, `jsr`, and `pub.dev` | Built in, but manual registry enrollment is still required                                   |
+| GitLab trusted-publishing auto-derivation                                | Not built in today                                                                           |
+| Release-retarget sync for hosted releases                                | GitHub first                                                                                 |
 
 <!-- {/projectCapabilityMatrix} -->
 
@@ -110,6 +112,7 @@ monochange can promote one prepared release into several source-provider automat
 - `mc publish-release --dry-run --format json` previews provider release payloads before publishing
 - `mc release-pr --dry-run --format json` previews the release branch, commit, and release-request body
 - `mc release-record --from <tag>` inspects the durable release declaration stored in the release commit body
+- `mc tag-release --from HEAD --dry-run --format json` previews the post-merge release tag set declared by that durable record
 - `mc repair-release --from <tag> --dry-run` previews a release-retarget plan before mutating tags
 - changelog templates can render linked change owners, review requests, commits, and closed issues through `{{ context }}` or fine-grained metadata variables
 - `mc affected --format json --changed-paths ...` evaluates pull-request changeset policy from CI-supplied paths and labels
@@ -130,6 +133,7 @@ mc release --dry-run --format json
 mc publish-release --dry-run --format json
 mc release-pr --dry-run --format json
 mc release-record --from v1.2.3
+mc tag-release --from HEAD --dry-run --format json
 mc repair-release --from v1.2.3 --target HEAD --dry-run
 mc release
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ mc release --dry-run --format json
 mc publish-release --dry-run --format json
 mc release-pr --dry-run --format json
 mc release-record --from v1.2.3
+mc tag-release --from HEAD --dry-run --format json
 mc repair-release --from v1.2.3 --target HEAD --dry-run
 mc release
 ```

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -131,6 +131,7 @@ fn cli_help_returns_success_output() {
 	assert!(output.contains("publish"));
 	assert!(output.contains("repair-release"));
 	assert!(output.contains("release-record"));
+	assert!(output.contains("tag-release"));
 }
 
 #[test]
@@ -194,6 +195,27 @@ fn release_record_help_describes_first_parent_discovery() {
 	assert!(
 		output.contains("Walks first-parent ancestry until it finds a monochange release record")
 	);
+}
+
+#[test]
+fn tag_release_help_describes_post_merge_tagging_workflow() {
+	let output = run_with_args(
+		"mc",
+		[
+			OsString::from("mc"),
+			OsString::from("tag-release"),
+			OsString::from("--help"),
+		],
+	)
+	.unwrap_or_else(|error| panic!("tag-release help: {error}"));
+
+	assert!(
+		output.contains(
+			"Create and push release tags from the monochange release record on a commit"
+		)
+	);
+	assert!(output.contains("mc tag-release --from HEAD --dry-run --format json"));
+	assert!(output.contains("reruns on the same commit as already up to date"));
 }
 
 #[test]
@@ -8174,6 +8196,10 @@ fn cli_command_after_help_covers_supported_commands_and_custom_commands() {
 		("affected", "Group-owned changesets cover all members"),
 		("diagnostics", "linked review request"),
 		("repair-release", "Defaults to descendant-only retargets"),
+		(
+			"tag-release",
+			"Treats reruns on the same commit as already up to date",
+		),
 	];
 	for (name, expected) in cases {
 		let after_help = crate::cli_command_after_help(&monochange_core::CliCommandDefinition {
@@ -9661,8 +9687,16 @@ fn init_with_github_provider_creates_workflow_files() {
 	let release = fs::read_to_string(tempdir.path().join(".github/workflows/release.yml"))
 		.unwrap_or_else(|error| panic!("release.yml: {error}"));
 	assert!(
-		release.contains("mc commit-release"),
-		"expected mc commit-release command"
+		release.contains("mc release-pr"),
+		"expected mc release-pr command"
+	);
+	assert!(
+		release.contains("mc tag-release --from HEAD"),
+		"expected mc tag-release command"
+	);
+	assert!(
+		release.contains("mc publish"),
+		"expected mc publish command"
 	);
 	assert!(
 		release.contains("github-actions[bot]"),

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -7545,7 +7545,17 @@ fn write_blank_monochange_config(root: &Path) {
 }
 
 fn create_release_record_history(root: &Path) {
+	create_release_record_commit(root);
+	git_in_temp_repo(root, &["tag", "v1.2.3"]);
+	fs::write(root.join("release.txt"), "follow-up\n")
+		.unwrap_or_else(|error| panic!("write follow-up file: {error}"));
+	git_in_temp_repo(root, &["add", "release.txt"]);
+	git_in_temp_repo(root, &["commit", "-m", "fix: follow-up release change"]);
+}
+
+fn create_release_record_commit(root: &Path) -> String {
 	init_git_repo(root);
+	write_blank_monochange_config(root);
 	fs::write(root.join("release.txt"), "release\n")
 		.unwrap_or_else(|error| panic!("write release file: {error}"));
 	git_in_temp_repo(root, &["add", "monochange.toml", "release.txt"]);
@@ -7562,11 +7572,7 @@ fn create_release_record_history(root: &Path) {
 			release_record.as_str(),
 		],
 	);
-	git_in_temp_repo(root, &["tag", "v1.2.3"]);
-	fs::write(root.join("release.txt"), "follow-up\n")
-		.unwrap_or_else(|error| panic!("write follow-up file: {error}"));
-	git_in_temp_repo(root, &["add", "release.txt"]);
-	git_in_temp_repo(root, &["commit", "-m", "fix: follow-up release change"]);
+	git_output_in_temp_repo(root, &["rev-parse", "HEAD"])
 }
 
 fn sample_release_record_for_retarget() -> monochange_core::ReleaseRecord {
@@ -8374,6 +8380,70 @@ fn render_release_record_discovery_supports_text_and_json_formats() {
 }
 
 #[test]
+fn render_release_tag_report_supports_text_and_json_formats() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	let release_commit = create_release_record_commit(root);
+
+	let text = crate::release_record::render_release_tag_report(
+		root,
+		"HEAD",
+		crate::OutputFormat::Text,
+		false,
+		true,
+	)
+	.unwrap_or_else(|error| panic!("tag-release text: {error}"));
+	assert!(text.contains("release tags:"));
+	assert!(text.contains("push: no"));
+	assert!(text.contains("status: dry-run"));
+	assert!(text.contains("[planned]"));
+
+	let json = crate::release_record::render_release_tag_report(
+		root,
+		"HEAD",
+		crate::OutputFormat::Json,
+		false,
+		true,
+	)
+	.unwrap_or_else(|error| panic!("tag-release json: {error}"));
+	assert!(json.contains("\"recordCommit\": "));
+	assert!(json.contains("\"push\": false"));
+	assert!(json.contains("\"status\": \"dry_run\""));
+	assert!(json.contains(&release_commit[..7]));
+}
+
+#[test]
+fn create_release_tags_creates_and_pushes_tags_in_process() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	let release_commit = create_release_record_commit(root);
+	configure_origin_remote(root);
+	git_in_temp_repo(root, &["push", "-u", "origin", "HEAD:main"]);
+	let discovery = crate::discover_release_record(root, "HEAD")
+		.unwrap_or_else(|error| panic!("discover release record: {error}"));
+
+	let report = crate::release_record::create_release_tags(root, &discovery, true, false)
+		.unwrap_or_else(|error| panic!("create release tags: {error}"));
+	assert_eq!(report.status, "completed");
+	assert_eq!(report.tag_results.len(), 1);
+	assert_eq!(
+		report.tag_results[0].operation,
+		crate::release_record::ReleaseTagOperation::Created
+	);
+	assert_eq!(
+		git_output_in_temp_repo(root, &["rev-parse", "refs/tags/v1.2.3^{commit}"]),
+		release_commit
+	);
+	assert_eq!(
+		git_output_in_temp_repo(root, &["ls-remote", "--tags", "origin", "v1.2.3"])
+			.split_whitespace()
+			.next()
+			.unwrap_or_else(|| panic!("expected remote tag sha")),
+		release_commit
+	);
+}
+
+#[test]
 fn render_tag_name_and_provider_urls_follow_provider_conventions() {
 	let github = sample_github_source_configuration("https://api.github.com");
 	assert_eq!(
@@ -9013,6 +9083,15 @@ fn init_git_repo(root: &Path) {
 	git_in_temp_repo(root, &["config", "user.name", "monochange Tests"]);
 	git_in_temp_repo(root, &["config", "user.email", "monochange@example.com"]);
 	git_in_temp_repo(root, &["config", "commit.gpgsign", "false"]);
+}
+
+fn configure_origin_remote(root: &Path) {
+	let remote_root = root.join("origin.git");
+	git_in_temp_repo(root, &["init", "--bare", &remote_root.to_string_lossy()]);
+	git_in_temp_repo(
+		root,
+		&["remote", "add", "origin", &remote_root.to_string_lossy()],
+	);
 }
 
 fn sanitized_git_command() -> std::process::Command {

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -192,6 +192,7 @@ When provided, the generated config includes:\n\
 			))
 			.subcommand(build_assist_subcommand())
 			.subcommand(build_release_record_subcommand())
+			.subcommand(build_tag_release_subcommand())
 			.subcommand(Command::new("mcp").about(
 				"Start the monochange MCP (Model Context Protocol) server over stdin/stdout",
 			))
@@ -241,6 +242,53 @@ Inspection notes:
 				.required(true)
 				.value_name("REF")
 				.help("Tag or commit-ish used to locate the release record"),
+		)
+		.arg(
+			Arg::new("format")
+				.long("format")
+				.help("Output format")
+				.default_value("text")
+				.value_parser(["text", "json"]),
+		)
+}
+
+pub(crate) fn build_tag_release_subcommand() -> Command {
+	Command::new("tag-release")
+		.about("Create and push release tags from the monochange release record on a commit")
+		.after_help(
+			r"Examples:
+  mc tag-release --from HEAD
+  mc tag-release --from HEAD --dry-run --format json
+  mc tag-release --from HEAD --push=false
+
+Tagging notes:
+  - Resolves the supplied ref to a commit and requires that commit itself to be the release commit.
+  - Creates the full tag set declared by the embedded monochange release record.
+  - Pushes tags to `origin` by default and treats reruns on the same commit as already up to date.",
+		)
+		.arg(
+			Arg::new("from")
+				.long("from")
+				.required(true)
+				.value_name("REF")
+				.help("Release commit ref used to create the declared tag set"),
+		)
+		.arg(
+			Arg::new("dry-run")
+				.long("dry-run")
+				.help("Preview release tag creation without mutating local or remote refs")
+				.action(ArgAction::SetTrue),
+		)
+		.arg(
+			Arg::new("push")
+				.long("push")
+				.help("Push created tags to origin")
+				.value_name("PUSH")
+				.num_args(0..=1)
+				.default_value("true")
+				.default_missing_value("true")
+				.require_equals(true)
+				.value_parser(["true", "false"]),
 		)
 		.arg(
 			Arg::new("format")
@@ -414,6 +462,20 @@ Repair notes:
   - Moves the full release tag set together.
   - Defaults to descendant-only retargets unless --force is set.
   - Hosted release sync runs by default and can be disabled with --sync-provider=false.",
+			)
+		}
+		"tag-release" => {
+			Some(
+				r"Examples:
+  mc tag-release --from HEAD
+  mc tag-release --from HEAD --dry-run --format json
+  mc tag-release --from HEAD --push=false
+
+Tagging notes:
+  - Requires the resolved ref itself to be the monochange release commit.
+  - Creates the full tag set declared by that release record.
+  - Treats reruns on the same commit as already up to date.
+  - Use `mc repair-release` if you need to move existing tags later.",
 			)
 		}
 		_ => None,

--- a/crates/monochange/src/git_support.rs
+++ b/crates/monochange/src/git_support.rs
@@ -42,6 +42,18 @@ pub(crate) fn git_is_ancestor(
 	}
 }
 
+pub(crate) fn create_git_tag(
+	root: &Path,
+	tag_name: &str,
+	target_commit: &str,
+) -> MonochangeResult<()> {
+	run_git_status(
+		root,
+		&["tag", tag_name, target_commit],
+		&format!("failed to create tag `{tag_name}`"),
+	)
+}
+
 pub(crate) fn move_git_tag(
 	root: &Path,
 	tag_name: &str,
@@ -56,7 +68,25 @@ pub(crate) fn move_git_tag(
 
 #[must_use = "the push result must be checked"]
 pub(crate) fn push_git_tags(root: &Path, tags: &[&str]) -> MonochangeResult<()> {
-	let mut args = vec!["push", "--force", "origin"];
+	push_git_tags_with_options(root, tags, true, "failed to push retargeted release tags")
+}
+
+#[must_use = "the push result must be checked"]
+pub(crate) fn push_git_tags_without_force(root: &Path, tags: &[&str]) -> MonochangeResult<()> {
+	push_git_tags_with_options(root, tags, false, "failed to push release tags")
+}
+
+fn push_git_tags_with_options(
+	root: &Path,
+	tags: &[&str],
+	force: bool,
+	error_message: &str,
+) -> MonochangeResult<()> {
+	let mut args = vec!["push"];
+	if force {
+		args.push("--force");
+	}
+	args.push("origin");
 
 	let tag_refs: Vec<String> = tags
 		.iter()
@@ -67,7 +97,7 @@ pub(crate) fn push_git_tags(root: &Path, tags: &[&str]) -> MonochangeResult<()> 
 		args.push(tag_ref.as_str());
 	}
 
-	run_git_status(root, &args, "failed to push retargeted release tags")
+	run_git_status(root, &args, error_message)
 }
 
 #[must_use = "the ref resolution result must be checked"]

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -220,6 +220,7 @@ pub use release_record::discover_release_record;
 pub use release_record::execute_release_retarget;
 pub use release_record::plan_release_retarget;
 use release_record::render_release_record_discovery;
+use release_record::render_release_tag_report;
 pub use release_record::retarget_release;
 use serde::Deserialize;
 use serde::Serialize;
@@ -712,6 +713,25 @@ where
 				OutputFormat::Text
 			};
 			render_release_record_discovery(root, from, format)
+		}
+		Some(("tag-release", tag_release_matches)) => {
+			let from = tag_release_matches
+				.get_one::<String>("from")
+				.map(String::as_str)
+				.ok_or_else(|| MonochangeError::Config("missing tag-release ref".to_string()))?;
+			let format = if tag_release_matches
+				.get_one::<String>("format")
+				.is_some_and(|value| value == "json")
+			{
+				OutputFormat::Json
+			} else {
+				OutputFormat::Text
+			};
+			let push = tag_release_matches
+				.get_one::<String>("push")
+				.is_none_or(|value| value == "true");
+			let dry_run = quiet || tag_release_matches.get_flag("dry-run");
+			render_release_tag_report(root, from, format, push, dry_run)
 		}
 		Some(("check", check_matches)) => {
 			if quiet {

--- a/crates/monochange/src/release_record.rs
+++ b/crates/monochange/src/release_record.rs
@@ -14,12 +14,15 @@ use monochange_core::SourceProvider;
 use monochange_core::parse_release_record_block;
 use monochange_core::release_record_release_tag_names;
 use monochange_core::release_record_tag_names;
+use serde::Serialize;
 
 use crate::OutputFormat;
+use crate::git_support::create_git_tag;
 use crate::git_support::first_parent_commits;
 use crate::git_support::git_is_ancestor;
 use crate::git_support::move_git_tag;
 use crate::git_support::push_git_tags;
+use crate::git_support::push_git_tags_without_force;
 use crate::git_support::read_git_commit_message;
 use crate::git_support::resolve_git_commit_ref;
 use crate::git_support::resolve_git_tag_commit;
@@ -306,6 +309,200 @@ pub(crate) fn sync_retargeted_provider_releases(
 		tag_results,
 		dry_run,
 	)
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ReleaseTagOperation {
+	Planned,
+	Created,
+	AlreadyUpToDate,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ReleaseTagResult {
+	pub tag_name: String,
+	pub target_commit: String,
+	#[serde(default)]
+	pub existing_commit: Option<String>,
+	pub operation: ReleaseTagOperation,
+}
+
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ReleaseTagReport {
+	pub from: String,
+	pub resolved_from_commit: String,
+	pub record_commit: String,
+	pub distance: usize,
+	pub push: bool,
+	pub dry_run: bool,
+	pub tag_results: Vec<ReleaseTagResult>,
+	pub status: String,
+}
+
+pub(crate) fn render_release_tag_report(
+	root: &Path,
+	from: &str,
+	format: OutputFormat,
+	push: bool,
+	dry_run: bool,
+) -> MonochangeResult<String> {
+	let discovery = discover_release_record(root, from)?;
+	let report = create_release_tags(root, &discovery, push, dry_run)?;
+
+	match format {
+		OutputFormat::Json => {
+			serde_json::to_string_pretty(&report)
+				.map_err(|error| MonochangeError::Discovery(error.to_string()))
+		}
+		OutputFormat::Markdown | OutputFormat::Text => Ok(text_release_tag_report(&report)),
+	}
+}
+
+pub(crate) fn create_release_tags(
+	root: &Path,
+	discovery: &ReleaseRecordDiscovery,
+	push: bool,
+	dry_run: bool,
+) -> MonochangeResult<ReleaseTagReport> {
+	if discovery.distance != 0 {
+		return Err(MonochangeError::Config(format!(
+			"resolved ref `{}` points to commit {}, but the nearest monochange release record is in ancestor commit {} at distance {}; `tag-release` only tags a commit that is itself the release commit",
+			discovery.input_ref,
+			crate::short_commit_sha(&discovery.resolved_commit),
+			crate::short_commit_sha(&discovery.record_commit),
+			discovery.distance,
+		)));
+	}
+
+	let tag_results = release_record_tag_names(&discovery.record)
+		.into_iter()
+		.map(|tag_name| {
+			let existing_commit = resolve_git_tag_commit(root, &tag_name).ok();
+			let operation = if existing_commit.as_deref() == Some(discovery.record_commit.as_str())
+			{
+				ReleaseTagOperation::AlreadyUpToDate
+			} else {
+				ReleaseTagOperation::Planned
+			};
+
+			Ok(ReleaseTagResult {
+				tag_name,
+				target_commit: discovery.record_commit.clone(),
+				existing_commit,
+				operation,
+			})
+		})
+		.collect::<MonochangeResult<Vec<_>>>()?;
+
+	for tag_result in &tag_results {
+		if let Some(existing_commit) = &tag_result.existing_commit
+			&& existing_commit != &tag_result.target_commit
+		{
+			return Err(MonochangeError::Config(format!(
+				"tag `{}` already points to commit {}; use `mc repair-release` if you need to move an existing release tag",
+				tag_result.tag_name,
+				crate::short_commit_sha(existing_commit),
+			)));
+		}
+	}
+
+	let mut tag_results = tag_results;
+
+	if !dry_run {
+		for tag_result in &mut tag_results {
+			if tag_result.operation == ReleaseTagOperation::AlreadyUpToDate {
+				continue;
+			}
+
+			create_git_tag(root, &tag_result.tag_name, &tag_result.target_commit)?;
+			tag_result.operation = ReleaseTagOperation::Created;
+		}
+
+		if push {
+			let tags_to_push = tag_results
+				.iter()
+				.filter(|tag_result| tag_result.operation == ReleaseTagOperation::Created)
+				.map(|tag_result| tag_result.tag_name.as_str())
+				.collect::<Vec<_>>();
+
+			if !tags_to_push.is_empty() {
+				push_git_tags_without_force(root, &tags_to_push)?;
+			}
+		}
+	}
+
+	let status = if dry_run {
+		"dry_run"
+	} else if tag_results.is_empty() {
+		"no_tags_declared"
+	} else if tag_results
+		.iter()
+		.all(|tag_result| tag_result.operation == ReleaseTagOperation::AlreadyUpToDate)
+	{
+		"already_up_to_date"
+	} else {
+		"completed"
+	};
+
+	Ok(ReleaseTagReport {
+		from: discovery.input_ref.clone(),
+		resolved_from_commit: discovery.resolved_commit.clone(),
+		record_commit: discovery.record_commit.clone(),
+		distance: discovery.distance,
+		push,
+		dry_run,
+		tag_results,
+		status: status.to_string(),
+	})
+}
+
+pub(crate) fn text_release_tag_report(report: &ReleaseTagReport) -> String {
+	let mut lines = vec!["release tags:".to_string()];
+	lines.push(format!("  from: {}", report.from));
+	lines.push(format!(
+		"  resolved commit: {}",
+		crate::short_commit_sha(&report.resolved_from_commit)
+	));
+	lines.push(format!(
+		"  record commit: {}",
+		crate::short_commit_sha(&report.record_commit)
+	));
+	lines.push(format!(
+		"  push: {}",
+		if report.push { "yes" } else { "no" }
+	));
+
+	if report.tag_results.is_empty() {
+		lines.push("  tags: none declared by release record".to_string());
+	} else {
+		lines.push("  tags:".to_string());
+		for tag_result in &report.tag_results {
+			let existing = tag_result
+				.existing_commit
+				.as_ref()
+				.map_or("missing".to_string(), |commit| {
+					crate::short_commit_sha(commit)
+				});
+			lines.push(format!(
+				"    - {} (existing: {}, target: {}) [{}]",
+				tag_result.tag_name,
+				existing,
+				crate::short_commit_sha(&tag_result.target_commit),
+				match tag_result.operation {
+					ReleaseTagOperation::Planned => "planned",
+					ReleaseTagOperation::Created => "created",
+					ReleaseTagOperation::AlreadyUpToDate => "already_up_to_date",
+				},
+			));
+		}
+	}
+
+	lines.push(format!("  status: {}", report.status.replace('_', "-")));
+	lines.join("\n")
 }
 
 pub(crate) fn text_release_record_discovery(discovery: &ReleaseRecordDiscovery) -> String {

--- a/crates/monochange/src/templates/release.yml
+++ b/crates/monochange/src/templates/release.yml
@@ -12,10 +12,11 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release:
-    timeout-minutes: 15
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -39,7 +40,31 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: prepare and open release PR
+      - name: refresh tags from origin
+        run: git fetch --force --tags origin
+
+      - name: detect merged release commit
+        id: release_record
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then
+            echo "is_release_commit=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_release_commit=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: refresh release PR
+        if: steps.release_record.outputs.is_release_commit != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mc commit-release
+        run: mc release-pr
+
+      - name: create release tags
+        if: steps.release_record.outputs.is_release_commit == 'true'
+        run: mc tag-release --from HEAD
+
+      - name: publish packages
+        if: steps.release_record.outputs.is_release_commit == 'true'
+        run: mc publish

--- a/crates/monochange/tests/release_record.rs
+++ b/crates/monochange/tests/release_record.rs
@@ -175,6 +175,93 @@ fn release_record_command_reports_unsupported_schema_version() {
 	);
 }
 
+#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+fn tag_release_command_creates_and_pushes_declared_tags() {
+	let mut settings = snapshot_settings();
+	settings.set_snapshot_suffix(current_test_name());
+	let _guard = settings.bind_to_scope();
+
+	let tempdir = setup_release_repo();
+	let repo = tempdir.path();
+	configure_origin_remote(repo);
+	let release_record = sample_release_record();
+	let (commit, _) = commit_release_record(repo, &release_record);
+	git(repo, &["push", "-u", "origin", "HEAD:main"]);
+
+	let output = tag_release_output(repo, &["--from", "HEAD", "--format", "json"]);
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	let parsed: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+		panic!("json: {error}\n{}", String::from_utf8_lossy(&output.stdout))
+	});
+	assert_json_snapshot!(parsed);
+	assert_eq!(
+		git_output_trimmed(repo, &["rev-parse", "refs/tags/v1.2.3^{commit}"]),
+		commit
+	);
+	assert_eq!(
+		git_output_trimmed(repo, &["ls-remote", "--tags", "origin", "v1.2.3"])
+			.split_whitespace()
+			.next()
+			.unwrap_or_else(|| panic!("expected remote tag sha")),
+		commit
+	);
+}
+
+#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+fn tag_release_command_is_idempotent_when_tags_already_exist() {
+	let mut settings = snapshot_settings();
+	settings.set_snapshot_suffix(current_test_name());
+	let _guard = settings.bind_to_scope();
+
+	let tempdir = setup_release_repo();
+	let repo = tempdir.path();
+	configure_origin_remote(repo);
+	let release_record = sample_release_record();
+	commit_release_record(repo, &release_record);
+	git(repo, &["push", "-u", "origin", "HEAD:main"]);
+
+	let first = tag_release_output(repo, &["--from", "HEAD"]);
+	assert!(
+		first.status.success(),
+		"{}",
+		String::from_utf8_lossy(&first.stderr)
+	);
+
+	let second = tag_release_output(repo, &["--from", "HEAD"]);
+	assert!(
+		second.status.success(),
+		"{}",
+		String::from_utf8_lossy(&second.stderr)
+	);
+	assert_snapshot!(
+		String::from_utf8(second.stdout).unwrap_or_else(|error| panic!("stdout utf8: {error}"))
+	);
+}
+
+#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+fn tag_release_command_rejects_descendant_refs_that_are_not_release_commits() {
+	let mut settings = snapshot_settings();
+	settings.set_snapshot_suffix(current_test_name());
+	let _guard = settings.bind_to_scope();
+
+	let tempdir = setup_release_repo();
+	let repo = tempdir.path();
+	configure_origin_remote(repo);
+	let release_record = sample_release_record();
+	commit_release_record(repo, &release_record);
+	commit_plain(repo, "fix: follow-up", "release-record/follow-up");
+
+	let output = tag_release_output(repo, &["--from", "HEAD"]);
+	assert!(!output.status.success());
+	assert_snapshot!(
+		String::from_utf8(output.stderr).unwrap_or_else(|error| panic!("stderr utf8: {error}"))
+	);
+}
+
 fn setup_release_repo() -> TempDir {
 	let tempdir = setup_fixture("release-record/base-repo");
 	let repo = tempdir.path();
@@ -194,6 +281,32 @@ fn release_record_output(root: &Path, args: &[&str]) -> std::process::Output {
 		.args(args)
 		.output()
 		.unwrap_or_else(|error| panic!("release-record output: {error}"))
+}
+
+fn tag_release_output(root: &Path, args: &[&str]) -> std::process::Output {
+	monochange_command(None)
+		.current_dir(root)
+		.arg("tag-release")
+		.args(args)
+		.output()
+		.unwrap_or_else(|error| panic!("tag-release output: {error}"))
+}
+
+fn configure_origin_remote(root: &Path) {
+	let remote_root = root.join("origin.git");
+	git(
+		root,
+		&["init", "--bare", remote_root.to_string_lossy().as_ref()],
+	);
+	git(
+		root,
+		&[
+			"remote",
+			"add",
+			"origin",
+			remote_root.to_string_lossy().as_ref(),
+		],
+	);
 }
 
 fn sample_release_record() -> ReleaseRecord {

--- a/crates/monochange/tests/release_record.rs
+++ b/crates/monochange/tests/release_record.rs
@@ -262,6 +262,88 @@ fn tag_release_command_rejects_descendant_refs_that_are_not_release_commits() {
 	);
 }
 
+#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+fn tag_release_command_dry_run_reports_planned_tags_without_creating_them() {
+	let mut settings = snapshot_settings();
+	settings.set_snapshot_suffix(current_test_name());
+	let _guard = settings.bind_to_scope();
+
+	let tempdir = setup_release_repo();
+	let repo = tempdir.path();
+	configure_origin_remote(repo);
+	let release_record = sample_release_record();
+	commit_release_record(repo, &release_record);
+	git(repo, &["push", "-u", "origin", "HEAD:main"]);
+
+	let output = tag_release_output(repo, &["--from", "HEAD", "--dry-run", "--push=false"]);
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	assert_snapshot!(
+		String::from_utf8(output.stdout).unwrap_or_else(|error| panic!("stdout utf8: {error}"))
+	);
+	assert!(
+		git_command(repo, &["rev-parse", "refs/tags/v1.2.3^{commit}"]).is_none(),
+		"expected dry run to avoid creating a local tag"
+	);
+	assert!(
+		git_command(repo, &["ls-remote", "--tags", "origin", "v1.2.3"]).is_none(),
+		"expected dry run to avoid pushing a remote tag"
+	);
+}
+
+#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+fn tag_release_command_reports_when_no_tags_are_declared() {
+	let mut settings = snapshot_settings();
+	settings.set_snapshot_suffix(current_test_name());
+	let _guard = settings.bind_to_scope();
+
+	let tempdir = setup_release_repo();
+	let repo = tempdir.path();
+	configure_origin_remote(repo);
+	let mut release_record = sample_release_record();
+	release_record.release_targets[0].tag = false;
+	let (commit, _) = commit_release_record(repo, &release_record);
+	git(repo, &["push", "-u", "origin", "HEAD:main"]);
+
+	let output = tag_release_output(repo, &["--from", "HEAD", "--push=false"]);
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	assert_snapshot!(
+		String::from_utf8(output.stdout).unwrap_or_else(|error| panic!("stdout utf8: {error}"))
+	);
+	assert_eq!(git_output_trimmed(repo, &["rev-parse", "HEAD"]), commit);
+	assert!(
+		git_command(repo, &["ls-remote", "--tags", "origin", "v1.2.3"]).is_none(),
+		"expected no declared tags to skip remote pushes"
+	);
+}
+
+#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+fn tag_release_command_rejects_existing_tags_that_point_elsewhere() {
+	let mut settings = snapshot_settings();
+	settings.set_snapshot_suffix(current_test_name());
+	let _guard = settings.bind_to_scope();
+
+	let tempdir = setup_release_repo();
+	let repo = tempdir.path();
+	let initial_commit = git_output_trimmed(repo, &["rev-parse", "HEAD"]);
+	let release_record = sample_release_record();
+	commit_release_record(repo, &release_record);
+	git(repo, &["tag", "v1.2.3", &initial_commit]);
+
+	let output = tag_release_output(repo, &["--from", "HEAD"]);
+	assert!(!output.status.success());
+	assert_snapshot!(
+		String::from_utf8(output.stderr).unwrap_or_else(|error| panic!("stderr utf8: {error}"))
+	);
+}
+
 fn setup_release_repo() -> TempDir {
 	let tempdir = setup_fixture("release-record/base-repo");
 	let repo = tempdir.path();
@@ -307,6 +389,27 @@ fn configure_origin_remote(root: &Path) {
 			remote_root.to_string_lossy().as_ref(),
 		],
 	);
+}
+
+fn git_command(root: &Path, args: &[&str]) -> Option<String> {
+	let output = std::process::Command::new("git")
+		.current_dir(root)
+		.args(args)
+		.output()
+		.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
+	if !output.status.success() {
+		return None;
+	}
+
+	let stdout = String::from_utf8(output.stdout)
+		.unwrap_or_else(|error| panic!("git stdout utf8: {error}"))
+		.trim()
+		.to_string();
+	if stdout.is_empty() {
+		None
+	} else {
+		Some(stdout)
+	}
 }
 
 fn sample_release_record() -> ReleaseRecord {

--- a/crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_prints_help.snap
+++ b/crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_prints_help.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/monochange/tests/cli_main_binary.rs
+assertion_line: 14
 info:
   program: monochange
   args:
@@ -19,6 +20,7 @@ Commands:
   populate             Add any missing built-in CLI commands to monochange.toml so you can customize them
   assist               Print assistant setup guidance, install steps, and MCP configuration
   release-record       Inspect the monochange release record associated with a tag or commit
+  tag-release          Create and push release tags from the monochange release record on a commit
   mcp                  Start the monochange MCP (Model Context Protocol) server over stdin/stdout
   check                Validate configuration, changesets, and run lint rules on package manifests
   validate             Validate monochange configuration and changesets

--- a/crates/monochange/tests/snapshots/release_record__tag_release_command_creates_and_pushes_declared_tags@tag_release_command_creates_and_pushes_declared_tags.snap
+++ b/crates/monochange/tests/snapshots/release_record__tag_release_command_creates_and_pushes_declared_tags@tag_release_command_creates_and_pushes_declared_tags.snap
@@ -1,0 +1,22 @@
+---
+source: crates/monochange/tests/release_record.rs
+assertion_line: 200
+expression: parsed
+---
+{
+  "distance": 0,
+  "dryRun": false,
+  "from": "HEAD",
+  "push": true,
+  "recordCommit": "[SHA]",
+  "resolvedFromCommit": "[SHA]",
+  "status": "completed",
+  "tagResults": [
+    {
+      "existingCommit": null,
+      "operation": "created",
+      "tagName": "v1.2.3",
+      "targetCommit": "[SHA]"
+    }
+  ]
+}

--- a/crates/monochange/tests/snapshots/release_record__tag_release_command_dry_run_reports_planned_tags_without_creating_them@tag_release_command_dry_run_reports_planned_tags_without_creating_them.snap
+++ b/crates/monochange/tests/snapshots/release_record__tag_release_command_dry_run_reports_planned_tags_without_creating_them@tag_release_command_dry_run_reports_planned_tags_without_creating_them.snap
@@ -1,0 +1,13 @@
+---
+source: crates/monochange/tests/release_record.rs
+assertion_line: 287
+expression: "String::from_utf8(output.stdout).unwrap_or_else(|error|\npanic!(\"stdout utf8: {error}\"))"
+---
+release tags:
+  from: HEAD
+  resolved commit: [SHA]
+  record commit: [SHA]
+  push: no
+  tags:
+    - v1.2.3 (existing: missing, target: [SHA]) [planned]
+  status: dry-run

--- a/crates/monochange/tests/snapshots/release_record__tag_release_command_is_idempotent_when_tags_already_exist@tag_release_command_is_idempotent_when_tags_already_exist.snap
+++ b/crates/monochange/tests/snapshots/release_record__tag_release_command_is_idempotent_when_tags_already_exist@tag_release_command_is_idempotent_when_tags_already_exist.snap
@@ -1,0 +1,13 @@
+---
+source: crates/monochange/tests/release_record.rs
+assertion_line: 236
+expression: "String::from_utf8(second.stdout).unwrap_or_else(|error|\npanic!(\"stdout utf8: {error}\"))"
+---
+release tags:
+  from: HEAD
+  resolved commit: [SHA]
+  record commit: [SHA]
+  push: yes
+  tags:
+    - v1.2.3 (existing: [SHA], target: [SHA]) [already_up_to_date]
+  status: already-up-to-date

--- a/crates/monochange/tests/snapshots/release_record__tag_release_command_rejects_descendant_refs_that_are_not_release_commits@tag_release_command_rejects_descendant_refs_that_are_not_release_commits.snap
+++ b/crates/monochange/tests/snapshots/release_record__tag_release_command_rejects_descendant_refs_that_are_not_release_commits@tag_release_command_rejects_descendant_refs_that_are_not_release_commits.snap
@@ -1,0 +1,6 @@
+---
+source: crates/monochange/tests/release_record.rs
+assertion_line: 256
+expression: "String::from_utf8(output.stderr).unwrap_or_else(|error|\npanic!(\"stderr utf8: {error}\"))"
+---
+config error: resolved ref `HEAD` points to commit [SHA], but the nearest monochange release record is in ancestor commit [SHA] at distance 1; `tag-release` only tags a commit that is itself the release commit

--- a/crates/monochange/tests/snapshots/release_record__tag_release_command_rejects_existing_tags_that_point_elsewhere@tag_release_command_rejects_existing_tags_that_point_elsewhere.snap
+++ b/crates/monochange/tests/snapshots/release_record__tag_release_command_rejects_existing_tags_that_point_elsewhere@tag_release_command_rejects_existing_tags_that_point_elsewhere.snap
@@ -1,0 +1,6 @@
+---
+source: crates/monochange/tests/release_record.rs
+assertion_line: 345
+expression: "String::from_utf8(output.stderr).unwrap_or_else(|error|\npanic!(\"stderr utf8: {error}\"))"
+---
+config error: tag `v1.2.3` already points to commit [SHA]; use `mc repair-release` if you need to move an existing release tag

--- a/crates/monochange/tests/snapshots/release_record__tag_release_command_reports_when_no_tags_are_declared@tag_release_command_reports_when_no_tags_are_declared.snap
+++ b/crates/monochange/tests/snapshots/release_record__tag_release_command_reports_when_no_tags_are_declared@tag_release_command_reports_when_no_tags_are_declared.snap
@@ -1,0 +1,12 @@
+---
+source: crates/monochange/tests/release_record.rs
+assertion_line: 320
+expression: "String::from_utf8(output.stdout).unwrap_or_else(|error|\npanic!(\"stdout utf8: {error}\"))"
+---
+release tags:
+  from: HEAD
+  resolved commit: [SHA]
+  record commit: [SHA]
+  push: no
+  tags: none declared by release record
+  status: no-tags-declared

--- a/docs/src/guide/01-installation.md
+++ b/docs/src/guide/01-installation.md
@@ -73,6 +73,7 @@ mc release --dry-run --format json
 mc publish-release --dry-run --format json
 mc release-pr --dry-run --format json
 mc release-record --from v1.2.3
+mc tag-release --from HEAD --dry-run --format json
 mc repair-release --from v1.2.3 --target HEAD --dry-run
 mc release
 ```

--- a/docs/src/guide/02-setup.md
+++ b/docs/src/guide/02-setup.md
@@ -86,7 +86,7 @@ name = "open release PR"
 
 The GitHub Actions workflows enable:
 
-- **Release automation** — `release.yml` builds binaries and creates GitHub releases from tags
+- **Release automation** — `release.yml` refreshes the release PR on normal `main` pushes, then tags and publishes when the merged release commit lands on `main`
 - **Changeset policy enforcement** — `changeset-policy.yml` validates PRs have required changeset coverage
 
 For GitLab and Gitea, the `[source]` section is configured but workflows are not generated (use their respective CI configuration files).

--- a/docs/src/guide/06-release-planning.md
+++ b/docs/src/guide/06-release-planning.md
@@ -330,12 +330,13 @@ Current planning rules:
 
 ### Diagnostics vs. release records
 
-These two commands answer different questions:
+These commands answer different questions:
 
 - `mc diagnostics --format json` — what is currently pending in `.changeset/*.md`, and who introduced it?
 - `mc release-record --from <ref>` — what did a past release commit declare durably in git history?
+- `mc tag-release --from HEAD` — if `HEAD` is the merged release commit, which release tags should be created now?
 
-Use diagnostics **before** you release. Use release records **after** a release exists and you need to inspect or repair it later.
+Use diagnostics **before** you release. Use release records **after** a release exists and you need to inspect it. Use `tag-release` in post-merge CI when the release commit has landed on the default branch and you want to create the declared tag set from that durable history record.
 
 Across release-oriented commands, global `--quiet` suppresses stdout/stderr and reuses dry-run behavior for commands that support it.
 

--- a/docs/src/guide/08-github-automation.md
+++ b/docs/src/guide/08-github-automation.md
@@ -55,10 +55,11 @@ mc affected --format json --changed-paths crates/monochange/src/lib.rs
 
 GitHub automation now has a repair-oriented history flow in addition to the existing manifest-driven execution flow.
 
-Use these commands when you need to inspect or repair a just-created release:
+Use these commands when you need to inspect, tag, or repair a just-created release:
 
 ```bash
 mc release-record --from v1.2.3
+mc tag-release --from HEAD --dry-run --format json
 mc repair-release --from v1.2.3 --target HEAD --dry-run
 mc repair-release --from v1.2.3 --target HEAD
 ```
@@ -67,6 +68,7 @@ The important distinction is:
 
 - the cached release manifest still describes the execution-time release plan for automation
 - `ReleaseRecord` describes the durable release declaration stored in the release commit body
+- `mc tag-release` consumes that durable record after merge and creates the declared tag set on the default branch
 
 Use `--dry-run` first for `repair-release`. It is a destructive workflow because it retargets release tags.
 
@@ -242,12 +244,13 @@ type = "AffectedPackages"
 
 ## Release and npm publish workflows
 
-monochange now includes a release workflow modeled after the latest `mdt` pattern:
+monochange now includes a release workflow modeled around long-running release PR refresh plus post-merge tagging:
 
-- `.github/workflows/release.yml` builds tagged release archives for the `monochange` binary across supported targets and uploads them to the GitHub release
-- `.github/workflows/npm-publish.yml` runs after a successful release workflow, downloads those exact release assets, repackages them into `@monochange/cli` platform packages plus the `@monochange/cli` root package, and publishes `@monochange/skill`
+- `.github/workflows/release.yml` refreshes the dedicated release PR branch on normal `main` pushes
+- the same workflow detects when `HEAD` is already a merged monochange release commit, runs `mc tag-release --from HEAD`, and then runs `mc publish`
+- tag-triggered or downstream workflows can then build archives, create hosted releases, or publish additional assets from the pushed tags
 
-That split keeps npm publication tied to the exact binaries shipped in the GitHub release instead of rebuilding them separately.
+That split keeps tag creation on the default branch side of the merge and lets downstream automation consume the exact durable release metadata that monochange stored in git history.
 
 For release repair, GitHub is also the first provider with hosted-release retarget sync support. monochange uses the durable release record plus tag names from that record to keep the hosted release view aligned with moved tags.
 

--- a/docs/src/guide/08-github-automation.md
+++ b/docs/src/guide/08-github-automation.md
@@ -248,7 +248,7 @@ monochange now includes a release workflow modeled around long-running release P
 
 - `.github/workflows/release.yml` refreshes the dedicated release PR branch on normal `main` pushes
 - the same workflow detects when `HEAD` is already a merged monochange release commit, runs `mc tag-release --from HEAD`, and then runs `mc publish`
-- tag-triggered or downstream workflows can then build archives, create hosted releases, or publish additional assets from the pushed tags
+- tag-triggered or downstream workflows can then build archives, create hosted releases, publish additional assets from the pushed tags, or run a separate `mc publish-release` job when you still want manifest-driven hosted-release publication
 
 That split keeps tag creation on the default branch side of the merge and lets downstream automation consume the exact durable release metadata that monochange stored in git history.
 

--- a/docs/src/guide/12-repairable-releases.md
+++ b/docs/src/guide/12-repairable-releases.md
@@ -2,6 +2,8 @@
 
 `mc repair-release` is for the stressful moment right after a release when you discover that a few follow-up commits still need to be part of that release.
 
+If you have **not created the tags yet** and only need the initial post-merge tag creation step, use `mc tag-release --from HEAD` instead. `repair-release` is the follow-up tool for moving an already-created release tag set.
+
 Examples:
 
 - a packaging file was missing from the release branch
@@ -31,7 +33,7 @@ If you prefer the emphasized version:
 
 The important consequence is that `ReleaseRecord` does **not** replace the cached release manifest.
 
-Use the manifest when you want execution-time automation. Use the release record when you want history-time inspection or repair.
+Use the manifest when you want execution-time automation. Use the release record when you want history-time inspection, post-merge tagging, or repair.
 
 ## Where the release record lives
 
@@ -51,6 +53,7 @@ Use `mc release-record` when you want to inspect the durable release declaration
 ```bash
 mc release-record --from v1.2.3
 mc release-record --from HEAD --format json
+mc tag-release --from HEAD --dry-run --format json
 ```
 
 monochange will:
@@ -138,6 +141,8 @@ It does **not**:
 ## When to use this vs publish a new patch release
 
 Use `repair-release` for **just-created source/provider releases** when the right fix is to move the release tags forward to a later commit.
+
+Use `tag-release` when the release commit has merged but the declared tags have not been created yet.
 
 Prefer publishing a new patch release when:
 

--- a/docs/src/guide/13-ci-and-publishing.md
+++ b/docs/src/guide/13-ci-and-publishing.md
@@ -2,7 +2,7 @@
 
 This guide brings together the practical CI patterns around `mc publish`, `mc placeholder-publish`, `mc release-pr`, `mc commit-release`, and provider release automation.
 
-It also captures an important proposed workflow for long-running release PR branches.
+It also documents the recommended workflow for long-running release PR branches.
 
 ## Start with the command surface
 
@@ -22,6 +22,7 @@ These commands solve different automation problems:
 | Publish packages to registries   | `mc publish`                                                | You want `cargo publish`, `npm publish`, `deno publish`, or `dart pub publish` style package publication |
 | Bootstrap missing packages       | `mc placeholder-publish`                                    | A package must exist in its registry before later automation can work                                    |
 | Inspect a past release commit    | `mc release-record --from <ref>`                            | You need the durable release declaration from git history                                                |
+| Create post-merge release tags   | `mc tag-release --from HEAD`                                | You merged a monochange release commit and now need to create and push its declared tag set              |
 | Repair a recent release          | `mc repair-release --from <tag> --target <commit>`          | You need to retarget a just-created release to a later commit                                            |
 | Publish hosted/provider releases | `mc publish-release`                                        | You want GitHub/GitLab/Gitea release objects from prepared release state                                 |
 
@@ -30,9 +31,10 @@ These commands solve different automation problems:
 A practical rule of thumb:
 
 - use **`mc publish`** for registry packages
-- use **`mc publish-release`** for hosted releases
+- use **`mc publish-release`** for hosted releases from prepared release state
 - use **`mc release-pr`** when you want a provider-backed release request branch
 - use **`mc commit-release`** when you want a durable local release commit in git history
+- use **`mc tag-release`** when that durable release commit has merged and you want to create its tag set on the default branch
 
 ## The three automation layers
 
@@ -48,20 +50,20 @@ Keeping those layers separate is important. Package publication and hosted-relea
 
 <!-- {=projectCapabilityMatrix} -->
 
-| Capability                                                               | Current status                                                             |
-| ------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
-| Multi-ecosystem discovery                                                | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter                                   |
-| Package release planning                                                 | Built in                                                                   |
-| Grouped/shared versioning                                                | Built in                                                                   |
-| Dry-run release diff previews                                            | Built in via `mc release --dry-run --diff`                                 |
-| Durable release history                                                  | Built in via `ReleaseRecord`, `mc release-record`, and `mc repair-release` |
-| Hosted provider releases                                                 | GitHub, GitLab, Gitea                                                      |
-| Hosted release requests                                                  | GitHub, GitLab, Gitea                                                      |
-| Built-in registry publishing                                             | `crates.io`, `npm`, `jsr`, `pub.dev`                                       |
-| GitHub npm trusted-publishing automation                                 | Built in                                                                   |
-| GitHub trusted-publishing guidance for `crates.io`, `jsr`, and `pub.dev` | Built in, but manual registry enrollment is still required                 |
-| GitLab trusted-publishing auto-derivation                                | Not built in today                                                         |
-| Release-retarget sync for hosted releases                                | GitHub first                                                               |
+| Capability                                                               | Current status                                                                               |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| Multi-ecosystem discovery                                                | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter                                                     |
+| Package release planning                                                 | Built in                                                                                     |
+| Grouped/shared versioning                                                | Built in                                                                                     |
+| Dry-run release diff previews                                            | Built in via `mc release --dry-run --diff`                                                   |
+| Durable release history and post-merge tagging                           | Built in via `ReleaseRecord`, `mc release-record`, `mc tag-release`, and `mc repair-release` |
+| Hosted provider releases                                                 | GitHub, GitLab, Gitea                                                                        |
+| Hosted release requests                                                  | GitHub, GitLab, Gitea                                                                        |
+| Built-in registry publishing                                             | `crates.io`, `npm`, `jsr`, `pub.dev`                                                         |
+| GitHub npm trusted-publishing automation                                 | Built in                                                                                     |
+| GitHub trusted-publishing guidance for `crates.io`, `jsr`, and `pub.dev` | Built in, but manual registry enrollment is still required                                   |
+| GitLab trusted-publishing auto-derivation                                | Not built in today                                                                           |
+| Release-retarget sync for hosted releases                                | GitHub first                                                                                 |
 
 <!-- {/projectCapabilityMatrix} -->
 
@@ -87,7 +89,9 @@ For GitHub Actions, the most common structure is:
 4. package publication runs from that durable release commit
 5. provider release and tag automation runs in a dedicated release workflow
 
-The important current implementation detail is that `mc publish` can publish from the `ReleaseRecord` on `HEAD`, while `mc publish-release` still works from prepared release state.
+The important current implementation detail is that `mc publish` can publish from the `ReleaseRecord` on `HEAD`, `mc tag-release` can create the declared release tags from that same durable record, and `mc publish-release` still works from prepared release state.
+
+If the same post-merge job is responsible for both tags and package publication, run `mc tag-release --from HEAD` immediately after release-commit detection and before `mc publish`.
 
 ### GitHub + npm trusted publishing
 
@@ -469,7 +473,15 @@ publish_npm:
     - if: "$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH"
   script:
     - corepack enable
-    - if mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then mc publish; else echo "not a release commit"; fi
+    - git fetch --force --tags origin
+    - |
+        set -euo pipefail
+        if mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then
+          mc tag-release --from HEAD
+          mc publish
+        else
+          echo "not a release commit"
+        fi
 ```
 
 If your npm flow needs registry-token setup or a custom `.npmrc`, do that in CI before running `mc publish`.
@@ -494,7 +506,15 @@ publish_cargo:
   rules:
     - if: "$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH"
   script:
-    - if mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then mc publish; else echo "not a release commit"; fi
+    - git fetch --force --tags origin
+    - |
+        set -euo pipefail
+        if mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then
+          mc tag-release --from HEAD
+          mc publish
+        else
+          echo "not a release commit"
+        fi
 ```
 
 If you need a crates.io token or a more customized release process, inject the credential in GitLab CI or switch the package to `mode = "external"`.
@@ -520,7 +540,15 @@ publish_jsr:
   rules:
     - if: "$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH"
   script:
-    - if mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then mc publish; else echo "not a release commit"; fi
+    - git fetch --force --tags origin
+    - |
+        set -euo pipefail
+        if mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then
+          mc tag-release --from HEAD
+          mc publish
+        else
+          echo "not a release commit"
+        fi
 ```
 
 If your JSR auth bootstrap is more specialized than the built-in path expects, prefer `mode = "external"` and run the native publish command yourself.
@@ -546,7 +574,15 @@ publish_pub_dev:
   rules:
     - if: "$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH"
   script:
-    - if mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then mc publish; else echo "not a release commit"; fi
+    - git fetch --force --tags origin
+    - |
+        set -euo pipefail
+        if mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then
+          mc tag-release --from HEAD
+          mc publish
+        else
+          echo "not a release commit"
+        fi
 ```
 
 As with JSR, use `mode = "external"` when you need CI-specific auth or publish orchestration outside monochange's built-in assumptions.
@@ -560,14 +596,15 @@ This is the flow you described:
 3. the release PR stays open and keeps tracking the latest releasable state
 4. when the PR merges, publication happens from that merged release commit
 
-### What monochange supports today
+### What monochange supports now
 
-monochange already supports a large part of this shape:
+monochange now supports the core post-merge pieces of this shape directly:
 
 - `mc release-pr` can open or update a release request branch from current release state
 - `mc commit-release` can create a durable monochange release commit with an embedded `ReleaseRecord`
 - `mc release-record --from HEAD` can detect whether the latest commit is a monochange release commit
-- `mc publish` can publish package registries from that durable record on `HEAD`
+- `mc tag-release --from HEAD` can create and push the declared tag set from that merged release commit
+- `mc publish` can publish package registries from that same durable record on `HEAD`
 
 ### The important tag semantics
 
@@ -583,43 +620,87 @@ That means:
 
 That is why pre-merge tagging on a long-running release PR is usually the wrong move.
 
-### Recommended current approach
+### Recommended workflow
 
-For the long-running release PR model, the safest current shape is:
+For the long-running release PR model, the recommended shape is now:
 
 1. on every push to `main`, run `mc release-pr` to refresh the dedicated release PR branch
 2. do **not** create tags on the release PR branch
 3. merge the release PR when you are ready
 4. on the post-merge workflow, run `mc release-record --from HEAD --format json`
-5. if the latest commit is a release commit, run `mc publish` for package registries
-6. handle tag creation and hosted-release publication in a dedicated follow-up workflow
+5. if the latest commit is a release commit, run `mc tag-release --from HEAD`
+6. after tags exist, run `mc publish` for package registries and let tag-triggered workflows create hosted releases or other downstream assets
 
-### Captured future workflow
+That keeps tag creation on the default branch side of the merge, which is much safer than tagging the PR branch early.
 
-The missing piece for a fully first-class version of this pattern is a built-in post-merge tagger.
+### GitHub Actions reference sketch
 
-The strongest future shape would be:
+```yaml
+name: release
 
-1. `mc release-pr` keeps the long-running release PR branch up to date
-2. the release PR merges into `main`
-3. a post-merge monochange command inspects `ReleaseRecord` on `HEAD`
-4. that command creates and pushes the declared tag set
-5. tag-triggered workflows publish hosted releases and any additional downstream assets
+on:
+  push:
+    branches: [main]
 
-That would keep tag creation on the default branch side of the merge, which is much safer than tagging the PR branch early.
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
-### Captured implementation gap
+      - name: fetch tags
+        run: git fetch --force --tags origin
 
-Today monochange does **not** ship a dedicated top-level command that says "read the `ReleaseRecord` on `HEAD` and create/push the release tags now".
+      - name: detect merged release commit
+        id: release_record
+        shell: bash
+        run: |
+          set -euo pipefail
+          if mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then
+            echo "is_release_commit=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_release_commit=false" >> "$GITHUB_OUTPUT"
+          fi
 
-That gap is important to capture because it affects exactly this release-PR-merge flow.
+      - name: refresh release PR
+        if: steps.release_record.outputs.is_release_commit != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mc release-pr
 
-A future enhancement in this area would likely include:
+      - name: create release tags
+        if: steps.release_record.outputs.is_release_commit == 'true'
+        run: mc tag-release --from HEAD
 
-- a built-in post-merge release-commit detector and tagger
-- a smoother first-class long-running release PR workflow
-- branch-refresh semantics that make repeated release-branch updates more explicit
-- possibly force-refresh behavior for workflows that intentionally rewrite the dedicated release branch over time
+      - name: publish packages
+        if: steps.release_record.outputs.is_release_commit == 'true'
+        run: mc publish
+```
+
+### GitLab CI reference sketch
+
+```yaml
+release_pr_or_publish:
+  stage: release
+  rules:
+    - if: "$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH"
+  script:
+    - git fetch --force --tags origin
+    - |
+        set -euo pipefail
+        if mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then
+          mc tag-release --from HEAD
+          mc publish
+        else
+          mc release-pr
+        fi
+```
 
 ## Choosing a CI pattern
 
@@ -627,7 +708,7 @@ Use this decision rule:
 
 - **Need human review before release files land?** → use `mc release-pr`
 - **Need a durable local release commit?** → use `mc commit-release`
-- **Need package registries after merge?** → detect `ReleaseRecord` on `HEAD`, then run `mc publish`
+- **Need package registries after merge?** → detect `ReleaseRecord` on `HEAD`, run `mc tag-release --from HEAD`, then run `mc publish`
 - **Need hosted provider releases from prepared release state?** → use `mc publish-release`
 - **Need to bootstrap a package that does not exist yet?** → use `mc placeholder-publish`
 - **Need GitHub npm trusted publishing with the least custom glue?** → use `trusted_publishing = true` with `mc publish`

--- a/docs/src/guide/13-ci-and-publishing.md
+++ b/docs/src/guide/13-ci-and-publishing.md
@@ -86,10 +86,10 @@ For GitHub Actions, the most common structure is:
 1. a workflow prepares or updates a release PR branch
 2. a release commit lands on `main`
 3. a post-merge workflow detects the release commit
-4. package publication runs from that durable release commit
-5. provider release and tag automation runs in a dedicated release workflow
+4. that workflow creates the declared tags and publishes packages from the durable release commit
+5. hosted release objects or extra assets come either from downstream tag-driven workflows or from a separate workflow that still uses `mc publish-release`
 
-The important current implementation detail is that `mc publish` can publish from the `ReleaseRecord` on `HEAD`, `mc tag-release` can create the declared release tags from that same durable record, and `mc publish-release` still works from prepared release state.
+The important current implementation detail is that `mc publish` can publish from the `ReleaseRecord` on `HEAD`, `mc tag-release` can create the declared release tags from that same durable record, and `mc publish-release` still works from prepared release state when you want a manifest-driven hosted-release job.
 
 If the same post-merge job is responsible for both tags and package publication, run `mc tag-release --from HEAD` immediately after release-commit detection and before `mc publish`.
 

--- a/docs/src/guide/14-multi-package-publishing.md
+++ b/docs/src/guide/14-multi-package-publishing.md
@@ -61,6 +61,9 @@ jobs:
             exit 0
           fi
 
+      - name: create release tags
+        run: devenv shell -- mc tag-release --from HEAD
+
       - name: publish packages
         run: devenv shell -- mc publish
 ```

--- a/docs/src/readme.md
+++ b/docs/src/readme.md
@@ -110,6 +110,7 @@ If you want a slower, more guided walkthrough, continue with [Start here](./guid
 | Publish packages to registries   | `mc publish`                                                | You want `cargo publish`, `npm publish`, `deno publish`, or `dart pub publish` style package publication |
 | Bootstrap missing packages       | `mc placeholder-publish`                                    | A package must exist in its registry before later automation can work                                    |
 | Inspect a past release commit    | `mc release-record --from <ref>`                            | You need the durable release declaration from git history                                                |
+| Create post-merge release tags   | `mc tag-release --from HEAD`                                | You merged a monochange release commit and now need to create and push its declared tag set              |
 | Repair a recent release          | `mc repair-release --from <tag> --target <commit>`          | You need to retarget a just-created release to a later commit                                            |
 | Publish hosted/provider releases | `mc publish-release`                                        | You want GitHub/GitLab/Gitea release objects from prepared release state                                 |
 
@@ -129,6 +130,7 @@ If you want a slower, more guided walkthrough, continue with [Start here](./guid
 - emit stable release-manifest JSON for downstream automation
 - preview or publish provider releases and release requests from typed command steps and shared release data
 - inspect durable release records from tags or descendant commits with `mc release-record`
+- create post-merge release tags from a merged release commit with `mc tag-release --from HEAD`
 - repair a recent source/provider release by retargeting its release tags with `mc repair-release`
 - inspect changeset context and review metadata with `mc diagnostics` for both human and automation workflows
 - apply Rust semver evidence when provided

--- a/packages/monochange__cli/README.md
+++ b/packages/monochange__cli/README.md
@@ -133,6 +133,7 @@ monochange can promote one prepared release into several source-provider automat
 - `mc publish-release --dry-run --format json` previews provider release payloads before publishing
 - `mc release-pr --dry-run --format json` previews the release branch, commit, and release-request body
 - `mc release-record --from <tag>` inspects the durable release declaration stored in the release commit body
+- `mc tag-release --from HEAD --dry-run --format json` previews the post-merge release tag set declared by that durable record
 - `mc repair-release --from <tag> --dry-run` previews a release-retarget plan before mutating tags
 - changelog templates can render linked change owners, review requests, commits, and closed issues through `{{ context }}` or fine-grained metadata variables
 - `mc affected --format json --changed-paths ...` evaluates pull-request changeset policy from CI-supplied paths and labels
@@ -169,6 +170,7 @@ See [Advanced: Assistant setup and MCP](docs/src/guide/09-assistant-setup.md) fo
 - emit stable release-manifest JSON for downstream automation
 - preview or publish provider releases and release requests from typed command steps and shared release data
 - inspect durable release records from tags or descendant commits with `mc release-record`
+- create post-merge release tags from a merged release commit with `mc tag-release --from HEAD`
 - repair a recent source/provider release by retargeting its release tags with `mc repair-release`
 - inspect changeset context and review metadata with `mc diagnostics` for both human and automation workflows
 - apply Rust semver evidence when provided
@@ -222,6 +224,7 @@ mc release --dry-run --format json
 mc publish-release --dry-run --format json
 mc release-pr --dry-run --format json
 mc release-record --from v1.2.3
+mc tag-release --from HEAD --dry-run --format json
 mc repair-release --from v1.2.3 --target HEAD --dry-run
 mc release
 ```

--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,7 @@ If you do not know which package id to target, rerun `mc discover --format json`
 | Publish packages to registries   | `mc publish`                                                | You want `cargo publish`, `npm publish`, `deno publish`, or `dart pub publish` style package publication |
 | Bootstrap missing packages       | `mc placeholder-publish`                                    | A package must exist in its registry before later automation can work                                    |
 | Inspect a past release commit    | `mc release-record --from <ref>`                            | You need the durable release declaration from git history                                                |
+| Create post-merge release tags   | `mc tag-release --from HEAD`                                | You merged a monochange release commit and now need to create and push its declared tag set              |
 | Repair a recent release          | `mc repair-release --from <tag> --target <commit>`          | You need to retarget a just-created release to a later commit                                            |
 | Publish hosted/provider releases | `mc publish-release`                                        | You want GitHub/GitLab/Gitea release objects from prepared release state                                 |
 
@@ -137,20 +138,20 @@ If you do not know which package id to target, rerun `mc discover --format json`
 
 <!-- {=projectCapabilityMatrix} -->
 
-| Capability                                                               | Current status                                                             |
-| ------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
-| Multi-ecosystem discovery                                                | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter                                   |
-| Package release planning                                                 | Built in                                                                   |
-| Grouped/shared versioning                                                | Built in                                                                   |
-| Dry-run release diff previews                                            | Built in via `mc release --dry-run --diff`                                 |
-| Durable release history                                                  | Built in via `ReleaseRecord`, `mc release-record`, and `mc repair-release` |
-| Hosted provider releases                                                 | GitHub, GitLab, Gitea                                                      |
-| Hosted release requests                                                  | GitHub, GitLab, Gitea                                                      |
-| Built-in registry publishing                                             | `crates.io`, `npm`, `jsr`, `pub.dev`                                       |
-| GitHub npm trusted-publishing automation                                 | Built in                                                                   |
-| GitHub trusted-publishing guidance for `crates.io`, `jsr`, and `pub.dev` | Built in, but manual registry enrollment is still required                 |
-| GitLab trusted-publishing auto-derivation                                | Not built in today                                                         |
-| Release-retarget sync for hosted releases                                | GitHub first                                                               |
+| Capability                                                               | Current status                                                                               |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| Multi-ecosystem discovery                                                | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter                                                     |
+| Package release planning                                                 | Built in                                                                                     |
+| Grouped/shared versioning                                                | Built in                                                                                     |
+| Dry-run release diff previews                                            | Built in via `mc release --dry-run --diff`                                                   |
+| Durable release history and post-merge tagging                           | Built in via `ReleaseRecord`, `mc release-record`, `mc tag-release`, and `mc repair-release` |
+| Hosted provider releases                                                 | GitHub, GitLab, Gitea                                                                        |
+| Hosted release requests                                                  | GitHub, GitLab, Gitea                                                                        |
+| Built-in registry publishing                                             | `crates.io`, `npm`, `jsr`, `pub.dev`                                                         |
+| GitHub npm trusted-publishing automation                                 | Built in                                                                                     |
+| GitHub trusted-publishing guidance for `crates.io`, `jsr`, and `pub.dev` | Built in, but manual registry enrollment is still required                                   |
+| GitLab trusted-publishing auto-derivation                                | Not built in today                                                                           |
+| Release-retarget sync for hosted releases                                | GitHub first                                                                                 |
 
 <!-- {/projectCapabilityMatrix} -->
 
@@ -178,6 +179,7 @@ monochange can promote one prepared release into several source-provider automat
 - `mc publish-release --dry-run --format json` previews provider release payloads before publishing
 - `mc release-pr --dry-run --format json` previews the release branch, commit, and release-request body
 - `mc release-record --from <tag>` inspects the durable release declaration stored in the release commit body
+- `mc tag-release --from HEAD --dry-run --format json` previews the post-merge release tag set declared by that durable record
 - `mc repair-release --from <tag> --dry-run` previews a release-retarget plan before mutating tags
 - changelog templates can render linked change owners, review requests, commits, and closed issues through `{{ context }}` or fine-grained metadata variables
 - `mc affected --format json --changed-paths ...` evaluates pull-request changeset policy from CI-supplied paths and labels
@@ -230,6 +232,7 @@ See [Advanced: Assistant setup and MCP](docs/src/guide/09-assistant-setup.md) fo
 - emit stable release-manifest JSON for downstream automation
 - preview or publish provider releases and release requests from typed command steps and shared release data
 - inspect durable release records from tags or descendant commits with `mc release-record`
+- create post-merge release tags from a merged release commit with `mc tag-release --from HEAD`
 - repair a recent source/provider release by retargeting its release tags with `mc repair-release`
 - inspect changeset context and review metadata with `mc diagnostics` for both human and automation workflows
 - apply Rust semver evidence when provided
@@ -283,6 +286,7 @@ mc release --dry-run --format json
 mc publish-release --dry-run --format json
 mc release-pr --dry-run --format json
 mc release-record --from v1.2.3
+mc tag-release --from HEAD --dry-run --format json
 mc repair-release --from v1.2.3 --target HEAD --dry-run
 mc release
 ```


### PR DESCRIPTION
## Summary

Closes #209.

This adds a first-class post-merge tagging flow for long-running release PR branches:

- adds `mc tag-release --from HEAD` to create and push the tag set declared by a merged monochange release commit
- makes the command idempotent when tags already point at the merged release commit
- rejects descendant refs that are not themselves the release commit, steering follow-up tag movement to `mc repair-release`
- updates the generated GitHub `release.yml` workflow to refresh the release PR on normal `main` pushes, then tag and publish after merge
- updates the long-running release PR documentation, repairable release guidance, installation docs, and bundled CLI docs

## Validation

- `devenv shell mc validate`
- `devenv shell lint:all`
- `devenv shell build:all`
- `devenv shell test:all`
- `devenv shell cargo test -p monochange --test release_record tag_release_command -- --nocapture`
- `devenv shell cargo test -p monochange --test cli_main_binary monochange_binary_prints_help -- --nocapture`
- `devenv shell cargo test -p monochange init_with_github_provider_creates_workflow_files -- --nocapture`
- `devenv shell cargo test -p monochange cli_command_after_help_covers_supported_commands_and_custom_commands -- --nocapture`
- `devenv shell -- mc affected ...`
