### PR TITLE
feat: add visual status summary to benchmark CI comment sections

### DIFF
--- a/.changeset/benchmark-comment-collapsible-sections.md
+++ b/.changeset/benchmark-comment-collapsible-sections.md
@@ -2,16 +2,20 @@
 monochange: patch
 ---
 
-#### collapse benchmark CI comment sections for faster review
+#### add visual status summary to benchmark CI comment sections
 
-`monochange` now wraps each benchmark fixture section in a GitHub `<details>` block so large benchmark comments are easier to scan.
+`monochange` benchmark PR comments now show an at-a-glance status summary inside each collapsed `<details>` section, so reviewers can see improvements and regressions without expanding anything.
 
 **Before:**
 
 - benchmark PR comments rendered every fixture table and phase timing table fully expanded
 - scrolling to later fixtures required paging through the entire earlier benchmark output
+- when sections were collapsed, there was no way to tell if a fixture improved or regressed without expanding it
 
 **After:**
 
-- each benchmark fixture renders as a collapsed section with a summary line
+- each benchmark fixture renders as a collapsed section with a summary line showing emoji indicators
+- per-command status: 🟢 improved · 🔴 regressed · ⚪ flat (for hyperfine tables with relative data)
+- phase-level status: 🟢 phases improved · 🔴 phases regressed (for tables without relative comparison data)
+- 🚨 over budget shown when any phase exceeds its configured budget
 - reviewers can expand only the fixture tables they need while keeping the rest of the comment compact

--- a/.github/scripts/benchmark_cli.sh
+++ b/.github/scripts/benchmark_cli.sh
@@ -32,6 +32,128 @@ COMMAND_ARGS=(
 	"release"
 )
 
+summarize_scenario_status() {
+	local table_path="$1"
+	local phase_table_path="$2"
+
+	python3 - "$table_path" "$phase_table_path" <<'PY'
+import re
+import sys
+
+(
+    table_path,
+    phase_table_path,
+) = sys.argv[1:]
+
+IMPROVED = "\U0001f7e2"
+REGRESSED = "\U0001f534"
+FLAT = "\u26aa"
+
+
+def parse_hyperfine_table(path):
+    """Parse a hyperfine markdown table and return per-command status."""
+    results = []
+    try:
+        with open(path, encoding="utf-8") as handle:
+            lines = handle.readlines()
+    except OSError:
+        return results
+
+    has_relative = False
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("|") and line.startswith("| Com"):
+            if "Relative" in line:
+                has_relative = True
+            continue
+        if line.startswith("|:"):
+            continue
+        if not line.startswith("|"):
+            continue
+        cols = [c.strip() for c in line.split("|")]
+        cols = [c for c in cols if c]
+        if not cols:
+            continue
+        command = cols[0].strip("`").strip()
+        if not command:
+            continue
+        label = command
+        if has_relative and len(cols) >= 5:
+            relative_str = cols[-1]
+            relative_str = re.sub(r"\\u00b1.*", "", relative_str).strip()
+            relative_str = re.sub(r"\u00b1.*", "", relative_str).strip()
+            relative_str = re.sub(r"±.*", "", relative_str).strip()
+            try:
+                relative = float(relative_str)
+            except (ValueError, TypeError):
+                continue
+            if not label.startswith("main"):
+                if relative < 0.98:
+                    results.append((label, "improved", relative))
+                elif relative > 1.02:
+                    results.append((label, "regressed", relative))
+                else:
+                    results.append((label, "flat", relative))
+
+    return results, has_relative
+
+
+def parse_phase_status(path):
+    """Parse phase timing markdown and count statuses."""
+    counts = {"improved": 0, "regressed": 0, "flat": 0, "over budget": 0}
+    try:
+        with open(path, encoding="utf-8") as handle:
+            text = handle.read()
+    except OSError:
+        return counts
+
+    for line in text.splitlines():
+        line = line.strip()
+        if "| regressed |" in line:
+            counts["regressed"] += 1
+        elif "| improved |" in line:
+            counts["improved"] += 1
+        elif "| flat |" in line:
+            counts["flat"] += 1
+        elif "| over budget |" in line:
+            counts["over budget"] += 1
+    return counts
+
+
+short_names = {
+    "mc validate": "validate",
+    "mc discover --format json": "discover",
+    "mc release --dry-run": "dry-run",
+    "mc release": "release",
+}
+
+hyperfine, has_relative = parse_hyperfine_table(table_path)
+phases = parse_phase_status(phase_table_path)
+
+if not hyperfine and not any(v > 0 for v in phases.values()):
+    sys.exit(0)
+
+parts = []
+for _label, status, _relative in hyperfine:
+    short = _label
+    for full, abbr in short_names.items():
+        if full in _label:
+            short = abbr
+            break
+    icon = IMPROVED if status == "improved" else REGRESSED if status == "regressed" else FLAT
+    parts.append(f"{icon} {short}")
+
+if phases.get("improved", 0) > 0 and not has_relative:
+    parts.append(f"{IMPROVED} phases improved")
+if phases.get("regressed", 0) > 0 and not has_relative:
+    parts.append(f"{REGRESSED} phases regressed")
+if phases.get("over budget", 0) > 0:
+    parts.append("\U0001f6a8 over budget")
+
+print(" ".join(parts))
+PY
+}
+
 render_comment() {
 	local output_path="$1"
 	shift
@@ -55,9 +177,16 @@ render_comment() {
 			local phase_table_path="$4"
 			shift 4
 
+			local status_summary
+			status_summary="$(summarize_scenario_status "$table_path" "$phase_table_path")"
+
 			echo
 			echo "<details>"
-			echo "<summary><strong>${scenario_name}</strong> — ${scenario_description}</summary>"
+			if [ -n "$status_summary" ]; then
+				echo "<summary><strong>${scenario_name}</strong> — ${scenario_description} &nbsp; ${status_summary}</summary>"
+			else
+				echo "<summary><strong>${scenario_name}</strong> — ${scenario_description}</summary>"
+			fi
 			echo
 			cat "$table_path"
 			if [ -f "$phase_table_path" ] && [ -s "$phase_table_path" ]; then

--- a/crates/monochange/tests/snapshots/benchmark_cli_comment__benchmark_cli_comment_renderer_matches_snapshot@benchmark_cli_comment_renderer_matches_snapshot.snap
+++ b/crates/monochange/tests/snapshots/benchmark_cli_comment__benchmark_cli_comment_renderer_matches_snapshot@benchmark_cli_comment_renderer_matches_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/monochange/tests/benchmark_cli_comment.rs
-assertion_line: 48
 expression: rendered
 ---
 ## Binary Benchmark: main vs PR
@@ -14,7 +13,7 @@ Commands:
 - `mc release`
 
 <details>
-<summary><strong>Baseline fixture</strong> — 20 packages, 50 changesets, 50 commits</summary>
+<summary><strong>Baseline fixture</strong> — 20 packages, 50 changesets, 50 commits &nbsp; 🔴 validate 🟢 discover 🔴 dry-run 🔴 release</summary>
 
 | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
 |:---|---:|---:|---:|---:|
@@ -52,7 +51,7 @@ Commands:
 </details>
 
 <details>
-<summary><strong>Large history fixture</strong> — 200 packages, 500 changesets, 500 commits</summary>
+<summary><strong>Large history fixture</strong> — 200 packages, 500 changesets, 500 commits &nbsp; 🔴 validate 🟢 discover 🔴 dry-run 🔴 release</summary>
 
 | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
 |:---|---:|---:|---:|---:|

--- a/crates/monochange/tests/snapshots/hosted_release_benchmarks__benchmark_cli_run_fixture_supports_hosted_fixture_metadata@benchmark_cli_run_fixture_supports_hosted_fixture_metadata.snap
+++ b/crates/monochange/tests/snapshots/hosted_release_benchmarks__benchmark_cli_run_fixture_supports_hosted_fixture_metadata@benchmark_cli_run_fixture_supports_hosted_fixture_metadata.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/monochange/tests/hosted_release_benchmarks.rs
-assertion_line: 323
 expression: rendered
 ---
 ## Binary Benchmark: main vs PR
@@ -14,7 +13,7 @@ Commands:
 - `mc release`
 
 <details>
-<summary><strong>Hosted GitHub fixture</strong> — 2 packages, local clone of the hosted fixture repo</summary>
+<summary><strong>Hosted GitHub fixture</strong> — 2 packages, local clone of the hosted fixture repo &nbsp; 🟢 phases improved</summary>
 
 | Command | Mean [ms] | Min [ms] | Max [ms] |
 |:---|---:|---:|---:|


### PR DESCRIPTION
## Summary
- add per-command emoji status indicators (🟢 improved · 🔴 regressed · ⚪ flat) to `<summary>` tags in benchmark PR comments so reviewers can see results at a glance without expanding collapsed sections
- for tables without relative comparison data (e.g. hosted fixtures), show phase-level verdicts (🟢 phases improved · 🔴 phases regressed) instead, and surface 🚨 over budget when any phase exceeds its budget
- update both benchmark comment test snapshots to reflect the new summary lines

## Testing
- `cargo test --package monochange --test benchmark_cli_comment --test hosted_release_benchmarks -- benchmark_cli`
- `devenv shell -- mc validate`
- `devenv shell -- docs:check`
- `devenv shell -- lint:format`
