### PR TITLE
fix(release): reorder published changelog entries

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,50 +2,6 @@
 
 All notable changes to the `main` release group will be documented in this file.
 
-## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
-
-Grouped release for `main`.
-
-Changed members: monochange, monochange_core, monochange_cargo, monochange_npm, monochange_config, monochange_deno, monochange_dart, monochange_graph, monochange_semver, monochange_github, monochange_gitlab, monochange_gitea, monochange_hosting
-
-### Breaking changes
-
-> [!NOTE]
-> _main_
-
-#### 🚀 Initial public release of monochange
-
-**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
-
-##### What is monochange?
-
-In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
-
-- **Change tracking**: Structured changesets that capture intent across multiple packages
-- **Release planning**: Automated versioning and changelog generation
-- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
-- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
-- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
-
-##### Why monochange matters for AI-driven workflows
-
-As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
-
-##### What's included in this release
-
-This first release includes:
-
-- Core changeset management engine
-- Multi-ecosystem package detection and versioning
-- Hosting provider integrations (Gitea, GitHub, GitLab)
-- Semantic versioning utilities
-- Configurable release workflows
-- CLI tooling for validation and release orchestration
-
-For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
-
-> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 Grouped release for `main`.
@@ -236,3 +192,47 @@ The new tests cover:
 - preservation of explicit trusted-publishing context in manual-action outcomes
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #215](https://github.com/ifiokjr/monochange/pull/215) _Introduced in:_ [`36c1d4e`](https://github.com/ifiokjr/monochange/commit/36c1d4ec3c2daa675c233e388e161f339a77b6c2) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2)
+## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
+
+Grouped release for `main`.
+
+Changed members: monochange, monochange_core, monochange_cargo, monochange_npm, monochange_config, monochange_deno, monochange_dart, monochange_graph, monochange_semver, monochange_github, monochange_gitlab, monochange_gitea, monochange_hosting
+
+### Breaking changes
+
+> [!NOTE]
+> _main_
+
+#### 🚀 Initial public release of monochange
+
+**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
+
+##### What is monochange?
+
+In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
+
+- **Change tracking**: Structured changesets that capture intent across multiple packages
+- **Release planning**: Automated versioning and changelog generation
+- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
+- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
+- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
+
+##### Why monochange matters for AI-driven workflows
+
+As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
+
+##### What's included in this release
+
+This first release includes:
+
+- Core changeset management engine
+- Multi-ecosystem package detection and versioning
+- Hosting provider integrations (Gitea, GitHub, GitLab)
+- Semantic versioning utilities
+- Configurable release workflows
+- CLI tooling for validation and release orchestration
+
+For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
+
+> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
+

--- a/changelog.md
+++ b/changelog.md
@@ -192,6 +192,7 @@ The new tests cover:
 - preservation of explicit trusted-publishing context in manual-action outcomes
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #215](https://github.com/ifiokjr/monochange/pull/215) _Introduced in:_ [`36c1d4e`](https://github.com/ifiokjr/monochange/commit/36c1d4ec3c2daa675c233e388e161f339a77b6c2) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2)
+
 ## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
 
 Grouped release for `main`.
@@ -235,4 +236,3 @@ This first release includes:
 For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
 
 > _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-

--- a/crates/monochange/changelog.md
+++ b/crates/monochange/changelog.md
@@ -2,43 +2,6 @@
 
 All notable changes to `monochange` will be documented in this file.
 
-## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
-
-### Breaking changes
-
-#### 🚀 Initial public release of monochange
-
-**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
-
-##### What is monochange?
-
-In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
-
-- **Change tracking**: Structured changesets that capture intent across multiple packages
-- **Release planning**: Automated versioning and changelog generation
-- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
-- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
-- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
-
-##### Why monochange matters for AI-driven workflows
-
-As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
-
-##### What's included in this release
-
-This first release includes:
-
-- Core changeset management engine
-- Multi-ecosystem package detection and versioning
-- Hosting provider integrations (Gitea, GitHub, GitLab)
-- Semantic versioning utilities
-- Configurable release workflows
-- CLI tooling for validation and release orchestration
-
-For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
-
-> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Breaking Change
@@ -921,3 +884,40 @@ The new tests cover:
 - preservation of explicit trusted-publishing context in manual-action outcomes
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #215](https://github.com/ifiokjr/monochange/pull/215) _Introduced in:_ [`36c1d4e`](https://github.com/ifiokjr/monochange/commit/36c1d4ec3c2daa675c233e388e161f339a77b6c2) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2)
+## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
+
+### Breaking changes
+
+#### 🚀 Initial public release of monochange
+
+**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
+
+##### What is monochange?
+
+In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
+
+- **Change tracking**: Structured changesets that capture intent across multiple packages
+- **Release planning**: Automated versioning and changelog generation
+- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
+- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
+- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
+
+##### Why monochange matters for AI-driven workflows
+
+As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
+
+##### What's included in this release
+
+This first release includes:
+
+- Core changeset management engine
+- Multi-ecosystem package detection and versioning
+- Hosting provider integrations (Gitea, GitHub, GitLab)
+- Semantic versioning utilities
+- Configurable release workflows
+- CLI tooling for validation and release orchestration
+
+For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
+
+> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
+

--- a/crates/monochange/changelog.md
+++ b/crates/monochange/changelog.md
@@ -884,6 +884,7 @@ The new tests cover:
 - preservation of explicit trusted-publishing context in manual-action outcomes
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #215](https://github.com/ifiokjr/monochange/pull/215) _Introduced in:_ [`36c1d4e`](https://github.com/ifiokjr/monochange/commit/36c1d4ec3c2daa675c233e388e161f339a77b6c2) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2)
+
 ## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
 
 ### Breaking changes
@@ -920,4 +921,3 @@ This first release includes:
 For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
 
 > _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-

--- a/crates/monochange_cargo/changelog.md
+++ b/crates/monochange_cargo/changelog.md
@@ -2,43 +2,6 @@
 
 All notable changes to `monochange_cargo` will be documented in this file.
 
-## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
-
-### Breaking changes
-
-#### 🚀 Initial public release of monochange
-
-**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
-
-##### What is monochange?
-
-In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
-
-- **Change tracking**: Structured changesets that capture intent across multiple packages
-- **Release planning**: Automated versioning and changelog generation
-- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
-- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
-- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
-
-##### Why monochange matters for AI-driven workflows
-
-As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
-
-##### What's included in this release
-
-This first release includes:
-
-- Core changeset management engine
-- Multi-ecosystem package detection and versioning
-- Hosting provider integrations (Gitea, GitHub, GitLab)
-- Semantic versioning utilities
-- Configurable release workflows
-- CLI tooling for validation and release orchestration
-
-For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
-
-> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added
@@ -327,3 +290,40 @@ This foundation change adds:
 - tests covering managed Dart lint target collection and fixture filtering
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #235](https://github.com/ifiokjr/monochange/pull/235) _Introduced in:_ [`5a7a4fe`](https://github.com/ifiokjr/monochange/commit/5a7a4fed84603f51dd5d152d11e739f30dea2b64) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2) _Closed issues:_ [#230](https://github.com/ifiokjr/monochange/issues/230)
+## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
+
+### Breaking changes
+
+#### 🚀 Initial public release of monochange
+
+**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
+
+##### What is monochange?
+
+In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
+
+- **Change tracking**: Structured changesets that capture intent across multiple packages
+- **Release planning**: Automated versioning and changelog generation
+- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
+- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
+- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
+
+##### Why monochange matters for AI-driven workflows
+
+As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
+
+##### What's included in this release
+
+This first release includes:
+
+- Core changeset management engine
+- Multi-ecosystem package detection and versioning
+- Hosting provider integrations (Gitea, GitHub, GitLab)
+- Semantic versioning utilities
+- Configurable release workflows
+- CLI tooling for validation and release orchestration
+
+For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
+
+> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
+

--- a/crates/monochange_cargo/changelog.md
+++ b/crates/monochange_cargo/changelog.md
@@ -290,6 +290,7 @@ This foundation change adds:
 - tests covering managed Dart lint target collection and fixture filtering
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #235](https://github.com/ifiokjr/monochange/pull/235) _Introduced in:_ [`5a7a4fe`](https://github.com/ifiokjr/monochange/commit/5a7a4fed84603f51dd5d152d11e739f30dea2b64) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2) _Closed issues:_ [#230](https://github.com/ifiokjr/monochange/issues/230)
+
 ## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
 
 ### Breaking changes
@@ -326,4 +327,3 @@ This first release includes:
 For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
 
 > _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-

--- a/crates/monochange_config/changelog.md
+++ b/crates/monochange_config/changelog.md
@@ -563,6 +563,7 @@ This foundation change adds:
 - tests covering managed Dart lint target collection and fixture filtering
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #235](https://github.com/ifiokjr/monochange/pull/235) _Introduced in:_ [`5a7a4fe`](https://github.com/ifiokjr/monochange/commit/5a7a4fed84603f51dd5d152d11e739f30dea2b64) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2) _Closed issues:_ [#230](https://github.com/ifiokjr/monochange/issues/230)
+
 ## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
 
 ### Breaking changes
@@ -599,4 +600,3 @@ This first release includes:
 For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
 
 > _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-

--- a/crates/monochange_config/changelog.md
+++ b/crates/monochange_config/changelog.md
@@ -2,43 +2,6 @@
 
 All notable changes to `monochange_config` will be documented in this file.
 
-## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
-
-### Breaking changes
-
-#### 🚀 Initial public release of monochange
-
-**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
-
-##### What is monochange?
-
-In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
-
-- **Change tracking**: Structured changesets that capture intent across multiple packages
-- **Release planning**: Automated versioning and changelog generation
-- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
-- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
-- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
-
-##### Why monochange matters for AI-driven workflows
-
-As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
-
-##### What's included in this release
-
-This first release includes:
-
-- Core changeset management engine
-- Multi-ecosystem package detection and versioning
-- Hosting provider integrations (Gitea, GitHub, GitLab)
-- Semantic versioning utilities
-- Configurable release workflows
-- CLI tooling for validation and release orchestration
-
-For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
-
-> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Breaking Change
@@ -600,3 +563,40 @@ This foundation change adds:
 - tests covering managed Dart lint target collection and fixture filtering
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #235](https://github.com/ifiokjr/monochange/pull/235) _Introduced in:_ [`5a7a4fe`](https://github.com/ifiokjr/monochange/commit/5a7a4fed84603f51dd5d152d11e739f30dea2b64) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2) _Closed issues:_ [#230](https://github.com/ifiokjr/monochange/issues/230)
+## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
+
+### Breaking changes
+
+#### 🚀 Initial public release of monochange
+
+**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
+
+##### What is monochange?
+
+In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
+
+- **Change tracking**: Structured changesets that capture intent across multiple packages
+- **Release planning**: Automated versioning and changelog generation
+- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
+- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
+- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
+
+##### Why monochange matters for AI-driven workflows
+
+As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
+
+##### What's included in this release
+
+This first release includes:
+
+- Core changeset management engine
+- Multi-ecosystem package detection and versioning
+- Hosting provider integrations (Gitea, GitHub, GitLab)
+- Semantic versioning utilities
+- Configurable release workflows
+- CLI tooling for validation and release orchestration
+
+For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
+
+> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
+

--- a/crates/monochange_core/changelog.md
+++ b/crates/monochange_core/changelog.md
@@ -2,43 +2,6 @@
 
 All notable changes to `monochange_core` will be documented in this file.
 
-## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
-
-### Breaking changes
-
-#### 🚀 Initial public release of monochange
-
-**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
-
-##### What is monochange?
-
-In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
-
-- **Change tracking**: Structured changesets that capture intent across multiple packages
-- **Release planning**: Automated versioning and changelog generation
-- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
-- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
-- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
-
-##### Why monochange matters for AI-driven workflows
-
-As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
-
-##### What's included in this release
-
-This first release includes:
-
-- Core changeset management engine
-- Multi-ecosystem package detection and versioning
-- Hosting provider integrations (Gitea, GitHub, GitLab)
-- Semantic versioning utilities
-- Configurable release workflows
-- CLI tooling for validation and release orchestration
-
-For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
-
-> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Breaking Change
@@ -703,3 +666,40 @@ This foundation change adds:
 - tests covering managed Dart lint target collection and fixture filtering
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #235](https://github.com/ifiokjr/monochange/pull/235) _Introduced in:_ [`5a7a4fe`](https://github.com/ifiokjr/monochange/commit/5a7a4fed84603f51dd5d152d11e739f30dea2b64) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2) _Closed issues:_ [#230](https://github.com/ifiokjr/monochange/issues/230)
+## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
+
+### Breaking changes
+
+#### 🚀 Initial public release of monochange
+
+**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
+
+##### What is monochange?
+
+In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
+
+- **Change tracking**: Structured changesets that capture intent across multiple packages
+- **Release planning**: Automated versioning and changelog generation
+- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
+- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
+- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
+
+##### Why monochange matters for AI-driven workflows
+
+As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
+
+##### What's included in this release
+
+This first release includes:
+
+- Core changeset management engine
+- Multi-ecosystem package detection and versioning
+- Hosting provider integrations (Gitea, GitHub, GitLab)
+- Semantic versioning utilities
+- Configurable release workflows
+- CLI tooling for validation and release orchestration
+
+For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
+
+> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
+

--- a/crates/monochange_core/changelog.md
+++ b/crates/monochange_core/changelog.md
@@ -666,6 +666,7 @@ This foundation change adds:
 - tests covering managed Dart lint target collection and fixture filtering
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #235](https://github.com/ifiokjr/monochange/pull/235) _Introduced in:_ [`5a7a4fe`](https://github.com/ifiokjr/monochange/commit/5a7a4fed84603f51dd5d152d11e739f30dea2b64) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2) _Closed issues:_ [#230](https://github.com/ifiokjr/monochange/issues/230)
+
 ## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
 
 ### Breaking changes
@@ -702,4 +703,3 @@ This first release includes:
 For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
 
 > _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-

--- a/crates/monochange_dart/changelog.md
+++ b/crates/monochange_dart/changelog.md
@@ -212,6 +212,7 @@ match existing {
 The result is more consistent crate documentation, less duplicated prose, and flatter control flow in a few high-traffic code paths.
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #224](https://github.com/ifiokjr/monochange/pull/224) _Introduced in:_ [`d0f76ed`](https://github.com/ifiokjr/monochange/commit/d0f76ed56fa18e0ca9d9ec20fa9e44d413014db7) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2)
+
 ## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
 
 ### Breaking changes
@@ -248,4 +249,3 @@ This first release includes:
 For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
 
 > _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-

--- a/crates/monochange_dart/changelog.md
+++ b/crates/monochange_dart/changelog.md
@@ -2,43 +2,6 @@
 
 All notable changes to `monochange_dart` will be documented in this file.
 
-## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
-
-### Breaking changes
-
-#### 🚀 Initial public release of monochange
-
-**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
-
-##### What is monochange?
-
-In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
-
-- **Change tracking**: Structured changesets that capture intent across multiple packages
-- **Release planning**: Automated versioning and changelog generation
-- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
-- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
-- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
-
-##### Why monochange matters for AI-driven workflows
-
-As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
-
-##### What's included in this release
-
-This first release includes:
-
-- Core changeset management engine
-- Multi-ecosystem package detection and versioning
-- Hosting provider integrations (Gitea, GitHub, GitLab)
-- Semantic versioning utilities
-- Configurable release workflows
-- CLI tooling for validation and release orchestration
-
-For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
-
-> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added
@@ -249,3 +212,40 @@ match existing {
 The result is more consistent crate documentation, less duplicated prose, and flatter control flow in a few high-traffic code paths.
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #224](https://github.com/ifiokjr/monochange/pull/224) _Introduced in:_ [`d0f76ed`](https://github.com/ifiokjr/monochange/commit/d0f76ed56fa18e0ca9d9ec20fa9e44d413014db7) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2)
+## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
+
+### Breaking changes
+
+#### 🚀 Initial public release of monochange
+
+**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
+
+##### What is monochange?
+
+In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
+
+- **Change tracking**: Structured changesets that capture intent across multiple packages
+- **Release planning**: Automated versioning and changelog generation
+- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
+- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
+- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
+
+##### Why monochange matters for AI-driven workflows
+
+As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
+
+##### What's included in this release
+
+This first release includes:
+
+- Core changeset management engine
+- Multi-ecosystem package detection and versioning
+- Hosting provider integrations (Gitea, GitHub, GitLab)
+- Semantic versioning utilities
+- Configurable release workflows
+- CLI tooling for validation and release orchestration
+
+For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
+
+> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
+

--- a/crates/monochange_deno/changelog.md
+++ b/crates/monochange_deno/changelog.md
@@ -221,6 +221,7 @@ This foundation change adds:
 - tests covering managed Dart lint target collection and fixture filtering
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #235](https://github.com/ifiokjr/monochange/pull/235) _Introduced in:_ [`5a7a4fe`](https://github.com/ifiokjr/monochange/commit/5a7a4fed84603f51dd5d152d11e739f30dea2b64) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2) _Closed issues:_ [#230](https://github.com/ifiokjr/monochange/issues/230)
+
 ## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
 
 ### Breaking changes
@@ -257,4 +258,3 @@ This first release includes:
 For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
 
 > _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-

--- a/crates/monochange_deno/changelog.md
+++ b/crates/monochange_deno/changelog.md
@@ -2,43 +2,6 @@
 
 All notable changes to `monochange_deno` will be documented in this file.
 
-## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
-
-### Breaking changes
-
-#### 🚀 Initial public release of monochange
-
-**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
-
-##### What is monochange?
-
-In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
-
-- **Change tracking**: Structured changesets that capture intent across multiple packages
-- **Release planning**: Automated versioning and changelog generation
-- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
-- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
-- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
-
-##### Why monochange matters for AI-driven workflows
-
-As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
-
-##### What's included in this release
-
-This first release includes:
-
-- Core changeset management engine
-- Multi-ecosystem package detection and versioning
-- Hosting provider integrations (Gitea, GitHub, GitLab)
-- Semantic versioning utilities
-- Configurable release workflows
-- CLI tooling for validation and release orchestration
-
-For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
-
-> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added
@@ -258,3 +221,40 @@ This foundation change adds:
 - tests covering managed Dart lint target collection and fixture filtering
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #235](https://github.com/ifiokjr/monochange/pull/235) _Introduced in:_ [`5a7a4fe`](https://github.com/ifiokjr/monochange/commit/5a7a4fed84603f51dd5d152d11e739f30dea2b64) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2) _Closed issues:_ [#230](https://github.com/ifiokjr/monochange/issues/230)
+## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
+
+### Breaking changes
+
+#### 🚀 Initial public release of monochange
+
+**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
+
+##### What is monochange?
+
+In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
+
+- **Change tracking**: Structured changesets that capture intent across multiple packages
+- **Release planning**: Automated versioning and changelog generation
+- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
+- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
+- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
+
+##### Why monochange matters for AI-driven workflows
+
+As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
+
+##### What's included in this release
+
+This first release includes:
+
+- Core changeset management engine
+- Multi-ecosystem package detection and versioning
+- Hosting provider integrations (Gitea, GitHub, GitLab)
+- Semantic versioning utilities
+- Configurable release workflows
+- CLI tooling for validation and release orchestration
+
+For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
+
+> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
+

--- a/crates/monochange_gitea/changelog.md
+++ b/crates/monochange_gitea/changelog.md
@@ -1,3 +1,5 @@
+
+
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added
@@ -223,6 +225,7 @@ This release also adds two new support crates:
 The Cargo and npm suites now live in `monochange_cargo::lints` and `monochange_npm::lints`, so ecosystem-specific parsing and rule behavior stay with their ecosystem adapters.
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #228](https://github.com/ifiokjr/monochange/pull/228) _Introduced in:_ [`94f06a0`](https://github.com/ifiokjr/monochange/commit/94f06a057150d26e5f330e2e49a08f71eb12fc92) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2)
+
 ## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
 
 ### Breaking changes
@@ -259,4 +262,3 @@ This first release includes:
 For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
 
 > _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-

--- a/crates/monochange_gitea/changelog.md
+++ b/crates/monochange_gitea/changelog.md
@@ -1,40 +1,3 @@
-## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
-
-### Breaking changes
-
-#### 🚀 Initial public release of monochange
-
-**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
-
-##### What is monochange?
-
-In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
-
-- **Change tracking**: Structured changesets that capture intent across multiple packages
-- **Release planning**: Automated versioning and changelog generation
-- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
-- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
-- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
-
-##### Why monochange matters for AI-driven workflows
-
-As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
-
-##### What's included in this release
-
-This first release includes:
-
-- Core changeset management engine
-- Multi-ecosystem package detection and versioning
-- Hosting provider integrations (Gitea, GitHub, GitLab)
-- Semantic versioning utilities
-- Configurable release workflows
-- CLI tooling for validation and release orchestration
-
-For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
-
-> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added
@@ -260,3 +223,40 @@ This release also adds two new support crates:
 The Cargo and npm suites now live in `monochange_cargo::lints` and `monochange_npm::lints`, so ecosystem-specific parsing and rule behavior stay with their ecosystem adapters.
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #228](https://github.com/ifiokjr/monochange/pull/228) _Introduced in:_ [`94f06a0`](https://github.com/ifiokjr/monochange/commit/94f06a057150d26e5f330e2e49a08f71eb12fc92) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2)
+## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
+
+### Breaking changes
+
+#### 🚀 Initial public release of monochange
+
+**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
+
+##### What is monochange?
+
+In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
+
+- **Change tracking**: Structured changesets that capture intent across multiple packages
+- **Release planning**: Automated versioning and changelog generation
+- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
+- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
+- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
+
+##### Why monochange matters for AI-driven workflows
+
+As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
+
+##### What's included in this release
+
+This first release includes:
+
+- Core changeset management engine
+- Multi-ecosystem package detection and versioning
+- Hosting provider integrations (Gitea, GitHub, GitLab)
+- Semantic versioning utilities
+- Configurable release workflows
+- CLI tooling for validation and release orchestration
+
+For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
+
+> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
+

--- a/crates/monochange_gitea/changelog.md
+++ b/crates/monochange_gitea/changelog.md
@@ -1,5 +1,3 @@
-
-
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added

--- a/crates/monochange_github/changelog.md
+++ b/crates/monochange_github/changelog.md
@@ -1,40 +1,3 @@
-## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
-
-### Breaking changes
-
-#### 🚀 Initial public release of monochange
-
-**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
-
-##### What is monochange?
-
-In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
-
-- **Change tracking**: Structured changesets that capture intent across multiple packages
-- **Release planning**: Automated versioning and changelog generation
-- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
-- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
-- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
-
-##### Why monochange matters for AI-driven workflows
-
-As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
-
-##### What's included in this release
-
-This first release includes:
-
-- Core changeset management engine
-- Multi-ecosystem package detection and versioning
-- Hosting provider integrations (Gitea, GitHub, GitLab)
-- Semantic versioning utilities
-- Configurable release workflows
-- CLI tooling for validation and release orchestration
-
-For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
-
-> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added
@@ -167,3 +130,40 @@ match existing {
 The result is more consistent crate documentation, less duplicated prose, and flatter control flow in a few high-traffic code paths.
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #224](https://github.com/ifiokjr/monochange/pull/224) _Introduced in:_ [`d0f76ed`](https://github.com/ifiokjr/monochange/commit/d0f76ed56fa18e0ca9d9ec20fa9e44d413014db7) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2)
+## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
+
+### Breaking changes
+
+#### 🚀 Initial public release of monochange
+
+**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
+
+##### What is monochange?
+
+In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
+
+- **Change tracking**: Structured changesets that capture intent across multiple packages
+- **Release planning**: Automated versioning and changelog generation
+- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
+- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
+- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
+
+##### Why monochange matters for AI-driven workflows
+
+As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
+
+##### What's included in this release
+
+This first release includes:
+
+- Core changeset management engine
+- Multi-ecosystem package detection and versioning
+- Hosting provider integrations (Gitea, GitHub, GitLab)
+- Semantic versioning utilities
+- Configurable release workflows
+- CLI tooling for validation and release orchestration
+
+For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
+
+> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
+

--- a/crates/monochange_github/changelog.md
+++ b/crates/monochange_github/changelog.md
@@ -1,5 +1,3 @@
-
-
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added

--- a/crates/monochange_github/changelog.md
+++ b/crates/monochange_github/changelog.md
@@ -1,3 +1,5 @@
+
+
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added
@@ -130,6 +132,7 @@ match existing {
 The result is more consistent crate documentation, less duplicated prose, and flatter control flow in a few high-traffic code paths.
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #224](https://github.com/ifiokjr/monochange/pull/224) _Introduced in:_ [`d0f76ed`](https://github.com/ifiokjr/monochange/commit/d0f76ed56fa18e0ca9d9ec20fa9e44d413014db7) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2)
+
 ## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
 
 ### Breaking changes
@@ -166,4 +169,3 @@ This first release includes:
 For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
 
 > _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-

--- a/crates/monochange_gitlab/changelog.md
+++ b/crates/monochange_gitlab/changelog.md
@@ -1,3 +1,5 @@
+
+
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added
@@ -223,6 +225,7 @@ This release also adds two new support crates:
 The Cargo and npm suites now live in `monochange_cargo::lints` and `monochange_npm::lints`, so ecosystem-specific parsing and rule behavior stay with their ecosystem adapters.
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #228](https://github.com/ifiokjr/monochange/pull/228) _Introduced in:_ [`94f06a0`](https://github.com/ifiokjr/monochange/commit/94f06a057150d26e5f330e2e49a08f71eb12fc92) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2)
+
 ## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
 
 ### Breaking changes
@@ -259,4 +262,3 @@ This first release includes:
 For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
 
 > _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-

--- a/crates/monochange_gitlab/changelog.md
+++ b/crates/monochange_gitlab/changelog.md
@@ -1,40 +1,3 @@
-## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
-
-### Breaking changes
-
-#### 🚀 Initial public release of monochange
-
-**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
-
-##### What is monochange?
-
-In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
-
-- **Change tracking**: Structured changesets that capture intent across multiple packages
-- **Release planning**: Automated versioning and changelog generation
-- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
-- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
-- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
-
-##### Why monochange matters for AI-driven workflows
-
-As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
-
-##### What's included in this release
-
-This first release includes:
-
-- Core changeset management engine
-- Multi-ecosystem package detection and versioning
-- Hosting provider integrations (Gitea, GitHub, GitLab)
-- Semantic versioning utilities
-- Configurable release workflows
-- CLI tooling for validation and release orchestration
-
-For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
-
-> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added
@@ -260,3 +223,40 @@ This release also adds two new support crates:
 The Cargo and npm suites now live in `monochange_cargo::lints` and `monochange_npm::lints`, so ecosystem-specific parsing and rule behavior stay with their ecosystem adapters.
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #228](https://github.com/ifiokjr/monochange/pull/228) _Introduced in:_ [`94f06a0`](https://github.com/ifiokjr/monochange/commit/94f06a057150d26e5f330e2e49a08f71eb12fc92) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2)
+## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
+
+### Breaking changes
+
+#### 🚀 Initial public release of monochange
+
+**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
+
+##### What is monochange?
+
+In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
+
+- **Change tracking**: Structured changesets that capture intent across multiple packages
+- **Release planning**: Automated versioning and changelog generation
+- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
+- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
+- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
+
+##### Why monochange matters for AI-driven workflows
+
+As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
+
+##### What's included in this release
+
+This first release includes:
+
+- Core changeset management engine
+- Multi-ecosystem package detection and versioning
+- Hosting provider integrations (Gitea, GitHub, GitLab)
+- Semantic versioning utilities
+- Configurable release workflows
+- CLI tooling for validation and release orchestration
+
+For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
+
+> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
+

--- a/crates/monochange_gitlab/changelog.md
+++ b/crates/monochange_gitlab/changelog.md
@@ -1,5 +1,3 @@
-
-
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added

--- a/crates/monochange_graph/changelog.md
+++ b/crates/monochange_graph/changelog.md
@@ -2,43 +2,6 @@
 
 All notable changes to `monochange_graph` will be documented in this file.
 
-## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
-
-### Breaking changes
-
-#### 🚀 Initial public release of monochange
-
-**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
-
-##### What is monochange?
-
-In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
-
-- **Change tracking**: Structured changesets that capture intent across multiple packages
-- **Release planning**: Automated versioning and changelog generation
-- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
-- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
-- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
-
-##### Why monochange matters for AI-driven workflows
-
-As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
-
-##### What's included in this release
-
-This first release includes:
-
-- Core changeset management engine
-- Multi-ecosystem package detection and versioning
-- Hosting provider integrations (Gitea, GitHub, GitLab)
-- Semantic versioning utilities
-- Configurable release workflows
-- CLI tooling for validation and release orchestration
-
-For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
-
-> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added
@@ -146,3 +109,40 @@ match existing {
 The result is more consistent crate documentation, less duplicated prose, and flatter control flow in a few high-traffic code paths.
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #224](https://github.com/ifiokjr/monochange/pull/224) _Introduced in:_ [`d0f76ed`](https://github.com/ifiokjr/monochange/commit/d0f76ed56fa18e0ca9d9ec20fa9e44d413014db7) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2)
+## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
+
+### Breaking changes
+
+#### 🚀 Initial public release of monochange
+
+**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
+
+##### What is monochange?
+
+In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
+
+- **Change tracking**: Structured changesets that capture intent across multiple packages
+- **Release planning**: Automated versioning and changelog generation
+- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
+- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
+- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
+
+##### Why monochange matters for AI-driven workflows
+
+As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
+
+##### What's included in this release
+
+This first release includes:
+
+- Core changeset management engine
+- Multi-ecosystem package detection and versioning
+- Hosting provider integrations (Gitea, GitHub, GitLab)
+- Semantic versioning utilities
+- Configurable release workflows
+- CLI tooling for validation and release orchestration
+
+For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
+
+> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
+

--- a/crates/monochange_graph/changelog.md
+++ b/crates/monochange_graph/changelog.md
@@ -109,6 +109,7 @@ match existing {
 The result is more consistent crate documentation, less duplicated prose, and flatter control flow in a few high-traffic code paths.
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #224](https://github.com/ifiokjr/monochange/pull/224) _Introduced in:_ [`d0f76ed`](https://github.com/ifiokjr/monochange/commit/d0f76ed56fa18e0ca9d9ec20fa9e44d413014db7) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2)
+
 ## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
 
 ### Breaking changes
@@ -145,4 +146,3 @@ This first release includes:
 For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
 
 > _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-

--- a/crates/monochange_hosting/changelog.md
+++ b/crates/monochange_hosting/changelog.md
@@ -1,40 +1,3 @@
-## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
-
-### Breaking changes
-
-#### 🚀 Initial public release of monochange
-
-**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
-
-##### What is monochange?
-
-In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
-
-- **Change tracking**: Structured changesets that capture intent across multiple packages
-- **Release planning**: Automated versioning and changelog generation
-- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
-- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
-- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
-
-##### Why monochange matters for AI-driven workflows
-
-As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
-
-##### What's included in this release
-
-This first release includes:
-
-- Core changeset management engine
-- Multi-ecosystem package detection and versioning
-- Hosting provider integrations (Gitea, GitHub, GitLab)
-- Semantic versioning utilities
-- Configurable release workflows
-- CLI tooling for validation and release orchestration
-
-For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
-
-> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added
@@ -167,3 +130,40 @@ match existing {
 The result is more consistent crate documentation, less duplicated prose, and flatter control flow in a few high-traffic code paths.
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #224](https://github.com/ifiokjr/monochange/pull/224) _Introduced in:_ [`d0f76ed`](https://github.com/ifiokjr/monochange/commit/d0f76ed56fa18e0ca9d9ec20fa9e44d413014db7) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2)
+## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
+
+### Breaking changes
+
+#### 🚀 Initial public release of monochange
+
+**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
+
+##### What is monochange?
+
+In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
+
+- **Change tracking**: Structured changesets that capture intent across multiple packages
+- **Release planning**: Automated versioning and changelog generation
+- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
+- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
+- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
+
+##### Why monochange matters for AI-driven workflows
+
+As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
+
+##### What's included in this release
+
+This first release includes:
+
+- Core changeset management engine
+- Multi-ecosystem package detection and versioning
+- Hosting provider integrations (Gitea, GitHub, GitLab)
+- Semantic versioning utilities
+- Configurable release workflows
+- CLI tooling for validation and release orchestration
+
+For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
+
+> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
+

--- a/crates/monochange_hosting/changelog.md
+++ b/crates/monochange_hosting/changelog.md
@@ -1,5 +1,3 @@
-
-
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added

--- a/crates/monochange_hosting/changelog.md
+++ b/crates/monochange_hosting/changelog.md
@@ -1,3 +1,5 @@
+
+
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added
@@ -130,6 +132,7 @@ match existing {
 The result is more consistent crate documentation, less duplicated prose, and flatter control flow in a few high-traffic code paths.
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #224](https://github.com/ifiokjr/monochange/pull/224) _Introduced in:_ [`d0f76ed`](https://github.com/ifiokjr/monochange/commit/d0f76ed56fa18e0ca9d9ec20fa9e44d413014db7) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2)
+
 ## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
 
 ### Breaking changes
@@ -166,4 +169,3 @@ This first release includes:
 For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
 
 > _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-

--- a/crates/monochange_npm/changelog.md
+++ b/crates/monochange_npm/changelog.md
@@ -2,43 +2,6 @@
 
 All notable changes to `monochange_npm` will be documented in this file.
 
-## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
-
-### Breaking changes
-
-#### 🚀 Initial public release of monochange
-
-**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
-
-##### What is monochange?
-
-In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
-
-- **Change tracking**: Structured changesets that capture intent across multiple packages
-- **Release planning**: Automated versioning and changelog generation
-- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
-- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
-- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
-
-##### Why monochange matters for AI-driven workflows
-
-As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
-
-##### What's included in this release
-
-This first release includes:
-
-- Core changeset management engine
-- Multi-ecosystem package detection and versioning
-- Hosting provider integrations (Gitea, GitHub, GitLab)
-- Semantic versioning utilities
-- Configurable release workflows
-- CLI tooling for validation and release orchestration
-
-For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
-
-> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added
@@ -479,3 +442,40 @@ This foundation change adds:
 - tests covering managed Dart lint target collection and fixture filtering
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #235](https://github.com/ifiokjr/monochange/pull/235) _Introduced in:_ [`5a7a4fe`](https://github.com/ifiokjr/monochange/commit/5a7a4fed84603f51dd5d152d11e739f30dea2b64) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2) _Closed issues:_ [#230](https://github.com/ifiokjr/monochange/issues/230)
+## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
+
+### Breaking changes
+
+#### 🚀 Initial public release of monochange
+
+**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
+
+##### What is monochange?
+
+In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
+
+- **Change tracking**: Structured changesets that capture intent across multiple packages
+- **Release planning**: Automated versioning and changelog generation
+- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
+- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
+- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
+
+##### Why monochange matters for AI-driven workflows
+
+As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
+
+##### What's included in this release
+
+This first release includes:
+
+- Core changeset management engine
+- Multi-ecosystem package detection and versioning
+- Hosting provider integrations (Gitea, GitHub, GitLab)
+- Semantic versioning utilities
+- Configurable release workflows
+- CLI tooling for validation and release orchestration
+
+For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
+
+> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
+

--- a/crates/monochange_npm/changelog.md
+++ b/crates/monochange_npm/changelog.md
@@ -442,6 +442,7 @@ This foundation change adds:
 - tests covering managed Dart lint target collection and fixture filtering
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #235](https://github.com/ifiokjr/monochange/pull/235) _Introduced in:_ [`5a7a4fe`](https://github.com/ifiokjr/monochange/commit/5a7a4fed84603f51dd5d152d11e739f30dea2b64) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2) _Closed issues:_ [#230](https://github.com/ifiokjr/monochange/issues/230)
+
 ## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
 
 ### Breaking changes
@@ -478,4 +479,3 @@ This first release includes:
 For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
 
 > _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-

--- a/crates/monochange_semver/changelog.md
+++ b/crates/monochange_semver/changelog.md
@@ -111,6 +111,7 @@ The result is more consistent crate documentation, less duplicated prose, and fl
 You can now annotate dependency-only follow-up changesets with `caused_by`, use `mc change --caused-by ...` to author them, inspect the linkage in diagnostics output, and suppress matching automatic dependency propagation during release planning.
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #245](https://github.com/ifiokjr/monochange/pull/245) _Introduced in:_ [`8ec612b`](https://github.com/ifiokjr/monochange/commit/8ec612beb9a8b8100037435695826042bc7361c4) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2) _Closed issues:_ [#208](https://github.com/ifiokjr/monochange/issues/208)
+
 ## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
 
 ### Breaking changes
@@ -147,4 +148,3 @@ This first release includes:
 For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
 
 > _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-

--- a/crates/monochange_semver/changelog.md
+++ b/crates/monochange_semver/changelog.md
@@ -2,43 +2,6 @@
 
 All notable changes to `monochange_semver` will be documented in this file.
 
-## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
-
-### Breaking changes
-
-#### 🚀 Initial public release of monochange
-
-**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
-
-##### What is monochange?
-
-In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
-
-- **Change tracking**: Structured changesets that capture intent across multiple packages
-- **Release planning**: Automated versioning and changelog generation
-- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
-- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
-- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
-
-##### Why monochange matters for AI-driven workflows
-
-As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
-
-##### What's included in this release
-
-This first release includes:
-
-- Core changeset management engine
-- Multi-ecosystem package detection and versioning
-- Hosting provider integrations (Gitea, GitHub, GitLab)
-- Semantic versioning utilities
-- Configurable release workflows
-- CLI tooling for validation and release orchestration
-
-For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
-
-> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
-
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added
@@ -148,3 +111,40 @@ The result is more consistent crate documentation, less duplicated prose, and fl
 You can now annotate dependency-only follow-up changesets with `caused_by`, use `mc change --caused-by ...` to author them, inspect the linkage in diagnostics output, and suppress matching automatic dependency propagation during release planning.
 
 > _Owner:_ [@ifiokjr](https://github.com/ifiokjr) _Review:_ [PR #245](https://github.com/ifiokjr/monochange/pull/245) _Introduced in:_ [`8ec612b`](https://github.com/ifiokjr/monochange/commit/8ec612beb9a8b8100037435695826042bc7361c4) _Last updated in:_ [`2bd10ab`](https://github.com/ifiokjr/monochange/commit/2bd10abcd34e0eca9f75cebdfafdf6347dc84ca2) _Closed issues:_ [#208](https://github.com/ifiokjr/monochange/issues/208)
+## [0.1.0](https://github.com/ifiokjr/monochange/releases/tag/v0.1.0) (2026-04-13)
+
+### Breaking changes
+
+#### 🚀 Initial public release of monochange
+
+**monochange** is a Rust-based release-planning toolkit for monorepos that span multiple package ecosystems. It is designed from the ground up to support the modern, AI-driven development landscape where agents and automation play a central role in software delivery.
+
+##### What is monochange?
+
+In today's agent-driven development environment, managing releases across diverse package ecosystems (Rust, JavaScript/TypeScript, Dart, Python, etc.) becomes increasingly complex. monochange provides a unified, programmatic interface for:
+
+- **Change tracking**: Structured changesets that capture intent across multiple packages
+- **Release planning**: Automated versioning and changelog generation
+- **Multi-ecosystem support**: Native handling of Cargo, NPM, Dart, Deno, and more
+- **CI/CD integration**: Seamless workflows for Gitea, GitHub, and GitLab
+- **Graph-based dependency analysis**: Understanding package relationships across your monorepo
+
+##### Why monochange matters for AI-driven workflows
+
+As development teams increasingly rely on AI agents to generate code, manage dependencies, and orchestrate releases, monochange provides the structured foundation these agents need to operate effectively. It transforms release management from a manual, error-prone process into a deterministic, automatable workflow.
+
+##### What's included in this release
+
+This first release includes:
+
+- Core changeset management engine
+- Multi-ecosystem package detection and versioning
+- Hosting provider integrations (Gitea, GitHub, GitLab)
+- Semantic versioning utilities
+- Configurable release workflows
+- CLI tooling for validation and release orchestration
+
+For complete feature details, architecture overview, and usage examples, see the [documentation](https://docs.rs/monochange).
+
+> _Owner:_ Ifiok Jr. _Introduced in:_ [`4542b5a`](https://github.com/ifiokjr/monochange/commit/4542b5aee8b63a86c7ffc0ea9436090162a18056)
+


### PR DESCRIPTION
## Summary
- move existing `0.2.0` release sections above `0.1.0` in the published changelogs
- keep each changelog intro and release content unchanged while restoring reverse-chronological order
- limit the backfill to the currently published workspace and crate changelogs

## Validation
- `devenv shell -- monochange affected --format json --verify --changed-paths changelog.md --changed-paths crates/monochange/changelog.md --changed-paths crates/monochange_cargo/changelog.md --changed-paths crates/monochange_config/changelog.md --changed-paths crates/monochange_core/changelog.md --changed-paths crates/monochange_dart/changelog.md --changed-paths crates/monochange_deno/changelog.md --changed-paths crates/monochange_gitea/changelog.md --changed-paths crates/monochange_github/changelog.md --changed-paths crates/monochange_gitlab/changelog.md --changed-paths crates/monochange_graph/changelog.md --changed-paths crates/monochange_hosting/changelog.md --changed-paths crates/monochange_npm/changelog.md --changed-paths crates/monochange_semver/changelog.md`