### PR TITLE
ci: add per-crate codecov coverage flags

### DIFF
--- a/.changeset/codecov-flags-per-crate-badges.md
+++ b/.changeset/codecov-flags-per-crate-badges.md
@@ -1,0 +1,33 @@
+---
+"@monochange/cli": patch
+monochange: patch
+monochange_analysis: patch
+monochange_cargo: patch
+monochange_config: patch
+monochange_core: patch
+monochange_dart: patch
+monochange_deno: patch
+monochange_gitea: patch
+monochange_github: patch
+monochange_gitlab: patch
+monochange_graph: patch
+monochange_hosting: patch
+monochange_npm: patch
+monochange_semver: patch
+---
+
+#### add per-crate Codecov coverage flags and crate-specific coverage badges
+
+monochange now uploads one Codecov coverage flag per public crate while keeping the existing workspace-wide upload.
+
+**Before:**
+
+- Codecov only received the overall workspace LCOV upload
+- crate READMEs linked their coverage badge to the shared repository-wide Codecov page
+- Codecov patch coverage enforced a 100% target for PR status checks
+
+**After:**
+
+- CI splits the workspace LCOV report into one upload per public crate using a Codecov flag named after the crate
+- each published crate README now points its coverage badge at that crate’s own Codecov flag page, for example `?flag=monochange_core`
+- the repository keeps the overall workspace coverage upload and lowers the Codecov patch coverage status target to 95%

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,8 @@ jobs:
   coverage:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    outputs:
+      codecov-flags: ${{ steps.prepare-codecov-flags.outputs.flags }}
     permissions:
       contents: read
       id-token: write
@@ -122,6 +124,24 @@ jobs:
         run: coverage:patch
         shell: devenv shell -- bash -e {0}
 
+      - name: prepare codecov flag reports
+        id: prepare-codecov-flags
+        run: |
+          node scripts/prepare-codecov-flags.mjs \
+            --lcov target/coverage/lcov.info \
+            --out-dir target/coverage/flags \
+            --github-output "$GITHUB_OUTPUT"
+        shell: devenv shell -- bash -e {0}
+
+      - name: upload codecov flag reports artifact
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/upload-artifact@v4
+        with:
+          name: codecov-flag-reports
+          path: target/coverage/flags/*.lcov
+          if-no-files-found: error
+          retention-days: 7
+
       - name: upload coverage to codecov
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@v5
@@ -130,8 +150,40 @@ jobs:
           files: ./target/coverage/lcov.info
           disable_search: true
           fail_ci_if_error: true
-          flags: rust
           name: monochange-rust-workspace
+          verbose: true
+
+  coverage-flags:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    needs: coverage
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        flag: ${{ fromJson(needs.coverage.outputs.codecov-flags) }}
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v6
+
+      - name: download codecov flag reports artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: codecov-flag-reports
+          path: target/coverage/flags
+
+      - name: upload crate coverage flag to codecov
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: ./target/coverage/flags/${{ matrix.flag }}.lcov
+          disable_search: true
+          fail_ci_if_error: true
+          flags: ${{ matrix.flag }}
+          name: ${{ matrix.flag }}
           verbose: true
 
   benchmark:

--- a/.templates/crates.t.md
+++ b/.templates/crates.t.md
@@ -8,8 +8,6 @@
 
 [ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
 [ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
-[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
-[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
 [license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
 [license-link]: https://opensource.org/license/unlicense
 
@@ -17,7 +15,7 @@
 
 <!-- {@crateBadgeLinks:"crate_name"} -->
 
-[crate-image]: https://img.shields.io/badge/crates.io-{{ crate_name|replace("_", "__") }}-orange?logo=rust [crate-link]: https://crates.io/crates/{{ crate_name }} [docs-image]: https://img.shields.io/badge/docs.rs-{{ crate_name|replace("_", "__") }}-1f425f?logo=docs.rs [docs-link]: https://docs.rs/{{ crate_name }}/
+[crate-image]: https://img.shields.io/badge/crates.io-{{ crate_name|replace("_", "__") }}-orange?logo=rust [crate-link]: https://crates.io/crates/{{ crate_name }} [docs-image]: https://img.shields.io/badge/docs.rs-{{ crate_name|replace("_", "__") }}-1f425f?logo=docs.rs [docs-link]: https://docs.rs/{{ crate_name }}/ [coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg?flag={{ crate_name }} [coverage-link]: https://codecov.io/gh/ifiokjr/monochange?flag={{ crate_name }}
 
 <!-- {/crateBadgeLinks} -->
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,59 @@
 codecov:
   require_ci_to_pass: true
 
+flags:
+  monochange:
+    paths:
+      - crates/monochange
+  monochange_analysis:
+    paths:
+      - crates/monochange_analysis
+  monochange_cargo:
+    paths:
+      - crates/monochange_cargo
+  monochange_config:
+    paths:
+      - crates/monochange_config
+  monochange_core:
+    paths:
+      - crates/monochange_core
+  monochange_dart:
+    paths:
+      - crates/monochange_dart
+  monochange_deno:
+    paths:
+      - crates/monochange_deno
+  monochange_ecmascript:
+    paths:
+      - crates/monochange_ecmascript
+  monochange_gitea:
+    paths:
+      - crates/monochange_gitea
+  monochange_github:
+    paths:
+      - crates/monochange_github
+  monochange_gitlab:
+    paths:
+      - crates/monochange_gitlab
+  monochange_graph:
+    paths:
+      - crates/monochange_graph
+  monochange_hosting:
+    paths:
+      - crates/monochange_hosting
+  monochange_lint:
+    paths:
+      - crates/monochange_lint
+  monochange_linting:
+    paths:
+      - crates/monochange_linting
+  monochange_npm:
+    paths:
+      - crates/monochange_npm
+  monochange_semver:
+    paths:
+      - crates/monochange_semver
+
 coverage:
   precision: 2
   round: down
@@ -12,5 +65,5 @@ coverage:
         threshold: 1%
     patch:
       default:
-        target: 100%
+        target: 95%
         threshold: 0%

--- a/crates/monochange/readme.md
+++ b/crates/monochange/readme.md
@@ -55,7 +55,7 @@ mc mcp
 
 <!-- {=crateBadgeLinks:"monochange"} -->
 
-[crate-image]: https://img.shields.io/badge/crates.io-monochange-orange?logo=rust [crate-link]: https://crates.io/crates/monochange [docs-image]: https://img.shields.io/badge/docs.rs-monochange-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange/
+[crate-image]: https://img.shields.io/badge/crates.io-monochange-orange?logo=rust [crate-link]: https://crates.io/crates/monochange [docs-image]: https://img.shields.io/badge/docs.rs-monochange-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange/ [coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg?flag=monochange [coverage-link]: https://codecov.io/gh/ifiokjr/monochange?flag=monochange
 
 <!-- {/crateBadgeLinks} -->
 
@@ -63,8 +63,6 @@ mc mcp
 
 [ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
 [ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
-[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
-[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
 [license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
 [license-link]: https://opensource.org/license/unlicense
 

--- a/crates/monochange_analysis/readme.md
+++ b/crates/monochange_analysis/readme.md
@@ -45,7 +45,7 @@ Reach for this crate when you want to classify changed packages as libraries, ap
 
 <!-- {=crateBadgeLinks:"monochange_analysis"} -->
 
-[crate-image]: https://img.shields.io/badge/crates.io-monochange__analysis-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_analysis [docs-image]: https://img.shields.io/badge/docs.rs-monochange__analysis-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_analysis/
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__analysis-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_analysis [docs-image]: https://img.shields.io/badge/docs.rs-monochange__analysis-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_analysis/ [coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg?flag=monochange_analysis [coverage-link]: https://codecov.io/gh/ifiokjr/monochange?flag=monochange_analysis
 
 <!-- {/crateBadgeLinks} -->
 
@@ -53,8 +53,6 @@ Reach for this crate when you want to classify changed packages as libraries, ap
 
 [ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
 [ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
-[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
-[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
 [license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
 [license-link]: https://opensource.org/license/unlicense
 

--- a/crates/monochange_cargo/readme.md
+++ b/crates/monochange_cargo/readme.md
@@ -45,7 +45,7 @@ Reach for this crate when you want to scan Cargo workspaces into normalized `mon
 
 <!-- {=crateBadgeLinks:"monochange_cargo"} -->
 
-[crate-image]: https://img.shields.io/badge/crates.io-monochange__cargo-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_cargo [docs-image]: https://img.shields.io/badge/docs.rs-monochange__cargo-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_cargo/
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__cargo-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_cargo [docs-image]: https://img.shields.io/badge/docs.rs-monochange__cargo-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_cargo/ [coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg?flag=monochange_cargo [coverage-link]: https://codecov.io/gh/ifiokjr/monochange?flag=monochange_cargo
 
 <!-- {/crateBadgeLinks} -->
 
@@ -53,8 +53,6 @@ Reach for this crate when you want to scan Cargo workspaces into normalized `mon
 
 [ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
 [ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
-[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
-[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
 [license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
 [license-link]: https://opensource.org/license/unlicense
 

--- a/crates/monochange_config/readme.md
+++ b/crates/monochange_config/readme.md
@@ -86,7 +86,7 @@ let _ = std::fs::remove_dir_all(&root);
 
 <!-- {=crateBadgeLinks:"monochange_config"} -->
 
-[crate-image]: https://img.shields.io/badge/crates.io-monochange__config-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_config [docs-image]: https://img.shields.io/badge/docs.rs-monochange__config-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_config/
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__config-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_config [docs-image]: https://img.shields.io/badge/docs.rs-monochange__config-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_config/ [coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg?flag=monochange_config [coverage-link]: https://codecov.io/gh/ifiokjr/monochange?flag=monochange_config
 
 <!-- {/crateBadgeLinks} -->
 
@@ -94,8 +94,6 @@ let _ = std::fs::remove_dir_all(&root);
 
 [ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
 [ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
-[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
-[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
 [license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
 [license-link]: https://opensource.org/license/unlicense
 

--- a/crates/monochange_core/readme.md
+++ b/crates/monochange_core/readme.md
@@ -64,7 +64,7 @@ assert!(rendered.contains("- add keep-a-changelog output"));
 
 <!-- {=crateBadgeLinks:"monochange_core"} -->
 
-[crate-image]: https://img.shields.io/badge/crates.io-monochange__core-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_core [docs-image]: https://img.shields.io/badge/docs.rs-monochange__core-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_core/
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__core-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_core [docs-image]: https://img.shields.io/badge/docs.rs-monochange__core-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_core/ [coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg?flag=monochange_core [coverage-link]: https://codecov.io/gh/ifiokjr/monochange?flag=monochange_core
 
 <!-- {/crateBadgeLinks} -->
 
@@ -72,8 +72,6 @@ assert!(rendered.contains("- add keep-a-changelog output"));
 
 [ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
 [ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
-[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
-[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
 [license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
 [license-link]: https://opensource.org/license/unlicense
 

--- a/crates/monochange_dart/readme.md
+++ b/crates/monochange_dart/readme.md
@@ -44,7 +44,7 @@ Reach for this crate when you need to scan `pubspec.yaml` files, expand Dart or 
 
 <!-- {=crateBadgeLinks:"monochange_dart"} -->
 
-[crate-image]: https://img.shields.io/badge/crates.io-monochange__dart-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_dart [docs-image]: https://img.shields.io/badge/docs.rs-monochange__dart-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_dart/
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__dart-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_dart [docs-image]: https://img.shields.io/badge/docs.rs-monochange__dart-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_dart/ [coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg?flag=monochange_dart [coverage-link]: https://codecov.io/gh/ifiokjr/monochange?flag=monochange_dart
 
 <!-- {/crateBadgeLinks} -->
 
@@ -52,8 +52,6 @@ Reach for this crate when you need to scan `pubspec.yaml` files, expand Dart or 
 
 [ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
 [ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
-[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
-[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
 [license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
 [license-link]: https://opensource.org/license/unlicense
 

--- a/crates/monochange_deno/readme.md
+++ b/crates/monochange_deno/readme.md
@@ -43,7 +43,7 @@ Reach for this crate when you need to scan `deno.json` or `deno.jsonc` files, ex
 
 <!-- {=crateBadgeLinks:"monochange_deno"} -->
 
-[crate-image]: https://img.shields.io/badge/crates.io-monochange__deno-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_deno [docs-image]: https://img.shields.io/badge/docs.rs-monochange__deno-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_deno/
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__deno-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_deno [docs-image]: https://img.shields.io/badge/docs.rs-monochange__deno-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_deno/ [coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg?flag=monochange_deno [coverage-link]: https://codecov.io/gh/ifiokjr/monochange?flag=monochange_deno
 
 <!-- {/crateBadgeLinks} -->
 
@@ -51,8 +51,6 @@ Reach for this crate when you need to scan `deno.json` or `deno.jsonc` files, ex
 
 [ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
 [ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
-[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
-[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
 [license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
 [license-link]: https://opensource.org/license/unlicense
 

--- a/crates/monochange_gitea/readme.md
+++ b/crates/monochange_gitea/readme.md
@@ -39,7 +39,7 @@ Reach for this crate when you want to preview or publish Gitea releases and rele
 
 <!-- {=crateBadgeLinks:"monochange_gitea"} -->
 
-[crate-image]: https://img.shields.io/badge/crates.io-monochange__gitea-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_gitea [docs-image]: https://img.shields.io/badge/docs.rs-monochange__gitea-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_gitea/
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__gitea-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_gitea [docs-image]: https://img.shields.io/badge/docs.rs-monochange__gitea-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_gitea/ [coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg?flag=monochange_gitea [coverage-link]: https://codecov.io/gh/ifiokjr/monochange?flag=monochange_gitea
 
 <!-- {/crateBadgeLinks} -->
 
@@ -47,8 +47,6 @@ Reach for this crate when you want to preview or publish Gitea releases and rele
 
 [ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
 [ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
-[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
-[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
 [license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
 [license-link]: https://opensource.org/license/unlicense
 

--- a/crates/monochange_github/readme.md
+++ b/crates/monochange_github/readme.md
@@ -104,7 +104,7 @@ assert_eq!(requests[0].repository, "ifiokjr/monochange");
 
 <!-- {=crateBadgeLinks:"monochange_github"} -->
 
-[crate-image]: https://img.shields.io/badge/crates.io-monochange__github-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_github [docs-image]: https://img.shields.io/badge/docs.rs-monochange__github-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_github/
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__github-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_github [docs-image]: https://img.shields.io/badge/docs.rs-monochange__github-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_github/ [coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg?flag=monochange_github [coverage-link]: https://codecov.io/gh/ifiokjr/monochange?flag=monochange_github
 
 <!-- {/crateBadgeLinks} -->
 
@@ -112,8 +112,6 @@ assert_eq!(requests[0].repository, "ifiokjr/monochange");
 
 [ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
 [ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
-[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
-[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
 [license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
 [license-link]: https://opensource.org/license/unlicense
 

--- a/crates/monochange_gitlab/readme.md
+++ b/crates/monochange_gitlab/readme.md
@@ -39,7 +39,7 @@ Reach for this crate when you want to preview or publish GitLab releases and mer
 
 <!-- {=crateBadgeLinks:"monochange_gitlab"} -->
 
-[crate-image]: https://img.shields.io/badge/crates.io-monochange__gitlab-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_gitlab [docs-image]: https://img.shields.io/badge/docs.rs-monochange__gitlab-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_gitlab/
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__gitlab-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_gitlab [docs-image]: https://img.shields.io/badge/docs.rs-monochange__gitlab-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_gitlab/ [coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg?flag=monochange_gitlab [coverage-link]: https://codecov.io/gh/ifiokjr/monochange?flag=monochange_gitlab
 
 <!-- {/crateBadgeLinks} -->
 
@@ -47,8 +47,6 @@ Reach for this crate when you want to preview or publish GitLab releases and mer
 
 [ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
 [ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
-[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
-[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
 [license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
 [license-link]: https://opensource.org/license/unlicense
 

--- a/crates/monochange_graph/readme.md
+++ b/crates/monochange_graph/readme.md
@@ -44,7 +44,7 @@ Reach for this crate when you already have discovered packages, dependency edges
 
 <!-- {=crateBadgeLinks:"monochange_graph"} -->
 
-[crate-image]: https://img.shields.io/badge/crates.io-monochange__graph-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_graph [docs-image]: https://img.shields.io/badge/docs.rs-monochange__graph-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_graph/
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__graph-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_graph [docs-image]: https://img.shields.io/badge/docs.rs-monochange__graph-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_graph/ [coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg?flag=monochange_graph [coverage-link]: https://codecov.io/gh/ifiokjr/monochange?flag=monochange_graph
 
 <!-- {/crateBadgeLinks} -->
 
@@ -52,8 +52,6 @@ Reach for this crate when you already have discovered packages, dependency edges
 
 [ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
 [ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
-[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
-[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
 [license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
 [license-link]: https://opensource.org/license/unlicense
 

--- a/crates/monochange_hosting/readme.md
+++ b/crates/monochange_hosting/readme.md
@@ -40,7 +40,7 @@ Reach for this crate when you are implementing GitHub, Gitea, or GitLab release 
 
 <!-- {=crateBadgeLinks:"monochange_hosting"} -->
 
-[crate-image]: https://img.shields.io/badge/crates.io-monochange__hosting-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_hosting [docs-image]: https://img.shields.io/badge/docs.rs-monochange__hosting-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_hosting/
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__hosting-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_hosting [docs-image]: https://img.shields.io/badge/docs.rs-monochange__hosting-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_hosting/ [coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg?flag=monochange_hosting [coverage-link]: https://codecov.io/gh/ifiokjr/monochange?flag=monochange_hosting
 
 <!-- {/crateBadgeLinks} -->
 
@@ -48,8 +48,6 @@ Reach for this crate when you are implementing GitHub, Gitea, or GitLab release 
 
 [ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
 [ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
-[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
-[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
 [license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
 [license-link]: https://opensource.org/license/unlicense
 

--- a/crates/monochange_npm/readme.md
+++ b/crates/monochange_npm/readme.md
@@ -44,7 +44,7 @@ Reach for this crate when you want one adapter for npm, pnpm, and Bun workspaces
 
 <!-- {=crateBadgeLinks:"monochange_npm"} -->
 
-[crate-image]: https://img.shields.io/badge/crates.io-monochange__npm-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_npm [docs-image]: https://img.shields.io/badge/docs.rs-monochange__npm-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_npm/
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__npm-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_npm [docs-image]: https://img.shields.io/badge/docs.rs-monochange__npm-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_npm/ [coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg?flag=monochange_npm [coverage-link]: https://codecov.io/gh/ifiokjr/monochange?flag=monochange_npm
 
 <!-- {/crateBadgeLinks} -->
 
@@ -52,8 +52,6 @@ Reach for this crate when you want one adapter for npm, pnpm, and Bun workspaces
 
 [ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
 [ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
-[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
-[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
 [license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
 [license-link]: https://opensource.org/license/unlicense
 

--- a/crates/monochange_semver/readme.md
+++ b/crates/monochange_semver/readme.md
@@ -53,7 +53,7 @@ assert_eq!(direct, BumpSeverity::Minor);
 
 <!-- {=crateBadgeLinks:"monochange_semver"} -->
 
-[crate-image]: https://img.shields.io/badge/crates.io-monochange__semver-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_semver [docs-image]: https://img.shields.io/badge/docs.rs-monochange__semver-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_semver/
+[crate-image]: https://img.shields.io/badge/crates.io-monochange__semver-orange?logo=rust [crate-link]: https://crates.io/crates/monochange_semver [docs-image]: https://img.shields.io/badge/docs.rs-monochange__semver-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange_semver/ [coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg?flag=monochange_semver [coverage-link]: https://codecov.io/gh/ifiokjr/monochange?flag=monochange_semver
 
 <!-- {/crateBadgeLinks} -->
 
@@ -61,8 +61,6 @@ assert_eq!(direct, BumpSeverity::Minor);
 
 [ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
 [ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
-[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
-[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
 [license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
 [license-link]: https://opensource.org/license/unlicense
 

--- a/docs/plans/active/codecov-flags.md
+++ b/docs/plans/active/codecov-flags.md
@@ -1,0 +1,20 @@
+# Codecov per-crate flags
+
+## Goal
+
+Improve coverage visibility by uploading one Codecov flag per public crate while keeping the overall workspace upload.
+
+## Scope
+
+- generate one Codecov flag report per public crate
+- keep the existing overall workspace coverage upload
+- update crate README badges to point at each crate's own coverage flag
+- lower the Codecov patch coverage target from 100% to 95%
+
+## Checklist
+
+- [x] add a script to split workspace LCOV output into per-crate LCOV files
+- [x] update CI coverage jobs to upload the overall report plus one flag per public crate
+- [x] update Codecov config with crate flags and a 95% patch target
+- [x] update crate README badge links to use per-crate Codecov flags
+- [x] run docs regeneration and validate the new coverage flag split locally

--- a/packages/monochange__cli/README.md
+++ b/packages/monochange__cli/README.md
@@ -261,7 +261,7 @@ See `docs/` for user-facing guides and `CONTRIBUTING.md` for contribution expect
 
 <!-- {=crateBadgeLinks:"monochange"} -->
 
-[crate-image]: https://img.shields.io/badge/crates.io-monochange-orange?logo=rust [crate-link]: https://crates.io/crates/monochange [docs-image]: https://img.shields.io/badge/docs.rs-monochange-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange/
+[crate-image]: https://img.shields.io/badge/crates.io-monochange-orange?logo=rust [crate-link]: https://crates.io/crates/monochange [docs-image]: https://img.shields.io/badge/docs.rs-monochange-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange/ [coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg?flag=monochange [coverage-link]: https://codecov.io/gh/ifiokjr/monochange?flag=monochange
 
 <!-- {/crateBadgeLinks} -->
 
@@ -269,8 +269,6 @@ See `docs/` for user-facing guides and `CONTRIBUTING.md` for contribution expect
 
 [ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
 [ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
-[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
-[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
 [license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
 [license-link]: https://opensource.org/license/unlicense
 

--- a/readme.md
+++ b/readme.md
@@ -339,7 +339,7 @@ See `docs/` for user-facing guides and `CONTRIBUTING.md` for contribution expect
 
 <!-- {=crateBadgeLinks:"monochange"} -->
 
-[crate-image]: https://img.shields.io/badge/crates.io-monochange-orange?logo=rust [crate-link]: https://crates.io/crates/monochange [docs-image]: https://img.shields.io/badge/docs.rs-monochange-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange/
+[crate-image]: https://img.shields.io/badge/crates.io-monochange-orange?logo=rust [crate-link]: https://crates.io/crates/monochange [docs-image]: https://img.shields.io/badge/docs.rs-monochange-1f425f?logo=docs.rs [docs-link]: https://docs.rs/monochange/ [coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg?flag=monochange [coverage-link]: https://codecov.io/gh/ifiokjr/monochange?flag=monochange
 
 <!-- {/crateBadgeLinks} -->
 
@@ -347,8 +347,6 @@ See `docs/` for user-facing guides and `CONTRIBUTING.md` for contribution expect
 
 [ci-status-image]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml/badge.svg
 [ci-status-link]: https://github.com/ifiokjr/monochange/actions/workflows/ci.yml
-[coverage-image]: https://codecov.io/gh/ifiokjr/monochange/branch/main/graph/badge.svg
-[coverage-link]: https://codecov.io/gh/ifiokjr/monochange
 [license-image]: https://img.shields.io/badge/license-Unlicense-blue.svg
 [license-link]: https://opensource.org/license/unlicense
 

--- a/scripts/prepare-codecov-flags.mjs
+++ b/scripts/prepare-codecov-flags.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import path, { isAbsolute, relative, resolve } from "node:path";
+
+function parseArgs(argv) {
+	const options = {};
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const token = argv[index];
+		if (!token.startsWith("--")) {
+			continue;
+		}
+
+		const value = argv[index + 1];
+		if (value === undefined || value.startsWith("--")) {
+			continue;
+		}
+
+		options[token.slice(2)] = value;
+		index += 1;
+	}
+
+	return options;
+}
+
+function normalizeSourcePath(filePath, repoRoot) {
+	return isAbsolute(filePath) ? filePath : resolve(repoRoot, filePath);
+}
+
+function isSubpath(candidatePath, parentPath) {
+	const relativePath = relative(parentPath, candidatePath);
+	return relativePath === "" ||
+		(!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
+}
+
+function parsePublicCrates(repoRoot) {
+	const cratesRoot = resolve(repoRoot, "crates");
+
+	return readdirSync(cratesRoot, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => {
+			const directory = resolve(cratesRoot, entry.name);
+			const cargoToml = readFileSync(resolve(directory, "Cargo.toml"), "utf8");
+			const nameMatch = /^name\s*=\s*"([^"]+)"/mu.exec(cargoToml);
+			if (!nameMatch) {
+				throw new Error(
+					`unable to read package name from crates/${entry.name}/Cargo.toml`,
+				);
+			}
+
+			return {
+				name: nameMatch[1],
+				directory,
+				publish: !/^publish\s*=\s*false$/mu.test(cargoToml),
+			};
+		})
+		.filter((crateInfo) => crateInfo.publish)
+		.sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function parseLcovRecords(text, repoRoot) {
+	return text
+		.split(/^end_of_record$/mu)
+		.map((chunk) => chunk.trim())
+		.filter(Boolean)
+		.map((chunk) => {
+			const sourceLine = chunk
+				.split(/\r?\n/u)
+				.find((line) => line.startsWith("SF:"));
+			if (!sourceLine) {
+				throw new Error("encountered LCOV record without an SF line");
+			}
+
+			return {
+				sourcePath: normalizeSourcePath(sourceLine.slice(3), repoRoot),
+				text: `${chunk}\nend_of_record\n`,
+			};
+		});
+}
+
+function splitCoverageByCrate({ lcovText, repoRoot }) {
+	const publicCrates = parsePublicCrates(repoRoot);
+	const records = parseLcovRecords(lcovText, repoRoot);
+	const coverageByCrate = new Map(
+		publicCrates.map((crateInfo) => [crateInfo.name, []]),
+	);
+
+	for (const record of records) {
+		const crateInfo = publicCrates.find((candidate) =>
+			isSubpath(record.sourcePath, candidate.directory)
+		);
+		if (!crateInfo) {
+			continue;
+		}
+
+		coverageByCrate.get(crateInfo.name).push(record.text);
+	}
+
+	for (const crateInfo of publicCrates) {
+		if ((coverageByCrate.get(crateInfo.name) ?? []).length > 0) {
+			continue;
+		}
+
+		throw new Error(
+			`no LCOV coverage records matched public crate ${crateInfo.name}`,
+		);
+	}
+
+	return publicCrates.map((crateInfo) => ({
+		name: crateInfo.name,
+		records: coverageByCrate.get(crateInfo.name) ?? [],
+	}));
+}
+
+function writeFlagReports(crateReports, outDir) {
+	mkdirSync(outDir, { recursive: true });
+
+	for (const crateReport of crateReports) {
+		writeFileSync(
+			resolve(outDir, `${crateReport.name}.lcov`),
+			crateReport.records.join(""),
+		);
+	}
+}
+
+function writeGitHubOutput(crateReports, githubOutputPath) {
+	if (!githubOutputPath) {
+		return;
+	}
+
+	writeFileSync(
+		githubOutputPath,
+		`flags=${
+			JSON.stringify(crateReports.map((crateReport) => crateReport.name))
+		}\n`,
+		{ flag: "a" },
+	);
+}
+
+function main(argv = process.argv.slice(2)) {
+	const options = parseArgs(argv);
+	const repoRoot = options["repo-root"]
+		? resolve(options["repo-root"])
+		: process.cwd();
+	const lcovPath = options.lcov
+		? resolve(repoRoot, options.lcov)
+		: resolve(repoRoot, "target/coverage/lcov.info");
+	const outDir = options["out-dir"]
+		? resolve(repoRoot, options["out-dir"])
+		: resolve(repoRoot, "target/coverage/flags");
+
+	const lcovText = readFileSync(lcovPath, "utf8");
+	const crateReports = splitCoverageByCrate({ lcovText, repoRoot });
+	writeFlagReports(crateReports, outDir);
+	writeGitHubOutput(crateReports, options["github-output"]);
+
+	console.log(
+		`prepared ${crateReports.length} Codecov flag report(s) in ${outDir}`,
+	);
+	for (const crateReport of crateReports) {
+		console.log(`- ${crateReport.name}`);
+	}
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+	try {
+		main();
+	} catch (error) {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exitCode = 1;
+	}
+}


### PR DESCRIPTION
## Summary
- split workspace LCOV output into one Codecov flag upload per public crate while keeping the overall workspace coverage upload
- lower Codecov patch coverage status from 100% to 95%
- update crate coverage badges so each crate README points at its own Codecov flag page

## Testing
- node scripts/prepare-codecov-flags.mjs --lcov /tmp/monochange-codecov-flags-sample.lcov --out-dir /tmp/monochange-codecov-flags-out
- devenv shell -- docs:update
- devenv shell -- docs:check
- devenv shell -- lint:format
