### PR TITLE
feat: add cargo-binstall metadata

### DIFF
--- a/.changeset/binstall-metadata.md
+++ b/.changeset/binstall-metadata.md
@@ -1,0 +1,5 @@
+---
+monochange: patch
+---
+
+Add cargo-binstall metadata so `cargo binstall monochange` can resolve the GitHub release archive layout.

--- a/crates/monochange/Cargo.toml
+++ b/crates/monochange/Cargo.toml
@@ -16,6 +16,11 @@ description = "Manage versions and releases for your multiplatform, multilanguag
 name = "mc"
 path = "src/bin/mc.rs"
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }{ archive-suffix }"
+pkg-fmt = "tgz"
+bin-dir = "{ bin }{ binary-ext }"
+
 [features]
 default = ["cargo", "npm", "deno", "dart", "github", "gitlab", "gitea"]
 cargo = ["monochange_cargo"]


### PR DESCRIPTION
## Summary
- add [package.metadata.binstall] to the monochange crate manifest
- map cargo-binstall downloads to the existing GitHub release archive names and root-level binary layout
- add a monochange patch changeset

## Validation
- cargo metadata --manifest-path crates/monochange/Cargo.toml --no-deps --format-version 1
- git diff --check