### PR TITLE
feat: guard cargo publish readiness

### DIFF
--- a/.changeset/publish-readiness-cargo-guards.md
+++ b/.changeset/publish-readiness-cargo-guards.md
@@ -1,0 +1,10 @@
+---
+"monochange": patch
+"@monochange/skill": patch
+---
+
+#### add Cargo publish-readiness guards
+
+Built-in crates.io publishing now fails readiness before registry mutation when the current `Cargo.toml` is not publishable: `publish = false`, `publish = [...]` without `crates-io`, missing `description`, or missing both `license` and `license-file`.
+
+Workspace-inherited Cargo metadata is accepted, and already-published package versions remain non-blocking when the saved readiness artifact still matches current readiness.

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -102,6 +102,8 @@ These are the commands most repositories use after running `mc init`. With the n
 
 <!-- {/projectCommandAutomationMatrix} -->
 
+`mc publish-readiness` performs non-mutating registry checks before `mc publish`. For built-in Cargo publishes to crates.io it also verifies current manifest publishability: `publish = false` blocks publishing, `publish = [...]` must include `crates-io`, `description` must be set, and either `license` or `license-file` must be set. Workspace-inherited Cargo metadata is accepted, and already-published versions remain non-blocking when the readiness artifact still matches the current package set.
+
 <!-- {@projectCapabilityMatrix} -->
 
 | Capability                                                               | Current status                                                                               |

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -5112,6 +5112,7 @@ fn execute_cli_command_supports_placeholder_and_package_publish_steps() {
 			"resolver = \"2\"\n\n",
 			"[workspace.package]\n",
 			"version = \"1.0.0\"\n",
+			"description = \"Workflow packages\"\n",
 			"license = \"Unlicense\"\n\n",
 			"[workspace.dependencies]\n",
 			"workflow-core = { path = \"./crates/core\", version = \"1.0.0\" }\n",
@@ -5127,6 +5128,32 @@ fn execute_cli_command_supports_placeholder_and_package_publish_steps() {
 		.unwrap_or_else(|error| panic!("core src file: {error}"));
 	fs::write(root.join("crates/app/src/lib.rs"), "pub fn app() {}\n")
 		.unwrap_or_else(|error| panic!("app src file: {error}"));
+	fs::write(
+		root.join("crates/core/Cargo.toml"),
+		concat!(
+			"[package]\n",
+			"name = \"workflow-core\"\n",
+			"version = { workspace = true }\n",
+			"description = { workspace = true }\n",
+			"license = { workspace = true }\n",
+			"edition = \"2021\"\n",
+		),
+	)
+	.unwrap_or_else(|error| panic!("core manifest: {error}"));
+	fs::write(
+		root.join("crates/app/Cargo.toml"),
+		concat!(
+			"[package]\n",
+			"name = \"workflow-app\"\n",
+			"version = { workspace = true }\n",
+			"description = { workspace = true }\n",
+			"license = { workspace = true }\n",
+			"edition = \"2021\"\n\n",
+			"[dependencies]\n",
+			"workflow-core = { workspace = true }\n",
+		),
+	)
+	.unwrap_or_else(|error| panic!("app manifest: {error}"));
 	let configuration =
 		load_workspace_configuration(root).unwrap_or_else(|error| panic!("configuration: {error}"));
 	let server = MockServer::start();
@@ -5190,7 +5217,10 @@ fn execute_cli_command_supports_placeholder_and_package_publish_steps() {
 			)
 			.unwrap_or_else(|error| panic!("publish packages: {error}"));
 			assert!(publish_output.contains("package publishing:"));
-			assert!(publish_output.contains("would publish workflow-core"));
+			assert!(
+				publish_output.contains("would publish workflow-core"),
+				"publish output:\n{publish_output}"
+			);
 			assert!(publish_output.contains("publish rate limits:"));
 		},
 	);

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -2152,6 +2152,7 @@ fn package_publish_status_label(status: package_publish::PackagePublishStatus) -
 		package_publish::PackagePublishStatus::Published => "published",
 		package_publish::PackagePublishStatus::SkippedExisting => "skipped-existing",
 		package_publish::PackagePublishStatus::SkippedExternal => "skipped-external",
+		package_publish::PackagePublishStatus::Blocked => "blocked",
 	}
 }
 
@@ -3975,6 +3976,10 @@ path = "crates/core"
 		assert_eq!(
 			package_publish_status_label(package_publish::PackagePublishStatus::SkippedExternal),
 			"skipped-external"
+		);
+		assert_eq!(
+			package_publish_status_label(package_publish::PackagePublishStatus::Blocked),
+			"blocked"
 		);
 	}
 

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -56,6 +56,7 @@ pub(crate) enum PackagePublishStatus {
 	Published,
 	SkippedExisting,
 	SkippedExternal,
+	Blocked,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
@@ -444,6 +445,108 @@ fn packages_by_config_id(packages: &[PackageRecord]) -> BTreeMap<&str, &PackageR
 		.collect()
 }
 
+fn cargo_publish_readiness_blockers(
+	root: &Path,
+	request: &PublishRequest,
+) -> MonochangeResult<Vec<String>> {
+	if request.ecosystem != Ecosystem::Cargo || request.registry != RegistryKind::CratesIo {
+		return Ok(Vec::new());
+	}
+
+	let contents = fs::read_to_string(&request.manifest_path).map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to read Cargo manifest {}: {error}",
+			request.manifest_path.display()
+		))
+	})?;
+	let parsed = toml::from_str::<TomlValue>(&contents).map_err(|error| {
+		MonochangeError::Config(format!(
+			"failed to parse {}: {error}",
+			request.manifest_path.display()
+		))
+	})?;
+	let Some(package) = parsed.get("package").and_then(TomlValue::as_table) else {
+		return Ok(vec!["Cargo manifest is missing [package]".to_string()]);
+	};
+	let workspace_package = read_workspace_package_table(root)?;
+	let mut blockers = Vec::new();
+
+	if package.get("publish").and_then(TomlValue::as_bool) == Some(false) {
+		blockers.push("package.publish is false".to_string());
+	}
+
+	if cargo_publish_array_excludes_crates_io(package) {
+		blockers.push("package.publish does not include crates-io".to_string());
+	}
+
+	if !cargo_string_field_is_present(package, workspace_package.as_ref(), "description") {
+		blockers.push("package.description is required for crates.io".to_string());
+	}
+
+	if !cargo_string_field_is_present(package, workspace_package.as_ref(), "license")
+		&& !cargo_string_field_is_present(package, workspace_package.as_ref(), "license-file")
+	{
+		blockers
+			.push("package.license or package.license-file is required for crates.io".to_string());
+	}
+
+	Ok(blockers)
+}
+
+fn cargo_publish_array_excludes_crates_io(package: &WorkspacePackageTable) -> bool {
+	let Some(publish) = package.get("publish") else {
+		return false;
+	};
+	let Some(registries) = publish.as_array() else {
+		return false;
+	};
+
+	!registries
+		.iter()
+		.filter_map(TomlValue::as_str)
+		.any(|registry| registry == "crates-io")
+}
+
+fn cargo_string_field_is_present(
+	package: &WorkspacePackageTable,
+	workspace_package: Option<&WorkspacePackageTable>,
+	field: &str,
+) -> bool {
+	if package
+		.get(field)
+		.and_then(TomlValue::as_str)
+		.is_some_and(|value| !value.trim().is_empty())
+	{
+		return true;
+	}
+
+	let inherits_workspace_field = package
+		.get(field)
+		.and_then(TomlValue::as_table)
+		.and_then(|table| table.get("workspace"))
+		.and_then(TomlValue::as_bool)
+		.unwrap_or(false);
+
+	if !inherits_workspace_field {
+		return false;
+	}
+
+	workspace_package
+		.and_then(|package| package.get(field))
+		.and_then(TomlValue::as_str)
+		.is_some_and(|value| !value.trim().is_empty())
+}
+
+fn publish_blocked_message(request: &PublishRequest, blockers: &[String]) -> String {
+	format!(
+		"{} {} is not ready to publish to {}: {}",
+		request.package_name,
+		request.version,
+		request.registry,
+		blockers.join("; ")
+	)
+}
+
 fn resolve_registry_kind(
 	registry: Option<&PublishRegistry>,
 	ecosystem: Ecosystem,
@@ -545,6 +648,31 @@ fn execute_publish_requests(
 				trusted_publishing: trust_outcome_for_skip(request, source, root, env_map),
 			});
 			continue;
+		}
+
+		let blockers = if mode == PackagePublishRunMode::Release {
+			cargo_publish_readiness_blockers(root, request)?
+		} else {
+			Vec::new()
+		};
+		if !blockers.is_empty() {
+			let message = publish_blocked_message(request, &blockers);
+
+			if dry_run {
+				outcomes.push(PackagePublishOutcome {
+					package: request.package_id.clone(),
+					ecosystem: request.ecosystem,
+					registry: request.registry.to_string(),
+					version: request.version.clone(),
+					status: PackagePublishStatus::Blocked,
+					message,
+					placeholder: mode == PackagePublishRunMode::Placeholder,
+					trusted_publishing: planned_trust_outcome(request, source, root, env_map),
+				});
+				continue;
+			}
+
+			return Err(MonochangeError::Config(message));
 		}
 
 		let placeholder_dir = if mode == PackagePublishRunMode::Placeholder {
@@ -3928,6 +4056,224 @@ jobs:
 				.to_string()
 				.contains("set `publish.trusted_publishing.workflow`")
 		);
+	}
+
+	fn write_cargo_manifest(root: &Path, contents: &str) -> PathBuf {
+		let package_root = root.join("pkg");
+		fs::create_dir_all(&package_root).expect("package dir");
+		let manifest_path = package_root.join("Cargo.toml");
+		fs::write(&manifest_path, contents).expect("write Cargo manifest");
+		manifest_path
+	}
+
+	fn sample_cargo_request(root: &Path, manifest_path: &Path) -> PublishRequest {
+		PublishRequest {
+			manifest_path: manifest_path.to_path_buf(),
+			package_root: root.join("pkg"),
+			..sample_request(RegistryKind::CratesIo)
+		}
+	}
+
+	#[test]
+	fn cargo_publish_readiness_blockers_require_crates_io_metadata_and_publish_access() {
+		let root = tempfile::tempdir().expect("tempdir");
+		let manifest_path = write_cargo_manifest(
+			root.path(),
+			r#"
+[package]
+name = "pkg"
+version = "1.2.3"
+publish = ["internal"]
+"#,
+		);
+		let request = sample_cargo_request(root.path(), &manifest_path);
+
+		let blockers = cargo_publish_readiness_blockers(root.path(), &request).expect("blockers");
+
+		assert!(blockers.contains(&"package.publish does not include crates-io".to_string()));
+		assert!(blockers.contains(&"package.description is required for crates.io".to_string()));
+		assert!(blockers.contains(
+			&"package.license or package.license-file is required for crates.io".to_string()
+		));
+	}
+
+	#[test]
+	fn cargo_publish_readiness_blockers_ignore_non_cargo_requests() {
+		let blockers =
+			cargo_publish_readiness_blockers(Path::new("."), &sample_request(RegistryKind::Npm))
+				.expect("blockers");
+
+		assert!(blockers.is_empty());
+	}
+
+	#[test]
+	fn cargo_publish_readiness_blockers_report_manifest_errors() {
+		let root = tempfile::tempdir().expect("tempdir");
+		let missing = root.path().join("pkg/Cargo.toml");
+		let missing_request = sample_cargo_request(root.path(), &missing);
+		let missing_error = cargo_publish_readiness_blockers(root.path(), &missing_request)
+			.expect_err("expected read error");
+		assert!(
+			missing_error
+				.to_string()
+				.contains("failed to read Cargo manifest")
+		);
+
+		let invalid = write_cargo_manifest(root.path(), "not valid toml");
+		let invalid_request = sample_cargo_request(root.path(), &invalid);
+		let invalid_error = cargo_publish_readiness_blockers(root.path(), &invalid_request)
+			.expect_err("expected parse error");
+		assert!(invalid_error.to_string().contains("failed to parse"));
+	}
+
+	#[test]
+	fn cargo_publish_readiness_blockers_report_missing_package_table() {
+		let root = tempfile::tempdir().expect("tempdir");
+		let manifest_path = write_cargo_manifest(root.path(), "[workspace]\nmembers = []\n");
+		let request = sample_cargo_request(root.path(), &manifest_path);
+
+		let blockers = cargo_publish_readiness_blockers(root.path(), &request).expect("blockers");
+
+		assert_eq!(
+			blockers,
+			vec!["Cargo manifest is missing [package]".to_string()]
+		);
+	}
+
+	#[test]
+	fn cargo_publish_readiness_blockers_reject_publish_false() {
+		let root = tempfile::tempdir().expect("tempdir");
+		let manifest_path = write_cargo_manifest(
+			root.path(),
+			r#"
+[package]
+name = "pkg"
+version = "1.2.3"
+description = "A package"
+license = "MIT"
+publish = false
+"#,
+		);
+		let request = sample_cargo_request(root.path(), &manifest_path);
+
+		let blockers = cargo_publish_readiness_blockers(root.path(), &request).expect("blockers");
+
+		assert_eq!(blockers, vec!["package.publish is false".to_string()]);
+	}
+
+	#[test]
+	fn cargo_publish_readiness_blockers_accept_workspace_inherited_metadata() {
+		let root = tempfile::tempdir().expect("tempdir");
+		fs::write(
+			root.path().join("Cargo.toml"),
+			r#"
+[workspace.package]
+description = "Workspace description"
+license = "MIT"
+"#,
+		)
+		.expect("write workspace manifest");
+		let manifest_path = write_cargo_manifest(
+			root.path(),
+			r#"
+[package]
+name = "pkg"
+version = "1.2.3"
+description = { workspace = true }
+license = { workspace = true }
+publish = ["crates-io"]
+"#,
+		);
+		let request = sample_cargo_request(root.path(), &manifest_path);
+
+		let blockers = cargo_publish_readiness_blockers(root.path(), &request).expect("blockers");
+
+		assert!(blockers.is_empty());
+	}
+
+	#[test]
+	fn execute_publish_requests_marks_dry_run_cargo_metadata_blockers() {
+		let root = tempfile::tempdir().expect("tempdir");
+		let server = MockServer::start();
+		server.mock(|when, then| {
+			when.method(GET).path("/crates/pkg");
+			then.status(404);
+		});
+		let manifest_path = write_cargo_manifest(
+			root.path(),
+			r#"
+[package]
+name = "pkg"
+version = "1.2.3"
+"#,
+		);
+		let client = Client::builder().build().expect("http client:");
+		let endpoints = sample_endpoints(&server.base_url());
+		let request = sample_cargo_request(root.path(), &manifest_path);
+		let mut executor = FakeExecutor::new(Vec::new());
+
+		let report = execute_publish_requests(
+			root.path(),
+			Some(&sample_source()),
+			PackagePublishRunMode::Release,
+			true,
+			&[request],
+			&client,
+			&endpoints,
+			&BTreeMap::new(),
+			&mut executor,
+		)
+		.expect("report");
+
+		assert_eq!(report.packages[0].status, PackagePublishStatus::Blocked);
+		assert!(
+			report.packages[0]
+				.message
+				.contains("package.description is required for crates.io")
+		);
+		assert!(executor.commands.is_empty());
+	}
+
+	#[test]
+	fn execute_publish_requests_rejects_real_cargo_metadata_blockers() {
+		let root = tempfile::tempdir().expect("tempdir");
+		let server = MockServer::start();
+		server.mock(|when, then| {
+			when.method(GET).path("/crates/pkg");
+			then.status(404);
+		});
+		let manifest_path = write_cargo_manifest(
+			root.path(),
+			r#"
+[package]
+name = "pkg"
+version = "1.2.3"
+"#,
+		);
+		let client = Client::builder().build().expect("http client:");
+		let endpoints = sample_endpoints(&server.base_url());
+		let request = sample_cargo_request(root.path(), &manifest_path);
+		let mut executor = FakeExecutor::new(Vec::new());
+
+		let error = execute_publish_requests(
+			root.path(),
+			Some(&sample_source()),
+			PackagePublishRunMode::Release,
+			false,
+			&[request],
+			&client,
+			&endpoints,
+			&BTreeMap::new(),
+			&mut executor,
+		)
+		.expect_err("expected readiness blocker");
+
+		assert!(
+			error
+				.to_string()
+				.contains("pkg 1.2.3 is not ready to publish to crates_io")
+		);
+		assert!(executor.commands.is_empty());
 	}
 
 	#[test]

--- a/crates/monochange/src/publish_readiness.rs
+++ b/crates/monochange/src/publish_readiness.rs
@@ -40,6 +40,7 @@ pub(crate) enum PublishReadinessPackageStatus {
 	Ready,
 	AlreadyPublished,
 	Unsupported,
+	Blocked,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -167,10 +168,12 @@ fn build_report_from_publish_report(
 			}
 		})
 		.collect::<Vec<_>>();
-	let status = if packages
-		.iter()
-		.any(|package| package.status == PublishReadinessPackageStatus::Unsupported)
-	{
+	let status = if packages.iter().any(|package| {
+		matches!(
+			package.status,
+			PublishReadinessPackageStatus::Unsupported | PublishReadinessPackageStatus::Blocked
+		)
+	}) {
 		PublishReadinessGlobalStatus::Blocked
 	} else {
 		PublishReadinessGlobalStatus::Ready
@@ -208,6 +211,7 @@ fn readiness_status_from_publish_status(
 		package_publish::PackagePublishStatus::SkippedExternal => {
 			PublishReadinessPackageStatus::Unsupported
 		}
+		package_publish::PackagePublishStatus::Blocked => PublishReadinessPackageStatus::Blocked,
 	}
 }
 
@@ -469,6 +473,7 @@ fn readiness_package_status_label(status: PublishReadinessPackageStatus) -> &'st
 		PublishReadinessPackageStatus::Ready => "ready",
 		PublishReadinessPackageStatus::AlreadyPublished => "already_published",
 		PublishReadinessPackageStatus::Unsupported => "unsupported",
+		PublishReadinessPackageStatus::Blocked => "blocked",
 	}
 }
 
@@ -590,6 +595,7 @@ mod tests {
 				sample_publish_outcome(package_publish::PackagePublishStatus::Planned),
 				sample_publish_outcome(package_publish::PackagePublishStatus::SkippedExisting),
 				sample_publish_outcome(package_publish::PackagePublishStatus::SkippedExternal),
+				sample_publish_outcome(package_publish::PackagePublishStatus::Blocked),
 			],
 		};
 		let readiness = build_report_from_publish_report(sample_source(), &report);
@@ -611,6 +617,10 @@ mod tests {
 		assert_eq!(
 			readiness.packages[2].status,
 			PublishReadinessPackageStatus::Unsupported
+		);
+		assert_eq!(
+			readiness.packages[3].status,
+			PublishReadinessPackageStatus::Blocked
 		);
 		assert!(!readiness.package_set_fingerprint.is_empty());
 	}
@@ -682,6 +692,11 @@ mod tests {
 				status: PublishReadinessPackageStatus::Unsupported,
 				..sample_readiness_package()
 			},
+			PublishReadinessPackage {
+				package: "blocked".to_string(),
+				status: PublishReadinessPackageStatus::Blocked,
+				..sample_readiness_package()
+			},
 		];
 		let report = PublishReadinessReport {
 			status: PublishReadinessGlobalStatus::Blocked,
@@ -695,6 +710,7 @@ mod tests {
 		assert!(markdown.contains("Status: `blocked`"));
 		assert!(markdown.contains("already_published"));
 		assert!(markdown.contains("unsupported"));
+		assert!(markdown.contains("blocked"));
 	}
 
 	#[test]

--- a/docs/plans/active/publish-readiness.md
+++ b/docs/plans/active/publish-readiness.md
@@ -1,103 +1,83 @@
-# Publish readiness enforcement
+# Publish readiness Cargo guards
 
 ## Status
 
-- Previous slice: `mc publish-readiness` shipped in PR #292.
-- Current branch: `feat/publish-readiness-enforcement`.
-- Current slice: require and validate a readiness artifact before real `mc publish` registry mutation.
+- Previous slices: `mc publish-readiness` shipped in PR #292; readiness artifact enforcement shipped in PR #301.
+- Current branch: `feat/publish-readiness-cargo-guards`.
+- Current slice: add Cargo-first publish-readiness blockers for current manifest publishability before built-in crates.io mutation.
 
 ## Problem
 
-Package publishing now has a standalone, non-mutating readiness command, but `mc publish` can still start registry mutation without proving that readiness was checked against the same release record and package selection. monochange needs an explicit artifact boundary so CI can fail before mutation when readiness is missing, blocked, stale, malformed, or generated for a different package set.
+Readiness artifacts protect `mc publish` from stale package sets, but the readiness check still mostly reflected registry dry-run status. Cargo packages can be known to fail crates.io publication before mutation when the current manifest opts out of publication or omits required crates.io metadata. monochange should catch those blockers during readiness and enforce the same result before real publish.
 
 ## Scope
 
-This slice covers the first enforcement step:
+This slice covers built-in Cargo publishes to crates.io:
 
-- Extend the publish-readiness JSON artifact with a schema version, kind, release-record commit metadata, and package-set fingerprint.
-- Add `readiness` as a publish workflow input.
-- Require `--readiness <PATH>` for real `PublishPackages` runs.
-- Keep `--dry-run` publish previews usable without a readiness artifact.
-- Validate artifact kind, schema, status, release-record commit, duplicate package entries, package fingerprint, and selected package set before registry mutation.
-- Treat already-published packages as non-blocking when the artifact and current readiness agree.
-- Update reference docs, CI guides, templates, and generated docs for the new publish flow.
+- Block current manifests with `publish = false`.
+- Block current manifests with `publish = [...]` when the registry list does not include `crates-io`.
+- Block missing `description`.
+- Block missing both `license` and `license-file`.
+- Accept workspace-inherited `description`, `license`, and `license-file` from `[workspace.package]`.
+- Keep already-published versions non-blocking when current readiness and the saved artifact agree.
+- Surface blocked dry-runs as readiness `blocked`, and reject real publishing before any publish command runs.
 
 ## Non-goals for this slice
 
-- Full config/manifests/lockfile hashing.
+- Cargo dependency packaging checks beyond existing `cargo publish` behavior.
+- Automated crates.io trusted-publisher enrollment.
+- npm, JSR, or pub.dev metadata-specific readiness expansion.
+- Full manifest/lockfile artifact hashing.
 - `mc publish-plan --readiness` integration.
-- `mc publish-bootstrap` or first-time placeholder orchestration changes.
-- `monochange/actions` publishing API redesign.
-- Cargo-specific metadata/remediation blockers beyond the existing dry-run publish checks.
 
 ## Affected files
 
-- `crates/monochange/src/cli_runtime.rs`
-- `crates/monochange/src/monochange.init.toml`
 - `crates/monochange/src/package_publish.rs`
 - `crates/monochange/src/publish_readiness.rs`
-- `monochange.toml`
-- `.templates/cli-steps.t.md`
-- `.templates/project.t.md`
-- `readme.md`
-- `docs/src/readme.md`
-- `docs/src/guide/02-setup.md`
-- `docs/src/guide/07-trusted-publishing.md`
-- `docs/src/guide/08-github-automation.md`
+- `crates/monochange/src/cli_runtime.rs`
 - `docs/src/guide/13-ci-and-publishing.md`
-- `docs/src/guide/14-multi-package-publishing.md`
-- `docs/src/guide/15-publish-rate-limits.md`
-- `docs/src/reference/cli-steps/00-index.md`
-- `docs/src/reference/cli-steps/10-publish-release.md`
 - `docs/src/reference/cli-steps/16-publish-packages.md`
-- `.changeset/publish-readiness-enforcement.md`
+- `docs/src/readme.md`
+- `readme.md`
+- `packages/monochange__skill/SKILL.md`
+- `packages/monochange__skill/skills/reference.md`
+- `packages/monochange__skill/skills/trusted-publishing.md`
+- `.changeset/publish-readiness-cargo-guards.md`
 
 ## Checklist
 
-- [x] Create isolated worktree and branch `feat/publish-readiness-enforcement`.
-- [x] Extend readiness artifacts with stable schema/kind and release-record metadata.
-- [x] Add package-set fingerprint validation.
-- [x] Add artifact loading and validation helpers.
-- [x] Require `--readiness <PATH>` for real `PublishPackages` runs.
-- [x] Keep dry-run publish previews artifact-free.
-- [x] Add unit coverage for successful validation and all validation failure classes.
-- [x] Add unit coverage for missing and blank readiness paths.
-- [x] Update publish command config in root and init templates.
-- [x] Update docs and templates for the readiness-enforced publish flow.
-- [x] Run generated docs update.
-- [x] Run formatting and lint checks.
-- [x] Run targeted tests.
-- [x] Run full validation.
-- [x] Run coverage and confirm 100% patch coverage.
+- [x] Create isolated worktree and branch `feat/publish-readiness-cargo-guards`.
+- [x] Add Cargo manifest readiness blockers.
+- [x] Map blocked publish dry-runs to blocked readiness status.
+- [x] Reject real publish before registry mutation when blockers are present.
+- [x] Add focused unit coverage for missing metadata, `publish = false`, publish registry arrays, workspace inheritance, dry-run blocking, and real-publish rejection.
+- [x] Update user docs and packaged skill docs for Cargo readiness behavior.
+- [ ] Run formatting and lint checks.
+- [ ] Run full validation.
+- [ ] Run coverage and confirm 100% patch coverage.
 - [ ] Push branch and open PR.
 - [ ] Merge after required checks pass.
 
 ## Validation log
 
-- [x] `devenv shell cargo test -p monochange readiness --lib` (initial implementation; passed with warnings that were fixed afterward)
-- [x] `devenv shell cargo test -p monochange execute_cli_command_requires_readiness_for_package_publish_steps_without_matching_packages --lib`
-- [x] `devenv shell cargo test -p monochange_core display_and_publish --lib`
-- [x] `devenv shell cargo fmt --check`
-- [x] `git diff --check`
-- [x] `devenv shell mdt update`
-- [x] `devenv shell lint:test`
-- [x] `devenv shell mc validate`
-- [x] `devenv shell coverage:all`
-- [x] `devenv shell coverage:patch` (`PATCH_COVERAGE 395/395 (100.00%)`)
+- [x] `devenv shell cargo fmt`
+- [x] `devenv shell cargo test -p monochange cargo_publish_readiness_blockers --lib`
+- [x] `devenv shell cargo test -p monochange execute_publish_requests_marks_dry_run_cargo_metadata_blockers --lib`
+- [x] `devenv shell cargo test -p monochange execute_publish_requests_rejects_real_cargo_metadata_blockers --lib`
+- [x] `devenv shell cargo test -p monochange publish_readiness --lib`
+- [x] `devenv shell cargo test -p monochange package_publish_status_label --lib`
 
 ## Decisions
 
-- Real package publication requires a readiness artifact; dry-runs remain frictionless.
-- Artifact validation happens immediately before the existing rate-limit plan and package publish execution, so failures happen before registry mutation.
-- The first fingerprint is intentionally a deterministic package-set identity rather than a cryptographic digest; it covers package id, ecosystem, registry, and version.
-- `already_published` remains non-blocking as long as current readiness and the artifact agree.
-- `unsupported` remains blocking because monochange cannot mutate unsupported ecosystem publications safely.
+- Validate the current manifest immediately after registry existence checks. Already-published versions are still skipped before manifest checks, which preserves idempotent/resumable publishes.
+- Limit this first ecosystem-specific guard to built-in Cargo publishes targeting crates.io.
+- Treat `repository`, `homepage`, and `documentation` as useful recommendations but not hard blockers for this slice.
+- Keep first-time bootstrap separate from readiness; `publish = false` or missing crates.io metadata should be fixed before built-in publication.
 
 ## Follow-up roadmap
 
 - [ ] Add deeper freshness checks for workspace config, manifests, lockfiles, and publish tooling inputs.
 - [ ] Add optional readiness consumption to `mc publish-plan`.
-- [ ] Expand Cargo readiness semantics first.
 - [ ] Expand npm readiness semantics second.
 - [ ] Add `mc publish-bootstrap` for first-time package setup.
 - [ ] Design retry/resume around explicit readiness for remaining work.

--- a/docs/src/guide/13-ci-and-publishing.md
+++ b/docs/src/guide/13-ci-and-publishing.md
@@ -264,6 +264,9 @@ Important current behavior:
 
 - monochange can carry the trust expectation in config
 - monochange can report the setup URL and enforce that trust is configured before built-in release publishing continues
+- for built-in crates.io publishing, `mc publish-readiness` now blocks packages whose current `Cargo.toml` cannot be published: `publish = false`, `publish = [...]` without `crates-io`, missing `description`, or missing both `license` and `license-file`
+- workspace-inherited Cargo metadata such as `description = { workspace = true }` and `license = { workspace = true }` is accepted when `[workspace.package]` supplies the value
+- already-published Cargo versions remain non-blocking and are skipped when current readiness and the saved readiness artifact agree
 - monochange does **not** currently auto-configure `crates.io` trust the way it can for npm on GitHub
 - if you want the most literal crates.io/OIDC workflow today, `mode = "external"` plus `rust-lang/crates-io-auth-action@v1` is the clearest path
 

--- a/docs/src/readme.md
+++ b/docs/src/readme.md
@@ -139,6 +139,8 @@ These are the commands most repositories use after running `mc init`. With the n
 
 <!-- {/projectCommandAutomationMatrix} -->
 
+`mc publish-readiness` performs non-mutating registry checks before `mc publish`. For built-in Cargo publishes to crates.io it also verifies current manifest publishability: `publish = false` blocks publishing, `publish = [...]` must include `crates-io`, `description` must be set, and either `license` or `license-file` must be set. Workspace-inherited Cargo metadata is accepted, and already-published versions remain non-blocking when the readiness artifact still matches the current package set.
+
 ## What monochange can do today
 
 <!-- {=projectMilestoneCapabilities} -->

--- a/docs/src/reference/cli-steps/16-publish-packages.md
+++ b/docs/src/reference/cli-steps/16-publish-packages.md
@@ -50,6 +50,7 @@ when = "{{ inputs.enabled }}"
 
 - a release record discoverable from `HEAD` that contains the package publication targets
 - for real publishes, a readiness artifact generated from that same release record and package selection with `mc publish-readiness --from HEAD --output <PATH>`
+- for built-in Cargo publishes to crates.io, a publishable current `Cargo.toml`: no `publish = false`, any `publish = [...]` list includes `crates-io`, `description` is set, and either `license` or `license-file` is set; workspace-inherited values are accepted
 
 ## Side effects and outputs
 

--- a/packages/monochange__skill/SKILL.md
+++ b/packages/monochange__skill/SKILL.md
@@ -164,6 +164,7 @@ Lockfile refresh is command-driven via `[ecosystems.<name>].lockfile_commands`. 
 
 - Package publishing is configured through `publish` on packages and ecosystems.
 - Built-in publishing currently supports only the canonical public registries: `crates.io`, `npm`, `jsr`, and `pub.dev`.
+- `mc publish-readiness` blocks built-in Cargo publishes to crates.io when the current `Cargo.toml` is not publishable: `publish = false`, `publish = [...]` without `crates-io`, missing `description`, or missing both `license` and `license-file`. Workspace-inherited Cargo metadata is accepted.
 - `mc placeholder-publish` exists for first-release bootstrap. It checks whether each managed package already exists in its registry and publishes a placeholder `0.0.0` version only for the missing ones.
 - Placeholder README content can come from `publish.placeholder.readme` or `publish.placeholder.readme_file`.
 - `publish.trusted_publishing = true` tells monochange to manage or verify trusted publishing for that package when supported.

--- a/packages/monochange__skill/skills/reference.md
+++ b/packages/monochange__skill/skills/reference.md
@@ -469,6 +469,8 @@ Built-in package publishing currently supports only the canonical public registr
 - Deno packages → `jsr`
 - Dart / Flutter packages → `pub.dev`
 
+For Cargo, readiness uses the current `Cargo.toml` as a pre-mutation guard. Built-in crates.io publishing is blocked by `publish = false`, by `publish = [...]` when the list omits `crates-io`, by a missing `description`, or by a missing `license`/`license-file`. Workspace-inherited `description`, `license`, and `license-file` values are accepted.
+
 If a workspace uses `pnpm`, monochange uses `pnpm publish` and `pnpm exec npm trust ...` instead of raw `npm` commands so workspace protocol and catalog dependency handling stays aligned with the workspace manager.
 
 Publishing is configured through `publish` on packages and ecosystems:

--- a/packages/monochange__skill/skills/trusted-publishing.md
+++ b/packages/monochange__skill/skills/trusted-publishing.md
@@ -232,6 +232,7 @@ If you configure an environment on crates.io, the GitHub job must use the same e
 ### Monochange notes
 
 - monochange does **not** create the crates.io trusted-publisher record for you yet.
+- `mc publish-readiness` also verifies the current crate manifest before built-in crates.io publishing: `publish = false` blocks, `publish = [...]` must include `crates-io`, `description` is required, and either `license` or `license-file` is required. Workspace-inherited values are accepted.
 - Once the registry-side configuration exists, monochange can publish with the temporary token exposed by `rust-lang/crates-io-auth-action@v1`.
 - crates.io issues a short-lived publish token; the current docs describe these tokens as expiring after 30 minutes.
 - Use a specific workflow filename and, when needed, a protected GitHub environment to reduce the publish attack surface.

--- a/readme.md
+++ b/readme.md
@@ -157,6 +157,8 @@ These are the commands most repositories use after running `mc init`. With the n
 
 <!-- {/projectCommandAutomationMatrix} -->
 
+`mc publish-readiness` performs non-mutating registry checks before `mc publish`. For built-in Cargo publishes to crates.io it also verifies current manifest publishability: `publish = false` blocks publishing, `publish = [...]` must include `crates-io`, `description` must be set, and either `license` or `license-file` must be set. Workspace-inherited Cargo metadata is accepted, and already-published versions remain non-blocking when the readiness artifact still matches the current package set.
+
 ## Capability matrix
 
 <!-- {=projectCapabilityMatrix} -->


### PR DESCRIPTION
## Summary
- add a blocked package-publish outcome and propagate it into publish-readiness reports
- block built-in crates.io release publishing when the current Cargo manifest cannot publish (`publish = false`, registry list excluding `crates-io`, missing `description`, or missing license metadata)
- document Cargo readiness behavior and add a changeset for `monochange` and `@monochange/skill`

## Validation
- `devenv shell cargo fmt --check`
- `git diff --check`
- `devenv shell cargo test -p monochange cargo_publish_readiness --lib`
- `devenv shell cargo test -p monochange execute_publish_requests --lib`
- `devenv shell cargo test -p monochange publish_readiness --lib`
- `devenv shell cargo test -p monochange execute_cli_command_supports_placeholder_and_package_publish_steps --lib`
- `devenv shell lint:test`
- `devenv shell mc validate`
- `devenv shell coverage:all`
- `devenv shell coverage:patch` (`PATCH_COVERAGE 283/283 (100.00%)`)
