### PR TITLE
fix: upload codecov reports before failing patch coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-      pull-requests: write
     steps:
       - name: checkout repository
         uses: actions/checkout@v6
@@ -124,8 +123,7 @@ jobs:
         env:
           MONOCHANGE_PATCH_COVERAGE_BASE: ${{ github.event.pull_request.base.sha }}
           MONOCHANGE_PATCH_COVERAGE_HEAD: ${{ github.sha }}
-        run: |
-          coverage:patch | tee target/coverage/patch-coverage.txt
+        run: coverage:patch
         shell: devenv shell -- bash -e {0}
 
       - name: prepare codecov flag reports
@@ -136,34 +134,6 @@ jobs:
             --lcov target/coverage/lcov.info \
             --out-dir target/coverage/flags \
             --github-output "$GITHUB_OUTPUT"
-        shell: devenv shell -- bash -e {0}
-
-      - name: write patch coverage comment body
-        if: always() && github.event_name == 'pull_request'
-        run: |
-          {
-            echo '## Patch coverage'
-            echo
-            echo '```text'
-            if [ -f target/coverage/patch-coverage.txt ]; then
-              cat target/coverage/patch-coverage.txt
-            else
-              echo 'Patch coverage check was skipped.'
-            fi
-            echo '```'
-          } > /tmp/patch-coverage-comment.md
-        shell: devenv shell -- bash -e {0}
-
-      - name: publish patch coverage comment
-        if: always() && github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: patch-coverage
-          path: /tmp/patch-coverage-comment.md
-
-      - name: fail when patch coverage is below target
-        if: github.event_name == 'pull_request' && steps.verify-patch-coverage.outcome == 'failure'
-        run: exit 1
         shell: devenv shell -- bash -e {0}
 
       - name: upload codecov flag reports artifact
@@ -185,6 +155,11 @@ jobs:
           fail_ci_if_error: true
           name: monochange-rust-workspace
           verbose: true
+
+      - name: fail when patch coverage is below target
+        if: github.event_name == 'pull_request' && steps.verify-patch-coverage.outcome == 'failure'
+        run: exit 1
+        shell: devenv shell -- bash -e {0}
 
   coverage-flags:
     timeout-minutes: 30


### PR DESCRIPTION
## Summary

- remove the patch coverage PR comment from the coverage job
- keep patch coverage non-blocking until after codecov artifacts and uploads run
- fail the coverage job only after the codecov upload steps complete

## Testing

- not run (workflow-only change)