### PR TITLE
fix: align publish rate-limit plans with pending publishes

### DIFF
--- a/.changeset/publish-rate-limit-pending-plans.md
+++ b/.changeset/publish-rate-limit-pending-plans.md
@@ -1,0 +1,27 @@
+---
+monochange: patch
+---
+
+#### align publish rate-limit plans with pending registry work
+
+`mc publish`, `mc placeholder-publish`, and `mc publish-plan` now count only the package versions that are still missing from their registries when they build `publishRateLimits` output.
+
+**Before:**
+
+```bash
+mc publish --dry-run --format json
+mc placeholder-publish --dry-run --format json
+mc publish-plan --format json
+```
+
+If some selected package versions were already present in their registries, the rate-limit report could still count them as pending work and recommend extra batches even though the publish command would skip them.
+
+**After:**
+
+```bash
+mc publish --dry-run --format json
+mc placeholder-publish --dry-run --format json
+mc publish-plan --format json
+```
+
+The `publishRateLimits` report now shrinks automatically on reruns, partial publishes, and placeholder bootstrap flows where some packages already exist. That keeps advisory warnings, optional enforcement, and CI batch plans aligned with the actual work left to publish.

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -356,6 +356,34 @@ pub(crate) fn build_release_requests(
 	Ok(requests)
 }
 
+pub(crate) fn filter_pending_publish_requests(
+	requests: &[PublishRequest],
+) -> MonochangeResult<Vec<PublishRequest>> {
+	let client = Client::new();
+	let endpoints = RegistryEndpoints::from_env();
+	filter_pending_publish_requests_with_transport(requests, &client, &endpoints)
+}
+
+fn filter_pending_publish_requests_with_transport(
+	requests: &[PublishRequest],
+	client: &Client,
+	endpoints: &RegistryEndpoints,
+) -> MonochangeResult<Vec<PublishRequest>> {
+	let mut pending_requests = Vec::with_capacity(requests.len());
+
+	for request in requests {
+		if request.mode == PublishMode::External {
+			continue;
+		}
+		if registry_version_exists(client, endpoints, request)? {
+			continue;
+		}
+		pending_requests.push(request.clone());
+	}
+
+	Ok(pending_requests)
+}
+
 fn packages_by_config_id(packages: &[PackageRecord]) -> BTreeMap<&str, &PackageRecord> {
 	packages
 		.iter()
@@ -3181,6 +3209,43 @@ jobs:
 			report.packages[1].status,
 			PackagePublishStatus::SkippedExisting
 		);
+	}
+
+	#[test]
+	fn filter_pending_publish_requests_skips_external_and_existing_versions() {
+		let server = MockServer::start();
+		server.mock(|when, then| {
+			when.method(GET).path("/pkg");
+			then.status(200).json_body_obj(&serde_json::json!({
+				"versions": { "1.2.3": {} }
+			}));
+		});
+		let client = Client::builder().build().expect("http client:");
+		let endpoints = sample_endpoints(&server.base_url());
+		let request = PublishRequest {
+			mode: PublishMode::External,
+			..sample_request(RegistryKind::Npm)
+		};
+		let existing = sample_request(RegistryKind::Npm);
+		let pending = PublishRequest {
+			package_id: "pkg-next".to_string(),
+			package_name: "pkg-next".to_string(),
+			..sample_request(RegistryKind::Npm)
+		};
+		server.mock(|when, then| {
+			when.method(GET).path("/pkg-next");
+			then.status(404);
+		});
+
+		let filtered = filter_pending_publish_requests_with_transport(
+			&[request, existing, pending],
+			&client,
+			&endpoints,
+		)
+		.expect("filtered requests:");
+
+		assert_eq!(filtered.len(), 1);
+		assert_eq!(filtered[0].package_id, "pkg-next");
 	}
 
 	#[test]

--- a/crates/monochange/src/publish_rate_limits.rs
+++ b/crates/monochange/src/publish_rate_limits.rs
@@ -73,7 +73,9 @@ fn build_placeholder_plan_requests(
 	packages: &[monochange_core::PackageRecord],
 	selected_packages: &BTreeSet<String>,
 ) -> MonochangeResult<Vec<package_publish::PublishRequest>> {
-	package_publish::build_placeholder_requests(root, configuration, packages, selected_packages)
+	#[rustfmt::skip]
+	let requests = package_publish::build_placeholder_requests(root, configuration, packages, selected_packages)?;
+	package_publish::filter_pending_publish_requests(&requests)
 }
 
 fn build_release_plan_requests(
@@ -84,7 +86,9 @@ fn build_release_plan_requests(
 ) -> MonochangeResult<Vec<package_publish::PublishRequest>> {
 	#[rustfmt::skip]
 	let publications = package_publish::release_record_package_publications_from_prepared_or_head(root, prepared_release)?;
-	package_publish::build_release_requests(packages, &publications, selected_packages)
+	let requests =
+		package_publish::build_release_requests(packages, &publications, selected_packages)?;
+	package_publish::filter_pending_publish_requests(&requests)
 }
 
 pub(crate) fn plan_publish_rate_limits_for_requests(
@@ -336,11 +340,14 @@ fn registry_policies() -> Vec<RegistryRateLimitPolicy> {
 mod tests {
 	use std::fs;
 
+	use httpmock::Method::GET;
+	use httpmock::MockServer;
 	use monochange_core::PackagePublicationTarget;
 	use monochange_core::PublishMode;
 	use monochange_core::PublishRegistry;
 	use monochange_core::TrustedPublishingSettings;
 	use semver::Version;
+	use temp_env::with_vars;
 	use tempfile::tempdir;
 
 	use super::*;
@@ -465,13 +472,41 @@ mod tests {
 			dry_run: true,
 		};
 
-		let report = plan_publish_rate_limits(
-			tempdir.path(),
-			&configuration,
-			Some(&prepared_release),
-			&BTreeSet::new(),
-			PublishRateLimitMode::Publish,
-			true,
+		let server = MockServer::start();
+		server.mock(|when, then| {
+			when.method(GET).path("/crates/core");
+			then.status(404);
+		});
+		server.mock(|when, then| {
+			when.method(GET).path("/docs");
+			then.status(404);
+		});
+		server.mock(|when, then| {
+			when.method(GET).path("/web");
+			then.status(404);
+		});
+
+		let report = with_vars(
+			[
+				(
+					"MONOCHANGE_CRATES_IO_API_URL",
+					Some(server.base_url().as_str()),
+				),
+				(
+					"MONOCHANGE_NPM_REGISTRY_URL",
+					Some(server.base_url().as_str()),
+				),
+			],
+			|| {
+				plan_publish_rate_limits(
+					tempdir.path(),
+					&configuration,
+					Some(&prepared_release),
+					&BTreeSet::new(),
+					PublishRateLimitMode::Publish,
+					true,
+				)
+			},
 		)
 		.unwrap_or_else(|error| panic!("plan rate limits: {error}"));
 
@@ -481,6 +516,176 @@ mod tests {
 			batch.registry == RegistryKind::Npm
 				&& batch.packages == vec!["docs".to_string(), "web".to_string()]
 		}));
+	}
+
+	#[test]
+	fn plan_publish_rate_limits_skips_versions_that_are_already_published() {
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+			.join("../../fixtures/tests/publish-rate-limits/single-window/workspace");
+		copy_fixture_dir(&fixture, tempdir.path());
+		let configuration = crate::load_workspace_configuration(tempdir.path())
+			.unwrap_or_else(|error| panic!("load config: {error}"));
+		let prepared_release = PreparedRelease {
+			plan: monochange_core::ReleasePlan {
+				workspace_root: tempdir.path().to_path_buf(),
+				decisions: Vec::new(),
+				groups: Vec::new(),
+				warnings: Vec::new(),
+				unresolved_items: Vec::new(),
+				compatibility_evidence: Vec::new(),
+			},
+			changeset_paths: Vec::new(),
+			changesets: Vec::new(),
+			released_packages: vec!["core".to_string(), "docs".to_string(), "web".to_string()],
+			package_publications: vec![
+				PackagePublicationTarget {
+					package: "core".to_string(),
+					ecosystem: monochange_core::Ecosystem::Cargo,
+					registry: Some(PublishRegistry::Builtin(RegistryKind::CratesIo)),
+					version: Version::new(1, 0, 0).to_string(),
+					mode: PublishMode::Builtin,
+					trusted_publishing: TrustedPublishingSettings::default(),
+				},
+				PackagePublicationTarget {
+					package: "docs".to_string(),
+					ecosystem: monochange_core::Ecosystem::Npm,
+					registry: Some(PublishRegistry::Builtin(RegistryKind::Npm)),
+					version: Version::new(1, 0, 0).to_string(),
+					mode: PublishMode::Builtin,
+					trusted_publishing: TrustedPublishingSettings::default(),
+				},
+				PackagePublicationTarget {
+					package: "web".to_string(),
+					ecosystem: monochange_core::Ecosystem::Npm,
+					registry: Some(PublishRegistry::Builtin(RegistryKind::Npm)),
+					version: Version::new(1, 0, 0).to_string(),
+					mode: PublishMode::Builtin,
+					trusted_publishing: TrustedPublishingSettings::default(),
+				},
+			],
+			version: None,
+			group_version: None,
+			release_targets: Vec::new(),
+			changed_files: Vec::new(),
+			changelogs: Vec::new(),
+			updated_changelogs: Vec::new(),
+			deleted_changesets: Vec::new(),
+			dry_run: true,
+		};
+		let server = MockServer::start();
+		server.mock(|when, then| {
+			when.method(GET).path("/crates/core");
+			then.status(200).json_body_obj(&serde_json::json!({
+				"versions": [{ "num": "1.0.0" }]
+			}));
+		});
+		server.mock(|when, then| {
+			when.method(GET).path("/docs");
+			then.status(404);
+		});
+		server.mock(|when, then| {
+			when.method(GET).path("/web");
+			then.status(404);
+		});
+
+		let report = with_vars(
+			[
+				(
+					"MONOCHANGE_CRATES_IO_API_URL",
+					Some(server.base_url().as_str()),
+				),
+				(
+					"MONOCHANGE_NPM_REGISTRY_URL",
+					Some(server.base_url().as_str()),
+				),
+			],
+			|| {
+				plan_publish_rate_limits(
+					tempdir.path(),
+					&configuration,
+					Some(&prepared_release),
+					&BTreeSet::new(),
+					PublishRateLimitMode::Publish,
+					true,
+				)
+			},
+		)
+		.unwrap_or_else(|error| panic!("plan rate limits: {error}"));
+
+		assert_eq!(report.windows.len(), 1);
+		assert_eq!(report.windows[0].registry, RegistryKind::Npm);
+		assert_eq!(report.windows[0].pending, 2);
+		assert!(
+			report
+				.batches
+				.iter()
+				.all(|batch| batch.registry == RegistryKind::Npm)
+		);
+		assert!(
+			report
+				.batches
+				.iter()
+				.flat_map(|batch| batch.packages.iter())
+				.all(|package| package != "core")
+		);
+	}
+
+	#[test]
+	fn build_placeholder_plan_requests_skips_placeholder_versions_that_already_exist() {
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+			.join("../../fixtures/tests/publish-rate-limits/single-window/workspace");
+		copy_fixture_dir(&fixture, tempdir.path());
+		let configuration = crate::load_workspace_configuration(tempdir.path())
+			.unwrap_or_else(|error| panic!("load config: {error}"));
+		let discovery = discover_workspace(tempdir.path())
+			.unwrap_or_else(|error| panic!("discover workspace: {error}"));
+		let server = MockServer::start();
+		server.mock(|when, then| {
+			when.method(GET).path("/crates/core");
+			then.status(200).json_body_obj(&serde_json::json!({
+				"versions": [{ "num": "0.0.0" }]
+			}));
+		});
+		server.mock(|when, then| {
+			when.method(GET).path("/docs");
+			then.status(404);
+		});
+		server.mock(|when, then| {
+			when.method(GET).path("/web");
+			then.status(404);
+		});
+
+		let requests = with_vars(
+			[
+				(
+					"MONOCHANGE_CRATES_IO_API_URL",
+					Some(server.base_url().as_str()),
+				),
+				(
+					"MONOCHANGE_NPM_REGISTRY_URL",
+					Some(server.base_url().as_str()),
+				),
+			],
+			|| {
+				build_placeholder_plan_requests(
+					tempdir.path(),
+					&configuration,
+					&discovery.packages,
+					&BTreeSet::new(),
+				)
+			},
+		)
+		.unwrap_or_else(|error| panic!("build placeholder plan requests: {error}"));
+
+		assert_eq!(
+			requests
+				.iter()
+				.map(|request| request.package_id.as_str())
+				.collect::<Vec<_>>(),
+			vec!["docs", "web"]
+		);
 	}
 
 	#[test]
@@ -520,13 +725,41 @@ mod tests {
 		let configuration = crate::load_workspace_configuration(tempdir.path())
 			.unwrap_or_else(|error| panic!("load config: {error}"));
 
-		let report = plan_publish_rate_limits(
-			tempdir.path(),
-			&configuration,
-			None,
-			&BTreeSet::new(),
-			PublishRateLimitMode::Placeholder,
-			true,
+		let server = MockServer::start();
+		server.mock(|when, then| {
+			when.method(GET).path("/crates/core");
+			then.status(404);
+		});
+		server.mock(|when, then| {
+			when.method(GET).path("/docs");
+			then.status(404);
+		});
+		server.mock(|when, then| {
+			when.method(GET).path("/web");
+			then.status(404);
+		});
+
+		let report = with_vars(
+			[
+				(
+					"MONOCHANGE_CRATES_IO_API_URL",
+					Some(server.base_url().as_str()),
+				),
+				(
+					"MONOCHANGE_NPM_REGISTRY_URL",
+					Some(server.base_url().as_str()),
+				),
+			],
+			|| {
+				plan_publish_rate_limits(
+					tempdir.path(),
+					&configuration,
+					None,
+					&BTreeSet::new(),
+					PublishRateLimitMode::Placeholder,
+					true,
+				)
+			},
 		)
 		.unwrap_or_else(|error| panic!("plan placeholder rate limits: {error}"));
 

--- a/docs/src/guide/15-publish-rate-limits.md
+++ b/docs/src/guide/15-publish-rate-limits.md
@@ -17,6 +17,8 @@ The report includes:
 - a provider-agnostic batch schedule with package ids per batch
 - evidence links and confidence levels for the built-in limits
 
+`mc publish-plan` only counts package versions that are still missing from their registries. If you rerun a release after some packages were already published, the remaining batches shrink automatically.
+
 ## Current built-in coverage
 
 - `crates.io` — source-backed publish window metadata

--- a/docs/src/reference/cli-steps/09-plan-publish-rate-limits.md
+++ b/docs/src/reference/cli-steps/09-plan-publish-rate-limits.md
@@ -24,6 +24,7 @@ A structured publish-rate-limit report containing:
 - batch counts
 - explicit package ids per batch
 - evidence and confidence metadata for each built-in policy
+- only versions that are still missing from their registries, so reruns reflect the remaining work
 
 ## Examples
 
@@ -77,3 +78,5 @@ inputs = { ci = "github-actions" }
 ## Notes
 
 `PlanPublishRateLimits` is advisory by default. Built-in publish commands only become blocking when matching packages enable `publish.rate_limits.enforce = true`.
+
+The step checks the target registries before counting pending work, so already-published versions and placeholder packages that already exist do not inflate the batch plan.


### PR DESCRIPTION
## Summary
- align publish rate-limit planning with the versions that are still missing from their registries
- skip already-published release versions and existing placeholder packages before building `publishRateLimits`
- document that reruns and partial publishes automatically shrink the remaining batch plan

## Testing
- `cargo fmt --all`
- `cargo test -p monochange --lib -- --nocapture`
- `devenv shell docs:check`
- `devenv shell -- mc affected --format json --verify --changed-paths crates/monochange/src/package_publish.rs --changed-paths crates/monochange/src/publish_rate_limits.rs --changed-paths docs/src/guide/15-publish-rate-limits.md --changed-paths docs/src/reference/cli-steps/09-plan-publish-rate-limits.md --changed-paths .changeset/publish-rate-limit-pending-plans.md`
- `devenv shell -- mc check`
- `devenv shell lint:all`
- `devenv shell build:all`

## Coverage
- changed Rust files diff coverage: `100.0%` (`278` executable added lines, `0` missed)
