### PR TITLE
feat: add release-aware semantic analysis frames

### DIFF
--- a/.changeset/release-aware-semantic-analysis-frames.md
+++ b/.changeset/release-aware-semantic-analysis-frames.md
@@ -1,0 +1,11 @@
+---
+monochange_analysis: minor
+---
+
+`monochange_analysis` can now return release-aware semantic analysis across three explicit frames:
+
+- `release -> main`
+- `main -> head`
+- `release -> head`
+
+This adds a first multi-frame API surface for issue #249, including explicit ref-based entry points plus automatic baseline resolution that uses the latest workspace-style release tag and the detected default branch.

--- a/crates/monochange_analysis/src/frame.rs
+++ b/crates/monochange_analysis/src/frame.rs
@@ -109,7 +109,7 @@ impl ChangeFrame {
 
 		// Get current branch
 		let current = get_current_branch(repo_root)?;
-		let default = get_default_branch(repo_root).unwrap_or_else(|_| "main".to_string());
+		let default = default_branch_name(repo_root).unwrap_or_else(|_| "main".to_string());
 
 		// If we're not on the default branch, compare against it
 		if current != default {
@@ -399,8 +399,8 @@ fn get_current_branch(repo_root: &Path) -> Result<String, FrameError> {
 	Ok(branch)
 }
 
-/// Get the default branch (usually "main" or "master").
-fn get_default_branch(repo_root: &Path) -> Result<String, FrameError> {
+/// Get the default branch (usually `main` or `master`).
+pub(crate) fn default_branch_name(repo_root: &Path) -> Result<String, FrameError> {
 	// Try to get from git config
 	let output = Command::new("git")
 		.current_dir(repo_root)

--- a/crates/monochange_analysis/src/lib.rs
+++ b/crates/monochange_analysis/src/lib.rs
@@ -35,6 +35,7 @@ use monochange_core::MonochangeResult;
 use monochange_core::PackageAnalysisContext;
 use monochange_core::PackageRecord;
 use monochange_core::SemanticAnalyzer;
+use monochange_core::git;
 use monochange_core::normalize_path;
 use monochange_core::relative_to_root;
 #[cfg(feature = "dart")]
@@ -132,6 +133,42 @@ pub struct ChangeAnalysis {
 	/// Semantic diffs grouped by package id.
 	pub package_analyses: BTreeMap<String, PackageChangeAnalysis>,
 	/// Root-level warnings such as unmatched paths or missing analyzers.
+	pub warnings: Vec<String>,
+}
+
+/// Explicit refs used for release-aware multi-frame semantic analysis.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReleaseTrajectoryRefs {
+	/// Release baseline ref, usually a workspace tag.
+	pub release_ref: String,
+	/// Default branch ref representing current `main`.
+	pub main_ref: String,
+	/// Head ref representing the current branch or PR head.
+	pub head_ref: String,
+}
+
+/// Release-aware semantic analyses for three comparison frames.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReleaseTrajectoryFrames {
+	/// Semantic analysis between the last release baseline and current `main`.
+	pub release_to_main: ChangeAnalysis,
+	/// Semantic analysis between current `main` and the current head/branch.
+	pub main_to_head: ChangeAnalysis,
+	/// Semantic analysis between the last release baseline and the current head/branch.
+	pub release_to_head: ChangeAnalysis,
+}
+
+/// Raw multi-frame semantic evidence for release-aware compatibility reasoning.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReleaseTrajectoryAnalysis {
+	/// Resolved refs used for the three comparison frames.
+	pub refs: ReleaseTrajectoryRefs,
+	/// Per-frame semantic analyses.
+	pub frames: ReleaseTrajectoryFrames,
+	/// Root-level warnings about baseline resolution.
 	pub warnings: Vec<String>,
 }
 
@@ -269,12 +306,110 @@ pub fn analyze_changes(
 	})
 }
 
+/// Analyze three release-aware semantic frames using explicit refs.
+///
+/// # Errors
+///
+/// Returns an error if any frame analysis or ref resolution fails.
+pub fn analyze_release_trajectory_for_refs(
+	repo_root: &Path,
+	refs: &ReleaseTrajectoryRefs,
+	config: &AnalysisConfig,
+) -> MonochangeResult<ReleaseTrajectoryAnalysis> {
+	let release_to_main =
+		analyze_custom_range(repo_root, &refs.release_ref, &refs.main_ref, config)?;
+	let main_to_head = analyze_custom_range(repo_root, &refs.main_ref, &refs.head_ref, config)?;
+	let release_to_head =
+		analyze_custom_range(repo_root, &refs.release_ref, &refs.head_ref, config)?;
+	let mut warnings = Vec::new();
+
+	if refs.main_ref == refs.head_ref {
+		warnings.push(
+			"release trajectory head matches main; `main_to_head` only reflects changes currently on the default branch"
+				.to_string(),
+		);
+	}
+
+	Ok(ReleaseTrajectoryAnalysis {
+		refs: refs.clone(),
+		frames: ReleaseTrajectoryFrames {
+			release_to_main,
+			main_to_head,
+			release_to_head,
+		},
+		warnings,
+	})
+}
+
+/// Analyze three release-aware semantic frames using the latest workspace tag,
+/// the detected default branch, and the current branch.
+///
+/// # Errors
+///
+/// Returns an error if release-baseline or branch resolution fails.
+pub fn analyze_release_trajectory(
+	repo_root: &Path,
+	config: &AnalysisConfig,
+) -> MonochangeResult<ReleaseTrajectoryAnalysis> {
+	let repo_root = normalize_path(repo_root);
+	let refs = ReleaseTrajectoryRefs {
+		release_ref: latest_workspace_release_tag(&repo_root)?,
+		main_ref: default_branch_ref(&repo_root)?,
+		head_ref: git::git_current_branch(&repo_root)?,
+	};
+
+	analyze_release_trajectory_for_refs(&repo_root, &refs, config)
+}
+
+fn analyze_custom_range(
+	repo_root: &Path,
+	base: &str,
+	head: &str,
+	config: &AnalysisConfig,
+) -> MonochangeResult<ChangeAnalysis> {
+	analyze_changes(
+		repo_root,
+		&ChangeFrame::CustomRange {
+			base: base.to_string(),
+			head: head.to_string(),
+		},
+		config,
+	)
+}
+
 fn preferred_package_id(package: &PackageRecord) -> String {
 	package
 		.metadata
 		.get("config_id")
 		.cloned()
 		.unwrap_or_else(|| package.id.clone())
+}
+
+fn latest_workspace_release_tag(repo_root: &Path) -> MonochangeResult<String> {
+	let output = git::git_command_output(repo_root, &["tag", "--list", "--sort=-v:refname"])
+		.map_err(|error| MonochangeError::Io(format!("failed to list git tags: {error}")))?;
+
+	if !output.status.success() {
+		return Err(MonochangeError::Config(format!(
+			"failed to list git tags: {}",
+			git::git_error_detail(&output)
+		)));
+	}
+
+	String::from_utf8_lossy(&output.stdout)
+		.lines()
+		.map(str::trim)
+		.find(|tag| tag.starts_with('v') && !tag.contains('/'))
+		.map(ToString::to_string)
+		.ok_or_else(|| {
+			MonochangeError::Config(
+				"failed to resolve a workspace release baseline from git tags".to_string(),
+			)
+		})
+}
+
+fn default_branch_ref(repo_root: &Path) -> MonochangeResult<String> {
+	frame::default_branch_name(repo_root).map_err(Into::into)
 }
 
 fn discover_analysis_workspace(root: &Path) -> MonochangeResult<AnalysisWorkspace> {
@@ -1010,6 +1145,151 @@ mod tests {
 				.unwrap_or_else(|| panic!("expected one built snapshot file"))
 				.path,
 			PathBuf::from("src/lib.rs")
+		);
+	}
+
+	#[test]
+	fn analyze_release_trajectory_for_refs_uses_explicit_ranges_and_warns_when_head_matches_main() {
+		let release = fixture_path("analysis/release-trajectory/release");
+		let main = fixture_path("analysis/release-trajectory/main");
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let root = tempdir.path();
+
+		copy_directory(&release, root);
+		git(root, &["init"]);
+		git(root, &["config", "user.name", "monochange-tests"]);
+		git(
+			root,
+			&["config", "user.email", "monochange-tests@example.com"],
+		);
+		git(root, &["add", "."]);
+		git(root, &["commit", "-m", "release"]);
+		git(root, &["branch", "-M", "main"]);
+		git(root, &["tag", "v1.0.0"]);
+
+		copy_directory(&main, root);
+		git(root, &["add", "."]);
+		git(root, &["commit", "-m", "main evolution"]);
+
+		let analysis = analyze_release_trajectory_for_refs(
+			root,
+			&ReleaseTrajectoryRefs {
+				release_ref: "v1.0.0".to_string(),
+				main_ref: "main".to_string(),
+				head_ref: "main".to_string(),
+			},
+			&AnalysisConfig::default(),
+		)
+		.unwrap_or_else(|error| panic!("release trajectory refs: {error}"));
+
+		assert_eq!(
+			analysis.frames.release_to_main.frame.revision_range(),
+			"v1.0.0...main"
+		);
+		assert_eq!(
+			analysis.frames.main_to_head.frame.revision_range(),
+			"main...main"
+		);
+		assert_eq!(
+			analysis.frames.release_to_head.frame.revision_range(),
+			"v1.0.0...main"
+		);
+		assert_eq!(analysis.warnings.len(), 1);
+		assert!(
+			analysis
+				.warnings
+				.first()
+				.unwrap_or_else(|| panic!("expected release trajectory warning"))
+				.contains("head matches main")
+		);
+		assert!(
+			analysis
+				.frames
+				.release_to_main
+				.package_analyses
+				.contains_key("core")
+		);
+	}
+
+	#[test]
+	fn latest_workspace_release_tag_reports_missing_tags_and_git_failures() {
+		let missing_repo = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let missing_repo_error = latest_workspace_release_tag(missing_repo.path())
+			.unwrap_err()
+			.render();
+		assert!(missing_repo_error.contains("failed to list git tags"));
+
+		let repo_without_tags = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let root = repo_without_tags.path();
+		copy_directory(&fixture_path("analysis/release-trajectory/release"), root);
+		git(root, &["init"]);
+		git(root, &["config", "user.name", "monochange-tests"]);
+		git(
+			root,
+			&["config", "user.email", "monochange-tests@example.com"],
+		);
+		git(root, &["add", "."]);
+		git(root, &["commit", "-m", "release"]);
+		git(root, &["branch", "-M", "main"]);
+
+		let no_tag_error = latest_workspace_release_tag(root).unwrap_err().render();
+		assert!(no_tag_error.contains("failed to resolve a workspace release baseline"));
+	}
+
+	#[test]
+	fn auto_release_trajectory_resolution_uses_latest_workspace_tag_and_branch_refs() {
+		let release = fixture_path("analysis/release-trajectory/release");
+		let main = fixture_path("analysis/release-trajectory/main");
+		let head = fixture_path("analysis/release-trajectory/head");
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let root = tempdir.path();
+
+		copy_directory(&release, root);
+		git(root, &["init"]);
+		git(root, &["config", "user.name", "monochange-tests"]);
+		git(
+			root,
+			&["config", "user.email", "monochange-tests@example.com"],
+		);
+		git(root, &["add", "."]);
+		git(root, &["commit", "-m", "release"]);
+		git(root, &["branch", "-M", "main"]);
+		git(root, &["tag", "pkg-a/v9.9.9"]);
+		git(root, &["tag", "v1.0.0"]);
+
+		copy_directory(&main, root);
+		git(root, &["add", "."]);
+		git(root, &["commit", "-m", "main evolution"]);
+		git(root, &["checkout", "-b", "feature"]);
+
+		copy_directory(&head, root);
+		git(root, &["add", "."]);
+		git(root, &["commit", "-m", "feature changes"]);
+
+		let latest_tag = latest_workspace_release_tag(root)
+			.unwrap_or_else(|error| panic!("latest workspace tag: {error}"));
+		assert_eq!(latest_tag, "v1.0.0");
+		assert_eq!(
+			default_branch_ref(root).unwrap_or_else(|error| panic!("default branch: {error}")),
+			"main"
+		);
+
+		let analysis = analyze_release_trajectory(root, &AnalysisConfig::default())
+			.unwrap_or_else(|error| panic!("release trajectory: {error}"));
+		assert_eq!(analysis.refs.release_ref, "v1.0.0");
+		assert_eq!(analysis.refs.main_ref, "main");
+		assert_eq!(analysis.refs.head_ref, "feature");
+		assert!(analysis.warnings.is_empty());
+		assert!(
+			analysis
+				.frames
+				.main_to_head
+				.package_analyses
+				.get("core")
+				.unwrap_or_else(|| panic!("missing core package analysis"))
+				.semantic_changes
+				.iter()
+				.any(|change| change.item_path == "shout")
 		);
 	}
 

--- a/crates/monochange_analysis/tests/cargo_semantic_analysis.rs
+++ b/crates/monochange_analysis/tests/cargo_semantic_analysis.rs
@@ -1,7 +1,9 @@
 use insta::assert_json_snapshot;
 use monochange_analysis::AnalysisConfig;
 use monochange_analysis::ChangeFrame;
+use monochange_analysis::ReleaseTrajectoryRefs;
 use monochange_analysis::analyze_changes;
+use monochange_analysis::analyze_release_trajectory_for_refs;
 use monochange_test_helpers::copy_directory;
 use monochange_test_helpers::git;
 use monochange_test_helpers::snapshot_settings;
@@ -65,6 +67,50 @@ fn analyze_changes_reports_multi_ecosystem_semantic_diffs() {
 		&AnalysisConfig::default(),
 	)
 	.unwrap_or_else(|error| panic!("analysis: {error}"));
+
+	snapshot_settings().bind(|| {
+		assert_json_snapshot!(analysis);
+	});
+}
+
+#[test]
+fn analyze_release_trajectory_reports_release_main_and_head_frames() {
+	let release = fixture_path("analysis/release-trajectory/release");
+	let main = fixture_path("analysis/release-trajectory/main");
+	let head = fixture_path("analysis/release-trajectory/head");
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+
+	copy_directory(&release, tempdir.path());
+	git(tempdir.path(), &["init"]);
+	git(tempdir.path(), &["config", "user.name", "monochange-tests"]);
+	git(
+		tempdir.path(),
+		&["config", "user.email", "monochange-tests@example.com"],
+	);
+	git(tempdir.path(), &["add", "."]);
+	git(tempdir.path(), &["commit", "-m", "release"]);
+	git(tempdir.path(), &["branch", "-M", "main"]);
+	git(tempdir.path(), &["tag", "v1.0.0"]);
+
+	copy_directory(&main, tempdir.path());
+	git(tempdir.path(), &["add", "."]);
+	git(tempdir.path(), &["commit", "-m", "main evolution"]);
+	git(tempdir.path(), &["checkout", "-b", "feature"]);
+
+	copy_directory(&head, tempdir.path());
+	git(tempdir.path(), &["add", "."]);
+	git(tempdir.path(), &["commit", "-m", "feature changes"]);
+
+	let analysis = analyze_release_trajectory_for_refs(
+		tempdir.path(),
+		&ReleaseTrajectoryRefs {
+			release_ref: "v1.0.0".to_string(),
+			main_ref: "main".to_string(),
+			head_ref: "feature".to_string(),
+		},
+		&AnalysisConfig::default(),
+	)
+	.unwrap_or_else(|error| panic!("trajectory analysis: {error}"));
 
 	snapshot_settings().bind(|| {
 		assert_json_snapshot!(analysis);

--- a/crates/monochange_analysis/tests/snapshots/cargo_semantic_analysis__analyze_release_trajectory_reports_release_main_and_head_frames.snap
+++ b/crates/monochange_analysis/tests/snapshots/cargo_semantic_analysis__analyze_release_trajectory_reports_release_main_and_head_frames.snap
@@ -1,0 +1,232 @@
+---
+source: crates/monochange_analysis/tests/cargo_semantic_analysis.rs
+assertion_line: 116
+expression: analysis
+---
+{
+  "refs": {
+    "releaseRef": "v1.0.0",
+    "mainRef": "main",
+    "headRef": "feature"
+  },
+  "frames": {
+    "releaseToMain": {
+      "frame": {
+        "CustomRange": {
+          "base": "v1.0.0",
+          "head": "main"
+        }
+      },
+      "detectionLevel": "signature",
+      "packageAnalyses": {
+        "core": {
+          "packageId": "core",
+          "packageRecordId": "cargo:crates/core/Cargo.toml",
+          "packageName": "core",
+          "ecosystem": "cargo",
+          "analyzerId": "cargo/public-api",
+          "changedFiles": [
+            "Cargo.toml",
+            "src/lib.rs"
+          ],
+          "semanticChanges": [
+            {
+              "category": "public_api",
+              "kind": "added",
+              "itemKind": "struct",
+              "itemPath": "Greeter",
+              "summary": "struct `Greeter` added",
+              "filePath": "src/lib.rs",
+              "beforeSignature": null,
+              "afterSignature": "pub struct Greeter ;"
+            },
+            {
+              "category": "public_api",
+              "kind": "modified",
+              "itemKind": "function",
+              "itemPath": "greet",
+              "summary": "function `greet` modified",
+              "filePath": "src/lib.rs",
+              "beforeSignature": "fn greet () -> & 'static str",
+              "afterSignature": "fn greet (name : & str) -> String"
+            },
+            {
+              "category": "dependency",
+              "kind": "added",
+              "itemKind": "dependency",
+              "itemPath": "tracing",
+              "summary": "dependency `tracing` added",
+              "filePath": "Cargo.toml",
+              "beforeSignature": null,
+              "afterSignature": "[dependencies] 0.1"
+            },
+            {
+              "category": "metadata",
+              "kind": "added",
+              "itemKind": "feature",
+              "itemPath": "feature.cli",
+              "summary": "feature `feature.cli` added",
+              "filePath": "Cargo.toml",
+              "beforeSignature": null,
+              "afterSignature": ""
+            },
+            {
+              "category": "metadata",
+              "kind": "modified",
+              "itemKind": "feature",
+              "itemPath": "feature.default",
+              "summary": "feature `feature.default` modified",
+              "filePath": "Cargo.toml",
+              "beforeSignature": "",
+              "afterSignature": "cli"
+            },
+            {
+              "category": "metadata",
+              "kind": "modified",
+              "itemKind": "manifest_field",
+              "itemPath": "package.edition",
+              "summary": "manifest_field `package.edition` modified",
+              "filePath": "Cargo.toml",
+              "beforeSignature": "2021",
+              "afterSignature": "2024"
+            }
+          ],
+          "warnings": []
+        }
+      },
+      "warnings": []
+    },
+    "mainToHead": {
+      "frame": {
+        "CustomRange": {
+          "base": "main",
+          "head": "feature"
+        }
+      },
+      "detectionLevel": "signature",
+      "packageAnalyses": {
+        "core": {
+          "packageId": "core",
+          "packageRecordId": "cargo:crates/core/Cargo.toml",
+          "packageName": "core",
+          "ecosystem": "cargo",
+          "analyzerId": "cargo/public-api",
+          "changedFiles": [
+            "src/lib.rs"
+          ],
+          "semanticChanges": [
+            {
+              "category": "public_api",
+              "kind": "added",
+              "itemKind": "function",
+              "itemPath": "shout",
+              "summary": "function `shout` added",
+              "filePath": "src/lib.rs",
+              "beforeSignature": null,
+              "afterSignature": "fn shout (name : & str) -> String"
+            }
+          ],
+          "warnings": []
+        }
+      },
+      "warnings": []
+    },
+    "releaseToHead": {
+      "frame": {
+        "CustomRange": {
+          "base": "v1.0.0",
+          "head": "feature"
+        }
+      },
+      "detectionLevel": "signature",
+      "packageAnalyses": {
+        "core": {
+          "packageId": "core",
+          "packageRecordId": "cargo:crates/core/Cargo.toml",
+          "packageName": "core",
+          "ecosystem": "cargo",
+          "analyzerId": "cargo/public-api",
+          "changedFiles": [
+            "Cargo.toml",
+            "src/lib.rs"
+          ],
+          "semanticChanges": [
+            {
+              "category": "public_api",
+              "kind": "added",
+              "itemKind": "function",
+              "itemPath": "shout",
+              "summary": "function `shout` added",
+              "filePath": "src/lib.rs",
+              "beforeSignature": null,
+              "afterSignature": "fn shout (name : & str) -> String"
+            },
+            {
+              "category": "public_api",
+              "kind": "added",
+              "itemKind": "struct",
+              "itemPath": "Greeter",
+              "summary": "struct `Greeter` added",
+              "filePath": "src/lib.rs",
+              "beforeSignature": null,
+              "afterSignature": "pub struct Greeter ;"
+            },
+            {
+              "category": "public_api",
+              "kind": "modified",
+              "itemKind": "function",
+              "itemPath": "greet",
+              "summary": "function `greet` modified",
+              "filePath": "src/lib.rs",
+              "beforeSignature": "fn greet () -> & 'static str",
+              "afterSignature": "fn greet (name : & str) -> String"
+            },
+            {
+              "category": "dependency",
+              "kind": "added",
+              "itemKind": "dependency",
+              "itemPath": "tracing",
+              "summary": "dependency `tracing` added",
+              "filePath": "Cargo.toml",
+              "beforeSignature": null,
+              "afterSignature": "[dependencies] 0.1"
+            },
+            {
+              "category": "metadata",
+              "kind": "added",
+              "itemKind": "feature",
+              "itemPath": "feature.cli",
+              "summary": "feature `feature.cli` added",
+              "filePath": "Cargo.toml",
+              "beforeSignature": null,
+              "afterSignature": ""
+            },
+            {
+              "category": "metadata",
+              "kind": "modified",
+              "itemKind": "feature",
+              "itemPath": "feature.default",
+              "summary": "feature `feature.default` modified",
+              "filePath": "Cargo.toml",
+              "beforeSignature": "",
+              "afterSignature": "cli"
+            },
+            {
+              "category": "metadata",
+              "kind": "modified",
+              "itemKind": "manifest_field",
+              "itemPath": "package.edition",
+              "summary": "manifest_field `package.edition` modified",
+              "filePath": "Cargo.toml",
+              "beforeSignature": "2021",
+              "afterSignature": "2024"
+            }
+          ],
+          "warnings": []
+        }
+      },
+      "warnings": []
+    }
+  },
+  "warnings": []
+}

--- a/fixtures/tests/analysis/release-trajectory/head/crates/core/Cargo.toml
+++ b/fixtures/tests/analysis/release-trajectory/head/crates/core/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "core"
+version = "1.0.0"
+edition = "2024"
+
+[dependencies]
+serde = "1"
+tracing = "0.1"
+
+[features]
+default = ["cli"]
+cli = []

--- a/fixtures/tests/analysis/release-trajectory/head/crates/core/src/lib.rs
+++ b/fixtures/tests/analysis/release-trajectory/head/crates/core/src/lib.rs
@@ -1,0 +1,9 @@
+pub struct Greeter;
+
+pub fn greet(name: &str) -> String {
+	format!("hello {name}")
+}
+
+pub fn shout(name: &str) -> String {
+	format!("HELLO {}", name.to_uppercase())
+}

--- a/fixtures/tests/analysis/release-trajectory/head/monochange.toml
+++ b/fixtures/tests/analysis/release-trajectory/head/monochange.toml
@@ -1,0 +1,3 @@
+[package.core]
+path = "crates/core"
+type = "cargo"

--- a/fixtures/tests/analysis/release-trajectory/main/crates/core/Cargo.toml
+++ b/fixtures/tests/analysis/release-trajectory/main/crates/core/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "core"
+version = "1.0.0"
+edition = "2024"
+
+[dependencies]
+serde = "1"
+tracing = "0.1"
+
+[features]
+default = ["cli"]
+cli = []

--- a/fixtures/tests/analysis/release-trajectory/main/crates/core/src/lib.rs
+++ b/fixtures/tests/analysis/release-trajectory/main/crates/core/src/lib.rs
@@ -1,0 +1,5 @@
+pub struct Greeter;
+
+pub fn greet(name: &str) -> String {
+	format!("hello {name}")
+}

--- a/fixtures/tests/analysis/release-trajectory/main/monochange.toml
+++ b/fixtures/tests/analysis/release-trajectory/main/monochange.toml
@@ -1,0 +1,3 @@
+[package.core]
+path = "crates/core"
+type = "cargo"

--- a/fixtures/tests/analysis/release-trajectory/release/crates/core/Cargo.toml
+++ b/fixtures/tests/analysis/release-trajectory/release/crates/core/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "core"
+version = "1.0.0"
+edition = "2021"
+
+[dependencies]
+serde = "1"
+
+[features]
+default = []

--- a/fixtures/tests/analysis/release-trajectory/release/crates/core/src/lib.rs
+++ b/fixtures/tests/analysis/release-trajectory/release/crates/core/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn greet() -> &'static str {
+	"hello"
+}

--- a/fixtures/tests/analysis/release-trajectory/release/monochange.toml
+++ b/fixtures/tests/analysis/release-trajectory/release/monochange.toml
@@ -1,0 +1,3 @@
+[package.core]
+path = "crates/core"
+type = "cargo"


### PR DESCRIPTION
## Summary

This PR starts phase 3 of semantic analysis work for #249 by adding a release-aware, multi-frame analysis API to `monochange_analysis`.

Instead of only looking at a single diff, the crate can now analyze three related semantic frames:

- `release -> main`
- `main -> head`
- `release -> head`

That gives callers raw semantic evidence they can later use to answer questions like:

- what changed since the last release?
- what is new in this PR relative to `main`?
- what is the net effect from the last release to the current head?

## Why

Issue #249 exists because a single PR-vs-main diff is not always enough for compatibility reasoning.

A change can look breaking relative to `main` while still being part of a larger sequence that replaces, reverts, or reshapes an earlier breaking change that already happened after the last release. To reason about that well, we need structured semantic facts from multiple comparison points before we layer semver judgment on top.

This PR intentionally keeps the work at the semantic-evidence layer.

## What changed

### New release-trajectory API

Added new public types in `crates/monochange_analysis/src/lib.rs`:

- `ReleaseTrajectoryRefs`
- `ReleaseTrajectoryFrames`
- `ReleaseTrajectoryAnalysis`

Added new public entry points:

- `analyze_release_trajectory_for_refs(...)`
- `analyze_release_trajectory(...)`

### Explicit three-frame analysis

`analyze_release_trajectory_for_refs(...)` accepts explicit refs and returns semantic analyses for:

- `release_to_main`
- `main_to_head`
- `release_to_head`

Each frame reuses the existing `ChangeAnalysis` shape, so this extends the analysis model without introducing a new incompatible semantic-diff format.

### Automatic baseline resolution

`analyze_release_trajectory(...)` adds a first automatic-resolution path using:

- the latest workspace-style release tag
- the detected default branch
- the current branch as the head ref

This gives us a usable default for local and CI-driven workflows while keeping the explicit ref API available when callers need tighter control.

### Warning coverage

The implementation also includes warning behavior for ambiguous cases, such as when `head` resolves to the same ref as `main`.

### Fixture-first tests and snapshots

Added fixture-backed release trajectory scenarios under:

- `fixtures/tests/analysis/release-trajectory/`

Added integration coverage and snapshot assertions for the three-frame output so the new API shape is pinned and reviewable.

## Scope / non-goals

This PR does **not**:

- expose the new release-trajectory API through MCP yet
- assign `patch` / `minor` / `major` judgments
- attempt full release-baseline intelligence beyond the current latest-tag heuristic

Those are follow-up concerns once the semantic shape settles.

## Why this shape

This keeps the architecture aligned with the earlier semantic-analysis work:

- ecosystem analyzers still produce semantic facts
- `monochange_analysis` still orchestrates and composes those facts
- higher-level compatibility or semver policy can be built later on top of the returned evidence

## Validation

Ran in `/tmp/monochange-semantic-analysis-phase-3`:

- `cargo fmt --all --check`
- `cargo clippy -p monochange_analysis --all-targets -- -D warnings`
- `cargo test -p monochange_analysis --lib`
- `cargo test -p monochange_analysis --test cargo_semantic_analysis`
- `docs:check`
- `mc affected --format json --verify --changed-paths ...`
- `coverage:all`
- `MONOCHANGE_PATCH_COVERAGE_BASE=origin/main MONOCHANGE_PATCH_COVERAGE_HEAD=HEAD coverage:patch`

Patch coverage result:

- `PATCH_COVERAGE 189/189 (100.00%)`

Refs #249
