### PR TITLE
refactor: clarify declare_lint_rule usage

### DIFF
--- a/.changeset/clarify-declare-lint-rule-usage.md
+++ b/.changeset/clarify-declare-lint-rule-usage.md
@@ -1,0 +1,7 @@
+---
+"monochange": patch
+"monochange_cargo": patch
+"monochange_linting": patch
+---
+
+Adopt `declare_lint_rule` for Cargo lint metadata and clarify when lint authors should use it.

--- a/crates/monochange/src/lint.rs
+++ b/crates/monochange/src/lint.rs
@@ -355,7 +355,9 @@ use monochange_linting::declare_lint_rule;
 use monochange_linting::LintCategory;
 use monochange_linting::LintMaturity;
 
-
+// Keep `declare_lint_rule!` for straightforward metadata-only construction.
+// If this rule later needs extra constructor state, switch to an explicit
+// `struct` plus `LintRule::new(...)`.
 declare_lint_rule! {{
     pub {struct_name},
     id: "{suite}/{rule_name}",
@@ -644,11 +646,9 @@ mod tests {
 		let odd_file = tempdir
 			.path()
 			.join("crates/monochange_cargo/src/lints/_foo.rs");
-		assert!(
-			fs::read_to_string(odd_file)
-				.unwrap()
-				.contains("pub FooRule")
-		);
+		let odd_contents = fs::read_to_string(odd_file).unwrap();
+		assert!(odd_contents.contains("pub FooRule"));
+		assert!(odd_contents.contains("Keep `declare_lint_rule!`"));
 
 		let dart_message =
 			scaffold_lint_rule(tempdir.path(), "dart/sdk-constraint-present").unwrap();

--- a/crates/monochange_cargo/src/lints/mod.rs
+++ b/crates/monochange_cargo/src/lints/mod.rs
@@ -274,30 +274,22 @@ fn preferred_dependency_order() -> [&'static str; 14] {
 	]
 }
 
-#[derive(Debug)]
-struct DependencyFieldOrderRule {
-	rule: LintRule,
+monochange_linting::declare_lint_rule! {
+	DependencyFieldOrderRule,
+	id: "cargo/dependency-field-order",
+	name: "Dependency field order",
+	description: "Enforces consistent ordering inside Cargo dependency tables",
+	category: LintCategory::Style,
+	maturity: LintMaturity::Stable,
+	autofixable: true,
+	options: vec![LintOptionDefinition::new(
+		"fix",
+		"apply an autofix that rewrites the dependency entry",
+		LintOptionKind::Boolean,
+	)],
 }
 
 impl DependencyFieldOrderRule {
-	fn new() -> Self {
-		Self {
-			rule: LintRule::new(
-				"cargo/dependency-field-order",
-				"Dependency field order",
-				"Enforces consistent ordering inside Cargo dependency tables",
-				LintCategory::Style,
-				LintMaturity::Stable,
-				true,
-			)
-			.with_options(vec![LintOptionDefinition::new(
-				"fix",
-				"apply an autofix that rewrites the dependency entry",
-				LintOptionKind::Boolean,
-			)]),
-		}
-	}
-
 	fn ordered_fields(table: &toml_edit::Table) -> Vec<&str> {
 		let order = preferred_dependency_order();
 		let mut keys = table
@@ -382,36 +374,26 @@ impl LintRuleRunner for DependencyFieldOrderRule {
 	}
 }
 
-#[derive(Debug)]
-struct InternalDependencyWorkspaceRule {
-	rule: LintRule,
-}
-
-impl InternalDependencyWorkspaceRule {
-	fn new() -> Self {
-		Self {
-			rule: LintRule::new(
-				"cargo/internal-dependency-workspace",
-				"Internal dependency workspace",
-				"Requires workspace = true for internal Cargo dependencies",
-				LintCategory::Correctness,
-				LintMaturity::Stable,
-				true,
-			)
-			.with_options(vec![
-				LintOptionDefinition::new(
-					"require_workspace",
-					"require internal dependencies to use workspace = true",
-					LintOptionKind::Boolean,
-				),
-				LintOptionDefinition::new(
-					"fix",
-					"apply an autofix when a dependency can be rewritten safely",
-					LintOptionKind::Boolean,
-				),
-			]),
-		}
-	}
+monochange_linting::declare_lint_rule! {
+	InternalDependencyWorkspaceRule,
+	id: "cargo/internal-dependency-workspace",
+	name: "Internal dependency workspace",
+	description: "Requires workspace = true for internal Cargo dependencies",
+	category: LintCategory::Correctness,
+	maturity: LintMaturity::Stable,
+	autofixable: true,
+	options: vec![
+		LintOptionDefinition::new(
+			"require_workspace",
+			"require internal dependencies to use workspace = true",
+			LintOptionKind::Boolean,
+		),
+		LintOptionDefinition::new(
+			"fix",
+			"apply an autofix when a dependency can be rewritten safely",
+			LintOptionKind::Boolean,
+		),
+	],
 }
 
 impl LintRuleRunner for InternalDependencyWorkspaceRule {
@@ -473,29 +455,19 @@ impl LintRuleRunner for InternalDependencyWorkspaceRule {
 	}
 }
 
-#[derive(Debug)]
-struct RequiredPackageFieldsRule {
-	rule: LintRule,
-}
-
-impl RequiredPackageFieldsRule {
-	fn new() -> Self {
-		Self {
-			rule: LintRule::new(
-				"cargo/required-package-fields",
-				"Required package fields",
-				"Requires selected fields in the [package] table",
-				LintCategory::Correctness,
-				LintMaturity::Stable,
-				false,
-			)
-			.with_options(vec![LintOptionDefinition::new(
-				"fields",
-				"list of package fields that must be present",
-				LintOptionKind::StringList,
-			)]),
-		}
-	}
+monochange_linting::declare_lint_rule! {
+	RequiredPackageFieldsRule,
+	id: "cargo/required-package-fields",
+	name: "Required package fields",
+	description: "Requires selected fields in the [package] table",
+	category: LintCategory::Correctness,
+	maturity: LintMaturity::Stable,
+	autofixable: false,
+	options: vec![LintOptionDefinition::new(
+		"fields",
+		"list of package fields that must be present",
+		LintOptionKind::StringList,
+	)],
 }
 
 impl LintRuleRunner for RequiredPackageFieldsRule {
@@ -537,29 +509,19 @@ impl LintRuleRunner for RequiredPackageFieldsRule {
 	}
 }
 
-#[derive(Debug)]
-struct SortedDependenciesRule {
-	rule: LintRule,
-}
-
-impl SortedDependenciesRule {
-	fn new() -> Self {
-		Self {
-			rule: LintRule::new(
-				"cargo/sorted-dependencies",
-				"Sorted dependencies",
-				"Requires Cargo dependency tables to be alphabetically sorted",
-				LintCategory::Style,
-				LintMaturity::Stable,
-				true,
-			)
-			.with_options(vec![LintOptionDefinition::new(
-				"fix",
-				"apply an autofix that rewrites the dependency section",
-				LintOptionKind::Boolean,
-			)]),
-		}
-	}
+monochange_linting::declare_lint_rule! {
+	SortedDependenciesRule,
+	id: "cargo/sorted-dependencies",
+	name: "Sorted dependencies",
+	description: "Requires Cargo dependency tables to be alphabetically sorted",
+	category: LintCategory::Style,
+	maturity: LintMaturity::Stable,
+	autofixable: true,
+	options: vec![LintOptionDefinition::new(
+		"fix",
+		"apply an autofix that rewrites the dependency section",
+		LintOptionKind::Boolean,
+	)],
 }
 
 impl LintRuleRunner for SortedDependenciesRule {
@@ -619,29 +581,19 @@ impl LintRuleRunner for SortedDependenciesRule {
 	}
 }
 
-#[derive(Debug)]
-struct UnlistedPackagePrivateRule {
-	rule: LintRule,
-}
-
-impl UnlistedPackagePrivateRule {
-	fn new() -> Self {
-		Self {
-			rule: LintRule::new(
-				"cargo/unlisted-package-private",
-				"Unlisted package must be private",
-				"Requires unmanaged Cargo packages to declare publish = false",
-				LintCategory::Correctness,
-				LintMaturity::Stable,
-				true,
-			)
-			.with_options(vec![LintOptionDefinition::new(
-				"fix",
-				"apply an autofix that inserts publish = false",
-				LintOptionKind::Boolean,
-			)]),
-		}
-	}
+monochange_linting::declare_lint_rule! {
+	UnlistedPackagePrivateRule,
+	id: "cargo/unlisted-package-private",
+	name: "Unlisted package must be private",
+	description: "Requires unmanaged Cargo packages to declare publish = false",
+	category: LintCategory::Correctness,
+	maturity: LintMaturity::Stable,
+	autofixable: true,
+	options: vec![LintOptionDefinition::new(
+		"fix",
+		"apply an autofix that inserts publish = false",
+		LintOptionKind::Boolean,
+	)],
 }
 
 impl LintRuleRunner for UnlistedPackagePrivateRule {

--- a/crates/monochange_linting/readme.md
+++ b/crates/monochange_linting/readme.md
@@ -3,3 +3,9 @@
 Authoring helpers and macros for monochange lint suites.
 
 This crate keeps lint declaration boilerplate small so ecosystem crates can focus on rule logic instead of repeatedly spelling out metadata constructors.
+
+## Guidance
+
+- Use `declare_lint_rule!` for straightforward rules whose custom behavior mostly lives in `run(...)`.
+- The Cargo suite uses the macro for real rules, so the helper now reflects actual ecosystem code instead of scaffolding-only examples.
+- If a rule eventually needs extra construction state or a custom constructor, an explicit `struct` plus `LintRule::new(...)` is still fine.

--- a/crates/monochange_linting/src/lib.rs
+++ b/crates/monochange_linting/src/lib.rs
@@ -1,6 +1,11 @@
 #![forbid(clippy::indexing_slicing)]
 
 //! Authoring helpers and macros for monochange lint suites.
+//!
+//! Use [`declare_lint_rule`] for straightforward rules whose customization mostly
+//! lives in `run(...)`. The Cargo suite uses the macro in real lint
+//! implementations, while rules that need additional constructor state can still
+//! use an explicit `struct` plus [`LintRule::new`].
 
 pub use monochange_core::lint::LintCategory;
 pub use monochange_core::lint::LintMaturity;


### PR DESCRIPTION
## Summary
- adopt `declare_lint_rule!` for the real Cargo lint implementations
- document when lint authors should keep using the macro versus switching to explicit constructors
- update generated lint scaffolds to explain the preferred authoring path

## Testing
- cargo fmt --all
- cargo test -p monochange_cargo --lib -- --nocapture
- cargo test -p monochange_linting --lib -- --nocapture
- cargo test -p monochange --lib scaffold_lint_rule_validates_ids_and_creates_expected_files -- --nocapture
- cargo test -p monochange --lib lint_cli_lists_and_explains_rules -- --nocapture
- cargo test -p monochange --lib render_lint_catalog_lists_rules_and_presets -- --nocapture
- cargo check -p monochange_cargo -p monochange_linting -p monochange --all-features
- devenv shell -- monochange affected --format json --verify ...

Closes #234