### PR TITLE
feat(telemetry): add local telemetry events

### DIFF
--- a/.changeset/local-telemetry.md
+++ b/.changeset/local-telemetry.md
@@ -1,0 +1,18 @@
+---
+"@monochange/cli": patch
+"monochange": patch
+"monochange_telemtry": patch
+---
+
+#### add local-only telemetry events
+
+Users can now opt in to local-only telemetry for CLI support and debugging without sending data over the network. By default, nothing is recorded. Setting `MC_TELEMETRY=local` writes OpenTelemetry-style JSON Lines events to the user state directory, while `MC_TELEMETRY_FILE=/path/to/telemetry.jsonl` writes to a chosen file.
+
+Command:
+
+```bash
+MC_TELEMETRY=local mc validate
+MC_TELEMETRY_FILE=/tmp/mc-telemetry.jsonl mc validate
+```
+
+The recorded events are limited to low-cardinality command and step metadata such as command name, step kind, duration, outcome, and sanitized error category. The local sink does not record package names, repository paths, repository URLs, branch names, tags, commit hashes, command strings, raw error messages, or release-note text.

--- a/.templates/crates.t.md
+++ b/.templates/crates.t.md
@@ -610,3 +610,56 @@ Reach for this crate when you are writing integration or fixture-heavy tests tha
 - `fixture_path!`, `setup_fixture!`, and `setup_scenario_workspace!` locate and materialize test fixtures
 
 <!-- {/monochangeTestHelpersCrateDocs} -->
+
+<!-- {@monochangeTelemtryCrateDocs} -->
+
+`monochange_telemtry` provides local-only telemetry primitives for the `monochange` CLI.
+
+Reach for this crate when you need the reusable event sink, event payloads, and privacy-preserving error classification that power opt-in local JSONL telemetry. The crate intentionally keeps transport simple: it appends OpenTelemetry-style JSON Lines records to a local file and does not send telemetry over the network.
+
+## Why use it?
+
+- keep telemetry capture separate from CLI orchestration and package discovery
+- share one local JSONL event schema across command and step instrumentation
+- classify errors into low-cardinality categories without exposing raw error text
+- make telemetry writes best-effort so observability cannot change command outcomes
+
+## Best for
+
+- embedding monochange's local telemetry sink in the CLI runtime
+- smoke-testing event schemas without provisioning a backend
+- building future telemetry commands, exporters, or redaction tests on top of a small public API
+
+## Public entry points
+
+- `TelemetrySink::from_env()` resolves `MC_TELEMETRY` and `MC_TELEMETRY_FILE` into either a disabled sink or a local JSONL sink
+- `TelemetrySink::capture_command(...)` writes `command_run` events
+- `TelemetrySink::capture_step(...)` writes `command_step` events
+- `CommandTelemetry`, `StepTelemetry`, and `TelemetryOutcome` describe the stable event payloads
+
+## Privacy boundaries
+
+The crate only accepts low-cardinality command metadata, booleans, counts, durations, enum outcomes, and sanitized `error_kind` values. It does not collect package names, paths, repository URLs, branch names, refs, commit hashes, shell command strings, environment values, changeset text, release notes, issue or pull request IDs, or raw errors.
+
+## Example
+
+```rust
+use monochange_telemtry::CommandTelemetry;
+use monochange_telemtry::TelemetryOutcome;
+use monochange_telemtry::TelemetrySink;
+use std::time::Duration;
+
+let sink = TelemetrySink::Disabled;
+sink.capture_command(CommandTelemetry {
+    command_name: "validate",
+    dry_run: false,
+    show_diff: false,
+    progress_format: "auto",
+    step_count: 1,
+    duration: Duration::from_millis(42),
+    outcome: TelemetryOutcome::Success,
+    error: None,
+});
+```
+
+<!-- {/monochangeTelemtryCrateDocs} -->

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -32,6 +32,8 @@ Use it when your repository has outgrown one-ecosystem release tooling and you w
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__github-orange?logo=rust)](https://crates.io/crates/monochange_github) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__github-1f425f?logo=docs.rs)](https://docs.rs/monochange_github/)
 - `monochange_semver` — merges requested bumps with compatibility-provider evidence.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__semver-orange?logo=rust)](https://crates.io/crates/monochange_semver) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__semver-1f425f?logo=docs.rs)](https://docs.rs/monochange_semver/)
+- `monochange_telemtry` — local-only telemetry event sink and privacy-preserving event schema helpers.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__telemtry-orange?logo=rust)](https://crates.io/crates/monochange_telemtry) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__telemtry-1f425f?logo=docs.rs)](https://docs.rs/monochange_telemtry/)
 - `monochange_cargo` — Cargo discovery plus Rust semver evidence integration.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__cargo-orange?logo=rust)](https://crates.io/crates/monochange_cargo) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__cargo-1f425f?logo=docs.rs)](https://docs.rs/monochange_cargo/)
 - `monochange_npm` — npm, pnpm, and Bun workspace discovery.

--- a/.templates/telemetry.t.md
+++ b/.templates/telemetry.t.md
@@ -1,0 +1,123 @@
+<!-- {@monochangeLocalTelemetryDocs} -->
+
+monochange can write local-only telemetry events for CLI command and step execution. The first implementation does not send data over the network and does not require a telemetry backend.
+
+## Current scope
+
+This release only supports a local JSON Lines sink with OpenTelemetry-style event envelopes. It is intended for debugging, support bundles, and validating the event schema before any hosted or remote telemetry work is considered.
+
+## Enabling local telemetry
+
+Telemetry is disabled by default. Enable the local sink with environment variables:
+
+```sh
+MC_TELEMETRY=local mc validate
+```
+
+By default, events are appended to:
+
+```text
+$XDG_STATE_HOME/monochange/telemetry.jsonl
+```
+
+When `XDG_STATE_HOME` is not set, monochange falls back to:
+
+```text
+$HOME/.local/state/monochange/telemetry.jsonl
+```
+
+For a one-off file path, set `MC_TELEMETRY_FILE`:
+
+```sh
+MC_TELEMETRY=local MC_TELEMETRY_FILE=/tmp/mc-telemetry.jsonl mc validate
+```
+
+Setting only `MC_TELEMETRY_FILE` also enables the local sink for that command:
+
+```sh
+MC_TELEMETRY_FILE=/tmp/mc-telemetry.jsonl mc discover
+```
+
+Disable telemetry explicitly with any of:
+
+```sh
+MC_TELEMETRY=0
+MC_TELEMETRY=false
+MC_TELEMETRY=off
+MC_TELEMETRY=disabled
+```
+
+## Events
+
+### `command_run`
+
+Emitted when a CLI command completes or fails after command execution starts.
+
+Attributes:
+
+- `command_name`
+- `command_source`: `configured` or `generated_step`
+- `dry_run`
+- `show_diff`
+- `progress_format`: `auto`, `unicode`, `ascii`, or `json`
+- `step_count`
+- `duration_ms`
+- `outcome`: `success` or `error`
+- `error_kind`: sanitized error category or `null`
+
+### `command_step`
+
+Emitted for each CLI step that succeeds, fails, or is skipped.
+
+Attributes:
+
+- `command_name`
+- `step_index`
+- `step_kind`
+- `skipped`
+- `duration_ms`
+- `outcome`: `success`, `skipped`, or `error`
+- `error_kind`: sanitized error category or `null`
+
+## Local event shape
+
+Each line is one JSON object:
+
+```json
+{
+	"resource": {
+		"service.name": "monochange",
+		"service.version": "0.2.0"
+	},
+	"scope": {
+		"name": "monochange.telemetry",
+		"version": "0.1.0"
+	},
+	"time_unix_nano": 1777338000000000000,
+	"severity_text": "INFO",
+	"body": {
+		"string_value": "command_run"
+	},
+	"attributes": {
+		"command_name": "validate",
+		"command_source": "configured",
+		"dry_run": false,
+		"show_diff": false,
+		"progress_format": "auto",
+		"step_count": 1,
+		"duration_ms": 42,
+		"outcome": "success",
+		"error_kind": null
+	}
+}
+```
+
+## Privacy boundaries
+
+The local sink intentionally records only low-cardinality command metadata and sanitized error categories. It does not record package names, paths, repository URLs, branch names, tag names, commit hashes, issue numbers, pull request numbers, shell command strings, environment values, changeset content, changelog content, release notes, or raw error messages.
+
+## Future work
+
+Remote export, a user-facing telemetry command group, persistent opt-in configuration, hosted dashboards, and richer workspace-shape events are tracked as follow-up issues. Until those are implemented, telemetry remains local-only and best-effort.
+
+<!-- {/monochangeLocalTelemetryDocs} -->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,6 +2061,7 @@ dependencies = [
  "monochange_lint",
  "monochange_npm",
  "monochange_semver",
+ "monochange_telemtry",
  "monochange_test_helpers",
  "portable-pty",
  "rayon",
@@ -2397,6 +2398,19 @@ dependencies = [
  "rstest",
  "semver",
  "similar-asserts",
+]
+
+[[package]]
+name = "monochange_telemtry"
+version = "0.2.0"
+dependencies = [
+ "monochange_core",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "temp-env",
+ "tempfile",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ monochange_lint_testing = { version = "0.2.0", path = "./crates/monochange_lint_
 monochange_linting = { version = "0.2.0", path = "./crates/monochange_linting" }
 monochange_npm = { version = "0.2.0", path = "./crates/monochange_npm" }
 monochange_semver = { version = "0.2.0", path = "./crates/monochange_semver" }
+monochange_telemtry = { version = "0.2.0", path = "./crates/monochange_telemtry" }
 monochange_test_helpers = { version = "0.0.2", path = "./crates/monochange_test_helpers" }
 
 [workspace.metadata.bin]

--- a/crates/monochange/Cargo.toml
+++ b/crates/monochange/Cargo.toml
@@ -51,6 +51,7 @@ monochange_graph = { workspace = true }
 monochange_lint = { workspace = true }
 monochange_npm = { workspace = true, optional = true }
 monochange_semver = { workspace = true }
+monochange_telemtry = { workspace = true }
 rayon = { workspace = true, default-features = true }
 regex = { workspace = true, default-features = true }
 reqwest = { workspace = true, default-features = true, features = ["blocking"] }

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -31,6 +31,10 @@ use monochange_core::SourceChangeRequestOutcome;
 use monochange_core::SourceConfiguration;
 use monochange_core::SourceReleaseOutcome;
 use monochange_core::SourceReleaseRequest;
+use monochange_telemtry::CommandTelemetry;
+use monochange_telemtry::StepTelemetry;
+use monochange_telemtry::TelemetryOutcome;
+use monochange_telemtry::TelemetrySink;
 use serde::Serialize;
 
 use crate::cli::command_supports_release_diff_preview;
@@ -120,6 +124,15 @@ fn parse_progress_format(value: &str) -> MonochangeResult<ProgressFormat> {
 			"unknown progress format `{value}`; expected one of: auto, unicode, ascii, json"
 		))
 	})
+}
+
+fn telemetry_progress_format(format: ProgressFormat) -> &'static str {
+	match format {
+		ProgressFormat::Auto => "auto",
+		ProgressFormat::Unicode => "unicode",
+		ProgressFormat::Ascii => "ascii",
+		ProgressFormat::Json => "json",
+	}
 }
 
 pub(crate) fn collect_cli_command_inputs(
@@ -518,15 +531,60 @@ pub(crate) fn execute_cli_command_with_options(
 	let mut output = None;
 	let command_started_at = Instant::now();
 	let mut progress = CliProgressReporter::new(cli_command, dry_run, quiet, progress_format);
+	let telemetry = CliTelemetry::new(
+		TelemetrySink::from_env(),
+		cli_command,
+		dry_run,
+		show_diff,
+		progress_format,
+		command_started_at,
+	);
 
 	for (step_index, step) in cli_command.steps.iter().enumerate() {
 		let step_started_at = Instant::now();
-		let step_inputs = resolve_step_inputs(&context, step)?;
+		let step_inputs = match resolve_step_inputs(&context, step) {
+			Ok(step_inputs) => step_inputs,
+			Err(error) => {
+				telemetry.capture_step(
+					step_index,
+					step,
+					false,
+					step_started_at.elapsed(),
+					TelemetryOutcome::Error,
+					Some(&error),
+				);
+				telemetry.capture_command(TelemetryOutcome::Error, Some(&error));
+				return Err(error);
+			}
+		};
 		context.last_step_inputs = step_inputs.clone();
 		let show_progress = step_shows_progress(step, &step_inputs);
 
-		if !should_execute_cli_step(step, &context, &step_inputs)? {
+		let should_execute = match should_execute_cli_step(step, &context, &step_inputs) {
+			Ok(should_execute) => should_execute,
+			Err(error) => {
+				telemetry.capture_step(
+					step_index,
+					step,
+					false,
+					step_started_at.elapsed(),
+					TelemetryOutcome::Error,
+					Some(&error),
+				);
+				telemetry.capture_command(TelemetryOutcome::Error, Some(&error));
+				return Err(error);
+			}
+		};
+		if !should_execute {
 			record_skipped_cli_step(&mut context, step, step_index, &mut progress, show_progress);
+			telemetry.capture_step(
+				step_index,
+				step,
+				true,
+				step_started_at.elapsed(),
+				TelemetryOutcome::Skipped,
+				None,
+			);
 			continue;
 		}
 
@@ -887,33 +945,114 @@ pub(crate) fn execute_cli_command_with_options(
 			}
 		})();
 		if let Err(error) = step_result {
+			let elapsed = step_started_at.elapsed();
 			report_cli_step_failure(
 				&mut progress,
 				show_progress,
 				step_index,
 				step,
-				step_started_at.elapsed(),
+				elapsed,
 				&error,
 			);
+			telemetry.capture_step(
+				step_index,
+				step,
+				false,
+				elapsed,
+				TelemetryOutcome::Error,
+				Some(&error),
+			);
+			telemetry.capture_command(TelemetryOutcome::Error, Some(&error));
 
 			return Err(error);
 		}
+		let elapsed = step_started_at.elapsed();
 		if show_progress {
-			progress.step_finished(
-				step_index,
-				step,
-				step_started_at.elapsed(),
-				&step_phase_timings,
-			);
+			progress.step_finished(step_index, step, elapsed, &step_phase_timings);
 		}
+		telemetry.capture_step(
+			step_index,
+			step,
+			false,
+			elapsed,
+			TelemetryOutcome::Success,
+			None,
+		);
 	}
 
 	progress.command_finished(command_started_at.elapsed());
 
 	let artifact_path = prepared_release_path.as_deref();
-	save_prepared_release_artifact(root, configuration, &context, artifact_path)?;
+	let result = save_prepared_release_artifact(root, configuration, &context, artifact_path)
+		.and_then(|()| resolve_command_output(cli_command, &context, dry_run, output));
+	match &result {
+		Ok(_) => telemetry.capture_command(TelemetryOutcome::Success, None),
+		Err(error) => telemetry.capture_command(TelemetryOutcome::Error, Some(error)),
+	}
 
-	resolve_command_output(cli_command, &context, dry_run, output)
+	result
+}
+
+struct CliTelemetry<'a> {
+	sink: TelemetrySink,
+	cli_command: &'a CliCommandDefinition,
+	dry_run: bool,
+	show_diff: bool,
+	progress_format: ProgressFormat,
+	started_at: Instant,
+}
+
+impl<'a> CliTelemetry<'a> {
+	fn new(
+		sink: TelemetrySink,
+		cli_command: &'a CliCommandDefinition,
+		dry_run: bool,
+		show_diff: bool,
+		progress_format: ProgressFormat,
+		started_at: Instant,
+	) -> Self {
+		Self {
+			sink,
+			cli_command,
+			dry_run,
+			show_diff,
+			progress_format,
+			started_at,
+		}
+	}
+
+	fn capture_command(&self, outcome: TelemetryOutcome, error: Option<&MonochangeError>) {
+		self.sink.capture_command(CommandTelemetry {
+			command_name: &self.cli_command.name,
+			dry_run: self.dry_run,
+			show_diff: self.show_diff,
+			progress_format: telemetry_progress_format(self.progress_format),
+			step_count: self.cli_command.steps.len(),
+			duration: self.started_at.elapsed(),
+			outcome,
+			error,
+		});
+	}
+
+	fn capture_step(
+		&self,
+		step_index: usize,
+		step: &CliStepDefinition,
+		skipped: bool,
+		duration: Duration,
+		outcome: TelemetryOutcome,
+		error: Option<&MonochangeError>,
+	) {
+		self.sink.capture_step(StepTelemetry {
+			command_name: &self.cli_command.name,
+			step_index,
+			step_kind: step.kind_name(),
+			skipped,
+			duration,
+			outcome,
+			error,
+		});
+	}
 }
 
 pub(crate) fn should_execute_cli_step(
@@ -3374,6 +3513,28 @@ mod tests {
 			.unwrap_or_else(|error| panic!("expected default cli command `{name}`: {error}"))
 	}
 
+	fn read_telemetry_events(path: &Path) -> Vec<serde_json::Value> {
+		fs::read_to_string(path)
+			.unwrap_or_else(|error| panic!("telemetry file should be written: {error}"))
+			.lines()
+			.map(|line| {
+				serde_json::from_str(line)
+					.unwrap_or_else(|error| panic!("valid telemetry json: {error}"))
+			})
+			.collect()
+	}
+
+	#[test]
+	fn telemetry_progress_format_uses_stable_labels() {
+		assert_eq!(telemetry_progress_format(ProgressFormat::Auto), "auto");
+		assert_eq!(
+			telemetry_progress_format(ProgressFormat::Unicode),
+			"unicode"
+		);
+		assert_eq!(telemetry_progress_format(ProgressFormat::Ascii), "ascii");
+		assert_eq!(telemetry_progress_format(ProgressFormat::Json), "json");
+	}
+
 	#[test]
 	fn default_cli_command_accepts_prefixed_step_names() {
 		let command = default_cli_command("step:discover");
@@ -4489,6 +4650,105 @@ path = "crates/core"
 			error.to_string(),
 			"io error: failed to wait for command `echo hello`: wait failed"
 		);
+	}
+
+	#[test]
+	fn execute_cli_command_captures_telemetry_when_step_input_resolution_fails() {
+		let _guard = TEST_ENV_LOCK
+			.lock()
+			.unwrap_or_else(|error| panic!("test env lock poisoned: {error}"));
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let telemetry_path = tempdir.path().join("telemetry-input-error.jsonl");
+		let telemetry_path_value = telemetry_path.to_string_lossy().to_string();
+		let configuration = sample_configuration(tempdir.path());
+		let cli_command = CliCommandDefinition {
+			name: "telemetry-input-error".to_string(),
+			help_text: None,
+			inputs: Vec::new(),
+			steps: vec![CliStepDefinition::Validate {
+				name: Some("invalid input".to_string()),
+				when: None,
+				inputs: BTreeMap::from([(
+					"target".to_string(),
+					CliStepInputValue::String("{{".to_string()),
+				)]),
+			}],
+		};
+
+		temp_env::with_vars(
+			[
+				("MC_TELEMETRY", None::<&str>),
+				("MC_TELEMETRY_FILE", Some(telemetry_path_value.as_str())),
+			],
+			|| {
+				let error = execute_cli_command(
+					tempdir.path(),
+					&configuration,
+					&cli_command,
+					true,
+					BTreeMap::new(),
+				)
+				.unwrap_err();
+				assert!(matches!(error, MonochangeError::Config(_)));
+			},
+		);
+
+		let events = read_telemetry_events(&telemetry_path);
+		assert_eq!(events.len(), 2);
+		assert_eq!(events[0]["body"]["string_value"], "command_step");
+		assert_eq!(events[0]["attributes"]["outcome"], "error");
+		assert_eq!(events[0]["attributes"]["error_kind"], "config_error");
+		assert_eq!(events[1]["body"]["string_value"], "command_run");
+		assert_eq!(events[1]["attributes"]["outcome"], "error");
+		assert_eq!(events[1]["attributes"]["error_kind"], "config_error");
+	}
+
+	#[test]
+	fn execute_cli_command_captures_telemetry_when_step_condition_fails() {
+		let _guard = TEST_ENV_LOCK
+			.lock()
+			.unwrap_or_else(|error| panic!("test env lock poisoned: {error}"));
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let telemetry_path = tempdir.path().join("telemetry-condition-error.jsonl");
+		let telemetry_path_value = telemetry_path.to_string_lossy().to_string();
+		let configuration = sample_configuration(tempdir.path());
+		let cli_command = CliCommandDefinition {
+			name: "telemetry-condition-error".to_string(),
+			help_text: None,
+			inputs: Vec::new(),
+			steps: vec![CliStepDefinition::Validate {
+				name: Some("invalid condition".to_string()),
+				when: Some("{{ missing.path }}".to_string()),
+				inputs: BTreeMap::new(),
+			}],
+		};
+
+		temp_env::with_vars(
+			[
+				("MC_TELEMETRY", None::<&str>),
+				("MC_TELEMETRY_FILE", Some(telemetry_path_value.as_str())),
+			],
+			|| {
+				let error = execute_cli_command(
+					tempdir.path(),
+					&configuration,
+					&cli_command,
+					true,
+					BTreeMap::new(),
+				)
+				.unwrap_err();
+				assert!(matches!(error, MonochangeError::Config(_)));
+			},
+		);
+
+		let events = read_telemetry_events(&telemetry_path);
+		assert_eq!(events.len(), 2);
+		assert_eq!(events[0]["body"]["string_value"], "command_step");
+		assert_eq!(events[0]["attributes"]["outcome"], "error");
+		assert_eq!(events[0]["attributes"]["error_kind"], "config_error");
+		assert_eq!(events[1]["body"]["string_value"], "command_run");
+		assert_eq!(events[1]["attributes"]["outcome"], "error");
+		assert_eq!(events[1]["attributes"]["error_kind"], "config_error");
 	}
 
 	#[test]

--- a/crates/monochange/tests/telemetry.rs
+++ b/crates/monochange/tests/telemetry.rs
@@ -1,0 +1,61 @@
+use std::fs;
+
+use serde_json::Value;
+
+mod test_support;
+use test_support::monochange_command;
+use test_support::setup_scenario_workspace;
+
+#[test]
+fn local_jsonl_telemetry_records_cli_command_and_step_events() {
+	let tempdir = setup_scenario_workspace("monochange/validate-workspace");
+	let telemetry_file = tempdir.path().join("telemetry.jsonl");
+
+	let output = monochange_command(None)
+		.current_dir(tempdir.path())
+		.env("MC_TELEMETRY_FILE", &telemetry_file)
+		.env_remove("MC_TELEMETRY")
+		.arg("validate")
+		.arg("--quiet")
+		.output()
+		.unwrap_or_else(|error| panic!("run validate with telemetry: {error}"));
+
+	assert!(
+		output.status.success(),
+		"expected validate to pass\nstdout:\n{}\nstderr:\n{}",
+		String::from_utf8_lossy(&output.stdout),
+		String::from_utf8_lossy(&output.stderr),
+	);
+
+	let events = read_jsonl_events(&telemetry_file);
+	assert_eq!(events.len(), 2);
+
+	let step = &events[0];
+	assert_eq!(step["body"]["string_value"], "command_step");
+	assert_eq!(step["resource"]["service.name"], "monochange");
+	assert_eq!(step["scope"]["name"], "monochange.telemetry");
+	assert_eq!(step["attributes"]["command_name"], "validate");
+	assert_eq!(step["attributes"]["step_kind"], "Validate");
+	assert_eq!(step["attributes"]["outcome"], "success");
+	assert!(step["attributes"]["error_kind"].is_null());
+
+	let command = &events[1];
+	assert_eq!(command["body"]["string_value"], "command_run");
+	assert_eq!(command["attributes"]["command_name"], "validate");
+	assert_eq!(command["attributes"]["command_source"], "configured");
+	assert_eq!(command["attributes"]["progress_format"], "auto");
+	assert_eq!(command["attributes"]["step_count"], 1);
+	assert_eq!(command["attributes"]["outcome"], "success");
+	assert!(command["attributes"]["error_kind"].is_null());
+}
+
+fn read_jsonl_events(path: &std::path::Path) -> Vec<Value> {
+	fs::read_to_string(path)
+		.unwrap_or_else(|error| panic!("read telemetry file {}: {error}", path.display()))
+		.lines()
+		.map(|line| {
+			serde_json::from_str(line)
+				.unwrap_or_else(|error| panic!("parse telemetry json line {line:?}: {error}"))
+		})
+		.collect()
+}

--- a/crates/monochange_telemtry/Cargo.toml
+++ b/crates/monochange_telemtry/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "monochange_telemtry"
+version = { workspace = true }
+authors = { workspace = true }
+categories = { workspace = true }
+documentation = "https://docs.rs/monochange_telemtry"
+edition = { workspace = true }
+homepage = { workspace = true }
+include = ["src/**/*.rs", "tests/**/*.rs", "Cargo.toml", "readme.md"]
+keywords = ["cli", "telemetry", "jsonl", "tracing", "monorepo"]
+license = { workspace = true }
+readme = "readme.md"
+repository = { workspace = true }
+rust-version = { workspace = true }
+description = "Local telemetry primitives for monochange"
+
+[features]
+default = []
+http = ["monochange_core/http"]
+
+[dependencies]
+monochange_core = { workspace = true }
+serde = { workspace = true, default-features = true }
+serde_json = { workspace = true, default-features = true }
+tracing = { workspace = true, default-features = true }
+
+[dev-dependencies]
+reqwest = { workspace = true, default-features = true, features = ["blocking"] }
+temp-env = { workspace = true, default-features = true }
+tempfile = { workspace = true, default-features = true }
+
+[lints]
+workspace = true

--- a/crates/monochange_telemtry/readme.md
+++ b/crates/monochange_telemtry/readme.md
@@ -1,0 +1,64 @@
+# `monochange_telemtry`
+
+<br />
+
+<!-- {=crateReadmeBadgeRow:"monochange_telemtry"} -->
+
+[![Crates.io](https://img.shields.io/badge/crates.io-monochange__telemtry-orange?logo=rust)](https://crates.io/crates/monochange_telemtry) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__telemtry-1f425f?logo=docs.rs)](https://docs.rs/monochange_telemtry/) [![CI](https://github.com/monochange/monochange/actions/workflows/ci.yml/badge.svg)](https://github.com/monochange/monochange/actions/workflows/ci.yml) [![Coverage](https://codecov.io/gh/monochange/monochange/branch/main/graph/badge.svg?flag=monochange_telemtry)](https://codecov.io/gh/monochange/monochange?flag=monochange_telemtry) [![License](https://img.shields.io/badge/license-Unlicense-blue.svg)](https://opensource.org/license/unlicense)
+
+<!-- {/crateReadmeBadgeRow} -->
+
+<br />
+
+<!-- {=monochangeTelemtryCrateDocs} -->
+
+`monochange_telemtry` provides local-only telemetry primitives for the `monochange` CLI.
+
+Reach for this crate when you need the reusable event sink, event payloads, and privacy-preserving error classification that power opt-in local JSONL telemetry. The crate intentionally keeps transport simple: it appends OpenTelemetry-style JSON Lines records to a local file and does not send telemetry over the network.
+
+## Why use it?
+
+- keep telemetry capture separate from CLI orchestration and package discovery
+- share one local JSONL event schema across command and step instrumentation
+- classify errors into low-cardinality categories without exposing raw error text
+- make telemetry writes best-effort so observability cannot change command outcomes
+
+## Best for
+
+- embedding monochange's local telemetry sink in the CLI runtime
+- smoke-testing event schemas without provisioning a backend
+- building future telemetry commands, exporters, or redaction tests on top of a small public API
+
+## Public entry points
+
+- `TelemetrySink::from_env()` resolves `MC_TELEMETRY` and `MC_TELEMETRY_FILE` into either a disabled sink or a local JSONL sink
+- `TelemetrySink::capture_command(...)` writes `command_run` events
+- `TelemetrySink::capture_step(...)` writes `command_step` events
+- `CommandTelemetry`, `StepTelemetry`, and `TelemetryOutcome` describe the stable event payloads
+
+## Privacy boundaries
+
+The crate only accepts low-cardinality command metadata, booleans, counts, durations, enum outcomes, and sanitized `error_kind` values. It does not collect package names, paths, repository URLs, branch names, refs, commit hashes, shell command strings, environment values, changeset text, release notes, issue or pull request IDs, or raw errors.
+
+## Example
+
+```rust
+use monochange_telemtry::CommandTelemetry;
+use monochange_telemtry::TelemetryOutcome;
+use monochange_telemtry::TelemetrySink;
+use std::time::Duration;
+
+let sink = TelemetrySink::Disabled;
+sink.capture_command(CommandTelemetry {
+    command_name: "validate",
+    dry_run: false,
+    show_diff: false,
+    progress_format: "auto",
+    step_count: 1,
+    duration: Duration::from_millis(42),
+    outcome: TelemetryOutcome::Success,
+    error: None,
+});
+```
+
+<!-- {/monochangeTelemtryCrateDocs} -->

--- a/crates/monochange_telemtry/src/lib.rs
+++ b/crates/monochange_telemtry/src/lib.rs
@@ -1,0 +1,610 @@
+//! # `monochange_telemtry`
+//!
+//! <!-- {=monochangeTelemtryCrateDocs|trim|linePrefix:"//! ":true} -->
+//! `monochange_telemtry` provides local-only telemetry primitives for the `monochange` CLI.
+//!
+//! Reach for this crate when you need the reusable event sink, event payloads, and privacy-preserving error classification that power opt-in local JSONL telemetry. The crate intentionally keeps transport simple: it appends OpenTelemetry-style JSON Lines records to a local file and does not send telemetry over the network.
+//!
+//! ## Why use it?
+//!
+//! - keep telemetry capture separate from CLI orchestration and package discovery
+//! - share one local JSONL event schema across command and step instrumentation
+//! - classify errors into low-cardinality categories without exposing raw error text
+//! - make telemetry writes best-effort so observability cannot change command outcomes
+//!
+//! ## Best for
+//!
+//! - embedding monochange's local telemetry sink in the CLI runtime
+//! - smoke-testing event schemas without provisioning a backend
+//! - building future telemetry commands, exporters, or redaction tests on top of a small public API
+//!
+//! ## Public entry points
+//!
+//! - `TelemetrySink::from_env()` resolves `MC_TELEMETRY` and `MC_TELEMETRY_FILE` into either a disabled sink or a local JSONL sink
+//! - `TelemetrySink::capture_command(...)` writes `command_run` events
+//! - `TelemetrySink::capture_step(...)` writes `command_step` events
+//! - `CommandTelemetry`, `StepTelemetry`, and `TelemetryOutcome` describe the stable event payloads
+//!
+//! ## Privacy boundaries
+//!
+//! The crate only accepts low-cardinality command metadata, booleans, counts, durations, enum outcomes, and sanitized `error_kind` values. It does not collect package names, paths, repository URLs, branch names, refs, commit hashes, shell command strings, environment values, changeset text, release notes, issue or pull request IDs, or raw errors.
+//!
+//! ## Example
+//!
+//! ```rust
+//! use monochange_telemtry::CommandTelemetry;
+//! use monochange_telemtry::TelemetryOutcome;
+//! use monochange_telemtry::TelemetrySink;
+//! use std::time::Duration;
+//!
+//! let sink = TelemetrySink::Disabled;
+//! sink.capture_command(CommandTelemetry {
+//!     command_name: "validate",
+//!     dry_run: false,
+//!     show_diff: false,
+//!     progress_format: "auto",
+//!     step_count: 1,
+//!     duration: Duration::from_millis(42),
+//!     outcome: TelemetryOutcome::Success,
+//!     error: None,
+//! });
+//! ```
+//! <!-- {/monochangeTelemtryCrateDocs} -->
+
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+#[cfg(test)]
+use std::sync::LazyLock;
+#[cfg(test)]
+use std::sync::Mutex;
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use monochange_core::MonochangeError;
+use serde::Serialize;
+use serde_json::json;
+
+const TELEMETRY_ENV: &str = "MC_TELEMETRY";
+const TELEMETRY_FILE_ENV: &str = "MC_TELEMETRY_FILE";
+const TELEMETRY_SCOPE_NAME: &str = "monochange.telemetry";
+const TELEMETRY_SCOPE_VERSION: &str = "0.1.0";
+
+#[cfg(test)]
+static TEST_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+#[derive(Debug, Clone)]
+pub enum TelemetrySink {
+	Disabled,
+	LocalJsonl { path: PathBuf },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct CommandTelemetry<'a> {
+	pub command_name: &'a str,
+	pub dry_run: bool,
+	pub show_diff: bool,
+	pub progress_format: &'a str,
+	pub step_count: usize,
+	pub duration: Duration,
+	pub outcome: TelemetryOutcome,
+	pub error: Option<&'a MonochangeError>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct StepTelemetry<'a> {
+	pub command_name: &'a str,
+	pub step_index: usize,
+	pub step_kind: &'a str,
+	pub skipped: bool,
+	pub duration: Duration,
+	pub outcome: TelemetryOutcome,
+	pub error: Option<&'a MonochangeError>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum TelemetryOutcome {
+	Success,
+	Skipped,
+	Error,
+}
+
+impl TelemetrySink {
+	pub fn from_env() -> Self {
+		let explicit_file = env::var_os(TELEMETRY_FILE_ENV).map(PathBuf::from);
+		let Some(mode) = env::var_os(TELEMETRY_ENV) else {
+			return explicit_file.map_or(Self::Disabled, Self::local_jsonl);
+		};
+		let mode = mode.to_string_lossy().to_ascii_lowercase();
+		if matches!(
+			mode.as_str(),
+			"1" | "true" | "on" | "yes" | "local" | "jsonl"
+		) {
+			return Self::local_jsonl(explicit_file.unwrap_or_else(default_telemetry_file));
+		}
+		Self::Disabled
+	}
+
+	pub fn capture_command(&self, telemetry: CommandTelemetry<'_>) {
+		let attributes = BTreeMap::from([
+			("command_name".to_string(), json!(telemetry.command_name)),
+			(
+				"command_source".to_string(),
+				json!(command_source(telemetry.command_name)),
+			),
+			("dry_run".to_string(), json!(telemetry.dry_run)),
+			("show_diff".to_string(), json!(telemetry.show_diff)),
+			(
+				"progress_format".to_string(),
+				json!(telemetry.progress_format),
+			),
+			("step_count".to_string(), json!(telemetry.step_count)),
+			(
+				"duration_ms".to_string(),
+				json!(duration_millis(telemetry.duration)),
+			),
+			("outcome".to_string(), json!(telemetry.outcome.as_str())),
+			(
+				"error_kind".to_string(),
+				json!(telemetry.error.map(error_kind)),
+			),
+		]);
+
+		self.capture("command_run", attributes);
+	}
+
+	pub fn capture_step(&self, telemetry: StepTelemetry<'_>) {
+		let attributes = BTreeMap::from([
+			("command_name".to_string(), json!(telemetry.command_name)),
+			("step_index".to_string(), json!(telemetry.step_index)),
+			("step_kind".to_string(), json!(telemetry.step_kind)),
+			("skipped".to_string(), json!(telemetry.skipped)),
+			(
+				"duration_ms".to_string(),
+				json!(duration_millis(telemetry.duration)),
+			),
+			("outcome".to_string(), json!(telemetry.outcome.as_str())),
+			(
+				"error_kind".to_string(),
+				json!(telemetry.error.map(error_kind)),
+			),
+		]);
+
+		self.capture("command_step", attributes);
+	}
+
+	fn local_jsonl(path: PathBuf) -> Self {
+		Self::LocalJsonl { path }
+	}
+
+	fn capture(&self, name: &'static str, attributes: BTreeMap<String, serde_json::Value>) {
+		let Self::LocalJsonl { path } = self else {
+			return;
+		};
+		if let Err(error) = write_event(path, name, attributes) {
+			tracing::debug!(?error, path = %path.display(), "failed to write local telemetry event");
+		}
+	}
+}
+
+impl TelemetryOutcome {
+	pub fn as_str(self) -> &'static str {
+		match self {
+			Self::Success => "success",
+			Self::Skipped => "skipped",
+			Self::Error => "error",
+		}
+	}
+}
+
+#[derive(Serialize)]
+struct LocalOpenTelemetryEvent {
+	resource: ResourceAttributes,
+	scope: InstrumentationScope,
+	time_unix_nano: u128,
+	severity_text: &'static str,
+	body: EventBody,
+	attributes: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Serialize)]
+struct ResourceAttributes {
+	#[serde(rename = "service.name")]
+	service_name: &'static str,
+	#[serde(rename = "service.version")]
+	service_version: &'static str,
+}
+
+#[derive(Serialize)]
+struct InstrumentationScope {
+	name: &'static str,
+	version: &'static str,
+}
+
+#[derive(Serialize)]
+struct EventBody {
+	#[serde(rename = "string_value")]
+	value: &'static str,
+}
+
+fn write_event(
+	path: &Path,
+	name: &'static str,
+	attributes: BTreeMap<String, serde_json::Value>,
+) -> std::io::Result<()> {
+	if let Some(parent) = path
+		.parent()
+		.filter(|parent| !parent.as_os_str().is_empty())
+	{
+		fs::create_dir_all(parent)?;
+	}
+	let event = LocalOpenTelemetryEvent {
+		resource: ResourceAttributes {
+			service_name: "monochange",
+			service_version: env!("CARGO_PKG_VERSION"),
+		},
+		scope: InstrumentationScope {
+			name: TELEMETRY_SCOPE_NAME,
+			version: TELEMETRY_SCOPE_VERSION,
+		},
+		time_unix_nano: timestamp_unix_nano(),
+		severity_text: "INFO",
+		body: EventBody { value: name },
+		attributes,
+	};
+	let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+	serde_json::to_writer(&mut file, &event)?;
+	file.write_all(b"\n")?;
+	Ok(())
+}
+
+fn timestamp_unix_nano() -> u128 {
+	SystemTime::now()
+		.duration_since(UNIX_EPOCH)
+		.map_or(0, |duration| duration.as_nanos())
+}
+
+fn duration_millis(duration: Duration) -> u128 {
+	duration.as_millis()
+}
+
+fn default_telemetry_file() -> PathBuf {
+	if let Some(state_home) = env::var_os("XDG_STATE_HOME") {
+		return PathBuf::from(state_home)
+			.join("monochange")
+			.join("telemetry.jsonl");
+	}
+	if let Some(home) = env::var_os("HOME") {
+		return PathBuf::from(home)
+			.join(".local")
+			.join("state")
+			.join("monochange")
+			.join("telemetry.jsonl");
+	}
+	PathBuf::from(".monochange").join("telemetry.jsonl")
+}
+
+fn command_source(command_name: &str) -> &'static str {
+	if command_name.starts_with("step:") {
+		"generated_step"
+	} else {
+		"configured"
+	}
+}
+
+fn error_kind(error: &MonochangeError) -> &'static str {
+	match error {
+		MonochangeError::Io(_) | MonochangeError::IoSource { .. } => "io_error",
+		MonochangeError::Config(_) => "config_error",
+		MonochangeError::Discovery(_) => "discovery_error",
+		MonochangeError::Diagnostic(_) => "diagnostic_error",
+		MonochangeError::Parse { .. } => "parse_error",
+		MonochangeError::Interactive { .. } => "interactive_error",
+		MonochangeError::Cancelled => "cancelled",
+		_ => "unknown_error",
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::io;
+	use std::path::Path;
+
+	use super::*;
+
+	#[test]
+	fn telemetry_is_disabled_without_environment_opt_in() {
+		let _guard = TEST_ENV_LOCK
+			.lock()
+			.unwrap_or_else(|error| panic!("test env lock poisoned: {error}"));
+		temp_env::with_vars(
+			[
+				(TELEMETRY_ENV, None::<&str>),
+				(TELEMETRY_FILE_ENV, None::<&str>),
+			],
+			|| assert!(matches!(TelemetrySink::from_env(), TelemetrySink::Disabled)),
+		);
+	}
+
+	#[test]
+	fn telemetry_file_environment_enables_local_jsonl_sink() {
+		let _guard = TEST_ENV_LOCK
+			.lock()
+			.unwrap_or_else(|error| panic!("test env lock poisoned: {error}"));
+		let temp =
+			tempfile::tempdir().unwrap_or_else(|error| panic!("temporary directory: {error}"));
+		let path = temp.path().join("telemetry.jsonl");
+		let path_value = path.to_string_lossy().to_string();
+		temp_env::with_vars(
+			[
+				(TELEMETRY_ENV, None::<&str>),
+				(TELEMETRY_FILE_ENV, Some(path_value.as_str())),
+			],
+			|| {
+				let sink = TelemetrySink::from_env();
+				sink.capture_command(CommandTelemetry {
+					command_name: "validate",
+					dry_run: false,
+					show_diff: false,
+					progress_format: "auto",
+					step_count: 1,
+					duration: Duration::from_millis(42),
+					outcome: TelemetryOutcome::Success,
+					error: None,
+				});
+			},
+		);
+
+		let events = read_events(&path);
+		assert_eq!(events.len(), 1);
+		let event = &events[0];
+		assert_eq!(event["body"]["string_value"], "command_run");
+		assert_eq!(event["resource"]["service.name"], "monochange");
+		assert_eq!(event["scope"]["name"], TELEMETRY_SCOPE_NAME);
+		assert_eq!(event["scope"]["version"], TELEMETRY_SCOPE_VERSION);
+		assert_eq!(event["severity_text"], "INFO");
+		assert!(event["time_unix_nano"].as_u64().is_some());
+		assert_eq!(event["attributes"]["command_name"], "validate");
+		assert_eq!(event["attributes"]["command_source"], "configured");
+		assert_eq!(event["attributes"]["dry_run"], false);
+		assert_eq!(event["attributes"]["show_diff"], false);
+		assert_eq!(event["attributes"]["progress_format"], "auto");
+		assert_eq!(event["attributes"]["step_count"], 1);
+		assert_eq!(event["attributes"]["duration_ms"], 42);
+		assert_eq!(event["attributes"]["outcome"], "success");
+		assert!(event["attributes"]["error_kind"].is_null());
+	}
+
+	#[test]
+	fn telemetry_mode_environment_uses_default_state_file() {
+		let _guard = TEST_ENV_LOCK
+			.lock()
+			.unwrap_or_else(|error| panic!("test env lock poisoned: {error}"));
+		let temp =
+			tempfile::tempdir().unwrap_or_else(|error| panic!("temporary directory: {error}"));
+		let state_home = temp.path().join("state");
+		let state_home_value = state_home.to_string_lossy().to_string();
+		temp_env::with_vars(
+			[
+				(TELEMETRY_ENV, Some("local")),
+				(TELEMETRY_FILE_ENV, None::<&str>),
+				("XDG_STATE_HOME", Some(state_home_value.as_str())),
+				("HOME", None::<&str>),
+			],
+			|| {
+				let sink = TelemetrySink::from_env();
+				assert!(matches!(sink, TelemetrySink::LocalJsonl { .. }));
+				sink.capture_step(StepTelemetry {
+					command_name: "step:validate",
+					step_index: 3,
+					step_kind: "Validate",
+					skipped: true,
+					duration: Duration::from_millis(7),
+					outcome: TelemetryOutcome::Skipped,
+					error: Some(&MonochangeError::Config(
+						"secret path /tmp/repo".to_string(),
+					)),
+				});
+			},
+		);
+
+		let events = read_events(&state_home.join("monochange").join("telemetry.jsonl"));
+		assert_eq!(events.len(), 1);
+		let event = &events[0];
+		assert_eq!(event["body"]["string_value"], "command_step");
+		assert_eq!(event["attributes"]["command_name"], "step:validate");
+		assert_eq!(event["attributes"]["step_index"], 3);
+		assert_eq!(event["attributes"]["step_kind"], "Validate");
+		assert_eq!(event["attributes"]["skipped"], true);
+		assert_eq!(event["attributes"]["duration_ms"], 7);
+		assert_eq!(event["attributes"]["outcome"], "skipped");
+		assert_eq!(event["attributes"]["error_kind"], "config_error");
+		assert!(!event.to_string().contains("/tmp/repo"));
+	}
+
+	#[test]
+	fn telemetry_disable_mode_overrides_custom_file() {
+		let _guard = TEST_ENV_LOCK
+			.lock()
+			.unwrap_or_else(|error| panic!("test env lock poisoned: {error}"));
+		let temp =
+			tempfile::tempdir().unwrap_or_else(|error| panic!("temporary directory: {error}"));
+		let path = temp.path().join("telemetry.jsonl");
+		let path_value = path.to_string_lossy().to_string();
+		temp_env::with_vars(
+			[
+				(TELEMETRY_ENV, Some("0")),
+				(TELEMETRY_FILE_ENV, Some(path_value.as_str())),
+			],
+			|| {
+				let sink = TelemetrySink::from_env();
+				assert!(matches!(sink, TelemetrySink::Disabled));
+				sink.capture_command(sample_command_telemetry("validate"));
+			},
+		);
+
+		assert!(!path.exists());
+	}
+
+	#[test]
+	fn telemetry_helpers_use_stable_labels() {
+		assert_eq!(TelemetryOutcome::Success.as_str(), "success");
+		assert_eq!(TelemetryOutcome::Skipped.as_str(), "skipped");
+		assert_eq!(TelemetryOutcome::Error.as_str(), "error");
+		assert_eq!(command_source("validate"), "configured");
+		assert_eq!(command_source("step:discover"), "generated_step");
+	}
+
+	#[test]
+	fn error_kind_uses_sanitized_categories() {
+		let parse_source: Box<dyn std::error::Error + Send + Sync> = Box::new(io::Error::new(
+			io::ErrorKind::InvalidData,
+			"raw parse details",
+		));
+		let errors = [
+			(MonochangeError::Io("raw io".to_string()), "io_error"),
+			(
+				MonochangeError::IoSource {
+					path: PathBuf::from("/secret/repo/file"),
+					source: io::Error::other("raw source"),
+				},
+				"io_error",
+			),
+			(
+				MonochangeError::Config("raw config".to_string()),
+				"config_error",
+			),
+			(
+				MonochangeError::Discovery("raw discovery".to_string()),
+				"discovery_error",
+			),
+			(
+				MonochangeError::Diagnostic("raw diagnostic".to_string()),
+				"diagnostic_error",
+			),
+			(
+				MonochangeError::Parse {
+					path: PathBuf::from("/secret/repo/config"),
+					source: parse_source,
+				},
+				"parse_error",
+			),
+			(
+				MonochangeError::Interactive {
+					message: "raw prompt".to_string(),
+				},
+				"interactive_error",
+			),
+			(MonochangeError::Cancelled, "cancelled"),
+		];
+
+		for (error, expected) in errors {
+			assert_eq!(error_kind(&error), expected);
+		}
+
+		#[cfg(feature = "http")]
+		{
+			let source = reqwest::blocking::get("http://[::1")
+				.expect_err("invalid URL should fail before making a request");
+			let error = MonochangeError::HttpRequest {
+				context: "request".to_string(),
+				source,
+			};
+			assert_eq!(error_kind(&error), "unknown_error");
+		}
+	}
+
+	#[test]
+	fn default_telemetry_file_uses_home_when_state_home_is_absent() {
+		let _guard = TEST_ENV_LOCK
+			.lock()
+			.unwrap_or_else(|error| panic!("test env lock poisoned: {error}"));
+		let temp =
+			tempfile::tempdir().unwrap_or_else(|error| panic!("temporary directory: {error}"));
+		let home = temp.path().join("home");
+		let home_value = home.to_string_lossy().to_string();
+		temp_env::with_vars(
+			[
+				("XDG_STATE_HOME", None::<&str>),
+				("HOME", Some(home_value.as_str())),
+			],
+			|| {
+				assert_eq!(
+					default_telemetry_file(),
+					home.join(".local")
+						.join("state")
+						.join("monochange")
+						.join("telemetry.jsonl"),
+				);
+			},
+		);
+	}
+
+	#[test]
+	fn default_telemetry_file_falls_back_to_workspace_relative_path() {
+		let _guard = TEST_ENV_LOCK
+			.lock()
+			.unwrap_or_else(|error| panic!("test env lock poisoned: {error}"));
+		temp_env::with_vars(
+			[("XDG_STATE_HOME", None::<&str>), ("HOME", None::<&str>)],
+			|| {
+				assert_eq!(
+					default_telemetry_file(),
+					PathBuf::from(".monochange").join("telemetry.jsonl")
+				);
+			},
+		);
+	}
+
+	#[test]
+	fn local_telemetry_write_failures_do_not_panic() {
+		let temp =
+			tempfile::tempdir().unwrap_or_else(|error| panic!("temporary directory: {error}"));
+		let sink = TelemetrySink::local_jsonl(temp.path().to_path_buf());
+		sink.capture_command(sample_command_telemetry("validate"));
+	}
+
+	#[test]
+	fn write_event_supports_paths_without_parent_directory() {
+		let temp =
+			tempfile::tempdir().unwrap_or_else(|error| panic!("temporary directory: {error}"));
+		let current_dir =
+			env::current_dir().unwrap_or_else(|error| panic!("current directory: {error}"));
+		env::set_current_dir(temp.path())
+			.unwrap_or_else(|error| panic!("move into temp dir: {error}"));
+		let result = write_event(Path::new("telemetry.jsonl"), "command_run", BTreeMap::new());
+		env::set_current_dir(current_dir)
+			.unwrap_or_else(|error| panic!("restore current dir: {error}"));
+		result.unwrap_or_else(|error| panic!("event written: {error}"));
+		assert!(temp.path().join("telemetry.jsonl").exists());
+	}
+
+	fn sample_command_telemetry(command_name: &str) -> CommandTelemetry<'_> {
+		CommandTelemetry {
+			command_name,
+			dry_run: false,
+			show_diff: false,
+			progress_format: "auto",
+			step_count: 1,
+			duration: Duration::from_millis(42),
+			outcome: TelemetryOutcome::Success,
+			error: None,
+		}
+	}
+
+	fn read_events(path: &Path) -> Vec<serde_json::Value> {
+		fs::read_to_string(path)
+			.unwrap_or_else(|error| panic!("telemetry file should be written: {error}"))
+			.lines()
+			.map(|line| {
+				serde_json::from_str(line)
+					.unwrap_or_else(|error| panic!("valid json event: {error}"))
+			})
+			.collect()
+	}
+}

--- a/crates/monochange_telemtry/tests/local_jsonl.rs
+++ b/crates/monochange_telemtry/tests/local_jsonl.rs
@@ -1,0 +1,68 @@
+use std::time::Duration;
+
+use monochange_core::MonochangeError;
+use monochange_telemtry::CommandTelemetry;
+use monochange_telemtry::StepTelemetry;
+use monochange_telemtry::TelemetryOutcome;
+use monochange_telemtry::TelemetrySink;
+use serde_json::Value;
+
+#[test]
+fn public_api_writes_sanitized_command_and_step_jsonl_events() {
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let telemetry_file = tempdir.path().join("telemetry.jsonl");
+	let telemetry_file_value = telemetry_file.to_string_lossy();
+	let config_error = MonochangeError::Config("do not include raw path /private/repo".to_string());
+
+	temp_env::with_vars(
+		[
+			("MC_TELEMETRY", None::<&str>),
+			("MC_TELEMETRY_FILE", Some(telemetry_file_value.as_ref())),
+		],
+		|| {
+			let sink = TelemetrySink::from_env();
+			sink.capture_step(StepTelemetry {
+				command_name: "validate",
+				step_index: 0,
+				step_kind: "Validate",
+				skipped: false,
+				duration: Duration::from_millis(3),
+				outcome: TelemetryOutcome::Error,
+				error: Some(&config_error),
+			});
+			sink.capture_command(CommandTelemetry {
+				command_name: "validate",
+				dry_run: true,
+				show_diff: false,
+				progress_format: "auto",
+				step_count: 1,
+				duration: Duration::from_millis(5),
+				outcome: TelemetryOutcome::Error,
+				error: Some(&config_error),
+			});
+		},
+	);
+
+	let events = read_jsonl_events(&telemetry_file);
+	assert_eq!(events.len(), 2);
+	assert_eq!(events[0]["body"]["string_value"], "command_step");
+	assert_eq!(events[0]["attributes"]["error_kind"], "config_error");
+	assert_eq!(events[1]["body"]["string_value"], "command_run");
+	assert_eq!(events[1]["attributes"]["dry_run"], true);
+	assert_eq!(events[1]["attributes"]["progress_format"], "auto");
+
+	let rendered =
+		serde_json::to_string(&events).unwrap_or_else(|error| panic!("render json: {error}"));
+	assert!(!rendered.contains("/private/repo"));
+}
+
+fn read_jsonl_events(path: &std::path::Path) -> Vec<Value> {
+	std::fs::read_to_string(path)
+		.unwrap_or_else(|error| panic!("read telemetry file {}: {error}", path.display()))
+		.lines()
+		.map(|line| {
+			serde_json::from_str(line)
+				.unwrap_or_else(|error| panic!("parse telemetry json line {line:?}: {error}"))
+		})
+		.collect()
+}

--- a/docs/plans/active/telemetry-research.md
+++ b/docs/plans/active/telemetry-research.md
@@ -1,0 +1,273 @@
+# Telemetry research
+
+## Status
+
+- Date: 2026-04-28
+- Branch/worktree: `chore/telemetry-research`
+- Scope: research, local-only telemetry implementation, and follow-up issue planning.
+- Initial implementation added local OpenTelemetry-style JSONL command/step events behind `MC_TELEMETRY` / `MC_TELEMETRY_FILE`.
+
+## Problem statement
+
+monochange is a Rust CLI and workspace library for planning releases in multi-ecosystem monorepos. Today it has local diagnostics through `tracing`, `tracing-subscriber`, and logging configured from `RUST_LOG` / `--log-level`, but it does not send product telemetry or analytics anywhere.
+
+The project could benefit from faster feedback about which commands, release flows, package ecosystems, and APIs are actually used. That feedback would help prioritize work while avoiding guesses based only on issues and maintainer intuition.
+
+## What telemetry means here
+
+Telemetry in this context means deliberately emitted, privacy-aware operational and product signals from the monochange CLI and library. It is different from local logging:
+
+- **Local tracing/logging**: developer-controlled diagnostics printed locally or written to a local collector. Useful for debugging a single run.
+- **Product telemetry**: aggregate usage events such as command names, step kinds, durations, outcomes, feature flags used, workspace shape counts, and sanitized error categories. Useful for understanding what users do across many installations.
+- **Error/performance monitoring**: crash reports, panic reports, and slow path traces. Useful for quality but more sensitive and not the same as feature analytics.
+
+For monochange, telemetry should be treated as an explicit product feature with a published privacy policy, opt-in or at least clear opt-out, and a strict schema that avoids collecting repository contents or package names by default.
+
+## High-value feedback questions
+
+Telemetry would be most useful if it answers questions like:
+
+- Which top-level commands are used: `validate`, `discover`, `change`, release commands, publish-related commands, and generated `step:*` commands?
+- Which `CliStepDefinition` variants are common or unused?
+- Which ecosystems are actually present in discovered workspaces: Cargo, npm, Deno, Dart, Flutter?
+- How often do users run dry-run versus real release/publish flows?
+- Which output/progress formats are used: markdown/json, unicode/ascii/json progress?
+- Which release/publish flows fail most often, and at what step?
+- How long do discovery, release planning, publishing, and hosted-source operations take?
+- Which optional API surfaces are used by downstream crates versus only by the binary? This is better answered with explicit library instrumentation or docs/API surveys, not just CLI telemetry.
+
+## Candidate instrumentation points
+
+### CLI command lifecycle
+
+File: `crates/monochange/src/cli_runtime.rs`
+
+- `execute_matches` resolves the command name, flags such as `--dry-run`, `--diff`, `--progress-format`, and CLI inputs.
+- `execute_cli_command_with_options` has a single command run boundary with `command_started_at` and `progress.command_finished(...)`.
+- Recommended event: `command_run` with command name, monochange version, dry-run, diff flag, progress format, step count, duration, exit status, and sanitized error kind.
+
+### Step lifecycle
+
+File: `crates/monochange/src/cli_runtime.rs`
+
+- The loop over `cli_command.steps.iter().enumerate()` already records `step_started_at` and has success/failure handling.
+- `CliStepDefinition::kind_name()` provides a stable low-cardinality step kind.
+- Recommended event: `command_step` with command name, step index, step kind, skipped/executed, duration, phase timings where available, and sanitized outcome.
+- Avoid sending rendered command strings, shell args, template inputs, refs, package IDs, file paths, or release notes unless a later explicit debug mode is added.
+
+### Progress/reporting
+
+File: `crates/monochange/src/cli_progress.rs`
+
+- `CliProgressReporter` already centralizes user-visible command/step state transitions.
+- It is a useful reference for lifecycle naming, but telemetry should not be coupled directly to terminal output because progress can be disabled or formatted as JSON.
+- If reused, keep a separate `TelemetryReporter` trait and call both reporters from `cli_runtime.rs`.
+
+### Discovery/workspace shape
+
+File: `crates/monochange/src/workspace_ops.rs`
+
+- `discover_workspace` and `discover_packages` detect packages across supported ecosystems.
+- Recommended event properties: total package count, ecosystem counts, version group count, CLI command count, source provider kind if configured, whether changesets/changelog are configured.
+- Do not send package names, paths, repository URLs, branch names, or manifest content by default.
+
+### Release planning and publish flows
+
+Files:
+
+- `crates/monochange/src/cli_runtime.rs`
+- `crates/monochange/src/package_publish.rs`
+- `crates/monochange/src/publish_rate_limits.rs`
+- `crates/monochange/src/prepared_release_cache.rs`
+
+High-signal events:
+
+- `release_prepare` — packages changed count, files planned count, phase timings, dry-run.
+- `release_publish` — provider kind, request count, dry-run, outcome category.
+- `package_publish` — selected package count, ecosystem counts, dry-run, trust/rate-limit outcome categories.
+- `prepared_release_cache` — cache hit/miss and artifact save/load outcome.
+
+### Hosted source integrations
+
+Files around GitHub/GitLab/Gitea adapters and hosted-source runtime should emit only provider kind and outcome category. Do not send repository owner/name, issue numbers, PR numbers, URLs, or tokens.
+
+## Data classification proposal
+
+### Safe by default
+
+- monochange version
+- OS family and architecture
+- command name and configured step kind names
+- boolean flags: dry-run, quiet, diff, progress format
+- counts: package count, ecosystem counts, version group count, step count
+- duration buckets or milliseconds
+- outcome category: success, canceled, config_error, network_error, provider_error, publish_error, unknown_error
+- randomly generated anonymous installation ID, resettable by the user
+
+### Avoid by default
+
+- package names
+- workspace paths
+- repository URLs, owners, names, branches, tags, refs, commit SHAs
+- command strings and shell arguments
+- changeset text, release notes, changelog bodies, issue IDs, PR IDs
+- environment variable names/values, tokens, usernames, emails
+- exact error messages unless sanitized and reviewed
+
+### Optional debug-only mode, if ever added
+
+A future `monochange telemetry export` or `monochange doctor --telemetry-bundle` could create a local support bundle that the user can inspect and manually attach to an issue. That should be separate from automatic product telemetry.
+
+## Privacy and UX guardrails
+
+Recommended guardrails before implementation:
+
+- Prefer **opt-in** telemetry for the initial release.
+- Provide a persistent status command, e.g. `monochange telemetry status`.
+- Provide explicit commands or environment variables to enable/disable:
+  - `monochange telemetry enable`
+  - `monochange telemetry disable`
+  - `MC_TELEMETRY=1`
+  - `MC_TELEMETRY=0`
+- Show what is collected in docs and ideally expose a local preview/export.
+- Generate a random anonymous installation ID stored in a user config file, and allow reset.
+- Keep event schemas low-cardinality and documented in-repo.
+- Never block CLI success on telemetry delivery.
+- Never send telemetry from tests unless explicitly enabled with a mock sink.
+- Batch and send asynchronously/best-effort with short timeouts.
+- Disable automatically in common CI environments unless explicitly enabled.
+
+Homebrew and GitHub CLI are useful UX references: both emphasize public documentation, limited collection, and user controls.
+
+## Rust telemetry library research
+
+Versions below were checked with `cargo search` / `cargo info` on 2026-04-28.
+
+| Option               | Current crate(s) checked                                                                                                | Primary fit                           | Notes for monochange                                                                                                                                                                                                                                                                          |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| OpenTelemetry        | `opentelemetry = 0.31.0`, `opentelemetry_sdk = 0.31.0`, `opentelemetry-otlp = 0.31.1`, `tracing-opentelemetry = 0.32.1` | Standards-based traces, metrics, logs | Best fit if monochange wants vendor-neutral observability or to export existing `tracing` spans. Less ideal alone for product analytics dashboards unless paired with a collector/backend. Rust docs list traces/metrics/logs as beta. MSRV is lower than monochange's current Rust `1.90.0`. |
+| PostHog              | `posthog-rs = 0.5.3`                                                                                                    | Product analytics, feature flags      | Strong fit for command/feature usage analytics. Official Rust client supports async client by default; docs mention capture and feature flag concepts. Requires selecting a PostHog project/host and being clear about privacy. MSRV `1.78.0`.                                                |
+| Sentry               | `sentry = 0.47.0`, `sentry-tracing = 0.47.0`, `sentry-opentelemetry = 0.47.0`                                           | Error and performance monitoring      | Good fit for panic/error reporting and performance traces. Not the best primary tool for product analytics. Higher MSRV `1.88`, still below monochange's Rust `1.90.0`. Needs careful PII scrubbing.                                                                                          |
+| RudderStack          | `rudderanalytics = 1.1.4`                                                                                               | Analytics routing/CDP                 | Useful if events should be routed to multiple destinations. Adds an analytics pipeline/vendor decision. Rust version was not declared in crate metadata.                                                                                                                                      |
+| Segment-style client | `analytics = 0.2.0`                                                                                                     | Segment tracking API                  | Small/simple Segment-style tracking client, but older and less obviously maintained. Rust version was not declared in crate metadata.                                                                                                                                                         |
+| OpenFeature          | `open-feature = 0.3.0`, `open-feature-flagd = 0.1.0`                                                                    | Feature flags, not telemetry          | Useful if monochange later wants remote feature flags or experiments. Not a telemetry/event collection system. MSRV `1.80.1`.                                                                                                                                                                 |
+| Custom minimal sink  | Existing `reqwest` workspace dependency                                                                                 | Product analytics with strict control | Could send a small documented JSON event envelope to a monochange endpoint or PostHog HTTP API without coupling the core architecture to a vendor SDK. More maintenance burden, but easier to guarantee schema/privacy and avoid heavy dependencies.                                          |
+
+## Recommendation
+
+Start with a **small internal telemetry abstraction** and defer vendor lock-in.
+
+Recommended first implementation shape:
+
+1. Add a dedicated telemetry crate, `crates/monochange_telemtry`, and import it from the main `monochange` crate.
+2. Define a `TelemetrySink` trait with a no-op implementation as the default.
+3. Define documented event structs/enums for command, step, discovery, release, and publish events.
+4. Gate all collection behind explicit opt-in configuration and `MC_TELEMETRY`.
+5. Instrument `execute_matches` / `execute_cli_command_with_options` first because it covers every CLI command and step with minimal code spread.
+6. Add discovery/workspace-shape telemetry next, using only aggregate counts.
+7. Choose a backend after event schemas are stable:
+   - PostHog if the goal is product analytics and feature usage dashboards.
+   - OpenTelemetry if the goal is vendor-neutral traces/metrics integrated with existing `tracing` spans.
+   - Sentry as a separate opt-in error-reporting layer, not the main product telemetry mechanism.
+
+The most practical path is probably:
+
+- Phase 1: no-op abstraction + local debug sink + docs.
+- Phase 2: opt-in product analytics sink, likely PostHog or a minimal HTTP sink using `reqwest`.
+- Phase 3: optional Sentry/OpenTelemetry integration for maintainers or enterprise users who want their own observability backend.
+
+## Suggested event schema draft
+
+```text
+Event: command_run
+Properties:
+  command_name: string
+  command_source: configured | generated_step
+  monochange_version: string
+  os_family: string
+  arch: string
+  dry_run: bool
+  diff: bool
+  progress_format: auto | unicode | ascii | json
+  step_count: integer
+  duration_ms: integer
+  outcome: success | error
+  error_kind: optional enum
+```
+
+```text
+Event: command_step
+Properties:
+  command_name: string
+  step_index: integer
+  step_kind: string
+  skipped: bool
+  duration_ms: integer
+  phase_count: integer
+  outcome: success | skipped | error
+  error_kind: optional enum
+```
+
+```text
+Event: workspace_discovered
+Properties:
+  package_count: integer
+  cargo_package_count: integer
+  npm_package_count: integer
+  deno_package_count: integer
+  dart_package_count: integer
+  flutter_package_count: integer
+  version_group_count: integer
+  cli_command_count: integer
+  has_source_provider: bool
+  source_provider_kind: optional enum
+  has_changelog_config: bool
+  has_changeset_config: bool
+```
+
+```text
+Event: release_flow
+Properties:
+  command_name: string
+  dry_run: bool
+  prepared_package_count: integer
+  changed_file_count: integer
+  provider_kind: optional enum
+  publish_request_count: integer
+  outcome: success | error
+  error_kind: optional enum
+```
+
+## Possible follow-up tasks
+
+- [x] Write `docs/telemetry.md` with privacy policy, event list, opt-in/opt-out UX, and examples.
+- [x] Add an internal telemetry abstraction with a no-op sink and a local JSON debug sink for tests.
+- [x] Add telemetry settings resolution for env-based local telemetry.
+- [x] Instrument `execute_cli_command_with_options` for command and step lifecycle events.
+- [ ] Add persistent telemetry settings and CI-specific defaults; tracked in [#298](https://github.com/monochange/monochange/issues/298).
+- [ ] Instrument `discover_workspace` / `discover_packages` for aggregate workspace shape events; tracked in [#296](https://github.com/monochange/monochange/issues/296).
+- [x] Add sanitized error classification for the core error enum without sending raw messages.
+- [ ] Decide backend: PostHog for product analytics, OpenTelemetry for standards-based traces, Sentry for error monitoring; remote OpenTelemetry tracked in [#297](https://github.com/monochange/monochange/issues/297).
+- [ ] Add stronger tests ensuring telemetry is disabled by default, never sends during tests by default, and redacts paths/package names; tracked in [#299](https://github.com/monochange/monochange/issues/299).
+- [ ] Add a `mc telemetry status|enable|disable|reset-id|preview` command set if the UX is accepted; tracked in [#295](https://github.com/monochange/monochange/issues/295).
+- [ ] Document self-hosted backend options; tracked in [#300](https://github.com/monochange/monochange/issues/300).
+
+## Acceptance checks for a future implementation
+
+- `cargo test --workspace`
+- `lint:all`
+- `mc validate`
+- Manual checks:
+  - fresh install reports telemetry disabled or asks for opt-in without sending anything
+  - `MC_TELEMETRY=0` suppresses all network sends
+  - CI disables telemetry unless explicitly enabled
+  - failing network telemetry delivery does not change command exit status
+  - telemetry preview contains no paths, package names, repository URLs, or raw command strings
+
+## Open questions
+
+- Should telemetry be opt-in forever, or opt-out after a prominent first-run notice? Research recommends starting opt-in.
+- Where should user telemetry configuration live across platforms?
+- Should library users have telemetry at all, or only the CLI binary?
+- Is monochange comfortable using a third-party SaaS analytics backend, or should it expose OpenTelemetry/export hooks and let users choose?
+- What retention period and public transparency commitments should be documented?

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -25,6 +25,7 @@
 
 - [Manifest linting with `mc check`](reference/linting.md)
 - [Progress output](reference/progress-output.md)
+- [Telemetry](reference/telemetry.md)
 - [Hosted release benchmarks](reference/hosted-release-benchmarks.md)
 - [CLI step reference](reference/cli-steps/00-index.md)
   - [Validate](reference/cli-steps/01-validate.md)

--- a/docs/src/reference/telemetry.md
+++ b/docs/src/reference/telemetry.md
@@ -1,0 +1,125 @@
+# Telemetry
+
+<!-- {=monochangeLocalTelemetryDocs} -->
+
+monochange can write local-only telemetry events for CLI command and step execution. The first implementation does not send data over the network and does not require a telemetry backend.
+
+## Current scope
+
+This release only supports a local JSON Lines sink with OpenTelemetry-style event envelopes. It is intended for debugging, support bundles, and validating the event schema before any hosted or remote telemetry work is considered.
+
+## Enabling local telemetry
+
+Telemetry is disabled by default. Enable the local sink with environment variables:
+
+```sh
+MC_TELEMETRY=local mc validate
+```
+
+By default, events are appended to:
+
+```text
+$XDG_STATE_HOME/monochange/telemetry.jsonl
+```
+
+When `XDG_STATE_HOME` is not set, monochange falls back to:
+
+```text
+$HOME/.local/state/monochange/telemetry.jsonl
+```
+
+For a one-off file path, set `MC_TELEMETRY_FILE`:
+
+```sh
+MC_TELEMETRY=local MC_TELEMETRY_FILE=/tmp/mc-telemetry.jsonl mc validate
+```
+
+Setting only `MC_TELEMETRY_FILE` also enables the local sink for that command:
+
+```sh
+MC_TELEMETRY_FILE=/tmp/mc-telemetry.jsonl mc discover
+```
+
+Disable telemetry explicitly with any of:
+
+```sh
+MC_TELEMETRY=0
+MC_TELEMETRY=false
+MC_TELEMETRY=off
+MC_TELEMETRY=disabled
+```
+
+## Events
+
+### `command_run`
+
+Emitted when a CLI command completes or fails after command execution starts.
+
+Attributes:
+
+- `command_name`
+- `command_source`: `configured` or `generated_step`
+- `dry_run`
+- `show_diff`
+- `progress_format`: `auto`, `unicode`, `ascii`, or `json`
+- `step_count`
+- `duration_ms`
+- `outcome`: `success` or `error`
+- `error_kind`: sanitized error category or `null`
+
+### `command_step`
+
+Emitted for each CLI step that succeeds, fails, or is skipped.
+
+Attributes:
+
+- `command_name`
+- `step_index`
+- `step_kind`
+- `skipped`
+- `duration_ms`
+- `outcome`: `success`, `skipped`, or `error`
+- `error_kind`: sanitized error category or `null`
+
+## Local event shape
+
+Each line is one JSON object:
+
+```json
+{
+	"resource": {
+		"service.name": "monochange",
+		"service.version": "0.2.0"
+	},
+	"scope": {
+		"name": "monochange.telemetry",
+		"version": "0.1.0"
+	},
+	"time_unix_nano": 1777338000000000000,
+	"severity_text": "INFO",
+	"body": {
+		"string_value": "command_run"
+	},
+	"attributes": {
+		"command_name": "validate",
+		"command_source": "configured",
+		"dry_run": false,
+		"show_diff": false,
+		"progress_format": "auto",
+		"step_count": 1,
+		"duration_ms": 42,
+		"outcome": "success",
+		"error_kind": null
+	}
+}
+```
+
+## Privacy boundaries
+
+The local sink intentionally records only low-cardinality command metadata and sanitized error categories. It does not record package names, paths, repository URLs, branch names, tag names, commit hashes, issue numbers, pull request numbers, shell command strings, environment values, changeset content, changelog content, release notes, or raw error messages.
+
+## Future work
+
+Remote export, a user-facing telemetry command group, persistent opt-in configuration, hosted dashboards, and richer workspace-shape events are tracked as follow-up issues. Until those are implemented, telemetry remains local-only and best-effort.
+
+<!-- {/monochangeLocalTelemetryDocs} -->

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,125 @@
+# Telemetry
+
+<!-- {=monochangeLocalTelemetryDocs} -->
+
+monochange can write local-only telemetry events for CLI command and step execution. The first implementation does not send data over the network and does not require a telemetry backend.
+
+## Current scope
+
+This release only supports a local JSON Lines sink with OpenTelemetry-style event envelopes. It is intended for debugging, support bundles, and validating the event schema before any hosted or remote telemetry work is considered.
+
+## Enabling local telemetry
+
+Telemetry is disabled by default. Enable the local sink with environment variables:
+
+```sh
+MC_TELEMETRY=local mc validate
+```
+
+By default, events are appended to:
+
+```text
+$XDG_STATE_HOME/monochange/telemetry.jsonl
+```
+
+When `XDG_STATE_HOME` is not set, monochange falls back to:
+
+```text
+$HOME/.local/state/monochange/telemetry.jsonl
+```
+
+For a one-off file path, set `MC_TELEMETRY_FILE`:
+
+```sh
+MC_TELEMETRY=local MC_TELEMETRY_FILE=/tmp/mc-telemetry.jsonl mc validate
+```
+
+Setting only `MC_TELEMETRY_FILE` also enables the local sink for that command:
+
+```sh
+MC_TELEMETRY_FILE=/tmp/mc-telemetry.jsonl mc discover
+```
+
+Disable telemetry explicitly with any of:
+
+```sh
+MC_TELEMETRY=0
+MC_TELEMETRY=false
+MC_TELEMETRY=off
+MC_TELEMETRY=disabled
+```
+
+## Events
+
+### `command_run`
+
+Emitted when a CLI command completes or fails after command execution starts.
+
+Attributes:
+
+- `command_name`
+- `command_source`: `configured` or `generated_step`
+- `dry_run`
+- `show_diff`
+- `progress_format`: `auto`, `unicode`, `ascii`, or `json`
+- `step_count`
+- `duration_ms`
+- `outcome`: `success` or `error`
+- `error_kind`: sanitized error category or `null`
+
+### `command_step`
+
+Emitted for each CLI step that succeeds, fails, or is skipped.
+
+Attributes:
+
+- `command_name`
+- `step_index`
+- `step_kind`
+- `skipped`
+- `duration_ms`
+- `outcome`: `success`, `skipped`, or `error`
+- `error_kind`: sanitized error category or `null`
+
+## Local event shape
+
+Each line is one JSON object:
+
+```json
+{
+	"resource": {
+		"service.name": "monochange",
+		"service.version": "0.2.0"
+	},
+	"scope": {
+		"name": "monochange.telemetry",
+		"version": "0.1.0"
+	},
+	"time_unix_nano": 1777338000000000000,
+	"severity_text": "INFO",
+	"body": {
+		"string_value": "command_run"
+	},
+	"attributes": {
+		"command_name": "validate",
+		"command_source": "configured",
+		"dry_run": false,
+		"show_diff": false,
+		"progress_format": "auto",
+		"step_count": 1,
+		"duration_ms": 42,
+		"outcome": "success",
+		"error_kind": null
+	}
+}
+```
+
+## Privacy boundaries
+
+The local sink intentionally records only low-cardinality command metadata and sanitized error categories. It does not record package names, paths, repository URLs, branch names, tag names, commit hashes, issue numbers, pull request numbers, shell command strings, environment values, changeset content, changelog content, release notes, or raw error messages.
+
+## Future work
+
+Remote export, a user-facing telemetry command group, persistent opt-in configuration, hosted dashboards, and richer workspace-shape events are tracked as follow-up issues. Until those are implemented, telemetry remains local-only and best-effort.
+
+<!-- {/monochangeLocalTelemetryDocs} -->

--- a/monochange.toml
+++ b/monochange.toml
@@ -249,6 +249,9 @@ path = "crates/monochange_graph"
 [package.monochange_semver]
 path = "crates/monochange_semver"
 
+[package.monochange_telemtry]
+path = "crates/monochange_telemtry"
+
 [package.monochange_github]
 path = "crates/monochange_github"
 
@@ -372,6 +375,7 @@ packages = [
 	"monochange_dart",
 	"monochange_graph",
 	"monochange_semver",
+	"monochange_telemtry",
 	"monochange_github",
 	"monochange_gitlab",
 	"monochange_gitea",

--- a/packages/monochange__cli/README.md
+++ b/packages/monochange__cli/README.md
@@ -203,6 +203,8 @@ See [Advanced: Assistant setup and MCP](docs/src/guide/09-assistant-setup.md) fo
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__github-orange?logo=rust)](https://crates.io/crates/monochange_github) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__github-1f425f?logo=docs.rs)](https://docs.rs/monochange_github/)
 - `monochange_semver` — merges requested bumps with compatibility-provider evidence.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__semver-orange?logo=rust)](https://crates.io/crates/monochange_semver) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__semver-1f425f?logo=docs.rs)](https://docs.rs/monochange_semver/)
+- `monochange_telemtry` — local-only telemetry event sink and privacy-preserving event schema helpers.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__telemtry-orange?logo=rust)](https://crates.io/crates/monochange_telemtry) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__telemtry-1f425f?logo=docs.rs)](https://docs.rs/monochange_telemtry/)
 - `monochange_cargo` — Cargo discovery plus Rust semver evidence integration.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__cargo-orange?logo=rust)](https://crates.io/crates/monochange_cargo) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__cargo-1f425f?logo=docs.rs)](https://docs.rs/monochange_cargo/)
 - `monochange_npm` — npm, pnpm, and Bun workspace discovery.

--- a/readme.md
+++ b/readme.md
@@ -282,6 +282,8 @@ See [Advanced: Assistant setup and MCP](docs/src/guide/09-assistant-setup.md) fo
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__github-orange?logo=rust)](https://crates.io/crates/monochange_github) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__github-1f425f?logo=docs.rs)](https://docs.rs/monochange_github/)
 - `monochange_semver` — merges requested bumps with compatibility-provider evidence.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__semver-orange?logo=rust)](https://crates.io/crates/monochange_semver) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__semver-1f425f?logo=docs.rs)](https://docs.rs/monochange_semver/)
+- `monochange_telemtry` — local-only telemetry event sink and privacy-preserving event schema helpers.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__telemtry-orange?logo=rust)](https://crates.io/crates/monochange_telemtry) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__telemtry-1f425f?logo=docs.rs)](https://docs.rs/monochange_telemtry/)
 - `monochange_cargo` — Cargo discovery plus Rust semver evidence integration.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__cargo-orange?logo=rust)](https://crates.io/crates/monochange_cargo) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__cargo-1f425f?logo=docs.rs)](https://docs.rs/monochange_cargo/)
 - `monochange_npm` — npm, pnpm, and Bun workspace discovery.


### PR DESCRIPTION
## Summary

- add disabled-by-default, local-only JSONL telemetry controlled by `MC_TELEMETRY` and `MC_TELEMETRY_FILE`
- move telemetry primitives into the dedicated `monochange_telemtry` crate and import them from the main CLI crate
- register `monochange_telemtry` in workspace/package configuration and Codecov flag generation
- emit privacy-aware `command_run` and `command_step` events with sanitized outcomes and error categories
- document telemetry behavior, research options, and follow-up work for future aggregate/export support

## Validation

- `cargo fmt --all`
- `cargo test -p monochange_telemtry --all-targets`
- `cargo test -p monochange --test telemetry`
- `cargo test -p monochange telemetry --lib`
- `cargo test -p monochange cli_runtime::tests::telemetry_progress_format_uses_stable_labels --lib`
- `cargo clippy -p monochange_telemtry --all-targets --all-features -- -D warnings`
- `cargo clippy -p monochange --lib --tests -- -D warnings`
- `devenv shell mc validate`
- `devenv shell coverage:all && devenv shell coverage:patch` → `PATCH_COVERAGE 600/600 (100.00%)`
- `devenv shell node scripts/prepare-codecov-flags.mjs --lcov target/coverage/lcov.info --out-dir target/coverage/flags-local` → includes `monochange_telemtry.lcov`
- pre-push `devenv shell git push --force-with-lease`

## Follow-up issues

- #295
- #296
- #297
- #298
- #299
- #300
