### PR TITLE
feat: collapse benchmark comment sections

### DIFF
--- a/.changeset/benchmark-comment-collapsible-sections.md
+++ b/.changeset/benchmark-comment-collapsible-sections.md
@@ -1,0 +1,17 @@
+---
+monochange: patch
+---
+
+#### collapse benchmark CI comment sections for faster review
+
+`monochange` now wraps each benchmark fixture section in a GitHub `<details>` block so large benchmark comments are easier to scan.
+
+**Before:**
+
+- benchmark PR comments rendered every fixture table and phase timing table fully expanded
+- scrolling to later fixtures required paging through the entire earlier benchmark output
+
+**After:**
+
+- each benchmark fixture renders as a collapsed section with a summary line
+- reviewers can expand only the fixture tables they need while keeping the rest of the comment compact

--- a/.github/scripts/benchmark_cli.sh
+++ b/.github/scripts/benchmark_cli.sh
@@ -56,15 +56,16 @@ render_comment() {
 			shift 4
 
 			echo
-			echo "### ${scenario_name}"
-			echo
-			echo "Fixture: ${scenario_description}"
+			echo "<details>"
+			echo "<summary><strong>${scenario_name}</strong> — ${scenario_description}</summary>"
 			echo
 			cat "$table_path"
 			if [ -f "$phase_table_path" ] && [ -s "$phase_table_path" ]; then
 				echo
 				cat "$phase_table_path"
 			fi
+			echo
+			echo "</details>"
 		done
 	} >"$output_path"
 }

--- a/crates/monochange/tests/snapshots/benchmark_cli_comment__benchmark_cli_comment_renderer_matches_snapshot@benchmark_cli_comment_renderer_matches_snapshot.snap
+++ b/crates/monochange/tests/snapshots/benchmark_cli_comment__benchmark_cli_comment_renderer_matches_snapshot@benchmark_cli_comment_renderer_matches_snapshot.snap
@@ -13,9 +13,8 @@ Commands:
 - `mc release --dry-run`
 - `mc release`
 
-### Baseline fixture
-
-Fixture: 20 packages, 50 changesets, 50 commits
+<details>
+<summary><strong>Baseline fixture</strong> — 20 packages, 50 changesets, 50 commits</summary>
 
 | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
 |:---|---:|---:|---:|---:|
@@ -50,9 +49,10 @@ Fixture: 20 packages, 50 changesets, 50 commits
 | `apply release changes` | 160 | 58 | 63 | +5 | regressed |
 | `build manifest updates` | 80 | 18 | 20 | +2 | regressed |
 
-### Large history fixture
+</details>
 
-Fixture: 200 packages, 500 changesets, 500 commits
+<details>
+<summary><strong>Large history fixture</strong> — 200 packages, 500 changesets, 500 commits</summary>
 
 | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
 |:---|---:|---:|---:|---:|
@@ -86,3 +86,5 @@ Fixture: 200 packages, 500 changesets, 500 commits
 | `parse changeset files` | 320 | 186 | 201 | +15 | regressed |
 | `apply release changes` | 260 | 132 | 146 | +14 | regressed |
 | `build manifest updates` | 180 | 81 | 88 | +7 | regressed |
+
+</details>

--- a/crates/monochange/tests/snapshots/hosted_release_benchmarks__benchmark_cli_run_fixture_supports_hosted_fixture_metadata@benchmark_cli_run_fixture_supports_hosted_fixture_metadata.snap
+++ b/crates/monochange/tests/snapshots/hosted_release_benchmarks__benchmark_cli_run_fixture_supports_hosted_fixture_metadata@benchmark_cli_run_fixture_supports_hosted_fixture_metadata.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/monochange/tests/hosted_release_benchmarks.rs
+assertion_line: 323
 expression: rendered
 ---
 ## Binary Benchmark: main vs PR
@@ -12,9 +13,8 @@ Commands:
 - `mc release --dry-run`
 - `mc release`
 
-### Hosted GitHub fixture
-
-Fixture: 2 packages, local clone of the hosted fixture repo
+<details>
+<summary><strong>Hosted GitHub fixture</strong> — 2 packages, local clone of the hosted fixture repo</summary>
 
 | Command | Mean [ms] | Min [ms] | Max [ms] |
 |:---|---:|---:|---:|
@@ -42,3 +42,5 @@ Fixture: 2 packages, local clone of the hosted fixture repo
 |:---|---:|---:|---:|---:|:---|
 | `prepare release total` | n/a | 150 | 140 | -10 | improved |
 | `enrich changeset context via github` | n/a | 80 | 70 | -10 | improved |
+
+</details>


### PR DESCRIPTION
## Summary
- wrap each benchmark fixture section in the benchmark PR comment inside a GitHub `<details>` block
- keep the benchmark and phase timing tables intact while making long comments easier to scan
- update benchmark comment snapshots for both the generic and hosted fixture renderers

## Testing
- cargo test --package monochange --test benchmark_cli_comment benchmark_cli_comment_renderer_matches_snapshot -- --exact
- cargo test --package monochange --test hosted_release_benchmarks benchmark_cli_run_fixture_supports_hosted_fixture_metadata -- --exact
- devenv shell -- mc affected --format json --changed-paths .changeset/benchmark-comment-collapsible-sections.md --changed-paths .github/scripts/benchmark_cli.sh --changed-paths crates/monochange/tests/snapshots/benchmark_cli_comment__benchmark_cli_comment_renderer_matches_snapshot@benchmark_cli_comment_renderer_matches_snapshot.snap --changed-paths crates/monochange/tests/snapshots/hosted_release_benchmarks__benchmark_cli_run_fixture_supports_hosted_fixture_metadata@benchmark_cli_run_fixture_supports_hosted_fixture_metadata.snap
