### PR TITLE
ci: enforce 100 percent patch coverage

### DIFF
--- a/.changeset/enforce-pr-patch-coverage.md
+++ b/.changeset/enforce-pr-patch-coverage.md
@@ -1,0 +1,5 @@
+---
+"@monochange/cli": none
+---
+
+Document the new 100% patch-coverage requirement in the generated repository command lists.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,8 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -106,6 +108,14 @@ jobs:
 
       - name: run coverage
         run: coverage:all
+        shell: devenv shell -- bash -e {0}
+
+      - name: verify 100% patch coverage
+        if: github.event_name == 'pull_request'
+        env:
+          MONOCHANGE_PATCH_COVERAGE_BASE: ${{ github.event.pull_request.base.sha }}
+          MONOCHANGE_PATCH_COVERAGE_HEAD: ${{ github.sha }}
+        run: coverage:patch
         shell: devenv shell -- bash -e {0}
 
       - name: upload coverage to codecov

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -165,6 +165,7 @@ mc validate
 lint:all
 test:all
 coverage:all
+coverage:patch
 build:all
 build:book
 ```
@@ -183,6 +184,7 @@ mc change --package monochange --bump patch --reason "describe the change"
 lint:all
 test:all
 coverage:all
+coverage:patch
 build:all
 build:book
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,7 @@ mc change --package monochange --bump patch --reason "describe the change"
 lint:all
 test:all
 coverage:all
+coverage:patch
 build:all
 build:book
 ```

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,5 +12,5 @@ coverage:
         threshold: 1%
     patch:
       default:
-        target: auto
-        threshold: 1%
+        target: 100%
+        threshold: 0%

--- a/devenv.nix
+++ b/devenv.nix
@@ -260,7 +260,7 @@ in
         set -e
         node --test npm/tests/*.test.mjs scripts/npm/tests/*.test.mjs
       '';
-      description = "Run npm helper and launcher tests with the built-in Node test runner.";
+      description = "Run npm helper, launcher, and repository utility tests with the built-in Node test runner.";
       binary = "bash";
     };
     "coverage:all" = {
@@ -273,6 +273,26 @@ in
         cargo llvm-cov report --lcov --output-path target/coverage/lcov.info
       '';
       description = "Run workspace coverage, enforce a 70% line-coverage floor, and write target/coverage/lcov.info.";
+      binary = "bash";
+    };
+    "coverage:patch" = {
+      exec = ''
+        set -euo pipefail
+        base_ref="''${MONOCHANGE_PATCH_COVERAGE_BASE:-origin/main}"
+        head_ref="''${MONOCHANGE_PATCH_COVERAGE_HEAD:-HEAD}"
+
+        if [ ! -f target/coverage/lcov.info ]; then
+          coverage:all
+        fi
+
+        node scripts/check-patch-coverage.mjs \
+          --repo-root "$DEVENV_ROOT" \
+          --lcov target/coverage/lcov.info \
+          --base "$base_ref" \
+          --head "$head_ref" \
+          --target 100
+      '';
+      description = "Fail when executable changed lines fall below 100% patch coverage.";
       binary = "bash";
     };
     "fix:all" = {

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -16,7 +16,7 @@ Before merging architecture-sensitive work, check:
 2. Did `crates/monochange` add adapter-specific mutation logic instead of dispatching to an adapter?
 3. Did `crates/monochange_config` add implementation-specific validation that belongs in an adapter crate?
 4. Did the change add fixtures and integration tests that exercise the adapter boundary from the public CLI/API surface?
-5. Is touched-code coverage still above 92%?
+5. Is patch coverage for executable changed lines still at 100%?
 
 ## Preferred direction
 

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -4,6 +4,7 @@
 - Release-planning logic needs realistic fixture coverage.
 - Cross-ecosystem behavior should remain consistent across Cargo, npm-family, Deno, Dart, and Flutter.
 - Keep `mc validate` green alongside the rest of the validation suite.
+- PRs must keep patch coverage at 100% for executable changed lines in the Rust coverage report.
 
 ## Fixture-first testing
 

--- a/docs/agents/tooling.md
+++ b/docs/agents/tooling.md
@@ -17,6 +17,7 @@
 - `test:all`
 - `test:node`
 - `coverage:all`
+- `coverage:patch`
 - `build:book`
 
 ## Useful task-specific commands

--- a/docs/agents/workflow.md
+++ b/docs/agents/workflow.md
@@ -18,6 +18,7 @@
 - Follow [Changeset generation](changeset-generation.md) when deciding changeset lifecycle actions, artifact-aware framing, and how granular to make release notes for libraries, CLI tools, and applications.
 - When adding or changing configuration options in any crate, update the annotations in `monochange.toml` to reflect the new option, its defaults, available values, and purpose. Use the existing comment style as a guide. Where possible, use mdt shared blocks in `.templates/` so the same documentation propagates to the guide, README, and config file.
 - Run the full local validation suite before opening a PR.
+- Patch coverage for executable changed lines must be 100% before opening or merging a PR. Treat anything lower as a blocker and add or adjust tests until the patch gate passes.
 - During review, explicitly check architecture boundaries for touched code: core defines contracts, adapter crates own implementation details, and `crates/monochange` only orchestrates.
 - If touched code adds provider/ecosystem-specific validation or mutation logic outside an adapter crate, either move it behind adapter dispatch or document why that exception is unavoidable.
-- For refactors that move implementation details across crate boundaries, add or update realistic fixtures and integration tests so touched-code coverage stays above 92%.
+- For refactors that move implementation details across crate boundaries, add or update realistic fixtures and integration tests so patch coverage for executable changed lines stays at 100%.

--- a/docs/src/guide/01-installation.md
+++ b/docs/src/guide/01-installation.md
@@ -95,6 +95,7 @@ mc validate
 lint:all
 test:all
 coverage:all
+coverage:patch
 build:all
 build:book
 ```

--- a/npm/tests/check-patch-coverage.test.mjs
+++ b/npm/tests/check-patch-coverage.test.mjs
@@ -1,0 +1,206 @@
+import assert from "node:assert/strict";
+import test, { describe } from "node:test";
+import {
+	computePatchCoverage,
+	parseArgs,
+	parseChangedLines,
+	parseLcov,
+	verifyPatchCoverage,
+} from "../../scripts/check-patch-coverage.mjs";
+
+const repoRoot = "/repo";
+
+describe("parseArgs", () => {
+	test("parses supported flags", () => {
+		assert.deepEqual(
+			parseArgs([
+				"--base",
+				"origin/main",
+				"--head",
+				"HEAD",
+				"--lcov",
+				"target/coverage/lcov.info",
+			]),
+			{
+				base: "origin/main",
+				head: "HEAD",
+				lcov: "target/coverage/lcov.info",
+			},
+		);
+	});
+
+	test("skips tokens without values", () => {
+		assert.deepEqual(parseArgs(["--base", "--head", "HEAD"]), {
+			head: "HEAD",
+		});
+	});
+});
+
+describe("parseLcov", () => {
+	test("collects per-line hit counts by source file", () => {
+		const coverageByFile = parseLcov(
+			[
+				"TN:",
+				"SF:crates/monochange/src/lib.rs",
+				"DA:10,3",
+				"DA:11,0",
+				"end_of_record",
+			].join("\n"),
+			repoRoot,
+		);
+
+		assert.equal(
+			coverageByFile.get("/repo/crates/monochange/src/lib.rs").get(10),
+			3,
+		);
+		assert.equal(
+			coverageByFile.get("/repo/crates/monochange/src/lib.rs").get(11),
+			0,
+		);
+	});
+});
+
+describe("parseChangedLines", () => {
+	test("collects added line numbers from zero-context unified diffs", () => {
+		const changedLinesByFile = parseChangedLines(
+			[
+				"diff --git a/crates/monochange/src/lib.rs b/crates/monochange/src/lib.rs",
+				"--- a/crates/monochange/src/lib.rs",
+				"+++ b/crates/monochange/src/lib.rs",
+				"@@ -10,0 +11,2 @@",
+				"+first",
+				"+second",
+				"@@ -20 +25 @@",
+				"+replacement",
+			].join("\n"),
+			repoRoot,
+		);
+
+		assert.deepEqual(
+			[...changedLinesByFile.get("/repo/crates/monochange/src/lib.rs")],
+			[11, 12, 25],
+		);
+	});
+
+	test("ignores deletion-only hunks", () => {
+		const changedLinesByFile = parseChangedLines(
+			[
+				"diff --git a/crates/monochange/src/lib.rs b/crates/monochange/src/lib.rs",
+				"--- a/crates/monochange/src/lib.rs",
+				"+++ b/crates/monochange/src/lib.rs",
+				"@@ -10,2 +10,0 @@",
+				"-first",
+				"-second",
+			].join("\n"),
+			repoRoot,
+		);
+
+		assert.equal(changedLinesByFile.size, 0);
+	});
+});
+
+describe("computePatchCoverage", () => {
+	test("counts only executable changed lines from the coverage report", () => {
+		const coverageByFile = parseLcov(
+			[
+				"SF:crates/monochange/src/lib.rs",
+				"DA:10,1",
+				"DA:11,0",
+				"DA:12,4",
+				"end_of_record",
+			].join("\n"),
+			repoRoot,
+		);
+		const changedLinesByFile = new Map([
+			[
+				"/repo/crates/monochange/src/lib.rs",
+				new Set([9, 10, 11, 12, 13]),
+			],
+		]);
+
+		const result = computePatchCoverage(coverageByFile, changedLinesByFile);
+		assert.equal(result.coveredLines, 2);
+		assert.equal(result.executableChangedLines, 3);
+		assert.equal(result.uncoveredLines.length, 1);
+		assert.deepEqual(result.uncoveredLines[0], {
+			filePath: "/repo/crates/monochange/src/lib.rs",
+			lineNumber: 11,
+		});
+	});
+});
+
+describe("verifyPatchCoverage", () => {
+	test("passes when every executable changed line is covered", () => {
+		const result = verifyPatchCoverage({
+			lcovText: [
+				"SF:crates/monochange/src/lib.rs",
+				"DA:10,1",
+				"DA:11,7",
+				"end_of_record",
+			].join("\n"),
+			diffText: [
+				"diff --git a/crates/monochange/src/lib.rs b/crates/monochange/src/lib.rs",
+				"--- a/crates/monochange/src/lib.rs",
+				"+++ b/crates/monochange/src/lib.rs",
+				"@@ -9,0 +10,2 @@",
+				"+covered",
+				"+also covered",
+			].join("\n"),
+			repoRoot,
+			target: 100,
+		});
+
+		assert.equal(result.passed, true);
+		assert.equal(result.coveredLines, 2);
+		assert.equal(result.executableChangedLines, 2);
+		assert.match(result.summary, /PATCH_COVERAGE 2\/2 \(100\.00%\)/);
+	});
+
+	test("fails when patch coverage drops below 100%", () => {
+		const result = verifyPatchCoverage({
+			lcovText: [
+				"SF:crates/monochange/src/lib.rs",
+				"DA:10,1",
+				"DA:11,0",
+				"end_of_record",
+			].join("\n"),
+			diffText: [
+				"diff --git a/crates/monochange/src/lib.rs b/crates/monochange/src/lib.rs",
+				"--- a/crates/monochange/src/lib.rs",
+				"+++ b/crates/monochange/src/lib.rs",
+				"@@ -9,0 +10,2 @@",
+				"+covered",
+				"+missed",
+			].join("\n"),
+			repoRoot,
+			target: 100,
+		});
+
+		assert.equal(result.passed, false);
+		assert.match(result.summary, /Required patch coverage: 100\.00%/);
+		assert.match(result.summary, /crates\/monochange\/src\/lib\.rs:11/);
+	});
+
+	test("treats diffs without executable changed lines as passing", () => {
+		const result = verifyPatchCoverage({
+			lcovText: [
+				"SF:crates/monochange/src/lib.rs",
+				"DA:10,1",
+				"end_of_record",
+			].join("\n"),
+			diffText: [
+				"diff --git a/docs/readme.md b/docs/readme.md",
+				"--- a/docs/readme.md",
+				"+++ b/docs/readme.md",
+				"@@ -1,0 +1 @@",
+				"+docs only",
+			].join("\n"),
+			repoRoot,
+			target: 100,
+		});
+
+		assert.equal(result.passed, true);
+		assert.equal(result.executableChangedLines, 0);
+		assert.match(result.summary, /No executable changed lines were found/);
+	});
+});

--- a/packages/monochange__cli/README.md
+++ b/packages/monochange__cli/README.md
@@ -244,6 +244,7 @@ mc validate
 lint:all
 test:all
 coverage:all
+coverage:patch
 build:all
 build:book
 ```

--- a/readme.md
+++ b/readme.md
@@ -322,6 +322,7 @@ mc validate
 lint:all
 test:all
 coverage:all
+coverage:patch
 build:all
 build:book
 ```

--- a/scripts/check-patch-coverage.mjs
+++ b/scripts/check-patch-coverage.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+
+export function parseArgs(argv) {
+	const options = {};
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const token = argv[index];
+		if (!token.startsWith("--")) {
+			continue;
+		}
+
+		const value = argv[index + 1];
+		if (value === undefined || value.startsWith("--")) {
+			continue;
+		}
+
+		options[token.slice(2)] = value;
+		index += 1;
+	}
+
+	return options;
+}
+
+function normalizePath(filePath, repoRoot) {
+	if (filePath === "/dev/null") {
+		return null;
+	}
+
+	if (filePath.startsWith("b/")) {
+		filePath = filePath.slice(2);
+	}
+
+	return isAbsolute(filePath) ? filePath : resolve(repoRoot, filePath);
+}
+
+export function parseLcov(text, repoRoot = process.cwd()) {
+	const coverageByFile = new Map();
+	let currentFile = null;
+
+	for (const line of text.split(/\r?\n/u)) {
+		if (line.startsWith("SF:")) {
+			currentFile = normalizePath(line.slice(3), repoRoot);
+			if (currentFile && !coverageByFile.has(currentFile)) {
+				coverageByFile.set(currentFile, new Map());
+			}
+			continue;
+		}
+
+		if (!currentFile || !line.startsWith("DA:")) {
+			continue;
+		}
+
+		const [lineNumberToken, hitsToken] = line.slice(3).split(",", 2);
+		const lineNumber = Number.parseInt(lineNumberToken, 10);
+		const hits = Number.parseInt(hitsToken, 10);
+
+		if (!Number.isFinite(lineNumber) || !Number.isFinite(hits)) {
+			continue;
+		}
+
+		coverageByFile.get(currentFile).set(lineNumber, hits);
+	}
+
+	return coverageByFile;
+}
+
+function ensureLineSet(changedLinesByFile, filePath) {
+	if (!changedLinesByFile.has(filePath)) {
+		changedLinesByFile.set(filePath, new Set());
+	}
+
+	return changedLinesByFile.get(filePath);
+}
+
+export function parseChangedLines(text, repoRoot = process.cwd()) {
+	const changedLinesByFile = new Map();
+	let currentFile = null;
+
+	for (const line of text.split(/\r?\n/u)) {
+		if (line.startsWith("+++ ")) {
+			currentFile = normalizePath(line.slice(4).trim(), repoRoot);
+			continue;
+		}
+
+		if (!currentFile || !line.startsWith("@@ ")) {
+			continue;
+		}
+
+		const match = /@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/u.exec(line);
+		if (!match) {
+			continue;
+		}
+
+		const start = Number.parseInt(match[1], 10);
+		const count = match[2] === undefined ? 1 : Number.parseInt(match[2], 10);
+		if (!Number.isFinite(start) || !Number.isFinite(count) || count === 0) {
+			continue;
+		}
+
+		const lines = ensureLineSet(changedLinesByFile, currentFile);
+		for (let lineNumber = start; lineNumber < start + count; lineNumber += 1) {
+			lines.add(lineNumber);
+		}
+	}
+
+	return changedLinesByFile;
+}
+
+export function computePatchCoverage(coverageByFile, changedLinesByFile) {
+	let coveredLines = 0;
+	let executableChangedLines = 0;
+	const uncoveredLines = [];
+
+	for (const [filePath, changedLines] of changedLinesByFile.entries()) {
+		const lineCoverage = coverageByFile.get(filePath);
+		if (!lineCoverage) {
+			continue;
+		}
+
+		const sortedChangedLines = [...changedLines].sort((left, right) =>
+			left - right
+		);
+		for (const lineNumber of sortedChangedLines) {
+			if (!lineCoverage.has(lineNumber)) {
+				continue;
+			}
+
+			executableChangedLines += 1;
+			if ((lineCoverage.get(lineNumber) ?? 0) > 0) {
+				coveredLines += 1;
+				continue;
+			}
+
+			uncoveredLines.push({ filePath, lineNumber });
+		}
+	}
+
+	const percentage = executableChangedLines === 0
+		? 100
+		: (coveredLines / executableChangedLines) * 100;
+
+	return {
+		coveredLines,
+		executableChangedLines,
+		percentage,
+		uncoveredLines,
+	};
+}
+
+export function formatCoverageSummary(result, target) {
+	const percentage = result.percentage.toFixed(2);
+	const summary =
+		`PATCH_COVERAGE ${result.coveredLines}/${result.executableChangedLines} (${percentage}%)`;
+	if (result.executableChangedLines === 0) {
+		return `${summary}\nNo executable changed lines were found in the coverage report.`;
+	}
+
+	if (target === 100 && result.coveredLines === result.executableChangedLines) {
+		return `${summary}\nPatch coverage meets the required 100.00% target.`;
+	}
+
+	if (result.percentage >= target) {
+		return `${summary}\nPatch coverage meets the required ${
+			target.toFixed(2)
+		}% target.`;
+	}
+
+	const missingLines = result.uncoveredLines
+		.map(({ filePath, lineNumber }) => `- ${filePath}:${lineNumber}`)
+		.join("\n");
+	return `${summary}\nRequired patch coverage: ${
+		target.toFixed(2)
+	}%\nUncovered executable changed lines:\n${missingLines}`;
+}
+
+export function verifyPatchCoverage(
+	{ lcovText, diffText, repoRoot, target = 100 },
+) {
+	const coverageByFile = parseLcov(lcovText, repoRoot);
+	const changedLinesByFile = parseChangedLines(diffText, repoRoot);
+	const result = computePatchCoverage(coverageByFile, changedLinesByFile);
+	const passed = target === 100
+		? result.coveredLines === result.executableChangedLines
+		: result.percentage >= target;
+
+	return {
+		...result,
+		passed,
+		summary: formatCoverageSummary(result, target),
+	};
+}
+
+function run(command, args, options = {}) {
+	const result = spawnSync(command, args, {
+		encoding: "utf8",
+		...options,
+	});
+
+	if (result.status === 0) {
+		return result.stdout;
+	}
+
+	const output = result.stderr || result.stdout || "command failed";
+	throw new Error(`${command} ${args.join(" ")} failed: ${output.trim()}`);
+}
+
+export function main(argv = process.argv.slice(2)) {
+	const options = parseArgs(argv);
+	const repoRoot = options["repo-root"]
+		? resolve(options["repo-root"])
+		: process.cwd();
+	const base = options.base;
+	const head = options.head ?? "HEAD";
+	const lcovPath = options.lcov
+		? resolve(repoRoot, options.lcov)
+		: resolve(repoRoot, "target/coverage/lcov.info");
+	const target = options.target === undefined
+		? 100
+		: Number.parseFloat(options.target);
+
+	if (!base) {
+		throw new Error("missing required --base <git-ref> option");
+	}
+	if (!Number.isFinite(target)) {
+		throw new Error(`invalid --target value: ${options.target}`);
+	}
+
+	const lcovText = readFileSync(lcovPath, "utf8");
+	const diffText = run(
+		"git",
+		[
+			"diff",
+			"--unified=0",
+			"--no-color",
+			"--no-ext-diff",
+			`${base}...${head}`,
+		],
+		{ cwd: repoRoot },
+	);
+
+	const result = verifyPatchCoverage({ lcovText, diffText, repoRoot, target });
+	console.log(result.summary);
+
+	if (!result.passed) {
+		process.exitCode = 1;
+	}
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+	try {
+		main();
+	} catch (error) {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exitCode = 1;
+	}
+}


### PR DESCRIPTION
## Summary
- enforce 100% patch coverage for executable changed lines in CI and Codecov
- add a local `coverage:patch` task plus a diff-based coverage checker script
- document the new repository rule in agent docs and generated contributor docs

## Validation
- devenv shell -- test:node
- devenv shell -- docs:update
- devenv shell -- docs:check
- devenv shell -- fix:format
- devenv shell -- coverage:all
- devenv shell -- coverage:patch
- devenv shell -- monochange affected --format json --verify --changed-paths ...
