### PR TITLE
chore: update owner references and pre-push hook after upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,7 +389,7 @@ jobs:
         if: steps.release_record.outputs.is_release_commit == 'true'
         run: echo "HEAD is already a merged release commit; skipping release PR refresh."
   release-post-merge:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'ifiokjr'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'monochange'
     needs: release-pr
     timeout-minutes: 10
     runs-on: ubuntu-latest

--- a/devenv.nix
+++ b/devenv.nix
@@ -74,11 +74,7 @@ in
         pass_filenames = false;
         name = "lint and test";
         description = "Run the local CI lint rules and test suite before push.";
-        entry = ''
-          set -euo pipefail
-          ${config.env.DEVENV_PROFILE}/bin/lint:all;
-          ${config.env.DEVENV_PROFILE}/bin/test:all
-        '';
+        entry = "${config.env.DEVENV_PROFILE}/bin/lint:test";
         stages = [ "pre-push" ];
       };
     };
@@ -299,6 +295,15 @@ in
         cargo deny check
       '';
       description = "Run cargo-deny checks for security advisories and license compliance.";
+      binary = "bash";
+    };
+    "lint:test" = {
+      exec = ''
+        set -euo pipefail
+        lint:all;
+        test:all;
+      '';
+      description = "Used for the pre push checks";
       binary = "bash";
     };
     "lint:all" = {

--- a/monochange.toml
+++ b/monochange.toml
@@ -560,7 +560,7 @@ enabled = true
 
 [source]
 provider = "github"
-owner = "ifiokjr"
+owner = "monochange"
 repo = "monochange"
 
 # [source.releases] — provider release settings


### PR DESCRIPTION
Updates GitHub owner references from `ifiokjr` to `monochange` and refactors the pre-push hook into a dedicated `lint:test` devenv script.