### PR TITLE
fix: restore --help colors and unify CLI color palette

### DIFF
--- a/.changeset/cli-help-colors.md
+++ b/.changeset/cli-help-colors.md
@@ -1,0 +1,17 @@
+---
+"monochange": patch
+---
+
+Fix `--help` (`-h`) color output and unify CLI color palette.
+
+- `mc --help` now emits ANSI colors in terminal emulators, matching `mc help <command>` behavior
+- Extract shared `cli_theme` module so clap built-in help and custom `mc help` renderer use identical colors:
+  - bright cyan for headers and accents
+  - bright white for usage
+  - bright yellow for flags and literals
+  - bright magenta for placeholders
+  - bright green for valid/code snippets
+  - bright red for errors
+  - bright black (gray) for muted text
+- Explicitly opt in to `ColorChoice::Auto` on the `Command` builder
+- Preserve plain text output in test and CI modes so existing snapshots stay stable

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -10604,6 +10604,24 @@ fn cli_help_subcommand_overview_without_argument() {
 }
 
 #[test]
+fn format_clap_error_returns_plain_text_without_color() {
+	use clap::Command;
+	let cmd = Command::new("test").about("test cmd");
+	let err = cmd.try_get_matches_from(["test", "--help"]).unwrap_err();
+	let out = crate::format_clap_error(&err, false);
+	assert!(out.contains("Usage: test"));
+}
+
+#[test]
+fn format_clap_error_returns_empty_with_color() {
+	use clap::Command;
+	let cmd = Command::new("test").about("test cmd");
+	let err = cmd.try_get_matches_from(["test", "--help"]).unwrap_err();
+	let out = crate::format_clap_error(&err, true);
+	assert_eq!(out, String::new());
+}
+
+#[test]
 fn parse_remote_url_extracts_owner_repo_from_ssh_url() {
 	let result = crate::workspace_ops::parse_remote_url("git@github.com:ifiokjr/monochange.git");
 	let info = result.unwrap_or_else(|| panic!("expected RemoteInfo"));

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -2,11 +2,9 @@ use std::collections::BTreeSet;
 use std::path::Path;
 use std::path::PathBuf;
 
-use anstyle::AnsiColor;
-use anstyle::Color;
-use anstyle::Style;
 use clap::Arg;
 use clap::ArgAction;
+use clap::ColorChoice;
 use clap::Command;
 use monochange_config::load_workspace_configuration;
 use monochange_core::CliCommandDefinition;
@@ -127,25 +125,13 @@ pub(crate) fn build_command_for_root(bin_name: &'static str, root: &Path) -> Com
 /// Color theme for monochange CLI help output.
 fn monochange_styles() -> clap::builder::Styles {
 	clap::builder::Styles::styled()
-		.header(
-			Style::new()
-				.bold()
-				.fg_color(Some(Color::Ansi(AnsiColor::Cyan))),
-		)
-		.usage(
-			Style::new()
-				.bold()
-				.fg_color(Some(Color::Ansi(AnsiColor::White))),
-		)
-		.literal(Style::new().fg_color(Some(Color::Ansi(AnsiColor::Yellow))))
-		.placeholder(Style::new().fg_color(Some(Color::Ansi(AnsiColor::Magenta))))
-		.error(
-			Style::new()
-				.bold()
-				.fg_color(Some(Color::Ansi(AnsiColor::Red))),
-		)
-		.valid(Style::new().fg_color(Some(Color::Ansi(AnsiColor::Green))))
-		.invalid(Style::new().fg_color(Some(Color::Ansi(AnsiColor::Red))))
+		.header(crate::cli_theme::header())
+		.usage(crate::cli_theme::usage())
+		.literal(crate::cli_theme::literal())
+		.placeholder(crate::cli_theme::placeholder())
+		.error(crate::cli_theme::error())
+		.valid(crate::cli_theme::valid())
+		.invalid(crate::cli_theme::error())
 }
 
 pub(crate) fn build_command_with_cli(
@@ -156,6 +142,7 @@ pub(crate) fn build_command_with_cli(
 		Command::new(bin_name)
 			.about("Manage versions and releases for your multiplatform, multilanguage monorepo")
 			.styles(monochange_styles())
+			.color(ColorChoice::Auto)
 			.disable_help_subcommand(true)
 			.subcommand_required(true)
 			.arg_required_else_help(true)

--- a/crates/monochange/src/cli_help.rs
+++ b/crates/monochange/src/cli_help.rs
@@ -48,39 +48,35 @@ fn paint_impl(text: &str, style: anstyle::Style, enabled: bool) -> String {
 }
 
 // Shorthand style constructors using the monochange palette.
+// These delegate to `crate::cli_theme` so clap `--help` and
+// `mc help` share the exact same ANSI styles.
 
 fn accent() -> anstyle::Style {
-	anstyle::Style::new()
-		.fg_color(Some(anstyle::Color::Ansi(anstyle::AnsiColor::Cyan)))
-		.bold()
+	crate::cli_theme::header()
 }
 
 fn header() -> anstyle::Style {
-	anstyle::Style::new()
-		.fg_color(Some(anstyle::Color::Ansi(anstyle::AnsiColor::White)))
-		.bold()
+	crate::cli_theme::usage()
 }
 
 fn flag_style() -> anstyle::Style {
-	anstyle::Style::new().fg_color(Some(anstyle::Color::Ansi(anstyle::AnsiColor::Yellow)))
+	crate::cli_theme::literal()
 }
 
 fn value_style() -> anstyle::Style {
-	anstyle::Style::new().fg_color(Some(anstyle::Color::Ansi(anstyle::AnsiColor::Magenta)))
+	crate::cli_theme::placeholder()
 }
 
 fn muted() -> anstyle::Style {
-	anstyle::Style::new().fg_color(Some(anstyle::Color::Ansi(anstyle::AnsiColor::BrightBlack)))
+	crate::cli_theme::muted()
 }
 
 fn error_style() -> anstyle::Style {
-	anstyle::Style::new()
-		.fg_color(Some(anstyle::Color::Ansi(anstyle::AnsiColor::Red)))
-		.bold()
+	crate::cli_theme::error()
 }
 
 fn code_style() -> anstyle::Style {
-	anstyle::Style::new().fg_color(Some(anstyle::Color::Ansi(anstyle::AnsiColor::Green)))
+	crate::cli_theme::valid()
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/monochange/src/cli_theme.rs
+++ b/crates/monochange/src/cli_theme.rs
@@ -1,0 +1,44 @@
+use anstyle::AnsiColor;
+use anstyle::Color;
+use anstyle::Style;
+
+/// Cyan bold for headers, command names, and accent text.
+pub(crate) fn header() -> Style {
+	Style::new()
+		.bold()
+		.fg_color(Some(Color::Ansi(AnsiColor::BrightCyan)))
+}
+
+/// White bold for usage lines and bordered header text.
+pub(crate) fn usage() -> Style {
+	Style::new()
+		.bold()
+		.fg_color(Some(Color::Ansi(AnsiColor::BrightWhite)))
+}
+
+/// Yellow for CLI flags and literals.
+pub(crate) fn literal() -> Style {
+	Style::new().fg_color(Some(Color::Ansi(AnsiColor::BrightYellow)))
+}
+
+/// Magenta for placeholders and values.
+pub(crate) fn placeholder() -> Style {
+	Style::new().fg_color(Some(Color::Ansi(AnsiColor::BrightMagenta)))
+}
+
+/// Red bold for errors.
+pub(crate) fn error() -> Style {
+	Style::new()
+		.bold()
+		.fg_color(Some(Color::Ansi(AnsiColor::BrightRed)))
+}
+
+/// Green for valid states and code snippets.
+pub(crate) fn valid() -> Style {
+	Style::new().fg_color(Some(Color::Ansi(AnsiColor::BrightGreen)))
+}
+
+/// Bright black (gray) for muted secondary text.
+pub(crate) fn muted() -> Style {
+	Style::new().fg_color(Some(Color::Ansi(AnsiColor::BrightBlack)))
+}

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -46,6 +46,7 @@ use std::collections::BTreeSet;
 use std::ffi::OsString;
 use std::fs;
 use std::future::Future;
+use std::io::IsTerminal;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command as ProcessCommand;
@@ -262,6 +263,7 @@ mod cli;
 mod cli_help;
 mod cli_progress;
 mod cli_runtime;
+mod cli_theme;
 mod git_support;
 mod hosted_sources;
 mod interactive;
@@ -690,6 +692,17 @@ where
 /// Execute the `monochange` CLI against an explicit repository root.
 ///
 /// This is primarily useful for tests and embedding, where the caller wants to
+/// Print a clap `DisplayHelp`/`DisplayVersion` error preserving ANSI colors
+/// when `colored` is true, or return plain text when false.
+fn format_clap_error(error: &clap::Error, colored: bool) -> String {
+	if colored {
+		let _ = error.print();
+		String::new()
+	} else {
+		error.to_string()
+	}
+}
+
 /// control both the argv payload and the workspace root used for config loading
 /// and command execution.
 #[doc(hidden)]
@@ -713,7 +726,10 @@ where
 				ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
 			) =>
 		{
-			return Ok(error.to_string());
+			return Ok(format_clap_error(
+				&error,
+				!cfg!(test) && std::io::stdout().is_terminal(),
+			));
 		}
 		Err(error) => return Err(MonochangeError::Config(error.to_string())),
 	};


### PR DESCRIPTION
Fixes the <!-- issue --> where `mc -h` shows no ANSI colors.

**What changed**

- `lib.rs`: When stdout is a real terminal, print clap's `DisplayHelp` error directly via `error.print()` instead of flattening it with `error.to_string()` (which strips all ANSI codes). In tests or piped mode, plain text is still returned so existing snapshots/assertions remain stable.
- `cli.rs`: Explicitly set `ColorChoice::Auto` on the `Command` builder.
- New `cli_theme.rs`: Shared color module so clap built-in `--help` and `mc help <cmd\u003e` use the **exact same ANSI styles**:
  - bright cyan for headers/accent
  - bright white for usage
  - bright yellow for flags/literals
  - bright magenta for placeholders
  - bright red for errors
  - bright green for valid/code
  - bright black (gray) for muted text
- `cli_help.rs`: Style constructors now delegate to `crate::cli_theme` instead of defining their own colors.

**Before / After**

`mc -h` (clap built-in help) now emits the same bright ANSI colors as `mc help change` (custom renderer), and both respect `NO_COLOR` + TTY detection.

**Testing**

- All 669+ `monochange` unit tests pass
- `cargo clippy -p monochange` clean
- Snapshots remain unchanged because output is only colored in terminal mode (`!cfg!(test) && is_terminal()`)