### PR TITLE
feat: add monochange adoption playbook and validated examples

### DIFF
--- a/.changeset/skill-adoption-playbook.md
+++ b/.changeset/skill-adoption-playbook.md
@@ -1,0 +1,13 @@
+---
+"@monochange/skill": minor
+---
+
+#### add an adoption playbook and example indexes to the packaged skill
+
+The packaged `@monochange/skill` now includes an interactive adoption guide plus bundled example indexes for choosing how deeply to set up monochange.
+
+**Before:** The skill explained commands, configuration, linting, and publishing, but it did not give agents a clear question tree for quickstart vs standard vs full vs migration adoption. It also lacked a dedicated examples surface for pointing users at setup patterns.
+
+**After:** The package adds `skills/adoption.md`, a bundled `examples/` folder with condensed scenario summaries, and references to a top-level repository `examples/` index for fuller repo-shaped setups.
+
+This makes the skill better at plan-mode interrogation, migration guidance, and recommendation-driven setup conversations.

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -849,10 +849,12 @@ After copying the bundled skill, you get a small documentation set that is desig
 - `SKILL.md` — concise entrypoint for agents
 - `REFERENCE.md` — broader high-context reference with more examples
 - `skills/README.md` — index of focused deep dives
+- `skills/adoption.md` — setup-depth questions, migration guidance, and recommendation patterns
 - `skills/changesets.md` — changeset authoring and lifecycle guidance
 - `skills/commands.md` — built-in command catalog and workflow selection
 - `skills/configuration.md` — `monochange.toml` setup and editing guidance
-- `skills/linting.md` — `[ecosystems.<name>.lints]` rules, `mc check`, and manifest-focused examples
+- `skills/linting.md` — `[lints]` presets, `mc check`, and manifest-focused examples
+- `examples/README.md` — condensed scenario examples for quick recommendations
 
 This layout keeps the top-level skill small while still making the richer guidance available when an assistant needs more context.
 
@@ -975,32 +977,30 @@ Common commands:
 mc check
 mc check --fix
 mc check --format json
+mc lint list
+mc lint explain cargo/recommended
 ```
 
 Use `--fix` when you want monochange to apply auto-fixes where a rule supports them.
 
 ## Where lint rules live
 
-Configure rules under the top-level lint section in `monochange.toml`:
+Configure presets, global rules, and scoped overrides in the top-level `[lints]` section of `monochange.toml`:
 
 ```toml
 [lints]
 use = ["cargo/recommended", "npm/recommended", "dart/recommended"]
 
 [lints.rules]
-"cargo/dependency-field-order" = "error"
 "cargo/internal-dependency-workspace" = "error"
-"cargo/required-package-fields" = { level = "warning", fields = ["description", "license", "repository"] }
-"cargo/sorted-dependencies" = "warning"
-"cargo/unlisted-package-private" = { level = "warning", fix = true }
 "npm/workspace-protocol" = "error"
-"npm/sorted-dependencies" = "warning"
-"npm/required-package-fields" = { level = "warning", fields = ["description", "repository", "license"] }
-"npm/root-no-prod-deps" = "error"
-"npm/no-duplicate-dependencies" = "error"
-"npm/unlisted-package-private" = { level = "warning", fix = true }
 "dart/sdk-constraint-modern" = { level = "warning", minimum = "3.6.0", require_upper_bound = false }
 "dart/no-unexpected-dependency-overrides" = { level = "warning", allow_for_private = true, allow_packages = ["app_shell"] }
+
+[[lints.scopes]]
+name = "published cargo packages"
+match = { ecosystems = ["cargo"], managed = true, publishable = true }
+rules = { "cargo/required-package-fields" = "error" }
 ```
 
 Rule configuration supports two forms:
@@ -1016,7 +1016,7 @@ Today, built-in manifest lint rules exist for:
 - **npm-family** manifests (`package.json`)
 - **Dart / Flutter** manifests (`pubspec.yaml`)
 
-monochange routes all manifest lint configuration through the top-level `[lints]` section, while each ecosystem crate provides its own built-in suites and presets.
+Lint suites still live in ecosystem crates, but monochange routes all manifest lint configuration through the top-level `[lints]` section via preset selection, rule overrides, and scoped matches.
 
 ## Cargo manifest lint rules
 
@@ -1424,6 +1424,8 @@ Example:
 
 - `dart/recommended` enables metadata/publishability checks, `dart/sdk-constraint-present`, and `dart/dependency-sorted` as a warning.
 - `dart/strict` adds `dart/sdk-constraint-modern`, `dart/no-unexpected-dependency-overrides`, `dart/internal-path-dependency-policy`, `dart/workspace-internal-version-consistency`, `dart/flutter-package-metadata-consistent`, and `dart/assets-sorted`, while promoting `dart/dependency-sorted` to an error.
+
+Use `mc lint list` to inspect registered rules and presets, and `mc lint explain <id>` to understand a rule or preset before enabling it.
 
 ## What `mc check` looks like in practice
 

--- a/docs/src/guide/01-installation.md
+++ b/docs/src/guide/01-installation.md
@@ -41,10 +41,12 @@ After copying the bundled skill, you get a small documentation set that is desig
 - `SKILL.md` — concise entrypoint for agents
 - `REFERENCE.md` — broader high-context reference with more examples
 - `skills/README.md` — index of focused deep dives
+- `skills/adoption.md` — setup-depth questions, migration guidance, and recommendation patterns
 - `skills/changesets.md` — changeset authoring and lifecycle guidance
 - `skills/commands.md` — built-in command catalog and workflow selection
 - `skills/configuration.md` — `monochange.toml` setup and editing guidance
-- `skills/linting.md` — `[ecosystems.<name>.lints]` rules, `mc check`, and manifest-focused examples
+- `skills/linting.md` — `[lints]` presets, `mc check`, and manifest-focused examples
+- `examples/README.md` — condensed scenario examples for quick recommendations
 
 This layout keeps the top-level skill small while still making the richer guidance available when an assistant needs more context.
 

--- a/docs/src/guide/09-assistant-setup.md
+++ b/docs/src/guide/09-assistant-setup.md
@@ -30,10 +30,12 @@ After copying the bundled skill, you get a small documentation set that is desig
 - `SKILL.md` — concise entrypoint for agents
 - `REFERENCE.md` — broader high-context reference with more examples
 - `skills/README.md` — index of focused deep dives
+- `skills/adoption.md` — setup-depth questions, migration guidance, and recommendation patterns
 - `skills/changesets.md` — changeset authoring and lifecycle guidance
 - `skills/commands.md` — built-in command catalog and workflow selection
 - `skills/configuration.md` — `monochange.toml` setup and editing guidance
-- `skills/linting.md` — `[ecosystems.<name>.lints]` rules, `mc check`, and manifest-focused examples
+- `skills/linting.md` — `[lints]` presets, `mc check`, and manifest-focused examples
+- `examples/README.md` — condensed scenario examples for quick recommendations
 
 This layout keeps the top-level skill small while still making the richer guidance available when an assistant needs more context.
 

--- a/docs/src/reference/linting.md
+++ b/docs/src/reference/linting.md
@@ -23,32 +23,30 @@ Common commands:
 mc check
 mc check --fix
 mc check --format json
+mc lint list
+mc lint explain cargo/recommended
 ```
 
 Use `--fix` when you want monochange to apply auto-fixes where a rule supports them.
 
 ## Where lint rules live
 
-Configure rules under the top-level lint section in `monochange.toml`:
+Configure presets, global rules, and scoped overrides in the top-level `[lints]` section of `monochange.toml`:
 
 ```toml
 [lints]
 use = ["cargo/recommended", "npm/recommended", "dart/recommended"]
 
 [lints.rules]
-"cargo/dependency-field-order" = "error"
 "cargo/internal-dependency-workspace" = "error"
-"cargo/required-package-fields" = { level = "warning", fields = ["description", "license", "repository"] }
-"cargo/sorted-dependencies" = "warning"
-"cargo/unlisted-package-private" = { level = "warning", fix = true }
 "npm/workspace-protocol" = "error"
-"npm/sorted-dependencies" = "warning"
-"npm/required-package-fields" = { level = "warning", fields = ["description", "repository", "license"] }
-"npm/root-no-prod-deps" = "error"
-"npm/no-duplicate-dependencies" = "error"
-"npm/unlisted-package-private" = { level = "warning", fix = true }
 "dart/sdk-constraint-modern" = { level = "warning", minimum = "3.6.0", require_upper_bound = false }
 "dart/no-unexpected-dependency-overrides" = { level = "warning", allow_for_private = true, allow_packages = ["app_shell"] }
+
+[[lints.scopes]]
+name = "published cargo packages"
+match = { ecosystems = ["cargo"], managed = true, publishable = true }
+rules = { "cargo/required-package-fields" = "error" }
 ```
 
 Rule configuration supports two forms:
@@ -64,7 +62,7 @@ Today, built-in manifest lint rules exist for:
 - **npm-family** manifests (`package.json`)
 - **Dart / Flutter** manifests (`pubspec.yaml`)
 
-monochange routes all manifest lint configuration through the top-level `[lints]` section, while each ecosystem crate provides its own built-in suites and presets.
+Lint suites still live in ecosystem crates, but monochange routes all manifest lint configuration through the top-level `[lints]` section via preset selection, rule overrides, and scoped matches.
 
 ## Cargo manifest lint rules
 
@@ -472,6 +470,8 @@ Example:
 
 - `dart/recommended` enables metadata/publishability checks, `dart/sdk-constraint-present`, and `dart/dependency-sorted` as a warning.
 - `dart/strict` adds `dart/sdk-constraint-modern`, `dart/no-unexpected-dependency-overrides`, `dart/internal-path-dependency-policy`, `dart/workspace-internal-version-consistency`, `dart/flutter-package-metadata-consistent`, and `dart/assets-sorted`, while promoting `dart/dependency-sorted` to an error.
+
+Use `mc lint list` to inspect registered rules and presets, and `mc lint explain <id>` to understand a rule or preset before enabling it.
 
 ## What `mc check` looks like in practice
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,58 @@
+# monochange examples
+
+This folder is the top-level index for repo-shaped monochange example setups.
+
+Use these examples when you want something larger and more concrete than the bundled skill examples in `packages/monochange__skill/examples/`. The goal is to give users and agents a place they can be pointed to for realistic setup patterns, migration shapes, and CI layouts.
+
+## Design goals
+
+- cover both greenfield and migration adoption
+- show GitHub and GitLab release flows side by side
+- separate release planning from package publishing and hosted/provider releases
+- make builtin vs external publishing recommendations explicit
+- keep examples small enough to understand, but structured enough to test end to end over time
+
+## Current example tracks
+
+- [github-npm-quickstart](./github-npm-quickstart/README.md) — greenfield GitHub Actions setup for npm or pnpm workspaces
+- [github-cargo-quickstart](./github-cargo-quickstart/README.md) — greenfield GitHub Actions setup for Cargo workspaces
+- [mixed-workspace](./mixed-workspace/README.md) — cross-ecosystem monorepo with mixed package types and shared discovery concerns
+- [gitlab-migration](./gitlab-migration/README.md) — adopting monochange into an existing GitLab-based repository
+- [public-packages-placeholder-publish](./public-packages-placeholder-publish/README.md) — reserving package names before the real release flow is ready
+- [internal-only-workspace](./internal-only-workspace/README.md) — release planning, linting, and changesets without public package publishing
+- [release-pr-workflow](./release-pr-workflow/README.md) — long-running release PR branch automation
+- [publishing-test-lab](./publishing-test-lab/README.md) — follow-up plan for real publishing verification outside this repository
+
+## Validation policy
+
+The long-term intent is:
+
+- config, discovery, linting, and dry-run release flows should be validated end to end inside this repository
+- real registry publishing should be validated in a separate test repository so package names, auth, and rate limits can be managed safely
+- examples in this folder should grow into repo-shaped test fixtures as the product surface stabilizes
+
+Today:
+
+- `github-cargo-quickstart`, `github-npm-quickstart`, `gitlab-migration`, `internal-only-workspace`, `mixed-workspace`, `public-packages-placeholder-publish`, and `release-pr-workflow` are repo-shaped examples with actual workspace and config files
+- `publishing-test-lab` remains an issue-driven planning directory because real publish verification belongs in a separate repository
+- `./validate-examples.sh` runs `mc validate`, `mc check`, and `mc release --dry-run --diff` against every repo-shaped example in this folder
+
+See also [publishing-test-lab/ISSUE.md](./publishing-test-lab/ISSUE.md) for a draft GitHub issue that scopes the external publishing-verification work.
+
+## Publishing test-lab recommendation
+
+Publishing is the one area that should not rely only on local fixtures.
+
+Recommended follow-up:
+
+1. create a dedicated external test repository for publish verification
+2. mirror changes from monochange into that repository on a controlled cadence
+3. use isolated namespaces, throwaway package names, or sandbox registries where the ecosystem supports them
+4. explicitly test rate limits, delayed publish windows, and multi-package ordering behavior
+5. keep production package names and production registries out of the test loop whenever possible
+
+Where ecosystems differ, prefer the safest option available:
+
+- use alternate or sandbox registries when they exist
+- otherwise use dedicated public test namespaces that are clearly non-production
+- for ecosystems with hard global naming constraints, keep a stable set of dedicated test packages and document ownership clearly

--- a/examples/github-cargo-quickstart/.changeset/add-cli-summary.md
+++ b/examples/github-cargo-quickstart/.changeset/add-cli-summary.md
@@ -1,0 +1,8 @@
+---
+cli: minor
+core: patch
+---
+
+#### add Cargo quickstart example output
+
+Introduces a sample CLI-facing change note so this example has a realistic pending release plan for validation and dry-run release previews.

--- a/examples/github-cargo-quickstart/.github/workflows/publish-cargo.yml
+++ b/examples/github-cargo-quickstart/.github/workflows/publish-cargo.yml
@@ -1,0 +1,30 @@
+name: publish-cargo
+
+on:
+  push:
+    tags:
+      - "core/v*"
+      - "cli/v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - name: publish core
+        if: startsWith(github.ref_name, 'core/')
+        run: cargo publish --package acme-core
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+      - name: publish cli
+        if: startsWith(github.ref_name, 'cli/')
+        run: cargo publish --package acme-cli
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/examples/github-cargo-quickstart/.github/workflows/release.yml
+++ b/examples/github-cargo-quickstart/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: install monochange
+        run: cargo install monochange
+
+      - name: fetch tags
+        run: git fetch --force --tags origin
+
+      - name: detect merged release commit
+        id: release_record
+        shell: bash
+        run: |
+          set -euo pipefail
+          if mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then
+            echo "is_release_commit=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_release_commit=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: refresh release PR
+        if: steps.release_record.outputs.is_release_commit != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mc release-pr
+
+      - name: create release tags
+        if: steps.release_record.outputs.is_release_commit == 'true'
+        run: mc tag-release --from HEAD

--- a/examples/github-cargo-quickstart/Cargo.toml
+++ b/examples/github-cargo-quickstart/Cargo.toml
@@ -1,0 +1,12 @@
+[workspace]
+members = ["crates/cli", "crates/core"]
+resolver = "2"
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/acme/monochange-github-cargo-quickstart"
+
+[workspace.dependencies]
+acme-core = { path = "crates/core", version = "0.1.0" }

--- a/examples/github-cargo-quickstart/README.md
+++ b/examples/github-cargo-quickstart/README.md
@@ -1,0 +1,25 @@
+# GitHub Cargo quickstart
+
+This is a repo-shaped example for a greenfield Cargo workspace that wants GitHub-hosted release automation, top-level `[lints]`, and registry-native Cargo publishing.
+
+## What this example includes
+
+- `monochange.toml` with GitHub source config, Cargo discovery, changeset policy, and `[lints]`
+- a small Cargo workspace with a library crate and a CLI crate
+- a sample `.changeset/*.md` file
+- `.github/workflows/release.yml` for release-PR refresh and post-merge tagging
+- `.github/workflows/publish-cargo.yml` for a registry-native external Cargo publish job
+
+## Recommended validation flow
+
+```bash
+mc validate
+mc check
+mc release --dry-run --diff
+```
+
+## Why this example is opinionated
+
+- it prefers `mode = "external"` so the official crates.io auth action can own token exchange
+- it uses `[lints].use = ["cargo/recommended"]` plus a small override instead of a handwritten full rule table
+- it keeps publish execution tag-driven and separate from release planning

--- a/examples/github-cargo-quickstart/crates/cli/Cargo.toml
+++ b/examples/github-cargo-quickstart/crates/cli/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "acme-cli"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "CLI crate for the monochange GitHub Cargo quickstart example"
+
+[[bin]]
+name = "acme-cli"
+path = "src/main.rs"
+
+[dependencies]
+acme-core = { workspace = true }

--- a/examples/github-cargo-quickstart/crates/cli/src/main.rs
+++ b/examples/github-cargo-quickstart/crates/cli/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+	println!("{}", acme_core::release_summary());
+}

--- a/examples/github-cargo-quickstart/crates/core/Cargo.toml
+++ b/examples/github-cargo-quickstart/crates/core/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "acme-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Core crate for the monochange GitHub Cargo quickstart example"
+
+[lib]
+path = "src/lib.rs"

--- a/examples/github-cargo-quickstart/crates/core/src/lib.rs
+++ b/examples/github-cargo-quickstart/crates/core/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn release_summary() -> &'static str {
+	"release planning for Cargo quickstart"
+}

--- a/examples/github-cargo-quickstart/monochange.toml
+++ b/examples/github-cargo-quickstart/monochange.toml
@@ -1,0 +1,60 @@
+[defaults]
+package_type = "cargo"
+warn_on_group_mismatch = true
+
+[defaults.changelog]
+path = "{{ path }}/CHANGELOG.md"
+format = "keep_a_changelog"
+
+[package.core]
+path = "crates/core"
+
+[package.cli]
+path = "crates/cli"
+
+[group.sdk]
+packages = ["core", "cli"]
+tag = true
+release = true
+version_format = "primary"
+
+[source]
+provider = "github"
+owner = "acme"
+repo = "monochange-github-cargo-quickstart"
+
+[source.releases]
+enabled = true
+draft = false
+prerelease = false
+source = "monochange"
+
+[source.pull_requests]
+enabled = true
+branch_prefix = "monochange/release"
+base = "main"
+title = "chore(release): prepare release"
+labels = ["release", "automated"]
+auto_merge = false
+
+[changesets.verify]
+enabled = true
+required = true
+skip_labels = ["no-changeset-required"]
+comment_on_failure = true
+changed_paths = ["crates/**"]
+ignored_paths = ["docs/**", "README.md"]
+
+[ecosystems.cargo]
+enabled = true
+
+[ecosystems.cargo.publish]
+enabled = true
+mode = "external"
+trusted_publishing = true
+
+[lints]
+use = ["cargo/recommended"]
+
+[lints.rules]
+"cargo/sorted-dependencies" = "error"

--- a/examples/github-npm-quickstart/.changeset/add-web-dashboard.md
+++ b/examples/github-npm-quickstart/.changeset/add-web-dashboard.md
@@ -1,0 +1,8 @@
+---
+web: minor
+shared: patch
+---
+
+#### add dashboard release planning example
+
+Adds a sample feature note for the `web` package and a compatibility follow-up for `shared` so this example has a realistic pending release plan.

--- a/examples/github-npm-quickstart/.github/workflows/changeset-policy.yml
+++ b/examples/github-npm-quickstart/.github/workflows/changeset-policy.yml
@@ -1,0 +1,51 @@
+name: changeset-policy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+concurrency:
+  group: changeset-policy-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: install monochange
+        run: npm install -g @monochange/cli
+
+      - name: collect changed files
+        id: changed
+        uses: tj-actions/changed-files@v46
+
+      - name: run changeset policy
+        env:
+          PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          CHANGED_FILES: ${{ steps.changed.outputs.all_changed_files }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -t labels < <(jq -r '.[]' <<<"$PR_LABELS_JSON")
+          args=(affected --format json --verify)
+
+          for path in $CHANGED_FILES; do
+            args+=(--changed-paths "$path")
+          done
+
+          for label in "${labels[@]}"; do
+            args+=(--label "$label")
+          done
+
+          mc "${args[@]}" | tee policy.json
+          jq -e '.status != "failed"' policy.json >/dev/null

--- a/examples/github-npm-quickstart/.github/workflows/release.yml
+++ b/examples/github-npm-quickstart/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: enable corepack
+        run: corepack enable
+
+      - name: install monochange
+        run: npm install -g @monochange/cli
+
+      - name: fetch tags
+        run: git fetch --force --tags origin
+
+      - name: detect merged release commit
+        id: release_record
+        shell: bash
+        run: |
+          set -euo pipefail
+          if mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then
+            echo "is_release_commit=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_release_commit=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: refresh release PR
+        if: steps.release_record.outputs.is_release_commit != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mc release-pr
+
+      - name: create release tags
+        if: steps.release_record.outputs.is_release_commit == 'true'
+        run: mc tag-release --from HEAD
+
+      - name: publish npm packages
+        if: steps.release_record.outputs.is_release_commit == 'true'
+        run: mc publish

--- a/examples/github-npm-quickstart/README.md
+++ b/examples/github-npm-quickstart/README.md
@@ -1,0 +1,47 @@
+# GitHub npm quickstart
+
+This is a repo-shaped example for a greenfield npm or pnpm workspace that wants GitHub-hosted release automation, top-level `[lints]` configuration, and built-in npm publishing.
+
+## What this example includes
+
+- `monochange.toml` with GitHub source config, npm publishing defaults, changeset policy, and `[lints]`
+- a small pnpm workspace with two public packages
+- a sample `.changeset/*.md` file
+- `.github/workflows/release.yml` for release-PR refresh and post-merge publish
+- `.github/workflows/changeset-policy.yml` for pull-request policy checks
+
+## File layout
+
+```text
+.github/workflows/
+.changeset/
+packages/
+  shared/
+  web/
+monochange.toml
+package.json
+pnpm-workspace.yaml
+```
+
+## Recommended validation flow
+
+From this directory, run:
+
+```bash
+mc validate
+mc check
+mc release --dry-run --diff
+```
+
+## Why this example is opinionated
+
+- it uses `pnpm` so the workspace protocol story is explicit
+- it enables built-in npm publishing because GitHub + npm is the most automated monochange publishing path today
+- it uses `[lints].use = ["npm/recommended"]` and a small scoped override instead of hand-writing every lint rule
+- it keeps publishing in CI, while local work stops at validation, linting, and dry-run release planning
+
+## Notes
+
+- the packages are intentionally small so the example stays readable
+- the workflow files are examples, not production secrets-management advice
+- placeholder publishing is not enabled here; see `../public-packages-placeholder-publish/` when name reservation matters

--- a/examples/github-npm-quickstart/monochange.toml
+++ b/examples/github-npm-quickstart/monochange.toml
@@ -1,0 +1,64 @@
+[defaults]
+package_type = "npm"
+warn_on_group_mismatch = true
+
+[defaults.changelog]
+path = "{{ path }}/CHANGELOG.md"
+format = "keep_a_changelog"
+
+[package.shared]
+path = "packages/shared"
+tag = true
+release = true
+
+[package.web]
+path = "packages/web"
+tag = true
+release = true
+
+[source]
+provider = "github"
+owner = "acme"
+repo = "monochange-github-npm-quickstart"
+
+[source.releases]
+enabled = true
+draft = false
+prerelease = false
+source = "monochange"
+
+[source.pull_requests]
+enabled = true
+branch_prefix = "monochange/release"
+base = "main"
+title = "chore(release): prepare release"
+labels = ["release", "automated"]
+auto_merge = false
+
+[changesets.verify]
+enabled = true
+required = true
+skip_labels = ["no-changeset-required"]
+comment_on_failure = true
+changed_paths = ["packages/**"]
+ignored_paths = ["docs/**", "README.md"]
+
+[ecosystems.npm]
+enabled = true
+
+[ecosystems.npm.publish]
+enabled = true
+mode = "builtin"
+registry = "npm"
+trusted_publishing = true
+
+[lints]
+use = ["npm/recommended"]
+
+[lints.rules]
+"npm/sorted-dependencies" = "error"
+
+[[lints.scopes]]
+name = "published npm packages"
+match = { ecosystems = ["npm"], managed = true, publishable = true }
+rules = { "npm/required-package-fields" = "error" }

--- a/examples/github-npm-quickstart/package.json
+++ b/examples/github-npm-quickstart/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "github-npm-quickstart",
+	"private": true,
+	"description": "Repo-shaped monochange GitHub npm quickstart example",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/acme/monochange-github-npm-quickstart.git"
+	},
+	"packageManager": "pnpm@10.8.0",
+	"workspaces": [
+		"packages/*"
+	],
+	"devDependencies": {
+		"typescript": "^5.8.0"
+	}
+}

--- a/examples/github-npm-quickstart/packages/shared/package.json
+++ b/examples/github-npm-quickstart/packages/shared/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "@acme/shared",
+	"version": "0.1.0",
+	"description": "Shared utilities for the monochange GitHub npm quickstart example",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/acme/monochange-github-npm-quickstart.git",
+		"directory": "packages/shared"
+	},
+	"exports": {
+		".": "./src/index.js"
+	}
+}

--- a/examples/github-npm-quickstart/packages/shared/src/index.js
+++ b/examples/github-npm-quickstart/packages/shared/src/index.js
@@ -1,0 +1,3 @@
+export function formatReleasePlan(name) {
+	return `release plan for ${name}`;
+}

--- a/examples/github-npm-quickstart/packages/web/package.json
+++ b/examples/github-npm-quickstart/packages/web/package.json
@@ -1,0 +1,18 @@
+{
+	"name": "@acme/web",
+	"version": "0.1.0",
+	"description": "Web package for the monochange GitHub npm quickstart example",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/acme/monochange-github-npm-quickstart.git",
+		"directory": "packages/web"
+	},
+	"publishConfig": {
+		"access": "public",
+		"provenance": true
+	},
+	"dependencies": {
+		"@acme/shared": "workspace:*"
+	}
+}

--- a/examples/github-npm-quickstart/packages/web/src/index.js
+++ b/examples/github-npm-quickstart/packages/web/src/index.js
@@ -1,0 +1,5 @@
+import { formatReleasePlan } from "@acme/shared";
+
+export function renderDashboardVersion(version) {
+	return formatReleasePlan(`dashboard ${version}`);
+}

--- a/examples/github-npm-quickstart/pnpm-workspace.yaml
+++ b/examples/github-npm-quickstart/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - packages/*

--- a/examples/gitlab-migration/.changeset/improve-cli-output.md
+++ b/examples/gitlab-migration/.changeset/improve-cli-output.md
@@ -1,0 +1,7 @@
+---
+cli: minor
+---
+
+#### improve GitLab migration example output
+
+Adds a sample CLI-facing change note so the migration example can preview a realistic release plan without needing extra setup.

--- a/examples/gitlab-migration/.gitlab-ci.yml
+++ b/examples/gitlab-migration/.gitlab-ci.yml
@@ -1,0 +1,42 @@
+stages:
+  - validate
+  - plan
+  - release
+
+variables:
+  GIT_DEPTH: "0"
+
+validate_monochange:
+  image: node:22
+  stage: validate
+  before_script:
+    - npm install -g @monochange/cli
+  script:
+    - mc validate
+    - mc check
+
+release_preview:
+  image: node:22
+  stage: plan
+  before_script:
+    - npm install -g @monochange/cli
+  script:
+    - mc release --dry-run --diff
+
+release_or_publish:
+  image: node:22
+  stage: release
+  rules:
+    - if: "$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH"
+  before_script:
+    - npm install -g @monochange/cli
+  script:
+    - git fetch --force --tags origin
+    - |
+        set -euo pipefail
+        if mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then
+          mc tag-release --from HEAD
+          ./scripts/legacy-release.sh
+        else
+          mc release-pr
+        fi

--- a/examples/gitlab-migration/Cargo.toml
+++ b/examples/gitlab-migration/Cargo.toml
@@ -1,0 +1,11 @@
+[workspace]
+members = ["crates/cli", "crates/core"]
+resolver = "2"
+
+[workspace.package]
+edition = "2021"
+license = "MIT"
+repository = "https://gitlab.example.com/acme/platform.git"
+
+[workspace.dependencies]
+acme-core = { path = "crates/core", version = "0.4.0" }

--- a/examples/gitlab-migration/README.md
+++ b/examples/gitlab-migration/README.md
@@ -1,0 +1,47 @@
+# GitLab migration
+
+This is a repo-shaped example for adopting monochange into an existing GitLab-hosted repository without replacing the current publish script on day one.
+
+## What this example includes
+
+- `monochange.toml` with GitLab source config, Cargo discovery, external publishing, and top-level `[lints]`
+- a small Cargo workspace with a library crate and a CLI crate
+- `.gitlab-ci.yml` that introduces validation and dry-run planning before replacing the legacy publish path
+- `scripts/legacy-release.sh` to show a coexistence phase where monochange handles planning while an older release script still owns the publish step
+- a sample `.changeset/*.md` file so the workspace has pending release intent
+
+## File layout
+
+```text
+.changeset/
+crates/
+  cli/
+  core/
+scripts/
+.gitlab-ci.yml
+Cargo.toml
+monochange.toml
+```
+
+## Recommended validation flow
+
+From this directory, run:
+
+```bash
+mc validate
+mc check
+mc release --dry-run --diff
+```
+
+## Why this example is opinionated
+
+- it models migration, so package publishing stays `mode = "external"`
+- it uses GitLab CI for validation, preview, and release detection, but keeps the actual publish command in a legacy script during the first phase
+- it uses `[lints].use = ["cargo/recommended"]` plus a scoped override rather than a large handwritten lint table
+- it shows that monochange can be introduced before the team is ready to replace existing release automation completely
+
+## Migration notes
+
+- the `legacy-release.sh` script is intentionally simple; in a real migration it could be a pre-existing script or wrapper around current jobs
+- once the team trusts monochange release planning, the legacy publish step can be replaced with `mc publish` or another registry-native workflow
+- if GitLab auth/bootstrap differs strongly from monochange's built-in assumptions, staying on `mode = "external"` is still the clearest path

--- a/examples/gitlab-migration/crates/cli/Cargo.toml
+++ b/examples/gitlab-migration/crates/cli/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "acme-cli"
+version = "0.4.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "CLI package for the monochange GitLab migration example"
+
+[[bin]]
+name = "acme-cli"
+path = "src/main.rs"
+
+[dependencies]
+acme-core = { workspace = true }

--- a/examples/gitlab-migration/crates/cli/src/main.rs
+++ b/examples/gitlab-migration/crates/cli/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+	println!("{}", acme_core::describe_release_flow());
+}

--- a/examples/gitlab-migration/crates/core/Cargo.toml
+++ b/examples/gitlab-migration/crates/core/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "acme-core"
+version = "0.4.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Core library for the monochange GitLab migration example"
+
+[lib]
+path = "src/lib.rs"

--- a/examples/gitlab-migration/crates/core/src/lib.rs
+++ b/examples/gitlab-migration/crates/core/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn describe_release_flow() -> &'static str {
+	"monochange plans the release while the legacy script still owns publishing"
+}

--- a/examples/gitlab-migration/monochange.toml
+++ b/examples/gitlab-migration/monochange.toml
@@ -1,0 +1,58 @@
+[defaults]
+package_type = "cargo"
+warn_on_group_mismatch = true
+
+[defaults.changelog]
+path = "{{ path }}/CHANGELOG.md"
+format = "keep_a_changelog"
+
+[package.core]
+path = "crates/core"
+
+[package.cli]
+path = "crates/cli"
+
+[group.sdk]
+packages = ["core", "cli"]
+tag = true
+release = true
+version_format = "primary"
+
+[source]
+provider = "gitlab"
+owner = "acme"
+repo = "platform"
+host = "https://gitlab.example.com"
+
+[source.releases]
+enabled = true
+draft = false
+prerelease = false
+source = "monochange"
+
+[source.pull_requests]
+enabled = true
+branch_prefix = "monochange/release"
+base = "main"
+title = "chore(release): prepare release"
+labels = ["release", "automated"]
+auto_merge = false
+
+[ecosystems.cargo]
+enabled = true
+
+[ecosystems.cargo.publish]
+enabled = true
+mode = "external"
+trusted_publishing = false
+
+[lints]
+use = ["cargo/recommended"]
+
+[lints.rules]
+"cargo/sorted-dependencies" = "error"
+
+[[lints.scopes]]
+name = "managed crates"
+match = { ecosystems = ["cargo"], managed = true }
+rules = { "cargo/internal-dependency-workspace" = "error" }

--- a/examples/gitlab-migration/scripts/legacy-release.sh
+++ b/examples/gitlab-migration/scripts/legacy-release.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "legacy publish flow would run here"
+echo "replace this script after the team trusts monochange planning and CI wiring"

--- a/examples/internal-only-workspace/.changeset/update-admin-app.md
+++ b/examples/internal-only-workspace/.changeset/update-admin-app.md
@@ -1,0 +1,7 @@
+---
+app: patch
+---
+
+#### update internal admin example
+
+Adds a sample internal-only change note so this example can still preview normal release planning and changelog output.

--- a/examples/internal-only-workspace/README.md
+++ b/examples/internal-only-workspace/README.md
@@ -1,0 +1,24 @@
+# Internal-only workspace
+
+This is a repo-shaped example for teams that want discovery, changelogs, changesets, and linting without public package publishing.
+
+## What this example includes
+
+- `monochange.toml` with npm discovery, publishing disabled, and top-level `[lints]`
+- a small private npm workspace with two internal packages
+- a sample `.changeset/*.md` file
+- no source-provider automation, because the focus is local validation and release planning discipline
+
+## Recommended validation flow
+
+```bash
+mc validate
+mc check
+mc release --dry-run --diff
+```
+
+## Why this example is opinionated
+
+- it keeps packages private to emphasize internal-only usage
+- it demonstrates that monochange still adds value even when no public registry is involved
+- it uses `[lints].use = ["npm/recommended"]` while keeping publishing disabled

--- a/examples/internal-only-workspace/monochange.toml
+++ b/examples/internal-only-workspace/monochange.toml
@@ -1,0 +1,25 @@
+[defaults]
+package_type = "npm"
+warn_on_group_mismatch = true
+
+[defaults.changelog]
+path = "{{ path }}/CHANGELOG.md"
+format = "keep_a_changelog"
+
+[package.shared]
+path = "packages/shared"
+
+[package.app]
+path = "packages/app"
+
+[ecosystems.npm]
+enabled = true
+
+[ecosystems.npm.publish]
+enabled = false
+
+[lints]
+use = ["npm/recommended"]
+
+[lints.rules]
+"npm/unlisted-package-private" = "error"

--- a/examples/internal-only-workspace/package.json
+++ b/examples/internal-only-workspace/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "internal-only-workspace",
+	"private": true,
+	"description": "Repo-shaped monochange internal-only workspace example",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/acme/monochange-internal-only-workspace.git"
+	},
+	"packageManager": "pnpm@10.8.0",
+	"workspaces": [
+		"packages/*"
+	]
+}

--- a/examples/internal-only-workspace/packages/app/package.json
+++ b/examples/internal-only-workspace/packages/app/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "@acme/internal-app",
+	"version": "1.2.0",
+	"private": true,
+	"description": "Internal app package for the monochange internal-only example",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/acme/monochange-internal-only-workspace.git",
+		"directory": "packages/app"
+	},
+	"dependencies": {
+		"@acme/internal-shared": "workspace:*"
+	}
+}

--- a/examples/internal-only-workspace/packages/app/src/index.js
+++ b/examples/internal-only-workspace/packages/app/src/index.js
@@ -1,0 +1,5 @@
+import { internalSharedMessage } from "@acme/internal-shared";
+
+export function renderInternalApp() {
+	return internalSharedMessage();
+}

--- a/examples/internal-only-workspace/packages/shared/package.json
+++ b/examples/internal-only-workspace/packages/shared/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "@acme/internal-shared",
+	"version": "1.2.0",
+	"private": true,
+	"description": "Shared internal package for the monochange internal-only example",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/acme/monochange-internal-only-workspace.git",
+		"directory": "packages/shared"
+	}
+}

--- a/examples/internal-only-workspace/packages/shared/src/index.js
+++ b/examples/internal-only-workspace/packages/shared/src/index.js
@@ -1,0 +1,3 @@
+export function internalSharedMessage() {
+	return "internal only release planning";
+}

--- a/examples/internal-only-workspace/pnpm-workspace.yaml
+++ b/examples/internal-only-workspace/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - packages/*

--- a/examples/mixed-workspace/.changeset/unify-sdk-release.md
+++ b/examples/mixed-workspace/.changeset/unify-sdk-release.md
@@ -1,0 +1,7 @@
+---
+sdk: minor
+---
+
+#### unify mixed-workspace release planning
+
+Uses a group-targeted changeset so the mixed Cargo and npm packages share one outward release identity.

--- a/examples/mixed-workspace/Cargo.toml
+++ b/examples/mixed-workspace/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+members = ["crates/core"]
+resolver = "2"
+
+[workspace.package]
+version = "0.7.0"
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/acme/monochange-mixed-workspace"

--- a/examples/mixed-workspace/README.md
+++ b/examples/mixed-workspace/README.md
@@ -1,0 +1,24 @@
+# Mixed workspace
+
+This is a repo-shaped example for a cross-ecosystem monorepo that manages Cargo and npm packages together under one monochange configuration.
+
+## What this example includes
+
+- `monochange.toml` with mixed package definitions, a shared release group, and top-level `[lints]`
+- a Cargo crate and an npm package in the same repository
+- a sample group-targeted `.changeset/*.md` file
+- a private root `package.json` plus a Cargo workspace manifest
+
+## Recommended validation flow
+
+```bash
+mc validate
+mc check
+mc release --dry-run --diff
+```
+
+## Why this example is opinionated
+
+- it keeps the top-level repo private while still modeling public child packages
+- it uses both `cargo/recommended` and `npm/recommended` presets from one shared `[lints]` section
+- it uses a group to model one outward release identity across ecosystems

--- a/examples/mixed-workspace/crates/core/Cargo.toml
+++ b/examples/mixed-workspace/crates/core/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "acme-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Core crate for the monochange mixed-workspace example"
+
+[lib]
+path = "src/lib.rs"

--- a/examples/mixed-workspace/crates/core/src/lib.rs
+++ b/examples/mixed-workspace/crates/core/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn mixed_workspace_message() -> &'static str {
+	"mixed workspace release planning"
+}

--- a/examples/mixed-workspace/monochange.toml
+++ b/examples/mixed-workspace/monochange.toml
@@ -1,0 +1,27 @@
+[defaults]
+warn_on_group_mismatch = true
+
+[defaults.changelog]
+path = "{{ path }}/CHANGELOG.md"
+format = "keep_a_changelog"
+
+[package.core]
+path = "crates/core"
+type = "cargo"
+
+[package.web]
+path = "packages/web"
+type = "npm"
+
+[group.sdk]
+packages = ["core", "web"]
+tag = true
+release = true
+version_format = "primary"
+
+[lints]
+use = ["cargo/recommended", "npm/recommended"]
+
+[lints.rules]
+"cargo/sorted-dependencies" = "error"
+"npm/sorted-dependencies" = "error"

--- a/examples/mixed-workspace/package.json
+++ b/examples/mixed-workspace/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "mixed-workspace",
+	"private": true,
+	"description": "Repo-shaped monochange mixed-workspace example",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/acme/monochange-mixed-workspace.git"
+	},
+	"packageManager": "pnpm@10.8.0",
+	"workspaces": [
+		"packages/*"
+	]
+}

--- a/examples/mixed-workspace/packages/web/package.json
+++ b/examples/mixed-workspace/packages/web/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "@acme/web-sdk",
+	"version": "0.7.0",
+	"description": "Web package for the monochange mixed-workspace example",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/acme/monochange-mixed-workspace.git",
+		"directory": "packages/web"
+	}
+}

--- a/examples/mixed-workspace/packages/web/src/index.js
+++ b/examples/mixed-workspace/packages/web/src/index.js
@@ -1,0 +1,3 @@
+export function mixedWorkspaceMessage() {
+	return "mixed workspace release planning";
+}

--- a/examples/mixed-workspace/pnpm-workspace.yaml
+++ b/examples/mixed-workspace/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - packages/*

--- a/examples/public-packages-placeholder-publish/.changeset/bootstrap-public-names.md
+++ b/examples/public-packages-placeholder-publish/.changeset/bootstrap-public-names.md
@@ -1,0 +1,8 @@
+---
+core: patch
+web: patch
+---
+
+#### prepare placeholder bootstrap examples
+
+Adds a small pending release so the placeholder example can still demonstrate normal release planning alongside placeholder configuration.

--- a/examples/public-packages-placeholder-publish/Cargo.toml
+++ b/examples/public-packages-placeholder-publish/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+members = ["crates/core"]
+resolver = "2"
+
+[workspace.package]
+version = "0.0.1"
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/acme/monochange-public-placeholder"

--- a/examples/public-packages-placeholder-publish/README.md
+++ b/examples/public-packages-placeholder-publish/README.md
@@ -1,0 +1,32 @@
+# Public packages with placeholder publishing
+
+This is a repo-shaped example for reserving public package names before the real publish flow is ready.
+
+## What this example includes
+
+- `monochange.toml` with npm and Cargo publishing defaults plus placeholder README overrides
+- a small mixed workspace with one Cargo crate and one npm package
+- placeholder README files under `docs/`
+- a sample `.changeset/*.md` file for release planning
+
+## Recommended validation flow
+
+```bash
+mc validate
+mc check
+mc release --dry-run --diff
+```
+
+## Recommended publish preview
+
+When you want to inspect the placeholder plan without publishing anything:
+
+```bash
+mc placeholder-publish --dry-run --format json
+```
+
+## Why this example is opinionated
+
+- it models the bootstrap case where names matter before the first real release
+- it keeps placeholder copy explicit so the public registry entry is readable during the reservation phase
+- it shows one shared repository can prepare placeholder strategy across more than one ecosystem

--- a/examples/public-packages-placeholder-publish/crates/core/Cargo.toml
+++ b/examples/public-packages-placeholder-publish/crates/core/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "acme-placeholder-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Cargo crate for the monochange placeholder publish example"
+
+[lib]
+path = "src/lib.rs"

--- a/examples/public-packages-placeholder-publish/crates/core/src/lib.rs
+++ b/examples/public-packages-placeholder-publish/crates/core/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn placeholder_message() -> &'static str {
+	"placeholder publish example"
+}

--- a/examples/public-packages-placeholder-publish/docs/core-placeholder.md
+++ b/examples/public-packages-placeholder-publish/docs/core-placeholder.md
@@ -1,0 +1,3 @@
+# acme-placeholder-core
+
+This is a placeholder crate published to reserve the package name while the real public release flow is being finalized.

--- a/examples/public-packages-placeholder-publish/docs/web-placeholder.md
+++ b/examples/public-packages-placeholder-publish/docs/web-placeholder.md
@@ -1,0 +1,3 @@
+# @acme/placeholder-web
+
+This is a placeholder npm package published to reserve the package name while the real public release flow is being finalized.

--- a/examples/public-packages-placeholder-publish/monochange.toml
+++ b/examples/public-packages-placeholder-publish/monochange.toml
@@ -1,0 +1,40 @@
+[defaults]
+warn_on_group_mismatch = true
+
+[defaults.changelog]
+path = "{{ path }}/CHANGELOG.md"
+format = "keep_a_changelog"
+
+[package.core]
+path = "crates/core"
+type = "cargo"
+
+[package.web]
+path = "packages/web"
+type = "npm"
+
+[ecosystems.cargo]
+enabled = true
+
+[ecosystems.cargo.publish]
+enabled = true
+mode = "builtin"
+trusted_publishing = false
+
+[ecosystems.npm]
+enabled = true
+
+[ecosystems.npm.publish]
+enabled = true
+mode = "builtin"
+registry = "npm"
+trusted_publishing = true
+
+[package.core.publish.placeholder]
+readme_file = "docs/core-placeholder.md"
+
+[package.web.publish.placeholder]
+readme_file = "docs/web-placeholder.md"
+
+[lints]
+use = ["cargo/recommended", "npm/recommended"]

--- a/examples/public-packages-placeholder-publish/package.json
+++ b/examples/public-packages-placeholder-publish/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "public-packages-placeholder-publish",
+	"private": true,
+	"description": "Repo-shaped monochange placeholder publish example",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/acme/monochange-public-placeholder.git"
+	},
+	"packageManager": "pnpm@10.8.0",
+	"workspaces": [
+		"packages/*"
+	]
+}

--- a/examples/public-packages-placeholder-publish/packages/web/package.json
+++ b/examples/public-packages-placeholder-publish/packages/web/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "@acme/placeholder-web",
+	"version": "0.0.1",
+	"description": "Web package for the monochange placeholder publish example",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/acme/monochange-public-placeholder.git",
+		"directory": "packages/web"
+	},
+	"publishConfig": {
+		"access": "public",
+		"provenance": true
+	}
+}

--- a/examples/public-packages-placeholder-publish/packages/web/src/index.js
+++ b/examples/public-packages-placeholder-publish/packages/web/src/index.js
@@ -1,0 +1,3 @@
+export function placeholderMessage() {
+	return "placeholder publish example";
+}

--- a/examples/public-packages-placeholder-publish/pnpm-workspace.yaml
+++ b/examples/public-packages-placeholder-publish/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - packages/*

--- a/examples/publishing-test-lab/ISSUE.md
+++ b/examples/publishing-test-lab/ISSUE.md
@@ -1,0 +1,100 @@
+# Create end-to-end publishing verification in an external test repository
+
+## Suggested labels
+
+- `enhancement`
+- `testing`
+- `publishing`
+- `ci`
+
+## Summary
+
+Create a dedicated external repository for end-to-end publish verification across the ecosystems monochange supports.
+
+The goal is to verify real registry publication, trusted-publishing enrollment, publish ordering, and rate-limit behavior without coupling those tests to the main monochange repository.
+
+## Problem
+
+monochange can already validate release planning and dry-run publish behavior locally, but real publishing still has gaps that only show up when talking to real registries:
+
+- trusted-publishing enrollment can drift from CI configuration
+- package ordering bugs may only appear when a registry enforces real dependencies or visibility timing
+- rate limits and delayed package availability can break otherwise-correct publish plans
+- different ecosystems need different test namespaces, auth models, and retry strategies
+
+Those concerns are awkward and risky to test inside this repository.
+
+## Proposal
+
+Create an external repository that is intentionally dedicated to publish verification.
+
+The repository should:
+
+- contain a small set of monochange-controlled fixture packages
+- mirror representative package shapes from this codebase on a controlled cadence
+- exercise GitHub and GitLab publish flows where possible
+- keep production package names and production release workflows isolated from test runs
+
+## Scope
+
+### In scope
+
+- GitHub-based publish verification for `npm`, `crates.io`, `jsr`, and `pub.dev`
+- GitLab-based publish verification where monochange supports a realistic external workflow
+- trusted-publishing / OIDC enrollment checks
+- publish ordering tests for multi-package releases
+- rate-limit and delayed-availability scenarios
+- documentation for which registry strategy each ecosystem should use
+
+### Out of scope
+
+- replacing unit, fixture, or dry-run tests in the main monochange repository
+- publishing the main monochange packages from the test repository
+- pretending that one registry strategy fits every ecosystem equally well
+
+## Recommended registry strategy
+
+Prefer the safest non-production target that still exercises the behavior you care about.
+
+### npm
+
+- prefer a dedicated public test scope if canonical npm trusted publishing must be exercised
+- use a private registry such as Verdaccio for fast non-production protocol checks that do not require npm-hosted trust state
+
+### crates.io
+
+- use dedicated long-lived public test crate names for canonical publish verification
+- use alternate Cargo registries only for non-canonical protocol checks, not as a substitute for real crates.io verification
+
+### JSR
+
+- use a dedicated JSR scope or organization for long-lived test packages
+
+### pub.dev
+
+- use dedicated long-lived test packages and uploader/admin ownership that is clearly separate from production packages
+
+## Acceptance criteria
+
+- a separate repository exists and is documented from monochange
+- at least one end-to-end publish scenario exists per supported public registry
+- GitHub trusted-publishing verification is covered where supported
+- rate-limit or delayed-availability scenarios are explicitly exercised
+- failures in the test repository do not block unrelated monochange repository work by default
+- the repository documents how fixtures are refreshed from monochange
+
+## Suggested implementation plan
+
+1. create the external repository and document ownership
+2. seed one minimal fixture per ecosystem
+3. wire GitHub publish verification first
+4. add GitLab verification for the flows that remain meaningful outside GitHub-specific trust automation
+5. add rate-limit and delayed-availability scenarios
+6. document which scenarios hit public registries vs sandbox or alternate registries
+
+## Open questions
+
+- which package names or namespaces should be reserved for long-lived public test packages?
+- how often should fixture content be synced from monochange?
+- should registry-intensive scenarios run on a schedule, manually, or only for tagged releases?
+- which failures should notify maintainers automatically versus stay as manual diagnostics?

--- a/examples/publishing-test-lab/README.md
+++ b/examples/publishing-test-lab/README.md
@@ -1,0 +1,27 @@
+# Publishing test lab
+
+This directory is a seed for a follow-up issue, not a real publish fixture yet.
+
+See [ISSUE.md](./ISSUE.md) for a draft issue that can be filed or adapted.
+
+## Goal
+
+Stand up a separate repository that exercises real registry publication across the ecosystems monochange supports, especially where rate limits, trust enrollment, and delayed publish windows can break otherwise-correct release plans.
+
+## Why a separate repository
+
+- package names and auth need stronger isolation than in-repo fixtures can provide
+- publish tests should be allowed to fail, retry, and back off without affecting the main monochange repository
+- different ecosystems may need different namespaces, registries, or cleanup rules
+
+## Recommended issue scope
+
+- mirror a small set of monochange-controlled fixture packages into an external test repo
+- validate GitHub and GitLab publish shapes where possible
+- test npm, `crates.io`, `jsr`, and `pub.dev` separately
+- add scenarios that intentionally hit publish ordering and rate-limit edges
+- document when to use sandbox registries, alternate registries, or dedicated public test namespaces
+
+## Registry strategy recommendation
+
+Use non-production registries or sandbox modes where the ecosystem supports them. When a public production registry is unavoidable, keep a tightly controlled set of dedicated test packages and treat them as long-lived test infrastructure.

--- a/examples/release-pr-workflow/.changeset/add-release-review.md
+++ b/examples/release-pr-workflow/.changeset/add-release-review.md
@@ -1,0 +1,7 @@
+---
+app: minor
+---
+
+#### add release PR review example
+
+Adds a sample release note so this example can preview how a long-running release PR branch would package pending work.

--- a/examples/release-pr-workflow/.github/workflows/release.yml
+++ b/examples/release-pr-workflow/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: install monochange
+        run: cargo install monochange
+
+      - name: fetch tags
+        run: git fetch --force --tags origin
+
+      - name: detect merged release commit
+        id: release_record
+        shell: bash
+        run: |
+          set -euo pipefail
+          if mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then
+            echo "is_release_commit=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_release_commit=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: refresh release PR
+        if: steps.release_record.outputs.is_release_commit != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mc release-pr
+
+      - name: create release tags
+        if: steps.release_record.outputs.is_release_commit == 'true'
+        run: mc tag-release --from HEAD
+
+      - name: downstream publish jobs would run here
+        if: steps.release_record.outputs.is_release_commit == 'true'
+        run: echo "run package publish or provider release workflows after tags exist"

--- a/examples/release-pr-workflow/Cargo.toml
+++ b/examples/release-pr-workflow/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+members = ["crates/app"]
+resolver = "2"
+
+[workspace.package]
+version = "2.3.0"
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/acme/monochange-release-pr-workflow"

--- a/examples/release-pr-workflow/README.md
+++ b/examples/release-pr-workflow/README.md
@@ -1,0 +1,24 @@
+# Release PR workflow
+
+This is a repo-shaped example for a long-running release PR branch flow where release files are reviewed before merge and tags are created only after the release commit lands on the default branch.
+
+## What this example includes
+
+- `monochange.toml` with GitHub source config and release-request settings
+- a small Cargo workspace with one publishable package
+- a sample `.changeset/*.md` file
+- `.github/workflows/release.yml` showing the release-PR refresh and post-merge tagging pattern
+
+## Recommended validation flow
+
+```bash
+mc validate
+mc check
+mc release --dry-run --diff
+```
+
+## Why this example is opinionated
+
+- it is optimized for human review before release files land on `main`
+- it keeps tag creation after merge, not on the release branch
+- it separates release planning from downstream publish jobs

--- a/examples/release-pr-workflow/crates/app/Cargo.toml
+++ b/examples/release-pr-workflow/crates/app/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "acme-release-app"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "App crate for the monochange release PR workflow example"
+
+[[bin]]
+name = "acme-release-app"
+path = "src/main.rs"

--- a/examples/release-pr-workflow/crates/app/src/main.rs
+++ b/examples/release-pr-workflow/crates/app/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+	println!("release PR workflow example");
+}

--- a/examples/release-pr-workflow/monochange.toml
+++ b/examples/release-pr-workflow/monochange.toml
@@ -1,0 +1,37 @@
+[defaults]
+package_type = "cargo"
+warn_on_group_mismatch = true
+
+[defaults.changelog]
+path = "{{ path }}/CHANGELOG.md"
+format = "keep_a_changelog"
+
+[package.app]
+path = "crates/app"
+tag = true
+release = true
+
+[source]
+provider = "github"
+owner = "acme"
+repo = "monochange-release-pr-workflow"
+
+[source.releases]
+enabled = true
+draft = false
+prerelease = false
+source = "monochange"
+
+[source.pull_requests]
+enabled = true
+branch_prefix = "monochange/release"
+base = "main"
+title = "chore(release): prepare release"
+labels = ["release", "automated"]
+auto_merge = false
+
+[ecosystems.cargo]
+enabled = true
+
+[lints]
+use = ["cargo/recommended"]

--- a/examples/validate-examples.sh
+++ b/examples/validate-examples.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+
+if [[ -n "${MONOCHANGE_BIN:-}" ]]; then
+	mc_cmd=("$MONOCHANGE_BIN")
+elif [[ -x "$repo_root/target/debug/mc" ]]; then
+	mc_cmd=("$repo_root/target/debug/mc")
+else
+	mc_cmd=(cargo run -p monochange --bin mc --manifest-path "$repo_root/Cargo.toml" --)
+fi
+
+examples=(
+	github-cargo-quickstart
+	github-npm-quickstart
+	gitlab-migration
+	internal-only-workspace
+	mixed-workspace
+	public-packages-placeholder-publish
+	release-pr-workflow
+)
+
+for example in "${examples[@]}"; do
+	example_dir="$script_dir/$example"
+	echo "== validating $example =="
+	(
+		cd "$example_dir"
+		"${mc_cmd[@]}" validate
+		"${mc_cmd[@]}" check
+		"${mc_cmd[@]}" release --dry-run --diff >/dev/null
+	)
+done
+
+echo "All repo-shaped examples passed validate/check/release --dry-run --diff."

--- a/packages/monochange__skill/README.md
+++ b/packages/monochange__skill/README.md
@@ -6,10 +6,12 @@ This package bundles:
 
 - `SKILL.md` — concise entrypoint for agents
 - `skills/README.md` — index of focused deep dives
+- `skills/adoption.md` — setup-depth questions, migration guidance, and recommendation patterns
 - `skills/changesets.md` — changeset authoring and lifecycle guidance
 - `skills/commands.md` — built-in command catalog and usage patterns
 - `skills/configuration.md` — `monochange.toml` setup and editing guidance
-- `skills/linting.md` — `mc check`, `[lints]`, and manifest-focused rule explanations with examples
+- `skills/linting.md` — `mc check`, `[lints]`, presets, and manifest-focused rule explanations with examples
+- `examples/README.md` — condensed scenario examples for quick recommendations
 - `REFERENCE.md` — high-context reference with broader examples
 - `TRUSTED-PUBLISHING.md` — GitHub/OIDC setup guidance for `npm`, `crates.io`, `jsr`, and `pub.dev`
 - `MULTI-PACKAGE-PUBLISHING.md` — monorepo-oriented publishing patterns for multiple public packages
@@ -29,12 +31,13 @@ monochange-skill --print-skill
 monochange-skill --copy ~/.pi/agent/skills/monochange
 ```
 
-`monochange-skill --copy` copies the full skill bundle, including `SKILL.md`, `REFERENCE.md`, `TRUSTED-PUBLISHING.md`, `MULTI-PACKAGE-PUBLISHING.md`, and the `skills/` deep-dive folder.
+`monochange-skill --copy` copies the full skill bundle, including `SKILL.md`, `REFERENCE.md`, `TRUSTED-PUBLISHING.md`, `MULTI-PACKAGE-PUBLISHING.md`, the `skills/` deep-dive folder, and the bundled `examples/` folder.
 
 ## What the skill teaches
 
 The bundled skill explains how to:
 
+- plan adoption in `quickstart`, `standard`, `full`, or `migration` mode
 - create or refine `monochange.toml` with `mc init`, `mc populate`, and `mc validate`
 - inspect the normalized model with `mc discover --format json`
 - create, update, and audit explicit change files with `mc change` and `mc diagnostics`
@@ -43,5 +46,8 @@ The bundled skill explains how to:
 - understand groups, package ids, changelogs, linting policy, package publishing, and source-provider release flows
 - set up trusted publishing / OIDC-backed package publishing for the registries that monochange supports
 - choose sane multi-package publish patterns when one repository ships multiple public packages
+- point users at condensed bundled examples and fuller repository-level example indexes
 
-Open [SKILL.md](./SKILL.md) first, then use [skills/README.md](./skills/README.md), [REFERENCE.md](./REFERENCE.md), [TRUSTED-PUBLISHING.md](./TRUSTED-PUBLISHING.md), and [MULTI-PACKAGE-PUBLISHING.md](./MULTI-PACKAGE-PUBLISHING.md) for the deeper sections.
+Open [SKILL.md](./SKILL.md) first, then use [skills/README.md](./skills/README.md), [examples/README.md](./examples/README.md), [REFERENCE.md](./REFERENCE.md), [TRUSTED-PUBLISHING.md](./TRUSTED-PUBLISHING.md), and [MULTI-PACKAGE-PUBLISHING.md](./MULTI-PACKAGE-PUBLISHING.md) for the deeper sections.
+
+For fuller repo-shaped examples in the monochange repository, see <https://github.com/ifiokjr/monochange/tree/main/examples>.

--- a/packages/monochange__skill/REFERENCE.md
+++ b/packages/monochange__skill/REFERENCE.md
@@ -46,14 +46,18 @@ Use the bundled docs like this:
 
 - [SKILL.md](./SKILL.md) — concise entrypoint for agents
 - [skills/README.md](./skills/README.md) — index of focused skill modules
+- [skills/adoption.md](./skills/adoption.md) — setup-depth questions, migration guidance, and recommendation patterns
 - [skills/changesets.md](./skills/changesets.md) — creating and managing changesets
 - [skills/commands.md](./skills/commands.md) — built-in commands and workflow selection
 - [skills/configuration.md](./skills/configuration.md) — creating and evolving `monochange.toml`
-- [skills/linting.md](./skills/linting.md) — `mc check`, `[lints]`, and manifest-focused rule explanations with examples
+- [skills/linting.md](./skills/linting.md) — `mc check`, `[lints]`, presets, and manifest-focused rule explanations with examples
+- [examples/README.md](./examples/README.md) — condensed scenario examples for quick recommendations
 - [CHANGESET-GUIDE.md](./CHANGESET-GUIDE.md) — full lifecycle guidance
 - [ARTIFACT-TYPES.md](./ARTIFACT-TYPES.md) — artifact-aware changeset framing
 
 Keep this `REFERENCE.md` open when you want one longer document with broader examples and copy-paste snippets.
+
+When the user is still choosing setup depth or migrating from existing tooling, start with [skills/adoption.md](./skills/adoption.md) before generating files.
 
 ## Recommended command flow
 
@@ -477,29 +481,28 @@ Placeholder README content can come from:
 
 ### Lint rules
 
-Configure ecosystem-specific manifest lint rules and run them through `mc check`:
+Configure manifest lint presets, global rules, and scoped overrides in the top-level `[lints]` section, then run them through `mc check`:
 
 ```toml
-[lints.rules]
-"cargo/dependency-field-order" = "error"
-"cargo/internal-dependency-workspace" = "error"
-"cargo/required-package-fields" = "error"
-"cargo/sorted-dependencies" = "error"
-"cargo/unlisted-package-private" = "warning"
+[lints]
+use = ["cargo/recommended", "npm/recommended"]
 
-# npm rules also live under [lints.rules]
+[lints.rules]
+"cargo/internal-dependency-workspace" = "error"
 "npm/workspace-protocol" = "error"
-"npm/sorted-dependencies" = "error"
-"npm/required-package-fields" = "error"
-"npm/root-no-prod-deps" = "error"
-"npm/no-duplicate-dependencies" = "error"
-"npm/unlisted-package-private" = "warning"
+
+[[lints.scopes]]
+name = "published cargo packages"
+match = { ecosystems = ["cargo"], managed = true, publishable = true }
+rules = { "cargo/required-package-fields" = "error" }
 ```
 
 Rule configuration:
 
 - Simple severity: `"rule-id" = "error"`, `"rule-id" = "warning"`, or `"rule-id" = "off"`
 - Detailed config: `{ level = "error", fix = true, ...options }`
+
+Use `mc lint list` to inspect registered rules and presets. Use `mc lint explain <id>` to see the details for a rule or preset before configuring it.
 
 Today the built-in rule sets focus on Cargo and npm-family manifests.
 
@@ -566,7 +569,7 @@ If you edited shared docs in `.templates/`, also run:
 devenv shell docs:check
 ```
 
-For the full rule-by-rule explanation — including the available `[lints]` rules, why you would enable them, and examples of what changes with and without them — see [skills/linting.md](./skills/linting.md).
+For the full rule-by-rule explanation — including the available `[lints]` presets and rules, why you would enable them, and examples of what changes with and without them — see [skills/linting.md](./skills/linting.md).
 
 ## Important modeling rules
 

--- a/packages/monochange__skill/SKILL.md
+++ b/packages/monochange__skill/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: monochange
-description: Guides agents through monochange discovery, changesets, release planning, and provider-aware release workflows. Use when working on `monochange.toml`, `.changeset/*.md`, release automation, grouped versions, cross-ecosystem monorepo releases, CLI step composition, MCP tool interactions, or linting configuration.
+description: Guides agents through monochange adoption planning, discovery, changesets, release planning, and provider-aware release workflows. Use when working on `monochange.toml`, `.changeset/*.md`, release automation, grouped versions, migration into existing monorepos, cross-ecosystem monorepo releases, CLI step composition, MCP tool interactions, or linting configuration.
 ---
 
 # monochange
 
 ## Quick start
+
+If the user is still deciding how deeply to adopt monochange, start with [skills/adoption.md](skills/adoption.md) and [examples/README.md](examples/README.md) before generating files.
 
 1. If `monochange.toml` does not exist yet, run `mc init`. If it exists but you want editable built-in command definitions, run `mc populate`.
 2. Read `monochange.toml` first — it is the single source of truth.
@@ -52,10 +54,12 @@ Release-oriented commands default to markdown output. Use `--format json` for au
 
 - [REFERENCE.md](REFERENCE.md) — high-context reference with more examples
 - [skills/README.md](skills/README.md) — index of focused skill modules
+- [skills/adoption.md](skills/adoption.md) — interactive setup planning, migration questions, and recommendation patterns
 - [skills/changesets.md](skills/changesets.md) — creating and managing changesets
 - [skills/commands.md](skills/commands.md) — built-in commands and workflow selection
 - [skills/configuration.md](skills/configuration.md) — creating and extending `monochange.toml`
-- [skills/linting.md](skills/linting.md) — `mc check`, `[lints]`, and manifest-focused rule explanations with examples
+- [skills/linting.md](skills/linting.md) — `mc check`, `[lints]`, presets, and manifest-focused rule explanations with examples
+- [examples/README.md](examples/README.md) — condensed setup examples for quick recommendations
 - [MULTI-PACKAGE-PUBLISHING.md](MULTI-PACKAGE-PUBLISHING.md) — patterns for publishing multiple public packages from one repository
 - [CHANGESET-GUIDE.md](CHANGESET-GUIDE.md) — full lifecycle guidance
 - [ARTIFACT-TYPES.md](ARTIFACT-TYPES.md) — package-type-specific release-note guidance
@@ -68,6 +72,7 @@ Release-oriented commands default to markdown output. Use `--format json` for au
 | `mc populate`            | Append missing built-in CLI command definitions to config              |
 | `mc validate`            | Validate config and changeset targets                                  |
 | `mc check`               | Validate config and run lint rules against package manifests           |
+| `mc lint`                | Inspect registered lint rules and presets                              |
 | `mc discover`            | Discover packages across ecosystems                                    |
 | `mc change`              | Create a `.changeset/*.md` file                                        |
 | `mc release`             | Prepare a release plan from changesets and refresh the cached manifest |
@@ -216,23 +221,20 @@ See [ARTIFACT-TYPES.md](ARTIFACT-TYPES.md) for per-type rules, templates, exampl
 
 ### Lint configuration
 
-Configure ecosystem-specific manifest lint rules in `monochange.toml` and run them with `mc check`:
+Configure manifest lint presets, global rules, and scoped overrides in the top-level `[lints]` section of `monochange.toml`, then run them with `mc check`:
 
 ```toml
-[lints.rules]
-"cargo/dependency-field-order" = "error"
-"cargo/internal-dependency-workspace" = "error"
-"cargo/required-package-fields" = "error"
-"cargo/sorted-dependencies" = "error"
-"cargo/unlisted-package-private" = "warning"
+[lints]
+use = ["cargo/recommended", "npm/recommended"]
 
-# npm rules also live under [lints.rules]
+[lints.rules]
+"cargo/internal-dependency-workspace" = "error"
 "npm/workspace-protocol" = "error"
-"npm/sorted-dependencies" = "error"
-"npm/required-package-fields" = "error"
-"npm/root-no-prod-deps" = "error"
-"npm/no-duplicate-dependencies" = "error"
-"npm/unlisted-package-private" = "warning"
+
+[[lints.scopes]]
+name = "published cargo packages"
+match = { ecosystems = ["cargo"], managed = true, publishable = true }
+rules = { "cargo/required-package-fields" = "error" }
 ```
 
 Each rule can be configured as:
@@ -240,13 +242,17 @@ Each rule can be configured as:
 - Simple severity: `"rule-id" = "error"`, `"rule-id" = "warning"`, or `"rule-id" = "off"`
 - Detailed config: `{ level = "error", ...rule_specific_options }`
 
+Use `mc lint list` or `mc lint explain <id>` to inspect available rules and presets.
+
 Use `mc check --fix` to auto-fix issues where possible. Today the built-in rule sets focus on Cargo and npm-family manifests.
 
 ## Guidance
 
 Start with [REFERENCE.md](REFERENCE.md) for the broad reference.
 
-Open [skills/README.md](skills/README.md) when you need the focused deep dives for changesets, commands, configuration, or linting.
+Open [skills/README.md](skills/README.md) when you need the focused deep dives for adoption planning, changesets, commands, configuration, or linting.
+
+Open [examples/README.md](examples/README.md) when a short scenario-based recommendation is more useful than a long reference document.
 
 See [TRUSTED-PUBLISHING.md](TRUSTED-PUBLISHING.md) for GitHub/OIDC trusted-publishing setup details across the registries that monochange supports.
 

--- a/packages/monochange__skill/examples/README.md
+++ b/packages/monochange__skill/examples/README.md
@@ -1,0 +1,22 @@
+# monochange skill examples
+
+Use these condensed examples when the main skill needs quick setup guidance without loading the larger repo-shaped examples from the monochange repository.
+
+## Example index
+
+- [quickstart.md](./quickstart.md) — choosing between quickstart and standard adoption
+- [migration.md](./migration.md) — adopting monochange into an existing repository safely
+- [publishing.md](./publishing.md) — builtin vs external publishing, trusted publishing, and placeholders
+- [release-pr.md](./release-pr.md) — long-running release PR branch recommendations
+
+## How to use this folder
+
+- start with `skills/adoption.md` when the user is still choosing setup depth
+- open one of the example pages here when you need a short recommendation pattern
+- use the top-level repository examples for fuller CI shapes and future end-to-end fixtures
+
+Full repository examples live in the monochange repository at:
+
+- <https://github.com/ifiokjr/monochange/tree/main/examples>
+
+That folder also includes `examples/validate-examples.sh` for running `mc validate`, `mc check`, and `mc release --dry-run --diff` across the repo-shaped examples.

--- a/packages/monochange__skill/examples/migration.md
+++ b/packages/monochange__skill/examples/migration.md
@@ -1,0 +1,21 @@
+# Migration example
+
+## Recommend this when
+
+- the repository already has release scripts, CI workflows, or tag conventions
+- monochange must coexist with current tooling first
+- the user wants a phased migration instead of a big-bang switch
+
+## Default recommendation
+
+- choose `migration` depth
+- inspect existing CI files, tag conventions, changelog flow, and competitor tooling first
+- keep publishing external more often during the first phase
+- move config validation, discovery, and release dry-runs into CI before replacing publish jobs
+
+## Good default output
+
+- current workflow summary
+- recommended coexistence phase
+- pieces safe to migrate now
+- pieces to delay until trust is established

--- a/packages/monochange__skill/examples/publishing.md
+++ b/packages/monochange__skill/examples/publishing.md
@@ -1,0 +1,21 @@
+# Publishing example
+
+## Recommend this when
+
+- the user is choosing between local-only, builtin, and external publishing
+- trusted publishing or placeholder publication needs to be planned
+- the workspace contains public packages
+
+## Default recommendation
+
+- GitHub + npm: builtin is the preferred default
+- `crates.io` and `pub.dev`: external is often clearer when the registry-maintained workflow should own the publish step
+- GitLab: builtin planning still fits well, but publishing is external more often
+- ask about placeholder publication only when public names matter and the first real release may be delayed
+
+## Good default output
+
+- public vs internal package split
+- recommended publish mode per ecosystem
+- trusted-publishing follow-up steps
+- placeholder strategy, if needed

--- a/packages/monochange__skill/examples/quickstart.md
+++ b/packages/monochange__skill/examples/quickstart.md
@@ -1,0 +1,22 @@
+# Quickstart example
+
+## Recommend this when
+
+- the repository is greenfield or nearly greenfield
+- the user wants a safe first success before full automation
+- package discovery and config quality matter more than publish setup right now
+
+## Default recommendation
+
+- ask for setup depth first: `quickstart` or `standard`
+- inspect the repository before asking ecosystem-specific questions
+- start with `mc init`, `mc validate`, `mc discover --format json`, and `mc release --dry-run --diff`
+- stop before real publishing unless the user explicitly wants a deeper setup
+
+## Good default output
+
+- detected provider and ecosystems
+- recommended lint profile
+- whether grouping is needed yet
+- next commands to run
+- what to defer until `full` mode

--- a/packages/monochange__skill/examples/release-pr.md
+++ b/packages/monochange__skill/examples/release-pr.md
@@ -1,0 +1,20 @@
+# Release PR example
+
+## Recommend this when
+
+- the team wants a reviewable release branch
+- release files should be inspected before they land on the default branch
+- tags and publishes should happen only after merge
+
+## Default recommendation
+
+- use `mc release-pr` for branch refresh
+- do not create tags on the release branch
+- after merge, detect the durable release commit with `mc release-record --from HEAD --format json`
+- run `mc tag-release --from HEAD` before package publishing
+
+## Good default output
+
+- release PR refresh strategy
+- post-merge tagging and publish steps
+- approval and human-review checkpoints

--- a/packages/monochange__skill/package.json
+++ b/packages/monochange__skill/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@monochange/skill",
 	"version": "0.1.0",
-	"description": "Skill for monochange workflows and release planning guidance",
+	"description": "Skill for monochange adoption, release planning, and publishing guidance",
 	"license": "Unlicense",
 	"repository": {
 		"type": "git",
@@ -19,6 +19,7 @@
 		"TRUSTED-PUBLISHING.md",
 		"MULTI-PACKAGE-PUBLISHING.md",
 		"skills",
+		"examples",
 		"README.md",
 		"LICENSE",
 		"changelog.md"

--- a/packages/monochange__skill/skills/README.md
+++ b/packages/monochange__skill/skills/README.md
@@ -2,10 +2,12 @@
 
 Use these focused guides when the top-level [SKILL.md](../SKILL.md) is not enough context:
 
+- [adoption.md](./adoption.md) — setup-depth questions, migration guidance, and recommendation patterns
 - [changesets.md](./changesets.md) — creating, updating, replacing, and removing `.changeset/*.md` files
 - [commands.md](./commands.md) — the built-in `mc` commands, when to run them, and how they fit together
 - [configuration.md](./configuration.md) — creating and evolving `monochange.toml`
-- [linting.md](./linting.md) — `mc check`, `[ecosystems.<name>].lints`, and manifest-focused rule explanations with examples
+- [linting.md](./linting.md) — `mc check`, `[lints]`, presets, and manifest-focused rule explanations with examples
+- [../examples/README.md](../examples/README.md) — condensed scenario examples for quick recommendations
 - [../MULTI-PACKAGE-PUBLISHING.md](../MULTI-PACKAGE-PUBLISHING.md) — publishing patterns for repositories that ship multiple public packages
 
 Keep [REFERENCE.md](../REFERENCE.md) open when you want a single high-context document with broader examples and copy-paste snippets.

--- a/packages/monochange__skill/skills/adoption.md
+++ b/packages/monochange__skill/skills/adoption.md
@@ -1,0 +1,125 @@
+# Adoption skill
+
+Use this guide when the user wants help deciding **how** to adopt monochange, not just which command to run next.
+
+## First move: inspect before interrogating
+
+Inspect the repository before asking detailed setup questions.
+
+Look for:
+
+- package ecosystems and workspace managers
+- existing CI files such as `.github/workflows/*` or `.gitlab-ci.yml`
+- existing release tooling such as changesets, knope, semantic-release, release-please, or custom scripts
+- whether packages appear public, private, or mixed
+- existing changelog, tag, and release-branch conventions
+
+Use that evidence to decide confidence:
+
+- **high confidence** — recommend a default and ask for confirmation
+- **medium confidence** — recommend a default and ask one or two targeted questions
+- **low confidence** — ask more questions before proposing file changes
+
+## Ask setup depth first
+
+Start with one question:
+
+- `quickstart` — generate or refine config and stop at validation plus dry-run release planning
+- `standard` — config, linting, and release preview
+- `full` — config, linting, CI automation, publishing, and placeholder strategy when relevant
+- `migration` — phase monochange into an existing repository safely
+
+## Core question tree
+
+### 1. Repository starting point
+
+Ask:
+
+- is this a greenfield repository or an existing one?
+- if it already exists, what handles releases today?
+- what must stay compatible during the first adoption phase?
+
+Recommendation:
+
+- prefer coexistence first for existing repositories
+- replace old tooling only after monochange discovery and dry-run planning are trusted
+
+### 2. Workspace shape
+
+Ask:
+
+- which ecosystems are present?
+- which packages are public, private, or internal-only?
+- should versions stay package-specific or move into groups?
+
+Recommendation:
+
+- prefer package ids first
+- create groups only when the outward release identity is truly shared
+
+### 3. Linting depth
+
+Ask:
+
+- does the team want minimal guardrails or stronger manifest consistency?
+
+Recommendation:
+
+- `minimal` — start with a small `[lints.rules]` set for publication-safety rules only
+- `balanced` — prefer `[lints].use = ["cargo/recommended", "npm/recommended"]` plus a few targeted overrides
+- `strict` — promote stricter presets or scoped overrides after the repo is already stable
+
+### 4. Release orchestration
+
+Ask:
+
+- should releases stay local-only, use a merged release commit, or use a long-running release PR branch?
+- which provider owns CI: GitHub, GitLab, or something custom?
+
+Recommendation:
+
+- default to hybrid: local discovery and dry-runs, CI for real release and publish work
+- prefer GitHub for the most automated builtin path today
+- on GitLab, keep planning builtin and keep publishing external more often when auth/bootstrap is already specialized
+
+### 5. Publishing and placeholders
+
+Ask these only if the workspace contains public packages.
+
+Ask:
+
+- which registries are involved?
+- does the team want builtin or external publish jobs?
+- do package names need to be reserved before the real release flow is ready?
+
+Recommendation:
+
+- GitHub + npm: builtin is the preferred default
+- `crates.io` and `pub.dev`: external is often clearer when the registry-maintained workflow should own the publish step
+- ask about `mc placeholder-publish` only when public names matter and the first real release may be delayed
+
+## Final output contract
+
+End the planning flow with a compact decision record:
+
+- detected repo profile
+- chosen setup depth
+- recommended adoption path
+- recommended `monochange.toml` shape
+- recommended lint profile
+- recommended CI and release strategy
+- recommended publishing and placeholder strategy, if applicable
+- open risks or unanswered questions
+- next commands to run
+
+## Guardrails
+
+- do not write CI or publish configuration without permission
+- do not force publishing questions into internal-only repositories
+- do not recommend big-bang migration by default
+- keep recommendations short, with the default plus a brief tradeoff explanation
+
+## Related examples
+
+- [../examples/README.md](../examples/README.md)
+- full repository examples: <https://github.com/ifiokjr/monochange/tree/main/examples>

--- a/packages/monochange__skill/skills/commands.md
+++ b/packages/monochange__skill/skills/commands.md
@@ -39,6 +39,24 @@ mc release-record --from v1.2.3
 mc release-record --from HEAD --format json
 ```
 
+### Inspect lint rules and presets
+
+| Goal                            | Command                | When to use it                                                          |
+| ------------------------------- | ---------------------- | ----------------------------------------------------------------------- |
+| List registered rules/presets   | `mc lint list`         | You want to see which lint ids and presets monochange currently exposes |
+| Explain one rule or preset      | `mc lint explain <id>` | You want the details before configuring a rule in `[lints]`             |
+| Run configured lint enforcement | `mc check`             | You want validation plus lint execution against manifests               |
+
+Examples:
+
+```bash
+mc lint list
+mc lint list --format json
+mc lint explain cargo/recommended
+mc lint explain npm/workspace-protocol
+mc check --fix
+```
+
 ### Create release intent
 
 | Goal                                     | Command       | When to use it                                                      |

--- a/packages/monochange__skill/skills/linting.md
+++ b/packages/monochange__skill/skills/linting.md
@@ -21,32 +21,30 @@ Common commands:
 mc check
 mc check --fix
 mc check --format json
+mc lint list
+mc lint explain cargo/recommended
 ```
 
 Use `--fix` when you want monochange to apply auto-fixes where a rule supports them.
 
 ## Where lint rules live
 
-Configure rules under the top-level lint section in `monochange.toml`:
+Configure presets, global rules, and scoped overrides in the top-level `[lints]` section of `monochange.toml`:
 
 ```toml
 [lints]
 use = ["cargo/recommended", "npm/recommended", "dart/recommended"]
 
 [lints.rules]
-"cargo/dependency-field-order" = "error"
 "cargo/internal-dependency-workspace" = "error"
-"cargo/required-package-fields" = { level = "warning", fields = ["description", "license", "repository"] }
-"cargo/sorted-dependencies" = "warning"
-"cargo/unlisted-package-private" = { level = "warning", fix = true }
 "npm/workspace-protocol" = "error"
-"npm/sorted-dependencies" = "warning"
-"npm/required-package-fields" = { level = "warning", fields = ["description", "repository", "license"] }
-"npm/root-no-prod-deps" = "error"
-"npm/no-duplicate-dependencies" = "error"
-"npm/unlisted-package-private" = { level = "warning", fix = true }
 "dart/sdk-constraint-modern" = { level = "warning", minimum = "3.6.0", require_upper_bound = false }
 "dart/no-unexpected-dependency-overrides" = { level = "warning", allow_for_private = true, allow_packages = ["app_shell"] }
+
+[[lints.scopes]]
+name = "published cargo packages"
+match = { ecosystems = ["cargo"], managed = true, publishable = true }
+rules = { "cargo/required-package-fields" = "error" }
 ```
 
 Rule configuration supports two forms:
@@ -62,7 +60,7 @@ Today, built-in manifest lint rules exist for:
 - **npm-family** manifests (`package.json`)
 - **Dart / Flutter** manifests (`pubspec.yaml`)
 
-monochange routes all manifest lint configuration through the top-level `[lints]` section, while each ecosystem crate provides its own built-in suites and presets.
+Lint suites still live in ecosystem crates, but monochange routes all manifest lint configuration through the top-level `[lints]` section via preset selection, rule overrides, and scoped matches.
 
 ## Cargo manifest lint rules
 
@@ -470,6 +468,8 @@ Example:
 
 - `dart/recommended` enables metadata/publishability checks, `dart/sdk-constraint-present`, and `dart/dependency-sorted` as a warning.
 - `dart/strict` adds `dart/sdk-constraint-modern`, `dart/no-unexpected-dependency-overrides`, `dart/internal-path-dependency-policy`, `dart/workspace-internal-version-consistency`, `dart/flutter-package-metadata-consistent`, and `dart/assets-sorted`, while promoting `dart/dependency-sorted` to an error.
+
+Use `mc lint list` to inspect registered rules and presets, and `mc lint explain <id>` to understand a rule or preset before enabling it.
 
 ## What `mc check` looks like in practice
 

--- a/readme.md
+++ b/readme.md
@@ -221,10 +221,12 @@ After copying the bundled skill, you get a small documentation set that is desig
 - `SKILL.md` — concise entrypoint for agents
 - `REFERENCE.md` — broader high-context reference with more examples
 - `skills/README.md` — index of focused deep dives
+- `skills/adoption.md` — setup-depth questions, migration guidance, and recommendation patterns
 - `skills/changesets.md` — changeset authoring and lifecycle guidance
 - `skills/commands.md` — built-in command catalog and workflow selection
 - `skills/configuration.md` — `monochange.toml` setup and editing guidance
-- `skills/linting.md` — `[ecosystems.<name>.lints]` rules, `mc check`, and manifest-focused examples
+- `skills/linting.md` — `[lints]` presets, `mc check`, and manifest-focused examples
+- `examples/README.md` — condensed scenario examples for quick recommendations
 
 This layout keeps the top-level skill small while still making the richer guidance available when an assistant needs more context.
 


### PR DESCRIPTION
## Summary
- add a new `skills/adoption.md` planning layer to the packaged `@monochange/skill`
- update skill docs for top-level `[lints]` plus `mc lint` discovery commands
- add bundled skill examples and top-level repo-shaped examples for GitHub, GitLab, mixed workspaces, internal-only setups, placeholders, and release PR workflows
- add `examples/validate-examples.sh` to validate the repo-shaped examples end to end through dry-run release planning
- add a GitHub-ready draft issue for the external publishing test-lab follow-up

## Validation
- `docs:check`
- `target/debug/mc validate`
- `target/debug/mc affected --format json --verify ...`
- `./examples/validate-examples.sh`
- pre-push `lint:all && test:all`
