### PR TITLE
fix: prefer verified GitHub release PR commits

### DIFF
--- a/.changeset/verified-release-pr-commits.md
+++ b/.changeset/verified-release-pr-commits.md
@@ -1,0 +1,10 @@
+---
+monochange: patch
+monochange_github: patch
+---
+
+#### prefer verified GitHub release PR commits in Actions
+
+When `mc release-pr` publishes a GitHub release pull request from GitHub Actions, monochange now asks the GitHub provider to recreate the release branch commit through the Git Database API and only moves the branch when GitHub marks the replacement commit as verified.
+
+If the API commit cannot be created, is not verified, or the branch changes before the replacement lands, monochange leaves the normal pushed git commit in place and continues with the release PR flow.

--- a/.changeset/verified-release-pr-commits.md
+++ b/.changeset/verified-release-pr-commits.md
@@ -1,6 +1,7 @@
 ---
 monochange: patch
 monochange_github: patch
+"@monochange/cli": patch
 ---
 
 #### prefer verified GitHub release PR commits in Actions

--- a/.changeset/verified-release-pr-commits.md
+++ b/.changeset/verified-release-pr-commits.md
@@ -1,11 +1,12 @@
 ---
 monochange: patch
+monochange_core: minor
 monochange_github: patch
 "@monochange/cli": patch
 ---
 
 #### prefer verified GitHub release PR commits in Actions
 
-When `mc release-pr` publishes a GitHub release pull request from GitHub Actions, monochange now asks the GitHub provider to recreate the release branch commit through the Git Database API and only moves the branch when GitHub marks the replacement commit as verified.
+When `[source.pull_requests].verified_commits = true`, `mc release-pr` publishes a GitHub release pull request from GitHub Actions by asking the GitHub provider to recreate the release branch commit through the Git Database API and only moves the branch when GitHub marks the replacement commit as verified.
 
-If the API commit cannot be created, is not verified, or the branch changes before the replacement lands, monochange leaves the normal pushed git commit in place and continues with the release PR flow.
+The setting defaults to `false`. If the API commit cannot be created, is not verified, or the branch changes before the replacement lands, monochange leaves the normal pushed git commit in place and continues with the release PR flow.

--- a/.templates/cli-steps.t.md
+++ b/.templates/cli-steps.t.md
@@ -217,6 +217,24 @@ type = "OpenReleaseRequest"
 
 <!-- {/cliStepOpenReleaseRequestExample} -->
 
+<!-- {@cliStepOpenReleaseRequestGitHubActionsVerifiedCommitBehavior} -->
+
+When `OpenReleaseRequest` publishes a GitHub release pull request in normal mode, monochange first uses local git as the durable fallback path: it checks out the release branch, stages the tracked release files, creates the release commit, and pushes that branch before opening or updating the pull request.
+
+If the command is running inside GitHub Actions for the same repository as `[source]`, the GitHub provider then tries to replace that pushed fallback commit with a GitHub-verified commit:
+
+1. It builds the GitHub API client from `GITHUB_TOKEN` or `GH_TOKEN`.
+2. It reads the pushed fallback commit through the Git Database API.
+3. It creates a new Git commit object with the same message, tree, and parents.
+4. It accepts the replacement only when GitHub returns `verification.verified = true` for the new commit.
+5. It confirms the release branch still points at the fallback commit, then moves the branch ref to the verified commit.
+
+Any failure keeps the original pushed git commit in place. That includes missing tokens, non-GitHub Actions environments, repository mismatches, GitHub returning an unverified commit, API errors, or the release branch moving between the fallback push and the ref update. The fallback is intentional: release PR automation should keep working even when verified commit replacement is unavailable.
+
+Dry runs never create commits, push branches, or call the provider APIs. Non-GitHub providers continue to use their normal release-request behavior.
+
+<!-- {/cliStepOpenReleaseRequestGitHubActionsVerifiedCommitBehavior} -->
+
 <!-- {@cliStepCommentReleasedIssuesExample} -->
 
 ```toml

--- a/.templates/cli-steps.t.md
+++ b/.templates/cli-steps.t.md
@@ -221,7 +221,7 @@ type = "OpenReleaseRequest"
 
 When `OpenReleaseRequest` publishes a GitHub release pull request in normal mode, monochange first uses local git as the durable fallback path: it checks out the release branch, stages the tracked release files, creates the release commit, and pushes that branch before opening or updating the pull request.
 
-If the command is running inside GitHub Actions for the same repository as `[source]`, the GitHub provider then tries to replace that pushed fallback commit with a GitHub-verified commit:
+When `[source.pull_requests].verified_commits = true` and the command is running inside GitHub Actions for the same repository as `[source]`, the GitHub provider then tries to replace that pushed fallback commit with a GitHub-verified commit:
 
 1. It builds the GitHub API client from `GITHUB_TOKEN` or `GH_TOKEN`.
 2. It reads the pushed fallback commit through the Git Database API.
@@ -229,7 +229,7 @@ If the command is running inside GitHub Actions for the same repository as `[sou
 4. It accepts the replacement only when GitHub returns `verification.verified = true` for the new commit.
 5. It confirms the release branch still points at the fallback commit, then moves the branch ref to the verified commit.
 
-Any failure keeps the original pushed git commit in place. That includes missing tokens, non-GitHub Actions environments, repository mismatches, GitHub returning an unverified commit, API errors, or the release branch moving between the fallback push and the ref update. The fallback is intentional: release PR automation should keep working even when verified commit replacement is unavailable.
+Verified commit replacement is opt-in and defaults to off. Any failure keeps the original pushed git commit in place. That includes missing tokens, non-GitHub Actions environments, repository mismatches, GitHub returning an unverified commit, API errors, or the release branch moving between the fallback push and the ref update. The fallback is intentional: release PR automation should keep working even when verified commit replacement is unavailable.
 
 Dry runs never create commits, push branches, or call the provider APIs. Non-GitHub providers continue to use their normal release-request behavior.
 

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -679,7 +679,7 @@ That means one set of `.changeset/*.md` inputs can drive all of these commands a
 
 - `mc release --dry-run --format json` refreshes the cached manifest and shows the downstream automation payload
 - `mc publish-release` previews or publishes provider releases from the structured release notes
-- `mc release-pr` previews or opens an idempotent provider release request
+- `mc release-pr` previews or opens an idempotent provider release request; on GitHub Actions for the configured repository, the GitHub provider pushes a normal release branch commit as a fallback and then only moves the branch to a Git Database API replacement commit when GitHub reports that replacement as verified
 - `mc step:affected-packages` evaluates pull-request changeset policy from CI-supplied changed paths and labels without requiring a config-defined wrapper command
 
 <!-- {/githubAutomationOverview} -->

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -679,7 +679,7 @@ That means one set of `.changeset/*.md` inputs can drive all of these commands a
 
 - `mc release --dry-run --format json` refreshes the cached manifest and shows the downstream automation payload
 - `mc publish-release` previews or publishes provider releases from the structured release notes
-- `mc release-pr` previews or opens an idempotent provider release request; on GitHub Actions for the configured repository, the GitHub provider pushes a normal release branch commit as a fallback and then only moves the branch to a Git Database API replacement commit when GitHub reports that replacement as verified
+- `mc release-pr` previews or opens an idempotent provider release request; when `[source.pull_requests].verified_commits = true` and the command runs on GitHub Actions for the configured repository, the GitHub provider pushes a normal release branch commit as a fallback and then only moves the branch to a Git Database API replacement commit when GitHub reports that replacement as verified
 - `mc step:affected-packages` evaluates pull-request changeset policy from CI-supplied changed paths and labels without requiring a config-defined wrapper command
 
 <!-- {/githubAutomationOverview} -->

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -131,6 +131,7 @@ monochange can promote one prepared release into several source-provider automat
 - `mc release --dry-run --format json` refreshes the cached manifest and shows downstream automation data, including authored changesets plus linked release context metadata
 - `mc publish-release --dry-run --format json` previews provider release payloads before publishing
 - `mc release-pr --dry-run --format json` previews the release branch, commit, and release-request body
+- when `mc release-pr` runs on GitHub Actions for the configured GitHub repository, the GitHub provider pushes a normal release branch commit first, then attempts to replace it with a Git Database API commit that GitHub reports as verified; if verification or the API update fails, the normal pushed commit remains in place
 - `mc release-record --from <tag>` inspects the durable release declaration stored in the release commit body
 - `mc tag-release --from HEAD --dry-run --format json` previews the post-merge release tag set declared by that durable record
 - `mc repair-release --from <tag> --dry-run` previews a release-retarget plan before mutating tags

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -131,7 +131,7 @@ monochange can promote one prepared release into several source-provider automat
 - `mc release --dry-run --format json` refreshes the cached manifest and shows downstream automation data, including authored changesets plus linked release context metadata
 - `mc publish-release --dry-run --format json` previews provider release payloads before publishing
 - `mc release-pr --dry-run --format json` previews the release branch, commit, and release-request body
-- when `mc release-pr` runs on GitHub Actions for the configured GitHub repository, the GitHub provider pushes a normal release branch commit first, then attempts to replace it with a Git Database API commit that GitHub reports as verified; if verification or the API update fails, the normal pushed commit remains in place
+- when `[source.pull_requests].verified_commits = true` and `mc release-pr` runs on GitHub Actions for the configured GitHub repository, the GitHub provider pushes a normal release branch commit first, then attempts to replace it with a Git Database API commit that GitHub reports as verified; if verification or the API update fails, the normal pushed commit remains in place
 - `mc release-record --from <tag>` inspects the durable release declaration stored in the release commit body
 - `mc tag-release --from HEAD --dry-run --format json` previews the post-merge release tag set declared by that durable record
 - `mc repair-release --from <tag> --dry-run` previews a release-retarget plan before mutating tags

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -3229,6 +3229,8 @@ pub struct ProviderMergeRequestSettings {
 	pub labels: Vec<String>,
 	#[serde(default)]
 	pub auto_merge: bool,
+	#[serde(default)]
+	pub verified_commits: bool,
 }
 
 impl Default for ProviderMergeRequestSettings {
@@ -3240,6 +3242,7 @@ impl Default for ProviderMergeRequestSettings {
 			title: default_pull_request_title(),
 			labels: default_pull_request_labels(),
 			auto_merge: false,
+			verified_commits: false,
 		}
 	}
 }

--- a/crates/monochange_github/src/__tests.rs
+++ b/crates/monochange_github/src/__tests.rs
@@ -42,6 +42,7 @@ use monochange_core::SourceProvider;
 use monochange_core::VersionFormat;
 use monochange_test_helpers::git;
 use monochange_test_helpers::git_output;
+use regex::Regex;
 use tempfile::tempdir;
 
 use super::*;
@@ -1123,6 +1124,147 @@ fn release_pull_request_commit_verification_falls_back_when_github_does_not_veri
 	original_commit.assert();
 	create_commit.assert();
 	assert!(result.is_err_and(|message| message.contains("without verification (unsigned)")));
+}
+
+#[test]
+fn release_pull_request_commit_verification_rejects_moved_branch() {
+	let server = MockServer::start();
+	let request = sample_pull_request_request();
+	let get_ref = server.mock(|when, then| {
+		when.method(GET)
+			.path("/repos/ifiokjr/monochange/git/ref/heads/monochange/release/release");
+		then.status(200)
+			.header("content-type", "application/json")
+			.body(r#"{"object":{"sha":"3333333333333333333333333333333333333333"}}"#);
+	});
+
+	let result = github_runtime()
+		.unwrap_or_else(|error| panic!("runtime: {error}"))
+		.block_on(async {
+			let client = build_test_client(&server);
+			update_github_branch_ref_to_verified_commit(
+				&client,
+				&request,
+				"1111111111111111111111111111111111111111",
+				"2222222222222222222222222222222222222222",
+			)
+			.await
+		});
+
+	get_ref.assert();
+	assert!(
+		result.is_err_and(|message| {
+			message.contains("release branch monochange/release/release moved")
+		})
+	);
+}
+
+#[test]
+fn release_pull_request_commit_verification_rejects_unexpected_updated_ref() {
+	let server = MockServer::start();
+	let request = sample_pull_request_request();
+	let fallback = "1111111111111111111111111111111111111111";
+	let verified = "2222222222222222222222222222222222222222";
+	let unexpected = "3333333333333333333333333333333333333333";
+	let get_ref = server.mock(|when, then| {
+		when.method(GET)
+			.path("/repos/ifiokjr/monochange/git/ref/heads/monochange/release/release");
+		then.status(200)
+			.header("content-type", "application/json")
+			.body(format!(r#"{{"object":{{"sha":"{fallback}"}}}}"#));
+	});
+	let update_ref = server.mock(|when, then| {
+		when.method(PATCH)
+			.path("/repos/ifiokjr/monochange/git/refs/heads/monochange/release/release")
+			.json_body(json!({ "sha": verified, "force": true }));
+		then.status(200)
+			.header("content-type", "application/json")
+			.body(format!(r#"{{"object":{{"sha":"{unexpected}"}}}}"#));
+	});
+
+	let result = github_runtime()
+		.unwrap_or_else(|error| panic!("runtime: {error}"))
+		.block_on(async {
+			let client = build_test_client(&server);
+			update_github_branch_ref_to_verified_commit(&client, &request, fallback, verified).await
+		});
+
+	get_ref.assert();
+	update_ref.assert();
+	assert!(result.is_err_and(|message| {
+		message.contains("expected 2222222222222222222222222222222222222222")
+	}));
+}
+
+#[etest::etest(skip=env::var_os("PRE_COMMIT").is_some())]
+fn publish_release_pull_request_falls_back_when_verified_commit_is_unavailable() {
+	let server = MockServer::start();
+	let (_tempdir, repo) = seed_git_repository();
+	let source = sample_source(Some(server.base_url()));
+	let request = sample_pull_request_request();
+	let list_pull_requests = server.mock(|when, then| {
+		when.method(GET).path("/repos/ifiokjr/monochange/pulls");
+		then.status(200)
+			.header("content-type", "application/json")
+			.body("[]");
+	});
+	let original_commit = server.mock(|when, then| {
+		when.method(GET).path_matches(
+			Regex::new(r"^/repos/ifiokjr/monochange/git/commits/[0-9a-f]{40}$")
+				.unwrap_or_else(|error| panic!("regex: {error}")),
+		);
+		then.status(200)
+			.header("content-type", "application/json")
+			.body(r#"{"sha":"1111111111111111111111111111111111111111","message":"chore(release): prepare release","tree":{"sha":"tree123"},"parents":[{"sha":"parent123"}],"verification":{"verified":false,"reason":"unsigned"}}"#);
+	});
+	let create_commit = server.mock(|when, then| {
+		when.method(POST)
+			.path("/repos/ifiokjr/monochange/git/commits");
+		then.status(201)
+			.header("content-type", "application/json")
+			.body(r#"{"sha":"2222222222222222222222222222222222222222","message":"chore(release): prepare release","tree":{"sha":"tree123"},"parents":[{"sha":"parent123"}],"verification":{"verified":false,"reason":"unsigned"}}"#);
+	});
+	let create_pull_request = server.mock(|when, then| {
+		when.method(POST).path("/repos/ifiokjr/monochange/pulls");
+		then.status(201)
+			.header("content-type", "application/json")
+			.body(
+				"{\"number\":7,\"html_url\":\"https://example.com/pr/7\",\"node_id\":\"PR_node\"}",
+			);
+	});
+	let add_labels = server.mock(|when, then| {
+		when.method(POST)
+			.path("/repos/ifiokjr/monochange/issues/7/labels");
+		then.status(200)
+			.header("content-type", "application/json")
+			.body("[]");
+	});
+
+	let outcome = temp_env::with_vars(
+		[
+			("GITHUB_TOKEN", Some("token")),
+			("GITHUB_ACTIONS", Some("true")),
+			("GITHUB_REPOSITORY", Some("ifiokjr/monochange")),
+		],
+		|| {
+			publish_release_pull_request(
+				&source,
+				&repo,
+				&request,
+				&[PathBuf::from("release.txt")],
+				false,
+			)
+			.unwrap_or_else(|error| panic!("publish pull request: {error}"))
+		},
+	);
+
+	list_pull_requests.assert();
+	original_commit.assert();
+	create_commit.assert();
+	create_pull_request.assert();
+	add_labels.assert();
+	assert_eq!(outcome.operation, GitHubPullRequestOperation::Created);
+	assert_eq!(outcome.number, 7);
 }
 
 #[test]

--- a/crates/monochange_github/src/__tests.rs
+++ b/crates/monochange_github/src/__tests.rs
@@ -1017,9 +1017,42 @@ fn publish_release_pull_request_updates_existing_pull_request_via_octocrab() {
 }
 
 #[test]
+fn release_pull_request_commit_verification_is_opt_in() {
+	let disabled_source = sample_source(None);
+	let enabled_source = sample_source_with_verified_commits(None);
+
+	temp_env::with_vars(
+		[
+			("GITHUB_ACTIONS", None),
+			("GITHUB_REPOSITORY", Some("ifiokjr/monochange")),
+		],
+		|| {
+			assert!(!github_actions_release_commit_verification_enabled(
+				&enabled_source
+			))
+		},
+	);
+
+	temp_env::with_vars(
+		[
+			("GITHUB_ACTIONS", Some("true")),
+			("GITHUB_REPOSITORY", Some("ifiokjr/monochange")),
+		],
+		|| {
+			assert!(!github_actions_release_commit_verification_enabled(
+				&disabled_source
+			));
+			assert!(github_actions_release_commit_verification_enabled(
+				&enabled_source
+			));
+		},
+	);
+}
+
+#[test]
 fn release_pull_request_commit_verification_uses_github_git_database_api() {
 	let server = MockServer::start();
-	let source = sample_source(Some(server.base_url()));
+	let source = sample_source_with_verified_commits(Some(server.base_url()));
 	let request = sample_pull_request_request();
 	let fallback = "1111111111111111111111111111111111111111";
 	let verified = "2222222222222222222222222222222222222222";
@@ -1085,7 +1118,7 @@ fn release_pull_request_commit_verification_uses_github_git_database_api() {
 #[test]
 fn release_pull_request_commit_verification_falls_back_when_github_does_not_verify_commit() {
 	let server = MockServer::start();
-	let source = sample_source(Some(server.base_url()));
+	let source = sample_source_with_verified_commits(Some(server.base_url()));
 	let request = sample_pull_request_request();
 	let fallback = "1111111111111111111111111111111111111111";
 	let unverified = "2222222222222222222222222222222222222222";
@@ -1198,7 +1231,7 @@ fn release_pull_request_commit_verification_rejects_unexpected_updated_ref() {
 fn publish_release_pull_request_falls_back_when_verified_commit_is_unavailable() {
 	let server = MockServer::start();
 	let (_tempdir, repo) = seed_git_repository();
-	let source = sample_source(Some(server.base_url()));
+	let source = sample_source_with_verified_commits(Some(server.base_url()));
 	let request = sample_pull_request_request();
 	let list_pull_requests = server.mock(|when, then| {
 		when.method(GET).path("/repos/ifiokjr/monochange/pulls");
@@ -2314,6 +2347,16 @@ fn sample_source(api_url: Option<String>) -> SourceConfiguration {
 		releases: ProviderReleaseSettings::default(),
 		pull_requests: ProviderMergeRequestSettings::default(),
 		bot: ProviderBotSettings::default(),
+	}
+}
+
+fn sample_source_with_verified_commits(api_url: Option<String>) -> SourceConfiguration {
+	SourceConfiguration {
+		pull_requests: ProviderMergeRequestSettings {
+			verified_commits: true,
+			..ProviderMergeRequestSettings::default()
+		},
+		..sample_source(api_url)
 	}
 }
 

--- a/crates/monochange_github/src/__tests.rs
+++ b/crates/monochange_github/src/__tests.rs
@@ -1029,7 +1029,7 @@ fn release_pull_request_commit_verification_is_opt_in() {
 		|| {
 			assert!(!github_actions_release_commit_verification_enabled(
 				&enabled_source
-			))
+			));
 		},
 	);
 

--- a/crates/monochange_github/src/__tests.rs
+++ b/crates/monochange_github/src/__tests.rs
@@ -1152,11 +1152,9 @@ fn release_pull_request_commit_verification_rejects_moved_branch() {
 		});
 
 	get_ref.assert();
-	assert!(
-		result.is_err_and(|message| {
-			message.contains("release branch monochange/release/release moved")
-		})
-	);
+	assert!(result.is_err_and(|message| {
+		message.contains("release branch monochange/release/release moved")
+	}));
 }
 
 #[test]

--- a/crates/monochange_github/src/__tests.rs
+++ b/crates/monochange_github/src/__tests.rs
@@ -1016,6 +1016,116 @@ fn publish_release_pull_request_updates_existing_pull_request_via_octocrab() {
 }
 
 #[test]
+fn release_pull_request_commit_verification_uses_github_git_database_api() {
+	let server = MockServer::start();
+	let source = sample_source(Some(server.base_url()));
+	let request = sample_pull_request_request();
+	let fallback = "1111111111111111111111111111111111111111";
+	let verified = "2222222222222222222222222222222222222222";
+	let original_commit = server.mock(|when, then| {
+		when.method(GET)
+			.path(format!("/repos/ifiokjr/monochange/git/commits/{fallback}"));
+		then.status(200)
+			.header("content-type", "application/json")
+			.body(format!(
+				r#"{{"sha":"{fallback}","message":"chore(release): prepare release\n\nbody","tree":{{"sha":"tree123"}},"parents":[{{"sha":"parent123"}}],"verification":{{"verified":false,"reason":"unsigned"}}}}"#
+			));
+	});
+	let create_commit = server.mock(|when, then| {
+		when.method(POST)
+			.path("/repos/ifiokjr/monochange/git/commits")
+			.json_body(json!({
+				"message": "chore(release): prepare release\n\nbody",
+				"tree": "tree123",
+				"parents": ["parent123"],
+			}));
+		then.status(201)
+			.header("content-type", "application/json")
+			.body(format!(
+				 r#"{{"sha":"{verified}","message":"chore(release): prepare release\n\nbody","tree":{{"sha":"tree123"}},"parents":[{{"sha":"parent123"}}],"verification":{{"verified":true,"reason":"valid"}}}}"#
+			));
+	});
+	let get_ref = server.mock(|when, then| {
+		when.method(GET)
+			.path("/repos/ifiokjr/monochange/git/ref/heads/monochange/release/release");
+		then.status(200)
+			.header("content-type", "application/json")
+			.body(format!(r#"{{"object":{{"sha":"{fallback}"}}}}"#));
+	});
+	let update_ref = server.mock(|when, then| {
+		when.method(PATCH)
+			.path("/repos/ifiokjr/monochange/git/refs/heads/monochange/release/release")
+			.json_body(json!({ "sha": verified, "force": true }));
+		then.status(200)
+			.header("content-type", "application/json")
+			.body(format!(r#"{{"object":{{"sha":"{verified}"}}}}"#));
+	});
+
+	let result = temp_env::with_vars(
+		[
+			("GITHUB_TOKEN", Some("token")),
+			("GITHUB_ACTIONS", Some("true")),
+			("GITHUB_REPOSITORY", Some("ifiokjr/monochange")),
+		],
+		|| {
+			maybe_replace_release_pull_request_commit_with_verified_github_commit(
+				&source, &request, fallback,
+			)
+		},
+	);
+
+	original_commit.assert();
+	create_commit.assert();
+	get_ref.assert();
+	update_ref.assert();
+	assert_eq!(result, Ok(verified.to_string()));
+}
+
+#[test]
+fn release_pull_request_commit_verification_falls_back_when_github_does_not_verify_commit() {
+	let server = MockServer::start();
+	let source = sample_source(Some(server.base_url()));
+	let request = sample_pull_request_request();
+	let fallback = "1111111111111111111111111111111111111111";
+	let unverified = "2222222222222222222222222222222222222222";
+	let original_commit = server.mock(|when, then| {
+		when.method(GET)
+			.path(format!("/repos/ifiokjr/monochange/git/commits/{fallback}"));
+		then.status(200)
+			.header("content-type", "application/json")
+			.body(format!(
+				r#"{{"sha":"{fallback}","message":"chore(release): prepare release","tree":{{"sha":"tree123"}},"parents":[{{"sha":"parent123"}}],"verification":{{"verified":false,"reason":"unsigned"}}}}"#
+			));
+	});
+	let create_commit = server.mock(|when, then| {
+		when.method(POST)
+			.path("/repos/ifiokjr/monochange/git/commits");
+		then.status(201)
+			.header("content-type", "application/json")
+			.body(format!(
+				r#"{{"sha":"{unverified}","message":"chore(release): prepare release","tree":{{"sha":"tree123"}},"parents":[{{"sha":"parent123"}}],"verification":{{"verified":false,"reason":"unsigned"}}}}"#
+			));
+	});
+
+	let result = temp_env::with_vars(
+		[
+			("GITHUB_TOKEN", Some("token")),
+			("GITHUB_ACTIONS", Some("true")),
+			("GITHUB_REPOSITORY", Some("ifiokjr/monochange")),
+		],
+		|| {
+			maybe_replace_release_pull_request_commit_with_verified_github_commit(
+				&source, &request, fallback,
+			)
+		},
+	);
+
+	original_commit.assert();
+	create_commit.assert();
+	assert!(result.is_err_and(|message| message.contains("without verification (unsigned)")));
+}
+
+#[test]
 fn publish_release_pull_request_skips_matching_existing_pull_request() {
 	let server = MockServer::start();
 	let request = sample_pull_request_request();

--- a/crates/monochange_github/src/lib.rs
+++ b/crates/monochange_github/src/lib.rs
@@ -159,6 +159,8 @@ pub type GitHubPullRequestRequest = SourceChangeRequest;
 pub type GitHubPullRequestOperation = SourceChangeRequestOperation;
 pub type GitHubPullRequestOutcome = SourceChangeRequestOutcome;
 
+type GitHubVerifiedCommitAttempt = Result<String, String>;
+
 /// Return the hosted-source capabilities supported by the GitHub provider.
 #[must_use]
 pub const fn source_capabilities() -> SourceCapabilities {
@@ -292,6 +294,54 @@ struct GitHubPullRequestUpdatePayload<'a> {
 #[derive(Debug, Serialize)]
 struct GitHubLabelsPayload<'a> {
 	labels: &'a [String],
+}
+
+#[derive(Debug, Serialize)]
+struct GitHubCreateCommitPayload {
+	message: String,
+	tree: String,
+	parents: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct GitHubUpdateRefPayload<'a> {
+	sha: &'a str,
+	force: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubGitCommitResponse {
+	sha: String,
+	message: String,
+	tree: GitHubGitCommitTree,
+	parents: Vec<GitHubGitCommitParent>,
+	verification: GitHubGitCommitVerification,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubGitCommitTree {
+	sha: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubGitCommitParent {
+	sha: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubGitCommitVerification {
+	verified: bool,
+	reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubGitRefResponse {
+	object: GitHubGitRefObject,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubGitRefObject {
+	sha: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1065,7 +1115,7 @@ pub fn publish_release_pull_request(
 	git_checkout_branch(root, &request.head_branch)?;
 	git_stage_paths(root, tracked_paths)?;
 	git_commit_paths(root, &request.commit_message, no_verify)?;
-	let head_commit = git_head_commit(root)?;
+	let mut head_commit = git_head_commit(root)?;
 	let existing = join_existing_pull_request_lookup(existing_pull_request)?;
 	let head_matches_existing = existing
 		.as_ref()
@@ -1073,6 +1123,18 @@ pub fn publish_release_pull_request(
 		== Some(head_commit.as_str());
 	if !head_matches_existing {
 		git_push_branch(root, &request.head_branch, no_verify)?;
+		// Commits created through GitHub's Git Database API from GitHub Actions can be
+		// marked verified by GitHub. Keep the pushed git commit as the fallback if the
+		// API commit cannot be created, verified, or moved onto the release branch.
+		head_commit = maybe_replace_release_pull_request_commit_with_verified_github_commit(
+			source,
+			request,
+			&head_commit,
+		)
+		.unwrap_or_else(|warning| {
+			tracing::warn!(%warning, commit = %head_commit, "falling back to regular release pull request commit");
+			head_commit.clone()
+		});
 	}
 
 	let runtime = github_runtime()?;
@@ -1087,6 +1149,133 @@ pub fn publish_release_pull_request(
 		)
 		.await
 	})
+}
+
+fn maybe_replace_release_pull_request_commit_with_verified_github_commit(
+	source: &SourceConfiguration,
+	request: &GitHubPullRequestRequest,
+	fallback_commit: &str,
+) -> GitHubVerifiedCommitAttempt {
+	if !github_actions_release_commit_verification_enabled(source) {
+		return Ok(fallback_commit.to_string());
+	}
+
+	let runtime = github_runtime().map_err(|error| error.to_string())?;
+	runtime.block_on(async {
+		let client = github_client_from_env(source).map_err(|error| error.to_string())?;
+		let verified_commit = create_verified_github_commit_for_release_pull_request(
+			&client,
+			request,
+			fallback_commit,
+		)
+		.await?;
+		update_github_branch_ref_to_verified_commit(
+			&client,
+			request,
+			fallback_commit,
+			&verified_commit,
+		)
+		.await?;
+		Ok(verified_commit)
+	})
+}
+
+fn github_actions_release_commit_verification_enabled(source: &SourceConfiguration) -> bool {
+	if env::var("GITHUB_ACTIONS").as_deref() != Ok("true") {
+		return false;
+	}
+	let repository = format!("{}/{}", source.owner, source.repo);
+	env::var("GITHUB_REPOSITORY").is_ok_and(|value| value.eq_ignore_ascii_case(&repository))
+}
+
+async fn create_verified_github_commit_for_release_pull_request(
+	client: &Octocrab,
+	request: &GitHubPullRequestRequest,
+	fallback_commit: &str,
+) -> GitHubVerifiedCommitAttempt {
+	let commit_path = format!(
+		"/repos/{}/{}/git/commits/{}",
+		request.owner, request.repo, fallback_commit
+	);
+	let original: GitHubGitCommitResponse = get_json(client, &commit_path)
+		.await
+		.map_err(|error| error.to_string())?;
+	let payload = GitHubCreateCommitPayload {
+		message: original.message,
+		tree: original.tree.sha,
+		parents: original
+			.parents
+			.into_iter()
+			.map(|parent| parent.sha)
+			.collect(),
+	};
+	let create_path = format!("/repos/{}/{}/git/commits", request.owner, request.repo);
+	let commit: GitHubGitCommitResponse = post_json(client, &create_path, &payload)
+		.await
+		.map_err(|error| error.to_string())?;
+	if commit.verification.verified {
+		tracing::info!(
+			commit = %commit.sha,
+			reason = ?commit.verification.reason,
+			"created verified GitHub release pull request commit"
+		);
+		return Ok(commit.sha);
+	}
+	Err(format!(
+		"GitHub Git Database API created commit {} without verification ({})",
+		commit.sha,
+		commit
+			.verification
+			.reason
+			.unwrap_or_else(|| "unknown reason".to_string())
+	))
+}
+
+async fn update_github_branch_ref_to_verified_commit(
+	client: &Octocrab,
+	request: &GitHubPullRequestRequest,
+	fallback_commit: &str,
+	verified_commit: &str,
+) -> GitHubVerifiedCommitAttempt {
+	let get_ref_path = github_head_ref_get_path(request);
+	let current: GitHubGitRefResponse = get_json(client, &get_ref_path)
+		.await
+		.map_err(|error| error.to_string())?;
+	if current.object.sha != fallback_commit {
+		return Err(format!(
+			"release branch {} moved from {} to {}; refusing to replace it with verified commit {}",
+			request.head_branch, fallback_commit, current.object.sha, verified_commit
+		));
+	}
+	let payload = GitHubUpdateRefPayload {
+		sha: verified_commit,
+		force: true,
+	};
+	let update_ref_path = github_head_ref_update_path(request);
+	let updated: GitHubGitRefResponse = patch_json(client, &update_ref_path, &payload)
+		.await
+		.map_err(|error| error.to_string())?;
+	if updated.object.sha != verified_commit {
+		return Err(format!(
+			"GitHub returned {} after updating {}, expected {}",
+			updated.object.sha, request.head_branch, verified_commit
+		));
+	}
+	Ok(updated.object.sha)
+}
+
+fn github_head_ref_get_path(request: &GitHubPullRequestRequest) -> String {
+	format!(
+		"/repos/{}/{}/git/ref/heads/{}",
+		request.owner, request.repo, request.head_branch
+	)
+}
+
+fn github_head_ref_update_path(request: &GitHubPullRequestRequest) -> String {
+	format!(
+		"/repos/{}/{}/git/refs/heads/{}",
+		request.owner, request.repo, request.head_branch
+	)
 }
 
 /// Sync existing GitHub releases so retargeted tags point at the new commits.

--- a/crates/monochange_github/src/lib.rs
+++ b/crates/monochange_github/src/lib.rs
@@ -1181,6 +1181,9 @@ fn maybe_replace_release_pull_request_commit_with_verified_github_commit(
 }
 
 fn github_actions_release_commit_verification_enabled(source: &SourceConfiguration) -> bool {
+	if !source.pull_requests.verified_commits {
+		return false;
+	}
 	if env::var("GITHUB_ACTIONS").as_deref() != Ok("true") {
 		return false;
 	}

--- a/docs/src/guide/08-github-automation.md
+++ b/docs/src/guide/08-github-automation.md
@@ -8,7 +8,7 @@ That means one set of `.changeset/*.md` inputs can drive all of these commands a
 
 - `mc release --dry-run --format json` refreshes the cached manifest and shows the downstream automation payload
 - `mc publish-release` previews or publishes provider releases from the structured release notes
-- `mc release-pr` previews or opens an idempotent provider release request
+- `mc release-pr` previews or opens an idempotent provider release request; on GitHub Actions for the configured repository, the GitHub provider pushes a normal release branch commit as a fallback and then only moves the branch to a Git Database API replacement commit when GitHub reports that replacement as verified
 - `mc step:affected-packages` evaluates pull-request changeset policy from CI-supplied changed paths and labels without requiring a config-defined wrapper command
 
 <!-- {/githubAutomationOverview} -->

--- a/docs/src/guide/08-github-automation.md
+++ b/docs/src/guide/08-github-automation.md
@@ -8,7 +8,7 @@ That means one set of `.changeset/*.md` inputs can drive all of these commands a
 
 - `mc release --dry-run --format json` refreshes the cached manifest and shows the downstream automation payload
 - `mc publish-release` previews or publishes provider releases from the structured release notes
-- `mc release-pr` previews or opens an idempotent provider release request; on GitHub Actions for the configured repository, the GitHub provider pushes a normal release branch commit as a fallback and then only moves the branch to a Git Database API replacement commit when GitHub reports that replacement as verified
+- `mc release-pr` previews or opens an idempotent provider release request; when `[source.pull_requests].verified_commits = true` and the command runs on GitHub Actions for the configured repository, the GitHub provider pushes a normal release branch commit as a fallback and then only moves the branch to a Git Database API replacement commit when GitHub reports that replacement as verified
 - `mc step:affected-packages` evaluates pull-request changeset policy from CI-supplied changed paths and labels without requiring a config-defined wrapper command
 
 <!-- {/githubAutomationOverview} -->

--- a/docs/src/reference/cli-steps/11-open-release-request.md
+++ b/docs/src/reference/cli-steps/11-open-release-request.md
@@ -47,7 +47,7 @@ when = "{{ inputs.enabled }}"
 
 When `OpenReleaseRequest` publishes a GitHub release pull request in normal mode, monochange first uses local git as the durable fallback path: it checks out the release branch, stages the tracked release files, creates the release commit, and pushes that branch before opening or updating the pull request.
 
-If the command is running inside GitHub Actions for the same repository as `[source]`, the GitHub provider then tries to replace that pushed fallback commit with a GitHub-verified commit:
+When `[source.pull_requests].verified_commits = true` and the command is running inside GitHub Actions for the same repository as `[source]`, the GitHub provider then tries to replace that pushed fallback commit with a GitHub-verified commit:
 
 1. It builds the GitHub API client from `GITHUB_TOKEN` or `GH_TOKEN`.
 2. It reads the pushed fallback commit through the Git Database API.
@@ -55,7 +55,7 @@ If the command is running inside GitHub Actions for the same repository as `[sou
 4. It accepts the replacement only when GitHub returns `verification.verified = true` for the new commit.
 5. It confirms the release branch still points at the fallback commit, then moves the branch ref to the verified commit.
 
-Any failure keeps the original pushed git commit in place. That includes missing tokens, non-GitHub Actions environments, repository mismatches, GitHub returning an unverified commit, API errors, or the release branch moving between the fallback push and the ref update. The fallback is intentional: release PR automation should keep working even when verified commit replacement is unavailable.
+Verified commit replacement is opt-in and defaults to off. Any failure keeps the original pushed git commit in place. That includes missing tokens, non-GitHub Actions environments, repository mismatches, GitHub returning an unverified commit, API errors, or the release branch moving between the fallback push and the ref update. The fallback is intentional: release PR automation should keep working even when verified commit replacement is unavailable.
 
 Dry runs never create commits, push branches, or call the provider APIs. Non-GitHub providers continue to use their normal release-request behavior.
 

--- a/docs/src/reference/cli-steps/11-open-release-request.md
+++ b/docs/src/reference/cli-steps/11-open-release-request.md
@@ -41,6 +41,26 @@ when = "{{ inputs.enabled }}"
 - in normal mode, performs git and provider operations needed to open or update the request
 - contributes release-request data to the command result
 
+## GitHub Actions verified commit behavior
+
+<!-- {=cliStepOpenReleaseRequestGitHubActionsVerifiedCommitBehavior} -->
+
+When `OpenReleaseRequest` publishes a GitHub release pull request in normal mode, monochange first uses local git as the durable fallback path: it checks out the release branch, stages the tracked release files, creates the release commit, and pushes that branch before opening or updating the pull request.
+
+If the command is running inside GitHub Actions for the same repository as `[source]`, the GitHub provider then tries to replace that pushed fallback commit with a GitHub-verified commit:
+
+1. It builds the GitHub API client from `GITHUB_TOKEN` or `GH_TOKEN`.
+2. It reads the pushed fallback commit through the Git Database API.
+3. It creates a new Git commit object with the same message, tree, and parents.
+4. It accepts the replacement only when GitHub returns `verification.verified = true` for the new commit.
+5. It confirms the release branch still points at the fallback commit, then moves the branch ref to the verified commit.
+
+Any failure keeps the original pushed git commit in place. That includes missing tokens, non-GitHub Actions environments, repository mismatches, GitHub returning an unverified commit, API errors, or the release branch moving between the fallback push and the ref update. The fallback is intentional: release PR automation should keep working even when verified commit replacement is unavailable.
+
+Dry runs never create commits, push branches, or call the provider APIs. Non-GitHub providers continue to use their normal release-request behavior.
+
+<!-- {/cliStepOpenReleaseRequestGitHubActionsVerifiedCommitBehavior} -->
+
 ## Example
 
 <!-- {=cliStepOpenReleaseRequestExample} -->

--- a/monochange.toml
+++ b/monochange.toml
@@ -592,8 +592,9 @@ source = "monochange"
 #   branch_prefix — branch name prefix for release PRs (default: "monochange/release")
 #   base          — target branch for the release PR (default: "main")
 #   title         — PR title template (default: "chore(release): prepare release")
-#   labels        — labels applied to the release PR (default: ["release", "automated"])
-#   auto_merge    — enable auto-merge on the PR when supported (default: false)
+#   labels           — labels applied to the release PR (default: ["release", "automated"])
+#   auto_merge       — enable auto-merge on the PR when supported (default: false)
+#   verified_commits — opt in to provider-verified release PR commits when supported (default: false)
 [source.pull_requests]
 enabled = true
 branch_prefix = "monochange/release"
@@ -601,6 +602,7 @@ base = "main"
 title = "chore(release): prepare release"
 labels = ["release", "automated"]
 auto_merge = false
+verified_commits = true
 
 # [source.bot.changesets] — changeset policy for the AffectedPackages / `mc affected` step
 #

--- a/packages/monochange__cli/README.md
+++ b/packages/monochange__cli/README.md
@@ -138,7 +138,7 @@ monochange can promote one prepared release into several source-provider automat
 - `mc release --dry-run --format json` refreshes the cached manifest and shows downstream automation data, including authored changesets plus linked release context metadata
 - `mc publish-release --dry-run --format json` previews provider release payloads before publishing
 - `mc release-pr --dry-run --format json` previews the release branch, commit, and release-request body
-- when `mc release-pr` runs on GitHub Actions for the configured GitHub repository, the GitHub provider pushes a normal release branch commit first, then attempts to replace it with a Git Database API commit that GitHub reports as verified; if verification or the API update fails, the normal pushed commit remains in place
+- when `[source.pull_requests].verified_commits = true` and `mc release-pr` runs on GitHub Actions for the configured GitHub repository, the GitHub provider pushes a normal release branch commit first, then attempts to replace it with a Git Database API commit that GitHub reports as verified; if verification or the API update fails, the normal pushed commit remains in place
 - `mc release-record --from <tag>` inspects the durable release declaration stored in the release commit body
 - `mc tag-release --from HEAD --dry-run --format json` previews the post-merge release tag set declared by that durable record
 - `mc repair-release --from <tag> --dry-run` previews a release-retarget plan before mutating tags

--- a/packages/monochange__cli/README.md
+++ b/packages/monochange__cli/README.md
@@ -138,6 +138,7 @@ monochange can promote one prepared release into several source-provider automat
 - `mc release --dry-run --format json` refreshes the cached manifest and shows downstream automation data, including authored changesets plus linked release context metadata
 - `mc publish-release --dry-run --format json` previews provider release payloads before publishing
 - `mc release-pr --dry-run --format json` previews the release branch, commit, and release-request body
+- when `mc release-pr` runs on GitHub Actions for the configured GitHub repository, the GitHub provider pushes a normal release branch commit first, then attempts to replace it with a Git Database API commit that GitHub reports as verified; if verification or the API update fails, the normal pushed commit remains in place
 - `mc release-record --from <tag>` inspects the durable release declaration stored in the release commit body
 - `mc tag-release --from HEAD --dry-run --format json` previews the post-merge release tag set declared by that durable record
 - `mc repair-release --from <tag> --dry-run` previews a release-retarget plan before mutating tags

--- a/readme.md
+++ b/readme.md
@@ -204,7 +204,7 @@ monochange can promote one prepared release into several source-provider automat
 - `mc release --dry-run --format json` refreshes the cached manifest and shows downstream automation data, including authored changesets plus linked release context metadata
 - `mc publish-release --dry-run --format json` previews provider release payloads before publishing
 - `mc release-pr --dry-run --format json` previews the release branch, commit, and release-request body
-- when `mc release-pr` runs on GitHub Actions for the configured GitHub repository, the GitHub provider pushes a normal release branch commit first, then attempts to replace it with a Git Database API commit that GitHub reports as verified; if verification or the API update fails, the normal pushed commit remains in place
+- when `[source.pull_requests].verified_commits = true` and `mc release-pr` runs on GitHub Actions for the configured GitHub repository, the GitHub provider pushes a normal release branch commit first, then attempts to replace it with a Git Database API commit that GitHub reports as verified; if verification or the API update fails, the normal pushed commit remains in place
 - `mc release-record --from <tag>` inspects the durable release declaration stored in the release commit body
 - `mc tag-release --from HEAD --dry-run --format json` previews the post-merge release tag set declared by that durable record
 - `mc repair-release --from <tag> --dry-run` previews a release-retarget plan before mutating tags

--- a/readme.md
+++ b/readme.md
@@ -204,6 +204,7 @@ monochange can promote one prepared release into several source-provider automat
 - `mc release --dry-run --format json` refreshes the cached manifest and shows downstream automation data, including authored changesets plus linked release context metadata
 - `mc publish-release --dry-run --format json` previews provider release payloads before publishing
 - `mc release-pr --dry-run --format json` previews the release branch, commit, and release-request body
+- when `mc release-pr` runs on GitHub Actions for the configured GitHub repository, the GitHub provider pushes a normal release branch commit first, then attempts to replace it with a Git Database API commit that GitHub reports as verified; if verification or the API update fails, the normal pushed commit remains in place
 - `mc release-record --from <tag>` inspects the durable release declaration stored in the release commit body
 - `mc tag-release --from HEAD --dry-run --format json` previews the post-merge release tag set declared by that durable record
 - `mc repair-release --from <tag> --dry-run` previews a release-retarget plan before mutating tags


### PR DESCRIPTION
## Summary
- attempt GitHub Git Database API replacement commits for release PR branches when running in GitHub Actions
- keep the pushed git commit as the fallback unless GitHub reports the replacement commit as verified and the branch still points at the fallback SHA
- cover verified and unverified API responses with monochange_github tests

## Validation
- cargo fmt --all
- cargo test -p monochange_github
- cargo clippy -p monochange_github --all-targets -- -D warnings
- cargo run -p monochange --bin mc -- validate
- git diff --check