### PR TITLE
feat: default output format to markdown with termimad terminal rendering

### DIFF
--- a/.changeset/formatted-output.md
+++ b/.changeset/formatted-output.md
@@ -1,0 +1,5 @@
+---
+monochange: minor
+---
+
+feat: default output format to markdown with termimad terminal rendering

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  publish:
+  plan:
     environment: publisher
     permissions:
       actions: read
@@ -26,6 +26,10 @@ jobs:
       github.repository_owner == 'ifiokjr'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      tag: ${{ steps.release_tag.outputs.tag }}
+      has-batches: ${{ steps.publish_plan.outputs.has_batches }}
+      matrix: ${{ steps.publish_plan.outputs.matrix }}
     steps:
       - name: resolve release tag
         id: release_tag
@@ -51,6 +55,10 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: get crates oidc auth token
+        uses: rust-lang/crates-io-auth-action@v1
+        id: crates-oidc
+
       - name: download release assets
         if: startsWith( steps.release_tag.outputs.tag , 'v')
         env:
@@ -64,18 +72,7 @@ jobs:
             --pattern "monochange-*-${RELEASE_TAG}.zip" \
             --dir "$RUNNER_TEMP/release-assets"
 
-      - name: get crates oidc auth token
-        uses: rust-lang/crates-io-auth-action@v1
-        id: crates-oidc
-
-      - name: publish unreleased packages
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.crates-oidc.outputs.token }}
-        run: mc publish
-        shell: devenv shell -- bash -e {0}
-
       - name: populate cli npm packages with release binaries
-        if: startsWith( steps.release_tag.outputs.tag , 'v')
         env:
           RELEASE_TAG: ${{ steps.release_tag.outputs.tag }}
         run: |
@@ -85,10 +82,79 @@ jobs:
         shell: devenv shell -- bash -e {0}
 
       - name: publish cli npm packages
-        if: startsWith( steps.release_tag.outputs.tag , 'v')
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           node scripts/npm/publish-packages.mjs \
             --packages-dir packages
+        shell: devenv shell -- bash -e {0}
+
+      - name: plan publish batches
+        id: publish_plan
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-oidc.outputs.token }}
+        run: |
+          report="$(mc publish-plan --format json)"
+          echo "report<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$report" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          batch_count="$(echo "$report" | jq '.publishRateLimits.batches | length')"
+          if [ "$batch_count" -eq 0 ]; then
+            echo "has_batches=false" >> "$GITHUB_OUTPUT"
+            # Emit a valid placeholder matrix so GitHub Actions can parse the output.
+            # The publish job is skipped via the has-batches gate so this is never used.
+            echo "matrix={\"include\":[{\"registry\":\"none\",\"batch\":0,\"total_batches\":0,\"packages\":\"\",\"wait_seconds\":0}]}" >> "$GITHUB_OUTPUT"
+            echo "No packages to publish — all versions already exist on their registries."
+            exit 0
+          fi
+
+          echo "has_batches=true" >> "$GITHUB_OUTPUT"
+          matrix="$(echo "$report" | jq -c '{include: [.publishRateLimits.batches[] | {registry: (.registry | tostring), batch: .batchIndex, total_batches: .totalBatches, packages: (.packages | map("--package " + .) | join(" ")), wait_seconds: (.recommendedWaitSeconds // 0)}]}')"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+          echo "Publish plan:"
+          echo "$report" | jq '.publishRateLimits'
+
+  publish:
+    needs: plan
+    environment: publisher
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    if: >-
+      needs.plan.outputs.has-batches == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
+    name: publish ${{ matrix.registry }} (${{ matrix.batch }}/${{ matrix.total_batches }})
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.plan.outputs.tag }}
+
+      - name: setup
+        uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: get crates oidc auth token
+        if: matrix.registry == 'crates_io'
+        uses: rust-lang/crates-io-auth-action@v1
+        id: crates-oidc
+
+      - name: wait for rate-limit window
+        if: matrix.wait_seconds > 0
+        run: |
+          echo "Waiting ${{ matrix.wait_seconds }} seconds before publishing batch ${{ matrix.batch }}..."
+          sleep "${{ matrix.wait_seconds }}"
+
+      - name: publish batch ${{ matrix.batch }} of ${{ matrix.total_batches }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-oidc.outputs.token }}
+        run: mc publish ${{ matrix.packages }} --format json
         shell: devenv shell -- bash -e {0}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,6 +502,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "coolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
+dependencies = [
+ "crossterm",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +587,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "crokey"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a63daf06a168535c74ab97cdba3ed4fa5d4f32cb36e437dcceb83d66854b7c"
+dependencies = [
+ "crokey-proc_macros",
+ "crossterm",
+ "once_cell",
+ "serde",
+ "strict",
+]
+
+[[package]]
+name = "crokey-proc_macros"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847f11a14855fc490bd5d059821895c53e77eeb3c2b73ee3dded7ce77c93b231"
+dependencies = [
+ "crossterm",
+ "proc-macro2",
+ "quote",
+ "strict",
+ "syn",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +649,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1805,6 +1871,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy-regex"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,6 +2019,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimad"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8b688969b16915f3ecadc7829d5b7779dee4977e503f767f34136803d5c06f"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,6 +2082,7 @@ dependencies = [
  "similar-asserts",
  "temp-env",
  "tempfile",
+ "termimad",
  "thiserror 2.0.18",
  "tokio",
  "toml",
@@ -3945,6 +4044,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strict"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42444fea5b87a39db4218d9422087e66a85d0e7a0963a439b07bcdf91804006"
+
+[[package]]
 name = "stringmetrics"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4043,6 +4148,22 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termimad"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "889a9370996b74cf46016ce35b96c248a9ac36d69aab1d112b3e09bc33affa49"
+dependencies = [
+ "coolor",
+ "crokey",
+ "crossbeam",
+ "lazy-regex",
+ "minimad",
+ "serde",
+ "thiserror 2.0.18",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]

--- a/crates/monochange/Cargo.toml
+++ b/crates/monochange/Cargo.toml
@@ -56,6 +56,7 @@ serde_yaml_ng = { workspace = true, default-features = true }
 shlex = { workspace = true, default-features = true }
 similar = { workspace = true, default-features = true }
 tempfile = { workspace = true, default-features = true }
+termimad = "0.34"
 thiserror = { workspace = true, default-features = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"], default-features = true }
 toml = { workspace = true, default-features = true }

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -2143,7 +2143,7 @@ fn command_release_uses_empty_update_message_precedence_for_grouped_changelogs()
 	let group_changelog = fs::read_to_string(tempdir.path().join("changelog.md"))
 		.unwrap_or_else(|error| panic!("group changelog: {error}"));
 
-	assert!(output.contains("command `release` completed"));
+	assert!(output.contains("# `release`"));
 	assert!(core_changelog.contains("Package override for workflow-core -> 1.0.1"));
 	assert!(app_changelog.contains("Update triggered by group sdk; version 1.0.1."));
 	assert!(group_changelog.contains("Update triggered by group sdk; version 1.0.1."));
@@ -4830,7 +4830,7 @@ fn execute_cli_command_prepare_release_writes_default_manifest_cache_and_follow_
 		&configuration,
 		&prepare_release,
 		true,
-		BTreeMap::new(),
+		BTreeMap::from([("format".to_string(), vec!["text".to_string()])]),
 	)
 	.unwrap_or_else(|error| panic!("prepare release: {error}"));
 	assert!(render_output.contains("release manifest: .monochange/release-manifest.json"));
@@ -4860,7 +4860,7 @@ fn execute_cli_command_prepare_release_writes_default_manifest_cache_and_follow_
 		&configuration,
 		&publish_release,
 		true,
-		BTreeMap::new(),
+		BTreeMap::from([("format".to_string(), vec!["text".to_string()])]),
 	)
 	.unwrap_or_else(|error| panic!("publish release: {error}"));
 	assert!(publish_output.contains("releases:"));
@@ -4888,7 +4888,7 @@ fn execute_cli_command_prepare_release_writes_default_manifest_cache_and_follow_
 		&configuration,
 		&release_request,
 		true,
-		BTreeMap::new(),
+		BTreeMap::from([("format".to_string(), vec!["text".to_string()])]),
 	)
 	.unwrap_or_else(|error| panic!("open release request: {error}"));
 	assert!(request_output.contains("release request:"));
@@ -4949,7 +4949,7 @@ fn execute_cli_command_supports_placeholder_and_package_publish_steps() {
 				&configuration,
 				&placeholder_command,
 				true,
-				BTreeMap::new(),
+				BTreeMap::from([("format".to_string(), vec!["text".to_string()])]),
 			)
 			.unwrap_or_else(|error| panic!("placeholder publish: {error}"));
 			assert!(placeholder_output.contains("placeholder publishing:"));
@@ -4978,7 +4978,7 @@ fn execute_cli_command_supports_placeholder_and_package_publish_steps() {
 				&configuration,
 				&publish_command,
 				true,
-				BTreeMap::new(),
+				BTreeMap::from([("format".to_string(), vec!["text".to_string()])]),
 			)
 			.unwrap_or_else(|error| panic!("publish packages: {error}"));
 			assert!(publish_output.contains("package publishing:"));
@@ -5000,9 +5000,6 @@ fn execute_cli_command_supports_rate_limit_publish_steps_without_matching_packag
 		when.method(GET);
 		then.status(404);
 	});
-	let no_match_inputs =
-		BTreeMap::from([("package".to_string(), vec!["missing-package".to_string()])]);
-
 	temp_env::with_var(
 		"MONOCHANGE_CRATES_IO_API_URL",
 		Some(server.base_url()),
@@ -5022,7 +5019,10 @@ fn execute_cli_command_supports_rate_limit_publish_steps_without_matching_packag
 				&configuration,
 				&placeholder_command,
 				false,
-				no_match_inputs.clone(),
+				BTreeMap::from([
+					("format".to_string(), vec!["text".to_string()]),
+					("package".to_string(), vec!["missing-package".to_string()]),
+				]),
 			)
 			.unwrap_or_else(|error| panic!("non-dry-run placeholder publish: {error}"));
 			assert!(placeholder_output.contains("placeholder publishing:"));
@@ -5051,7 +5051,10 @@ fn execute_cli_command_supports_rate_limit_publish_steps_without_matching_packag
 				&configuration,
 				&publish_command,
 				false,
-				no_match_inputs.clone(),
+				BTreeMap::from([
+					("format".to_string(), vec!["text".to_string()]),
+					("package".to_string(), vec!["missing-package".to_string()]),
+				]),
 			)
 			.unwrap_or_else(|error| panic!("non-dry-run publish packages: {error}"));
 			assert!(publish_output.contains("package publishing:"));
@@ -8965,7 +8968,7 @@ fn subagent_parsing_helpers_cover_defaults_deduplication_and_errors() {
 	);
 	assert_eq!(
 		crate::parse_subagent_output_format_or_default(None),
-		crate::SubagentOutputFormat::Text
+		crate::SubagentOutputFormat::Markdown
 	);
 
 	let claude = String::from("claude");
@@ -9650,6 +9653,10 @@ fn parse_output_format_accepts_markdown_text_and_json_and_rejects_invalid_values
 		crate::OutputFormat::Markdown
 	);
 	assert_eq!(
+		crate::parse_output_format("md").unwrap(),
+		crate::OutputFormat::Markdown
+	);
+	assert_eq!(
 		crate::parse_output_format("text").unwrap(),
 		crate::OutputFormat::Text
 	);
@@ -9661,6 +9668,96 @@ fn parse_output_format_accepts_markdown_text_and_json_and_rejects_invalid_values
 		.err()
 		.unwrap_or_else(|| panic!("expected output format error"));
 	assert!(error.to_string().contains("unsupported output format"));
+}
+
+#[test]
+fn maybe_render_markdown_for_terminal_returns_original_when_not_tty() {
+	let markdown = "# Hello\n\n**bold** text";
+	let result = crate::maybe_render_markdown_for_terminal(markdown);
+	assert_eq!(result, markdown);
+}
+
+#[test]
+fn render_markdown_if_terminal_returns_styled_when_terminal() {
+	let markdown = "# Hello\n\n**bold** text";
+	let result = crate::render_markdown_if_terminal(markdown, true);
+	// termimad produces ANSI-styled output when terminal is true
+	assert!(result.contains("Hello"));
+	assert_ne!(result, markdown);
+}
+
+#[test]
+fn render_markdown_if_terminal_returns_original_when_not_terminal() {
+	let markdown = "# Hello\n\n**bold** text";
+	let result = crate::render_markdown_if_terminal(markdown, false);
+	assert_eq!(result, markdown);
+}
+
+#[test]
+fn detect_output_format_from_env_args_defaults_to_markdown() {
+	let args: Vec<String> = vec!["monochange".to_string()];
+	assert_eq!(
+		crate::detect_output_format_from_env_args(args.into_iter()),
+		crate::OutputFormat::Markdown
+	);
+}
+
+#[test]
+fn detect_output_format_from_env_args_parses_format_flag() {
+	let args: Vec<String> = vec![
+		"monochange".to_string(),
+		"--format".to_string(),
+		"json".to_string(),
+	];
+	assert_eq!(
+		crate::detect_output_format_from_env_args(args.into_iter()),
+		crate::OutputFormat::Json
+	);
+}
+
+#[test]
+fn detect_output_format_from_env_args_parses_format_equals() {
+	let args: Vec<String> = vec!["monochange".to_string(), "--format=md".to_string()];
+	assert_eq!(
+		crate::detect_output_format_from_env_args(args.into_iter()),
+		crate::OutputFormat::Markdown
+	);
+}
+
+#[test]
+fn detect_output_format_from_env_args_falls_back_to_markdown_for_invalid() {
+	let args: Vec<String> = vec![
+		"monochange".to_string(),
+		"--format".to_string(),
+		"invalid".to_string(),
+	];
+	assert_eq!(
+		crate::detect_output_format_from_env_args(args.into_iter()),
+		crate::OutputFormat::Markdown
+	);
+}
+
+#[test]
+fn parse_subagent_output_format_or_default_prefers_markdown() {
+	assert_eq!(
+		crate::parse_subagent_output_format_or_default(None),
+		crate::SubagentOutputFormat::Markdown
+	);
+	let json = String::from("json");
+	assert_eq!(
+		crate::parse_subagent_output_format_or_default(Some(&json)),
+		crate::SubagentOutputFormat::Json
+	);
+	let md = String::from("md");
+	assert_eq!(
+		crate::parse_subagent_output_format_or_default(Some(&md)),
+		crate::SubagentOutputFormat::Markdown
+	);
+	let text = String::from("text");
+	assert_eq!(
+		crate::parse_subagent_output_format_or_default(Some(&text)),
+		crate::SubagentOutputFormat::Text
+	);
 }
 
 #[test]

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -105,6 +105,11 @@ pub(crate) fn apply_runtime_prepare_release_markdown_defaults(cli: &mut [CliComm
 			format_input.choices.insert(0, "markdown".to_string());
 		}
 
+		let has_md = format_input.choices.iter().any(|choice| choice == "md");
+		if !has_md {
+			format_input.choices.push("md".to_string());
+		}
+
 		if format_input.default.as_deref() == Some("text") {
 			format_input.default = Some("markdown".to_string());
 		}
@@ -294,8 +299,8 @@ Use `--no-mcp` to skip MCP config files for targets that support repo-local MCP 
 			Arg::new("format")
 				.long("format")
 				.help("Output format for the generated subagent plan")
-				.default_value("text")
-				.value_parser(["text", "json"]),
+				.default_value("markdown")
+				.value_parser(["text", "json", "markdown", "md"]),
 		)
 		.arg(
 			Arg::new("no-mcp")
@@ -355,8 +360,8 @@ Analysis notes:
 		.arg(
 			Arg::new("format")
 				.long("format")
-				.default_value("text")
-				.value_parser(["text", "json"])
+				.default_value("markdown")
+				.value_parser(["text", "json", "markdown", "md"])
 				.help("Output format"),
 		)
 }
@@ -385,8 +390,8 @@ Inspection notes:
 			Arg::new("format")
 				.long("format")
 				.help("Output format")
-				.default_value("text")
-				.value_parser(["text", "json"]),
+				.default_value("markdown")
+				.value_parser(["text", "json", "markdown", "md"]),
 		)
 }
 
@@ -432,8 +437,8 @@ Tagging notes:
 			Arg::new("format")
 				.long("format")
 				.help("Output format")
-				.default_value("text")
-				.value_parser(["text", "json"]),
+				.default_value("markdown")
+				.value_parser(["text", "json", "markdown", "md"]),
 		)
 }
 
@@ -472,8 +477,8 @@ pub(crate) fn build_check_subcommand() -> Command {
 			Arg::new("format")
 				.long("format")
 				.help("Output format")
-				.default_value("text")
-				.value_parser(["text", "json"]),
+				.default_value("markdown")
+				.value_parser(["text", "json", "markdown", "md"]),
 		)
 }
 
@@ -489,8 +494,8 @@ pub(crate) fn build_lint_subcommand() -> Command {
 					Arg::new("format")
 						.long("format")
 						.help("Output format")
-						.default_value("text")
-						.value_parser(["text", "json"]),
+						.default_value("markdown")
+						.value_parser(["text", "json", "markdown", "md"]),
 				),
 		)
 		.subcommand(
@@ -505,8 +510,8 @@ pub(crate) fn build_lint_subcommand() -> Command {
 					Arg::new("format")
 						.long("format")
 						.help("Output format")
-						.default_value("text")
-						.value_parser(["text", "json"]),
+						.default_value("markdown")
+						.value_parser(["text", "json", "markdown", "md"]),
 				),
 		)
 		.subcommand(

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -557,7 +557,9 @@ pub(crate) fn execute_cli_command_with_options(
 					let format = step_inputs
 						.get("format")
 						.and_then(|values| values.first())
-						.map_or(Ok(OutputFormat::Text), |value| parse_output_format(value))?;
+						.map_or(Ok(OutputFormat::Markdown), |value| {
+							parse_output_format(value)
+						})?;
 					output = Some(render_discovery_report(&discover_workspace(root)?, format)?);
 					Ok(())
 				}
@@ -2817,14 +2819,16 @@ fn cli_command_output_format(
 	inputs
 		.get("format")
 		.and_then(|values| values.first())
-		.map_or(Ok(OutputFormat::Text), |value| parse_output_format(value))
+		.map_or(Ok(OutputFormat::Markdown), |value| {
+			parse_output_format(value)
+		})
 }
 
 #[must_use = "the output format result must be checked"]
 pub(crate) fn parse_output_format(value: &str) -> MonochangeResult<OutputFormat> {
 	match value {
 		"text" => Ok(OutputFormat::Text),
-		"markdown" => Ok(OutputFormat::Markdown),
+		"markdown" | "md" => Ok(OutputFormat::Markdown),
 		"json" => Ok(OutputFormat::Json),
 		other => {
 			Err(MonochangeError::Config(format!(
@@ -2832,6 +2836,23 @@ pub(crate) fn parse_output_format(value: &str) -> MonochangeResult<OutputFormat>
 			)))
 		}
 	}
+}
+
+/// Render raw markdown into terminal-styled text when stdout is a TTY.
+///
+/// When stdout is not an interactive terminal (e.g. piped to a file),
+/// the original markdown string is returned unchanged so that downstream
+/// consumers still receive valid markdown.
+pub(crate) fn render_markdown_if_terminal(markdown: &str, is_terminal: bool) -> String {
+	if is_terminal {
+		termimad::MadSkin::default().term_text(markdown).to_string()
+	} else {
+		markdown.to_string()
+	}
+}
+
+pub(crate) fn maybe_render_markdown_for_terminal(markdown: &str) -> String {
+	render_markdown_if_terminal(markdown, std::io::stdout().is_terminal())
 }
 
 #[must_use = "the change bump result must be checked"]
@@ -3088,7 +3109,9 @@ fn resolve_command_output(
 			.inputs
 			.get("format")
 			.and_then(|values| values.first())
-			.map_or(Ok(OutputFormat::Text), |value| parse_output_format(value))?;
+			.map_or(Ok(OutputFormat::Markdown), |value| {
+				parse_output_format(value)
+			})?;
 		let rendered = match format {
 			OutputFormat::Json => render_json_output(report, "changeset diagnostics")?,
 			OutputFormat::Markdown | OutputFormat::Text => render_changeset_diagnostics(report),

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -101,18 +101,20 @@ use cli_runtime::execute_matches;
 pub(crate) use cli_runtime::inferred_retarget_source_configuration;
 #[cfg(test)]
 pub(crate) use cli_runtime::lookup_template_value;
+pub(crate) use cli_runtime::maybe_render_markdown_for_terminal;
 #[cfg(test)]
 pub(crate) use cli_runtime::parse_boolean_step_input;
 #[cfg(test)]
 pub(crate) use cli_runtime::parse_change_bump;
 #[cfg(test)]
 pub(crate) use cli_runtime::parse_direct_template_reference;
-#[cfg(test)]
 pub(crate) use cli_runtime::parse_output_format;
 #[cfg(test)]
 pub(crate) use cli_runtime::render_cli_command_markdown_result;
 #[cfg(test)]
 pub(crate) use cli_runtime::render_cli_command_result;
+#[cfg(test)]
+pub(crate) use cli_runtime::render_markdown_if_terminal;
 #[cfg(test)]
 pub(crate) use cli_runtime::render_retarget_release_report;
 #[cfg(test)]
@@ -347,14 +349,16 @@ impl SubagentTarget {
 /// Output renderer for `mc subagents`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SubagentOutputFormat {
+	Markdown,
 	Text,
 	Json,
 }
 
 fn parse_subagent_output_format_or_default(value: Option<&String>) -> SubagentOutputFormat {
-	match value.map_or("text", String::as_str) {
+	match value.map_or("markdown", String::as_str) {
 		"json" => SubagentOutputFormat::Json,
-		_ => SubagentOutputFormat::Text,
+		"text" => SubagentOutputFormat::Text,
+		_ => SubagentOutputFormat::Markdown,
 	}
 }
 
@@ -610,9 +614,31 @@ pub fn run_from_env(bin_name: &'static str) -> MonochangeResult<()> {
 	let args = std::env::args_os();
 	let output = run_with_args(bin_name, args)?;
 	if !quiet && !output.is_empty() {
-		println!("{output}");
+		let format = detect_output_format_from_env_args(std::env::args());
+		if format == OutputFormat::Markdown {
+			println!("{}", maybe_render_markdown_for_terminal(&output));
+		} else {
+			println!("{output}");
+		}
 	}
 	Ok(())
+}
+
+pub(crate) fn detect_output_format_from_env_args(
+	args: impl Iterator<Item = String>,
+) -> OutputFormat {
+	let args: Vec<String> = args.collect();
+	for (i, arg) in args.iter().enumerate() {
+		if arg == "--format"
+			&& let Some(value) = args.get(i + 1)
+		{
+			return parse_output_format(value).unwrap_or(OutputFormat::Markdown);
+		}
+		if let Some(value) = arg.strip_prefix("--format=") {
+			return parse_output_format(value).unwrap_or(OutputFormat::Markdown);
+		}
+	}
+	OutputFormat::Markdown
 }
 
 fn extract_log_level_from_args() -> Option<String> {
@@ -771,14 +797,11 @@ where
 			let detection_level = analyze_matches
 				.get_one::<String>("detection-level")
 				.map_or("signature", String::as_str);
-			let format = if analyze_matches
+			let format = analyze_matches
 				.get_one::<String>("format")
-				.is_some_and(|value| value == "json")
-			{
-				OutputFormat::Json
-			} else {
-				OutputFormat::Text
-			};
+				.map_or(Ok(OutputFormat::Markdown), |value| {
+					parse_output_format(value)
+				})?;
 			render_analyze_report(
 				root,
 				package,
@@ -795,14 +818,11 @@ where
 				.get_one::<String>("from")
 				.map(String::as_str)
 				.ok_or_else(|| MonochangeError::Config("missing release-record ref".to_string()))?;
-			let format = if release_record_matches
+			let format = release_record_matches
 				.get_one::<String>("format")
-				.is_some_and(|value| value == "json")
-			{
-				OutputFormat::Json
-			} else {
-				OutputFormat::Text
-			};
+				.map_or(Ok(OutputFormat::Markdown), |value| {
+					parse_output_format(value)
+				})?;
 			render_release_record_discovery(root, from, format)
 		}
 		Some(("tag-release", tag_release_matches)) => {
@@ -810,14 +830,11 @@ where
 				.get_one::<String>("from")
 				.map(String::as_str)
 				.ok_or_else(|| MonochangeError::Config("missing tag-release ref".to_string()))?;
-			let format = if tag_release_matches
+			let format = tag_release_matches
 				.get_one::<String>("format")
-				.is_some_and(|value| value == "json")
-			{
-				OutputFormat::Json
-			} else {
-				OutputFormat::Text
-			};
+				.map_or(Ok(OutputFormat::Markdown), |value| {
+					parse_output_format(value)
+				})?;
 			let push = tag_release_matches
 				.get_one::<String>("push")
 				.is_none_or(|value| value == "true");
@@ -829,14 +846,11 @@ where
 				return Ok(String::new());
 			}
 			let fix = check_matches.get_flag("fix");
-			let format = if check_matches
+			let format = check_matches
 				.get_one::<String>("format")
-				.is_some_and(|value| value == "json")
-			{
-				OutputFormat::Json
-			} else {
-				OutputFormat::Text
-			};
+				.map_or(Ok(OutputFormat::Markdown), |value| {
+					parse_output_format(value)
+				})?;
 			let ecosystems: Vec<String> = check_matches
 				.get_many::<String>("ecosystem")
 				.map(|values| values.map(String::as_str).map(String::from).collect())

--- a/crates/monochange/src/lint.rs
+++ b/crates/monochange/src/lint.rs
@@ -257,26 +257,20 @@ pub(crate) fn handle_lint_subcommand(
 		.expect("clap requires a lint subcommand");
 
 	if subcommand == "list" {
-		let format = if subcommand_matches
+		let format = subcommand_matches
 			.get_one::<String>("format")
-			.is_some_and(|value| value == "json")
-		{
-			OutputFormat::Json
-		} else {
-			OutputFormat::Text
-		};
+			.map_or(Ok(OutputFormat::Markdown), |value| {
+				crate::parse_output_format(value)
+			})?;
 		return render_lint_catalog(format);
 	}
 
 	if subcommand == "explain" {
-		let format = if subcommand_matches
+		let format = subcommand_matches
 			.get_one::<String>("format")
-			.is_some_and(|value| value == "json")
-		{
-			OutputFormat::Json
-		} else {
-			OutputFormat::Text
-		};
+			.map_or(Ok(OutputFormat::Markdown), |value| {
+				crate::parse_output_format(value)
+			})?;
 		let id = subcommand_matches
 			.get_one::<String>("id")
 			.expect("clap requires a lint id")

--- a/crates/monochange/src/snapshots/monochange____tests__subagents_help_describes_supported_targets.snap
+++ b/crates/monochange/src/snapshots/monochange____tests__subagents_help_describes_supported_targets.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/monochange/src/__tests.rs
+assertion_line: 351
 expression: output
 ---
 Generate repo-local monochange subagents and agent guidance files
@@ -15,7 +16,7 @@ Options:
   -q, --quiet                     Suppress stdout/stderr output and run in dry-run mode when supported
       --dry-run                   Preview the generated files without writing them
       --progress-format <FORMAT>  Control progress output on stderr [possible values: auto, unicode, ascii, json]
-      --format <format>           Output format for the generated subagent plan [default: text] [possible values: text, json]
+      --format <format>           Output format for the generated subagent plan [default: markdown] [possible values: text, json, markdown, md]
       --no-mcp                    Skip repo-local MCP config files for supported targets
   -h, --help                      Print help
 

--- a/crates/monochange/src/subagents.rs
+++ b/crates/monochange/src/subagents.rs
@@ -63,7 +63,11 @@ pub(crate) fn run_subagents(root: &Path, options: &SubagentOptions) -> Monochang
 			serde_json::to_string_pretty(&plan)
 				.map_err(|error| MonochangeError::Config(error.to_string()))
 		}
-
+		SubagentOutputFormat::Markdown => {
+			Ok(crate::maybe_render_markdown_for_terminal(
+				&render_subagent_plan_text(&plan),
+			))
+		}
 		SubagentOutputFormat::Text => Ok(render_subagent_plan_text(&plan)),
 	}
 }

--- a/crates/monochange/tests/cli_progress.rs
+++ b/crates/monochange/tests/cli_progress.rs
@@ -206,7 +206,7 @@ fn release_progress_streams_named_steps_on_tty() {
 	assert!(transcript.contains("stream summary [stdout] streamed line 1"));
 	assert!(transcript.contains("stream summary [stdout] streamed line 2"));
 	assert!(transcript.contains("`progress-release` finished"));
-	assert!(transcript.contains("command `progress-release` completed"));
+	assert!(transcript.contains("Summary"));
 }
 
 #[test]

--- a/crates/monochange/tests/snapshots/cli_output__prepare_release_writes_manifest_json@prepare_release_writes_manifest_json.snap
+++ b/crates/monochange/tests/snapshots/cli_output__prepare_release_writes_manifest_json@prepare_release_writes_manifest_json.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/monochange/tests/cli_output.rs
-assertion_line: 255
+assertion_line: 462
 info:
   program: mc
   args:
@@ -14,18 +14,29 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-command `release` completed (dry-run)
-version: 1.1.0
-released packages: workflow-app, workflow-core
-release targets:
-- group sdk -> v1.1.0 (tag: true, release: true)
-release manifest: .monochange/release-manifest.json
-changed files:
-- Cargo.toml
-- changelog.md
-- crates/app/Cargo.toml
-- crates/core/CHANGELOG.md
-- crates/core/Cargo.toml
-- group.toml
+# `release` (dry-run)
+
+## Summary
+
+- **Version:** `1.1.0`
+- **Released packages:** `workflow-app`, `workflow-core`
+
+## Release targets
+
+- **group `sdk`** → `v1.1.0`
+  - tag: yes · release: yes
+
+## Release manifest
+
+- `.monochange/release-manifest.json`
+
+## Changed files
+
+- `Cargo.toml`
+- `changelog.md`
+- `crates/app/Cargo.toml`
+- `crates/core/CHANGELOG.md`
+- `crates/core/Cargo.toml`
+- `group.toml`
 
 ----- stderr -----

--- a/crates/monochange/tests/snapshots/cli_output__release_pr_workflow_reports_dry_run_pull_request_preview@release_pr_workflow_reports_dry_run_pull_request_preview.snap
+++ b/crates/monochange/tests/snapshots/cli_output__release_pr_workflow_reports_dry_run_pull_request_preview@release_pr_workflow_reports_dry_run_pull_request_preview.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/monochange/tests/cli_output.rs
-assertion_line: 240
+assertion_line: 447
 info:
   program: mc
   args:
@@ -14,20 +14,33 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-command `release-pr` completed (dry-run)
-version: 1.1.0
-released packages: workflow-app, workflow-core
-release targets:
-- group sdk -> v1.1.0 (tag: true, release: true)
-release manifest: .monochange/release-manifest.json
-release request:
+# `release-pr` (dry-run)
+
+## Summary
+
+- **Version:** `1.1.0`
+- **Released packages:** `workflow-app`, `workflow-core`
+
+## Release targets
+
+- **group `sdk`** → `v1.1.0`
+  - tag: yes · release: yes
+
+## Release manifest
+
+- `.monochange/release-manifest.json`
+
+## Release request
+
 - dry-run ifiokjr/monochange monochange/release/release-pr -> main via github
-changed files:
-- Cargo.toml
-- changelog.md
-- crates/app/Cargo.toml
-- crates/core/CHANGELOG.md
-- crates/core/Cargo.toml
-- group.toml
+
+## Changed files
+
+- `Cargo.toml`
+- `changelog.md`
+- `crates/app/Cargo.toml`
+- `crates/core/CHANGELOG.md`
+- `crates/core/Cargo.toml`
+- `group.toml`
 
 ----- stderr -----

--- a/monochange.toml
+++ b/monochange.toml
@@ -698,8 +698,9 @@ steps = [
 ]
 
 [cli.publish]
-help_text = "Publish all packages after a release"
-steps = [
-	{ type = "Command", command = "cargo workspaces publish --from-git --allow-dirty --yes", name = "publish cargo workspace crates" },
-	{ type = "Command", command = "pnpm -r publish --access public --no-git-checks", name = "publish npm packages" },
+help_text = "Publish packages from this release using built-in publishing workflows"
+inputs = [
+	{ name = "package", type = "string_list" },
+	{ name = "format", type = "choice", choices = ["text", "markdown", "json"], default = "text" },
 ]
+steps = [{ name = "publish packages", type = "PublishPackages" }]


### PR DESCRIPTION
- Add termimad dependency for rendering markdown in the terminal
- Change default output format from text to markdown across all commands
- Add --format md alias for --format markdown
- Integrate termimad rendering into run_from_env when stdout is a TTY
- Update SubagentOutputFormat to include Markdown variant
- Fix direct subcommands to properly parse all output formats
- Update tests and snapshots for new markdown defaults