### PR TITLE
docs: add PublishPackages and PlaceholderPublish CLI step reference

### DIFF
--- a/.templates/cli-steps.t.md
+++ b/.templates/cli-steps.t.md
@@ -24,20 +24,24 @@ The reference pages in this section document each built-in step with:
 
 <!-- {@cliStepReferenceChoosingGuide} -->
 
-| Step                    | Use it when you want to…                                                 | Requires previous step?          | Typical follow-up                                                                           |
-| ----------------------- | ------------------------------------------------------------------------ | -------------------------------- | ------------------------------------------------------------------------------------------- |
-| `Validate`              | fail fast on invalid config, groups, or changesets                       | no                               | CI gate or local preflight                                                                  |
-| `Discover`              | inspect normalized package discovery across ecosystems                   | no                               | local inspection, debug commands                                                            |
-| `CreateChangeFile`      | author a `.changeset/*.md` file from CLI inputs                          | no                               | run independently, or before planning                                                       |
-| `PrepareRelease`        | build the release result, update files, and refresh the cached manifest  | no                               | `CommitRelease`, `PublishRelease`, `OpenReleaseRequest`, `CommentReleasedIssues`, `Command` |
-| `CommitRelease`         | create a local release commit with an embedded `ReleaseRecord`           | `PrepareRelease`                 | `OpenReleaseRequest`, manual review, custom `Command`                                       |
-| `PublishRelease`        | create or update hosted provider releases                                | `PrepareRelease` + `[source]`    | `CommentReleasedIssues`, custom notification commands                                       |
-| `OpenReleaseRequest`    | create or update a hosted release PR/MR                                  | `PrepareRelease` + `[source]`    | provider review, follow-up `Command` steps                                                  |
-| `CommentReleasedIssues` | post release follow-up comments to closed issues                         | `PrepareRelease` + GitHub source | normally after `PublishRelease`                                                             |
-| `AffectedPackages`      | evaluate changeset coverage for changed files                            | no                               | CI enforcement, custom failure messaging                                                    |
-| `DiagnoseChangesets`    | inspect changeset context, commit provenance, and linked review metadata | no                               | local debugging, CI inspection                                                              |
-| `RetargetRelease`       | repair a recent release by moving its tag set                            | no                               | custom `Command` steps using `retarget.*`                                                   |
-| `Command`               | run arbitrary shell/program commands with monochange context             | depends on your workflow         | any external tool                                                                           |
+| Step                    | Use it when you want to…                                                  | Requires previous step?          | Typical follow-up                                                                           |
+| ----------------------- | ------------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------- |
+| `Validate`              | fail fast on invalid config, groups, or changesets                        | no                               | CI gate or local preflight                                                                  |
+| `Discover`              | inspect normalized package discovery across ecosystems                    | no                               | local inspection, debug commands                                                            |
+| `CreateChangeFile`      | author a `.changeset/*.md` file from CLI inputs                           | no                               | run independently, or before planning                                                       |
+| `PrepareRelease`        | build the release result, update files, and refresh the cached manifest   | no                               | `CommitRelease`, `PublishRelease`, `OpenReleaseRequest`, `CommentReleasedIssues`, `Command` |
+| `DisplayVersions`       | display planned package and group versions without mutating release files | no                               | `PrepareRelease`                                                                            |
+| `CommitRelease`         | create a local release commit with an embedded `ReleaseRecord`            | `PrepareRelease`                 | `OpenReleaseRequest`, manual review, custom `Command`                                       |
+| `PublishRelease`        | create or update hosted provider releases                                 | `PrepareRelease` + `[source]`    | `CommentReleasedIssues`, custom notification commands                                       |
+| `OpenReleaseRequest`    | create or update a hosted release PR/MR                                   | `PrepareRelease` + `[source]`    | provider review, follow-up `Command` steps                                                  |
+| `PlanPublishRateLimits` | plan package-registry publish work against known rate limits              | no                               | `PublishPackages`, `PlaceholderPublish`                                                     |
+| `PlaceholderPublish`    | publish `0.0.0` placeholder versions for missing registry packages        | no                               | normally before `PublishPackages`                                                           |
+| `PublishPackages`       | publish package versions to registries using built-in ecosystem workflows | `PrepareRelease`                 | custom `Command` steps using `publish.*`                                                    |
+| `CommentReleasedIssues` | post release follow-up comments to closed issues                          | `PrepareRelease` + GitHub source | normally after `PublishRelease`                                                             |
+| `AffectedPackages`      | evaluate changeset coverage for changed files                             | no                               | CI enforcement, custom failure messaging                                                    |
+| `DiagnoseChangesets`    | inspect changeset context, commit provenance, and linked review metadata  | no                               | local debugging, CI inspection                                                              |
+| `RetargetRelease`       | repair a recent release by moving its tag set                             | no                               | custom `Command` steps using `retarget.*`                                                   |
+| `Command`               | run arbitrary shell/program commands with monochange context              | depends on your workflow         | any external tool                                                                           |
 
 <!-- {/cliStepReferenceChoosingGuide} -->
 
@@ -378,6 +382,52 @@ shell = true
 ```
 
 <!-- {/cliStepCommandStepOutputExample} -->
+
+<!-- {@cliStepPlaceholderPublishExample} -->
+
+```toml
+[cli.placeholder-publish]
+help_text = "Publish placeholder package versions for missing registry packages"
+
+[[cli.placeholder-publish.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "markdown", "json"]
+default = "text"
+
+[[cli.placeholder-publish.inputs]]
+name = "package"
+type = "string_list"
+
+[[cli.placeholder-publish.steps]]
+name = "publish placeholder packages"
+type = "PlaceholderPublish"
+```
+
+<!-- {/cliStepPlaceholderPublishExample} -->
+
+<!-- {@cliStepPublishPackagesExample} -->
+
+```toml
+[cli.publish]
+help_text = "Publish package versions from monochange release state using built-in workflows"
+
+[[cli.publish.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "markdown", "json"]
+default = "text"
+
+[[cli.publish.inputs]]
+name = "package"
+type = "string_list"
+
+[[cli.publish.steps]]
+name = "publish packages"
+type = "PublishPackages"
+```
+
+<!-- {/cliStepPublishPackagesExample} -->
 
 <!-- {@cliStepRetargetCommandCompositionExample} -->
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -41,3 +41,5 @@
   - [CommentReleasedIssues](reference/cli-steps/12-comment-released-issues.md)
   - [Command](reference/cli-steps/13-command.md)
   - [DisplayVersions](reference/cli-steps/14-display-versions.md)
+  - [PlaceholderPublish](reference/cli-steps/15-placeholder-publish.md)
+  - [PublishPackages](reference/cli-steps/16-publish-packages.md)

--- a/docs/src/reference/cli-steps/00-index.md
+++ b/docs/src/reference/cli-steps/00-index.md
@@ -28,20 +28,24 @@ The reference pages in this section document each built-in step with:
 
 <!-- {=cliStepReferenceChoosingGuide} -->
 
-| Step                    | Use it when you want to…                                                 | Requires previous step?          | Typical follow-up                                                                           |
-| ----------------------- | ------------------------------------------------------------------------ | -------------------------------- | ------------------------------------------------------------------------------------------- |
-| `Validate`              | fail fast on invalid config, groups, or changesets                       | no                               | CI gate or local preflight                                                                  |
-| `Discover`              | inspect normalized package discovery across ecosystems                   | no                               | local inspection, debug commands                                                            |
-| `CreateChangeFile`      | author a `.changeset/*.md` file from CLI inputs                          | no                               | run independently, or before planning                                                       |
-| `PrepareRelease`        | build the release result, update files, and refresh the cached manifest  | no                               | `CommitRelease`, `PublishRelease`, `OpenReleaseRequest`, `CommentReleasedIssues`, `Command` |
-| `CommitRelease`         | create a local release commit with an embedded `ReleaseRecord`           | `PrepareRelease`                 | `OpenReleaseRequest`, manual review, custom `Command`                                       |
-| `PublishRelease`        | create or update hosted provider releases                                | `PrepareRelease` + `[source]`    | `CommentReleasedIssues`, custom notification commands                                       |
-| `OpenReleaseRequest`    | create or update a hosted release PR/MR                                  | `PrepareRelease` + `[source]`    | provider review, follow-up `Command` steps                                                  |
-| `CommentReleasedIssues` | post release follow-up comments to closed issues                         | `PrepareRelease` + GitHub source | normally after `PublishRelease`                                                             |
-| `AffectedPackages`      | evaluate changeset coverage for changed files                            | no                               | CI enforcement, custom failure messaging                                                    |
-| `DiagnoseChangesets`    | inspect changeset context, commit provenance, and linked review metadata | no                               | local debugging, CI inspection                                                              |
-| `RetargetRelease`       | repair a recent release by moving its tag set                            | no                               | custom `Command` steps using `retarget.*`                                                   |
-| `Command`               | run arbitrary shell/program commands with monochange context             | depends on your workflow         | any external tool                                                                           |
+| Step                    | Use it when you want to…                                                  | Requires previous step?          | Typical follow-up                                                                           |
+| ----------------------- | ------------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------- |
+| `Validate`              | fail fast on invalid config, groups, or changesets                        | no                               | CI gate or local preflight                                                                  |
+| `Discover`              | inspect normalized package discovery across ecosystems                    | no                               | local inspection, debug commands                                                            |
+| `CreateChangeFile`      | author a `.changeset/*.md` file from CLI inputs                           | no                               | run independently, or before planning                                                       |
+| `PrepareRelease`        | build the release result, update files, and refresh the cached manifest   | no                               | `CommitRelease`, `PublishRelease`, `OpenReleaseRequest`, `CommentReleasedIssues`, `Command` |
+| `DisplayVersions`       | display planned package and group versions without mutating release files | no                               | `PrepareRelease`                                                                            |
+| `CommitRelease`         | create a local release commit with an embedded `ReleaseRecord`            | `PrepareRelease`                 | `OpenReleaseRequest`, manual review, custom `Command`                                       |
+| `PublishRelease`        | create or update hosted provider releases                                 | `PrepareRelease` + `[source]`    | `CommentReleasedIssues`, custom notification commands                                       |
+| `OpenReleaseRequest`    | create or update a hosted release PR/MR                                   | `PrepareRelease` + `[source]`    | provider review, follow-up `Command` steps                                                  |
+| `PlanPublishRateLimits` | plan package-registry publish work against known rate limits              | no                               | `PublishPackages`, `PlaceholderPublish`                                                     |
+| `PlaceholderPublish`    | publish `0.0.0` placeholder versions for missing registry packages        | no                               | normally before `PublishPackages`                                                           |
+| `PublishPackages`       | publish package versions to registries using built-in ecosystem workflows | `PrepareRelease`                 | custom `Command` steps using `publish.*`                                                    |
+| `CommentReleasedIssues` | post release follow-up comments to closed issues                          | `PrepareRelease` + GitHub source | normally after `PublishRelease`                                                             |
+| `AffectedPackages`      | evaluate changeset coverage for changed files                             | no                               | CI enforcement, custom failure messaging                                                    |
+| `DiagnoseChangesets`    | inspect changeset context, commit provenance, and linked review metadata  | no                               | local debugging, CI inspection                                                              |
+| `RetargetRelease`       | repair a recent release by moving its tag set                             | no                               | custom `Command` steps using `retarget.*`                                                   |
+| `Command`               | run arbitrary shell/program commands with monochange context              | depends on your workflow         | any external tool                                                                           |
 
 <!-- {/cliStepReferenceChoosingGuide} -->
 
@@ -148,3 +152,5 @@ Those namespaces are the main reason to prefer built-in steps over reimplementin
 - [CommentReleasedIssues](12-comment-released-issues.md)
 - [Command](13-command.md)
 - [DisplayVersions](14-display-versions.md)
+- [PlaceholderPublish](15-placeholder-publish.md)
+- [PublishPackages](16-publish-packages.md)

--- a/docs/src/reference/cli-steps/15-placeholder-publish.md
+++ b/docs/src/reference/cli-steps/15-placeholder-publish.md
@@ -1,0 +1,133 @@
+# `PlaceholderPublish`
+
+## What it does
+
+`PlaceholderPublish` publishes minimal `0.0.0` placeholder versions for packages that do not yet exist in their target registries.
+
+This is useful when you need to:
+
+- reserve a package name before the first real release
+- enable registry automation (such as trusted publishing or downstream dependency resolution) that requires the package to already be present
+- bootstrap a new package into a registry so that later `PublishPackages` can update it with a real version
+
+The step inspects each package's publish configuration, checks the registry to see if the package already exists, and only attempts to publish when the package is missing.
+
+## Why use it
+
+Use `PlaceholderPublish` when you want monochange to handle the initial registry bootstrap rather than running manual publish commands.
+
+That gives you:
+
+- automatic registry detection (the step skips packages that already exist)
+- ecosystem-aware publish commands (`cargo publish`, `npm publish`, `dart pub publish`, `deno publish`, and so on)
+- rate-limit planning before any mutation happens
+- dry-run previews that show what would be published without touching registries
+- structured `publish.*` template context for later `Command` steps
+
+Use `PublishPackages` instead when you want to publish the real planned versions from a prepared release.
+
+## Inputs
+
+- `format` — `text`, `markdown`, or `json`
+- `package` — optional repeated package ids used to filter the publish set
+
+## Step-level `when` condition
+
+All CLI steps support an optional `when = "..."` condition.
+
+If the expression resolves to false at runtime, monochange skips the step and continues with the next step.
+
+```toml
+when = "{{ inputs.enabled }}"
+```
+
+## Prerequisites
+
+None. `PlaceholderPublish` does not require a previous `PrepareRelease` step.
+
+## Side effects and outputs
+
+- in dry-run mode, plans and previews placeholder publish operations without touching registries
+- in normal mode, publishes `0.0.0` placeholder versions for missing packages
+- contributes `publish.*` and `publish_rate_limits.*` template context to the command result
+
+## Example
+
+<!-- {=cliStepPlaceholderPublishExample} -->
+
+```toml
+[cli.placeholder-publish]
+help_text = "Publish placeholder package versions for missing registry packages"
+
+[[cli.placeholder-publish.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "markdown", "json"]
+default = "text"
+
+[[cli.placeholder-publish.inputs]]
+name = "package"
+type = "string_list"
+
+[[cli.placeholder-publish.steps]]
+name = "publish placeholder packages"
+type = "PlaceholderPublish"
+```
+
+<!-- {/cliStepPlaceholderPublishExample} -->
+
+## Composition ideas
+
+### Plan placeholder publishing before running it
+
+```toml
+[cli.placeholder-plan]
+help_text = "Plan and preview placeholder publishing"
+
+[[cli.placeholder-plan.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
+[[cli.placeholder-plan.steps]]
+name = "plan publish rate limits"
+type = "PlanPublishRateLimits"
+inputs = { mode = "placeholder" }
+
+[[cli.placeholder-plan.steps]]
+name = "publish placeholder packages"
+type = "PlaceholderPublish"
+```
+
+### Placeholder publish as part of a CI bootstrapping command
+
+```toml
+[ci.bootstrap]
+help_text = "Reserve package names for new packages"
+
+[[ci.bootstrap.steps]]
+type = "PlaceholderPublish"
+
+[[ci.bootstrap.steps]]
+type = "Command"
+command = "echo placeholder publish completed for {{ publish.packages }}"
+shell = true
+```
+
+## Why choose it over a raw `Command` step?
+
+Because `PlaceholderPublish` understands:
+
+- which packages are configured for publish
+- which registries each ecosystem targets
+- whether a package already exists (and should be skipped)
+- ecosystem-specific publish commands and flags
+- rate-limit planning across registries
+- dry-run behavior for safe CI previews
+
+## Common mistakes
+
+- confusing `PlaceholderPublish` with `PublishPackages`: the former publishes `0.0.0` placeholders, the latter publishes the real planned versions
+- forgetting that `PlaceholderPublish` does not require `PrepareRelease`, but `PublishPackages` does
+- expecting placeholder versions to be updated automatically: placeholder publish is a one-time bootstrap step

--- a/docs/src/reference/cli-steps/16-publish-packages.md
+++ b/docs/src/reference/cli-steps/16-publish-packages.md
@@ -1,0 +1,150 @@
+# `PublishPackages`
+
+## What it does
+
+`PublishPackages` publishes package versions to their target registries using monochange's built-in ecosystem workflows.
+
+For each package with a planned release version, the step:
+
+- resolves the registry from the package's publish configuration
+- checks whether the version already exists (skipping if it does)
+- plans against registry rate limits before attempting any mutation
+- runs the ecosystem-specific publish command (`cargo publish`, `npm publish`, `dart pub publish`, `flutter pub publish`, `deno publish`, and so on)
+- produces a structured report of what was published, skipped, or planned
+
+You can filter the publish set with the `package` input, or use an empty set to publish everything that is ready.
+
+## Why use it
+
+Use `PublishPackages` when you want monochange to handle the full package-registry publication workflow rather than scripting individual publish commands.
+
+That gives you:
+
+- one publish step for all supported ecosystems
+- automatic rate-limit planning and enforcement
+- version-existence checks that prevent duplicate publish attempts
+- dry-run previews that show the full publish plan without touching registries
+- structured `publish.*` template context for later `Command` steps
+
+Use `PlaceholderPublish` instead when you need to bootstrap a package that does not yet exist in its registry with a minimal `0.0.0` placeholder.
+
+## Inputs
+
+- `format` — `text`, `markdown`, or `json`
+- `package` — optional repeated package ids used to filter the publish set
+
+## Step-level `when` condition
+
+All CLI steps support an optional `when = "..."` condition.
+
+If the expression resolves to false at runtime, monochange skips the step and continues with the next step.
+
+```toml
+when = "{{ inputs.enabled }}"
+```
+
+## Prerequisites
+
+- a previous `PrepareRelease` step in the same command, or a release record discoverable from `HEAD` that contains the package publication targets
+
+## Side effects and outputs
+
+- in dry-run mode, plans and previews publish operations without touching registries
+- in normal mode, publishes package versions to their configured registries
+- contributes `publish.*` and `publish_rate_limits.*` template context to the command result
+
+## Example
+
+<!-- {=cliStepPublishPackagesExample} -->
+
+```toml
+[cli.publish]
+help_text = "Publish package versions from monochange release state using built-in workflows"
+
+[[cli.publish.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "markdown", "json"]
+default = "text"
+
+[[cli.publish.inputs]]
+name = "package"
+type = "string_list"
+
+[[cli.publish.steps]]
+name = "publish packages"
+type = "PublishPackages"
+```
+
+<!-- {/cliStepPublishPackagesExample} -->
+
+## Composition ideas
+
+### Publish after preparing a release
+
+```toml
+[cli.release-and-publish]
+help_text = "Prepare a release and publish packages"
+
+[[cli.release-and-publish.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
+[[cli.release-and-publish.steps]]
+type = "PrepareRelease"
+
+[[cli.release-and-publish.steps]]
+name = "publish packages"
+type = "PublishPackages"
+```
+
+### Publish only a specific package
+
+```toml
+[cli.publish-core]
+help_text = "Publish a specific package"
+
+[[cli.publish-core.inputs]]
+name = "package"
+type = "string_list"
+required = true
+
+[[cli.publish-core.steps]]
+name = "publish packages"
+type = "PublishPackages"
+```
+
+### Publish with rate-limit planning
+
+```toml
+[cli.publish-planned]
+help_text = "Plan and publish with rate-limit awareness"
+
+[[cli.publish-planned.steps]]
+name = "plan publish rate limits"
+type = "PlanPublishRateLimits"
+
+[[cli.publish-planned.steps]]
+name = "publish packages"
+type = "PublishPackages"
+```
+
+## Why choose it over a raw `Command` step?
+
+Because `PublishPackages` understands:
+
+- which packages were planned for release
+- which ecosystem and registry each package targets
+- whether a version already exists (and should be skipped)
+- ecosystem-specific publish commands, flags, and auth patterns
+- rate-limit planning across registries
+- dry-run behavior for safe CI previews
+- trusted publishing setup and configuration
+
+## Common mistakes
+
+- confusing `PublishPackages` with `PublishRelease`: the former publishes to package registries, the latter creates hosted provider releases (such as GitHub releases)
+- forgetting that `PublishPackages` needs a previous `PrepareRelease` step or a release record in `HEAD`
+- running `PublishPackages` without rate-limit planning: use `PlanPublishRateLimits` first when you are unsure about registry windows


### PR DESCRIPTION
This PR adds documentation for the two previously undocumented CLI steps: PublishPackages and PlaceholderPublish.

Changes:
- Add PlaceholderPublish CLI step reference page
- Add PublishPackages CLI step reference page
- Update CLI step index with new pages
- Update SUMMARY.md navigation
- Update mdt template with new examples and choosing guide entries