### PR TITLE
feat: plan publish from readiness artifacts

### DIFF
--- a/.changeset/publish-plan-readiness.md
+++ b/.changeset/publish-plan-readiness.md
@@ -1,0 +1,12 @@
+---
+"monochange": minor
+"monochange_core": patch
+"@monochange/cli": patch
+"@monochange/skill": patch
+---
+
+#### add readiness-backed publish planning
+
+`mc publish-plan` now accepts `--readiness <path>` for normal package publish planning. The plan validates that the `mc publish-readiness` artifact matches the current release record and covers the selected package set, then limits rate-limit batches to package ids that are ready in both the artifact and a fresh local readiness check.
+
+Placeholder publish planning continues to reject readiness artifacts and should be run with `mc publish-plan --mode placeholder`.

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -94,6 +94,7 @@ These are the commands most repositories use after running `mc init`. With the n
 | Open or update a release request | `mc release-pr`                                             | You want a long-lived release PR/MR branch updated from current release state                            |
 | Inspect a past release commit    | `mc release-record --from <ref>`                            | You need the durable release declaration from git history                                                |
 | Check package publish readiness  | `mc publish-readiness --from HEAD --output <path>`          | You need a validated readiness artifact before package publication                                       |
+| Plan ready package publishing    | `mc publish-plan --readiness <path>`                        | You want rate-limit batches that exclude non-ready package work                                          |
 | Publish packages to registries   | `mc publish --readiness <path>`                             | You want `cargo publish`, `npm publish`, `deno publish`, or `dart pub publish` style package publication |
 | Bootstrap missing packages       | `mc placeholder-publish`                                    | A package must exist in its registry before later automation can work                                    |
 | Create post-merge release tags   | `mc tag-release --from HEAD`                                | You merged a monochange release commit and now need to create and push its declared tag set              |
@@ -102,7 +103,7 @@ These are the commands most repositories use after running `mc init`. With the n
 
 <!-- {/projectCommandAutomationMatrix} -->
 
-`mc publish-readiness` performs non-mutating registry checks before `mc publish`. For built-in Cargo publishes to crates.io it also verifies current manifest publishability: `publish = false` blocks publishing, `publish = [...]` must include `crates-io`, `description` must be set, and either `license` or `license-file` must be set. Workspace-inherited Cargo metadata is accepted, and already-published versions remain non-blocking when the readiness artifact still matches the current package set.
+`mc publish-readiness` performs non-mutating registry checks before `mc publish`. For built-in Cargo publishes to crates.io it also verifies current manifest publishability: `publish = false` blocks publishing, `publish = [...]` must include `crates-io`, `description` must be set, and either `license` or `license-file` must be set. Workspace-inherited Cargo metadata is accepted, and already-published versions remain non-blocking when the readiness artifact still matches the current package set. `mc publish-plan --readiness <path>` validates the same artifact for planning and limits rate-limit batches to package ids that are ready in both the artifact and the fresh local readiness check.
 
 <!-- {@projectCapabilityMatrix} -->
 
@@ -154,6 +155,7 @@ mc release-pr --dry-run --format json
 mc release-record --from v1.2.3
 mc tag-release --from HEAD --dry-run --format json
 mc publish-readiness --from HEAD --output .monochange/readiness.json
+mc publish-plan --readiness .monochange/readiness.json --format json
 mc publish --readiness .monochange/readiness.json
 mc repair-release --from v1.2.3 --target HEAD --dry-run
 mc release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ mc release-pr --dry-run --format json
 mc release-record --from v1.2.3
 mc tag-release --from HEAD --dry-run --format json
 mc publish-readiness --from HEAD --output .monochange/readiness.json
+mc publish-plan --readiness .monochange/readiness.json --format json
 mc publish --readiness .monochange/readiness.json
 mc repair-release --from v1.2.3 --target HEAD --dry-run
 mc release

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -691,8 +691,16 @@ pub(crate) fn execute_cli_command_with_options(
 					Ok(())
 				}
 				CliStepDefinition::PlanPublishRateLimits { .. } => {
+					let mode = publish_rate_limit_mode_from_inputs(&step_inputs)?;
+					let selected_packages = publish_rate_limit_selected_package_ids(
+						root,
+						configuration,
+						context.prepared_release.as_ref(),
+						&step_inputs,
+						mode,
+					)?;
 					#[rustfmt::skip]
-					let report = publish_rate_limits::plan_publish_rate_limits(root, configuration, context.prepared_release.as_ref(), &selected_package_ids(&step_inputs), publish_rate_limit_mode_from_inputs(&step_inputs)?, context.dry_run)?;
+					let report = publish_rate_limits::plan_publish_rate_limits(root, configuration, context.prepared_release.as_ref(), &selected_packages, mode, context.dry_run)?;
 					context.rate_limit_report = Some(report);
 					output = None;
 					Ok(())
@@ -1895,16 +1903,54 @@ fn selected_package_ids(inputs: &BTreeMap<String, Vec<String>>) -> BTreeSet<Stri
 fn required_publish_readiness_artifact_path(
 	inputs: &BTreeMap<String, Vec<String>>,
 ) -> MonochangeResult<PathBuf> {
-	inputs
-		.get("readiness")
-		.and_then(|values| values.first())
-		.filter(|path| !path.trim().is_empty())
-		.map(PathBuf::from)
-		.ok_or_else(|| {
-			MonochangeError::Config(
-				"`PublishPackages` requires `--readiness <PATH>` when publishing; run `mc publish-readiness --from HEAD --output <PATH>` first".to_string(),
-			)
-		})
+	optional_publish_readiness_artifact_path(inputs)?.ok_or_else(|| {
+		MonochangeError::Config(
+			"`PublishPackages` requires `--readiness <PATH>` when publishing; run `mc publish-readiness --from HEAD --output <PATH>` first".to_string(),
+		)
+	})
+}
+
+fn optional_publish_readiness_artifact_path(
+	inputs: &BTreeMap<String, Vec<String>>,
+) -> MonochangeResult<Option<PathBuf>> {
+	let Some(path) = inputs.get("readiness").and_then(|values| values.first()) else {
+		return Ok(None);
+	};
+
+	if path.trim().is_empty() {
+		return Err(MonochangeError::Config(
+			"`--readiness <PATH>` must not be blank; run `mc publish-readiness --from HEAD --output <PATH>` first".to_string(),
+		));
+	}
+
+	Ok(Some(PathBuf::from(path)))
+}
+
+fn publish_rate_limit_selected_package_ids(
+	root: &Path,
+	configuration: &monochange_core::WorkspaceConfiguration,
+	prepared_release: Option<&PreparedRelease>,
+	inputs: &BTreeMap<String, Vec<String>>,
+	mode: publish_rate_limits::PublishRateLimitMode,
+) -> MonochangeResult<BTreeSet<String>> {
+	let selected_packages = selected_package_ids(inputs);
+	let Some(readiness_path) = optional_publish_readiness_artifact_path(inputs)? else {
+		return Ok(selected_packages);
+	};
+
+	if mode != publish_rate_limits::PublishRateLimitMode::Publish {
+		return Err(MonochangeError::Config(
+			"`--readiness <PATH>` is only supported for publish rate-limit plans".to_string(),
+		));
+	}
+
+	publish_readiness::publish_plan_package_filter_from_readiness_artifact(
+		root,
+		configuration,
+		prepared_release,
+		&selected_packages,
+		&readiness_path,
+	)
 }
 
 fn publish_rate_limit_mode_from_inputs(
@@ -3217,6 +3263,7 @@ fn resolve_command_output(
 #[cfg(test)]
 mod tests {
 	use std::collections::BTreeMap;
+	use std::collections::BTreeSet;
 	use std::fs;
 	use std::io;
 	use std::path::Path;
@@ -4637,6 +4684,96 @@ path = "crates/core"
 	}
 
 	#[test]
+	fn execute_cli_command_with_options_plans_publish_rate_limits_from_prepared_release_artifact() {
+		let root = fs::canonicalize(Path::new(env!("CARGO_MANIFEST_DIR")).join("../.."))
+			.unwrap_or_else(|error| panic!("workspace root: {error}"));
+		let configuration = sample_configuration(&root);
+		let artifact_dir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let artifact_path = artifact_dir.path().join("prepared-release.json");
+		let cli_command = CliCommandDefinition {
+			name: "publish-plan".to_string(),
+			help_text: Some("plan publish rate limits".to_string()),
+			inputs: Vec::new(),
+			steps: vec![
+				CliStepDefinition::PrepareRelease {
+					name: None,
+					when: None,
+					inputs: BTreeMap::new(),
+				},
+				CliStepDefinition::PlanPublishRateLimits {
+					name: None,
+					when: None,
+					inputs: BTreeMap::new(),
+				},
+			],
+		};
+		save_prepared_release_execution(
+			&root,
+			&configuration,
+			&sample_prepared_release(),
+			&[],
+			Some(artifact_path.as_path()),
+		)
+		.unwrap_or_else(|error| panic!("save prepared release artifact: {error}"));
+
+		let output = execute_cli_command_with_options(
+			&root,
+			&configuration,
+			&cli_command,
+			ExecuteCliCommandOptions {
+				dry_run: true,
+				quiet: false,
+				show_diff: false,
+				inputs: BTreeMap::new(),
+				prepared_release_path: Some(artifact_path),
+				progress_format: ProgressFormat::Auto,
+			},
+		)
+		.unwrap_or_else(|error| panic!("execute publish-plan command: {error}"));
+
+		assert!(output.contains("reused prepared release artifact"));
+	}
+
+	#[test]
+	fn execute_cli_command_with_options_rejects_readiness_for_placeholder_publish_plans() {
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let cli_command = CliCommandDefinition {
+			name: "publish-plan".to_string(),
+			help_text: Some("plan publish rate limits".to_string()),
+			inputs: Vec::new(),
+			steps: vec![CliStepDefinition::PlanPublishRateLimits {
+				name: None,
+				when: None,
+				inputs: BTreeMap::new(),
+			}],
+		};
+
+		let error = execute_cli_command_with_options(
+			tempdir.path(),
+			&sample_configuration(tempdir.path()),
+			&cli_command,
+			ExecuteCliCommandOptions {
+				dry_run: true,
+				quiet: true,
+				show_diff: false,
+				inputs: BTreeMap::from([
+					("mode".to_string(), vec!["placeholder".to_string()]),
+					("readiness".to_string(), vec!["readiness.json".to_string()]),
+				]),
+				prepared_release_path: None,
+				progress_format: ProgressFormat::Auto,
+			},
+		)
+		.expect_err("placeholder publish plans should reject readiness artifacts");
+
+		assert!(
+			error
+				.to_string()
+				.contains("only supported for publish rate-limit plans")
+		);
+	}
+
+	#[test]
 	fn execute_cli_command_with_options_reuses_prepared_release_artifact_for_versions() {
 		let root = fs::canonicalize(Path::new(env!("CARGO_MANIFEST_DIR")).join("../.."))
 			.unwrap_or_else(|error| panic!("workspace root: {error}"));
@@ -4963,6 +5100,93 @@ path = "crates/core"
 				assert!(!stdout_supports_color());
 			},
 		);
+	}
+
+	#[test]
+	fn publish_rate_limit_selected_package_ids_uses_package_inputs_without_readiness() {
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let configuration = sample_configuration(tempdir.path());
+		let inputs = BTreeMap::from([(
+			"package".to_string(),
+			vec!["core".to_string(), "web".to_string()],
+		)]);
+
+		let selected = publish_rate_limit_selected_package_ids(
+			tempdir.path(),
+			&configuration,
+			None,
+			&inputs,
+			publish_rate_limits::PublishRateLimitMode::Placeholder,
+		)
+		.unwrap_or_else(|error| panic!("selected packages: {error}"));
+
+		assert_eq!(
+			selected,
+			BTreeSet::from(["core".to_string(), "web".to_string()])
+		);
+	}
+
+	#[test]
+	fn publish_rate_limit_selected_package_ids_rejects_readiness_for_placeholder_plans() {
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let configuration = sample_configuration(tempdir.path());
+		let inputs = BTreeMap::from([(
+			"readiness".to_string(),
+			vec![".monochange/readiness.json".to_string()],
+		)]);
+
+		let error = publish_rate_limit_selected_package_ids(
+			tempdir.path(),
+			&configuration,
+			Some(&sample_prepared_release()),
+			&inputs,
+			publish_rate_limits::PublishRateLimitMode::Placeholder,
+		)
+		.expect_err("placeholder publish plans should reject readiness artifacts");
+
+		assert!(
+			error
+				.to_string()
+				.contains("only supported for publish rate-limit plans")
+		);
+	}
+
+	#[test]
+	fn publish_rate_limit_selected_package_ids_uses_readiness_artifact_for_publish_plans() {
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let configuration = sample_configuration(tempdir.path());
+		let artifact_path = tempdir.path().join("readiness.json");
+		let report = publish_readiness::PublishReadinessReport {
+			schema_version: 1,
+			kind: "monochange.publishReadiness".to_string(),
+			status: publish_readiness::PublishReadinessGlobalStatus::Ready,
+			from: "prepared-release".to_string(),
+			resolved_commit: "prepared-release".to_string(),
+			record_commit: "prepared-release".to_string(),
+			package_set_fingerprint: String::new(),
+			packages: Vec::new(),
+		};
+		let inputs = BTreeMap::from([(
+			"readiness".to_string(),
+			vec![artifact_path.display().to_string()],
+		)]);
+		fs::write(
+			&artifact_path,
+			serde_json::to_string_pretty(&report)
+				.unwrap_or_else(|error| panic!("serialize readiness artifact: {error}")),
+		)
+		.unwrap_or_else(|error| panic!("write readiness artifact: {error}"));
+
+		let selected = publish_rate_limit_selected_package_ids(
+			tempdir.path(),
+			&configuration,
+			Some(&sample_prepared_release()),
+			&inputs,
+			publish_rate_limits::PublishRateLimitMode::Publish,
+		)
+		.unwrap_or_else(|error| panic!("selected packages from readiness: {error}"));
+
+		assert!(selected.is_empty());
 	}
 
 	#[test]

--- a/crates/monochange/src/monochange.init.toml
+++ b/crates/monochange/src/monochange.init.toml
@@ -870,6 +870,7 @@ inputs = [
 	{ name = "format", type = "choice", choices = ["text", "markdown", "json"], default = "text" },
 	{ name = "mode", type = "choice", choices = ["publish", "placeholder"], default = "publish" },
 	{ name = "package", type = "string_list" },
+	{ name = "readiness", type = "path", help_text = "JSON artifact from mc publish-readiness; limits publish plans to ready package work" },
 	{ name = "ci", type = "choice", choices = ["github-actions", "gitlab-ci"] },
 ]
 steps = [{ name = "plan publish rate limits", type = "PlanPublishRateLimits" }]

--- a/crates/monochange/src/publish_readiness.rs
+++ b/crates/monochange/src/publish_readiness.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;
@@ -116,6 +117,26 @@ pub(crate) fn validate_publish_readiness_artifact(
 	validate_publish_readiness_report(&artifact, &current_report)
 }
 
+pub(crate) fn publish_plan_package_filter_from_readiness_artifact(
+	root: &Path,
+	configuration: &WorkspaceConfiguration,
+	prepared_release: Option<&PreparedRelease>,
+	selected_packages: &BTreeSet<String>,
+	artifact_path: &Path,
+) -> MonochangeResult<BTreeSet<String>> {
+	let artifact = read_report_artifact(artifact_path)?;
+	#[rustfmt::skip]
+	let current_report = build_publish_readiness_report_for_publish(root, configuration, prepared_release, selected_packages)?;
+	validate_publish_readiness_plan_artifact(&artifact, &current_report)?;
+
+	let artifact_ready_packages = publish_plan_ready_package_ids(&artifact);
+	let current_ready_packages = publish_plan_ready_package_ids(&current_report);
+	Ok(current_ready_packages
+		.intersection(&artifact_ready_packages)
+		.cloned()
+		.collect())
+}
+
 fn build_publish_readiness_report(
 	root: &Path,
 	configuration: &WorkspaceConfiguration,
@@ -215,6 +236,26 @@ fn readiness_status_from_publish_status(
 	}
 }
 
+fn publish_plan_ready_package_ids(report: &PublishReadinessReport) -> BTreeSet<String> {
+	let mut package_readiness = BTreeMap::<String, bool>::new();
+
+	for package in &report.packages {
+		let is_ready = matches!(
+			package.status,
+			PublishReadinessPackageStatus::Ready | PublishReadinessPackageStatus::AlreadyPublished
+		);
+		package_readiness
+			.entry(package.package.clone())
+			.and_modify(|ready| *ready &= is_ready)
+			.or_insert(is_ready);
+	}
+
+	package_readiness
+		.into_iter()
+		.filter_map(|(package, ready)| ready.then_some(package))
+		.collect()
+}
+
 fn write_report_artifact(output: &Path, report: &PublishReadinessReport) -> MonochangeResult<()> {
 	output
 		.parent()
@@ -249,6 +290,15 @@ fn validate_publish_readiness_report(
 	validate_readiness_current_status(current)?;
 	validate_readiness_release_commit(artifact, current)?;
 	validate_readiness_packages(artifact, current)
+}
+
+fn validate_publish_readiness_plan_artifact(
+	artifact: &PublishReadinessReport,
+	current: &PublishReadinessReport,
+) -> MonochangeResult<()> {
+	validate_readiness_artifact_header(artifact)?;
+	validate_readiness_release_commit(artifact, current)?;
+	validate_readiness_package_subset(artifact, current)
 }
 
 fn validate_readiness_artifact_header(report: &PublishReadinessReport) -> MonochangeResult<()> {
@@ -325,6 +375,35 @@ fn validate_readiness_packages(
 		"publish readiness artifact package set is stale or does not match selected packages (missing: {}; stale: {})",
 		render_package_identity_list(&missing),
 		render_package_identity_list(&stale)
+	)))
+}
+
+fn validate_readiness_package_subset(
+	artifact: &PublishReadinessReport,
+	current: &PublishReadinessReport,
+) -> MonochangeResult<()> {
+	let artifact_packages = package_identities(&artifact.packages)?;
+	let current_packages = package_identities(&current.packages)?;
+
+	if artifact.package_set_fingerprint != package_set_fingerprint(&artifact.packages) {
+		return Err(MonochangeError::Config(
+			"publish readiness artifact package fingerprint does not match its package list"
+				.to_string(),
+		));
+	}
+
+	let missing = current_packages
+		.difference(&artifact_packages)
+		.map(render_package_identity)
+		.collect::<Vec<_>>();
+
+	if missing.is_empty() {
+		return Ok(());
+	}
+
+	Err(MonochangeError::Config(format!(
+		"publish readiness artifact does not cover selected packages: {}",
+		render_package_identity_list(&missing)
 	)))
 }
 
@@ -540,6 +619,20 @@ mod tests {
 			version: "1.2.3".to_string(),
 			status: PublishReadinessPackageStatus::Ready,
 			message: "ready to publish core 1.2.3".to_string(),
+		}
+	}
+
+	fn readiness_package(
+		package: &str,
+		registry: &str,
+		status: PublishReadinessPackageStatus,
+	) -> PublishReadinessPackage {
+		PublishReadinessPackage {
+			package: package.to_string(),
+			registry: registry.to_string(),
+			status,
+			message: format!("{package} readiness"),
+			..sample_readiness_package()
 		}
 	}
 
@@ -797,6 +890,114 @@ mod tests {
 			&artifact_path,
 		)
 		.unwrap_or_else(|error| panic!("validate readiness artifact: {error}"));
+	}
+
+	#[test]
+	fn publish_plan_ready_package_ids_requires_every_package_row_to_be_ready() {
+		let report = sample_readiness_report(vec![
+			readiness_package("core", "crates.io", PublishReadinessPackageStatus::Ready),
+			readiness_package(
+				"core",
+				"npm",
+				PublishReadinessPackageStatus::AlreadyPublished,
+			),
+			readiness_package("web", "crates.io", PublishReadinessPackageStatus::Ready),
+			readiness_package("web", "npm", PublishReadinessPackageStatus::Blocked),
+			readiness_package(
+				"docs",
+				"crates.io",
+				PublishReadinessPackageStatus::AlreadyPublished,
+			),
+			readiness_package(
+				"external",
+				"crates.io",
+				PublishReadinessPackageStatus::Unsupported,
+			),
+		]);
+
+		let ready_packages = publish_plan_ready_package_ids(&report);
+
+		assert_eq!(
+			ready_packages,
+			BTreeSet::from(["core".to_string(), "docs".to_string()])
+		);
+	}
+
+	#[test]
+	fn validate_publish_readiness_plan_artifact_accepts_blocked_subset_reports() {
+		let artifact = sample_readiness_report(vec![
+			readiness_package("core", "crates.io", PublishReadinessPackageStatus::Ready),
+			readiness_package("web", "crates.io", PublishReadinessPackageStatus::Blocked),
+			readiness_package("extra", "crates.io", PublishReadinessPackageStatus::Ready),
+		]);
+		let current = PublishReadinessReport {
+			status: PublishReadinessGlobalStatus::Blocked,
+			packages: vec![
+				readiness_package("core", "crates.io", PublishReadinessPackageStatus::Ready),
+				readiness_package("web", "crates.io", PublishReadinessPackageStatus::Blocked),
+			],
+			..sample_readiness_report(Vec::new())
+		};
+
+		validate_publish_readiness_plan_artifact(&artifact, &current)
+			.unwrap_or_else(|error| panic!("planning readiness artifact: {error}"));
+	}
+
+	#[test]
+	fn validate_publish_readiness_plan_artifact_rejects_tampering_and_missing_coverage() {
+		let current = sample_readiness_report(vec![
+			readiness_package("core", "crates.io", PublishReadinessPackageStatus::Ready),
+			readiness_package("web", "crates.io", PublishReadinessPackageStatus::Ready),
+		]);
+
+		let mut tampered = current.clone();
+		tampered.package_set_fingerprint = "tampered".to_string();
+		let tampered_error = validate_publish_readiness_plan_artifact(&tampered, &current)
+			.expect_err("tampered planning artifact should fail validation");
+		assert!(tampered_error.to_string().contains("package fingerprint"));
+
+		let missing = sample_readiness_report(vec![readiness_package(
+			"core",
+			"crates.io",
+			PublishReadinessPackageStatus::Ready,
+		)]);
+		let missing_error = validate_publish_readiness_plan_artifact(&missing, &current)
+			.expect_err("planning artifact missing current package should fail");
+		assert!(
+			missing_error
+				.to_string()
+				.contains("does not cover selected packages")
+		);
+	}
+
+	#[test]
+	fn publish_plan_package_filter_from_readiness_artifact_accepts_empty_prepared_release() {
+		let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let root = tempdir.path();
+		let artifact_path = root.join("readiness.json");
+		let configuration = sample_configuration(root);
+		let prepared_release = sample_prepared_release(root);
+		let selected_packages = BTreeSet::new();
+		let report = build_publish_readiness_report_for_publish(
+			root,
+			&configuration,
+			Some(&prepared_release),
+			&selected_packages,
+		)
+		.unwrap_or_else(|error| panic!("prepared release readiness: {error}"));
+
+		write_report_artifact(&artifact_path, &report)
+			.unwrap_or_else(|error| panic!("write readiness artifact: {error}"));
+		let planned_packages = publish_plan_package_filter_from_readiness_artifact(
+			root,
+			&configuration,
+			Some(&prepared_release),
+			&selected_packages,
+			&artifact_path,
+		)
+		.unwrap_or_else(|error| panic!("publish plan readiness filter: {error}"));
+
+		assert!(planned_packages.is_empty());
 	}
 
 	#[test]

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -1219,7 +1219,7 @@ fn valid_input_names_returns_expected_names_for_display_and_publish_steps() {
 		inputs: BTreeMap::new(),
 	};
 	let names = plan.valid_input_names().unwrap();
-	for expected in ["format", "mode", "package", "ci"] {
+	for expected in ["format", "mode", "package", "ci", "readiness"] {
 		assert!(names.contains(&expected), "missing: {expected}");
 	}
 }
@@ -1380,6 +1380,10 @@ fn expected_input_kind_returns_correct_types_for_display_and_publish_steps() {
 		Some(CliInputKind::StringList)
 	);
 	assert_eq!(plan.expected_input_kind("ci"), Some(CliInputKind::Choice));
+	assert_eq!(
+		plan.expected_input_kind("readiness"),
+		Some(CliInputKind::Path)
+	);
 	assert_eq!(plan.expected_input_kind("unknown"), None);
 }
 

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -2048,7 +2048,9 @@ impl CliStepDefinition {
 			Self::OpenReleaseRequest { .. } => Some(&["format", "no_verify"]),
 			Self::PlaceholderPublish { .. } => Some(&["format", "package"]),
 			Self::PublishPackages { .. } => Some(&["format", "package", "readiness"]),
-			Self::PlanPublishRateLimits { .. } => Some(&["format", "mode", "package", "ci"]),
+			Self::PlanPublishRateLimits { .. } => {
+				Some(&["format", "mode", "package", "ci", "readiness"])
+			}
 			Self::CreateChangeFile { .. } => {
 				Some(&[
 					"interactive",
@@ -2161,6 +2163,7 @@ impl CliStepDefinition {
 			Self::PlanPublishRateLimits { .. } => {
 				match name {
 					"package" => Some(CliInputKind::StringList),
+					"readiness" => Some(CliInputKind::Path),
 					"format" | "mode" | "ci" => Some(CliInputKind::Choice),
 					_ => None,
 				}

--- a/docs/plans/active/publish-readiness.md
+++ b/docs/plans/active/publish-readiness.md
@@ -1,10 +1,10 @@
-# Publish readiness Cargo guards
+# Publish readiness and publish planning
 
 ## Status
 
-- Previous slices: `mc publish-readiness` shipped in PR #292; readiness artifact enforcement shipped in PR #301.
-- Current branch: `feat/publish-readiness-cargo-guards`.
-- Current slice: add Cargo-first publish-readiness blockers for current manifest publishability before built-in crates.io mutation.
+- Previous slices: `mc publish-readiness` shipped in PR #292; readiness artifact enforcement shipped in PR #301; Cargo-first publish-readiness blockers shipped in PR #303.
+- Current branch: `feat/publish-plan-readiness`.
+- Current slice: add readiness-artifact support to `mc publish-plan --readiness <path>` so publish rate-limit plans exclude non-ready package work.
 
 ## Problem
 
@@ -28,7 +28,7 @@ This slice covers built-in Cargo publishes to crates.io:
 - Automated crates.io trusted-publisher enrollment.
 - npm, JSR, or pub.dev metadata-specific readiness expansion.
 - Full manifest/lockfile artifact hashing.
-- `mc publish-plan --readiness` integration.
+- Retry/resume or `mc publish-bootstrap` implementation.
 
 ## Affected files
 
@@ -77,7 +77,7 @@ This slice covers built-in Cargo publishes to crates.io:
 ## Follow-up roadmap
 
 - [ ] Add deeper freshness checks for workspace config, manifests, lockfiles, and publish tooling inputs.
-- [ ] Add optional readiness consumption to `mc publish-plan`.
+- [x] Add optional readiness consumption to `mc publish-plan`.
 - [ ] Expand npm readiness semantics second.
 - [ ] Add `mc publish-bootstrap` for first-time package setup.
 - [ ] Design retry/resume around explicit readiness for remaining work.

--- a/docs/src/guide/01-installation.md
+++ b/docs/src/guide/01-installation.md
@@ -80,6 +80,7 @@ mc release-pr --dry-run --format json
 mc release-record --from v1.2.3
 mc tag-release --from HEAD --dry-run --format json
 mc publish-readiness --from HEAD --output .monochange/readiness.json
+mc publish-plan --readiness .monochange/readiness.json --format json
 mc publish --readiness .monochange/readiness.json
 mc repair-release --from v1.2.3 --target HEAD --dry-run
 mc release

--- a/docs/src/guide/13-ci-and-publishing.md
+++ b/docs/src/guide/13-ci-and-publishing.md
@@ -23,6 +23,7 @@ These are the commands most repositories use after running `mc init`. With the n
 | Open or update a release request | `mc release-pr`                                             | You want a long-lived release PR/MR branch updated from current release state                            |
 | Inspect a past release commit    | `mc release-record --from <ref>`                            | You need the durable release declaration from git history                                                |
 | Check package publish readiness  | `mc publish-readiness --from HEAD --output <path>`          | You need a validated readiness artifact before package publication                                       |
+| Plan ready package publishing    | `mc publish-plan --readiness <path>`                        | You want rate-limit batches that exclude non-ready package work                                          |
 | Publish packages to registries   | `mc publish --readiness <path>`                             | You want `cargo publish`, `npm publish`, `deno publish`, or `dart pub publish` style package publication |
 | Bootstrap missing packages       | `mc placeholder-publish`                                    | A package must exist in its registry before later automation can work                                    |
 | Create post-merge release tags   | `mc tag-release --from HEAD`                                | You merged a monochange release commit and now need to create and push its declared tag set              |
@@ -44,7 +45,7 @@ A practical rule of thumb:
 monochange has three related but different automation layers:
 
 1. **Release planning** — `mc release --dry-run`, `mc release`, `mc diagnostics`
-2. **Package registries** — `mc placeholder-publish`, `mc publish-readiness`, `mc publish --readiness <path>`
+2. **Package registries** — `mc placeholder-publish`, `mc publish-readiness`, `mc publish-plan --readiness <path>`, `mc publish --readiness <path>`
 3. **Hosted providers** — `mc release-pr`, `mc publish-release`, `mc repair-release`
 
 Keeping those layers separate is important. Package publication and hosted-release publication are not the same job.
@@ -94,7 +95,7 @@ For GitHub Actions, the most common structure is:
 
 The important current implementation detail is that `mc publish-readiness` can write a readiness artifact from the `ReleaseRecord` on `HEAD`, `mc publish --readiness <path>` can validate that artifact before package registry mutation, `mc tag-release` can create the declared release tags from that same durable record, and `mc publish-release` still works from prepared release state when you want a manifest-driven hosted-release job.
 
-If the same post-merge job is responsible for both tags and package publication, run `mc tag-release --from HEAD` immediately after release-commit detection, then run `mc publish-readiness --from HEAD --output <path>` before `mc publish --readiness <path>`.
+If the same post-merge job is responsible for both tags and package publication, run `mc tag-release --from HEAD` immediately after release-commit detection, then run `mc publish-readiness --from HEAD --output <path>`, optionally inspect `mc publish-plan --readiness <path>`, and finally run `mc publish --readiness <path>`.
 
 ### GitHub + npm trusted publishing
 

--- a/docs/src/guide/15-publish-rate-limits.md
+++ b/docs/src/guide/15-publish-rate-limits.md
@@ -3,7 +3,8 @@
 `mc publish-plan` previews package-registry publish work against monochange's built-in ecosystem rate-limit metadata.
 
 ```bash
-mc publish-plan --format json
+mc publish-readiness --from HEAD --output .monochange/readiness.json
+mc publish-plan --readiness .monochange/readiness.json --format json
 mc publish-plan --mode placeholder --format json
 mc publish-plan --ci github-actions
 ```
@@ -17,7 +18,7 @@ The report includes:
 - a provider-agnostic batch schedule with package ids per batch
 - evidence links and confidence levels for the built-in limits
 
-`mc publish-plan` only counts package versions that are still missing from their registries. If you rerun a release after some packages were already published, the remaining batches shrink automatically.
+`mc publish-plan` only counts package versions that are still missing from their registries. If you rerun a release after some packages were already published, the remaining batches shrink automatically. When you pass `--readiness <path>`, the plan first validates that the readiness artifact covers the current release record and selected package set, then excludes package ids that are not ready in both the artifact and the fresh local readiness check.
 
 ## Current built-in coverage
 
@@ -26,11 +27,11 @@ The report includes:
 - `jsr` — official publish-window metadata
 - `pub.dev` — conservative daily publish planning metadata for CI batching
 
-Use `mc publish-plan` before `mc publish-readiness` and `mc publish --readiness <path>` when you want CI to fail early instead of discovering registry throttling mid-release.
+Use `mc publish-readiness --from HEAD --output <path>`, then `mc publish-plan --readiness <path>`, then `mc publish --readiness <path>` when you want CI to fail early instead of discovering registry throttling mid-release. The `--readiness` input is only valid for normal publish planning; placeholder planning still uses `mc publish-plan --mode placeholder` without a readiness artifact.
 
 ## Filtering and enforcement
 
-Both `mc publish` and `mc placeholder-publish` accept repeated `--package <id>` filters so you can execute one planned batch at a time. For real `mc publish --package <id>` runs, generate the readiness artifact with the same `--package <id>` selection.
+Both `mc publish` and `mc placeholder-publish` accept repeated `--package <id>` filters so you can execute one planned batch at a time. For real `mc publish --package <id>` runs, generate the readiness artifact with the same `--package <id>` selection, or pass a broader readiness artifact to `mc publish-plan --readiness <path> --package <id>` so the plan can validate that the artifact covers the selected package subset.
 
 If you want monochange to block risky built-in publishes instead of only warning, enable:
 

--- a/docs/src/readme.md
+++ b/docs/src/readme.md
@@ -131,6 +131,7 @@ These are the commands most repositories use after running `mc init`. With the n
 | Open or update a release request | `mc release-pr`                                             | You want a long-lived release PR/MR branch updated from current release state                            |
 | Inspect a past release commit    | `mc release-record --from <ref>`                            | You need the durable release declaration from git history                                                |
 | Check package publish readiness  | `mc publish-readiness --from HEAD --output <path>`          | You need a validated readiness artifact before package publication                                       |
+| Plan ready package publishing    | `mc publish-plan --readiness <path>`                        | You want rate-limit batches that exclude non-ready package work                                          |
 | Publish packages to registries   | `mc publish --readiness <path>`                             | You want `cargo publish`, `npm publish`, `deno publish`, or `dart pub publish` style package publication |
 | Bootstrap missing packages       | `mc placeholder-publish`                                    | A package must exist in its registry before later automation can work                                    |
 | Create post-merge release tags   | `mc tag-release --from HEAD`                                | You merged a monochange release commit and now need to create and push its declared tag set              |
@@ -139,7 +140,7 @@ These are the commands most repositories use after running `mc init`. With the n
 
 <!-- {/projectCommandAutomationMatrix} -->
 
-`mc publish-readiness` performs non-mutating registry checks before `mc publish`. For built-in Cargo publishes to crates.io it also verifies current manifest publishability: `publish = false` blocks publishing, `publish = [...]` must include `crates-io`, `description` must be set, and either `license` or `license-file` must be set. Workspace-inherited Cargo metadata is accepted, and already-published versions remain non-blocking when the readiness artifact still matches the current package set.
+`mc publish-readiness` performs non-mutating registry checks before `mc publish`. For built-in Cargo publishes to crates.io it also verifies current manifest publishability: `publish = false` blocks publishing, `publish = [...]` must include `crates-io`, `description` must be set, and either `license` or `license-file` must be set. Workspace-inherited Cargo metadata is accepted, and already-published versions remain non-blocking when the readiness artifact still matches the current package set. `mc publish-plan --readiness <path>` validates the same artifact for planning and limits rate-limit batches to package ids that are ready in both the artifact and the fresh local readiness check.
 
 ## What monochange can do today
 

--- a/docs/src/reference/cli-steps/09-plan-publish-rate-limits.md
+++ b/docs/src/reference/cli-steps/09-plan-publish-rate-limits.md
@@ -14,6 +14,7 @@ Use it when you want to answer questions like:
 - `format` — `text`, `markdown`, or `json`
 - `mode` — `publish` (default) or `placeholder`
 - `package` — optional repeated package ids used to filter the plan
+- `readiness` — optional path to a JSON artifact from `mc publish-readiness`; only valid when `mode = "publish"`
 - `ci` — optional `github-actions` or `gitlab-ci` snippet renderer
 
 ## Produces
@@ -25,6 +26,7 @@ A structured publish-rate-limit report containing:
 - explicit package ids per batch
 - evidence and confidence metadata for each built-in policy
 - only versions that are still missing from their registries, so reruns reflect the remaining work
+- when `readiness` is provided, only package ids ready in both the artifact and the fresh local readiness check
 
 ## Examples
 
@@ -40,10 +42,17 @@ type = "choice"
 default = "json"
 choices = ["text", "markdown", "json"]
 
+[[cli.publish-plan.inputs]]
+name = "readiness"
+type = "path"
+help_text = "JSON artifact from mc publish-readiness; limits publish plans to ready package work"
+
 [[cli.publish-plan.steps]]
 name = "plan publish rate limits"
 type = "PlanPublishRateLimits"
 ```
+
+A readiness-backed plan validates the artifact header, release record commit, selected package coverage, and package-set fingerprint before planning. The artifact may contain non-ready packages, but those package ids are excluded from the plan. Placeholder plans reject `readiness`; use `mode = "placeholder"` without an artifact for first-time bootstrap planning.
 
 ### Plan placeholder bootstrap publishing
 

--- a/packages/monochange__cli/README.md
+++ b/packages/monochange__cli/README.md
@@ -233,6 +233,7 @@ mc release-pr --dry-run --format json
 mc release-record --from v1.2.3
 mc tag-release --from HEAD --dry-run --format json
 mc publish-readiness --from HEAD --output .monochange/readiness.json
+mc publish-plan --readiness .monochange/readiness.json --format json
 mc publish --readiness .monochange/readiness.json
 mc repair-release --from v1.2.3 --target HEAD --dry-run
 mc release

--- a/packages/monochange__skill/SKILL.md
+++ b/packages/monochange__skill/SKILL.md
@@ -67,27 +67,28 @@ Release-oriented commands default to markdown output. Use `--format json` for au
 
 ## CLI commands
 
-| Command                     | Purpose                                                                |
-| --------------------------- | ---------------------------------------------------------------------- |
-| `mc init`                   | Generate a starter `monochange.toml` from detected packages            |
-| `mc validate`               | Validate config and changeset targets                                  |
-| `mc check`                  | Validate config and run lint rules against package manifests           |
-| `mc lint`                   | Inspect registered lint rules and presets                              |
-| `mc discover`               | Discover packages across ecosystems                                    |
-| `mc change`                 | Create a `.changeset/*.md` file                                        |
-| `mc release`                | Prepare a release plan from changesets and refresh the cached manifest |
-| `mc placeholder-publish`    | Publish placeholder versions for packages missing from registries      |
-| `mc publish-readiness`      | Check package-registry readiness and write a validation artifact       |
-| `mc publish --readiness`    | Publish package artifacts using built-in registry workflows            |
-| `mc commit-release`         | Prepare a release and create a local commit                            |
-| `mc publish-release`        | Create provider releases                                               |
-| `mc release-pr`             | Open or update a release pull request                                  |
-| `mc step:affected-packages` | Evaluate changeset policy from changed paths without a config wrapper  |
-| `mc diagnostics`            | Show changeset context with git and review metadata                    |
-| `mc release-record`         | Inspect a durable release declaration from git history                 |
-| `mc repair-release`         | Repair a recent release by retargeting tags                            |
-| `mc subagents`              | Generate repo-local monochange agent, subagent, and rule files         |
-| `mc mcp`                    | Start the stdio MCP server                                             |
+| Command                       | Purpose                                                                |
+| ----------------------------- | ---------------------------------------------------------------------- |
+| `mc init`                     | Generate a starter `monochange.toml` from detected packages            |
+| `mc validate`                 | Validate config and changeset targets                                  |
+| `mc check`                    | Validate config and run lint rules against package manifests           |
+| `mc lint`                     | Inspect registered lint rules and presets                              |
+| `mc discover`                 | Discover packages across ecosystems                                    |
+| `mc change`                   | Create a `.changeset/*.md` file                                        |
+| `mc release`                  | Prepare a release plan from changesets and refresh the cached manifest |
+| `mc placeholder-publish`      | Publish placeholder versions for packages missing from registries      |
+| `mc publish-readiness`        | Check package-registry readiness and write a validation artifact       |
+| `mc publish-plan --readiness` | Plan rate-limit batches from ready package work only                   |
+| `mc publish --readiness`      | Publish package artifacts using built-in registry workflows            |
+| `mc commit-release`           | Prepare a release and create a local commit                            |
+| `mc publish-release`          | Create provider releases                                               |
+| `mc release-pr`               | Open or update a release pull request                                  |
+| `mc step:affected-packages`   | Evaluate changeset policy from changed paths without a config wrapper  |
+| `mc diagnostics`              | Show changeset context with git and review metadata                    |
+| `mc release-record`           | Inspect a durable release declaration from git history                 |
+| `mc repair-release`           | Repair a recent release by retargeting tags                            |
+| `mc subagents`                | Generate repo-local monochange agent, subagent, and rule files         |
+| `mc mcp`                      | Start the stdio MCP server                                             |
 
 ## CLI step types
 
@@ -165,6 +166,7 @@ Lockfile refresh is command-driven via `[ecosystems.<name>].lockfile_commands`. 
 - Package publishing is configured through `publish` on packages and ecosystems.
 - Built-in publishing currently supports only the canonical public registries: `crates.io`, `npm`, `jsr`, and `pub.dev`.
 - `mc publish-readiness` blocks built-in Cargo publishes to crates.io when the current `Cargo.toml` is not publishable: `publish = false`, `publish = [...]` without `crates-io`, missing `description`, or missing both `license` and `license-file`. Workspace-inherited Cargo metadata is accepted.
+- `mc publish-plan --readiness <path>` validates a readiness artifact for the current release record and excludes package ids that are not ready in both the artifact and the fresh local readiness check. Placeholder planning does not accept readiness artifacts.
 - `mc placeholder-publish` exists for first-release bootstrap. It checks whether each managed package already exists in its registry and publishes a placeholder `0.0.0` version only for the missing ones.
 - Placeholder README content can come from `publish.placeholder.readme` or `publish.placeholder.readme_file`.
 - `publish.trusted_publishing = true` tells monochange to manage or verify trusted publishing for that package when supported.

--- a/packages/monochange__skill/skills/commands.md
+++ b/packages/monochange__skill/skills/commands.md
@@ -93,6 +93,7 @@ mc release --dry-run --format json
 mc commit-release --dry-run --diff
 mc publish --dry-run --format json
 mc publish-readiness --from HEAD --output .monochange/readiness.json
+mc publish-plan --readiness .monochange/readiness.json --format json
 mc publish --readiness .monochange/readiness.json
 mc publish-release --dry-run --format json
 mc release-pr --dry-run --format json
@@ -148,7 +149,7 @@ Then choose the next step:
 
 - `mc release` to apply
 - `mc commit-release` to produce the local release commit
-- `mc publish-readiness --from HEAD --output <path>` and `mc publish --readiness <path>` to publish package artifacts
+- `mc publish-readiness --from HEAD --output <path>`, `mc publish-plan --readiness <path>`, and `mc publish --readiness <path>` to plan and publish package artifacts
 - `mc publish-release` to create provider releases
 - `mc release-pr` to update a release request instead
 

--- a/packages/monochange__skill/skills/reference.md
+++ b/packages/monochange__skill/skills/reference.md
@@ -459,6 +459,7 @@ Package publishing is separate from provider release publishing:
 
 - `mc placeholder-publish` bootstraps missing registry packages with placeholder `0.0.0` releases
 - `mc publish-readiness --from HEAD --output <path>` checks package-registry readiness from release state
+- `mc publish-plan --readiness <path>` validates readiness for planning and excludes non-ready package ids from rate-limit batches
 - `mc publish --readiness <path>` validates readiness and runs built-in package-registry publishing
 - `mc publish-release` publishes hosted/provider releases such as GitHub releases
 

--- a/readme.md
+++ b/readme.md
@@ -149,6 +149,7 @@ These are the commands most repositories use after running `mc init`. With the n
 | Open or update a release request | `mc release-pr`                                             | You want a long-lived release PR/MR branch updated from current release state                            |
 | Inspect a past release commit    | `mc release-record --from <ref>`                            | You need the durable release declaration from git history                                                |
 | Check package publish readiness  | `mc publish-readiness --from HEAD --output <path>`          | You need a validated readiness artifact before package publication                                       |
+| Plan ready package publishing    | `mc publish-plan --readiness <path>`                        | You want rate-limit batches that exclude non-ready package work                                          |
 | Publish packages to registries   | `mc publish --readiness <path>`                             | You want `cargo publish`, `npm publish`, `deno publish`, or `dart pub publish` style package publication |
 | Bootstrap missing packages       | `mc placeholder-publish`                                    | A package must exist in its registry before later automation can work                                    |
 | Create post-merge release tags   | `mc tag-release --from HEAD`                                | You merged a monochange release commit and now need to create and push its declared tag set              |
@@ -157,7 +158,7 @@ These are the commands most repositories use after running `mc init`. With the n
 
 <!-- {/projectCommandAutomationMatrix} -->
 
-`mc publish-readiness` performs non-mutating registry checks before `mc publish`. For built-in Cargo publishes to crates.io it also verifies current manifest publishability: `publish = false` blocks publishing, `publish = [...]` must include `crates-io`, `description` must be set, and either `license` or `license-file` must be set. Workspace-inherited Cargo metadata is accepted, and already-published versions remain non-blocking when the readiness artifact still matches the current package set.
+`mc publish-readiness` performs non-mutating registry checks before `mc publish`. For built-in Cargo publishes to crates.io it also verifies current manifest publishability: `publish = false` blocks publishing, `publish = [...]` must include `crates-io`, `description` must be set, and either `license` or `license-file` must be set. Workspace-inherited Cargo metadata is accepted, and already-published versions remain non-blocking when the readiness artifact still matches the current package set. `mc publish-plan --readiness <path>` validates the same artifact for planning and limits rate-limit batches to package ids that are ready in both the artifact and the fresh local readiness check.
 
 ## Capability matrix
 
@@ -314,6 +315,7 @@ mc release-pr --dry-run --format json
 mc release-record --from v1.2.3
 mc tag-release --from HEAD --dry-run --format json
 mc publish-readiness --from HEAD --output .monochange/readiness.json
+mc publish-plan --readiness .monochange/readiness.json --format json
 mc publish --readiness .monochange/readiness.json
 mc repair-release --from v1.2.3 --target HEAD --dry-run
 mc release


### PR DESCRIPTION
## Summary
- add `mc publish-plan --readiness <path>` support for normal publish planning
- validate readiness artifacts for the selected/current package subset and filter plans to packages ready in both saved and fresh readiness checks
- document the publish-readiness → publish-plan → publish lifecycle and update CLI step metadata/templates

## Validation
- `devenv shell mc validate`
- `devenv shell lint:test`
- `devenv shell coverage:all`
- `devenv shell coverage:patch` → `PATCH_COVERAGE 353/353 (100.00%)`
