### PR TITLE
build: move crate include lists into crate manifests

### DIFF
--- a/.changeset/crate-include-manifests.md
+++ b/.changeset/crate-include-manifests.md
@@ -1,0 +1,43 @@
+---
+monochange_cargo: patch
+monochange_config: patch
+monochange_core: patch
+monochange_dart: patch
+monochange_deno: patch
+monochange_gitea: patch
+monochange_github: patch
+monochange_gitlab: patch
+monochange_graph: patch
+monochange_hosting: patch
+monochange_npm: patch
+monochange_semver: patch
+---
+
+#### move crate include lists into published manifests
+
+The published library crates in this workspace now declare their `include` file lists in each crate's own `Cargo.toml` instead of inheriting that setting from `[workspace.package]`.
+
+**Before (`crates/monochange_core/Cargo.toml`):**
+
+```toml
+[package]
+include = { workspace = true }
+readme = "readme.md"
+```
+
+The package contents depended on the root workspace manifest carrying:
+
+```toml
+[workspace.package]
+include = ["src/**/*.rs", "Cargo.toml", "readme.md"]
+```
+
+**After:**
+
+```toml
+[package]
+include = ["src/**/*.rs", "Cargo.toml", "readme.md"]
+readme = "readme.md"
+```
+
+This keeps each published crate self-contained when packaging, auditing, or updating manifest metadata and avoids relying on a shared workspace-level `include` definition for crates.io package contents.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ authors = ["Ifiok Jr. <ifiokotung@gmail.com>"]
 categories = ["development-tools"]
 edition = "2024"
 homepage = "https://github.com/ifiokjr/monochange"
-include = ["src/**/*.rs", "Cargo.toml", "readme.md"]
 license = "Unlicense"
 readme = "readme.md"
 repository = "https://github.com/ifiokjr/monochange"

--- a/crates/monochange_cargo/Cargo.toml
+++ b/crates/monochange_cargo/Cargo.toml
@@ -4,7 +4,7 @@ version = { workspace = true }
 categories = { workspace = true }
 documentation = "https://docs.rs/monochange_cargo"
 edition = { workspace = true }
-include = { workspace = true }
+include = ["src/**/*.rs", "Cargo.toml", "readme.md"]
 keywords = ["cli", "changelog", "releases", "versioning", "monorepo"]
 license = { workspace = true }
 readme = "readme.md"

--- a/crates/monochange_config/Cargo.toml
+++ b/crates/monochange_config/Cargo.toml
@@ -4,7 +4,7 @@ version = { workspace = true }
 categories = { workspace = true }
 documentation = "https://docs.rs/monochange_config"
 edition = { workspace = true }
-include = { workspace = true }
+include = ["src/**/*.rs", "Cargo.toml", "readme.md"]
 keywords = ["cli", "config", "releases", "versioning", "monorepo"]
 license = { workspace = true }
 readme = "readme.md"

--- a/crates/monochange_core/Cargo.toml
+++ b/crates/monochange_core/Cargo.toml
@@ -4,7 +4,7 @@ version = { workspace = true }
 categories = { workspace = true }
 documentation = "https://docs.rs/monochange_core"
 edition = { workspace = true }
-include = { workspace = true }
+include = ["src/**/*.rs", "Cargo.toml", "readme.md"]
 keywords = ["cli", "changelog", "releases", "versioning", "monorepo"]
 license = { workspace = true }
 readme = "readme.md"

--- a/crates/monochange_dart/Cargo.toml
+++ b/crates/monochange_dart/Cargo.toml
@@ -4,7 +4,7 @@ version = { workspace = true }
 categories = { workspace = true }
 documentation = "https://docs.rs/monochange_dart"
 edition = { workspace = true }
-include = { workspace = true }
+include = ["src/**/*.rs", "Cargo.toml", "readme.md"]
 keywords = ["cli", "dart", "flutter", "releases", "monorepo"]
 license = { workspace = true }
 readme = "readme.md"

--- a/crates/monochange_deno/Cargo.toml
+++ b/crates/monochange_deno/Cargo.toml
@@ -4,7 +4,7 @@ version = { workspace = true }
 categories = { workspace = true }
 documentation = "https://docs.rs/monochange_deno"
 edition = { workspace = true }
-include = { workspace = true }
+include = ["src/**/*.rs", "Cargo.toml", "readme.md"]
 keywords = ["cli", "deno", "releases", "versioning", "monorepo"]
 license = { workspace = true }
 readme = "readme.md"

--- a/crates/monochange_gitea/Cargo.toml
+++ b/crates/monochange_gitea/Cargo.toml
@@ -4,7 +4,7 @@ version = { workspace = true }
 categories = { workspace = true }
 documentation = "https://docs.rs/monochange_gitea"
 edition = { workspace = true }
-include = { workspace = true }
+include = ["src/**/*.rs", "Cargo.toml", "readme.md"]
 keywords = ["gitea", "releases", "versioning", "monorepo"]
 license = { workspace = true }
 readme = "readme.md"

--- a/crates/monochange_github/Cargo.toml
+++ b/crates/monochange_github/Cargo.toml
@@ -4,7 +4,7 @@ version = { workspace = true }
 categories = { workspace = true }
 documentation = "https://docs.rs/monochange_github"
 edition = { workspace = true }
-include = { workspace = true }
+include = ["src/**/*.rs", "Cargo.toml", "readme.md"]
 keywords = ["github", "releases", "versioning", "monorepo"]
 license = { workspace = true }
 readme = "readme.md"

--- a/crates/monochange_gitlab/Cargo.toml
+++ b/crates/monochange_gitlab/Cargo.toml
@@ -4,7 +4,7 @@ version = { workspace = true }
 categories = { workspace = true }
 documentation = "https://docs.rs/monochange_gitlab"
 edition = { workspace = true }
-include = { workspace = true }
+include = ["src/**/*.rs", "Cargo.toml", "readme.md"]
 keywords = ["gitlab", "releases", "versioning", "monorepo"]
 license = { workspace = true }
 readme = "readme.md"

--- a/crates/monochange_graph/Cargo.toml
+++ b/crates/monochange_graph/Cargo.toml
@@ -4,7 +4,7 @@ version = { workspace = true }
 categories = { workspace = true }
 documentation = "https://docs.rs/monochange_graph"
 edition = { workspace = true }
-include = { workspace = true }
+include = ["src/**/*.rs", "Cargo.toml", "readme.md"]
 keywords = ["cli", "graph", "releases", "versioning", "monorepo"]
 license = { workspace = true }
 readme = "readme.md"

--- a/crates/monochange_hosting/Cargo.toml
+++ b/crates/monochange_hosting/Cargo.toml
@@ -4,7 +4,7 @@ version = { workspace = true }
 categories = { workspace = true }
 documentation = "https://docs.rs/monochange_hosting"
 edition = { workspace = true }
-include = { workspace = true }
+include = ["src/**/*.rs", "Cargo.toml", "readme.md"]
 keywords = ["hosting", "releases", "versioning", "monorepo"]
 license = { workspace = true }
 readme = "readme.md"

--- a/crates/monochange_npm/Cargo.toml
+++ b/crates/monochange_npm/Cargo.toml
@@ -4,7 +4,7 @@ version = { workspace = true }
 categories = { workspace = true }
 documentation = "https://docs.rs/monochange_npm"
 edition = { workspace = true }
-include = { workspace = true }
+include = ["src/**/*.rs", "Cargo.toml", "readme.md"]
 keywords = ["cli", "changelog", "releases", "versioning", "monorepo"]
 license = { workspace = true }
 readme = "readme.md"

--- a/crates/monochange_semver/Cargo.toml
+++ b/crates/monochange_semver/Cargo.toml
@@ -4,7 +4,7 @@ version = { workspace = true }
 categories = { workspace = true }
 documentation = "https://docs.rs/monochange_semver"
 edition = { workspace = true }
-include = { workspace = true }
+include = ["src/**/*.rs", "Cargo.toml", "readme.md"]
 keywords = ["cli", "semver", "releases", "versioning", "monorepo"]
 license = { workspace = true }
 readme = "readme.md"


### PR DESCRIPTION
## Summary
- remove the shared `include` list from `[workspace.package]`
- replace every `include = { workspace = true }` entry with an explicit per-crate include array
- add a grouped changeset covering the published crates whose package manifests now carry their own include metadata

## Validation
- `devenv shell fix:all lint:all build:all test:all mc validate`
- `mc affected --changed-paths Cargo.toml --changed-paths crates/monochange_cargo/Cargo.toml --changed-paths crates/monochange_config/Cargo.toml --changed-paths crates/monochange_core/Cargo.toml --changed-paths crates/monochange_dart/Cargo.toml --changed-paths crates/monochange_deno/Cargo.toml --changed-paths crates/monochange_gitea/Cargo.toml --changed-paths crates/monochange_github/Cargo.toml --changed-paths crates/monochange_gitlab/Cargo.toml --changed-paths crates/monochange_graph/Cargo.toml --changed-paths crates/monochange_hosting/Cargo.toml --changed-paths crates/monochange_npm/Cargo.toml --changed-paths crates/monochange_semver/Cargo.toml --changed-paths .changeset/crate-include-manifests.md`