### PR TITLE
ci: add guarded release PR merge workflow

### DIFF
--- a/.changeset/release-pr-merge-automation.md
+++ b/.changeset/release-pr-merge-automation.md
@@ -1,0 +1,26 @@
+---
+monochange: patch
+---
+
+#### require release PRs to use an explicit merge-commit workflow
+
+The repository release-PR automation can now block normal GitHub merges for branches under `monochange/release/` and route them through a dedicated `release-pr-merge` workflow instead.
+
+**Before (manual process):**
+
+- the release PR could be merged from the normal GitHub UI
+- maintainers had to remember to use a merge commit instead of squash or rebase
+- accidental merge-method changes could rewrite the durable monochange release commit before post-merge tagging and publish
+
+**After:**
+
+- `ci.yml` exposes a required `release-pr-manual-merge-blocker` job that fails for release PR branches
+- `.github/workflows/release-pr-merge.yml` verifies every other check is green and then runs:
+
+```bash
+gh pr merge <release-pr> --merge --admin --match-head-commit <sha>
+```
+
+- the merge workflow expects a `RELEASE_PR_MERGE_TOKEN` secret that is allowed to bypass branch protection for that one intentional path
+
+That setup keeps the exact monochange release commit intact when it lands on `main`, which means the later `mc release-record --from HEAD`, `mc tag-release --from HEAD`, and `mc publish` steps still operate on the durable release record that the PR prepared.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,27 @@ jobs:
           fi
         shell: devenv shell -- bash -e {0}
 
+  release-pr-manual-merge-blocker:
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: enforce automated merge for release pull requests
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release_branch_prefix='monochange/release/'
+          branch='${{ github.head_ref }}'
+
+          if [[ "$branch" == "$release_branch_prefix"* ]]; then
+            echo "::error::Release pull requests must be merged by the release-pr-merge workflow so the release commit lands on main unchanged."
+            echo "::error::Run the release-pr-merge workflow with a bypass-capable token instead of using GitHub's merge button."
+            exit 1
+          fi
+
+          echo "Branch '$branch' is not a release PR branch; manual release-PR merge blocking is not needed."
+
   release-pr:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'ifiokjr'
     timeout-minutes: 20

--- a/.github/workflows/release-pr-merge.yml
+++ b/.github/workflows/release-pr-merge.yml
@@ -1,0 +1,171 @@
+name: "release-pr-merge"
+
+on:
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: "Optional release PR number. Leave empty to auto-detect the single open release PR."
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.pull_request || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  merge:
+    if: github.repository_owner == 'ifiokjr'
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    env:
+      RELEASE_PR_BRANCH_PREFIX: monochange/release/
+      RELEASE_PR_MANUAL_MERGE_BLOCKER: release-pr-manual-merge-blocker
+    steps:
+      - name: verify bypass token
+        env:
+          RELEASE_PR_MERGE_TOKEN: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${RELEASE_PR_MERGE_TOKEN:-}" ]; then
+            echo "::error::Set the RELEASE_PR_MERGE_TOKEN secret to a token or GitHub App installation token that can bypass branch protection for release PR merges."
+            exit 1
+          fi
+
+      - name: resolve release PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          requested='${{ inputs.pull_request }}'
+
+          if [ -n "$requested" ]; then
+            pr_json="$(gh pr view "$requested" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json number,title,url)"
+          else
+            candidates="$(gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --base main \
+              --json number,headRefName,title,url \
+              | jq '[.[] | select(.headRefName | startswith(env.RELEASE_PR_BRANCH_PREFIX))]')"
+            candidate_count="$(jq 'length' <<<"$candidates")"
+
+            if [ "$candidate_count" -ne 1 ]; then
+              echo "::error::Expected exactly one open release PR on main, found $candidate_count. Re-run the workflow with the pull_request input set explicitly."
+              jq -r '.[] | "- #\(.number) \(.headRefName) — \(.title) (\(.url))"' <<<"$candidates"
+              exit 1
+            fi
+
+            pr_json="$(jq '.[0]' <<<"$candidates")"
+          fi
+
+          echo "number=$(jq -r '.number' <<<"$pr_json")" >> "$GITHUB_OUTPUT"
+          echo "title=$(jq -r '.title' <<<"$pr_json")" >> "$GITHUB_OUTPUT"
+          echo "url=$(jq -r '.url' <<<"$pr_json")" >> "$GITHUB_OUTPUT"
+
+      - name: inspect release PR state
+        id: inspect
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          pr='${{ steps.pr.outputs.number }}'
+          pr_json="$(gh pr view "$pr" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json number,title,url,state,baseRefName,headRefName,headRefOid,isCrossRepository,mergeable)"
+
+          if ! jq -e '.state == "OPEN"' <<<"$pr_json" >/dev/null; then
+            echo "::error::PR #$pr is not open."
+            exit 1
+          fi
+
+          if ! jq -e '.baseRefName == "main"' <<<"$pr_json" >/dev/null; then
+            echo "::error::PR #$pr does not target main."
+            exit 1
+          fi
+
+          if ! jq -e '.headRefName | startswith(env.RELEASE_PR_BRANCH_PREFIX)' <<<"$pr_json" >/dev/null; then
+            echo "::error::PR #$pr is not a release PR branch."
+            exit 1
+          fi
+
+          if ! jq -e '.isCrossRepository == false' <<<"$pr_json" >/dev/null; then
+            echo "::error::Release PR merges must come from the same repository."
+            exit 1
+          fi
+
+          mergeable="$(jq -r '.mergeable' <<<"$pr_json")"
+          if [ "$mergeable" != "MERGEABLE" ]; then
+            echo "::error::GitHub reports PR #$pr as $mergeable. Resolve conflicts or wait for GitHub to finish computing mergeability, then re-run this workflow."
+            exit 1
+          fi
+
+          echo "head_sha=$(jq -r '.headRefOid' <<<"$pr_json")" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$(jq -r '.headRefName' <<<"$pr_json")" >> "$GITHUB_OUTPUT"
+
+      - name: require green checks except the manual merge blocker
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          pr='${{ steps.pr.outputs.number }}'
+          checks="$(gh pr checks "$pr" --repo "$GITHUB_REPOSITORY" --required --json name,bucket,link)"
+
+          if [ "$(jq 'length' <<<"$checks")" -eq 0 ]; then
+            echo "::error::No status checks were found for PR #$pr."
+            exit 1
+          fi
+
+          blocker_failures="$(jq --arg blocker "$RELEASE_PR_MANUAL_MERGE_BLOCKER" '[.[] | select(.name == $blocker and .bucket == "fail")] | length' <<<"$checks")"
+          pending_checks="$(jq '[.[] | select(.bucket == "pending")] | length' <<<"$checks")"
+          cancelled_checks="$(jq '[.[] | select(.bucket == "cancel")] | length' <<<"$checks")"
+          failing_checks="$(jq --arg blocker "$RELEASE_PR_MANUAL_MERGE_BLOCKER" '[.[] | select(.bucket == "fail" and .name != $blocker)] | length' <<<"$checks")"
+
+          if [ "$blocker_failures" -ne 1 ] || [ "$pending_checks" -ne 0 ] || [ "$cancelled_checks" -ne 0 ] || [ "$failing_checks" -ne 0 ]; then
+            echo "Current PR checks:"
+            echo "$checks" | jq
+
+            if [ "$blocker_failures" -ne 1 ]; then
+              echo "::error::Expected exactly one failing '$RELEASE_PR_MANUAL_MERGE_BLOCKER' check before bypass merging."
+            fi
+
+            if [ "$pending_checks" -ne 0 ]; then
+              echo "::error::PR #$pr still has pending checks."
+            fi
+
+            if [ "$cancelled_checks" -ne 0 ]; then
+              echo "::error::PR #$pr has cancelled checks. Re-run them before merging."
+            fi
+
+            if [ "$failing_checks" -ne 0 ]; then
+              echo "::error::PR #$pr has failing checks other than the intentional manual-merge blocker."
+            fi
+
+            exit 1
+          fi
+
+      - name: merge release PR with a merge commit
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          gh pr merge '${{ steps.pr.outputs.number }}' \
+            --repo "$GITHUB_REPOSITORY" \
+            --merge \
+            --admin \
+            --match-head-commit '${{ steps.inspect.outputs.head_sha }}'
+
+      - name: report merged release PR
+        run: |
+          echo "Merged release PR #${{ steps.pr.outputs.number }} (${{ steps.inspect.outputs.head_ref }}) via merge commit."
+          echo "PR URL: ${{ steps.pr.outputs.url }}"

--- a/docs/src/guide/13-ci-and-publishing.md
+++ b/docs/src/guide/13-ci-and-publishing.md
@@ -633,6 +633,25 @@ For the long-running release PR model, the recommended shape is now:
 
 That keeps tag creation on the default branch side of the merge, which is much safer than tagging the PR branch early.
 
+### Blocking manual release-PR merges while keeping merge commits
+
+If you want to stop humans from accidentally using **Squash and merge** or **Rebase and merge** on release PRs, add a required job that fails whenever the PR head branch starts with your release-branch prefix, then provide a separate maintainer-triggered workflow that merges the PR with `gh pr merge --merge`.
+
+That pattern works around GitHub's repository-level merge-method settings:
+
+1. the release PR stays blocked in the normal merge UI because the required blocker job fails
+2. the dedicated merge workflow verifies every other check is green
+3. the workflow merges with `--merge` so the durable monochange release commit lands on `main` unchanged
+4. the workflow uses a dedicated token or GitHub App installation token that is allowed to bypass branch protection for that one intentional merge path
+
+A practical repository setup looks like this:
+
+- required PR job: `release-pr-manual-merge-blocker`
+- manual merge workflow: `.github/workflows/release-pr-merge.yml`
+- bypass token secret: `RELEASE_PR_MERGE_TOKEN`
+
+That gives you a selective policy for release PRs even though GitHub cannot disable squash/rebase only for one class of pull request.
+
 ### GitHub Actions reference sketch
 
 ```yaml

--- a/examples/release-pr-workflow/.github/workflows/release-pr-merge.yml
+++ b/examples/release-pr-workflow/.github/workflows/release-pr-merge.yml
@@ -1,0 +1,128 @@
+name: release-pr-merge
+
+on:
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: Optional release PR number. Leave empty to auto-detect the single open release PR.
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.pull_request || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    env:
+      RELEASE_PR_BRANCH_PREFIX: monochange/release/
+      RELEASE_PR_MANUAL_MERGE_BLOCKER: release-pr-manual-merge-blocker
+    steps:
+      - name: verify bypass token
+        env:
+          RELEASE_PR_MERGE_TOKEN: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${RELEASE_PR_MERGE_TOKEN:-}" ]; then
+            echo "::error::Set RELEASE_PR_MERGE_TOKEN to a token or GitHub App installation token that can bypass branch protection for release PR merges."
+            exit 1
+          fi
+
+      - name: resolve release PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          requested='${{ inputs.pull_request }}'
+
+          if [ -n "$requested" ]; then
+            pr_json="$(gh pr view "$requested" --repo "$GITHUB_REPOSITORY" --json number,url)"
+          else
+            candidates="$(gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --base main \
+              --json number,headRefName,url \
+              | jq '[.[] | select(.headRefName | startswith(env.RELEASE_PR_BRANCH_PREFIX))]')"
+            candidate_count="$(jq 'length' <<<"$candidates")"
+
+            if [ "$candidate_count" -ne 1 ]; then
+              echo "::error::Expected exactly one open release PR on main, found $candidate_count. Re-run the workflow with the pull_request input set explicitly."
+              jq -r '.[] | "- #\(.number) \(.headRefName) (\(.url))"' <<<"$candidates"
+              exit 1
+            fi
+
+            pr_json="$(jq '.[0]' <<<"$candidates")"
+          fi
+
+          echo "number=$(jq -r '.number' <<<"$pr_json")" >> "$GITHUB_OUTPUT"
+          echo "url=$(jq -r '.url' <<<"$pr_json")" >> "$GITHUB_OUTPUT"
+
+      - name: inspect release PR state
+        id: inspect
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          pr='${{ steps.pr.outputs.number }}'
+          pr_json="$(gh pr view "$pr" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json state,baseRefName,headRefName,headRefOid,isCrossRepository,mergeable)"
+
+          jq -e '.state == "OPEN"' <<<"$pr_json" >/dev/null
+          jq -e '.baseRefName == "main"' <<<"$pr_json" >/dev/null
+          jq -e '.headRefName | startswith(env.RELEASE_PR_BRANCH_PREFIX)' <<<"$pr_json" >/dev/null
+          jq -e '.isCrossRepository == false' <<<"$pr_json" >/dev/null
+
+          mergeable="$(jq -r '.mergeable' <<<"$pr_json")"
+          if [ "$mergeable" != "MERGEABLE" ]; then
+            echo "::error::GitHub reports PR #$pr as $mergeable. Resolve conflicts or wait for mergeability to finish computing, then re-run this workflow."
+            exit 1
+          fi
+
+          echo "head_sha=$(jq -r '.headRefOid' <<<"$pr_json")" >> "$GITHUB_OUTPUT"
+
+      - name: require green checks except the manual merge blocker
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          pr='${{ steps.pr.outputs.number }}'
+          checks="$(gh pr checks "$pr" --repo "$GITHUB_REPOSITORY" --required --json name,bucket)"
+
+          blocker_failures="$(jq --arg blocker "$RELEASE_PR_MANUAL_MERGE_BLOCKER" '[.[] | select(.name == $blocker and .bucket == "fail")] | length' <<<"$checks")"
+          pending_checks="$(jq '[.[] | select(.bucket == "pending")] | length' <<<"$checks")"
+          cancelled_checks="$(jq '[.[] | select(.bucket == "cancel")] | length' <<<"$checks")"
+          failing_checks="$(jq --arg blocker "$RELEASE_PR_MANUAL_MERGE_BLOCKER" '[.[] | select(.bucket == "fail" and .name != $blocker)] | length' <<<"$checks")"
+
+          if [ "$blocker_failures" -ne 1 ] || [ "$pending_checks" -ne 0 ] || [ "$cancelled_checks" -ne 0 ] || [ "$failing_checks" -ne 0 ]; then
+            echo "$checks" | jq
+            echo "::error::Only the intentional manual-merge blocker may be failing before this workflow bypass merges the release PR."
+            exit 1
+          fi
+
+      - name: merge release PR with a merge commit
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          gh pr merge '${{ steps.pr.outputs.number }}' \
+            --repo "$GITHUB_REPOSITORY" \
+            --merge \
+            --admin \
+            --match-head-commit '${{ steps.inspect.outputs.head_sha }}'
+
+      - name: report merged release PR
+        run: |
+          echo "Merged release PR #${{ steps.pr.outputs.number }} via merge commit."
+          echo "PR URL: ${{ steps.pr.outputs.url }}"

--- a/examples/release-pr-workflow/README.md
+++ b/examples/release-pr-workflow/README.md
@@ -8,6 +8,7 @@ This is a repo-shaped example for a long-running release PR branch flow where re
 - a small Cargo workspace with one publishable package
 - a sample `.changeset/*.md` file
 - `.github/workflows/release.yml` showing the release-PR refresh and post-merge tagging pattern
+- `.github/workflows/release-pr-merge.yml` showing a maintainer-triggered merge-commit workflow for release PRs that are intentionally blocked in the normal merge UI
 
 ## Recommended validation flow
 
@@ -21,4 +22,5 @@ mc release --dry-run --diff
 
 - it is optimized for human review before release files land on `main`
 - it keeps tag creation after merge, not on the release branch
+- it can pair a failing `release-pr-manual-merge-blocker` required check with a dedicated merge workflow so release PRs are merged only through an explicit merge-commit path
 - it separates release planning from downstream publish jobs


### PR DESCRIPTION
## Summary
- add a guarded `release-pr-merge` workflow that merges release PRs with a merge commit only after required checks pass
- add a CI blocker job that intentionally fails on `monochange/release/*` PRs to prevent normal/manual UI merges
- document the flow and include the example workflow updates

## Notes
- this also includes small test hardening fixes needed to satisfy local push hooks while preparing the branch
- repository setup is still required after merge: configure `RELEASE_PR_MERGE_TOKEN` and mark `release-pr-manual-merge-blocker` as a required branch protection check

## Validation
- `devenv shell -- fix:all`
- `devenv shell -- mc validate`
- `devenv shell -- mc affected --changed-paths .github/workflows/ci.yml --changed-paths .github/workflows/release-pr-merge.yml --changed-paths docs/src/guide/13-ci-and-publishing.md --changed-paths examples/release-pr-workflow/README.md --changed-paths examples/release-pr-workflow/.github/workflows/release-pr-merge.yml --changed-paths .changeset/release-pr-merge-automation.md`
- `devenv shell -- bash -lc 'lint:all && test:all'`
