### PR TITLE
test: add manual trust diagnostics coverage

### DIFF
--- a/.changeset/manual-trust-diagnostics-integration-tests.md
+++ b/.changeset/manual-trust-diagnostics-integration-tests.md
@@ -1,0 +1,13 @@
+---
+monochange: patch
+---
+
+#### add fixture-first integration coverage for manual trust diagnostics
+
+Adds fixture-based CLI coverage for manual-registry trusted-publishing diagnostics.
+
+The new integration tests cover:
+
+- resolved GitHub trusted-publishing context for `crates.io`, `jsr`, and `pub.dev`
+- missing workflow configuration guidance when monochange cannot resolve the GitHub workflow yet
+- placeholder-publish dry-run output in both text and JSON formats

--- a/crates/monochange/tests/cli_output.rs
+++ b/crates/monochange/tests/cli_output.rs
@@ -1,5 +1,7 @@
 use std::fs;
 
+use httpmock::Method::GET;
+use httpmock::MockServer;
 use insta::assert_snapshot;
 use insta_cmd::assert_cmd_snapshot;
 
@@ -13,6 +15,27 @@ fn release_cli_command() -> std::process::Command {
 	monochange_command(Some("2026-04-06"))
 }
 
+fn mock_missing_publish_versions(server: &MockServer) {
+	server.mock(|when, then| {
+		when.method(GET).path("/crates/core");
+		then.status(200).json_body_obj(&serde_json::json!({
+			"versions": []
+		}));
+	});
+	server.mock(|when, then| {
+		when.method(GET).path("/packages/dart_pkg");
+		then.status(200).json_body_obj(&serde_json::json!({
+			"versions": []
+		}));
+	});
+	server.mock(|when, then| {
+		when.method(GET).path("/@scope/jsr-pkg/meta.json");
+		then.status(200).json_body_obj(&serde_json::json!({
+			"versions": {}
+		}));
+	});
+}
+
 #[test]
 fn validate_cli_succeeds_for_valid_workspace() {
 	let mut settings = snapshot_settings();
@@ -24,6 +47,57 @@ fn validate_cli_succeeds_for_valid_workspace() {
 		monochange_command(None)
 			.current_dir(tempdir.path())
 			.arg("validate")
+	);
+}
+
+#[test]
+fn placeholder_publish_dry_run_reports_manual_registry_trust_contexts() {
+	let mut settings = snapshot_settings();
+	settings.set_snapshot_suffix(current_test_name());
+	let _guard = settings.bind_to_scope();
+
+	let tempdir = setup_scenario_workspace("cli-output/manual-trust-diagnostics");
+	let server = MockServer::start();
+	mock_missing_publish_versions(&server);
+	assert_cmd_snapshot!(
+		monochange_command(None)
+			.current_dir(tempdir.path())
+			.env(
+				"GITHUB_WORKFLOW_REF",
+				"ifiokjr/monochange/.github/workflows/publish.yml@refs/heads/main"
+			)
+			.env("GITHUB_JOB", "release")
+			.env("MONOCHANGE_CRATES_IO_API_URL", server.base_url())
+			.env("MONOCHANGE_PUB_DEV_API_URL", server.base_url())
+			.env("MONOCHANGE_JSR_BASE_URL", server.base_url())
+			.arg("placeholder-publish")
+			.arg("--dry-run")
+			.arg("--format")
+			.arg("text")
+	);
+}
+
+#[test]
+fn placeholder_publish_dry_run_reports_missing_manual_registry_workflow_configuration() {
+	let mut settings = snapshot_settings();
+	settings.set_snapshot_suffix(current_test_name());
+	let _guard = settings.bind_to_scope();
+
+	let tempdir = setup_scenario_workspace("cli-output/manual-trust-diagnostics");
+	let server = MockServer::start();
+	mock_missing_publish_versions(&server);
+	assert_cmd_snapshot!(
+		monochange_command(None)
+			.current_dir(tempdir.path())
+			.env_remove("GITHUB_WORKFLOW_REF")
+			.env_remove("GITHUB_JOB")
+			.env("MONOCHANGE_CRATES_IO_API_URL", server.base_url())
+			.env("MONOCHANGE_PUB_DEV_API_URL", server.base_url())
+			.env("MONOCHANGE_JSR_BASE_URL", server.base_url())
+			.arg("placeholder-publish")
+			.arg("--dry-run")
+			.arg("--format")
+			.arg("json")
 	);
 }
 

--- a/crates/monochange/tests/snapshots/cli_output__placeholder_publish_dry_run_reports_manual_registry_trust_contexts@placeholder_publish_dry_run_reports_manual_registry_trust_contexts.snap
+++ b/crates/monochange/tests/snapshots/cli_output__placeholder_publish_dry_run_reports_manual_registry_trust_contexts@placeholder_publish_dry_run_reports_manual_registry_trust_contexts.snap
@@ -1,0 +1,58 @@
+---
+source: crates/monochange/tests/cli_output.rs
+info:
+  program: mc
+  args:
+    - placeholder-publish
+    - "--dry-run"
+    - "--format"
+    - text
+  env:
+    GITHUB_JOB: release
+    GITHUB_WORKFLOW_REF: ifiokjr/monochange/.github/workflows/publish.yml@refs/heads/main
+    MONOCHANGE_CRATES_IO_API_URL: "http://127.0.0.1:64982"
+    MONOCHANGE_JSR_BASE_URL: "http://127.0.0.1:64982"
+    MONOCHANGE_PUB_DEV_API_URL: "http://127.0.0.1:64982"
+    NO_COLOR: "1"
+    RUST_LOG: ""
+---
+success: true
+exit_code: 0
+----- stdout -----
+command `placeholder-publish` completed (dry-run)
+placeholder publishing:
+- core 0.0.0 via crates_io -> planned
+  ecosystem: cargo
+  placeholder: yes
+  publish: would publish placeholder core 0.0.0 to crates_io
+  trusted publishing: manual-action-required
+  trust message: configure trusted publishing manually for `core` before the next built-in release publish; open https://crates.io/crates/core and register repository `ifiokjr/monochange`, workflow `publish.yml`, environment `publisher` there
+  repository: ifiokjr/monochange
+  workflow: publish.yml
+  environment: publisher
+  setup: https://crates.io/crates/core
+  next: open the setup URL, configure trusted publishing for this package, then rerun `mc publish`
+- dart_pkg 0.0.0 via pub_dev -> planned
+  ecosystem: dart
+  placeholder: yes
+  publish: would publish placeholder dart_pkg 0.0.0 to pub_dev
+  trusted publishing: manual-action-required
+  trust message: configure trusted publishing manually for `dart_pkg` before the next built-in release publish; open https://pub.dev/packages/dart_pkg/admin and register repository `ifiokjr/monochange`, workflow `publish.yml`, environment `publisher` there
+  repository: ifiokjr/monochange
+  workflow: publish.yml
+  environment: publisher
+  setup: https://pub.dev/packages/dart_pkg/admin
+  next: open the setup URL, configure trusted publishing for this package, then rerun `mc publish`
+- jsr_pkg 0.0.0 via jsr -> planned
+  ecosystem: deno
+  placeholder: yes
+  publish: would publish placeholder @scope/jsr-pkg 0.0.0 to jsr
+  trusted publishing: manual-action-required
+  trust message: configure trusted publishing manually for `@scope/jsr-pkg` before the next built-in release publish; open https://jsr.io/@scope/jsr-pkg and register repository `ifiokjr/monochange`, workflow `publish.yml`, environment `publisher` there
+  repository: ifiokjr/monochange
+  workflow: publish.yml
+  environment: publisher
+  setup: https://jsr.io/@scope/jsr-pkg
+  next: open the setup URL, configure trusted publishing for this package, then rerun `mc publish`
+
+----- stderr -----

--- a/crates/monochange/tests/snapshots/cli_output__placeholder_publish_dry_run_reports_missing_manual_registry_workflow_configuration@placeholder_publish_dry_run_reports_missing_manual_registry_workflow_configuration.snap
+++ b/crates/monochange/tests/snapshots/cli_output__placeholder_publish_dry_run_reports_missing_manual_registry_workflow_configuration@placeholder_publish_dry_run_reports_missing_manual_registry_workflow_configuration.snap
@@ -1,0 +1,78 @@
+---
+source: crates/monochange/tests/cli_output.rs
+info:
+  program: mc
+  args:
+    - placeholder-publish
+    - "--dry-run"
+    - "--format"
+    - json
+  env:
+    MONOCHANGE_CRATES_IO_API_URL: "http://127.0.0.1:65017"
+    MONOCHANGE_JSR_BASE_URL: "http://127.0.0.1:65017"
+    MONOCHANGE_PUB_DEV_API_URL: "http://127.0.0.1:65017"
+    NO_COLOR: "1"
+    RUST_LOG: ""
+---
+success: true
+exit_code: 0
+----- stdout -----
+{
+  "mode": "placeholder",
+  "dryRun": true,
+  "packages": [
+    {
+      "package": "core",
+      "ecosystem": "cargo",
+      "registry": "crates_io",
+      "version": "0.0.0",
+      "status": "planned",
+      "message": "would publish placeholder core 0.0.0 to crates_io",
+      "placeholder": true,
+      "trustedPublishing": {
+        "status": "manual_action_required",
+        "repository": null,
+        "workflow": null,
+        "environment": null,
+        "setupUrl": "https://crates.io/crates/core",
+        "message": "configure trusted publishing manually for `core` before the next built-in release publish; open https://crates.io/crates/core and finish the GitHub context setup first: config error: trusted publishing could not determine the GitHub workflow; set `publish.trusted_publishing.workflow`"
+      }
+    },
+    {
+      "package": "dart_pkg",
+      "ecosystem": "dart",
+      "registry": "pub_dev",
+      "version": "0.0.0",
+      "status": "planned",
+      "message": "would publish placeholder dart_pkg 0.0.0 to pub_dev",
+      "placeholder": true,
+      "trustedPublishing": {
+        "status": "manual_action_required",
+        "repository": null,
+        "workflow": null,
+        "environment": null,
+        "setupUrl": "https://pub.dev/packages/dart_pkg/admin",
+        "message": "configure trusted publishing manually for `dart_pkg` before the next built-in release publish; open https://pub.dev/packages/dart_pkg/admin and finish the GitHub context setup first: config error: trusted publishing could not determine the GitHub workflow; set `publish.trusted_publishing.workflow`"
+      }
+    },
+    {
+      "package": "jsr_pkg",
+      "ecosystem": "deno",
+      "registry": "jsr",
+      "version": "0.0.0",
+      "status": "planned",
+      "message": "would publish placeholder @scope/jsr-pkg 0.0.0 to jsr",
+      "placeholder": true,
+      "trustedPublishing": {
+        "status": "manual_action_required",
+        "repository": null,
+        "workflow": null,
+        "environment": null,
+        "setupUrl": "https://jsr.io/@scope/jsr-pkg",
+        "message": "configure trusted publishing manually for `@scope/jsr-pkg` before the next built-in release publish; open https://jsr.io/@scope/jsr-pkg and finish the GitHub context setup first: config error: trusted publishing could not determine the GitHub workflow; set `publish.trusted_publishing.workflow`"
+      }
+    }
+  ]
+}
+
+----- stderr -----

--- a/fixtures/tests/cli-output/manual-trust-diagnostics/workspace/.github/workflows/publish.yml
+++ b/fixtures/tests/cli-output/manual-trust-diagnostics/workspace/.github/workflows/publish.yml
@@ -1,0 +1,11 @@
+name: publish
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: publisher
+    steps:
+      - run: echo publish

--- a/fixtures/tests/cli-output/manual-trust-diagnostics/workspace/crates/core/Cargo.toml
+++ b/fixtures/tests/cli-output/manual-trust-diagnostics/workspace/crates/core/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "core"
+version = "1.2.3"

--- a/fixtures/tests/cli-output/manual-trust-diagnostics/workspace/monochange.toml
+++ b/fixtures/tests/cli-output/manual-trust-diagnostics/workspace/monochange.toml
@@ -1,0 +1,31 @@
+[source]
+provider = "github"
+owner = "ifiokjr"
+repo = "monochange"
+
+[package.core]
+path = "crates/core"
+type = "cargo"
+
+[package.core.publish]
+enabled = true
+mode = "builtin"
+trusted_publishing = true
+
+[package.jsr_pkg]
+path = "packages/jsr-pkg"
+type = "deno"
+
+[package.jsr_pkg.publish]
+enabled = true
+mode = "builtin"
+trusted_publishing = true
+
+[package.dart_pkg]
+path = "packages/dart-pkg"
+type = "dart"
+
+[package.dart_pkg.publish]
+enabled = true
+mode = "builtin"
+trusted_publishing = true

--- a/fixtures/tests/cli-output/manual-trust-diagnostics/workspace/packages/dart-pkg/pubspec.yaml
+++ b/fixtures/tests/cli-output/manual-trust-diagnostics/workspace/packages/dart-pkg/pubspec.yaml
@@ -1,0 +1,2 @@
+name: dart_pkg
+version: 1.2.3

--- a/fixtures/tests/cli-output/manual-trust-diagnostics/workspace/packages/jsr-pkg/deno.json
+++ b/fixtures/tests/cli-output/manual-trust-diagnostics/workspace/packages/jsr-pkg/deno.json
@@ -1,0 +1,4 @@
+{
+  "name": "@scope/jsr-pkg",
+  "version": "1.2.3"
+}


### PR DESCRIPTION
## Summary

- add fixture-first CLI integration coverage for manual-registry trusted-publishing diagnostics
- cover `crates.io`, `jsr`, and `pub.dev` in one copied scenario workspace
- snapshot the placeholder-publish dry-run output when monochange can resolve the GitHub trusted-publishing context
- snapshot the JSON output when the GitHub workflow context is still missing so the preflight guidance stays regression-tested

## Testing

- `devenv shell -- cargo test -p monochange --test cli_output placeholder_publish_dry_run_reports_manual_registry`
- `devenv shell -- cargo test -p monochange --test cli_output placeholder_publish_dry_run_reports_missing_manual_registry_workflow_configuration`
- `devenv shell docs:check`
- `devenv shell fix:all`
