### PR TITLE
docs: summarize publishing improvements

### DIFF
--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -64,6 +64,20 @@ Use it when your repository has outgrown one-ecosystem release tooling and you w
 
 <!-- {/projectMilestoneCapabilities} -->
 
+<!-- {@projectRecentPublishingImprovements} -->
+
+### Recent package publishing improvements
+
+Recent `monochange` improvements made package publishing guidance and diagnostics much more actionable:
+
+- a dedicated trusted-publishing guide now covers `npm`, `crates.io`, `jsr`, and `pub.dev`
+- CI examples now prefer the official registry-maintained workflows for `crates.io` and `pub.dev`
+- a dedicated multi-package publishing guide now covers monorepo tag, workflow, and package-boundary patterns
+- CLI output now gives clearer manual next steps for registries that still require registry-side trusted-publishing enrollment
+- built-in publish preflight now validates and reports the expected GitHub repository, workflow, and environment context for manual registries when it can infer them
+
+<!-- {/projectRecentPublishingImprovements} -->
+
 <!-- {@projectCommandAutomationMatrix} -->
 
 | Goal                             | Command                                                     | Use it when                                                                                              |

--- a/docs/src/readme.md
+++ b/docs/src/readme.md
@@ -94,6 +94,20 @@ If you want a slower, more guided walkthrough, continue with [Start here](./guid
 - [Advanced: Assistant setup and MCP](./guide/09-assistant-setup.md) — optional AI-assisted workflows
 - [Reference: Manifest linting with `mc check`](./reference/linting.md) — `[ecosystems.<name>.lints]` rules for Cargo and npm-family manifests
 
+<!-- {=projectRecentPublishingImprovements} -->
+
+### Recent package publishing improvements
+
+Recent `monochange` improvements made package publishing guidance and diagnostics much more actionable:
+
+- a dedicated trusted-publishing guide now covers `npm`, `crates.io`, `jsr`, and `pub.dev`
+- CI examples now prefer the official registry-maintained workflows for `crates.io` and `pub.dev`
+- a dedicated multi-package publishing guide now covers monorepo tag, workflow, and package-boundary patterns
+- CLI output now gives clearer manual next steps for registries that still require registry-side trusted-publishing enrollment
+- built-in publish preflight now validates and reports the expected GitHub repository, workflow, and environment context for manual registries when it can infer them
+
+<!-- {/projectRecentPublishingImprovements} -->
+
 ## Command and automation matrix
 
 <!-- {=projectCommandAutomationMatrix} -->

--- a/readme.md
+++ b/readme.md
@@ -112,6 +112,20 @@ If you do not know which package id to target, rerun `mc discover --format json`
 - [Advanced: CI, package publishing, and release PR flows](docs/src/guide/13-ci-and-publishing.md) — per-provider CI patterns, trusted publishing, and long-running release PR design notes
 - [Reference: Manifest linting with `mc check`](docs/src/reference/linting.md) — `[ecosystems.<name>.lints]` rules for Cargo and npm-family manifests
 
+<!-- {=projectRecentPublishingImprovements} -->
+
+### Recent package publishing improvements
+
+Recent `monochange` improvements made package publishing guidance and diagnostics much more actionable:
+
+- a dedicated trusted-publishing guide now covers `npm`, `crates.io`, `jsr`, and `pub.dev`
+- CI examples now prefer the official registry-maintained workflows for `crates.io` and `pub.dev`
+- a dedicated multi-package publishing guide now covers monorepo tag, workflow, and package-boundary patterns
+- CLI output now gives clearer manual next steps for registries that still require registry-side trusted-publishing enrollment
+- built-in publish preflight now validates and reports the expected GitHub repository, workflow, and environment context for manual registries when it can infer them
+
+<!-- {/projectRecentPublishingImprovements} -->
+
 ## Command and automation matrix
 
 <!-- {=projectCommandAutomationMatrix} -->


### PR DESCRIPTION
## Summary

- update the packaged skill to explicitly prefer the official GitHub publishing workflows for manual trusted-publishing registries
- recommend `rust-lang/crates-io-auth-action@v1` for `crates.io`
- recommend `dart-lang/setup-dart/.github/workflows/publish.yml@v1` for `pub.dev`
- clarify that `mode = "external"` is often the clearest fit when those workflows should own the publish command directly

## Testing

- `devenv shell docs:check`
- `devenv shell fix:all`
