### PR TITLE
fix(docs): add missing collapsed field to ReleaseNotesSection doctest

### DIFF
--- a/crates/monochange_core/readme.md
+++ b/crates/monochange_core/readme.md
@@ -50,6 +50,7 @@ let notes = ReleaseNotesDocument {
     sections: vec![ReleaseNotesSection {
         title: "Features".to_string(),
         entries: vec!["- add keep-a-changelog output".to_string()],
+        collapsed: false,
     }],
 };
 

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -41,6 +41,7 @@
 //!     sections: vec![ReleaseNotesSection {
 //!         title: "Features".to_string(),
 //!         entries: vec!["- add keep-a-changelog output".to_string()],
+//!         collapsed: false,
 //!     }],
 //! };
 //!


### PR DESCRIPTION
Fixes failing doc tests caused by missing `collapsed` field in `ReleaseNotesSection` initializer.