### PR TITLE
feat: add caused_by changeset context

### DIFF
--- a/.changeset/add-caused-by-changeset-context.md
+++ b/.changeset/add-caused-by-changeset-context.md
@@ -1,0 +1,13 @@
+---
+monochange: minor
+monochange_config: minor
+monochange_core: minor
+monochange_graph: minor
+monochange_cargo: none
+monochange_semver: none
+monochange_lint_testing: none
+---
+
+#### add `caused_by` changeset context for dependency propagation
+
+You can now annotate dependency-only follow-up changesets with `caused_by`, use `mc change --caused-by ...` to author them, inspect the linkage in diagnostics output, and suppress matching automatic dependency propagation during release planning.

--- a/.changeset/add-caused-by-changeset-context.md
+++ b/.changeset/add-caused-by-changeset-context.md
@@ -6,6 +6,8 @@ monochange_graph: minor
 monochange_cargo: none
 monochange_semver: none
 monochange_lint_testing: none
+"@monochange/cli": none
+"@monochange/skill": none
 ---
 
 #### add `caused_by` changeset context for dependency propagation

--- a/.templates/changeset.t.md
+++ b/.templates/changeset.t.md
@@ -472,7 +472,7 @@ These tools integrate with the changeset lifecycle:
 
 When a dependency changes, monochange automatically patches all dependents. This creates release notes with no context for _why_ the dependent is being updated.
 
-The `caused_by` field in changeset frontmatter provides that context. It lists the root package(s) or group(s) that triggered this dependent change:
+The `caused_by` field in changeset frontmatter provides that context. It lists the root package(s) or group(s) that triggered this dependent change. Because `caused_by` is part of the object form, use table syntax instead of scalar shorthand whenever you need it:
 
 ```markdown
 ---
@@ -489,9 +489,10 @@ Bumps `monochange_core` dependency to v2.1.0 after the public API change to `Cha
 **How it works:**
 
 1. Without `caused_by`: a dependent gets an automatic "dependency changed → patch" record with no explanation
-2. With `caused_by`: the authored changeset **replaces** the automatic propagation — it provides human-readable context instead
-3. A changeset with `caused_by` and `bump: patch` suppresses the automatic "dependency changed → patch" record for that package
-4. A changeset with `caused_by` and `bump: none` suppresses propagation entirely — the package is acknowledged as affected but no version bump is warranted
+2. With `caused_by`: the authored changeset **replaces** the matching automatic propagation — it provides human-readable context instead
+3. A changeset with `caused_by` and `bump: patch` suppresses the automatic "dependency changed → patch" record for that package when the same upstream package or group triggered it
+4. A changeset with `caused_by` and `bump: none` suppresses that matching propagation entirely — the package is acknowledged as affected but no version bump is warranted
+5. Unrelated upstream sources can still propagate normally; `caused_by` is not a global opt-out for every dependency edge
 
 **`none` bump with `caused_by` — the "nothing meaningful changed" case:**
 
@@ -510,8 +511,11 @@ monochange_config:
 No user-facing changes. Dependency version updated to match the group release.
 ```
 
-This tells monochange: "this package is affected, but the change doesn't warrant a version bump for consumers. Suppress the automatic patch propagation entirely."
+This tells monochange: "this package is affected, but the change doesn't warrant a version bump for consumers. Suppress the matching automatic patch propagation entirely."
 
-CLI flag: `mc change --package <id> --bump patch --caused-by monochange_core --reason "update dependency"`
+CLI authoring supports one or more `--caused-by` flags:
+
+- `mc change --package <id> --bump patch --caused-by monochange_core --reason "update dependency"`
+- `mc change --package <id> --bump none --caused-by sdk --reason "dependency-only follow-up"`
 
 <!-- {/changesetCausedByField} -->

--- a/.templates/cli-steps.t.md
+++ b/.templates/cli-steps.t.md
@@ -93,11 +93,27 @@ choices = ["none", "patch", "minor", "major"]
 default = "patch"
 
 [[cli.change.inputs]]
+name = "version"
+type = "string"
+
+[[cli.change.inputs]]
+name = "type"
+type = "string"
+
+[[cli.change.inputs]]
+name = "caused_by"
+type = "string_list"
+
+[[cli.change.inputs]]
 name = "reason"
 type = "string"
 
 [[cli.change.inputs]]
 name = "details"
+type = "string"
+
+[[cli.change.inputs]]
+name = "output"
 type = "string"
 
 [[cli.change.steps]]

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -554,11 +554,13 @@ When `version` is provided without `bump`, the bump is inferred from the current
 <!-- {@releasePlanningRules} -->
 
 - `mc change` defaults `--bump` to `patch`; use `--bump none` when you want a type-only or version-only entry, and pass `--version` to pin an explicit release version
-- markdown change files use package/group ids as the only top-level frontmatter keys, with scalar shorthand for `none`/`patch`/`minor`/`major` or configured change types, plus object syntax for `bump`, `version`, and/or `type`
+- markdown change files use package/group ids as the only top-level frontmatter keys, with scalar shorthand for `none`/`patch`/`minor`/`major` or configured change types, plus object syntax for `bump`, `version`, `type`, and `caused_by`
 - when `version` is given without `bump`, the bump is inferred by comparing the current and target versions
 - explicit versions from grouped members propagate to the group version; conflicts take the highest semver or fail when `defaults.strict_version_conflicts = true`
 - prefer package ids over group ids in authored changesets when possible; direct package changes still propagate to dependents and synchronize configured groups
 - optional change `type` values can route entries into custom changelog sections, and configured section `default_bump` values let scalar type shorthand imply the desired semver behavior
+- `caused_by` references package or group ids and suppresses only the matching dependency-propagation records; use object syntax whenever you need it
+- `mc change` accepts repeated `--caused-by <id>` flags, and `--bump none` is the right fit when you want to acknowledge an affected package without forcing a user-facing version bump
 - `mc change` can write to a deterministic path with `--output ...`
 - change templates support detailed multi-line release-note entries through `{{ details }}`, compact metadata blocks through `{{ context }}`, and fine-grained linked metadata like `{{ change_owner_link }}`, `{{ review_request_link }}`, and `{{ closed_issue_links }}`
 - dependents default to the configured `parent_bump`, including packages outside a changed version group when they depend on a synchronized member

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -517,6 +517,12 @@ mc change --package <id> --bump patch --reason "describe the change"
 
 Most changes should target a package id. Use group ids only when the change is intentionally owned by the whole group.
 
+When a package is only changing because another dependency or version group moved first, author that context explicitly instead of relying on anonymous propagation:
+
+```bash
+mc change --package <dependent-id> --bump none --caused-by <upstream-id> --reason "dependency-only follow-up"
+```
+
 Preview the release plan safely:
 
 ```bash

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -1241,11 +1241,109 @@ fn add_change_file_rejects_none_without_type_or_version() {
 			.build(),
 	)
 	.expect_err("none bump without type/version should fail");
-	assert!(
-		error
-			.to_string()
-			.contains("must not use a `none` bump without also declaring `type` or `version`")
+	assert!(error.to_string().contains(
+		"must not use a `none` bump without also declaring `type`, `version`, or `caused_by`"
+	));
+}
+
+#[test]
+fn add_change_file_allows_none_with_caused_by_context() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_fixture("changeset-target-metadata/render-workspace", tempdir.path());
+	let output_path = tempdir.path().join("dependency-follow-up.md");
+
+	add_change_file(
+		tempdir.path(),
+		crate::AddChangeFileRequest::builder()
+			.package_refs(&["core".to_string()])
+			.bump(BumpSeverity::None)
+			.reason("dependency-only follow-up")
+			.caused_by(&["sdk".to_string()])
+			.output(Some(&output_path))
+			.build(),
+	)
+	.unwrap_or_else(|error| panic!("change file output: {error}"));
+
+	let content = fs::read_to_string(output_path).unwrap_or_else(|error| panic!("read: {error}"));
+	assert!(content.contains("core:"));
+	assert!(content.contains("  bump: none"));
+	assert!(content.contains("  caused_by: [\"sdk\"]"));
+}
+
+#[test]
+fn render_change_target_markdown_uses_object_syntax_for_caused_by_context() {
+	let root = fixture_path("changeset-target-metadata/render-workspace");
+	let configuration =
+		load_workspace_configuration(&root).unwrap_or_else(|error| panic!("config: {error}"));
+	let caused_by = vec!["sdk".to_string()];
+	let lines = render_change_target_markdown(
+		&configuration,
+		"core",
+		BumpSeverity::Patch,
+		None,
+		Some("security"),
+		&caused_by,
+	)
+	.unwrap_or_else(|error| panic!("render target: {error}"));
+	assert_eq!(
+		lines,
+		vec![
+			"core:".to_string(),
+			"  bump: patch".to_string(),
+			"  type: security".to_string(),
+			"  caused_by: [\"sdk\"]".to_string(),
+		]
 	);
+}
+
+#[test]
+fn render_change_target_markdown_renders_version_and_caused_by_context() {
+	let root = fixture_path("changeset-target-metadata/render-workspace");
+	let configuration =
+		load_workspace_configuration(&root).unwrap_or_else(|error| panic!("config: {error}"));
+	let lines = render_change_target_markdown(
+		&configuration,
+		"core",
+		BumpSeverity::Patch,
+		Some("2.0.0"),
+		None,
+		&["sdk".to_string()],
+	)
+	.unwrap_or_else(|error| panic!("render version target: {error}"));
+	assert_eq!(
+		lines,
+		vec![
+			"core:".to_string(),
+			"  bump: patch".to_string(),
+			"  version: \"2.0.0\"".to_string(),
+			"  caused_by: [\"sdk\"]".to_string(),
+		]
+	);
+}
+
+#[test]
+fn add_interactive_change_file_renders_caused_by_context_for_none_bumps() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_fixture("changeset-target-metadata/render-workspace", tempdir.path());
+	let output_path = tempdir.path().join("interactive-caused-by.md");
+	let result = InteractiveChangeResult {
+		targets: vec![InteractiveTarget {
+			id: "core".to_string(),
+			bump: BumpSeverity::None,
+			version: None,
+			change_type: None,
+		}],
+		caused_by: vec!["sdk".to_string()],
+		reason: "dependency follow-up".to_string(),
+		details: None,
+	};
+
+	add_interactive_change_file(tempdir.path(), &result, Some(&output_path))
+		.unwrap_or_else(|error| panic!("interactive caused_by change file: {error}"));
+	let content = fs::read_to_string(output_path).unwrap_or_else(|error| panic!("read: {error}"));
+	assert!(content.contains("core:"));
+	assert!(content.contains("  bump: none"));
+	assert!(content.contains("  caused_by: [\"sdk\"]"));
 }
 
 #[test]
@@ -1281,6 +1379,7 @@ fn render_change_target_markdown_uses_package_defaults() {
 		BumpSeverity::Patch,
 		None,
 		Some("security"),
+		&[],
 	)
 	.unwrap_or_else(|error| panic!("render target: {error}"));
 	assert_eq!(lines, vec!["core: security".to_string()]);
@@ -1297,6 +1396,7 @@ fn render_change_target_markdown_uses_group_defaults() {
 		BumpSeverity::Minor,
 		None,
 		Some("test"),
+		&[],
 	)
 	.unwrap_or_else(|error| panic!("render target: {error}"));
 	assert_eq!(lines, vec!["sdk: test".to_string()]);
@@ -1313,6 +1413,7 @@ fn render_change_target_markdown_quotes_special_character_ids() {
 		BumpSeverity::Patch,
 		None,
 		None,
+		&[],
 	)
 	.unwrap_or_else(|error| panic!("render target: {error}"));
 	assert_eq!(lines, vec!["\"@monochange/skill\": patch".to_string()]);
@@ -1323,6 +1424,7 @@ fn render_change_target_markdown_quotes_special_character_ids() {
 		BumpSeverity::Patch,
 		None,
 		None,
+		&[],
 	)
 	.unwrap_or_else(|error| panic!("render simple target: {error}"));
 	assert_eq!(simple, vec!["plain-package: patch".to_string()]);
@@ -1333,6 +1435,7 @@ fn render_change_target_markdown_quotes_special_character_ids() {
 		BumpSeverity::Patch,
 		None,
 		None,
+		&[],
 	)
 	.unwrap_or_else(|error| panic!("render escaped target: {error}"));
 	assert_eq!(escaped, vec!["\"pkg\\\\\\\"name\": patch".to_string()]);
@@ -1369,6 +1472,7 @@ fn add_interactive_change_file_writes_target_owned_metadata() {
 			version: None,
 			change_type: Some("test".to_string()),
 		}],
+		caused_by: Vec::new(),
 		reason: "broaden integration coverage".to_string(),
 		details: Some("Exercise the group-authored shorthand path.".to_string()),
 	};
@@ -1403,6 +1507,7 @@ fn add_interactive_change_file_quotes_special_character_targets() {
 			version: None,
 			change_type: None,
 		}],
+		caused_by: Vec::new(),
 		reason: "ship special package id support".to_string(),
 		details: None,
 	};
@@ -1602,6 +1707,7 @@ fn render_interactive_changeset_markdown_uses_natural_summary_heading() {
 			version: None,
 			change_type: None,
 		}],
+		caused_by: Vec::new(),
 		reason: "interactive heading".to_string(),
 		details: Some("Details body".to_string()),
 	};
@@ -1609,6 +1715,29 @@ fn render_interactive_changeset_markdown_uses_natural_summary_heading() {
 		.unwrap_or_else(|error| panic!("render interactive markdown: {error}"));
 	assert!(rendered.contains("# interactive heading"));
 	assert!(rendered.contains("Details body"));
+}
+
+#[test]
+fn render_interactive_changeset_markdown_renders_caused_by_context() {
+	let root = fixture_path("changeset-target-metadata/render-workspace");
+	let configuration =
+		load_workspace_configuration(&root).unwrap_or_else(|error| panic!("config: {error}"));
+	let result = InteractiveChangeResult {
+		targets: vec![InteractiveTarget {
+			id: "core".to_string(),
+			bump: BumpSeverity::None,
+			version: None,
+			change_type: None,
+		}],
+		caused_by: vec!["sdk".to_string()],
+		reason: "interactive caused_by".to_string(),
+		details: None,
+	};
+	let rendered = crate::render_interactive_changeset_markdown(&configuration, &result)
+		.unwrap_or_else(|error| panic!("render interactive caused_by markdown: {error}"));
+	assert!(rendered.contains("core:"));
+	assert!(rendered.contains("  bump: none"));
+	assert!(rendered.contains("  caused_by: [\"sdk\"]"));
 }
 
 #[test]
@@ -7901,6 +8030,7 @@ fn filter_group_release_note_change_handles_missing_context_and_direct_group_tar
 			origin: "author".to_string(),
 			evidence_refs: Vec::new(),
 			change_type: None,
+			caused_by: Vec::new(),
 		}],
 	)]);
 	let renamed = crate::filter_group_release_note_change(
@@ -7921,6 +8051,7 @@ fn filter_group_release_note_change_handles_missing_context_and_direct_group_tar
 			origin: "author".to_string(),
 			evidence_refs: Vec::new(),
 			change_type: None,
+			caused_by: Vec::new(),
 		}],
 	)]);
 	assert!(
@@ -7949,6 +8080,7 @@ fn filter_group_release_note_change_respects_member_allowlists() {
 			origin: "author".to_string(),
 			evidence_refs: Vec::new(),
 			change_type: None,
+			caused_by: Vec::new(),
 		}],
 	)]);
 	assert!(
@@ -7971,6 +8103,7 @@ fn filter_group_release_note_change_respects_member_allowlists() {
 				origin: "author".to_string(),
 				evidence_refs: Vec::new(),
 				change_type: None,
+				caused_by: Vec::new(),
 			},
 			PreparedChangesetTarget {
 				id: "app".to_string(),
@@ -7979,6 +8112,7 @@ fn filter_group_release_note_change_respects_member_allowlists() {
 				origin: "author".to_string(),
 				evidence_refs: Vec::new(),
 				change_type: None,
+				caused_by: Vec::new(),
 			},
 		],
 	)]);

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -1241,9 +1241,8 @@ fn add_change_file_rejects_none_without_type_or_version() {
 			.build(),
 	)
 	.expect_err("none bump without type/version should fail");
-	assert!(error.to_string().contains(
-		"must not use a `none` bump without also declaring `type`, `version`, or `caused_by`"
-	));
+	let _guard = snapshot_settings().bind_to_scope();
+	insta::assert_snapshot!(error.to_string());
 }
 
 #[test]
@@ -1265,9 +1264,8 @@ fn add_change_file_allows_none_with_caused_by_context() {
 	.unwrap_or_else(|error| panic!("change file output: {error}"));
 
 	let content = fs::read_to_string(output_path).unwrap_or_else(|error| panic!("read: {error}"));
-	assert!(content.contains("core:"));
-	assert!(content.contains("  bump: none"));
-	assert!(content.contains("  caused_by: [\"sdk\"]"));
+	let _guard = snapshot_settings().bind_to_scope();
+	insta::assert_snapshot!(content);
 }
 
 #[test]
@@ -1341,9 +1339,8 @@ fn add_interactive_change_file_renders_caused_by_context_for_none_bumps() {
 	add_interactive_change_file(tempdir.path(), &result, Some(&output_path))
 		.unwrap_or_else(|error| panic!("interactive caused_by change file: {error}"));
 	let content = fs::read_to_string(output_path).unwrap_or_else(|error| panic!("read: {error}"));
-	assert!(content.contains("core:"));
-	assert!(content.contains("  bump: none"));
-	assert!(content.contains("  caused_by: [\"sdk\"]"));
+	let _guard = snapshot_settings().bind_to_scope();
+	insta::assert_snapshot!(content);
 }
 
 #[test]

--- a/crates/monochange/src/changelog.rs
+++ b/crates/monochange/src/changelog.rs
@@ -1460,6 +1460,7 @@ mod tests {
 				origin: "manual".to_string(),
 				evidence_refs: Vec::new(),
 				change_type: Some("note".to_string()),
+				caused_by: Vec::new(),
 			}],
 			context: Some(ChangesetContext {
 				provider: HostingProviderKind::GitHub,
@@ -1590,6 +1591,7 @@ mod tests {
 			notes: Some("Added release note support".to_string()),
 			details: Some("Detailed explanation".to_string()),
 			change_type: Some("note".to_string()),
+			caused_by: Vec::new(),
 			source_path: changeset_path.clone(),
 		};
 		let source_path = root_relative(tempdir.path(), &changeset.path);
@@ -1900,6 +1902,7 @@ mod tests {
 					origin: "changeset".to_string(),
 					evidence_refs: Vec::new(),
 					change_type: None,
+					caused_by: Vec::new(),
 				},
 				PreparedChangesetTarget {
 					id: "pkg-b".to_string(),
@@ -1908,6 +1911,7 @@ mod tests {
 					origin: "changeset".to_string(),
 					evidence_refs: Vec::new(),
 					change_type: None,
+					caused_by: Vec::new(),
 				},
 			],
 		)]);
@@ -1989,6 +1993,7 @@ mod tests {
 				origin: "changeset".to_string(),
 				evidence_refs: Vec::new(),
 				change_type: None,
+				caused_by: Vec::new(),
 			}],
 		)]);
 		let group_target_change = sample_change("pkg-a", "pkg-a", ".changeset/group.md");

--- a/crates/monochange/src/changesets.rs
+++ b/crates/monochange/src/changesets.rs
@@ -131,6 +131,10 @@ pub(crate) fn render_changeset_diagnostics(report: &ChangesetDiagnosticsReport) 
 					target.kind, target.id, bump, target.origin,
 				));
 
+				if !target.caused_by.is_empty() {
+					lines.push(format!("    caused by: {}", target.caused_by.join(", ")));
+				}
+
 				if !target.evidence_refs.is_empty() {
 					lines.push(format!("    evidence: {}", target.evidence_refs.join(", ")));
 				}
@@ -259,6 +263,7 @@ pub(crate) fn build_prepared_changesets(
 							origin: target.origin.clone(),
 							evidence_refs: target.evidence_refs.clone(),
 							change_type: target.change_type.clone(),
+							caused_by: target.caused_by.clone(),
 						}
 					})
 					.collect(),
@@ -411,6 +416,7 @@ mod diagnostics_tests {
 					origin: "manual".to_string(),
 					evidence_refs: vec!["src/lib.rs".to_string()],
 					change_type: Some("feature".to_string()),
+					caused_by: vec!["core".to_string()],
 				}],
 				context: Some(ChangesetContext {
 					provider: HostingProviderKind::GitHub,
@@ -473,6 +479,7 @@ mod diagnostics_tests {
 		assert!(rendered.contains("summary: ship feature"));
 		assert!(rendered.contains("details: long details"));
 		assert!(rendered.contains("- package core (bump: minor, origin: manual)"));
+		assert!(rendered.contains("caused by: core"));
 		assert!(rendered.contains("evidence: src/lib.rs"));
 		assert!(rendered.contains("introduced: abc1234"));
 		assert!(rendered.contains("last-updated: def1234"));
@@ -535,6 +542,7 @@ mod diagnostics_tests {
 				origin: "manual".to_string(),
 				evidence_refs: vec!["src/lib.rs".to_string()],
 				change_type: Some("fix".to_string()),
+				caused_by: Vec::new(),
 			}],
 			signals: Vec::new(),
 		}];
@@ -895,6 +903,7 @@ pub(crate) fn default_change_path(root: &Path, package_refs: &[String]) -> PathB
 		.join(format!("{timestamp}-{slug}.md"))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn render_changeset_markdown(
 	configuration: &monochange_core::WorkspaceConfiguration,
 	package_refs: &[String],
@@ -902,6 +911,7 @@ pub(crate) fn render_changeset_markdown(
 	version: Option<&str>,
 	reason: &str,
 	change_type: Option<&str>,
+	caused_by: &[String],
 	details: Option<&str>,
 ) -> MonochangeResult<String> {
 	let mut lines = vec!["---".to_string()];
@@ -912,6 +922,7 @@ pub(crate) fn render_changeset_markdown(
 			bump,
 			version,
 			change_type,
+			caused_by,
 		)?);
 	}
 	lines.push("---".to_string());

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -445,11 +445,13 @@ pub(crate) fn cli_command_after_help(cli_command: &CliCommandDefinition) -> Opti
   mc change --package sdk-core --bump patch --reason "fix panic"
   mc change --package sdk-core --bump minor --reason "add API" --output .changeset/sdk-core.md
   mc change --package sdk --bump minor --reason "coordinated release"
+  mc change --package sdk-config --bump none --caused-by sdk-core --reason "dependency-only follow-up"
 
 Rules:
   - Prefer configured package ids in change files whenever a leaf package changed.
   - Use a group id only when the change is intentionally owned by the whole group.
   - Dependents and grouped members are propagated automatically during planning.
+  - Use `--caused-by` when a package is only changing because another package or group moved first.
   - Legacy manifest paths may still resolve during migration, but declared ids are the stable interface."#,
 			)
 		}

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -2861,6 +2861,7 @@ fn execute_create_change_file_step(
 
 	if is_interactive {
 		let options = interactive::InteractiveOptions {
+			caused_by: step_inputs.get("caused_by").cloned().unwrap_or_default(),
 			reason: step_inputs
 				.get("reason")
 				.and_then(|values| values.first())
@@ -2918,6 +2919,7 @@ fn execute_create_change_file_step(
 			.get("details")
 			.and_then(|values| values.first())
 			.cloned();
+		let caused_by = step_inputs.get("caused_by").cloned().unwrap_or_default();
 		let output_path = step_inputs
 			.get("output")
 			.and_then(|values| values.first())
@@ -2930,6 +2932,7 @@ fn execute_create_change_file_step(
 				.reason(&reason)
 				.version(version.as_deref())
 				.change_type(change_type.as_deref())
+				.caused_by(&caused_by)
 				.details(details.as_deref())
 				.output(output_path.as_deref())
 				.build(),

--- a/crates/monochange/src/interactive.rs
+++ b/crates/monochange/src/interactive.rs
@@ -36,6 +36,8 @@ impl fmt::Display for SelectableTarget {
 pub struct InteractiveChangeResult {
 	/// Per-target (package or group id) selections.
 	pub targets: Vec<InteractiveTarget>,
+	/// Package or group ids that caused this dependent change.
+	pub caused_by: Vec<String>,
 	/// Release-note summary.
 	pub reason: String,
 	/// Optional long-form details.
@@ -52,6 +54,7 @@ pub struct InteractiveTarget {
 /// CLI-provided values that bypass their interactive prompts when present.
 #[derive(Debug, Default)]
 pub struct InteractiveOptions {
+	pub caused_by: Vec<String>,
 	pub reason: Option<String>,
 	pub details: Option<String>,
 }
@@ -112,6 +115,7 @@ pub fn run_interactive_change(
 
 	Ok(InteractiveChangeResult {
 		targets: interactive_targets,
+		caused_by: options.caused_by.clone(),
 		reason,
 		details,
 	})

--- a/crates/monochange/src/mcp.rs
+++ b/crates/monochange/src/mcp.rs
@@ -37,6 +37,8 @@ pub struct ChangeParam {
 	pub reason: String,
 	#[serde(rename = "type")]
 	pub change_type: Option<String>,
+	#[serde(default)]
+	pub caused_by: Vec<String>,
 	pub details: Option<String>,
 	pub output: Option<String>,
 }
@@ -321,6 +323,7 @@ impl MonochangeMcpServer {
 			.reason(&params.reason)
 			.version(params.version.as_deref())
 			.change_type(params.change_type.as_deref())
+			.caused_by(&params.caused_by)
 			.details(params.details.as_deref())
 			.output(output)
 			.build();
@@ -819,6 +822,7 @@ mod __tests {
 				version: None,
 				reason: "add test coverage".to_string(),
 				change_type: None,
+				caused_by: Vec::new(),
 				details: None,
 				output: Some(
 					tempdir
@@ -872,6 +876,7 @@ mod __tests {
 				version: None,
 				reason: "document the migration".to_string(),
 				change_type: Some("docs".to_string()),
+				caused_by: Vec::new(),
 				details: None,
 				output: Some(
 					tempdir
@@ -922,6 +927,7 @@ mod __tests {
 				version: None,
 				reason: "missing package".to_string(),
 				change_type: None,
+				caused_by: Vec::new(),
 				details: None,
 				output: None,
 			}))

--- a/crates/monochange/src/monochange.init.toml
+++ b/crates/monochange/src/monochange.init.toml
@@ -760,6 +760,7 @@ inputs = [
 	{ name = "bump", type = "choice", choices = ["none", "patch", "minor", "major"], default = "patch" },
 	{ name = "reason", type = "string", required = true },
 	{ name = "type", type = "string" },
+	{ name = "caused_by", type = "string_list" },
 	{ name = "details", type = "string" },
 	{ name = "output", type = "path" },
 ]

--- a/crates/monochange/src/snapshots/monochange____tests__add_change_file_allows_none_with_caused_by_context.snap
+++ b/crates/monochange/src/snapshots/monochange____tests__add_change_file_allows_none_with_caused_by_context.snap
@@ -1,0 +1,11 @@
+---
+source: crates/monochange/src/__tests.rs
+expression: content
+---
+---
+core:
+  bump: none
+  caused_by: ["sdk"]
+---
+
+# dependency-only follow-up

--- a/crates/monochange/src/snapshots/monochange____tests__add_change_file_rejects_none_without_type_or_version.snap
+++ b/crates/monochange/src/snapshots/monochange____tests__add_change_file_rejects_none_without_type_or_version.snap
@@ -1,0 +1,5 @@
+---
+source: crates/monochange/src/__tests.rs
+expression: error.to_string()
+---
+config error: target `core` must not use a `none` bump without also declaring `type`, `version`, or `caused_by`

--- a/crates/monochange/src/snapshots/monochange____tests__add_interactive_change_file_renders_caused_by_context_for_none_bumps.snap
+++ b/crates/monochange/src/snapshots/monochange____tests__add_interactive_change_file_renders_caused_by_context_for_none_bumps.snap
@@ -1,0 +1,11 @@
+---
+source: crates/monochange/src/__tests.rs
+expression: content
+---
+---
+core:
+  bump: none
+  caused_by: ["sdk"]
+---
+
+# dependency follow-up

--- a/crates/monochange/src/snapshots/monochange__mcp____tests__release_manifest_returns_dry_run_manifest@release_manifest_returns_dry_run_manifest.snap
+++ b/crates/monochange/src/snapshots/monochange__mcp____tests__release_manifest_returns_dry_run_manifest@release_manifest_returns_dry_run_manifest.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/monochange/src/mcp.rs
-assertion_line: 731
 expression: content_text(&result)
 ---
 {

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -986,6 +986,8 @@ pub struct AddChangeFileRequest<'a> {
 	#[builder(default)]
 	pub change_type: Option<&'a str>,
 	#[builder(default)]
+	pub caused_by: &'a [String],
+	#[builder(default)]
 	pub details: Option<&'a str>,
 	#[builder(default)]
 	pub output: Option<&'a Path>,
@@ -1030,6 +1032,7 @@ pub fn add_change_file(
 		request.version,
 		request.reason,
 		request.change_type,
+		request.caused_by,
 		request.details,
 	)?;
 
@@ -1121,15 +1124,30 @@ pub(crate) fn render_change_target_markdown(
 	bump: BumpSeverity,
 	version: Option<&str>,
 	change_type: Option<&str>,
+	caused_by: &[String],
 ) -> MonochangeResult<Vec<String>> {
-	if change_type.is_none() && version.is_none() && bump == BumpSeverity::None {
+	if change_type.is_none()
+		&& version.is_none()
+		&& bump == BumpSeverity::None
+		&& caused_by.is_empty()
+	{
 		return Err(MonochangeError::Config(format!(
-			"target `{target_id}` must not use a `none` bump without also declaring `type` or `version`"
+			"target `{target_id}` must not use a `none` bump without also declaring `type`, `version`, or `caused_by`"
 		)));
 	}
 
 	let mut lines = Vec::new();
 	let target_key = render_changeset_target_key(target_id);
+	let caused_by = caused_by
+		.iter()
+		.map(|reference| {
+			format!(
+				"\"{}\"",
+				reference.replace('\\', "\\\\").replace('"', "\\\"")
+			)
+		})
+		.collect::<Vec<_>>();
+	let forced_object_syntax = !caused_by.is_empty();
 
 	// Handle explicit change type
 	if let Some(change_type) = change_type.filter(|value| !value.trim().is_empty()) {
@@ -1140,7 +1158,7 @@ pub(crate) fn render_change_target_markdown(
 				))
 			})?;
 
-		if version.is_none() && bump == default_bump {
+		if !forced_object_syntax && version.is_none() && bump == default_bump {
 			lines.push(format!("{target_key}: {change_type}"));
 			return Ok(lines);
 		}
@@ -1153,22 +1171,49 @@ pub(crate) fn render_change_target_markdown(
 		if let Some(version) = version {
 			lines.push(format!("  version: \"{version}\""));
 		}
+		if !caused_by.is_empty() {
+			lines.push(format!("  caused_by: [{}]", caused_by.join(", ")));
+		}
 		return Ok(lines);
 	}
 
-	// Handle explicit version
 	if let Some(version) = version {
 		lines.push(format!("{target_key}:"));
 		if bump != BumpSeverity::None {
 			lines.push(format!("  bump: {bump}"));
 		}
 		lines.push(format!("  version: \"{version}\""));
+		if !caused_by.is_empty() {
+			lines.push(format!("  caused_by: [{}]", caused_by.join(", ")));
+		}
+		return Ok(lines);
+	}
+
+	if !caused_by.is_empty() {
+		lines.push(format!("{target_key}:"));
+		lines.push(format!("  bump: {bump}"));
+		lines.push(format!("  caused_by: [{}]", caused_by.join(", ")));
 		return Ok(lines);
 	}
 
 	lines.push(format!("{target_key}: {bump}"));
 
 	Ok(lines)
+}
+
+fn render_interactive_target_markdown(
+	configuration: &monochange_core::WorkspaceConfiguration,
+	target: &interactive::InteractiveTarget,
+	caused_by: &[String],
+) -> MonochangeResult<Vec<String>> {
+	render_change_target_markdown(
+		configuration,
+		&target.id,
+		target.bump,
+		target.version.as_deref(),
+		target.change_type.as_deref(),
+		caused_by,
+	)
 }
 
 pub(crate) fn render_interactive_changeset_markdown(
@@ -1178,11 +1223,8 @@ pub(crate) fn render_interactive_changeset_markdown(
 	let mut lines = vec!["---".to_string()];
 
 	for target in &result.targets {
-		let id = &target.id;
-		let version = target.version.as_deref();
-		let change_type = target.change_type.as_deref();
 		let target_lines =
-			render_change_target_markdown(configuration, id, target.bump, version, change_type)?;
+			render_interactive_target_markdown(configuration, target, &result.caused_by)?;
 		lines.extend(target_lines);
 	}
 
@@ -2606,6 +2648,7 @@ path = "packages/web"
 					version: None,
 					change_type: None,
 				}],
+				caused_by: Vec::new(),
 				reason: "reason".to_string(),
 				details: None,
 			},
@@ -2661,6 +2704,7 @@ path = "packages/web"
 					version: None,
 					change_type: None,
 				}],
+				caused_by: Vec::new(),
 				reason: "reason".to_string(),
 				details: Some("extra details".to_string()),
 			},
@@ -2683,6 +2727,7 @@ path = "packages/web"
 					version: None,
 					change_type: None,
 				}],
+				caused_by: Vec::new(),
 				reason: "reason".to_string(),
 				details: None,
 			},

--- a/crates/monochange/tests/release_notes_and_propagation.rs
+++ b/crates/monochange/tests/release_notes_and_propagation.rs
@@ -13,6 +13,7 @@ use test_support::snapshot_settings;
 
 #[rstest]
 #[case::ungrouped_patch("ungrouped-patch")]
+#[case::ungrouped_caused_by("ungrouped-caused-by")]
 #[case::grouped_default("grouped-default")]
 fn release_note_changelog_snapshots_match_expected_output(#[case] scenario: &str) {
 	let mut settings = snapshot_settings();
@@ -32,7 +33,7 @@ fn release_note_changelog_snapshots_match_expected_output(#[case] scenario: &str
 	);
 
 	match scenario {
-		"ungrouped-patch" => {
+		"ungrouped-patch" | "ungrouped-caused-by" => {
 			let core_changelog =
 				fs::read_to_string(tempdir.path().join("crates/core/CHANGELOG.md"))
 					.unwrap_or_else(|error| panic!("core changelog: {error}"));

--- a/crates/monochange/tests/release_notes_and_propagation.rs
+++ b/crates/monochange/tests/release_notes_and_propagation.rs
@@ -81,11 +81,7 @@ fn ungrouped_transitive_bump_with_parent_bump_minor_escalates_dependent_version(
 		.as_array()
 		.unwrap_or_else(|| panic!("decisions array"))
 		.iter()
-		.find(|decision| {
-			decision["package"]
-				.as_str()
-				.is_some_and(|package| package.contains("app"))
-		})
+		.find(|decision| decision["package"].as_str() == Some("cargo:crates/app/Cargo.toml"))
 		.unwrap_or_else(|| panic!("expected app decision"));
 
 	assert_json_snapshot!(app_decision);

--- a/crates/monochange/tests/snapshots/cli_output__change_cli_help_documents_package_and_group_targeting_rules@change_cli_help_documents_package_and_group_targeting_rules.snap
+++ b/crates/monochange/tests/snapshots/cli_output__change_cli_help_documents_package_and_group_targeting_rules@change_cli_help_documents_package_and_group_targeting_rules.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/monochange/tests/cli_output.rs
-assertion_line: 36
 info:
   program: mc
   args:
@@ -27,6 +26,7 @@ Options:
       --version <VERSION>         Pin an explicit version for this release
       --reason <REASON>           Short release-note summary for this change
       --type <TYPE>               Optional release-note type such as `security` or `note`
+      --caused-by <CAUSED_BY>     Package or group ids that caused this dependent change
       --details <DETAILS>         Optional multi-line release-note details
       --output <PATH>             Write the generated change file to a specific path
   -h, --help                      Print help
@@ -35,11 +35,13 @@ Examples:
   mc change --package sdk-core --bump patch --reason "fix panic"
   mc change --package sdk-core --bump minor --reason "add API" --output .changeset/sdk-core.md
   mc change --package sdk --bump minor --reason "coordinated release"
+  mc change --package sdk-config --bump none --caused-by sdk-core --reason "dependency-only follow-up"
 
 Rules:
   - Prefer configured package ids in change files whenever a leaf package changed.
   - Use a group id only when the change is intentionally owned by the whole group.
   - Dependents and grouped members are propagated automatically during planning.
+  - Use `--caused-by` when a package is only changing because another package or group moved first.
   - Legacy manifest paths may still resolve during migration, but declared ids are the stable interface.
 
 

--- a/crates/monochange/tests/snapshots/release_notes_and_propagation__app@ungrouped_caused_by.snap
+++ b/crates/monochange/tests/snapshots/release_notes_and_propagation__app@ungrouped_caused_by.snap
@@ -1,0 +1,13 @@
+---
+source: crates/monochange/tests/release_notes_and_propagation.rs
+expression: app_changelog
+---
+# Changelog
+
+## app 1.0.1 ([DATE])
+
+### Fixes
+
+#### update dependency on core
+
+Bumps the app dependency to consume the latest core API.

--- a/crates/monochange/tests/snapshots/release_notes_and_propagation__core@ungrouped_caused_by.snap
+++ b/crates/monochange/tests/snapshots/release_notes_and_propagation__core@ungrouped_caused_by.snap
@@ -1,0 +1,11 @@
+---
+source: crates/monochange/tests/release_notes_and_propagation.rs
+expression: core_changelog
+---
+# Changelog
+
+## core 1.1.0 ([DATE])
+
+### Features
+
+- add core feature

--- a/crates/monochange_cargo/src/__tests.rs
+++ b/crates/monochange_cargo/src/__tests.rs
@@ -272,6 +272,7 @@ fn rust_semver_provider_parses_compatibility_evidence() {
 		notes: Some("breaking change".to_string()),
 		details: None,
 		change_type: None,
+		caused_by: Vec::new(),
 		source_path: PathBuf::from(".changeset/feature.md"),
 	};
 	let provider = RustSemverProvider;
@@ -1282,6 +1283,7 @@ fn rust_semver_provider_defaults_unknown_severity_to_none() {
 		notes: None,
 		details: None,
 		change_type: None,
+		caused_by: Vec::new(),
 		source_path: PathBuf::from(".changeset/feature.md"),
 	};
 	let assessment = RustSemverProvider
@@ -1371,6 +1373,7 @@ fn rust_semver_provider_returns_none_for_non_cargo_packages() {
 		notes: None,
 		details: None,
 		change_type: None,
+		caused_by: Vec::new(),
 		source_path: PathBuf::from(".changeset/feature.md"),
 	};
 	assert_eq!(

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -22,6 +22,7 @@ use monochange_core::RegistryKind;
 use monochange_core::ShellConfig;
 use monochange_core::SourceProvider;
 use monochange_test_helpers::current_test_name;
+use monochange_test_helpers::snapshot_settings;
 use semver::Version;
 use tempfile::tempdir;
 
@@ -3939,10 +3940,9 @@ fn parse_markdown_change_target_and_validation_helpers_cover_remaining_error_pat
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected unknown caused_by error"));
-	assert!(
-		unknown_caused_by_error
-			.to_string()
-			.contains("unknown `caused_by` package or group `missing`")
+	insta::assert_snapshot!(
+		"parse_markdown_change_target_unknown_caused_by_error",
+		unknown_caused_by_error.to_string()
 	);
 
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
@@ -3968,15 +3968,15 @@ fn parse_markdown_change_target_and_validation_helpers_cover_remaining_error_pat
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected invalid type error"));
-	assert!(
-		no_types_error
-			.to_string()
-			.contains("no configured types are available")
+	insta::assert_snapshot!(
+		"parse_markdown_change_target_no_configured_types_error",
+		no_types_error.to_string()
 	);
 }
 
 #[test]
 fn parse_markdown_change_target_covers_caused_by_scalar_and_error_paths() {
+	let _guard = snapshot_settings().bind_to_scope();
 	let root = fixture_path("changeset-target-metadata/render-workspace");
 	let configuration = load_workspace_configuration(&root)
 		.unwrap_or_else(|error| panic!("configuration: {error}"));
@@ -4010,32 +4010,31 @@ fn parse_markdown_change_target_covers_caused_by_scalar_and_error_paths() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected invalid compound error"));
-	assert!(
-		invalid_compound_error
-			.to_string()
-			.contains("must map to `none`, `patch`, `minor`, `major`")
+	insta::assert_snapshot!(
+		"parse_markdown_change_target_invalid_compound_error",
+		invalid_compound_error.to_string()
 	);
 
-	for (label, yaml, expected) in [
+	for (label, snapshot_name, yaml) in [
 		(
 			"empty string",
+			"parse_markdown_change_target_empty_caused_by_string_error",
 			"bump: patch\ncaused_by: \"   \"",
-			"must not use an empty `caused_by` reference",
 		),
 		(
 			"empty sequence",
+			"parse_markdown_change_target_empty_caused_by_sequence_error",
 			"bump: patch\ncaused_by: []",
-			"must list at least one `caused_by` reference",
 		),
 		(
 			"non-string entry",
+			"parse_markdown_change_target_non_string_caused_by_entry_error",
 			"bump: patch\ncaused_by: [123]",
-			"must use string package or group ids in `caused_by`",
 		),
 		(
 			"non-sequence type",
+			"parse_markdown_change_target_invalid_caused_by_type_error",
 			"bump: patch\ncaused_by: 123",
-			"must use a string or list of strings for `caused_by`",
 		),
 	] {
 		let value = serde_yaml_ng::from_str::<serde_yaml_ng::Value>(yaml)
@@ -4048,15 +4047,13 @@ fn parse_markdown_change_target_covers_caused_by_scalar_and_error_paths() {
 		)
 		.err()
 		.unwrap_or_else(|| panic!("expected caused_by error for {label}"));
-		assert!(
-			error.to_string().contains(expected),
-			"unexpected error for {label}: {error}"
-		);
+		insta::assert_snapshot!(snapshot_name, error.to_string());
 	}
 }
 
 #[test]
 fn load_change_signals_covers_configured_type_and_caused_by_context_paths() {
+	let _guard = snapshot_settings().bind_to_scope();
 	let tempdir = setup_fixture("changeset-target-metadata/render-workspace");
 	std::fs::write(
 		tempdir.path().join("change.md"),
@@ -4117,10 +4114,9 @@ fn load_change_signals_covers_configured_type_and_caused_by_context_paths() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected invalid compound target error"));
-	assert!(
-		error
-			.to_string()
-			.contains("must map to `none`, `patch`, `minor`, `major`")
+	insta::assert_snapshot!(
+		"load_change_signals_invalid_compound_target_error",
+		error.to_string()
 	);
 
 	std::fs::write(
@@ -4135,7 +4131,10 @@ fn load_change_signals_covers_configured_type_and_caused_by_context_paths() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected unknown target error"));
-	assert!(!unknown_target_error.to_string().trim().is_empty());
+	insta::assert_snapshot!(
+		"load_change_signals_unknown_target_error",
+		unknown_target_error.to_string()
+	);
 }
 
 #[test]

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -1460,11 +1460,9 @@ fn load_change_signals_reject_none_bump_without_type_or_version() {
 	let error = load_change_signals(&root.join("change.md"), &configuration, &packages)
 		.err()
 		.unwrap_or_else(|| panic!("expected parse error"));
-	assert!(
-		error
-			.to_string()
-			.contains("must not use `bump = \"none\"` without also declaring `type` or `version`")
-	);
+	assert!(error.to_string().contains(
+		"must not use `bump = \"none\"` without also declaring `type`, `version`, or `caused_by`"
+	));
 }
 
 #[test]
@@ -1519,7 +1517,7 @@ fn parse_markdown_change_target_accepts_unconfigured_object_type_literal() {
 		&configuration,
 	)
 	.unwrap_or_else(|error| panic!("parse target: {error}"));
-	assert_eq!(parsed, (None, None, Some("docs".to_string())));
+	assert_eq!(parsed, (None, None, Some("docs".to_string()), Vec::new()));
 }
 
 #[test]
@@ -1536,7 +1534,7 @@ fn parse_markdown_change_target_accepts_unconfigured_scalar_type_literal() {
 		&configuration,
 	)
 	.unwrap_or_else(|error| panic!("parse target: {error}"));
-	assert_eq!(parsed, (None, None, Some("docs".to_string())));
+	assert_eq!(parsed, (None, None, Some("docs".to_string()), Vec::new()));
 }
 
 #[test]
@@ -3910,6 +3908,43 @@ fn parse_markdown_change_target_and_validation_helpers_cover_remaining_error_pat
 			.contains("must not use `bump = \"none\"`")
 	);
 
+	let none_with_caused_by =
+		serde_yaml_ng::from_str::<serde_yaml_ng::Value>("bump: none\ncaused_by: [\"sdk\"]")
+			.unwrap_or_else(|error| panic!("yaml parse: {error}"));
+	let parsed_none_with_caused_by = crate::parse_markdown_change_target(
+		&none_with_caused_by,
+		Path::new("change.md"),
+		"core",
+		&configuration,
+	)
+	.unwrap_or_else(|error| panic!("parse none caused_by: {error}"));
+	assert_eq!(
+		parsed_none_with_caused_by,
+		(
+			Some(BumpSeverity::None),
+			None,
+			None,
+			vec!["sdk".to_string()]
+		)
+	);
+
+	let unknown_caused_by =
+		serde_yaml_ng::from_str::<serde_yaml_ng::Value>("bump: patch\ncaused_by: [\"missing\"]")
+			.unwrap_or_else(|error| panic!("yaml parse: {error}"));
+	let unknown_caused_by_error = crate::parse_markdown_change_target(
+		&unknown_caused_by,
+		Path::new("change.md"),
+		"core",
+		&configuration,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected unknown caused_by error"));
+	assert!(
+		unknown_caused_by_error
+			.to_string()
+			.contains("unknown `caused_by` package or group `missing`")
+	);
+
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	std::fs::create_dir_all(tempdir.path().join("crates/core"))
 		.unwrap_or_else(|error| panic!("mkdir core: {error}"));
@@ -3938,6 +3973,217 @@ fn parse_markdown_change_target_and_validation_helpers_cover_remaining_error_pat
 			.to_string()
 			.contains("no configured types are available")
 	);
+}
+
+#[test]
+fn parse_markdown_change_target_covers_caused_by_scalar_and_error_paths() {
+	let root = fixture_path("changeset-target-metadata/render-workspace");
+	let configuration = load_workspace_configuration(&root)
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+
+	let scalar_type = serde_yaml_ng::from_str::<serde_yaml_ng::Value>("security")
+		.unwrap_or_else(|error| panic!("yaml parse: {error}"));
+	let parsed_scalar_type = crate::parse_markdown_change_target(
+		&scalar_type,
+		Path::new("change.md"),
+		"core",
+		&configuration,
+	)
+	.unwrap_or_else(|error| panic!("parse scalar type: {error}"));
+	assert_eq!(
+		parsed_scalar_type,
+		(
+			Some(BumpSeverity::Patch),
+			None,
+			Some("security".to_string()),
+			Vec::new(),
+		)
+	);
+
+	let invalid_compound = serde_yaml_ng::from_str::<serde_yaml_ng::Value>("- security")
+		.unwrap_or_else(|error| panic!("yaml parse: {error}"));
+	let invalid_compound_error = crate::parse_markdown_change_target(
+		&invalid_compound,
+		Path::new("change.md"),
+		"core",
+		&configuration,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected invalid compound error"));
+	assert!(
+		invalid_compound_error
+			.to_string()
+			.contains("must map to `none`, `patch`, `minor`, `major`")
+	);
+
+	for (label, yaml, expected) in [
+		(
+			"empty string",
+			"bump: patch\ncaused_by: \"   \"",
+			"must not use an empty `caused_by` reference",
+		),
+		(
+			"empty sequence",
+			"bump: patch\ncaused_by: []",
+			"must list at least one `caused_by` reference",
+		),
+		(
+			"non-string entry",
+			"bump: patch\ncaused_by: [123]",
+			"must use string package or group ids in `caused_by`",
+		),
+		(
+			"non-sequence type",
+			"bump: patch\ncaused_by: 123",
+			"must use a string or list of strings for `caused_by`",
+		),
+	] {
+		let value = serde_yaml_ng::from_str::<serde_yaml_ng::Value>(yaml)
+			.unwrap_or_else(|error| panic!("yaml parse for {label}: {error}"));
+		let error = crate::parse_markdown_change_target(
+			&value,
+			Path::new("change.md"),
+			"core",
+			&configuration,
+		)
+		.err()
+		.unwrap_or_else(|| panic!("expected caused_by error for {label}"));
+		assert!(
+			error.to_string().contains(expected),
+			"unexpected error for {label}: {error}"
+		);
+	}
+}
+
+#[test]
+fn load_change_signals_covers_configured_type_and_caused_by_context_paths() {
+	let tempdir = setup_fixture("changeset-target-metadata/render-workspace");
+	std::fs::write(
+		tempdir.path().join("change.md"),
+		"---\ncore: security\napp:\n  bump: none\n  caused_by: sdk\n---\n\n# follow-up\n",
+	)
+	.unwrap_or_else(|error| panic!("write change.md: {error}"));
+	let configuration = load_workspace_configuration(tempdir.path())
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+	let mut packages = vec![
+		PackageRecord::new(
+			Ecosystem::Cargo,
+			"core",
+			tempdir.path().join("crates/core/Cargo.toml"),
+			tempdir.path().to_path_buf(),
+			Some(Version::new(1, 0, 0)),
+			PublishState::Public,
+		),
+		PackageRecord::new(
+			Ecosystem::Cargo,
+			"app",
+			tempdir.path().join("crates/app/Cargo.toml"),
+			tempdir.path().to_path_buf(),
+			Some(Version::new(1, 0, 0)),
+			PublishState::Public,
+		),
+	];
+	for (package, id) in packages.iter_mut().zip(["core", "app"]) {
+		package.id = id.to_string();
+	}
+	apply_version_groups(&mut packages, &configuration)
+		.unwrap_or_else(|error| panic!("version groups: {error}"));
+
+	let signals = load_change_signals(&tempdir.path().join("change.md"), &configuration, &packages)
+		.unwrap_or_else(|error| panic!("change signals: {error}"));
+	assert_eq!(signals.len(), 2);
+	let core_signal = signals
+		.iter()
+		.find(|signal| signal.package_id == "core")
+		.unwrap_or_else(|| panic!("expected core signal"));
+	assert_eq!(core_signal.requested_bump, Some(BumpSeverity::Patch));
+	assert_eq!(core_signal.change_type.as_deref(), Some("security"));
+	let app_signal = signals
+		.iter()
+		.find(|signal| signal.package_id == "app")
+		.unwrap_or_else(|| panic!("expected app signal"));
+	assert_eq!(app_signal.requested_bump, Some(BumpSeverity::None));
+	assert_eq!(app_signal.caused_by, vec!["sdk".to_string()]);
+
+	std::fs::write(
+		tempdir.path().join("invalid-change.md"),
+		"---\ncore:\n  - invalid\n---\n\n# invalid\n",
+	)
+	.unwrap_or_else(|error| panic!("write invalid-change.md: {error}"));
+	let error = load_change_signals(
+		&tempdir.path().join("invalid-change.md"),
+		&configuration,
+		&packages,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected invalid compound target error"));
+	assert!(
+		error
+			.to_string()
+			.contains("must map to `none`, `patch`, `minor`, `major`")
+	);
+
+	std::fs::write(
+		tempdir.path().join("unknown-target.md"),
+		"---\nunknown: note\n---\n\n# unknown\n",
+	)
+	.unwrap_or_else(|error| panic!("write unknown-target.md: {error}"));
+	let unknown_target_error = load_change_signals(
+		&tempdir.path().join("unknown-target.md"),
+		&configuration,
+		&packages,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected unknown target error"));
+	assert!(!unknown_target_error.to_string().trim().is_empty());
+}
+
+#[test]
+fn load_change_signals_applies_default_bump_for_object_type_with_context() {
+	let tempdir = setup_fixture("changeset-target-metadata/render-workspace");
+	std::fs::write(
+		tempdir.path().join("object-type.md"),
+		"---\nsdk:\n  type: test\n---\n\n# grouped object type\n",
+	)
+	.unwrap_or_else(|error| panic!("write object-type.md: {error}"));
+	let configuration = load_workspace_configuration(tempdir.path())
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+	let mut packages = vec![
+		PackageRecord::new(
+			Ecosystem::Cargo,
+			"core",
+			tempdir.path().join("crates/core/Cargo.toml"),
+			tempdir.path().to_path_buf(),
+			Some(Version::new(1, 0, 0)),
+			PublishState::Public,
+		),
+		PackageRecord::new(
+			Ecosystem::Cargo,
+			"app",
+			tempdir.path().join("crates/app/Cargo.toml"),
+			tempdir.path().to_path_buf(),
+			Some(Version::new(1, 0, 0)),
+			PublishState::Public,
+		),
+	];
+	for (package, id) in packages.iter_mut().zip(["core", "app"]) {
+		package.id = id.to_string();
+	}
+	apply_version_groups(&mut packages, &configuration)
+		.unwrap_or_else(|error| panic!("version groups: {error}"));
+
+	let signals = load_change_signals(
+		&tempdir.path().join("object-type.md"),
+		&configuration,
+		&packages,
+	)
+	.unwrap_or_else(|error| panic!("change signals: {error}"));
+	assert_eq!(signals.len(), 2);
+	for signal in &signals {
+		assert!(signal.package_id == "core" || signal.package_id == "app");
+		assert_eq!(signal.requested_bump, Some(BumpSeverity::Minor));
+		assert_eq!(signal.change_type.as_deref(), Some("test"));
+	}
 }
 
 #[test]

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -454,6 +454,8 @@ struct RawChangeEntry {
 	details: Option<String>,
 	#[serde(rename = "type", default)]
 	change_type: Option<String>,
+	#[serde(default)]
+	caused_by: Vec<String>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -465,6 +467,7 @@ pub struct LoadedChangesetTarget {
 	pub origin: String,
 	pub evidence_refs: Vec<String>,
 	pub change_type: Option<String>,
+	pub caused_by: Vec<String>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -1493,6 +1496,7 @@ pub fn load_changeset_contents_with_context(
 	for change in raw.changes {
 		if let Some(group) = context.groups_by_id.get(change.package.as_str()) {
 			let explicit_version = change.version.clone();
+			let caused_by = change.caused_by.clone();
 			let inferred_bump = match change.bump {
 				Some(bump) => Some(bump),
 				None => {
@@ -1511,6 +1515,7 @@ pub fn load_changeset_contents_with_context(
 				origin: "direct-change".to_string(),
 				evidence_refs: Vec::new(),
 				change_type: change.change_type.clone(),
+				caused_by: caused_by.clone(),
 			});
 			for member_id in &group.packages {
 				if referenced_packages.contains(member_id.as_str()) {
@@ -1542,12 +1547,14 @@ pub fn load_changeset_contents_with_context(
 					notes: change.reason.clone(),
 					details: change.details.clone(),
 					change_type: change.change_type.clone(),
+					caused_by: caused_by.clone(),
 					source_path: changes_path.to_path_buf(),
 				});
 			}
 		} else {
 			let package_id = resolve_package_reference_with_context(&change.package, context)?;
 			let explicit_version = change.version;
+			let caused_by = change.caused_by;
 			let inferred_bump = change.bump.or_else(|| {
 				infer_package_bump_from_explicit_version_with_context(
 					&package_id,
@@ -1563,6 +1570,7 @@ pub fn load_changeset_contents_with_context(
 				origin: "direct-change".to_string(),
 				evidence_refs: Vec::new(),
 				change_type: change.change_type.clone(),
+				caused_by: caused_by.clone(),
 			});
 			if !seen_package_ids.insert(package_id.clone()) {
 				return Err(changeset_diagnostic(
@@ -1589,6 +1597,7 @@ pub fn load_changeset_contents_with_context(
 				notes: change.reason,
 				details: change.details,
 				change_type: change.change_type,
+				caused_by,
 				source_path: changes_path.to_path_buf(),
 			});
 		}
@@ -1714,7 +1723,7 @@ fn parse_markdown_change_file_with_context(
 		let Some(package) = key.as_str() else {
 			continue;
 		};
-		let (requested_bump, explicit_version, change_type) =
+		let (requested_bump, explicit_version, change_type, caused_by) =
 			parse_markdown_change_target_with_context(value, changes_path, package, context)?;
 		changes.push(RawChangeEntry {
 			package: package.to_string(),
@@ -1723,30 +1732,43 @@ fn parse_markdown_change_file_with_context(
 			reason: reason.clone(),
 			details: details.clone(),
 			change_type,
+			caused_by,
 		});
 	}
 
 	Ok(RawChangeFile { changes })
 }
 
+type ParsedMarkdownChangeTarget = (
+	Option<BumpSeverity>,
+	Option<Version>,
+	Option<String>,
+	Vec<String>,
+);
+
 fn parse_markdown_change_target_with_context(
 	value: &serde_yaml_ng::Value,
 	changes_path: &Path,
 	package: &str,
 	context: &ChangesetLoadContext<'_>,
-) -> MonochangeResult<(Option<BumpSeverity>, Option<Version>, Option<String>)> {
+) -> MonochangeResult<ParsedMarkdownChangeTarget> {
 	if let Some(token) = value
 		.as_str()
 		.map(str::trim)
 		.filter(|value| !value.is_empty())
 	{
 		if let Some(bump) = parse_bump_severity(token) {
-			return Ok((Some(bump), None, None));
+			return Ok((Some(bump), None, None, Vec::new()));
 		}
 		if let Some(default_bump) =
 			configured_change_type_default_bump_with_context(context, package, token)
 		{
-			return Ok((Some(default_bump), None, Some(token.to_string())));
+			return Ok((
+				Some(default_bump),
+				None,
+				Some(token.to_string()),
+				Vec::new(),
+			));
 		}
 		if context.package_ids.contains(package) || context.groups_by_id.contains_key(package) {
 			let valid_types = configured_change_types_with_context(context, package);
@@ -1763,17 +1785,17 @@ fn parse_markdown_change_target_with_context(
 				changes_path.display()
 			)));
 		}
-		return Ok((None, None, Some(token.to_string())));
+		return Ok((None, None, Some(token.to_string()), Vec::new()));
 	}
 
 	let Some(mapping) = value.as_mapping() else {
 		return Err(MonochangeError::Config(format!(
-			"failed to parse {}: target `{package}` must map to `none`, `patch`, `minor`, `major`, a configured change type, or to a table with `bump`, `version`, and/or `type`",
+			"failed to parse {}: target `{package}` must map to `none`, `patch`, `minor`, `major`, a configured change type, or to a table with `bump`, `version`, `type`, and/or `caused_by`",
 			changes_path.display()
 		)));
 	};
 
-	let allowed_keys = ["bump", "version", "type"];
+	let allowed_keys = ["bump", "version", "type", "caused_by"];
 	let unknown_keys = mapping
 		.keys()
 		.filter_map(serde_yaml_ng::Value::as_str)
@@ -1820,6 +1842,10 @@ fn parse_markdown_change_target_with_context(
 	if let Some(change_type) = change_type.as_deref() {
 		validate_configured_change_type_with_context(context, changes_path, package, change_type)?;
 	}
+	let caused_by_value = mapping.get(serde_yaml_ng::Value::String("caused_by".to_string()));
+	let caused_by = parse_caused_by_refs(caused_by_value, changes_path, package, |reference| {
+		context.package_ids.contains(reference) || context.groups_by_id.contains_key(reference)
+	})?;
 	let requested_bump = requested_bump.or_else(|| {
 		change_type.as_deref().and_then(|change_type| {
 			configured_change_type_default_bump_with_context(context, package, change_type)
@@ -1834,13 +1860,78 @@ fn parse_markdown_change_target_with_context(
 	if requested_bump == Some(BumpSeverity::None)
 		&& explicit_version.is_none()
 		&& change_type.is_none()
+		&& caused_by.is_empty()
 	{
 		return Err(MonochangeError::Config(format!(
-			"failed to parse {}: target `{package}` must not use `bump = \"none\"` without also declaring `type` or `version`",
+			"failed to parse {}: target `{package}` must not use `bump = \"none\"` without also declaring `type`, `version`, or `caused_by`",
 			changes_path.display()
 		)));
 	}
-	Ok((requested_bump, explicit_version, change_type))
+	Ok((requested_bump, explicit_version, change_type, caused_by))
+}
+
+fn parse_caused_by_refs(
+	value: Option<&serde_yaml_ng::Value>,
+	changes_path: &Path,
+	target: &str,
+	is_valid_reference: impl Fn(&str) -> bool,
+) -> MonochangeResult<Vec<String>> {
+	let Some(value) = value else {
+		return Ok(Vec::new());
+	};
+
+	let references = match value {
+		serde_yaml_ng::Value::String(reference) => {
+			let reference = reference.trim();
+			if reference.is_empty() {
+				return Err(MonochangeError::Config(format!(
+					"failed to parse {}: target `{target}` must not use an empty `caused_by` reference",
+					changes_path.display()
+				)));
+			}
+			vec![reference.to_string()]
+		}
+		serde_yaml_ng::Value::Sequence(sequence) => {
+			if sequence.is_empty() {
+				return Err(MonochangeError::Config(format!(
+					"failed to parse {}: target `{target}` must list at least one `caused_by` reference",
+					changes_path.display()
+				)));
+			}
+			let mut references = Vec::with_capacity(sequence.len());
+			for item in sequence {
+				let Some(reference) = item
+					.as_str()
+					.map(str::trim)
+					.filter(|value| !value.is_empty())
+				else {
+					return Err(MonochangeError::Config(format!(
+						"failed to parse {}: target `{target}` must use string package or group ids in `caused_by`",
+						changes_path.display()
+					)));
+				};
+				references.push(reference.to_string());
+			}
+			references
+		}
+		_ => {
+			return Err(MonochangeError::Config(format!(
+				"failed to parse {}: target `{target}` must use a string or list of strings for `caused_by`",
+				changes_path.display()
+			)));
+		}
+	};
+
+	for reference in &references {
+		if !is_valid_reference(reference) {
+			return Err(MonochangeError::Config(format!(
+				"failed to parse {}: target `{target}` references unknown `caused_by` package or group `{reference}`",
+				changes_path.display()
+			)));
+		}
+	}
+
+	Ok(references)
 }
 
 fn validate_configured_change_type_with_context(
@@ -1985,7 +2076,7 @@ fn parse_markdown_change_file(
 		let Some(package) = key.as_str() else {
 			continue;
 		};
-		let (requested_bump, explicit_version, change_type) =
+		let (requested_bump, explicit_version, change_type, caused_by) =
 			parse_markdown_change_target(value, changes_path, package, configuration)?;
 		changes.push(RawChangeEntry {
 			package: package.to_string(),
@@ -1994,6 +2085,7 @@ fn parse_markdown_change_file(
 			reason: reason.clone(),
 			details: details.clone(),
 			change_type,
+			caused_by,
 		});
 	}
 
@@ -2199,19 +2291,24 @@ fn parse_markdown_change_target(
 	changes_path: &Path,
 	package: &str,
 	configuration: &WorkspaceConfiguration,
-) -> MonochangeResult<(Option<BumpSeverity>, Option<Version>, Option<String>)> {
+) -> MonochangeResult<ParsedMarkdownChangeTarget> {
 	if let Some(token) = value
 		.as_str()
 		.map(str::trim)
 		.filter(|value| !value.is_empty())
 	{
 		if let Some(bump) = parse_bump_severity(token) {
-			return Ok((Some(bump), None, None));
+			return Ok((Some(bump), None, None, Vec::new()));
 		}
 		if let Some(default_bump) =
 			configured_change_type_default_bump(configuration, package, token)
 		{
-			return Ok((Some(default_bump), None, Some(token.to_string())));
+			return Ok((
+				Some(default_bump),
+				None,
+				Some(token.to_string()),
+				Vec::new(),
+			));
 		}
 		if configuration.package_by_id(package).is_some()
 			|| configuration.group_by_id(package).is_some()
@@ -2230,17 +2327,17 @@ fn parse_markdown_change_target(
 				changes_path.display()
 			)));
 		}
-		return Ok((None, None, Some(token.to_string())));
+		return Ok((None, None, Some(token.to_string()), Vec::new()));
 	}
 
 	let Some(mapping) = value.as_mapping() else {
 		return Err(MonochangeError::Config(format!(
-			"failed to parse {}: target `{package}` must map to `none`, `patch`, `minor`, `major`, a configured change type, or to a table with `bump`, `version`, and/or `type`",
+			"failed to parse {}: target `{package}` must map to `none`, `patch`, `minor`, `major`, a configured change type, or to a table with `bump`, `version`, `type`, and/or `caused_by`",
 			changes_path.display()
 		)));
 	};
 
-	let allowed_keys = ["bump", "version", "type"];
+	let allowed_keys = ["bump", "version", "type", "caused_by"];
 	let unknown_keys = mapping
 		.keys()
 		.filter_map(serde_yaml_ng::Value::as_str)
@@ -2284,6 +2381,15 @@ fn parse_markdown_change_target(
 		.map(str::trim)
 		.filter(|value| !value.is_empty())
 		.map(ToString::to_string);
+	let caused_by = parse_caused_by_refs(
+		mapping.get(serde_yaml_ng::Value::String("caused_by".to_string())),
+		changes_path,
+		package,
+		|reference| {
+			configuration.package_by_id(reference).is_some()
+				|| configuration.group_by_id(reference).is_some()
+		},
+	)?;
 
 	if let Some(change_type) = change_type.as_deref() {
 		validate_configured_change_type(configuration, changes_path, package, change_type)?;
@@ -2296,14 +2402,18 @@ fn parse_markdown_change_target(
 		)));
 	}
 
-	if bump == Some(BumpSeverity::None) && version.is_none() && change_type.is_none() {
+	if bump == Some(BumpSeverity::None)
+		&& version.is_none()
+		&& change_type.is_none()
+		&& caused_by.is_empty()
+	{
 		return Err(MonochangeError::Config(format!(
-			"failed to parse {}: target `{package}` must not use `bump = \"none\"` without also declaring `type` or `version`",
+			"failed to parse {}: target `{package}` must not use `bump = \"none\"` without also declaring `type`, `version`, or `caused_by`",
 			changes_path.display()
 		)));
 	}
 
-	Ok((bump, version, change_type))
+	Ok((bump, version, change_type, caused_by))
 }
 
 fn parse_bump_severity(value: &str) -> Option<BumpSeverity> {

--- a/crates/monochange_config/src/snapshots/monochange_config____tests__load_change_signals_invalid_compound_target_error.snap
+++ b/crates/monochange_config/src/snapshots/monochange_config____tests__load_change_signals_invalid_compound_target_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/monochange_config/src/__tests.rs
+expression: error.to_string()
+---
+config error: failed to parse [ROOT]/invalid-change.md: target `core` must map to `none`, `patch`, `minor`, `major`, a configured change type, or to a table with `bump`, `version`, `type`, and/or `caused_by`

--- a/crates/monochange_config/src/snapshots/monochange_config____tests__load_change_signals_unknown_target_error.snap
+++ b/crates/monochange_config/src/snapshots/monochange_config____tests__load_change_signals_unknown_target_error.snap
@@ -1,0 +1,12 @@
+---
+source: crates/monochange_config/src/__tests.rs
+expression: unknown_target_error.to_string()
+---
+error: changeset `[ROOT]/unknown-target.md` references unknown package or group `unknown`
+  --> [ROOT]/unknown-target.md:2:2
+
+  |
+2 | unknown: note
+  |  ^^^^^^^^ unknown package or group
+
+  = help: declare the package or group id in monochange.toml before referencing it in a changeset

--- a/crates/monochange_config/src/snapshots/monochange_config____tests__parse_markdown_change_target_empty_caused_by_sequence_error.snap
+++ b/crates/monochange_config/src/snapshots/monochange_config____tests__parse_markdown_change_target_empty_caused_by_sequence_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/monochange_config/src/__tests.rs
+expression: error.to_string()
+---
+config error: failed to parse change.md: target `core` must list at least one `caused_by` reference

--- a/crates/monochange_config/src/snapshots/monochange_config____tests__parse_markdown_change_target_empty_caused_by_string_error.snap
+++ b/crates/monochange_config/src/snapshots/monochange_config____tests__parse_markdown_change_target_empty_caused_by_string_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/monochange_config/src/__tests.rs
+expression: error.to_string()
+---
+config error: failed to parse change.md: target `core` must not use an empty `caused_by` reference

--- a/crates/monochange_config/src/snapshots/monochange_config____tests__parse_markdown_change_target_invalid_caused_by_type_error.snap
+++ b/crates/monochange_config/src/snapshots/monochange_config____tests__parse_markdown_change_target_invalid_caused_by_type_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/monochange_config/src/__tests.rs
+expression: error.to_string()
+---
+config error: failed to parse change.md: target `core` must use a string or list of strings for `caused_by`

--- a/crates/monochange_config/src/snapshots/monochange_config____tests__parse_markdown_change_target_invalid_compound_error.snap
+++ b/crates/monochange_config/src/snapshots/monochange_config____tests__parse_markdown_change_target_invalid_compound_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/monochange_config/src/__tests.rs
+expression: invalid_compound_error.to_string()
+---
+config error: failed to parse change.md: target `core` must map to `none`, `patch`, `minor`, `major`, a configured change type, or to a table with `bump`, `version`, `type`, and/or `caused_by`

--- a/crates/monochange_config/src/snapshots/monochange_config____tests__parse_markdown_change_target_no_configured_types_error.snap
+++ b/crates/monochange_config/src/snapshots/monochange_config____tests__parse_markdown_change_target_no_configured_types_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/monochange_config/src/__tests.rs
+expression: no_types_error.to_string()
+---
+config error: failed to parse change.md: target `core` has invalid type `docs`; no configured types are available for this target

--- a/crates/monochange_config/src/snapshots/monochange_config____tests__parse_markdown_change_target_non_string_caused_by_entry_error.snap
+++ b/crates/monochange_config/src/snapshots/monochange_config____tests__parse_markdown_change_target_non_string_caused_by_entry_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/monochange_config/src/__tests.rs
+expression: error.to_string()
+---
+config error: failed to parse change.md: target `core` must use string package or group ids in `caused_by`

--- a/crates/monochange_config/src/snapshots/monochange_config____tests__parse_markdown_change_target_unknown_caused_by_error.snap
+++ b/crates/monochange_config/src/snapshots/monochange_config____tests__parse_markdown_change_target_unknown_caused_by_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/monochange_config/src/__tests.rs
+expression: unknown_caused_by_error.to_string()
+---
+config error: failed to parse change.md: target `core` references unknown `caused_by` package or group `missing`

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -2351,6 +2351,8 @@ pub struct PreparedChangesetTarget {
 	pub evidence_refs: Vec<String>,
 	#[serde(default)]
 	pub change_type: Option<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub caused_by: Vec<String>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -3379,6 +3381,17 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 					short: None,
 				},
 				CliInputDefinition {
+					name: "caused_by".to_string(),
+					kind: CliInputKind::StringList,
+					help_text: Some(
+						"Package or group ids that caused this dependent change".to_string(),
+					),
+					required: false,
+					default: None,
+					choices: Vec::new(),
+					short: None,
+				},
+				CliInputDefinition {
 					name: "details".to_string(),
 					kind: CliInputKind::String,
 					help_text: Some("Optional multi-line release-note details".to_string()),
@@ -3772,6 +3785,7 @@ pub struct ChangeSignal {
 	pub notes: Option<String>,
 	pub details: Option<String>,
 	pub change_type: Option<String>,
+	pub caused_by: Vec<String>,
 	pub source_path: PathBuf,
 }
 

--- a/crates/monochange_graph/src/__tests.rs
+++ b/crates/monochange_graph/src/__tests.rs
@@ -444,9 +444,10 @@ fn build_release_plan_uses_highest_conflicting_explicit_version_with_warning() {
 		.unwrap_or_else(|| panic!("expected one warning"));
 	assert_eq!(decision.planned_version, Some(Version::new(2, 0, 0)));
 	assert_eq!(plan.warnings.len(), 1);
-	assert!(warning.contains("conflicting explicit versions"));
-	assert!(warning.contains("001-first.md"));
-	assert!(warning.contains("002-second.md"));
+	insta::assert_snapshot!(
+		"build_release_plan_conflicting_explicit_versions_warning",
+		warning
+	);
 }
 
 #[test]
@@ -490,7 +491,10 @@ fn build_release_plan_rejects_conflicting_explicit_versions_in_strict_mode() {
 	.err()
 	.unwrap_or_else(|| panic!("expected strict conflict error"));
 
-	assert!(error.to_string().contains("conflicting explicit versions"));
+	insta::assert_snapshot!(
+		"build_release_plan_conflicting_explicit_versions_strict_error",
+		error.to_string()
+	);
 }
 
 #[test]
@@ -520,10 +524,9 @@ fn build_release_plan_rejects_explicit_versions_not_greater_than_current() {
 	.err()
 	.unwrap_or_else(|| panic!("expected invalid explicit version error"));
 
-	assert!(
-		error
-			.to_string()
-			.contains("must be greater than current version")
+	insta::assert_snapshot!(
+		"build_release_plan_explicit_version_not_greater_error",
+		error.to_string()
 	);
 }
 
@@ -553,8 +556,10 @@ fn build_release_plan_returns_error_for_unknown_package_in_changeset() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected error for unknown package"));
-	assert!(error.to_string().contains("cargo:nonexistent"));
-	assert!(error.to_string().contains("not found"));
+	insta::assert_snapshot!(
+		"build_release_plan_unknown_package_error",
+		error.to_string()
+	);
 }
 
 #[test]
@@ -594,8 +599,7 @@ fn build_release_plan_returns_error_for_unknown_group_in_changeset() {
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected error for unknown group"));
-	assert!(error.to_string().contains("nonexistent-group"));
-	assert!(error.to_string().contains("not found"));
+	insta::assert_snapshot!("build_release_plan_unknown_group_error", error.to_string());
 }
 
 #[test]

--- a/crates/monochange_graph/src/__tests.rs
+++ b/crates/monochange_graph/src/__tests.rs
@@ -90,6 +90,7 @@ fn build_release_plan_patches_direct_parents_when_a_dependency_changes() {
 			notes: Some("feature".to_string()),
 			details: None,
 			change_type: None,
+			caused_by: Vec::new(),
 			source_path: PathBuf::from(".changeset/feature.md"),
 		}],
 		&[],
@@ -132,6 +133,7 @@ fn build_release_plan_propagates_direct_and_transitive_dependency_impact() {
 			notes: Some("public API addition".to_string()),
 			details: None,
 			change_type: None,
+			caused_by: Vec::new(),
 			source_path: PathBuf::from(".changeset/feature.md"),
 		}],
 		&[],
@@ -189,6 +191,7 @@ fn build_release_plan_synchronizes_version_groups() {
 			notes: Some("feature".to_string()),
 			details: None,
 			change_type: None,
+			caused_by: Vec::new(),
 			source_path: PathBuf::from(".changeset/feature.md"),
 		}],
 		&[],
@@ -238,6 +241,7 @@ fn build_release_plan_shifts_major_to_minor_for_pre_stable_versions() {
 			notes: Some("breaking change".to_string()),
 			details: None,
 			change_type: None,
+			caused_by: Vec::new(),
 			source_path: PathBuf::from(".changeset/feature.md"),
 		}],
 		&[],
@@ -286,6 +290,7 @@ fn build_release_plan_uses_compatibility_assessments_to_escalate_parents() {
 			notes: Some("breaking change".to_string()),
 			details: None,
 			change_type: None,
+			caused_by: Vec::new(),
 			source_path: PathBuf::from(".changeset/feature.md"),
 		}],
 		&[CompatibilityAssessment {
@@ -326,6 +331,7 @@ fn build_release_plan_uses_explicit_package_versions() {
 			notes: Some("pin release".to_string()),
 			details: None,
 			change_type: None,
+			caused_by: Vec::new(),
 			source_path: PathBuf::from(".changeset/pin.md"),
 		}],
 		&[],
@@ -367,6 +373,7 @@ fn build_release_plan_propagates_explicit_member_versions_to_group_version() {
 			notes: Some("promote sdk".to_string()),
 			details: None,
 			change_type: None,
+			caused_by: Vec::new(),
 			source_path: PathBuf::from(".changeset/group-pin.md"),
 		}],
 		&[],
@@ -405,6 +412,7 @@ fn build_release_plan_uses_highest_conflicting_explicit_version_with_warning() {
 				notes: Some("first pin".to_string()),
 				details: None,
 				change_type: None,
+				caused_by: Vec::new(),
 				source_path: PathBuf::from(".changeset/001-first.md"),
 			},
 			ChangeSignal {
@@ -416,6 +424,7 @@ fn build_release_plan_uses_highest_conflicting_explicit_version_with_warning() {
 				notes: Some("second pin".to_string()),
 				details: None,
 				change_type: None,
+				caused_by: Vec::new(),
 				source_path: PathBuf::from(".changeset/002-second.md"),
 			},
 		],
@@ -458,6 +467,7 @@ fn build_release_plan_rejects_conflicting_explicit_versions_in_strict_mode() {
 				notes: Some("first pin".to_string()),
 				details: None,
 				change_type: None,
+				caused_by: Vec::new(),
 				source_path: PathBuf::from(".changeset/001-first.md"),
 			},
 			ChangeSignal {
@@ -469,6 +479,7 @@ fn build_release_plan_rejects_conflicting_explicit_versions_in_strict_mode() {
 				notes: Some("second pin".to_string()),
 				details: None,
 				change_type: None,
+				caused_by: Vec::new(),
 				source_path: PathBuf::from(".changeset/002-second.md"),
 			},
 		],
@@ -499,6 +510,7 @@ fn build_release_plan_rejects_explicit_versions_not_greater_than_current() {
 			notes: Some("same version".to_string()),
 			details: None,
 			change_type: None,
+			caused_by: Vec::new(),
 			source_path: PathBuf::from(".changeset/same.md"),
 		}],
 		&[],
@@ -532,6 +544,7 @@ fn build_release_plan_returns_error_for_unknown_package_in_changeset() {
 			notes: None,
 			details: None,
 			change_type: None,
+			caused_by: Vec::new(),
 			source_path: PathBuf::from(".changeset/ghost.md"),
 		}],
 		&[],
@@ -572,6 +585,7 @@ fn build_release_plan_returns_error_for_unknown_group_in_changeset() {
 			notes: None,
 			details: None,
 			change_type: None,
+			caused_by: Vec::new(),
 			source_path: PathBuf::from(".changeset/orphan.md"),
 		}],
 		&[],
@@ -612,6 +626,7 @@ fn build_release_plan_warns_on_missing_group_member_during_traversal() {
 			notes: Some("feature".to_string()),
 			details: None,
 			change_type: None,
+			caused_by: Vec::new(),
 			source_path: PathBuf::from(".changeset/feature.md"),
 		}],
 		&[],
@@ -627,4 +642,180 @@ fn build_release_plan_warns_on_missing_group_member_during_traversal() {
 		.find(|decision| decision.package_id == core.id)
 		.unwrap_or_else(|| panic!("expected core decision"));
 	assert_eq!(core_decision.recommended_bump, BumpSeverity::Minor);
+}
+
+#[test]
+fn build_release_plan_suppresses_matching_dependency_propagation_when_caused_by_is_authored() {
+	let packages = vec![
+		package("cargo:core", Version::new(1, 0, 0)),
+		package("cargo:app", Version::new(1, 0, 0)),
+	];
+	let plan = build_release_plan(
+		PathBuf::from("fixtures/cargo").as_path(),
+		&packages,
+		&[edge("cargo:app", "cargo:core")],
+		&[],
+		&[
+			ChangeSignal {
+				package_id: "cargo:core".to_string(),
+				requested_bump: Some(BumpSeverity::Minor),
+				explicit_version: None,
+				change_origin: "direct-change".to_string(),
+				evidence_refs: Vec::new(),
+				notes: Some("core feature".to_string()),
+				details: None,
+				change_type: None,
+				caused_by: Vec::new(),
+				source_path: PathBuf::from(".changeset/core.md"),
+			},
+			ChangeSignal {
+				package_id: "cargo:app".to_string(),
+				requested_bump: Some(BumpSeverity::Patch),
+				explicit_version: None,
+				change_origin: "direct-change".to_string(),
+				evidence_refs: Vec::new(),
+				notes: Some("update dependency on core".to_string()),
+				details: None,
+				change_type: None,
+				caused_by: vec!["cargo:core".to_string()],
+				source_path: PathBuf::from(".changeset/app.md"),
+			},
+		],
+		&[],
+		BumpSeverity::Patch,
+		false,
+	)
+	.unwrap_or_else(|error| panic!("release plan: {error}"));
+
+	let app = plan
+		.decisions
+		.iter()
+		.find(|decision| decision.package_id == "cargo:app")
+		.unwrap_or_else(|| panic!("expected app decision"));
+	assert_eq!(app.recommended_bump, BumpSeverity::Patch);
+	assert_eq!(app.trigger_type, "direct-change");
+	assert_eq!(app.upstream_sources, vec!["cargo:core".to_string()]);
+}
+
+#[test]
+fn build_release_plan_keeps_unrelated_dependency_propagation_when_caused_by_does_not_match() {
+	let packages = vec![
+		package("cargo:core", Version::new(1, 0, 0)),
+		package("cargo:util", Version::new(1, 0, 0)),
+		package("cargo:app", Version::new(1, 0, 0)),
+	];
+	let plan = build_release_plan(
+		PathBuf::from("fixtures/cargo").as_path(),
+		&packages,
+		&[
+			edge("cargo:app", "cargo:core"),
+			edge("cargo:app", "cargo:util"),
+		],
+		&[],
+		&[
+			ChangeSignal {
+				package_id: "cargo:util".to_string(),
+				requested_bump: Some(BumpSeverity::Minor),
+				explicit_version: None,
+				change_origin: "direct-change".to_string(),
+				evidence_refs: Vec::new(),
+				notes: Some("util feature".to_string()),
+				details: None,
+				change_type: None,
+				caused_by: Vec::new(),
+				source_path: PathBuf::from(".changeset/util.md"),
+			},
+			ChangeSignal {
+				package_id: "cargo:app".to_string(),
+				requested_bump: Some(BumpSeverity::None),
+				explicit_version: None,
+				change_origin: "direct-change".to_string(),
+				evidence_refs: Vec::new(),
+				notes: Some("dependency-only follow-up".to_string()),
+				details: None,
+				change_type: None,
+				caused_by: vec!["cargo:core".to_string()],
+				source_path: PathBuf::from(".changeset/app.md"),
+			},
+		],
+		&[],
+		BumpSeverity::Patch,
+		false,
+	)
+	.unwrap_or_else(|error| panic!("release plan: {error}"));
+
+	let app = plan
+		.decisions
+		.iter()
+		.find(|decision| decision.package_id == "cargo:app")
+		.unwrap_or_else(|| panic!("expected app decision"));
+	assert_eq!(app.recommended_bump, BumpSeverity::Patch);
+	assert!(app.upstream_sources.contains(&"cargo:util".to_string()));
+}
+
+#[test]
+fn build_release_plan_suppresses_matching_dependency_propagation_when_caused_by_references_group() {
+	let mut core = package("cargo:core", Version::new(1, 0, 0));
+	core.version_group_id = Some("sdk".to_string());
+	let mut util = package("cargo:util", Version::new(1, 0, 0));
+	util.version_group_id = Some("sdk".to_string());
+	let packages = vec![
+		core.clone(),
+		util.clone(),
+		package("cargo:app", Version::new(1, 0, 0)),
+	];
+	let version_group = VersionGroup {
+		group_id: "sdk".to_string(),
+		display_name: "sdk".to_string(),
+		members: vec![core.id.clone(), util.id.clone()],
+		mismatch_detected: false,
+	};
+	let plan = build_release_plan(
+		PathBuf::from("fixtures/cargo").as_path(),
+		&packages,
+		&[edge("cargo:app", "cargo:core")],
+		&[version_group],
+		&[
+			ChangeSignal {
+				package_id: core.id.clone(),
+				requested_bump: Some(BumpSeverity::Minor),
+				explicit_version: None,
+				change_origin: "direct-change".to_string(),
+				evidence_refs: Vec::new(),
+				notes: Some("core feature".to_string()),
+				details: None,
+				change_type: None,
+				caused_by: Vec::new(),
+				source_path: PathBuf::from(".changeset/core.md"),
+			},
+			ChangeSignal {
+				package_id: "cargo:app".to_string(),
+				requested_bump: Some(BumpSeverity::None),
+				explicit_version: None,
+				change_origin: "direct-change".to_string(),
+				evidence_refs: Vec::new(),
+				notes: Some("dependency-only follow-up".to_string()),
+				details: None,
+				change_type: None,
+				caused_by: vec!["sdk".to_string()],
+				source_path: PathBuf::from(".changeset/app.md"),
+			},
+		],
+		&[],
+		BumpSeverity::Patch,
+		false,
+	)
+	.unwrap_or_else(|error| panic!("release plan: {error}"));
+
+	let app = plan
+		.decisions
+		.iter()
+		.find(|decision| decision.package_id == "cargo:app")
+		.unwrap_or_else(|| panic!("expected app decision"));
+	assert_eq!(app.recommended_bump, BumpSeverity::None);
+	assert_eq!(app.trigger_type, "direct-change");
+	assert_eq!(
+		app.upstream_sources,
+		vec!["cargo:core".to_string(), "cargo:util".to_string()]
+	);
 }

--- a/crates/monochange_graph/src/lib.rs
+++ b/crates/monochange_graph/src/lib.rs
@@ -170,6 +170,8 @@ pub fn build_release_plan(
 		change_signals,
 		strict_version_conflicts,
 	)?;
+	let propagation_suppression =
+		build_propagation_suppression(change_signals, &package_by_id, &group_by_id);
 
 	let mut states = packages
 		.iter()
@@ -195,7 +197,8 @@ pub fn build_release_plan(
 			.notes
 			.clone()
 			.unwrap_or_else(|| "explicit change input".to_string());
-		let upstream_sources = BTreeSet::from([change_signal.package_id.clone()]);
+		let upstream_sources =
+			resolved_upstream_sources(change_signal, &package_by_id, &group_by_id);
 
 		apply_decision(
 			&mut states,
@@ -227,6 +230,13 @@ pub fn build_release_plan(
 
 		if propagated_severity.is_release() {
 			for dependent_id in graph.direct_dependents(source_package_id) {
+				if propagation_is_suppressed(
+					dependent_id,
+					&source_state.upstream_sources,
+					&propagation_suppression,
+				) {
+					continue;
+				}
 				let reason = format!("depends on `{source_package_id}`");
 				apply_decision(
 					&mut states,
@@ -344,6 +354,8 @@ type ExplicitVersionResolution = (
 	BTreeMap<String, Version>,
 	Vec<String>,
 );
+
+type PropagationSuppression = BTreeMap<String, BTreeSet<String>>;
 
 fn resolve_explicit_versions(
 	package_by_id: &BTreeMap<&str, &PackageRecord>,
@@ -486,6 +498,81 @@ struct ExplicitVersionInput {
 	package_id: String,
 	source_path: PathBuf,
 	version: Version,
+}
+
+fn build_propagation_suppression(
+	change_signals: &[ChangeSignal],
+	package_by_id: &BTreeMap<&str, &PackageRecord>,
+	group_by_id: &BTreeMap<&str, &VersionGroup>,
+) -> PropagationSuppression {
+	let mut suppression = BTreeMap::<String, BTreeSet<String>>::new();
+
+	for signal in change_signals
+		.iter()
+		.filter(|signal| !signal.caused_by.is_empty())
+	{
+		let resolved = resolve_caused_by_sources(&signal.caused_by, package_by_id, group_by_id);
+		if resolved.is_empty() {
+			continue;
+		}
+		suppression
+			.entry(signal.package_id.clone())
+			.or_default()
+			.extend(resolved);
+	}
+
+	suppression
+}
+
+fn resolved_upstream_sources(
+	signal: &ChangeSignal,
+	package_by_id: &BTreeMap<&str, &PackageRecord>,
+	group_by_id: &BTreeMap<&str, &VersionGroup>,
+) -> BTreeSet<String> {
+	if signal.caused_by.is_empty() {
+		return BTreeSet::from([signal.package_id.clone()]);
+	}
+
+	let resolved = resolve_caused_by_sources(&signal.caused_by, package_by_id, group_by_id);
+	if resolved.is_empty() {
+		return BTreeSet::from([signal.package_id.clone()]);
+	}
+
+	resolved
+}
+
+fn resolve_caused_by_sources(
+	caused_by: &[String],
+	package_by_id: &BTreeMap<&str, &PackageRecord>,
+	group_by_id: &BTreeMap<&str, &VersionGroup>,
+) -> BTreeSet<String> {
+	let mut resolved = BTreeSet::new();
+
+	for reference in caused_by {
+		if package_by_id.contains_key(reference.as_str()) {
+			resolved.insert(reference.clone());
+			continue;
+		}
+		if let Some(group) = group_by_id.get(reference.as_str()) {
+			resolved.extend(group.members.iter().cloned());
+		}
+	}
+
+	resolved
+}
+
+fn propagation_is_suppressed(
+	dependent_id: &str,
+	upstream_sources: &BTreeSet<String>,
+	propagation_suppression: &PropagationSuppression,
+) -> bool {
+	propagation_suppression
+		.get(dependent_id)
+		.is_some_and(|suppressed_sources| {
+			suppressed_sources
+				.iter()
+				.any(|source| upstream_sources.contains(source))
+		})
 }
 
 fn apply_decision<'a>(

--- a/crates/monochange_graph/src/snapshots/monochange_graph____tests__build_release_plan_conflicting_explicit_versions_strict_error.snap
+++ b/crates/monochange_graph/src/snapshots/monochange_graph____tests__build_release_plan_conflicting_explicit_versions_strict_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/monochange_graph/src/__tests.rs
+expression: error.to_string()
+---
+config error: conflicting explicit versions for package `cargo:core`; using highest version `2.0.0` from: 1.1.0 @ .changeset/001-first.md [cargo:core], 2.0.0 @ .changeset/002-second.md [cargo:core]

--- a/crates/monochange_graph/src/snapshots/monochange_graph____tests__build_release_plan_conflicting_explicit_versions_warning.snap
+++ b/crates/monochange_graph/src/snapshots/monochange_graph____tests__build_release_plan_conflicting_explicit_versions_warning.snap
@@ -1,0 +1,5 @@
+---
+source: crates/monochange_graph/src/__tests.rs
+expression: warning
+---
+conflicting explicit versions for package `cargo:core`; using highest version `2.0.0` from: 1.1.0 @ .changeset/001-first.md [cargo:core], 2.0.0 @ .changeset/002-second.md [cargo:core]

--- a/crates/monochange_graph/src/snapshots/monochange_graph____tests__build_release_plan_explicit_version_not_greater_error.snap
+++ b/crates/monochange_graph/src/snapshots/monochange_graph____tests__build_release_plan_explicit_version_not_greater_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/monochange_graph/src/__tests.rs
+expression: error.to_string()
+---
+config error: explicit version `1.0.0` for package `cargo:core` must be greater than current version `1.0.0`

--- a/crates/monochange_graph/src/snapshots/monochange_graph____tests__build_release_plan_unknown_group_error.snap
+++ b/crates/monochange_graph/src/snapshots/monochange_graph____tests__build_release_plan_unknown_group_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/monochange_graph/src/__tests.rs
+expression: error.to_string()
+---
+config error: changeset references group `nonexistent-group` which was not found in the workspace configuration

--- a/crates/monochange_graph/src/snapshots/monochange_graph____tests__build_release_plan_unknown_package_error.snap
+++ b/crates/monochange_graph/src/snapshots/monochange_graph____tests__build_release_plan_unknown_package_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/monochange_graph/src/__tests.rs
+expression: error.to_string()
+---
+config error: changeset references package `cargo:nonexistent` which was not found in the workspace

--- a/crates/monochange_lint_testing/Cargo.toml
+++ b/crates/monochange_lint_testing/Cargo.toml
@@ -6,6 +6,7 @@ categories = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
+publish = false
 readme = "readme.md"
 repository = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/monochange_semver/src/__tests.rs
+++ b/crates/monochange_semver/src/__tests.rs
@@ -226,6 +226,7 @@ fn collect_assessments_gathers_from_matching_packages() {
 		evidence_refs: Vec::new(),
 		notes: None,
 		details: None,
+		caused_by: Vec::new(),
 		source_path: PathBuf::from(".changeset/feature.md"),
 	}];
 	let provider = TestProvider {
@@ -258,6 +259,7 @@ fn collect_assessments_returns_empty_for_unmatched_signals() {
 		evidence_refs: Vec::new(),
 		notes: None,
 		details: None,
+		caused_by: Vec::new(),
 		source_path: PathBuf::from(".changeset/fix.md"),
 	}];
 	let provider = TestProvider {
@@ -287,6 +289,7 @@ fn collect_assessments_returns_empty_without_providers() {
 		evidence_refs: Vec::new(),
 		notes: None,
 		details: None,
+		caused_by: Vec::new(),
 		source_path: PathBuf::from(".changeset/fix.md"),
 	}];
 	let providers: Vec<&dyn CompatibilityProvider> = vec![];

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -24,6 +24,9 @@
 - Prefer **external `insta` snapshots** over inline snapshots when comparing output.
 - This applies to human-readable output such as CLI help, stdout/stderr text, changelog text, markdown, and rendered release bodies **and** to structured machine-readable output such as JSON manifests or dry-run payloads.
 - For Rust tests, prefer built-in snapshot generation via `insta::assert_snapshot!`, `insta::assert_json_snapshot!`, or `insta_cmd::assert_cmd_snapshot!` instead of maintaining parallel hand-authored `expected` files.
+- Treat `String::contains(...)` assertions on rendered output as a code smell. When the output matters enough to assert, snapshot the full rendered value instead of checking a few substrings.
+- Prefer **insta redactions** over **insta filters** when stabilizing dynamic output. Redactions preserve the structural assertion while replacing environment-, time-, or input-dependent fields with stable placeholders.
+- Use filters only when the snapshot target is effectively unstructured text and selector-based redactions are not practical.
 - When using `rstest`, give each parametrized case a stable snapshot suffix so every case gets its own external snapshot file.
 - If a test can be expressed as “copy scenario workspace, run command, snapshot the output”, prefer that pattern over large in-test `assert_eq!` trees.
 - Keep imperative assertions for scenarios that are genuinely stateful or easier to understand as focused semantic checks (for example multi-step git history setup, partial property assertions, or intentionally dynamic output).

--- a/docs/src/guide/06-release-planning.md
+++ b/docs/src/guide/06-release-planning.md
@@ -312,11 +312,13 @@ Current planning rules:
 <!-- {=releasePlanningRules} -->
 
 - `mc change` defaults `--bump` to `patch`; use `--bump none` when you want a type-only or version-only entry, and pass `--version` to pin an explicit release version
-- markdown change files use package/group ids as the only top-level frontmatter keys, with scalar shorthand for `none`/`patch`/`minor`/`major` or configured change types, plus object syntax for `bump`, `version`, and/or `type`
+- markdown change files use package/group ids as the only top-level frontmatter keys, with scalar shorthand for `none`/`patch`/`minor`/`major` or configured change types, plus object syntax for `bump`, `version`, `type`, and `caused_by`
 - when `version` is given without `bump`, the bump is inferred by comparing the current and target versions
 - explicit versions from grouped members propagate to the group version; conflicts take the highest semver or fail when `defaults.strict_version_conflicts = true`
 - prefer package ids over group ids in authored changesets when possible; direct package changes still propagate to dependents and synchronize configured groups
 - optional change `type` values can route entries into custom changelog sections, and configured section `default_bump` values let scalar type shorthand imply the desired semver behavior
+- `caused_by` references package or group ids and suppresses only the matching dependency-propagation records; use object syntax whenever you need it
+- `mc change` accepts repeated `--caused-by <id>` flags, and `--bump none` is the right fit when you want to acknowledge an affected package without forcing a user-facing version bump
 - `mc change` can write to a deterministic path with `--output ...`
 - change templates support detailed multi-line release-note entries through `{{ details }}`, compact metadata blocks through `{{ context }}`, and fine-grained linked metadata like `{{ change_owner_link }}`, `{{ review_request_link }}`, and `{{ closed_issue_links }}`
 - dependents default to the configured `parent_bump`, including packages outside a changed version group when they depend on a synchronized member

--- a/docs/src/guide/06-release-planning.md
+++ b/docs/src/guide/06-release-planning.md
@@ -96,6 +96,10 @@ When `version` is provided without `bump`, the bump is inferred from the current
 
 When a dependent package changes only because another package moved first, author that context explicitly with `caused_by`:
 
+```bash
+mc change --package sdk-config --bump none --caused-by sdk-core --reason "dependency-only follow-up"
+```
+
 ```markdown
 ---
 sdk-config:

--- a/docs/src/readme.md
+++ b/docs/src/readme.md
@@ -60,6 +60,12 @@ mc change --package <id> --bump patch --reason "describe the change"
 
 Most changes should target a package id. Use group ids only when the change is intentionally owned by the whole group.
 
+When a package is only changing because another dependency or version group moved first, author that context explicitly instead of relying on anonymous propagation:
+
+```bash
+mc change --package <dependent-id> --bump none --caused-by <upstream-id> --reason "dependency-only follow-up"
+```
+
 Preview the release plan safely:
 
 ```bash

--- a/docs/src/reference/cli-steps/03-create-change-file.md
+++ b/docs/src/reference/cli-steps/03-create-change-file.md
@@ -78,11 +78,27 @@ choices = ["none", "patch", "minor", "major"]
 default = "patch"
 
 [[cli.change.inputs]]
+name = "version"
+type = "string"
+
+[[cli.change.inputs]]
+name = "type"
+type = "string"
+
+[[cli.change.inputs]]
+name = "caused_by"
+type = "string_list"
+
+[[cli.change.inputs]]
 name = "reason"
 type = "string"
 
 [[cli.change.inputs]]
 name = "details"
+type = "string"
+
+[[cli.change.inputs]]
+name = "output"
 type = "string"
 
 [[cli.change.steps]]

--- a/docs/src/reference/cli-steps/03-create-change-file.md
+++ b/docs/src/reference/cli-steps/03-create-change-file.md
@@ -6,7 +6,7 @@
 
 It supports both:
 
-- explicit non-interactive authoring from inputs such as `package`, `bump`, `reason`, and `details`
+- explicit non-interactive authoring from inputs such as `package`, `bump`, `caused_by`, `reason`, and `details`
 - interactive authoring when `interactive = true`
 
 ## Why use it
@@ -28,6 +28,7 @@ That gives you a few advantages over rolling your own shell template generator:
 - `version` — explicit version pin for the change
 - `reason` — summary line
 - `type` — optional release-note type
+- `caused_by` — optional list of package or group ids that explain dependency-only follow-up changes
 - `details` — optional long-form body
 - `output` — optional explicit file path
 
@@ -147,3 +148,4 @@ inputs = { interactive = true }
 - omitting `package` in non-interactive mode
 - expecting `CreateChangeFile` to release anything immediately
 - using raw manifest paths when configured package ids are the stable interface
+- forgetting `caused_by` when a dependent package only changed because another package or group moved first

--- a/fixtures/tests/release-notes-and-propagation/ungrouped-caused-by/.changeset/app-follow-up.md
+++ b/fixtures/tests/release-notes-and-propagation/ungrouped-caused-by/.changeset/app-follow-up.md
@@ -1,0 +1,9 @@
+---
+app:
+  bump: patch
+  caused_by: ["core"]
+---
+
+#### update dependency on core
+
+Bumps the app dependency to consume the latest core API.

--- a/fixtures/tests/release-notes-and-propagation/ungrouped-caused-by/.changeset/core-feature.md
+++ b/fixtures/tests/release-notes-and-propagation/ungrouped-caused-by/.changeset/core-feature.md
@@ -1,0 +1,5 @@
+---
+core: minor
+---
+
+#### add core feature

--- a/fixtures/tests/release-notes-and-propagation/ungrouped-caused-by/Cargo.toml
+++ b/fixtures/tests/release-notes-and-propagation/ungrouped-caused-by/Cargo.toml
@@ -1,0 +1,10 @@
+[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[workspace.package]
+version = "1.0.0"
+
+[workspace.dependencies]
+workflow-core = { path = "./crates/core", version = "1.0.0" }
+workflow-app = { path = "./crates/app", version = "1.0.0" }

--- a/fixtures/tests/release-notes-and-propagation/ungrouped-caused-by/crates/app/CHANGELOG.md
+++ b/fixtures/tests/release-notes-and-propagation/ungrouped-caused-by/crates/app/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/fixtures/tests/release-notes-and-propagation/ungrouped-caused-by/crates/app/Cargo.toml
+++ b/fixtures/tests/release-notes-and-propagation/ungrouped-caused-by/crates/app/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "workflow-app"
+version = { workspace = true }
+edition = "2021"
+
+[dependencies]
+workflow-core = { workspace = true }

--- a/fixtures/tests/release-notes-and-propagation/ungrouped-caused-by/crates/core/CHANGELOG.md
+++ b/fixtures/tests/release-notes-and-propagation/ungrouped-caused-by/crates/core/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/fixtures/tests/release-notes-and-propagation/ungrouped-caused-by/crates/core/Cargo.toml
+++ b/fixtures/tests/release-notes-and-propagation/ungrouped-caused-by/crates/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "workflow-core"
+version = { workspace = true }
+edition = "2021"

--- a/fixtures/tests/release-notes-and-propagation/ungrouped-caused-by/monochange.toml
+++ b/fixtures/tests/release-notes-and-propagation/ungrouped-caused-by/monochange.toml
@@ -1,0 +1,26 @@
+[defaults]
+parent_bump = "patch"
+package_type = "cargo"
+
+[defaults.changelog]
+path = "{{ path }}/CHANGELOG.md"
+
+[package.core]
+path = "crates/core"
+
+[package.app]
+path = "crates/app"
+
+[ecosystems.cargo]
+enabled = true
+
+[cli.release]
+
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
+[[cli.release.steps]]
+type = "PrepareRelease"

--- a/packages/monochange__cli/README.md
+++ b/packages/monochange__cli/README.md
@@ -80,6 +80,12 @@ mc change --package <id> --bump patch --reason "describe the change"
 
 Most changes should target a package id. Use group ids only when the change is intentionally owned by the whole group.
 
+When a package is only changing because another dependency or version group moved first, author that context explicitly instead of relying on anonymous propagation:
+
+```bash
+mc change --package <dependent-id> --bump none --caused-by <upstream-id> --reason "dependency-only follow-up"
+```
+
 Preview the release plan safely:
 
 ```bash

--- a/packages/monochange__skill/ARTIFACT-TYPES.md
+++ b/packages/monochange__skill/ARTIFACT-TYPES.md
@@ -477,7 +477,7 @@ Or use relative paths if screenshots are committed alongside changesets:
 
 When a dependency changes, monochange automatically patches all dependents. This creates release notes with no context for _why_ the dependent is being updated.
 
-The `caused_by` field in changeset frontmatter provides that context. It lists the root package(s) or group(s) that triggered this dependent change:
+The `caused_by` field in changeset frontmatter provides that context. It lists the root package(s) or group(s) that triggered this dependent change. Because `caused_by` is part of the object form, use table syntax instead of scalar shorthand whenever you need it:
 
 ```markdown
 ---
@@ -494,9 +494,10 @@ Bumps `monochange_core` dependency to v2.1.0 after the public API change to `Cha
 **How it works:**
 
 1. Without `caused_by`: a dependent gets an automatic "dependency changed → patch" record with no explanation
-2. With `caused_by`: the authored changeset **replaces** the automatic propagation — it provides human-readable context instead
-3. A changeset with `caused_by` and `bump: patch` suppresses the automatic "dependency changed → patch" record for that package
-4. A changeset with `caused_by` and `bump: none` suppresses propagation entirely — the package is acknowledged as affected but no version bump is warranted
+2. With `caused_by`: the authored changeset **replaces** the matching automatic propagation — it provides human-readable context instead
+3. A changeset with `caused_by` and `bump: patch` suppresses the automatic "dependency changed → patch" record for that package when the same upstream package or group triggered it
+4. A changeset with `caused_by` and `bump: none` suppresses that matching propagation entirely — the package is acknowledged as affected but no version bump is warranted
+5. Unrelated upstream sources can still propagate normally; `caused_by` is not a global opt-out for every dependency edge
 
 **`none` bump with `caused_by` — the "nothing meaningful changed" case:**
 
@@ -515,8 +516,11 @@ monochange_config:
 No user-facing changes. Dependency version updated to match the group release.
 ```
 
-This tells monochange: "this package is affected, but the change doesn't warrant a version bump for consumers. Suppress the automatic patch propagation entirely."
+This tells monochange: "this package is affected, but the change doesn't warrant a version bump for consumers. Suppress the matching automatic patch propagation entirely."
 
-CLI flag: `mc change --package <id> --bump patch --caused-by monochange_core --reason "update dependency"`
+CLI authoring supports one or more `--caused-by` flags:
+
+- `mc change --package <id> --bump patch --caused-by monochange_core --reason "update dependency"`
+- `mc change --package <id> --bump none --caused-by sdk --reason "dependency-only follow-up"`
 
 <!-- {/changesetCausedByField} -->

--- a/packages/monochange__skill/CHANGESET-GUIDE.md
+++ b/packages/monochange__skill/CHANGESET-GUIDE.md
@@ -156,7 +156,7 @@ These tools integrate with the changeset lifecycle:
 
 When a dependency changes, monochange automatically patches all dependents. This creates release notes with no context for _why_ the dependent is being updated.
 
-The `caused_by` field in changeset frontmatter provides that context. It lists the root package(s) or group(s) that triggered this dependent change:
+The `caused_by` field in changeset frontmatter provides that context. It lists the root package(s) or group(s) that triggered this dependent change. Because `caused_by` is part of the object form, use table syntax instead of scalar shorthand whenever you need it:
 
 ```markdown
 ---
@@ -173,9 +173,10 @@ Bumps `monochange_core` dependency to v2.1.0 after the public API change to `Cha
 **How it works:**
 
 1. Without `caused_by`: a dependent gets an automatic "dependency changed → patch" record with no explanation
-2. With `caused_by`: the authored changeset **replaces** the automatic propagation — it provides human-readable context instead
-3. A changeset with `caused_by` and `bump: patch` suppresses the automatic "dependency changed → patch" record for that package
-4. A changeset with `caused_by` and `bump: none` suppresses propagation entirely — the package is acknowledged as affected but no version bump is warranted
+2. With `caused_by`: the authored changeset **replaces** the matching automatic propagation — it provides human-readable context instead
+3. A changeset with `caused_by` and `bump: patch` suppresses the automatic "dependency changed → patch" record for that package when the same upstream package or group triggered it
+4. A changeset with `caused_by` and `bump: none` suppresses that matching propagation entirely — the package is acknowledged as affected but no version bump is warranted
+5. Unrelated upstream sources can still propagate normally; `caused_by` is not a global opt-out for every dependency edge
 
 **`none` bump with `caused_by` — the "nothing meaningful changed" case:**
 
@@ -194,9 +195,12 @@ monochange_config:
 No user-facing changes. Dependency version updated to match the group release.
 ```
 
-This tells monochange: "this package is affected, but the change doesn't warrant a version bump for consumers. Suppress the automatic patch propagation entirely."
+This tells monochange: "this package is affected, but the change doesn't warrant a version bump for consumers. Suppress the matching automatic patch propagation entirely."
 
-CLI flag: `mc change --package <id> --bump patch --caused-by monochange_core --reason "update dependency"`
+CLI authoring supports one or more `--caused-by` flags:
+
+- `mc change --package <id> --bump patch --caused-by monochange_core --reason "update dependency"`
+- `mc change --package <id> --bump none --caused-by sdk --reason "dependency-only follow-up"`
 
 <!-- {/changesetCausedByField} -->
 

--- a/packages/monochange__skill/README.md
+++ b/packages/monochange__skill/README.md
@@ -40,7 +40,7 @@ The bundled skill explains how to:
 - plan adoption in `quickstart`, `standard`, `full`, or `migration` mode
 - create or refine `monochange.toml` with `mc init`, `mc populate`, and `mc validate`
 - inspect the normalized model with `mc discover --format json`
-- create, update, and audit explicit change files with `mc change` and `mc diagnostics`
+- create, update, and audit explicit change files with `mc change` and `mc diagnostics`, including dependency-follow-up notes with `caused_by`
 - preview release effects with `mc release --dry-run --format json` and `mc release --dry-run --diff`
 - inspect durable release history with `mc release-record`
 - understand groups, package ids, changelogs, linting policy, package publishing, and source-provider release flows

--- a/packages/monochange__skill/REFERENCE.md
+++ b/packages/monochange__skill/REFERENCE.md
@@ -177,7 +177,7 @@ Redesign the public API surface.
 
 ### Dependency propagation with `caused_by`
 
-When a dependency changes, monochange automatically patches all dependents with no context. The `caused_by` field provides that context and suppresses the automatic propagation:
+When a dependency changes, monochange automatically patches all dependents with no context. The `caused_by` field provides that context and suppresses the matching automatic propagation. Because `caused_by` is part of the object form, use table syntax when you need it:
 
 ```markdown
 ---
@@ -206,7 +206,12 @@ monochange_config:
 No user-facing changes. Dependency version updated to match the group release.
 ```
 
-CLI flag: `mc change --package <id> --bump patch --caused-by monochange_core --reason "update dependency"`
+`caused_by` can reference package ids or group ids. It suppresses only the matching propagated entry, so unrelated upstream dependency changes can still propagate normally.
+
+CLI authoring accepts one or more `--caused-by <id>` flags:
+
+- `mc change --package <id> --bump patch --caused-by monochange_core --reason "update dependency"`
+- `mc change --package <id> --bump none --caused-by sdk --reason "dependency-only follow-up"`
 
 ### Granularity and lifecycle rules
 

--- a/packages/monochange__skill/SKILL.md
+++ b/packages/monochange__skill/SKILL.md
@@ -23,7 +23,8 @@ If the user is still deciding how deeply to adopt monochange, start with [skills
 - Treat `monochange.toml` as the source of truth for packages, groups, source providers, ecosystems, `[cli.<command>]` entries, and lint configuration.
 - Prefer configured package or group ids over guessing manifest names.
 - Use `.changeset/*.md` files for explicit release intent — each targets one or more package/group ids with a bump severity, optional `type`, optional explicit `version`, and a human-readable summary.
-- Use `caused_by` in changeset frontmatter when a dependent package is updating because of a dependency change — this provides context and replaces the automatic "dependency changed → patch" propagation.
+- Use `caused_by` in changeset frontmatter when a dependent package is updating because of a dependency change — this provides context and replaces the matching automatic "dependency changed → patch" propagation.
+- `caused_by` uses object syntax in markdown changesets and can reference package ids or group ids; in CLI form, pass one or more `--caused-by <id>` flags.
 - When `mc affected` flags a package that has no meaningful change, create a changeset with `bump: none` and `caused_by` listing the root cause package(s).
 - Review existing `.changeset/*.md` files before creating a new one so you can decide whether the right lifecycle action is create, update, replace, or remove.
 - Keep changesets package-centric and granular. Distinct features should get distinct changesets even when they land in the same package; only expand an existing changeset when the new work is clearly the same feature growing in scope.

--- a/packages/monochange__skill/skills/changesets.md
+++ b/packages/monochange__skill/skills/changesets.md
@@ -100,6 +100,8 @@ Use object syntax when you need:
 - `type` for a custom changelog section
 - `caused_by` for dependency propagation context
 
+`caused_by` always uses the object form and can point at package ids or group ids.
+
 ## `caused_by` and dependency propagation
 
 Without `caused_by`, a dependent package gets an automatic dependency-bump record with little context.
@@ -127,6 +129,10 @@ Bumps `monochange_core` after the `ChangelogFormat` API change.
 ```
 
 Use `bump: none` when the package is affected but users do not need a version bump.
+
+`caused_by` suppresses only the matching automatic propagation. Other unrelated upstream changes can still propagate normally.
+
+CLI authoring accepts repeated `--caused-by <id>` flags when more than one upstream package or group explains the follow-up change.
 
 ## Create vs. update vs. replace vs. remove
 

--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,12 @@ mc change --package <id> --bump patch --reason "describe the change"
 
 Most changes should target a package id. Use group ids only when the change is intentionally owned by the whole group.
 
+When a package is only changing because another dependency or version group moved first, author that context explicitly instead of relying on anonymous propagation:
+
+```bash
+mc change --package <dependent-id> --bump none --caused-by <upstream-id> --reason "dependency-only follow-up"
+```
+
 Preview the release plan safely:
 
 ```bash


### PR DESCRIPTION
Closes #208

## Summary
- add `caused_by` frontmatter parsing and validation for changesets
- support `mc change --caused-by ...` and surface causation in diagnostics
- suppress matching automatic dependency propagation when an authored causation changeset exists
- add fixtures, docs, and snapshot coverage for dependency-follow-up release notes
