### PR TITLE
fix(release): handle changelog-only release updates

### DIFF
--- a/.changeset/release-changelog-handling.md
+++ b/.changeset/release-changelog-handling.md
@@ -1,0 +1,57 @@
+---
+monochange: patch
+---
+
+#### ignore configured changelog files in affected-package verification and keep newest changelog entries first
+
+Release automation now treats configured changelog targets as release metadata instead of as ordinary package source changes. That means changelog-only updates no longer make `mc affected --verify` fail with an uncovered package error, and newly generated release notes are inserted above older release headings so the latest release stays at the top of each changelog.
+
+Configured changelog targets are unchanged:
+
+```toml
+[package.core.changelog]
+path = "crates/core/changelog.md"
+```
+
+Command used by CI and local verification:
+
+```bash
+mc affected --format json --verify --changed-paths crates/core/changelog.md
+```
+
+**Before (output):**
+
+```json
+{
+	"status": "failed",
+	"affectedPackageIds": ["core"],
+	"matchedPaths": ["crates/core/changelog.md"],
+	"uncoveredPackageIds": ["core"]
+}
+```
+
+**After (output):**
+
+```json
+{
+	"status": "not_required",
+	"affectedPackageIds": [],
+	"ignoredPaths": ["crates/core/changelog.md"],
+	"matchedPaths": [],
+	"uncoveredPackageIds": []
+}
+```
+
+Generated changelog sections also stay in reverse-chronological order:
+
+```md
+# Changelog
+
+## [0.3.0] - 2026-04-23
+
+- latest release notes
+
+## [0.2.0] - 2026-03-01
+
+- previous release notes
+```

--- a/crates/monochange/src/changelog.rs
+++ b/crates/monochange/src/changelog.rs
@@ -218,16 +218,55 @@ fn append_changelog_section(path: &Path, section: &str) -> MonochangeResult<Stri
 		String::new()
 	};
 
-	let mut content = current.trim_end().to_string();
+	let current = current.trim_end();
+	if current.is_empty() {
+		return Ok(format!("{section}\n"));
+	}
 
-	if !content.is_empty() {
+	let Some(offset) = current
+		.lines()
+		.scan(0usize, |start, line| {
+			let offset = *start;
+			*start += line.len() + 1;
+			Some((offset, line))
+		})
+		.find_map(|(offset, line)| is_release_heading(line).then_some(offset))
+	else {
+		return Ok(format!("{current}\n\n{section}\n"));
+	};
+
+	let prefix = current[..offset].trim_end();
+	let suffix = current[offset..].trim_start();
+	let mut content = String::new();
+
+	if !prefix.is_empty() {
+		content.push_str(prefix);
 		content.push_str("\n\n");
 	}
 
 	content.push_str(section);
 	content.push('\n');
 
+	if !suffix.is_empty() {
+		content.push('\n');
+		content.push_str(suffix);
+		content.push('\n');
+	}
+
 	Ok(content)
+}
+
+fn is_release_heading(line: &str) -> bool {
+	let Some(heading) = line.strip_prefix("## ") else {
+		return false;
+	};
+
+	let heading = heading.trim_start();
+	heading.starts_with('[')
+		|| heading
+			.chars()
+			.next()
+			.is_some_and(|character| character.is_ascii_digit())
 }
 
 fn dedup_changelog_updates(updates: Vec<ChangelogUpdate>) -> Vec<ChangelogUpdate> {
@@ -1327,7 +1366,7 @@ mod tests {
 			.unwrap_or_else(|error| panic!("append second changelog section: {error}"));
 		assert_eq!(
 			appended,
-			"# Changelog\n\n## 0.9.0\n- older\n\n## 1.0.0\n- latest\n"
+			"# Changelog\n\n## 1.0.0\n- latest\n\n## 0.9.0\n- older\n"
 		);
 
 		let earlier = ChangelogUpdate {

--- a/crates/monochange/src/changeset_policy.rs
+++ b/crates/monochange/src/changeset_policy.rs
@@ -85,6 +85,15 @@ pub fn affected_packages(
 		.iter()
 		.filter(|path| !is_changeset_markdown_path(path))
 	{
+		if path_matches_any_configured_changelog(
+			path,
+			&configuration.packages,
+			&configuration.groups,
+		) {
+			ignored_paths.push(path.clone());
+			continue;
+		}
+
 		let mut matched_any_package = false;
 		let mut ignored_by_package = false;
 		for package in &configuration.packages {
@@ -300,6 +309,28 @@ fn path_touches_package(path: &str, package: &monochange_core::PackageDefinition
 fn path_is_ignored_for_package(path: &str, package: &monochange_core::PackageDefinition) -> bool {
 	path_is_within_package(path, package)
 		&& matches_any_package_pattern(path, package, &package.ignored_paths)
+}
+
+fn path_matches_any_configured_changelog(
+	path: &str,
+	packages: &[monochange_core::PackageDefinition],
+	groups: &[monochange_core::GroupDefinition],
+) -> bool {
+	packages.iter().any(|package| {
+		package
+			.changelog
+			.as_ref()
+			.is_some_and(|target| path_matches_changelog_target(path, &target.path))
+	}) || groups.iter().any(|group| {
+		group
+			.changelog
+			.as_ref()
+			.is_some_and(|target| path_matches_changelog_target(path, &target.path))
+	})
+}
+
+fn path_matches_changelog_target(path: &str, changelog_path: &Path) -> bool {
+	normalize_changed_path(&changelog_path.to_string_lossy()) == path
 }
 
 fn path_is_within_package(path: &str, package: &monochange_core::PackageDefinition) -> bool {

--- a/crates/monochange/tests/affected.rs
+++ b/crates/monochange/tests/affected.rs
@@ -27,6 +27,10 @@ use test_support::snapshot_settings;
 	"affected/ignored-paths",
 	&["--changed-paths", "crates/core/tests/smoke.rs"]
 )]
+#[case::ignores_configured_package_changelog_paths(
+	"affected/changelog-paths",
+	&["--changed-paths", "crates/core/changelog.md"]
+)]
 #[case::respects_package_additional_paths(
 	"affected/additional-paths",
 	&["--changed-paths", "Cargo.lock"]

--- a/crates/monochange/tests/snapshots/affected__affected_scenarios_match_snapshot@ignores_configured_package_changelog_paths.snap
+++ b/crates/monochange/tests/snapshots/affected__affected_scenarios_match_snapshot@ignores_configured_package_changelog_paths.snap
@@ -1,0 +1,26 @@
+---
+source: crates/monochange/tests/affected.rs
+assertion_line: 111
+expression: output
+---
+{
+  "affectedPackageIds": [],
+  "changedPaths": [
+    "crates/core/changelog.md"
+  ],
+  "changesetPaths": [],
+  "comment": null,
+  "coveredPackageIds": [],
+  "enforce": false,
+  "errors": [],
+  "ignoredPaths": [
+    "crates/core/changelog.md"
+  ],
+  "labels": [],
+  "matchedPaths": [],
+  "matchedSkipLabels": [],
+  "required": false,
+  "status": "not_required",
+  "summary": "changeset verification passed: no configured packages were affected by the changed files",
+  "uncoveredPackageIds": []
+}

--- a/crates/monochange/tests/snapshots/cli_step_input_overrides__cli_step_override_json_scenarios_match_snapshot@affected_packages.snap
+++ b/crates/monochange/tests/snapshots/cli_step_input_overrides__cli_step_override_json_scenarios_match_snapshot@affected_packages.snap
@@ -1,11 +1,10 @@
 ---
 source: crates/monochange/tests/cli_step_input_overrides.rs
+assertion_line: 45
 expression: json
 ---
 {
-  "affectedPackageIds": [
-    "core"
-  ],
+  "affectedPackageIds": [],
   "changedPaths": [
     "crates/core/CHANGELOG.md"
   ],
@@ -14,20 +13,18 @@ expression: json
   "coveredPackageIds": [],
   "enforce": true,
   "errors": [],
-  "ignoredPaths": [],
+  "ignoredPaths": [
+    "crates/core/CHANGELOG.md"
+  ],
   "labels": [
     "no-changeset-required"
   ],
-  "matchedPaths": [
-    "crates/core/CHANGELOG.md"
-  ],
+  "matchedPaths": [],
   "matchedSkipLabels": [
     "no-changeset-required"
   ],
   "required": false,
   "status": "skipped",
   "summary": "changeset verification skipped because the change has an allowed label: no-changeset-required",
-  "uncoveredPackageIds": [
-    "core"
-  ]
+  "uncoveredPackageIds": []
 }

--- a/fixtures/tests/affected/changelog-paths/crates/core/Cargo.toml
+++ b/fixtures/tests/affected/changelog-paths/crates/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "core"
+version = "1.0.0"
+edition = "2021"

--- a/fixtures/tests/affected/changelog-paths/crates/core/changelog.md
+++ b/fixtures/tests/affected/changelog-paths/crates/core/changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [1.0.0](https://example.com/releases/v1.0.0) (2026-04-01)
+
+- initial release

--- a/fixtures/tests/affected/changelog-paths/crates/core/src/lib.rs
+++ b/fixtures/tests/affected/changelog-paths/crates/core/src/lib.rs
@@ -1,0 +1,1 @@
+pub fn core() {}

--- a/fixtures/tests/affected/changelog-paths/monochange.toml
+++ b/fixtures/tests/affected/changelog-paths/monochange.toml
@@ -1,0 +1,35 @@
+[defaults]
+package_type = "cargo"
+
+[defaults.changelog]
+path = "{{ path }}/changelog.md"
+format = "keep_a_changelog"
+
+[changesets.verify]
+enabled = true
+required = true
+skip_labels = ["no-changeset-required"]
+
+[package.core]
+path = "crates/core"
+
+[cli.affected]
+[[cli.affected.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+[[cli.affected.inputs]]
+name = "changed_paths"
+type = "string_list"
+[[cli.affected.inputs]]
+name = "since"
+type = "string"
+[[cli.affected.inputs]]
+name = "verify"
+type = "boolean"
+[[cli.affected.inputs]]
+name = "label"
+type = "string_list"
+[[cli.affected.steps]]
+type = "AffectedPackages"

--- a/npm/tests/monochange-bin.test.mjs
+++ b/npm/tests/monochange-bin.test.mjs
@@ -18,6 +18,14 @@ function createSandbox() {
 
 function createRoot(root) {
 	mkdirSync(join(root, "bin"), { recursive: true });
+	writeFileSync(
+		join(root, "package.json"),
+		JSON.stringify({
+			name: "monochange-bin-test",
+			private: true,
+			type: "commonjs",
+		}),
+	);
 	cpSync(launcherPath, join(root, "bin", "monochange.js"));
 }
 


### PR DESCRIPTION
## Summary
- ignore configured changelog targets when determining affected packages for release verification
- insert newly generated changelog sections before existing release headings so the latest release stays at the top
- cover the behavior with affected-package fixtures, snapshot updates, and the launcher sandbox test fix needed by the current pre-push/test matrix

## Testing
- `devenv shell -- test:all`
- `devenv shell -- lint:all`
- `devenv shell -- mc validate`