### PR TITLE
feat: complete PR slash-command release flow (followup)

### DIFF
--- a/crates/monochange/src/git_support.rs
+++ b/crates/monochange/src/git_support.rs
@@ -195,6 +195,30 @@ pub(crate) fn git_stage_paths(root: &Path, tracked_paths: &[PathBuf]) -> Monocha
 	)
 }
 
+pub(crate) fn run_git_fetch_origin(root: &Path, branch: &str) -> MonochangeResult<()> {
+	let args: Vec<String> = vec![
+		"fetch".to_string(),
+		"origin".to_string(),
+		branch.to_string(),
+	];
+	let output = git_command_output(root, &args.iter().map(String::as_str).collect::<Vec<_>>())
+		.map_err(|error| {
+			MonochangeError::Discovery(format!(
+				"failed to fetch origin/{branch} to resolve merge commit: {error}"
+			))
+		})?;
+
+	if !output.status.success() {
+		let stderr = git_stderr_trimmed(&output);
+		tracing::warn!(%branch, %stderr, "git fetch origin failed");
+		return Err(MonochangeError::Discovery(format!(
+			"git fetch origin/{branch} failed: {stderr}"
+		)));
+	}
+
+	Ok(())
+}
+
 fn resolve_stageable_release_paths(
 	root: &Path,
 	tracked_paths: &[PathBuf],

--- a/crates/monochange/src/release_record.rs
+++ b/crates/monochange/src/release_record.rs
@@ -32,6 +32,7 @@ use crate::git_support::push_git_tags_without_force;
 use crate::git_support::read_git_commit_message;
 use crate::git_support::resolve_git_commit_ref;
 use crate::git_support::resolve_git_tag_commit;
+use crate::git_support::run_git_fetch_origin;
 use crate::hosted_sources;
 
 pub(crate) fn render_release_record_discovery(
@@ -600,13 +601,24 @@ pub(crate) fn render_merge_release_pr_report(
 		Some(adapter.merge_release_pull_request(source, &request)?)
 	};
 
+	let mut tag_count = None;
+	if let Some(ref merge) = merge_outcome {
+		if let Some(ref sha) = merge.merge_commit_sha {
+			// Fetch the base branch so the merge commit is available locally
+			let _ = run_git_fetch_origin(root, &source.pull_requests.base);
+			let discovery = discover_release_record(root, sha)?;
+			let tag_report = create_release_tags(root, &discovery, true, dry_run)?;
+			tag_count = Some(tag_report.tag_results.len());
+		}
+	}
+
 	let report = MergeReleasePrReport {
 		pr_number,
 		repository: request.repository,
 		dry_run,
 		authorization,
 		merge_outcome,
-		tag_count: None,
+		tag_count,
 		release_outcomes: None,
 		status: if dry_run {
 			"dry_run".to_string()

--- a/crates/monochange_gitea/src/lib.rs
+++ b/crates/monochange_gitea/src/lib.rs
@@ -34,6 +34,10 @@ use std::thread;
 
 use monochange_core::CommitMessage;
 use monochange_core::HostedSourceAdapter;
+use monochange_core::MergeReleasePullRequestOperation;
+use monochange_core::MergeReleasePullRequestOutcome;
+use monochange_core::MergeReleasePullRequestRequest;
+use monochange_core::SlashCommandAuthorizationResult;
 use monochange_core::HostedSourceFeatures;
 use monochange_core::HostingCapabilities;
 use monochange_core::HostingProviderKind;
@@ -695,3 +699,81 @@ fn auth_headers(token: &str) -> MonochangeResult<HeaderMap> {
 
 #[cfg(test)]
 mod __tests;
+
+fn authorize_slash_command_release(
+	source: &SourceConfiguration,
+	author: &str,
+) -> MonochangeResult<SlashCommandAuthorizationResult> {
+	let settings = &source.pull_requests.slash_commands;
+	if !settings.enabled {
+		return Ok(SlashCommandAuthorizationResult::Denied);
+	}
+
+	let config = &settings.authorization;
+	if config.allowed_users.iter().any(|u| u == author) {
+		return Ok(SlashCommandAuthorizationResult::Authorized);
+	}
+	if !config.allowed_users.is_empty() {
+		return Ok(SlashCommandAuthorizationResult::Denied);
+	}
+
+	let client = build_http_client("Gitea")?;
+	let api_base = gitea_api_base(source)?;
+	let token = gitea_token()?;
+	let headers = auth_headers(&token)?;
+	let url = format!(
+		"{api_base}/repos/{}/{}/collaborators/{}/permission",
+		encode(&source.owner),
+		encode(&source.repo),
+		encode(author),
+	);
+
+	if config.allow_admins {
+		let result: serde_json::Value = get_json(&client, &headers, &url, "Gitea")?;
+		if result.get("permission").and_then(|p| p.as_str()) == Some("admin") {
+			return Ok(SlashCommandAuthorizationResult::Authorized);
+		}
+	}
+
+	Ok(SlashCommandAuthorizationResult::Denied)
+}
+
+fn merge_release_pull_request(
+	source: &SourceConfiguration,
+	request: &MergeReleasePullRequestRequest,
+) -> MonochangeResult<MergeReleasePullRequestOutcome> {
+	let client = build_http_client("Gitea")?;
+	let api_base = gitea_api_base(source)?;
+	let token = gitea_token()?;
+	let headers = auth_headers(&token)?;
+	let url = format!(
+		"{api_base}/repos/{}/{}/pulls/{}/merge",
+		encode(&request.owner),
+		encode(&request.repo),
+		request.pr_number,
+	);
+
+	let body = serde_json::json!({
+		"Do": "squash",
+		"title": request.commit_message.subject,
+		"message": request.commit_message.body.clone().unwrap_or_default(),
+	});
+
+	let response: serde_json::Value = post_json(
+		&client, &headers, &url, &body, "Gitea")?;
+
+	Ok(MergeReleasePullRequestOutcome {
+		provider: SourceProvider::Gitea,
+		repository: request.repository.clone(),
+		pr_number: request.pr_number,
+		merge_commit_sha: response
+			.get("sha")
+			.and_then(|s| s.as_str())
+			.map(String::from),
+		url: response
+			.get("html_url")
+			.and_then(|s| s.as_str())
+			.map(String::from),
+		operation: MergeReleasePullRequestOperation::Merged,
+	})
+}

--- a/crates/monochange_github/src/__tests.rs
+++ b/crates/monochange_github/src/__tests.rs
@@ -19,6 +19,9 @@ use monochange_core::HostedIssueRelationshipKind;
 use monochange_core::HostedSourceAdapter;
 use monochange_core::HostingCapabilities;
 use monochange_core::HostingProviderKind;
+use monochange_core::MergeReleasePullRequestOperation;
+use monochange_core::MergeReleasePullRequestOutcome;
+use monochange_core::MergeReleasePullRequestRequest;
 use monochange_core::MonochangeError;
 use monochange_core::MonochangeResult;
 use monochange_core::PreparedChangeset;
@@ -33,6 +36,7 @@ use monochange_core::ReleaseManifestTarget;
 use monochange_core::ReleaseNotesDocument;
 use monochange_core::ReleaseNotesSection;
 use monochange_core::ReleaseOwnerKind;
+use monochange_core::SlashCommandAuthorizationResult;
 use monochange_core::RetargetOperation;
 use monochange_core::RetargetProviderOperation;
 use monochange_core::RetargetTagResult;
@@ -2017,3 +2021,98 @@ fn seed_git_repository() -> (tempfile::TempDir, PathBuf) {
 		.unwrap_or_else(|error| panic!("update release file: {error}"));
 	(tempdir, repo)
 }
+
+
+#[test]
+fn authorize_slash_command_release_explicit_allow_list_authorized() {
+	let source = SourceConfiguration {
+		provider: SourceProvider::GitHub,
+		host: None,
+		api_url: None,
+		owner: "ifiokjr".to_string(),
+		repo: "monochange".to_string(),
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings {
+			slash_commands: monochange_core::ProviderSlashCommandSettings {
+				enabled: true,
+				authorization: monochange_core::SlashCommandAuthorizationSettings {
+					allow_admins: false,
+					allowed_users: vec!["trusted_user".to_string()],
+					allowed_teams: Vec::new(),
+				},
+			},
+			..ProviderMergeRequestSettings::default()
+		},
+		bot: ProviderBotSettings::default(),
+	};
+
+	let result = authorize_slash_command_release(&source, "trusted_user"
+	);
+	assert_eq!(result.unwrap(), SlashCommandAuthorizationResult::Authorized);
+}
+
+#[test]
+fn authorize_slash_command_release_explicit_allow_list_denied() {
+	let source = SourceConfiguration {
+		provider: SourceProvider::GitHub,
+		host: None,
+		api_url: None,
+		owner: "ifiokjr".to_string(),
+		repo: "monochange".to_string(),
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings {
+			slash_commands: monochange_core::ProviderSlashCommandSettings {
+				enabled: true,
+				authorization: monochange_core::SlashCommandAuthorizationSettings {
+					allow_admins: false,
+					allowed_users: vec!["trusted_user".to_string()],
+					allowed_teams: Vec::new(),
+				},
+			},
+			..ProviderMergeRequestSettings::default()
+		},
+		bot: ProviderBotSettings::default(),
+	};
+
+	let result = authorize_slash_command_release(&source, "untrusted_user"
+	);
+	assert_eq!(result.unwrap(), SlashCommandAuthorizationResult::Denied);
+}
+
+#[test]
+fn authorize_slash_command_release_disabled_returns_denied() {
+	let source = SourceConfiguration {
+		provider: SourceProvider::GitHub,
+		host: None,
+		api_url: None,
+		owner: "ifiokjr".to_string(),
+		repo: "monochange".to_string(),
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings {
+			slash_commands: monochange_core::ProviderSlashCommandSettings {
+				enabled: false,
+				authorization: monochange_core::SlashCommandAuthorizationSettings {
+					allow_admins: true,
+					allowed_users: Vec::new(),
+					allowed_teams: Vec::new(),
+				},
+			},
+			..ProviderMergeRequestSettings::default()
+		},
+		bot: ProviderBotSettings::default(),
+	};
+
+	let result = authorize_slash_command_release(&source, "anyone"
+	);
+	assert_eq!(result.unwrap(), SlashCommandAuthorizationResult::Denied);
+}
+
+// NOTE: API-level tests for authorize_slash_command_release and
+// merge_release_pull_request require a running GitHub mock server that
+// octocrab can talk to. These are better suited as integration tests.
+
+// #[test]
+// fn authorize_slash_command_release_admin_check_uses_api() { ... }
+
+// #[test]
+// fn merge_release_pull_request_calls_correct_endpoint() { ... }

--- a/crates/monochange_gitlab/src/lib.rs
+++ b/crates/monochange_gitlab/src/lib.rs
@@ -28,12 +28,17 @@
 //! <!-- {/monochangeGitlabCrateDocs} -->
 
 use std::env;
+
 use std::path::Path;
 use std::path::PathBuf;
 use std::thread;
 
 use monochange_core::CommitMessage;
 use monochange_core::HostedSourceAdapter;
+use monochange_core::MergeReleasePullRequestOperation;
+use monochange_core::MergeReleasePullRequestOutcome;
+use monochange_core::MergeReleasePullRequestRequest;
+use monochange_core::SlashCommandAuthorizationResult;
 use monochange_core::HostedSourceFeatures;
 use monochange_core::HostingCapabilities;
 use monochange_core::HostingProviderKind;
@@ -119,6 +124,22 @@ impl HostedSourceAdapter for GitLabHostedSourceAdapter {
 		changesets: &mut [PreparedChangeset],
 	) {
 		enrich_changeset_context(source, changesets);
+	}
+
+	fn authorize_slash_command_release(
+		&self,
+		source: &SourceConfiguration,
+		author: &str,
+	) -> MonochangeResult<SlashCommandAuthorizationResult> {
+		authorize_slash_command_release(source, author)
+	}
+
+	fn merge_release_pull_request(
+		&self,
+		source: &SourceConfiguration,
+		request: &MergeReleasePullRequestRequest,
+	) -> MonochangeResult<MergeReleasePullRequestOutcome> {
+		merge_release_pull_request(source, request)
 	}
 }
 
@@ -669,3 +690,80 @@ fn auth_headers(token: &str) -> MonochangeResult<HeaderMap> {
 
 #[cfg(test)]
 mod __tests;
+
+fn authorize_slash_command_release(
+	source: &SourceConfiguration,
+	author: &str,
+) -> MonochangeResult<SlashCommandAuthorizationResult> {
+	let settings = &source.pull_requests.slash_commands;
+	if !settings.enabled {
+		return Ok(SlashCommandAuthorizationResult::Denied);
+	}
+
+	let config = &settings.authorization;
+	if config.allowed_users.iter().any(|u| u == author) {
+		return Ok(SlashCommandAuthorizationResult::Authorized);
+	}
+	if !config.allowed_users.is_empty() {
+		return Ok(SlashCommandAuthorizationResult::Denied);
+	}
+
+	let client = build_http_client("GitLab")?;
+	let api_base = gitlab_api_base(source)?;
+	let token = gitlab_token()?;
+	let headers = auth_headers(&token)?;
+	let project_id = encode(&format!("{}/{}", source.owner, source.repo)).into_owned();
+
+	if config.allow_admins {
+		let url = format!(
+			"{api_base}/projects/{project_id}/members?query={}",
+			encode(author),
+		);
+		let members: Vec<serde_json::Value> = get_json(&client, &headers, &url, "GitLab")?;
+		if members.iter().any(|m| {
+			m.get("username").and_then(|u| u.as_str()) == Some(author)
+				&& m.get("access_level").and_then(|l| l.as_u64()).unwrap_or(0) >= 40
+		}) {
+			return Ok(SlashCommandAuthorizationResult::Authorized);
+		}
+	}
+
+	Ok(SlashCommandAuthorizationResult::Denied)
+}
+
+fn merge_release_pull_request(
+	source: &SourceConfiguration,
+	request: &MergeReleasePullRequestRequest,
+) -> MonochangeResult<MergeReleasePullRequestOutcome> {
+	let client = build_http_client("GitLab")?;
+	let api_base = gitlab_api_base(source)?;
+	let token = gitlab_token()?;
+	let headers = auth_headers(&token)?;
+	let project_id = encode(&format!("{}/{}", request.owner, request.repo)).into_owned();
+	let url = format!(
+		"{api_base}/projects/{project_id}/merge_requests/{}/merge",
+		request.pr_number,
+	);
+
+	let body = serde_json::json!({
+		"squash": true,
+		"squash_commit_message": request.commit_message.subject,
+	});
+
+	let response: serde_json::Value = put_json(&client, &headers, &url, &body, "GitLab")?;
+
+	Ok(MergeReleasePullRequestOutcome {
+		provider: SourceProvider::GitLab,
+		repository: request.repository.clone(),
+		pr_number: request.pr_number,
+		merge_commit_sha: response
+			.get("merge_commit_sha")
+			.and_then(|s| s.as_str())
+			.map(String::from),
+		url: response
+			.get("web_url")
+			.and_then(|s| s.as_str())
+			.map(String::from),
+		operation: MergeReleasePullRequestOperation::Merged,
+	})
+}


### PR DESCRIPTION
## Summary
Implements the remaining pieces for the `/release` slash-command release flow.

## Previous PR
- #269 has the foundation (core types, GitHub adapter, CI workflows)

## What's new in this followup

### GitLab adapter (`monochange_gitlab`)
- `authorize_slash_command_release` — checks maintainer access level >= 40 via GitLab API (`GET /projects/:id/members`)
- `merge_release_pull_request` — squash-merges MR via `PUT /projects/:id/merge_requests/:iid/merge` with `squash=true`

### Gitea adapter (`monochange_gitea`)
- `authorize_slash_command_release` — checks admin permission via `GET /repos/:owner/:repo/collaborators/:username/permission`
- `merge_release_pull_request` — squash-merges PR via `POST /repos/:owner/:repo/pulls/:index/merge` with `{"Do": "squash"}`

### Completed orchestration (`release_record.rs`)
- After successful merge: `git fetch origin <base>` so merge commit is locally discoverable
- `discover_release_record` from the merge commit SHA
- `create_release_tags` to create and push release tags
- `tag_count` now populated in `MergeReleasePrReport`

### GitHub adapter tests
- `authorize_slash_command_release_explicit_allow_list_authorized`
- `authorize_slash_command_release_explicit_allow_list_denied`
- `authorize_slash_command_release_disabled_returns_denied`

## Validation
- `cargo check --all` ✅
- `cargo test --all --lib` ✅ (all lib tests pass)
