### PR TITLE
feat: add publish readiness command

### DIFF
--- a/.changeset/publish-readiness-command.md
+++ b/.changeset/publish-readiness-command.md
@@ -1,0 +1,7 @@
+---
+"monochange": patch
+---
+
+#### add initial publish readiness command
+
+Adds `mc publish-readiness` as a non-mutating preflight command for package registry publishing. The command reads a release record from `--from`, dry-runs registry publish checks for the selected package set, reports ready/already-published/unsupported package states, and can write a JSON readiness artifact with `--output`.

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -90,9 +90,10 @@ Recent `monochange` improvements made package publishing guidance and diagnostic
 | Preview the release plan         | `mc release --dry-run --diff`                               | You want changelog/version patches without mutating the repo                                             |
 | Create a durable release commit  | `mc commit-release`                                         | You want a monochange-managed release commit with an embedded `ReleaseRecord`                            |
 | Open or update a release request | `mc release-pr`                                             | You want a long-lived release PR/MR branch updated from current release state                            |
+| Inspect a past release commit    | `mc release-record --from <ref>`                            | You need the durable release declaration from git history                                                |
+| Check package publish readiness  | `mc publish-readiness --from <ref>`                         | You need non-mutating registry readiness output before package publication                               |
 | Publish packages to registries   | `mc publish`                                                | You want `cargo publish`, `npm publish`, `deno publish`, or `dart pub publish` style package publication |
 | Bootstrap missing packages       | `mc placeholder-publish`                                    | A package must exist in its registry before later automation can work                                    |
-| Inspect a past release commit    | `mc release-record --from <ref>`                            | You need the durable release declaration from git history                                                |
 | Create post-merge release tags   | `mc tag-release --from HEAD`                                | You merged a monochange release commit and now need to create and push its declared tag set              |
 | Repair a recent release          | `mc repair-release --from <tag> --target <commit>`          | You need to retarget a just-created release to a later commit                                            |
 | Publish hosted/provider releases | `mc publish-release`                                        | You want GitHub/GitLab/Gitea release objects from prepared release state                                 |

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -567,6 +567,77 @@ fn release_record_supports_json_output() {
 }
 
 #[test]
+fn publish_readiness_dispatches_from_release_record_and_writes_artifact() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	create_release_record_commit(root);
+	let output_path = root.join(".monochange/readiness.json");
+	let output = run_cli(
+		root,
+		[
+			OsString::from("mc"),
+			OsString::from("publish-readiness"),
+			OsString::from("--from"),
+			OsString::from("HEAD"),
+			OsString::from("--package"),
+			OsString::from("missing"),
+			OsString::from("--format"),
+			OsString::from("text"),
+			OsString::from("--output"),
+			output_path.clone().into_os_string(),
+		],
+	)
+	.unwrap_or_else(|error| panic!("publish-readiness output: {error}"));
+
+	assert!(output.contains("publish readiness: ready"));
+	assert!(output.contains("release ref: HEAD"));
+	assert!(output.contains("packages: none"));
+
+	let artifact = fs::read_to_string(&output_path)
+		.unwrap_or_else(|error| panic!("read readiness artifact: {error}"));
+	assert!(artifact.contains("\"status\": \"ready\""));
+	assert!(artifact.contains("\"from\": \"HEAD\""));
+	assert!(artifact.contains("\"packages\": []"));
+}
+
+#[test]
+fn publish_readiness_reports_release_ref_and_output_errors() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	create_release_record_commit(root);
+
+	let missing_ref = run_cli(
+		root,
+		[
+			OsString::from("mc"),
+			OsString::from("publish-readiness"),
+			OsString::from("--from"),
+			OsString::from("missing-ref"),
+		],
+	)
+	.expect_err("missing release ref should fail readiness");
+	assert!(missing_ref.to_string().contains("missing-ref"));
+
+	let output_error = run_cli(
+		root,
+		[
+			OsString::from("mc"),
+			OsString::from("publish-readiness"),
+			OsString::from("--from"),
+			OsString::from("HEAD"),
+			OsString::from("--output"),
+			root.into(),
+		],
+	)
+	.expect_err("directory output should fail readiness artifact write");
+	assert!(
+		output_error
+			.to_string()
+			.contains("failed to write publish readiness output")
+	);
+}
+
+#[test]
 fn init_writes_detected_packages_groups_and_default_cli_commands() {
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	copy_fixture("monochange/init-scan", tempdir.path());

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -206,6 +206,7 @@ When provided, the generated config includes:\n\
 			.subcommand(build_subagents_subcommand())
 			.subcommand(build_analyze_subcommand())
 			.subcommand(build_release_record_subcommand())
+			.subcommand(build_publish_readiness_subcommand())
 			.subcommand(build_tag_release_subcommand())
 			.subcommand(build_lint_subcommand())
 			.subcommand(Command::new("mcp").about(
@@ -414,6 +415,50 @@ Inspection notes:
 				.required(true)
 				.value_name("REF")
 				.help("Tag or commit-ish used to locate the release record"),
+		)
+		.arg(
+			Arg::new("format")
+				.long("format")
+				.help("Output format")
+				.default_value("markdown")
+				.value_parser(["text", "json", "markdown", "md"]),
+		)
+}
+
+pub(crate) fn build_publish_readiness_subcommand() -> Command {
+	Command::new("publish-readiness")
+		.about("Check package registry publishing readiness without publishing packages")
+		.after_help(
+			r"Examples:
+  mc publish-readiness --from HEAD
+  mc publish-readiness --from v1.2.3 --package core --format json
+  mc publish-readiness --from HEAD --output .monochange/readiness.json
+
+Readiness notes:
+  - Uses the release record at the supplied ref to select package versions.
+  - Checks registry state in dry-run mode and reports already-published packages as resumable.
+  - Treats packages configured for external publishing as blocked for built-in publishing.",
+		)
+		.arg(
+			Arg::new("from")
+				.long("from")
+				.required(true)
+				.value_name("REF")
+				.help("Tag or commit-ish used to locate the release record"),
+		)
+		.arg(
+			Arg::new("package")
+				.long("package")
+				.short('p')
+				.help("Limit readiness to one or more package ids")
+				.value_name("PACKAGE")
+				.action(ArgAction::Append),
+		)
+		.arg(
+			Arg::new("output")
+				.long("output")
+				.help("Write a JSON readiness artifact to this path")
+				.value_name("PATH"),
 		)
 		.arg(
 			Arg::new("format")

--- a/crates/monochange/src/cli_help.rs
+++ b/crates/monochange/src/cli_help.rs
@@ -817,6 +817,53 @@ fn builtin_command_helps() -> Vec<CommandHelp> {
 			see_also: &["validate", "init"],
 		},
 		CommandHelp {
+			name: "publish-readiness",
+			summary: "Check package registry publishing readiness without publishing packages",
+			description: "Evaluates the package publications recorded on a release commit against the\
+				current workspace configuration and target registries. The command is read-only: it\
+				runs registry existence checks in dry-run mode, reports packages that are ready,\
+				already published, or unsupported by built-in publishing, and can write a JSON\
+				readiness artifact for later publish orchestration.",
+			usage: "mc publish-readiness --from <REF> [OPTIONS]",
+			options: &[
+				(
+					"--from",
+					"<REF>",
+					"Tag or commit-ish used to locate the release record",
+				),
+				(
+					"--format",
+					"<FORMAT>",
+					"text, markdown, json (default: markdown)",
+				),
+				(
+					"--package",
+					"<PACKAGE>",
+					"Restrict to specific package ids (repeatable)",
+				),
+				("--output", "<PATH>", "Write a JSON readiness artifact"),
+			],
+			examples: &[
+				(
+					"Check the current release commit:",
+					"mc publish-readiness --from HEAD",
+				),
+				(
+					"Write a readiness artifact:",
+					"mc publish-readiness --from HEAD --output .monochange/readiness.json",
+				),
+				(
+					"JSON for one package:",
+					"mc publish-readiness --from v1.2.3 --package core --format json",
+				),
+			],
+			tips: &[
+				"Run readiness before mutating registry state with mc publish.",
+				"Already-published versions are reported as resumable instead of blocking.",
+			],
+			see_also: &["publish-plan", "publish", "placeholder-publish"],
+		},
+		CommandHelp {
 			name: "placeholder-publish",
 			summary: "Publish placeholder versions for missing registry packages",
 			description: "Packages that have never been published to their target registry (crates.io, \
@@ -1398,6 +1445,13 @@ mod tests {
 	fn render_command_help_for_release_record() {
 		let out = render_command_help("mc", "release-record");
 		assert!(out.contains("release-record"));
+	}
+
+	#[test]
+	fn render_command_help_for_publish_readiness() {
+		let out = render_command_help("mc", "publish-readiness");
+		assert!(out.contains("publish-readiness"));
+		assert!(out.contains("readiness artifact"));
 	}
 
 	#[test]

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -300,6 +300,7 @@ mod mcp;
 mod package_publish;
 mod prepared_release_cache;
 mod publish_rate_limits;
+mod publish_readiness;
 mod release_artifacts;
 mod release_record;
 mod skill;
@@ -881,6 +882,34 @@ where
 					parse_output_format(value)
 				})?;
 			render_release_record_discovery(root, from, format)
+		}
+		Some(("publish-readiness", publish_readiness_matches)) => {
+			let configuration = configuration?;
+			let from = publish_readiness_matches
+				.get_one::<String>("from")
+				.cloned()
+				.ok_or(MonochangeError::Config(
+					"missing publish-readiness ref".to_string(),
+				))?;
+			let selected_packages = publish_readiness_matches
+				.get_many::<String>("package")
+				.map(|values| values.cloned().collect::<BTreeSet<_>>())
+				.unwrap_or_default();
+			let format = publish_readiness_matches
+				.get_one::<String>("format")
+				.map_or(Ok(OutputFormat::Markdown), |value| {
+					parse_output_format(value)
+				})?;
+			let output = publish_readiness_matches
+				.get_one::<String>("output")
+				.map(PathBuf::from);
+			let options = publish_readiness::PublishReadinessOptions {
+				from,
+				selected_packages,
+				format,
+				output,
+			};
+			publish_readiness::run_publish_readiness(root, &configuration, &options)
 		}
 		Some(("tag-release", tag_release_matches)) => {
 			let from = tag_release_matches

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -222,11 +222,46 @@ pub(crate) fn run_publish_packages(
 	selected_packages: &BTreeSet<String>,
 	dry_run: bool,
 ) -> MonochangeResult<PackagePublishReport> {
-	let discovery = discover_workspace(root)?;
 	let publication_targets =
 		release_record_package_publications_from_prepared_or_head(root, prepared_release)?;
+	run_publish_packages_with_publications(
+		root,
+		configuration,
+		&publication_targets,
+		selected_packages,
+		dry_run,
+	)
+}
+
+pub(crate) fn run_publish_packages_from_ref(
+	root: &Path,
+	configuration: &WorkspaceConfiguration,
+	release_ref: &str,
+	selected_packages: &BTreeSet<String>,
+	dry_run: bool,
+) -> MonochangeResult<PackagePublishReport> {
+	let publication_targets = discover_release_record(root, release_ref)?
+		.record
+		.package_publications;
+	run_publish_packages_with_publications(
+		root,
+		configuration,
+		&publication_targets,
+		selected_packages,
+		dry_run,
+	)
+}
+
+fn run_publish_packages_with_publications(
+	root: &Path,
+	configuration: &WorkspaceConfiguration,
+	publication_targets: &[PackagePublicationTarget],
+	selected_packages: &BTreeSet<String>,
+	dry_run: bool,
+) -> MonochangeResult<PackagePublishReport> {
+	let discovery = discover_workspace(root)?;
 	#[rustfmt::skip]
-	let requests = build_release_requests(configuration, &discovery.packages, &publication_targets, selected_packages)?;
+	let requests = build_release_requests(configuration, &discovery.packages, publication_targets, selected_packages)?;
 	let env_map = current_env_map();
 	let endpoints = RegistryEndpoints::from_env();
 	let client = registry_client()?;

--- a/crates/monochange/src/publish_readiness.rs
+++ b/crates/monochange/src/publish_readiness.rs
@@ -1,0 +1,402 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
+use monochange_core::Ecosystem;
+use monochange_core::MonochangeError;
+use monochange_core::MonochangeResult;
+use monochange_core::WorkspaceConfiguration;
+use serde::Serialize;
+
+use crate::OutputFormat;
+use crate::package_publish;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct PublishReadinessOptions {
+	pub from: String,
+	pub selected_packages: BTreeSet<String>,
+	pub format: OutputFormat,
+	pub output: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum PublishReadinessGlobalStatus {
+	Ready,
+	Blocked,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum PublishReadinessPackageStatus {
+	Ready,
+	AlreadyPublished,
+	Unsupported,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PublishReadinessPackage {
+	pub package: String,
+	pub ecosystem: Ecosystem,
+	pub registry: String,
+	pub version: String,
+	pub status: PublishReadinessPackageStatus,
+	pub message: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PublishReadinessReport {
+	pub status: PublishReadinessGlobalStatus,
+	pub from: String,
+	pub packages: Vec<PublishReadinessPackage>,
+}
+
+pub(crate) fn run_publish_readiness(
+	root: &Path,
+	configuration: &WorkspaceConfiguration,
+	options: &PublishReadinessOptions,
+) -> MonochangeResult<String> {
+	let publish_report = package_publish::run_publish_packages_from_ref(
+		root,
+		configuration,
+		&options.from,
+		&options.selected_packages,
+		true,
+	)?;
+	let report = build_report_from_publish_report(&options.from, &publish_report);
+	options
+		.output
+		.as_deref()
+		.map(|output| write_report_artifact(output, &report))
+		.transpose()?;
+	render_report(&report, options.format)
+}
+
+fn build_report_from_publish_report(
+	from: &str,
+	report: &package_publish::PackagePublishReport,
+) -> PublishReadinessReport {
+	let packages = report
+		.packages
+		.iter()
+		.map(|package| {
+			PublishReadinessPackage {
+				package: package.package.clone(),
+				ecosystem: package.ecosystem,
+				registry: package.registry.clone(),
+				version: package.version.clone(),
+				status: readiness_status_from_publish_status(package.status),
+				message: package.message.clone(),
+			}
+		})
+		.collect::<Vec<_>>();
+	let status = if packages
+		.iter()
+		.any(|package| package.status == PublishReadinessPackageStatus::Unsupported)
+	{
+		PublishReadinessGlobalStatus::Blocked
+	} else {
+		PublishReadinessGlobalStatus::Ready
+	};
+	PublishReadinessReport {
+		status,
+		from: from.to_string(),
+		packages,
+	}
+}
+
+fn readiness_status_from_publish_status(
+	status: package_publish::PackagePublishStatus,
+) -> PublishReadinessPackageStatus {
+	match status {
+		package_publish::PackagePublishStatus::Planned
+		| package_publish::PackagePublishStatus::Published => PublishReadinessPackageStatus::Ready,
+		package_publish::PackagePublishStatus::SkippedExisting => {
+			PublishReadinessPackageStatus::AlreadyPublished
+		}
+		package_publish::PackagePublishStatus::SkippedExternal => {
+			PublishReadinessPackageStatus::Unsupported
+		}
+	}
+}
+
+fn write_report_artifact(output: &Path, report: &PublishReadinessReport) -> MonochangeResult<()> {
+	output
+		.parent()
+		.filter(|parent| !parent.as_os_str().is_empty())
+		.map(create_report_artifact_directory)
+		.transpose()?;
+	let body = serde_json::to_string_pretty(report).map_err(publish_readiness_json_error)?;
+	fs::write(output, format!("{body}\n")).map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to write publish readiness output {}: {error}",
+			output.display()
+		))
+	})
+}
+
+fn publish_readiness_json_error(error: impl std::fmt::Display) -> MonochangeError {
+	MonochangeError::Config(format!("publish readiness JSON: {error}"))
+}
+
+fn create_report_artifact_directory(parent: &Path) -> MonochangeResult<()> {
+	fs::create_dir_all(parent).map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to create publish readiness output directory {}: {error}",
+			parent.display()
+		))
+	})
+}
+
+fn render_report(
+	report: &PublishReadinessReport,
+	format: OutputFormat,
+) -> MonochangeResult<String> {
+	match format {
+		OutputFormat::Json => {
+			serde_json::to_string_pretty(report)
+				.map(|body| format!("{body}\n"))
+				.map_err(publish_readiness_json_error)
+		}
+		OutputFormat::Markdown => Ok(render_markdown_report(report)),
+		OutputFormat::Text => Ok(render_text_report(report)),
+	}
+}
+fn render_text_report(report: &PublishReadinessReport) -> String {
+	let mut lines = vec![format!(
+		"publish readiness: {}",
+		readiness_global_status_label(report.status)
+	)];
+	lines.push(format!("release ref: {}", report.from));
+	if report.packages.is_empty() {
+		lines.push("packages: none".to_string());
+	} else {
+		lines.push("packages:".to_string());
+		for package in &report.packages {
+			lines.push(format!(
+				"- {} {} {} [{}]: {}",
+				package.package,
+				package.version,
+				package.registry,
+				readiness_package_status_label(package.status),
+				package.message
+			));
+		}
+	}
+	format!("{}\n", lines.join("\n"))
+}
+
+fn render_markdown_report(report: &PublishReadinessReport) -> String {
+	let mut lines = vec![
+		"## Publish readiness".to_string(),
+		String::new(),
+		format!(
+			"- Status: `{}`",
+			readiness_global_status_label(report.status)
+		),
+		format!("- Release ref: `{}`", report.from),
+		String::new(),
+	];
+	if report.packages.is_empty() {
+		lines.push("No packages selected for publishing.".to_string());
+	} else {
+		lines.push("| Package | Version | Registry | Status | Message |".to_string());
+		lines.push("| --- | --- | --- | --- | --- |".to_string());
+		for package in &report.packages {
+			lines.push(format!(
+				"| `{}` | `{}` | `{}` | `{}` | {} |",
+				package.package,
+				package.version,
+				package.registry,
+				readiness_package_status_label(package.status),
+				package.message.replace('|', "\\|")
+			));
+		}
+	}
+	format!("{}\n", lines.join("\n"))
+}
+
+fn readiness_global_status_label(status: PublishReadinessGlobalStatus) -> &'static str {
+	match status {
+		PublishReadinessGlobalStatus::Ready => "ready",
+		PublishReadinessGlobalStatus::Blocked => "blocked",
+	}
+}
+
+fn readiness_package_status_label(status: PublishReadinessPackageStatus) -> &'static str {
+	match status {
+		PublishReadinessPackageStatus::Ready => "ready",
+		PublishReadinessPackageStatus::AlreadyPublished => "already_published",
+		PublishReadinessPackageStatus::Unsupported => "unsupported",
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn sample_publish_outcome(
+		status: package_publish::PackagePublishStatus,
+	) -> package_publish::PackagePublishOutcome {
+		package_publish::PackagePublishOutcome {
+			package: "core".to_string(),
+			ecosystem: Ecosystem::Cargo,
+			registry: "crates.io".to_string(),
+			version: "1.2.3".to_string(),
+			status,
+			message: "ready to publish core 1.2.3".to_string(),
+			placeholder: false,
+			trusted_publishing: package_publish::TrustedPublishingOutcome {
+				status: package_publish::TrustedPublishingStatus::Disabled,
+				repository: None,
+				workflow: None,
+				environment: None,
+				setup_url: None,
+				message: "trusted publishing disabled".to_string(),
+			},
+		}
+	}
+
+	fn sample_readiness_report(packages: Vec<PublishReadinessPackage>) -> PublishReadinessReport {
+		PublishReadinessReport {
+			status: PublishReadinessGlobalStatus::Ready,
+			from: "HEAD".to_string(),
+			packages,
+		}
+	}
+
+	fn sample_readiness_package() -> PublishReadinessPackage {
+		PublishReadinessPackage {
+			package: "core".to_string(),
+			ecosystem: Ecosystem::Cargo,
+			registry: "crates.io".to_string(),
+			version: "1.2.3".to_string(),
+			status: PublishReadinessPackageStatus::Ready,
+			message: "ready to publish core 1.2.3".to_string(),
+		}
+	}
+
+	#[test]
+	fn build_report_maps_publish_dry_run_statuses_to_readiness_statuses() {
+		let report = package_publish::PackagePublishReport {
+			mode: package_publish::PackagePublishRunMode::Release,
+			dry_run: true,
+			packages: vec![
+				sample_publish_outcome(package_publish::PackagePublishStatus::Planned),
+				sample_publish_outcome(package_publish::PackagePublishStatus::SkippedExisting),
+				sample_publish_outcome(package_publish::PackagePublishStatus::SkippedExternal),
+			],
+		};
+		let readiness = build_report_from_publish_report("HEAD", &report);
+
+		assert_eq!(readiness.status, PublishReadinessGlobalStatus::Blocked);
+		assert_eq!(
+			readiness.packages[0].status,
+			PublishReadinessPackageStatus::Ready
+		);
+		assert_eq!(
+			readiness.packages[1].status,
+			PublishReadinessPackageStatus::AlreadyPublished
+		);
+		assert_eq!(
+			readiness.packages[2].status,
+			PublishReadinessPackageStatus::Unsupported
+		);
+	}
+
+	#[test]
+	fn render_report_supports_json_text_and_markdown() {
+		let report = sample_readiness_report(vec![sample_readiness_package()]);
+
+		let text = render_report(&report, OutputFormat::Text)
+			.unwrap_or_else(|error| panic!("text report: {error}"));
+		assert!(text.contains("publish readiness: ready"));
+		let markdown = render_report(&report, OutputFormat::Markdown)
+			.unwrap_or_else(|error| panic!("markdown report: {error}"));
+		assert!(markdown.contains("## Publish readiness"));
+		let json = render_report(&report, OutputFormat::Json)
+			.unwrap_or_else(|error| panic!("json report: {error}"));
+		assert!(json.contains("\"status\": \"ready\""));
+	}
+
+	#[test]
+	fn render_report_handles_empty_package_sections() {
+		let report = sample_readiness_report(Vec::new());
+		let text = render_report(&report, OutputFormat::Text)
+			.unwrap_or_else(|error| panic!("empty text report: {error}"));
+		let markdown = render_report(&report, OutputFormat::Markdown)
+			.unwrap_or_else(|error| panic!("empty markdown report: {error}"));
+
+		assert!(text.contains("packages: none"));
+		assert!(markdown.contains("No packages selected for publishing."));
+	}
+
+	#[test]
+	fn publish_readiness_json_error_renders_context() {
+		let error = serde_json::from_str::<serde_json::Value>("{")
+			.expect_err("invalid JSON should produce serde error");
+		let error = publish_readiness_json_error(error);
+
+		assert!(error.to_string().contains("publish readiness JSON"));
+	}
+
+	#[test]
+	fn render_report_labels_blocked_already_published_and_unsupported_packages() {
+		let report = PublishReadinessReport {
+			status: PublishReadinessGlobalStatus::Blocked,
+			from: "HEAD".to_string(),
+			packages: vec![
+				PublishReadinessPackage {
+					status: PublishReadinessPackageStatus::AlreadyPublished,
+					..sample_readiness_package()
+				},
+				PublishReadinessPackage {
+					package: "external".to_string(),
+					status: PublishReadinessPackageStatus::Unsupported,
+					..sample_readiness_package()
+				},
+			],
+		};
+		let markdown = render_report(&report, OutputFormat::Markdown)
+			.unwrap_or_else(|error| panic!("blocked markdown report: {error}"));
+
+		assert!(markdown.contains("Status: `blocked`"));
+		assert!(markdown.contains("already_published"));
+		assert!(markdown.contains("unsupported"));
+	}
+
+	#[test]
+	fn write_report_artifact_creates_parent_directory_and_reports_io_errors() {
+		let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let report = sample_readiness_report(vec![sample_readiness_package()]);
+		let output = tempdir.path().join("nested/readiness.json");
+
+		write_report_artifact(&output, &report)
+			.unwrap_or_else(|error| panic!("write readiness artifact: {error}"));
+		let body = fs::read_to_string(&output)
+			.unwrap_or_else(|error| panic!("read readiness artifact: {error}"));
+		assert!(body.contains("\"package\": \"core\""));
+
+		let parent_file = tempdir.path().join("parent-file");
+		fs::write(&parent_file, "not a directory")
+			.unwrap_or_else(|error| panic!("write parent file: {error}"));
+		let create_dir_error = write_report_artifact(&parent_file.join("readiness.json"), &report)
+			.expect_err("file parent should fail directory creation");
+		assert!(
+			create_dir_error
+				.to_string()
+				.contains("failed to create publish readiness output directory")
+		);
+
+		let write_error = write_report_artifact(tempdir.path(), &report)
+			.expect_err("directory output should fail file write");
+		assert!(
+			write_error
+				.to_string()
+				.contains("failed to write publish readiness output")
+		);
+	}
+}

--- a/crates/monochange/tests/snapshots/cli_help__help_overview_lists_all_commands@help_overview_lists_all_commands.snap
+++ b/crates/monochange/tests/snapshots/cli_help__help_overview_lists_all_commands@help_overview_lists_all_commands.snap
@@ -44,6 +44,7 @@ Run `mc help <command>` for detailed examples and usage tips for any command.
   mcp                  Start the monochange MCP server over stdin/stdout
   validate             Validate monochange configuration and changesets
   discover             Discover packages across supported ecosystems
+  publish-readiness    Check package registry publishing readiness without publishing packages
   placeholder-publish  Publish placeholder versions for missing registry packages
   publish-packages     Publish package versions from release state
 

--- a/crates/monochange/tests/snapshots/cli_help__help_unknown_command_shows_error_and_list@help_unknown_command_shows_error_and_list.snap
+++ b/crates/monochange/tests/snapshots/cli_help__help_unknown_command_shows_error_and_list@help_unknown_command_shows_error_and_list.snap
@@ -35,6 +35,7 @@ error: Unknown command `nonexistent`
   mcp                  Start the monochange MCP server over stdin/stdout
   validate             Validate monochange configuration and changesets
   discover             Discover packages across supported ecosystems
+  publish-readiness    Check package registry publishing readiness without publishing packages
   placeholder-publish  Publish placeholder versions for missing registry packages
   publish-packages     Publish package versions from release state
 

--- a/crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_prints_help.snap
+++ b/crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_prints_help.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/monochange/tests/cli_main_binary.rs
-assertion_line: 19
 info:
   program: monochange
   args:
@@ -22,6 +21,7 @@ Commands:
   subagents                      Generate repo-local monochange subagents and agent guidance files
   analyze                        Analyze semantic changes for one package across main, head, and optional release baselines
   release-record                 Inspect the monochange release record associated with a tag or commit
+  publish-readiness              Check package registry publishing readiness without publishing packages
   tag-release                    Create and push release tags from the monochange release record on a commit
   lint                           Inspect and scaffold manifest lint rules
   mcp                            Start the monochange MCP (Model Context Protocol) server over stdin/stdout

--- a/devenv.nix
+++ b/devenv.nix
@@ -301,6 +301,9 @@ in
     "lint:test" = {
       exec = ''
         set -euo pipefail
+        while IFS= read -r name; do
+          unset "$name"
+        done < <(git rev-parse --local-env-vars)
         lint:all;
         test:all;
       '';

--- a/docs/plans/active/publish-readiness.md
+++ b/docs/plans/active/publish-readiness.md
@@ -1,0 +1,100 @@
+# Publish readiness command
+
+## Status
+
+- Branch: `feat/publish-readiness-command`
+- Pull request: <https://github.com/monochange/monochange/pull/292>
+- Current slice: initial top-level, non-mutating `mc publish-readiness` command
+
+## Problem
+
+Package publishing currently starts from release state and registry dry-run behavior without a standalone readiness artifact that CI can inspect before mutating registries. monochange needs a CLI-first readiness boundary so future publishing can fail early for blocked, stale, ambiguous, or unsupported package publish state.
+
+## Scope
+
+This plan covers the first incremental slice:
+
+- Add `mc publish-readiness` as a top-level command.
+- Reuse existing dry-run package publish checks to report initial readiness.
+- Support package filtering and machine-readable artifacts.
+- Document the command in CLI docs and command matrices.
+- Keep the implementation non-mutating.
+
+## Non-goals for this slice
+
+- Require readiness artifacts from `mc publish`.
+- Add fingerprint/freshness validation.
+- Add `mc publish-bootstrap`.
+- Redesign `monochange/actions` publishing APIs.
+- Implement full ecosystem-specific blocker/remediation semantics.
+
+## Affected files
+
+- `crates/monochange/src/cli.rs`
+- `crates/monochange/src/cli_help.rs`
+- `crates/monochange/src/lib.rs`
+- `crates/monochange/src/package_publish.rs`
+- `crates/monochange/src/publish_readiness.rs`
+- `crates/monochange/tests/snapshots/`
+- `.templates/project.t.md`
+- `readme.md`
+- `docs/src/readme.md`
+- `docs/src/guide/13-ci-and-publishing.md`
+- `.changeset/publish-readiness-command.md`
+- `tsconfig.json`
+- `devenv.nix`
+
+## Checklist
+
+- [x] Create isolated worktree and branch `feat/publish-readiness-command`.
+- [x] Add `mc publish-readiness` CLI definition with `--from`, `--package`, `--output`, and `--format`.
+- [x] Wire command dispatch through `crates/monochange/src/lib.rs`.
+- [x] Refactor package publishing dry-run execution for reuse by release ref.
+- [x] Add `publish_readiness` report model and renderers for Markdown, text, and JSON.
+- [x] Map existing package publish statuses to initial readiness statuses.
+- [x] Add unit coverage for status mapping and render formats.
+- [x] Add CLI help coverage for `publish-readiness`.
+- [x] Update generated docs and command matrices.
+- [x] Add changeset for the `monochange` crate.
+- [x] Add root `tsconfig.json` so JS type linting has a project configuration.
+- [x] Fix local worktree git configuration so pre-push tests run against isolated fixture repositories.
+- [x] Update CLI snapshots for the new command.
+- [x] Run targeted validation.
+- [x] Run full local `devenv shell lint:test` successfully.
+- [x] Create PR #292.
+- [x] Raise patch coverage to 100% after the initial PR coverage failure.
+- [ ] Wait for PR checks to complete.
+- [ ] Fix any failed PR checks.
+- [ ] Merge PR #292 after required checks pass.
+- [ ] Move this plan to `docs/plans/completed/` after merge, or keep remaining readiness-enforcement work in a follow-up plan.
+
+## Validation log
+
+- [x] `devenv shell cargo test -p monochange publish_readiness --lib`
+- [x] `devenv shell cargo test -p monochange cli_help::tests::render_command_help_for_publish_readiness --lib`
+- [x] `devenv shell cargo check -p monochange`
+- [x] `devenv shell cargo fmt --check`
+- [x] `devenv shell dprint check ...`
+- [x] `git diff --check`
+- [x] `devenv shell cargo test -p monochange --test cli_help`
+- [x] `devenv shell lint:test`
+- [x] `devenv shell coverage:all`
+- [x] `devenv shell coverage:patch` (`PATCH_COVERAGE 419/419 (100.00%)`)
+
+## Decisions
+
+- `publish-readiness` is intentionally top-level instead of hidden inside `mc publish`.
+- The first implementation reuses existing publish dry-run checks to avoid duplicating registry logic prematurely.
+- The artifact is JSON when written with `--output`, while display output defaults to Markdown for CI summaries.
+- `already_published` is non-blocking so retries can skip consistently published versions.
+- `unsupported` is blocking in the initial global status calculation.
+
+## Follow-up roadmap
+
+- [ ] Add readiness artifact fingerprinting for commit, release ref, selected packages, config, manifests, lockfiles, and schema version.
+- [ ] Add `mc publish --readiness <PATH>` and reject missing, blocked, stale, or mismatched readiness.
+- [ ] Add optional readiness consumption to `mc publish-plan`.
+- [ ] Expand Cargo readiness semantics first.
+- [ ] Expand npm readiness semantics second.
+- [ ] Add `mc publish-bootstrap` for first-time package setup.
+- [ ] Design retry/resume around explicit readiness for remaining work.

--- a/docs/src/guide/13-ci-and-publishing.md
+++ b/docs/src/guide/13-ci-and-publishing.md
@@ -19,9 +19,10 @@ These commands solve different automation problems:
 | Preview the release plan         | `mc release --dry-run --diff`                               | You want changelog/version patches without mutating the repo                                             |
 | Create a durable release commit  | `mc commit-release`                                         | You want a monochange-managed release commit with an embedded `ReleaseRecord`                            |
 | Open or update a release request | `mc release-pr`                                             | You want a long-lived release PR/MR branch updated from current release state                            |
+| Inspect a past release commit    | `mc release-record --from <ref>`                            | You need the durable release declaration from git history                                                |
+| Check package publish readiness  | `mc publish-readiness --from <ref>`                         | You need non-mutating registry readiness output before package publication                               |
 | Publish packages to registries   | `mc publish`                                                | You want `cargo publish`, `npm publish`, `deno publish`, or `dart pub publish` style package publication |
 | Bootstrap missing packages       | `mc placeholder-publish`                                    | A package must exist in its registry before later automation can work                                    |
-| Inspect a past release commit    | `mc release-record --from <ref>`                            | You need the durable release declaration from git history                                                |
 | Create post-merge release tags   | `mc tag-release --from HEAD`                                | You merged a monochange release commit and now need to create and push its declared tag set              |
 | Repair a recent release          | `mc repair-release --from <tag> --target <commit>`          | You need to retarget a just-created release to a later commit                                            |
 | Publish hosted/provider releases | `mc publish-release`                                        | You want GitHub/GitLab/Gitea release objects from prepared release state                                 |

--- a/docs/src/readme.md
+++ b/docs/src/readme.md
@@ -127,9 +127,10 @@ Recent `monochange` improvements made package publishing guidance and diagnostic
 | Preview the release plan         | `mc release --dry-run --diff`                               | You want changelog/version patches without mutating the repo                                             |
 | Create a durable release commit  | `mc commit-release`                                         | You want a monochange-managed release commit with an embedded `ReleaseRecord`                            |
 | Open or update a release request | `mc release-pr`                                             | You want a long-lived release PR/MR branch updated from current release state                            |
+| Inspect a past release commit    | `mc release-record --from <ref>`                            | You need the durable release declaration from git history                                                |
+| Check package publish readiness  | `mc publish-readiness --from <ref>`                         | You need non-mutating registry readiness output before package publication                               |
 | Publish packages to registries   | `mc publish`                                                | You want `cargo publish`, `npm publish`, `deno publish`, or `dart pub publish` style package publication |
 | Bootstrap missing packages       | `mc placeholder-publish`                                    | A package must exist in its registry before later automation can work                                    |
-| Inspect a past release commit    | `mc release-record --from <ref>`                            | You need the durable release declaration from git history                                                |
 | Create post-merge release tags   | `mc tag-release --from HEAD`                                | You merged a monochange release commit and now need to create and push its declared tag set              |
 | Repair a recent release          | `mc repair-release --from <tag> --target <commit>`          | You need to retarget a just-created release to a later commit                                            |
 | Publish hosted/provider releases | `mc publish-release`                                        | You want GitHub/GitLab/Gitea release objects from prepared release state                                 |

--- a/readme.md
+++ b/readme.md
@@ -145,9 +145,10 @@ Recent `monochange` improvements made package publishing guidance and diagnostic
 | Preview the release plan         | `mc release --dry-run --diff`                               | You want changelog/version patches without mutating the repo                                             |
 | Create a durable release commit  | `mc commit-release`                                         | You want a monochange-managed release commit with an embedded `ReleaseRecord`                            |
 | Open or update a release request | `mc release-pr`                                             | You want a long-lived release PR/MR branch updated from current release state                            |
+| Inspect a past release commit    | `mc release-record --from <ref>`                            | You need the durable release declaration from git history                                                |
+| Check package publish readiness  | `mc publish-readiness --from <ref>`                         | You need non-mutating registry readiness output before package publication                               |
 | Publish packages to registries   | `mc publish`                                                | You want `cargo publish`, `npm publish`, `deno publish`, or `dart pub publish` style package publication |
 | Bootstrap missing packages       | `mc placeholder-publish`                                    | A package must exist in its registry before later automation can work                                    |
-| Inspect a past release commit    | `mc release-record --from <ref>`                            | You need the durable release declaration from git history                                                |
 | Create post-merge release tags   | `mc tag-release --from HEAD`                                | You merged a monochange release commit and now need to create and push its declared tag set              |
 | Repair a recent release          | `mc repair-release --from <tag> --target <commit>`          | You need to retarget a just-created release to a later commit                                            |
 | Publish hosted/provider releases | `mc publish-release`                                        | You want GitHub/GitLab/Gitea release objects from prepared release state                                 |

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": false,
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"noEmit": true,
+		"skipLibCheck": true,
+		"target": "ES2024"
+	},
+	"exclude": ["dist", "fixtures", "node_modules", "target"],
+	"include": ["npm/tests/**/*.mjs", "scripts/**/*.mjs"]
+}


### PR DESCRIPTION
## Summary

- Adds a top-level, non-mutating `mc publish-readiness` command.
- Reuses existing package publish dry-run checks against a release record ref.
- Supports package filtering, Markdown/text/JSON display, and JSON artifact output.
- Documents the command in generated docs and tracks the slice in `docs/plans/active/publish-readiness.md`.

## Validation

- `devenv shell cargo test -p monochange publish_readiness --lib`
- `devenv shell cargo test -p monochange cli_help::tests::render_command_help_for_publish_readiness --lib`
- `devenv shell cargo check -p monochange`
- `devenv shell cargo fmt --check`
- `devenv shell lint:test`
- PR checks are being monitored; patch coverage is currently being raised to 100%.

## Follow-up

Future PRs will wire readiness artifacts into `mc publish`, add freshness/fingerprint validation, and expand ecosystem-specific readiness blockers.
