### PR TITLE
feat: add Dart SDK and dependency hygiene lints

### DIFF
--- a/.changeset/add-dart-sdk-dependency-hygiene-lints.md
+++ b/.changeset/add-dart-sdk-dependency-hygiene-lints.md
@@ -1,4 +1,5 @@
 ---
+"@monochange/skill": none
 "monochange": minor
 "monochange_dart": minor
 ---

--- a/.changeset/add-dart-sdk-dependency-hygiene-lints.md
+++ b/.changeset/add-dart-sdk-dependency-hygiene-lints.md
@@ -1,0 +1,6 @@
+---
+"monochange": minor
+"monochange_dart": minor
+---
+
+Add Dart SDK constraint and dependency hygiene lint rules.

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -958,7 +958,7 @@ release_title = "v{{ version }} — released {{ date }}"
 
 Use this guide when the task is to configure or explain monochange's **manifest lint rules**.
 
-These are the rules that run through **`mc check`** and are configured in `monochange.toml` under **`[ecosystems.<name>.lints]`**.
+These are the rules that run through **`mc check`** and are configured in `monochange.toml` under the top-level **`[lints]`** section.
 
 They are separate from Rust compiler or Clippy lints used to develop monochange itself.
 
@@ -981,23 +981,26 @@ Use `--fix` when you want monochange to apply auto-fixes where a rule supports t
 
 ## Where lint rules live
 
-Configure rules per ecosystem in `monochange.toml`:
+Configure rules under the top-level lint section in `monochange.toml`:
 
 ```toml
-[ecosystems.cargo.lints]
+[lints]
+use = ["cargo/recommended", "npm/recommended", "dart/recommended"]
+
+[lints.rules]
 "cargo/dependency-field-order" = "error"
 "cargo/internal-dependency-workspace" = "error"
 "cargo/required-package-fields" = { level = "warning", fields = ["description", "license", "repository"] }
 "cargo/sorted-dependencies" = "warning"
 "cargo/unlisted-package-private" = { level = "warning", fix = true }
-
-[ecosystems.npm.lints]
 "npm/workspace-protocol" = "error"
 "npm/sorted-dependencies" = "warning"
 "npm/required-package-fields" = { level = "warning", fields = ["description", "repository", "license"] }
 "npm/root-no-prod-deps" = "error"
 "npm/no-duplicate-dependencies" = "error"
 "npm/unlisted-package-private" = { level = "warning", fix = true }
+"dart/sdk-constraint-modern" = { level = "warning", minimum = "3.6.0", require_upper_bound = false }
+"dart/no-unexpected-dependency-overrides" = { level = "warning", allow_for_private = true, allow_packages = ["app_shell"] }
 ```
 
 Rule configuration supports two forms:
@@ -1011,8 +1014,9 @@ Today, built-in manifest lint rules exist for:
 
 - **Cargo** manifests (`Cargo.toml`)
 - **npm-family** manifests (`package.json`)
+- **Dart / Flutter** manifests (`pubspec.yaml`)
 
-monochange already wires lint configuration through `configuration.cargo.lints`, `configuration.npm.lints`, `configuration.deno.lints`, and `configuration.dart.lints`, but the current built-in rule sets are implemented for Cargo and npm manifests.
+monochange routes all manifest lint configuration through the top-level `[lints]` section, while each ecosystem crate provides its own built-in suites and presets.
 
 ## Cargo manifest lint rules
 
@@ -1095,7 +1099,7 @@ version = "0.1.0"
 Example:
 
 ```toml
-[ecosystems.cargo.lints]
+[lints.rules]
 "cargo/required-package-fields" = { level = "error", fields = ["description", "license"] }
 ```
 
@@ -1321,6 +1325,64 @@ publish = false
 **Useful option:**
 
 - `fix` — defaults to `true`
+
+## Dart manifest lint rules
+
+### `dart/sdk-constraint-present`
+
+**Why:** every managed Dart package should declare the SDK range it expects rather than inheriting whatever the developer machine happens to provide.
+
+**With the rule:** monochange reports any `pubspec.yaml` that omits `environment.sdk`.
+
+### `dart/sdk-constraint-modern`
+
+**Why:** old or overly broad SDK ranges quietly expand your support policy and make releases harder to reason about.
+
+**Default policy:**
+
+- minimum lower bound: `3.0.0`
+- upper bound required by default
+
+**Useful options:**
+
+- `minimum` — override the minimum lower bound for your workspace
+- `require_upper_bound` — set to `false` if your policy intentionally omits an upper bound
+
+Example:
+
+```toml
+[lints.rules]
+"dart/sdk-constraint-modern" = { level = "warning", minimum = "3.6.0", require_upper_bound = false }
+```
+
+### `dart/dependency-sorted`
+
+**Why:** alphabetized `dependencies`, `dev_dependencies`, and `dependency_overrides` blocks reduce review noise and make Dart manifest diffs easier to scan.
+
+**Useful option:**
+
+- `fix` — defaults to `true`
+
+### `dart/no-unexpected-dependency-overrides`
+
+**Why:** `dependency_overrides` are sometimes necessary, but they should usually be limited to private packages or a small allow list of explicitly approved packages.
+
+**Useful options:**
+
+- `allow_for_private` — defaults to `true`
+- `allow_packages` — list package names that may keep `dependency_overrides`
+
+Example:
+
+```toml
+[lints.rules]
+"dart/no-unexpected-dependency-overrides" = { level = "warning", allow_for_private = true, allow_packages = ["app_shell"] }
+```
+
+### Dart presets
+
+- `dart/recommended` enables metadata/publishability checks, `dart/sdk-constraint-present`, and `dart/dependency-sorted` as a warning.
+- `dart/strict` adds `dart/sdk-constraint-modern`, `dart/no-unexpected-dependency-overrides`, and promotes `dart/dependency-sorted` to an error.
 
 ## What `mc check` looks like in practice
 

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -10185,6 +10185,8 @@ fn lint_cli_lists_and_explains_rules() {
 	assert!(list_output.contains("npm/recommended"));
 	assert!(list_output.contains("dart/recommended"));
 	assert!(list_output.contains("dart/required-package-fields"));
+	assert!(list_output.contains("dart/sdk-constraint-present"));
+	assert!(list_output.contains("dart/no-unexpected-dependency-overrides"));
 
 	let explain_output = run_cli(
 		&root,

--- a/crates/monochange/src/lint.rs
+++ b/crates/monochange/src/lint.rs
@@ -526,7 +526,9 @@ mod tests {
 		assert!(text.contains("cargo/internal-dependency-workspace"));
 		assert!(text.contains("cargo/recommended"));
 		assert!(text.contains("dart/required-package-fields"));
+		assert!(text.contains("dart/sdk-constraint-present"));
 		assert!(text.contains("dart/recommended"));
+		assert!(text.contains("dart/strict"));
 
 		let json = render_lint_catalog(OutputFormat::Json).unwrap();
 		assert!(json.contains("\"rules\""));

--- a/crates/monochange_dart/src/lints/mod.rs
+++ b/crates/monochange_dart/src/lints/mod.rs
@@ -27,6 +27,7 @@ use monochange_core::lint::LintSuite;
 use monochange_core::lint::LintTarget;
 use monochange_core::lint::LintTargetMetadata;
 use monochange_core::relative_to_root;
+use semver::Version;
 use serde_yaml_ng::Mapping;
 use serde_yaml_ng::Value;
 
@@ -57,8 +58,12 @@ impl LintSuite for DartLintSuite {
 
 	fn rules(&self) -> Vec<Box<dyn LintRuleRunner>> {
 		vec![
+			Box::new(DependencySortedRule::new()),
 			Box::new(NoGitDependenciesInPublishedPackagesRule::new()),
+			Box::new(NoUnexpectedDependencyOverridesRule::new()),
 			Box::new(RequiredPackageFieldsRule::new()),
+			Box::new(SdkConstraintModernRule::new()),
+			Box::new(SdkConstraintPresentRule::new()),
 			Box::new(UnlistedPackagePrivateRule::new()),
 		]
 	}
@@ -68,16 +73,24 @@ impl LintSuite for DartLintSuite {
 			LintPreset::new(
 				"dart/recommended",
 				"Dart recommended",
-				"Balanced Dart manifest linting for published package metadata and publishability",
+				"Balanced Dart manifest linting for metadata, publishability, and baseline SDK hygiene",
 				LintMaturity::Stable,
 			)
 			.with_rules(BTreeMap::from([
+				(
+					"dart/dependency-sorted".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Warning),
+				),
 				(
 					"dart/no-git-dependencies-in-published-packages".to_string(),
 					LintRuleConfig::Severity(LintSeverity::Error),
 				),
 				(
 					"dart/required-package-fields".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Error),
+				),
+				(
+					"dart/sdk-constraint-present".to_string(),
 					LintRuleConfig::Severity(LintSeverity::Error),
 				),
 				(
@@ -88,16 +101,32 @@ impl LintSuite for DartLintSuite {
 			LintPreset::new(
 				"dart/strict",
 				"Dart strict",
-				"Opinionated Dart manifest linting with the same publishability rules enabled by default",
+				"Opinionated Dart manifest linting with SDK policy and dependency overrides enforced",
 				LintMaturity::Strict,
 			)
 			.with_rules(BTreeMap::from([
+				(
+					"dart/dependency-sorted".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Error),
+				),
 				(
 					"dart/no-git-dependencies-in-published-packages".to_string(),
 					LintRuleConfig::Severity(LintSeverity::Error),
 				),
 				(
+					"dart/no-unexpected-dependency-overrides".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Error),
+				),
+				(
 					"dart/required-package-fields".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Error),
+				),
+				(
+					"dart/sdk-constraint-modern".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Error),
+				),
+				(
+					"dart/sdk-constraint-present".to_string(),
 					LintRuleConfig::Severity(LintSeverity::Error),
 				),
 				(
@@ -226,6 +255,60 @@ fn manifest_declares_private(mapping: &Mapping) -> bool {
 	)
 }
 
+fn dependency_sections() -> [&'static str; 3] {
+	["dependencies", "dev_dependencies", "dependency_overrides"]
+}
+
+fn sdk_constraint_value(mapping: &Mapping) -> Option<&str> {
+	yaml_mapping(mapping, "environment")?
+		.get(yaml_key("sdk"))
+		.and_then(Value::as_str)
+}
+
+fn parse_constraint_version(value: &str) -> Option<Version> {
+	let trimmed = value.trim().trim_matches('"').trim_matches('\'');
+	if trimmed.is_empty() {
+		return None;
+	}
+	let mut parts = trimmed.split('.').collect::<Vec<_>>();
+	if parts.len() == 1 {
+		parts.extend(["0", "0"]);
+	} else if parts.len() == 2 {
+		parts.push("0");
+	}
+	Version::parse(&parts.join(".")).ok()
+}
+
+#[derive(Debug, Default)]
+struct ParsedSdkConstraint {
+	lower_bound: Option<Version>,
+	has_upper_bound: bool,
+}
+
+fn parse_sdk_constraint(value: &str) -> ParsedSdkConstraint {
+	let trimmed = value.trim();
+	if let Some(caret) = trimmed.strip_prefix('^') {
+		return ParsedSdkConstraint {
+			lower_bound: parse_constraint_version(caret),
+			has_upper_bound: true,
+		};
+	}
+
+	let mut parsed = ParsedSdkConstraint::default();
+	for token in trimmed.split_whitespace() {
+		if let Some(version) = token.strip_prefix(">=").or_else(|| token.strip_prefix('>'))
+			&& parsed.lower_bound.is_none()
+		{
+			parsed.lower_bound = parse_constraint_version(version);
+		}
+		if token.starts_with('<') {
+			parsed.has_upper_bound = true;
+		}
+	}
+
+	parsed
+}
+
 fn insert_publish_to_none(contents: &str) -> String {
 	if contents.is_empty() {
 		return "publish_to: none\n".to_string();
@@ -233,6 +316,182 @@ fn insert_publish_to_none(contents: &str) -> String {
 
 	let separator = if contents.ends_with('\n') { "" } else { "\n" };
 	format!("{contents}{separator}publish_to: none\n")
+}
+
+fn render_manifest(mapping: &Mapping, fallback: &str) -> String {
+	serde_yaml_ng::to_string(mapping).unwrap_or_else(|_| fallback.to_string())
+}
+
+fn sort_manifest_section(mapping: &mut Mapping, section: &str) {
+	let Some(Value::Mapping(section_mapping)) = mapping.get_mut(yaml_key(section)) else {
+		return;
+	};
+	let mut entries = section_mapping
+		.iter()
+		.map(|(key, value)| {
+			(
+				key.as_str().unwrap_or_default().to_string(),
+				key.clone(),
+				value.clone(),
+			)
+		})
+		.collect::<Vec<_>>();
+	entries.sort_by(|left, right| left.0.cmp(&right.0));
+	section_mapping.clear();
+	for (_, key, value) in entries {
+		section_mapping.insert(key, value);
+	}
+}
+
+fn yaml_line_ranges(contents: &str) -> Vec<(usize, usize)> {
+	let mut ranges = Vec::new();
+	let mut start = 0usize;
+	for (index, ch) in contents.char_indices() {
+		if ch == '\n' {
+			ranges.push((start, index));
+			start = index + 1;
+		}
+	}
+	if start <= contents.len() {
+		ranges.push((start, contents.len()));
+	}
+	ranges
+}
+
+struct ParsedYamlLine<'a> {
+	indent: usize,
+	key: &'a str,
+}
+
+fn parse_yaml_line(contents: &str, range: (usize, usize)) -> Option<ParsedYamlLine<'_>> {
+	let line = &contents[range.0..range.1];
+	let trimmed = line.trim_start_matches([' ', '\t']);
+	if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with('-') {
+		return None;
+	}
+	let indent = line.len() - trimmed.len();
+	let colon = trimmed.find(':')?;
+	let key = trimmed[..colon].trim();
+	if key.is_empty() {
+		return None;
+	}
+	Some(ParsedYamlLine { indent, key })
+}
+
+fn find_yaml_key_line(
+	contents: &str,
+	line_ranges: &[(usize, usize)],
+	indent: usize,
+	key: &str,
+) -> Option<usize> {
+	line_ranges.iter().position(|range| {
+		parse_yaml_line(contents, *range)
+			.is_some_and(|line| line.indent == indent && line.key == key)
+	})
+}
+
+fn source_key_order(contents: &str, section: &str) -> Option<Vec<String>> {
+	let line_ranges = yaml_line_ranges(contents);
+	let section_index = find_yaml_key_line(contents, &line_ranges, 0, section)?;
+	let section_line = parse_yaml_line(contents, *line_ranges.get(section_index)?)?;
+	let mut keys = Vec::new();
+	let mut index = section_index + 1;
+	while let Some(range) = line_ranges.get(index) {
+		let Some(line) = parse_yaml_line(contents, *range) else {
+			index += 1;
+			continue;
+		};
+		if line.indent <= section_line.indent {
+			break;
+		}
+		if line.indent == section_line.indent + 2 {
+			keys.push(line.key.to_string());
+		}
+		index += 1;
+	}
+	Some(keys)
+}
+
+#[derive(Debug)]
+struct DependencySortedRule {
+	rule: LintRule,
+}
+
+impl DependencySortedRule {
+	fn new() -> Self {
+		Self {
+			rule: LintRule::new(
+				"dart/dependency-sorted",
+				"Dependency sections sorted",
+				"Requires Dart dependency sections to be alphabetically sorted",
+				LintCategory::Style,
+				LintMaturity::Stable,
+				true,
+			)
+			.with_options(vec![LintOptionDefinition::new(
+				"fix",
+				"apply an autofix that rewrites dependency sections in sorted order",
+				LintOptionKind::Boolean,
+			)]),
+		}
+	}
+}
+
+impl LintRuleRunner for DependencySortedRule {
+	fn rule(&self) -> &LintRule {
+		&self.rule
+	}
+
+	fn run(&self, ctx: &LintContext<'_>, config: &LintRuleConfig) -> Vec<LintResult> {
+		let Some(file) = dart_file(ctx) else {
+			return Vec::new();
+		};
+		let mut results = Vec::new();
+
+		for section in dependency_sections() {
+			let Some(mapping) = yaml_mapping(&file.manifest, section) else {
+				continue;
+			};
+			let mut sorted_keys = mapping
+				.keys()
+				.filter_map(Value::as_str)
+				.map(ToString::to_string)
+				.collect::<Vec<_>>();
+			sorted_keys.sort();
+			let source_order = source_key_order(ctx.contents, section).unwrap_or_else(|| {
+				mapping
+					.keys()
+					.filter_map(Value::as_str)
+					.map(ToString::to_string)
+					.collect::<Vec<_>>()
+			});
+			if source_order == sorted_keys {
+				continue;
+			}
+
+			let mut result = LintResult::new(
+				self.rule.id.clone(),
+				location(ctx),
+				format!("dependencies in `{section}` are not sorted alphabetically"),
+				config.severity(),
+			);
+			if config.bool_option("fix", true) {
+				let mut rewritten = file.manifest.clone();
+				for sortable in dependency_sections() {
+					sort_manifest_section(&mut rewritten, sortable);
+				}
+				result = result.with_fix(LintFix::single(
+					"sort dependency sections alphabetically",
+					(0, ctx.contents.len()),
+					render_manifest(&rewritten, ctx.contents),
+				));
+			}
+
+			results.push(result);
+		}
+
+		results
+	}
 }
 
 #[derive(Debug)]
@@ -316,6 +575,78 @@ impl LintRuleRunner for NoGitDependenciesInPublishedPackagesRule {
 }
 
 #[derive(Debug)]
+struct NoUnexpectedDependencyOverridesRule {
+	rule: LintRule,
+}
+
+impl NoUnexpectedDependencyOverridesRule {
+	fn new() -> Self {
+		Self {
+			rule: LintRule::new(
+				"dart/no-unexpected-dependency-overrides",
+				"No unexpected dependency overrides",
+				"Warns when dependency_overrides appear outside explicitly allowed Dart packages",
+				LintCategory::BestPractice,
+				LintMaturity::Stable,
+				false,
+			)
+			.with_options(vec![
+				LintOptionDefinition::new(
+					"allow_for_private",
+					"allow dependency_overrides in private packages",
+					LintOptionKind::Boolean,
+				),
+				LintOptionDefinition::new(
+					"allow_packages",
+					"list of package names that may declare dependency_overrides",
+					LintOptionKind::StringList,
+				),
+			]),
+		}
+	}
+}
+
+impl LintRuleRunner for NoUnexpectedDependencyOverridesRule {
+	fn rule(&self) -> &LintRule {
+		&self.rule
+	}
+
+	fn run(&self, ctx: &LintContext<'_>, config: &LintRuleConfig) -> Vec<LintResult> {
+		let Some(file) = dart_file(ctx) else {
+			return Vec::new();
+		};
+		let Some(overrides) = yaml_mapping(&file.manifest, "dependency_overrides") else {
+			return Vec::new();
+		};
+		if overrides.is_empty() {
+			return Vec::new();
+		}
+		if ctx.metadata.private == Some(true) && config.bool_option("allow_for_private", true) {
+			return Vec::new();
+		}
+
+		let allowed_packages = config
+			.string_list_option("allow_packages")
+			.unwrap_or_default()
+			.into_iter()
+			.collect::<BTreeSet<_>>();
+		let package_name = ctx.metadata.package_name.as_deref().unwrap_or_default();
+		if allowed_packages.contains(package_name) {
+			return Vec::new();
+		}
+
+		vec![LintResult::new(
+			self.rule.id.clone(),
+			location(ctx),
+			format!(
+				"package `{package_name}` declares dependency_overrides without an allow-list entry"
+			),
+			config.severity(),
+		)]
+	}
+}
+
+#[derive(Debug)]
 struct RequiredPackageFieldsRule {
 	rule: LintRule,
 }
@@ -367,6 +698,127 @@ impl LintRuleRunner for RequiredPackageFieldsRule {
 				)
 			})
 			.collect()
+	}
+}
+
+#[derive(Debug)]
+struct SdkConstraintModernRule {
+	rule: LintRule,
+}
+
+impl SdkConstraintModernRule {
+	fn new() -> Self {
+		Self {
+			rule: LintRule::new(
+				"dart/sdk-constraint-modern",
+				"SDK constraint modern",
+				"Requires Dart packages to use a modern environment.sdk lower bound and, by default, an upper bound",
+				LintCategory::BestPractice,
+				LintMaturity::Stable,
+				false,
+			)
+			.with_options(vec![
+				LintOptionDefinition::new(
+					"minimum",
+					"minimum supported SDK version, such as 3.0.0 or 3.6.0",
+					LintOptionKind::String,
+				),
+				LintOptionDefinition::new(
+					"require_upper_bound",
+					"require environment.sdk to include an upper bound",
+					LintOptionKind::Boolean,
+				),
+			]),
+		}
+	}
+}
+
+impl LintRuleRunner for SdkConstraintModernRule {
+	fn rule(&self) -> &LintRule {
+		&self.rule
+	}
+
+	fn run(&self, ctx: &LintContext<'_>, config: &LintRuleConfig) -> Vec<LintResult> {
+		let Some(file) = dart_file(ctx) else {
+			return Vec::new();
+		};
+		let Some(sdk_constraint) = sdk_constraint_value(&file.manifest) else {
+			return Vec::new();
+		};
+
+		let minimum = config
+			.string_option("minimum")
+			.and_then(|value| parse_constraint_version(&value))
+			.unwrap_or_else(|| Version::new(3, 0, 0));
+		let require_upper_bound = config.bool_option("require_upper_bound", true);
+		let parsed = parse_sdk_constraint(sdk_constraint);
+		let mut reasons = Vec::new();
+
+		match parsed.lower_bound {
+			Some(ref lower_bound) if lower_bound < &minimum => {
+				reasons.push(format!("lower bound must be at least {minimum}"));
+			}
+			None => reasons.push("lower bound could not be determined".to_string()),
+			_ => {}
+		}
+		if require_upper_bound && !parsed.has_upper_bound {
+			reasons.push("constraint should include an upper bound".to_string());
+		}
+		if reasons.is_empty() {
+			return Vec::new();
+		}
+
+		vec![LintResult::new(
+			self.rule.id.clone(),
+			location(ctx),
+			format!(
+				"environment.sdk `{sdk_constraint}` is not modern enough: {}",
+				reasons.join("; ")
+			),
+			config.severity(),
+		)]
+	}
+}
+
+#[derive(Debug)]
+struct SdkConstraintPresentRule {
+	rule: LintRule,
+}
+
+impl SdkConstraintPresentRule {
+	fn new() -> Self {
+		Self {
+			rule: LintRule::new(
+				"dart/sdk-constraint-present",
+				"SDK constraint present",
+				"Requires an explicit environment.sdk constraint in pubspec.yaml",
+				LintCategory::Correctness,
+				LintMaturity::Stable,
+				false,
+			),
+		}
+	}
+}
+
+impl LintRuleRunner for SdkConstraintPresentRule {
+	fn rule(&self) -> &LintRule {
+		&self.rule
+	}
+
+	fn run(&self, ctx: &LintContext<'_>, config: &LintRuleConfig) -> Vec<LintResult> {
+		let Some(file) = dart_file(ctx) else {
+			return Vec::new();
+		};
+		if sdk_constraint_value(&file.manifest).is_some() {
+			return Vec::new();
+		}
+
+		vec![LintResult::new(
+			self.rule.id.clone(),
+			location(ctx),
+			"pubspec.yaml must declare environment.sdk explicitly",
+			config.severity(),
+		)]
 	}
 }
 
@@ -435,6 +887,7 @@ mod tests {
 	use monochange_core::lint::LintTarget;
 	use monochange_test_helpers::fixture_path;
 	use serde_json::json;
+	use serde_yaml_ng::Mapping;
 
 	use super::*;
 
@@ -449,6 +902,19 @@ mod tests {
 		lint_suite()
 			.collect_targets(&root, &configuration)
 			.unwrap_or_else(|error| panic!("collect dart lint fixture targets: {error}"))
+	}
+
+	fn sdk_dependency_hygiene_root() -> std::path::PathBuf {
+		fixture_path!("dart-lints/sdk-dependency-hygiene/workspace")
+	}
+
+	fn sdk_dependency_hygiene_targets() -> Vec<LintTarget> {
+		let root = sdk_dependency_hygiene_root();
+		let configuration = load_workspace_configuration(&root)
+			.unwrap_or_else(|error| panic!("load dart sdk fixture config: {error}"));
+		lint_suite()
+			.collect_targets(&root, &configuration)
+			.unwrap_or_else(|error| panic!("collect dart sdk fixture targets: {error}"))
 	}
 
 	fn find_target<'a>(targets: &'a [LintTarget], package_name: &str) -> &'a LintTarget {
@@ -479,13 +945,31 @@ mod tests {
 	fn presets_are_exposed() {
 		let presets = DartLintSuite.presets();
 		assert_eq!(presets.len(), 2);
+
+		let recommended = presets.first().expect("expected recommended preset");
+		assert_eq!(recommended.id, "dart/recommended");
 		assert_eq!(
-			presets.first().map(|preset| preset.id.as_str()),
-			Some("dart/recommended")
+			recommended.rules.get("dart/dependency-sorted"),
+			Some(&LintRuleConfig::Severity(LintSeverity::Warning))
 		);
 		assert_eq!(
-			presets.get(1).map(|preset| preset.id.as_str()),
-			Some("dart/strict")
+			recommended.rules.get("dart/sdk-constraint-present"),
+			Some(&LintRuleConfig::Severity(LintSeverity::Error))
+		);
+
+		let strict = presets.get(1).expect("expected strict preset");
+		assert_eq!(strict.id, "dart/strict");
+		assert_eq!(
+			strict.rules.get("dart/dependency-sorted"),
+			Some(&LintRuleConfig::Severity(LintSeverity::Error))
+		);
+		assert_eq!(
+			strict.rules.get("dart/sdk-constraint-modern"),
+			Some(&LintRuleConfig::Severity(LintSeverity::Error))
+		);
+		assert_eq!(
+			strict.rules.get("dart/no-unexpected-dependency-overrides"),
+			Some(&LintRuleConfig::Severity(LintSeverity::Error))
 		);
 	}
 
@@ -532,6 +1016,101 @@ mod tests {
 	}
 
 	#[test]
+	fn sdk_constraint_present_rule_reports_missing_constraints() {
+		let targets = sdk_dependency_hygiene_targets();
+		let missing = find_target(&targets, "missing_sdk");
+		let modern = find_target(&targets, "modern_ok");
+
+		let results = SdkConstraintPresentRule::new().run(&ctx(missing), &config());
+		assert_eq!(results.len(), 1);
+		assert!(
+			results
+				.first()
+				.expect("expected lint result")
+				.message
+				.contains("environment.sdk")
+		);
+		assert!(
+			SdkConstraintPresentRule::new()
+				.run(&ctx(modern), &config())
+				.is_empty()
+		);
+	}
+
+	#[test]
+	fn sdk_constraint_modern_rule_reports_legacy_and_overly_broad_constraints() {
+		let targets = sdk_dependency_hygiene_targets();
+		let legacy = find_target(&targets, "legacy_sdk");
+		let wide = find_target(&targets, "wide_sdk");
+
+		let legacy_results = SdkConstraintModernRule::new().run(&ctx(legacy), &config());
+		assert_eq!(legacy_results.len(), 1);
+		assert!(
+			legacy_results
+				.first()
+				.expect("expected lint result")
+				.message
+				.contains("3.0.0")
+		);
+
+		let wide_results = SdkConstraintModernRule::new().run(&ctx(wide), &config());
+		assert_eq!(wide_results.len(), 1);
+		assert!(
+			wide_results
+				.first()
+				.expect("expected lint result")
+				.message
+				.contains("upper bound")
+		);
+
+		let tuned_config = LintRuleConfig::Detailed {
+			level: LintSeverity::Error,
+			options: BTreeMap::from([
+				("minimum".to_string(), json!("2.19.0")),
+				("require_upper_bound".to_string(), json!(false)),
+			]),
+		};
+		assert!(
+			SdkConstraintModernRule::new()
+				.run(&ctx(legacy), &tuned_config)
+				.is_empty()
+		);
+		assert!(
+			SdkConstraintModernRule::new()
+				.run(&ctx(wide), &tuned_config)
+				.is_empty()
+		);
+	}
+
+	#[test]
+	fn dependency_sorted_rule_reports_unsorted_sections_and_emits_parseable_fix() {
+		let targets = sdk_dependency_hygiene_targets();
+		let target = find_target(&targets, "unsorted_deps");
+		let results = DependencySortedRule::new().run(&ctx(target), &config());
+		assert_eq!(results.len(), 3);
+
+		let replacement = results
+			.first()
+			.and_then(|result| result.fix.as_ref())
+			.and_then(|fix| fix.edits.first())
+			.map(|edit| edit.replacement.clone())
+			.expect("expected fix replacement");
+		assert!(serde_yaml_ng::from_str::<Mapping>(&replacement).is_ok());
+		assert_eq!(
+			source_key_order(&replacement, "dependencies"),
+			Some(vec!["alpha".to_string(), "zebra".to_string()])
+		);
+		assert_eq!(
+			source_key_order(&replacement, "dev_dependencies"),
+			Some(vec!["beta".to_string(), "zeta".to_string()])
+		);
+		assert_eq!(
+			source_key_order(&replacement, "dependency_overrides"),
+			Some(vec!["analyzer".to_string(), "yaml".to_string()])
+		);
+	}
+
+	#[test]
 	fn no_git_dependencies_rule_reports_published_git_dependencies_and_supports_allow_list() {
 		let targets = metadata_publishability_targets();
 		let failing = find_target(&targets, "git_dep_fail");
@@ -559,6 +1138,39 @@ mod tests {
 		assert!(
 			NoGitDependenciesInPublishedPackagesRule::new()
 				.run(&ctx(private), &config())
+				.is_empty()
+		);
+	}
+
+	#[test]
+	fn no_unexpected_dependency_overrides_rule_supports_allow_list_and_private_packages() {
+		let targets = sdk_dependency_hygiene_targets();
+		let failing = find_target(&targets, "override_fail");
+		let private = find_target(&targets, "override_private");
+		let allowed = find_target(&targets, "override_allowed");
+
+		let results = NoUnexpectedDependencyOverridesRule::new().run(&ctx(failing), &config());
+		assert_eq!(results.len(), 1);
+		assert!(
+			results
+				.first()
+				.expect("expected lint result")
+				.message
+				.contains("override_fail")
+		);
+		assert!(
+			NoUnexpectedDependencyOverridesRule::new()
+				.run(&ctx(private), &config())
+				.is_empty()
+		);
+
+		let allow_config = LintRuleConfig::Detailed {
+			level: LintSeverity::Error,
+			options: BTreeMap::from([("allow_packages".to_string(), json!(["override_allowed"]))]),
+		};
+		assert!(
+			NoUnexpectedDependencyOverridesRule::new()
+				.run(&ctx(allowed), &allow_config)
 				.is_empty()
 		);
 	}

--- a/docs/src/reference/linting.md
+++ b/docs/src/reference/linting.md
@@ -6,7 +6,7 @@ monochange can lint monorepo package manifests through `mc check`, using rules c
 
 Use this guide when the task is to configure or explain monochange's **manifest lint rules**.
 
-These are the rules that run through **`mc check`** and are configured in `monochange.toml` under **`[ecosystems.<name>.lints]`**.
+These are the rules that run through **`mc check`** and are configured in `monochange.toml` under the top-level **`[lints]`** section.
 
 They are separate from Rust compiler or Clippy lints used to develop monochange itself.
 
@@ -29,23 +29,26 @@ Use `--fix` when you want monochange to apply auto-fixes where a rule supports t
 
 ## Where lint rules live
 
-Configure rules per ecosystem in `monochange.toml`:
+Configure rules under the top-level lint section in `monochange.toml`:
 
 ```toml
-[ecosystems.cargo.lints]
+[lints]
+use = ["cargo/recommended", "npm/recommended", "dart/recommended"]
+
+[lints.rules]
 "cargo/dependency-field-order" = "error"
 "cargo/internal-dependency-workspace" = "error"
 "cargo/required-package-fields" = { level = "warning", fields = ["description", "license", "repository"] }
 "cargo/sorted-dependencies" = "warning"
 "cargo/unlisted-package-private" = { level = "warning", fix = true }
-
-[ecosystems.npm.lints]
 "npm/workspace-protocol" = "error"
 "npm/sorted-dependencies" = "warning"
 "npm/required-package-fields" = { level = "warning", fields = ["description", "repository", "license"] }
 "npm/root-no-prod-deps" = "error"
 "npm/no-duplicate-dependencies" = "error"
 "npm/unlisted-package-private" = { level = "warning", fix = true }
+"dart/sdk-constraint-modern" = { level = "warning", minimum = "3.6.0", require_upper_bound = false }
+"dart/no-unexpected-dependency-overrides" = { level = "warning", allow_for_private = true, allow_packages = ["app_shell"] }
 ```
 
 Rule configuration supports two forms:
@@ -59,8 +62,9 @@ Today, built-in manifest lint rules exist for:
 
 - **Cargo** manifests (`Cargo.toml`)
 - **npm-family** manifests (`package.json`)
+- **Dart / Flutter** manifests (`pubspec.yaml`)
 
-monochange already wires lint configuration through `configuration.cargo.lints`, `configuration.npm.lints`, `configuration.deno.lints`, and `configuration.dart.lints`, but the current built-in rule sets are implemented for Cargo and npm manifests.
+monochange routes all manifest lint configuration through the top-level `[lints]` section, while each ecosystem crate provides its own built-in suites and presets.
 
 ## Cargo manifest lint rules
 
@@ -143,7 +147,7 @@ version = "0.1.0"
 Example:
 
 ```toml
-[ecosystems.cargo.lints]
+[lints.rules]
 "cargo/required-package-fields" = { level = "error", fields = ["description", "license"] }
 ```
 
@@ -369,6 +373,64 @@ publish = false
 **Useful option:**
 
 - `fix` — defaults to `true`
+
+## Dart manifest lint rules
+
+### `dart/sdk-constraint-present`
+
+**Why:** every managed Dart package should declare the SDK range it expects rather than inheriting whatever the developer machine happens to provide.
+
+**With the rule:** monochange reports any `pubspec.yaml` that omits `environment.sdk`.
+
+### `dart/sdk-constraint-modern`
+
+**Why:** old or overly broad SDK ranges quietly expand your support policy and make releases harder to reason about.
+
+**Default policy:**
+
+- minimum lower bound: `3.0.0`
+- upper bound required by default
+
+**Useful options:**
+
+- `minimum` — override the minimum lower bound for your workspace
+- `require_upper_bound` — set to `false` if your policy intentionally omits an upper bound
+
+Example:
+
+```toml
+[lints.rules]
+"dart/sdk-constraint-modern" = { level = "warning", minimum = "3.6.0", require_upper_bound = false }
+```
+
+### `dart/dependency-sorted`
+
+**Why:** alphabetized `dependencies`, `dev_dependencies`, and `dependency_overrides` blocks reduce review noise and make Dart manifest diffs easier to scan.
+
+**Useful option:**
+
+- `fix` — defaults to `true`
+
+### `dart/no-unexpected-dependency-overrides`
+
+**Why:** `dependency_overrides` are sometimes necessary, but they should usually be limited to private packages or a small allow list of explicitly approved packages.
+
+**Useful options:**
+
+- `allow_for_private` — defaults to `true`
+- `allow_packages` — list package names that may keep `dependency_overrides`
+
+Example:
+
+```toml
+[lints.rules]
+"dart/no-unexpected-dependency-overrides" = { level = "warning", allow_for_private = true, allow_packages = ["app_shell"] }
+```
+
+### Dart presets
+
+- `dart/recommended` enables metadata/publishability checks, `dart/sdk-constraint-present`, and `dart/dependency-sorted` as a warning.
+- `dart/strict` adds `dart/sdk-constraint-modern`, `dart/no-unexpected-dependency-overrides`, and promotes `dart/dependency-sorted` to an error.
 
 ## What `mc check` looks like in practice
 

--- a/fixtures/tests/dart-lints/sdk-dependency-hygiene/workspace/monochange.toml
+++ b/fixtures/tests/dart-lints/sdk-dependency-hygiene/workspace/monochange.toml
@@ -1,0 +1,30 @@
+[defaults]
+parent_bump = "patch"
+package_type = "dart"
+
+[package.modern_ok]
+path = "packages/modern_ok"
+
+[package.missing_sdk]
+path = "packages/missing_sdk"
+
+[package.legacy_sdk]
+path = "packages/legacy_sdk"
+
+[package.wide_sdk]
+path = "packages/wide_sdk"
+
+[package.unsorted_deps]
+path = "packages/unsorted_deps"
+
+[package.override_fail]
+path = "packages/override_fail"
+
+[package.override_private]
+path = "packages/override_private"
+
+[package.override_allowed]
+path = "packages/override_allowed"
+
+[ecosystems.dart]
+enabled = true

--- a/fixtures/tests/dart-lints/sdk-dependency-hygiene/workspace/packages/legacy_sdk/pubspec.yaml
+++ b/fixtures/tests/dart-lints/sdk-dependency-hygiene/workspace/packages/legacy_sdk/pubspec.yaml
@@ -1,0 +1,4 @@
+name: legacy_sdk
+version: 1.0.0
+environment:
+  sdk: ">=2.19.0 <4.0.0"

--- a/fixtures/tests/dart-lints/sdk-dependency-hygiene/workspace/packages/missing_sdk/pubspec.yaml
+++ b/fixtures/tests/dart-lints/sdk-dependency-hygiene/workspace/packages/missing_sdk/pubspec.yaml
@@ -1,0 +1,4 @@
+name: missing_sdk
+version: 1.0.0
+dependencies:
+  alpha: ^1.0.0

--- a/fixtures/tests/dart-lints/sdk-dependency-hygiene/workspace/packages/modern_ok/pubspec.yaml
+++ b/fixtures/tests/dart-lints/sdk-dependency-hygiene/workspace/packages/modern_ok/pubspec.yaml
@@ -1,0 +1,7 @@
+name: modern_ok
+version: 1.0.0
+environment:
+  sdk: ^3.6.0
+dependencies:
+  alpha: ^1.0.0
+  beta: ^1.0.0

--- a/fixtures/tests/dart-lints/sdk-dependency-hygiene/workspace/packages/override_allowed/pubspec.yaml
+++ b/fixtures/tests/dart-lints/sdk-dependency-hygiene/workspace/packages/override_allowed/pubspec.yaml
@@ -1,0 +1,6 @@
+name: override_allowed
+version: 1.0.0
+environment:
+  sdk: ^3.6.0
+dependency_overrides:
+  analyzer: ^7.0.0

--- a/fixtures/tests/dart-lints/sdk-dependency-hygiene/workspace/packages/override_fail/pubspec.yaml
+++ b/fixtures/tests/dart-lints/sdk-dependency-hygiene/workspace/packages/override_fail/pubspec.yaml
@@ -1,0 +1,6 @@
+name: override_fail
+version: 1.0.0
+environment:
+  sdk: ^3.6.0
+dependency_overrides:
+  analyzer: ^7.0.0

--- a/fixtures/tests/dart-lints/sdk-dependency-hygiene/workspace/packages/override_private/pubspec.yaml
+++ b/fixtures/tests/dart-lints/sdk-dependency-hygiene/workspace/packages/override_private/pubspec.yaml
@@ -1,0 +1,7 @@
+name: override_private
+version: 1.0.0
+publish_to: none
+environment:
+  sdk: ^3.6.0
+dependency_overrides:
+  analyzer: ^7.0.0

--- a/fixtures/tests/dart-lints/sdk-dependency-hygiene/workspace/packages/unsorted_deps/pubspec.yaml
+++ b/fixtures/tests/dart-lints/sdk-dependency-hygiene/workspace/packages/unsorted_deps/pubspec.yaml
@@ -1,0 +1,13 @@
+name: unsorted_deps
+version: 1.0.0
+environment:
+  sdk: ^3.6.0
+dependencies:
+  zebra: ^1.0.0
+  alpha: ^1.0.0
+dev_dependencies:
+  zeta: ^1.0.0
+  beta: ^1.0.0
+dependency_overrides:
+  yaml: ^3.0.0
+  analyzer: ^7.0.0

--- a/fixtures/tests/dart-lints/sdk-dependency-hygiene/workspace/packages/wide_sdk/pubspec.yaml
+++ b/fixtures/tests/dart-lints/sdk-dependency-hygiene/workspace/packages/wide_sdk/pubspec.yaml
@@ -1,0 +1,4 @@
+name: wide_sdk
+version: 1.0.0
+environment:
+  sdk: ">=3.0.0"

--- a/fixtures/tests/dart-lints/sdk-dependency-hygiene/workspace/pubspec.yaml
+++ b/fixtures/tests/dart-lints/sdk-dependency-hygiene/workspace/pubspec.yaml
@@ -1,0 +1,2 @@
+workspace:
+  - packages/*

--- a/packages/monochange__skill/skills/linting.md
+++ b/packages/monochange__skill/skills/linting.md
@@ -4,7 +4,7 @@
 
 Use this guide when the task is to configure or explain monochange's **manifest lint rules**.
 
-These are the rules that run through **`mc check`** and are configured in `monochange.toml` under **`[ecosystems.<name>.lints]`**.
+These are the rules that run through **`mc check`** and are configured in `monochange.toml` under the top-level **`[lints]`** section.
 
 They are separate from Rust compiler or Clippy lints used to develop monochange itself.
 
@@ -27,23 +27,26 @@ Use `--fix` when you want monochange to apply auto-fixes where a rule supports t
 
 ## Where lint rules live
 
-Configure rules per ecosystem in `monochange.toml`:
+Configure rules under the top-level lint section in `monochange.toml`:
 
 ```toml
-[ecosystems.cargo.lints]
+[lints]
+use = ["cargo/recommended", "npm/recommended", "dart/recommended"]
+
+[lints.rules]
 "cargo/dependency-field-order" = "error"
 "cargo/internal-dependency-workspace" = "error"
 "cargo/required-package-fields" = { level = "warning", fields = ["description", "license", "repository"] }
 "cargo/sorted-dependencies" = "warning"
 "cargo/unlisted-package-private" = { level = "warning", fix = true }
-
-[ecosystems.npm.lints]
 "npm/workspace-protocol" = "error"
 "npm/sorted-dependencies" = "warning"
 "npm/required-package-fields" = { level = "warning", fields = ["description", "repository", "license"] }
 "npm/root-no-prod-deps" = "error"
 "npm/no-duplicate-dependencies" = "error"
 "npm/unlisted-package-private" = { level = "warning", fix = true }
+"dart/sdk-constraint-modern" = { level = "warning", minimum = "3.6.0", require_upper_bound = false }
+"dart/no-unexpected-dependency-overrides" = { level = "warning", allow_for_private = true, allow_packages = ["app_shell"] }
 ```
 
 Rule configuration supports two forms:
@@ -57,8 +60,9 @@ Today, built-in manifest lint rules exist for:
 
 - **Cargo** manifests (`Cargo.toml`)
 - **npm-family** manifests (`package.json`)
+- **Dart / Flutter** manifests (`pubspec.yaml`)
 
-monochange already wires lint configuration through `configuration.cargo.lints`, `configuration.npm.lints`, `configuration.deno.lints`, and `configuration.dart.lints`, but the current built-in rule sets are implemented for Cargo and npm manifests.
+monochange routes all manifest lint configuration through the top-level `[lints]` section, while each ecosystem crate provides its own built-in suites and presets.
 
 ## Cargo manifest lint rules
 
@@ -141,7 +145,7 @@ version = "0.1.0"
 Example:
 
 ```toml
-[ecosystems.cargo.lints]
+[lints.rules]
 "cargo/required-package-fields" = { level = "error", fields = ["description", "license"] }
 ```
 
@@ -367,6 +371,64 @@ publish = false
 **Useful option:**
 
 - `fix` — defaults to `true`
+
+## Dart manifest lint rules
+
+### `dart/sdk-constraint-present`
+
+**Why:** every managed Dart package should declare the SDK range it expects rather than inheriting whatever the developer machine happens to provide.
+
+**With the rule:** monochange reports any `pubspec.yaml` that omits `environment.sdk`.
+
+### `dart/sdk-constraint-modern`
+
+**Why:** old or overly broad SDK ranges quietly expand your support policy and make releases harder to reason about.
+
+**Default policy:**
+
+- minimum lower bound: `3.0.0`
+- upper bound required by default
+
+**Useful options:**
+
+- `minimum` — override the minimum lower bound for your workspace
+- `require_upper_bound` — set to `false` if your policy intentionally omits an upper bound
+
+Example:
+
+```toml
+[lints.rules]
+"dart/sdk-constraint-modern" = { level = "warning", minimum = "3.6.0", require_upper_bound = false }
+```
+
+### `dart/dependency-sorted`
+
+**Why:** alphabetized `dependencies`, `dev_dependencies`, and `dependency_overrides` blocks reduce review noise and make Dart manifest diffs easier to scan.
+
+**Useful option:**
+
+- `fix` — defaults to `true`
+
+### `dart/no-unexpected-dependency-overrides`
+
+**Why:** `dependency_overrides` are sometimes necessary, but they should usually be limited to private packages or a small allow list of explicitly approved packages.
+
+**Useful options:**
+
+- `allow_for_private` — defaults to `true`
+- `allow_packages` — list package names that may keep `dependency_overrides`
+
+Example:
+
+```toml
+[lints.rules]
+"dart/no-unexpected-dependency-overrides" = { level = "warning", allow_for_private = true, allow_packages = ["app_shell"] }
+```
+
+### Dart presets
+
+- `dart/recommended` enables metadata/publishability checks, `dart/sdk-constraint-present`, and `dart/dependency-sorted` as a warning.
+- `dart/strict` adds `dart/sdk-constraint-modern`, `dart/no-unexpected-dependency-overrides`, and promotes `dart/dependency-sorted` to an error.
 
 ## What `mc check` looks like in practice
 


### PR DESCRIPTION
## Summary
- add Dart lint rules for SDK constraints, dependency sorting, and dependency override policy
- update Dart recommended and strict presets plus lint discovery coverage
- document the new Dart lint configuration and preset tuning guidance

## Testing
- cargo fmt --all
- cargo test -p monochange_dart --lib -- --nocapture
- cargo test -p monochange --lib lint_cli_lists_and_explains_rules -- --nocapture
- cargo test -p monochange --lib render_lint_catalog_lists_rules_and_presets -- --nocapture
- cargo check -p monochange_dart -p monochange --all-features
- devenv shell docs:update
- pre-push `lint:test` hook

Closes #232