### PR TITLE
docs: document ecosystem support

### DIFF
--- a/.changeset/ecosystem-documentation.md
+++ b/.changeset/ecosystem-documentation.md
@@ -1,0 +1,11 @@
+---
+monochange: patch
+monochange_python: patch
+"@monochange/skill": patch
+---
+
+#### Document supported ecosystem capabilities
+
+The documentation now includes a dedicated ecosystem guide that compares Cargo, npm-family, Deno, Dart / Flutter, and Python support across discovery, manifest updates, lockfile handling, and built-in registry publishing. Python is documented as a supported release-planning ecosystem with uv workspace discovery, Poetry and PEP 621 `pyproject.toml` parsing, Python dependency normalization, manifest version rewrites, internal dependency rewrites, and inferred `uv lock` / `poetry lock --no-update` lockfile commands.
+
+The guide also clarifies the current publishing boundary: Python packages participate in monochange release planning, but PyPI publication remains external for now and should use `mode = "external"` or custom CI until built-in PyPI publishing exists.

--- a/.templates/crates.t.md
+++ b/.templates/crates.t.md
@@ -8,7 +8,7 @@
 
 `monochange` is the top-level entry point for the workspace.
 
-Reach for this crate when you want one API and CLI surface that discovers packages across Cargo, npm/pnpm/Bun, Deno, and Dart/Flutter workspaces, exposes top-level commands from `monochange.toml`, and runs configured CLI commands from those definitions.
+Reach for this crate when you want one API and CLI surface that discovers packages across Cargo, npm/pnpm/Bun, Deno, Dart/Flutter, and Python workspaces, exposes top-level commands from `monochange.toml`, and runs configured CLI commands from those definitions.
 
 ## Why use it?
 
@@ -542,6 +542,42 @@ Reach for this crate when you need to scan `pubspec.yaml` files, expand Dart or 
 - normalized dependency extraction
 
 <!-- {/monochangeDartCrateDocs} -->
+
+<!-- {@monochangePythonCrateDocs} -->
+
+`monochange_python` discovers Python packages for the shared planner.
+
+Reach for this crate when you need to scan uv workspaces, Poetry projects, and standalone `pyproject.toml` packages, then normalize package metadata and dependency edges into `monochange_core` records.
+
+## Why use it?
+
+- cover uv workspaces, Poetry projects, and standalone PEP 621 packages with one adapter
+- normalize Python names and dependency edges for shared release planning
+- infer package-manager lockfile refresh commands without directly mutating fragile lockfiles
+
+## Best for
+
+- scanning Python monorepos into normalized workspace records
+- adding Python package versions and dependency edges to a mixed-language release plan
+- refreshing `uv.lock` or `poetry.lock` through native package-manager commands after manifest updates
+
+## Public entry points
+
+- `discover_python_packages(root)` discovers uv workspace members plus standalone Python packages
+- `PythonAdapter` exposes the shared adapter interface
+
+## Scope
+
+- uv workspace member expansion
+- `pyproject.toml` parsing for PEP 621 `[project]` and Poetry `[tool.poetry]` metadata
+- PEP 503-style dependency name normalization
+- PEP 440 version parsing into the shared semantic-version model when possible
+- dependency extraction from PEP 621 runtime and optional dependencies
+- dependency extraction from Poetry runtime dependencies and dependency groups
+- version and internal dependency rewrites for `pyproject.toml`
+- lockfile command inference for `uv.lock` and `poetry.lock`
+
+<!-- {/monochangePythonCrateDocs} -->
 
 <!-- {@monochangeSemverCrateDocs} -->
 

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -105,24 +105,25 @@ These are the commands most repositories use after running `mc init`. With the n
 
 <!-- {/projectCommandAutomationMatrix} -->
 
-`mc publish-readiness` performs non-mutating registry checks before `mc publish`. For built-in Cargo publishes to crates.io it also verifies current manifest publishability: `publish = false` blocks publishing, `publish = [...]` must include `crates-io`, `description` must be set, and either `license` or `license-file` must be set. Workspace-inherited Cargo metadata is accepted, and already-published versions remain non-blocking when the readiness artifact still matches the current package set. `mc publish-plan --readiness <path>` validates the same artifact for planning and limits rate-limit batches to package ids that are ready in both the artifact and the fresh local readiness check.
+`mc publish-readiness` performs non-mutating registry checks before `mc publish`. For built-in Cargo publishes to crates.io it also verifies current manifest publishability: `publish = false` blocks publishing, `publish = [...]` must include `crates-io`, `description` must be set, and either `license` or `license-file` must be set. Workspace-inherited Cargo metadata is accepted, and already-published versions remain non-blocking when the readiness artifact still matches the current package set. `mc publish-plan --readiness <path>` validates the same artifact for planning and limits rate-limit batches to package ids that are ready in both the artifact and the fresh local readiness check. Python packages participate in discovery and release planning, but PyPI publishing should use `mode = "external"` or a custom CI command today.
 
 <!-- {@projectCapabilityMatrix} -->
 
-| Capability                                                               | Current status                                                                               |
-| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
-| Multi-ecosystem discovery                                                | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter                                                     |
-| Package release planning                                                 | Built in                                                                                     |
-| Grouped/shared versioning                                                | Built in                                                                                     |
-| Dry-run release diff previews                                            | Built in via `mc release --dry-run --diff`                                                   |
-| Durable release history and post-merge tagging                           | Built in via `ReleaseRecord`, `mc release-record`, `mc tag-release`, and `mc repair-release` |
-| Hosted provider releases                                                 | GitHub, GitLab, Gitea                                                                        |
-| Hosted release requests                                                  | GitHub, GitLab, Gitea                                                                        |
-| Built-in registry publishing                                             | `crates.io`, `npm`, `jsr`, `pub.dev`                                                         |
-| GitHub npm trusted-publishing automation                                 | Built in                                                                                     |
-| GitHub trusted-publishing guidance for `crates.io`, `jsr`, and `pub.dev` | Built in, but manual registry enrollment is still required                                   |
-| GitLab trusted-publishing auto-derivation                                | Not built in today                                                                           |
-| Release-retarget sync for hosted releases                                | GitHub first                                                                                 |
+| Capability                                                               | Current status                                                                                |
+| ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| Multi-ecosystem discovery                                                | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, Python                                              |
+| Package release planning                                                 | Built in                                                                                      |
+| Grouped/shared versioning                                                | Built in                                                                                      |
+| Dry-run release diff previews                                            | Built in via `mc release --dry-run --diff`                                                    |
+| Durable release history and post-merge tagging                           | Built in via `ReleaseRecord`, `mc release-record`, `mc tag-release`, and `mc repair-release`  |
+| Hosted provider releases                                                 | GitHub, GitLab, Gitea                                                                         |
+| Hosted release requests                                                  | GitHub, GitLab, Gitea                                                                         |
+| Python release planning                                                  | Built in for discovery, version rewrites, dependency rewrites, and lockfile command inference |
+| Built-in registry publishing                                             | `crates.io`, `npm`, `jsr`, `pub.dev`; use external mode for PyPI and custom registries        |
+| GitHub npm trusted-publishing automation                                 | Built in                                                                                      |
+| GitHub trusted-publishing guidance for `crates.io`, `jsr`, and `pub.dev` | Built in, but manual registry enrollment is still required                                    |
+| GitLab trusted-publishing auto-derivation                                | Not built in today                                                                            |
+| Release-retarget sync for hosted releases                                | GitHub first                                                                                  |
 
 <!-- {/projectCapabilityMatrix} -->
 

--- a/crates/monochange/readme.md
+++ b/crates/monochange/readme.md
@@ -14,7 +14,7 @@
 
 `monochange` is the top-level entry point for the workspace.
 
-Reach for this crate when you want one API and CLI surface that discovers packages across Cargo, npm/pnpm/Bun, Deno, and Dart/Flutter workspaces, exposes top-level commands from `monochange.toml`, and runs configured CLI commands from those definitions.
+Reach for this crate when you want one API and CLI surface that discovers packages across Cargo, npm/pnpm/Bun, Deno, Dart/Flutter, and Python workspaces, exposes top-level commands from `monochange.toml`, and runs configured CLI commands from those definitions.
 
 ## Why use it?
 

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -3,7 +3,7 @@
 //! <!-- {=monochangeCrateDocs|trim|linePrefix:"//! ":true} -->
 //! `monochange` is the top-level entry point for the workspace.
 //!
-//! Reach for this crate when you want one API and CLI surface that discovers packages across Cargo, npm/pnpm/Bun, Deno, and Dart/Flutter workspaces, exposes top-level commands from `monochange.toml`, and runs configured CLI commands from those definitions.
+//! Reach for this crate when you want one API and CLI surface that discovers packages across Cargo, npm/pnpm/Bun, Deno, Dart/Flutter, and Python workspaces, exposes top-level commands from `monochange.toml`, and runs configured CLI commands from those definitions.
 //!
 //! ## Why use it?
 //!

--- a/crates/monochange_python/readme.md
+++ b/crates/monochange_python/readme.md
@@ -1,0 +1,47 @@
+# `monochange_python`
+
+<br />
+
+<!-- {=crateReadmeBadgeRow:"monochange_python"} -->
+
+[![Crates.io](https://img.shields.io/badge/crates.io-monochange__python-orange?logo=rust)](https://crates.io/crates/monochange_python) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__python-1f425f?logo=docs.rs)](https://docs.rs/monochange_python/) [![CI](https://github.com/monochange/monochange/actions/workflows/ci.yml/badge.svg)](https://github.com/monochange/monochange/actions/workflows/ci.yml) [![Coverage](https://codecov.io/gh/monochange/monochange/branch/main/graph/badge.svg?flag=monochange_python)](https://codecov.io/gh/monochange/monochange?flag=monochange_python) [![License](https://img.shields.io/badge/license-Unlicense-blue.svg)](https://opensource.org/license/unlicense)
+
+<!-- {/crateReadmeBadgeRow} -->
+
+<br />
+
+<!-- {=monochangePythonCrateDocs} -->
+
+`monochange_python` discovers Python packages for the shared planner.
+
+Reach for this crate when you need to scan uv workspaces, Poetry projects, and standalone `pyproject.toml` packages, then normalize package metadata and dependency edges into `monochange_core` records.
+
+## Why use it?
+
+- cover uv workspaces, Poetry projects, and standalone PEP 621 packages with one adapter
+- normalize Python names and dependency edges for shared release planning
+- infer package-manager lockfile refresh commands without directly mutating fragile lockfiles
+
+## Best for
+
+- scanning Python monorepos into normalized workspace records
+- adding Python package versions and dependency edges to a mixed-language release plan
+- refreshing `uv.lock` or `poetry.lock` through native package-manager commands after manifest updates
+
+## Public entry points
+
+- `discover_python_packages(root)` discovers uv workspace members plus standalone Python packages
+- `PythonAdapter` exposes the shared adapter interface
+
+## Scope
+
+- uv workspace member expansion
+- `pyproject.toml` parsing for PEP 621 `[project]` and Poetry `[tool.poetry]` metadata
+- PEP 503-style dependency name normalization
+- PEP 440 version parsing into the shared semantic-version model when possible
+- dependency extraction from PEP 621 runtime and optional dependencies
+- dependency extraction from Poetry runtime dependencies and dependency groups
+- version and internal dependency rewrites for `pyproject.toml`
+- lockfile command inference for `uv.lock` and `poetry.lock`
+
+<!-- {/monochangePythonCrateDocs} -->

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -8,6 +8,7 @@
 - [Installation](guide/01-installation.md)
 - [Your first release plan](guide/02-setup.md)
 - [Discovery](guide/03-discovery.md)
+- [Ecosystems](guide/ecosystems.md)
 - [Configuration reference](guide/04-configuration.md)
 - [Groups and shared release identity](guide/05-version-groups.md)
 - [Release planning](guide/06-release-planning.md)

--- a/docs/src/guide/03-discovery.md
+++ b/docs/src/guide/03-discovery.md
@@ -1,6 +1,6 @@
 # Discovery
 
-`monochange` discovers packages from native manifests and workspace definitions.
+`monochange` discovers packages from native manifests and workspace definitions. For a capability-by-capability comparison of each adapter, see [Ecosystems](./ecosystems.md).
 
 Supported sources today:
 

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -64,6 +64,7 @@ Supported `type` values:
 - `deno`
 - `dart`
 - `flutter`
+- `python`
 
 Optional package fields:
 
@@ -167,7 +168,7 @@ Built-in publishing currently targets only the canonical public registry for eac
 - Deno packages → `jsr`
 - Dart / Flutter packages → `pub.dev`
 
-If you need a private or custom registry, set `mode = "external"` and handle publication outside monochange.
+Python package discovery and release planning are supported, but built-in PyPI publishing is not available yet. For Python packages, private registries, or any other custom publication flow, set `mode = "external"` and handle publication outside monochange.
 
 ### Placeholder publishing
 
@@ -343,7 +344,7 @@ Built-in direct lockfile updates cover:
 - Deno: `deno.lock`
 - Dart / Flutter: `pubspec.lock`
 
-For Python projects, monochange infers package-manager lockfile commands instead of mutating lockfiles directly: `uv.lock` uses `uv lock`, and `poetry.lock` uses `poetry lock --no-update`.
+For Python projects, monochange infers package-manager lockfile commands instead of mutating lockfiles directly: `uv.lock` uses `uv lock`, and `poetry.lock` uses `poetry lock --no-update`. Unknown Python lockfile names are skipped rather than guessed.
 
 If you configure `lockfile_commands` for an ecosystem, monochange stops using the built-in direct updater for that ecosystem and those commands fully own lockfile refresh. Use that escape hatch only when your workspace needs package-manager-side regeneration beyond version rewrites.
 

--- a/docs/src/guide/07-trusted-publishing.md
+++ b/docs/src/guide/07-trusted-publishing.md
@@ -7,7 +7,7 @@ monochange supports built-in package publishing for the canonical public registr
 - Deno packages → `jsr`
 - Dart / Flutter packages → `pub.dev`
 
-For those registries, monochange can also manage or verify **trusted publishing** when the registry supports publishing directly from a verified GitHub Actions identity.
+For those registries, monochange can also manage or verify **trusted publishing** when the registry supports publishing directly from a verified GitHub Actions identity. Python packages are supported for release planning, but PyPI publishing and PyPI trusted-publisher setup are external to monochange today.
 
 Different registries use different names for the same general pattern:
 
@@ -31,7 +31,7 @@ The goal is the same in every case:
 | deno           | jsr       | GitHub Actions publishing | Yes                         | Reports the setup URL; repository linking is still manual                             |
 | dart / flutter | pub.dev   | Automated publishing      | Yes                         | Reports the setup URL; admin-page setup is still manual                               |
 
-npm is currently the only ecosystem where monochange performs bulk trusted-publishing setup itself.
+npm is currently the only ecosystem where monochange performs bulk trusted-publishing setup itself. Use `mode = "external"` for Python/PyPI and for any registry workflow that should stay outside monochange's built-in publisher.
 
 For `crates.io`, `jsr`, and `pub.dev`, monochange reports the setup URL for each package and blocks the next built-in registry publish until the trust configuration has been completed manually. It also preflights the GitHub trusted-publishing context for those registries, surfacing the repository, workflow, and environment it expects when that context can be resolved.
 

--- a/docs/src/guide/10-migrating-from-knope.md
+++ b/docs/src/guide/10-migrating-from-knope.md
@@ -6,20 +6,20 @@ monochange was originally inspired by knope and shares many of the same ideas â€
 
 ## Quick comparison
 
-| Feature                | knope                         | monochange                                |
-| ---------------------- | ----------------------------- | ----------------------------------------- |
-| Config file            | `knope.toml`                  | `monochange.toml`                         |
-| CLI binary             | `knope`                       | `monochange` / `mc`                       |
-| Changeset directory    | `.changeset/`                 | `.changeset/`                             |
-| Changeset format       | Markdown frontmatter          | Markdown frontmatter                      |
-| Conventional commits   | Supported                     | Not supported                             |
-| Single-package config  | `[package]`                   | `[package.<id>]`                          |
-| Multi-package config   | `[packages.<name>]`           | `[package.<id>]`                          |
-| Version groups         | Implicit (single `[package]`) | Explicit `[group.<id>]`                   |
-| Workflows              | `[[workflows]]`               | `[cli.<command>]`                         |
-| GitHub config          | `[github]`                    | `[source]` (provider-neutral)             |
-| Ecosystem support      | Rust, Go, JS                  | Rust, npm, pnpm, Bun, Deno, Dart, Flutter |
-| Dependency propagation | Not built-in                  | Automatic parent bumps                    |
+| Feature                | knope                         | monochange                                        |
+| ---------------------- | ----------------------------- | ------------------------------------------------- |
+| Config file            | `knope.toml`                  | `monochange.toml`                                 |
+| CLI binary             | `knope`                       | `monochange` / `mc`                               |
+| Changeset directory    | `.changeset/`                 | `.changeset/`                                     |
+| Changeset format       | Markdown frontmatter          | Markdown frontmatter                              |
+| Conventional commits   | Supported                     | Not supported                                     |
+| Single-package config  | `[package]`                   | `[package.<id>]`                                  |
+| Multi-package config   | `[packages.<name>]`           | `[package.<id>]`                                  |
+| Version groups         | Implicit (single `[package]`) | Explicit `[group.<id>]`                           |
+| Workflows              | `[[workflows]]`               | `[cli.<command>]`                                 |
+| GitHub config          | `[github]`                    | `[source]` (provider-neutral)                     |
+| Ecosystem support      | Rust, Go, JS                  | Rust, npm, pnpm, Bun, Deno, Dart, Flutter, Python |
+| Dependency propagation | Not built-in                  | Automatic parent bumps                            |
 
 ## Step 1 â€” Replace the config file
 

--- a/docs/src/guide/13-ci-and-publishing.md
+++ b/docs/src/guide/13-ci-and-publishing.md
@@ -54,20 +54,21 @@ Keeping those layers separate is important. Package publication and hosted-relea
 
 <!-- {=projectCapabilityMatrix} -->
 
-| Capability                                                               | Current status                                                                               |
-| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
-| Multi-ecosystem discovery                                                | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter                                                     |
-| Package release planning                                                 | Built in                                                                                     |
-| Grouped/shared versioning                                                | Built in                                                                                     |
-| Dry-run release diff previews                                            | Built in via `mc release --dry-run --diff`                                                   |
-| Durable release history and post-merge tagging                           | Built in via `ReleaseRecord`, `mc release-record`, `mc tag-release`, and `mc repair-release` |
-| Hosted provider releases                                                 | GitHub, GitLab, Gitea                                                                        |
-| Hosted release requests                                                  | GitHub, GitLab, Gitea                                                                        |
-| Built-in registry publishing                                             | `crates.io`, `npm`, `jsr`, `pub.dev`                                                         |
-| GitHub npm trusted-publishing automation                                 | Built in                                                                                     |
-| GitHub trusted-publishing guidance for `crates.io`, `jsr`, and `pub.dev` | Built in, but manual registry enrollment is still required                                   |
-| GitLab trusted-publishing auto-derivation                                | Not built in today                                                                           |
-| Release-retarget sync for hosted releases                                | GitHub first                                                                                 |
+| Capability                                                               | Current status                                                                                |
+| ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| Multi-ecosystem discovery                                                | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, Python                                              |
+| Package release planning                                                 | Built in                                                                                      |
+| Grouped/shared versioning                                                | Built in                                                                                      |
+| Dry-run release diff previews                                            | Built in via `mc release --dry-run --diff`                                                    |
+| Durable release history and post-merge tagging                           | Built in via `ReleaseRecord`, `mc release-record`, `mc tag-release`, and `mc repair-release`  |
+| Hosted provider releases                                                 | GitHub, GitLab, Gitea                                                                         |
+| Hosted release requests                                                  | GitHub, GitLab, Gitea                                                                         |
+| Python release planning                                                  | Built in for discovery, version rewrites, dependency rewrites, and lockfile command inference |
+| Built-in registry publishing                                             | `crates.io`, `npm`, `jsr`, `pub.dev`; use external mode for PyPI and custom registries        |
+| GitHub npm trusted-publishing automation                                 | Built in                                                                                      |
+| GitHub trusted-publishing guidance for `crates.io`, `jsr`, and `pub.dev` | Built in, but manual registry enrollment is still required                                    |
+| GitLab trusted-publishing auto-derivation                                | Not built in today                                                                            |
+| Release-retarget sync for hosted releases                                | GitHub first                                                                                  |
 
 <!-- {/projectCapabilityMatrix} -->
 
@@ -76,7 +77,7 @@ Keeping those layers separate is important. Package publication and hosted-relea
 The workflow sketches below assume the job already has:
 
 - the `monochange` CLI available as `mc`
-- the native ecosystem toolchain it needs (`npm`/`pnpm`, `cargo`, `deno`, `dart`, or `flutter`)
+- the native ecosystem toolchain it needs (`npm`/`pnpm`, `cargo`, `deno`, `dart`, `flutter`, `uv`, `poetry`, or your Python publishing tool)
 - repository checkout with enough history for release-record inspection
 
 In the monochange repository itself, that usually means entering the `devenv` shell. In other repositories, it may mean installing `@monochange/cli` or `monochange` explicitly before the publish step.

--- a/docs/src/guide/ecosystems.md
+++ b/docs/src/guide/ecosystems.md
@@ -1,0 +1,183 @@
+# Ecosystems
+
+monochange uses ecosystem adapters to translate native package-manager files into one release-planning model. Each adapter answers the same questions:
+
+- which package manifests exist in the repository?
+- which packages depend on other packages?
+- where should a package version and internal dependency references be rewritten during a release?
+- should lockfiles be rewritten directly, refreshed with a command, or left to external tooling?
+- can monochange publish the package directly, or should publication stay external?
+
+## Capability matrix
+
+| Ecosystem      | Package type      | Discovery sources                                                                       | Version and dependency updates                                                             | Lockfile behavior                                                                                                                                       | Built-in registry publishing                                         |
+| -------------- | ----------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Cargo          | `cargo`           | `Cargo.toml` workspaces and standalone crates                                           | `Cargo.toml` package versions and internal dependency requirements                         | Direct `Cargo.lock` rewrite by default; configure `cargo generate-lockfile`, `cargo check`, or another command when you need package-manager resolution | `crates.io`                                                          |
+| npm-family     | `npm`             | npm workspaces, pnpm workspaces, Bun workspaces, and standalone `package.json` packages | `package.json` versions and dependency ranges                                              | Direct `package-lock.json`, `pnpm-lock.yaml`, `bun.lock`, and `bun.lockb` updates by default; command overrides support package-manager refreshes       | `npm`                                                                |
+| Deno           | `deno`            | Deno workspaces and standalone `deno.json` / `deno.jsonc` packages                      | Deno manifest versions, exports/imports metadata, and dependency references                | Direct `deno.lock` update when possible; no inferred lockfile command                                                                                   | `jsr`                                                                |
+| Dart / Flutter | `dart`, `flutter` | Dart and Flutter workspaces plus standalone `pubspec.yaml` packages                     | `pubspec.yaml` versions and dependency ranges                                              | Direct `pubspec.lock` update by default; configure `dart pub get` or `flutter pub get` when you need full solver refreshes                              | `pub.dev`                                                            |
+| Python         | `python`          | uv workspaces, Poetry projects, and standalone `pyproject.toml` packages                | PEP 621 `[project]` and Poetry `[tool.poetry]` package versions plus dependency specifiers | Does not mutate `uv.lock` or `poetry.lock` directly; infers `uv lock` and `poetry lock --no-update` commands; unknown Python lockfiles are skipped      | Not built in; use `mode = "external"` for PyPI or private registries |
+
+The built-in publishing column is intentionally narrower than release planning. Python packages are fully supported for discovery, changesets, release plans, version rewrites, internal dependency rewrites, and lockfile command inference, but monochange does not publish to PyPI yet.
+
+## Shared behavior across ecosystems
+
+All supported ecosystems feed the same planner. After discovery, monochange can:
+
+- render package ids and manifest paths relative to the repository root
+- normalize dependency edges into one graph
+- apply `[group.<id>]` version synchronization rules
+- propagate dependent bumps through internal dependency edges
+- update native manifests during `mc release`
+- update extra `versioned_files` entries, including regex-managed files
+- render changelogs and release notes from `.changeset/*.md`
+- create durable release records and post-merge tags
+
+`[ecosystems.<name>]` configuration currently controls settings such as dependency-version prefixes, extra versioned files, publish defaults, and lockfile commands. Discovery still scans every supported ecosystem regardless of `[ecosystems.*].enabled`, `roots`, or `exclude` toggles.
+
+## Cargo
+
+Cargo support is designed for Rust crates that keep version data in `Cargo.toml` and dependency resolution in `Cargo.lock`.
+
+Use Cargo support when your repository has:
+
+- a root Cargo workspace with `members`
+- standalone crates outside a workspace
+- internal crate dependencies that should move together when one crate is released
+- crates published to `crates.io`
+
+Cargo-specific behavior:
+
+- package ids come from each crate manifest
+- dependency references use Cargo's native requirement style; the default dependency version prefix is empty
+- `Cargo.lock` is updated directly by default for fast release preparation
+- incomplete or complex lockfile cases can be delegated to explicit lockfile commands
+- built-in publishing targets `crates.io`
+- publish readiness validates common crates.io requirements, including `publish`, `description`, and license metadata
+
+## npm, pnpm, and Bun
+
+The npm-family adapter covers JavaScript and TypeScript packages that share `package.json` as their manifest format.
+
+Use npm-family support when your repository has:
+
+- npm workspaces declared in `package.json`
+- pnpm workspaces declared in `pnpm-workspace.yaml`
+- Bun workspaces and Bun lockfiles
+- standalone `package.json` packages
+- internal workspace dependencies that use npm-compatible version ranges
+
+npm-family behavior:
+
+- package ids come from `package.json` names
+- internal dependency ranges default to the `^` prefix
+- `dependencies`, `devDependencies`, and `peerDependencies` participate in dependency updates
+- direct lockfile support covers `package-lock.json`, `pnpm-lock.yaml`, `bun.lock`, and `bun.lockb`
+- built-in publishing targets the public `npm` registry
+- GitHub npm trusted-publishing automation is built in; pnpm workspaces use pnpm-compatible trust and publish commands
+
+## Deno
+
+Deno support is for packages described by `deno.json` or `deno.jsonc`, including workspaces that publish to JSR.
+
+Use Deno support when your repository has:
+
+- `deno.json` or `deno.jsonc` package manifests
+- Deno workspace members
+- `imports` entries that connect internal packages
+- packages published to `jsr`
+
+Deno behavior:
+
+- internal dependency ranges default to `^`
+- `imports` are the primary dependency field
+- `deno.lock` can be updated directly when present
+- monochange does not infer a default Deno lockfile command; configure one if your release flow needs `deno cache`, `deno task`, or another resolver step
+- built-in publishing targets `jsr`
+
+## Dart and Flutter
+
+Dart and Flutter share the Dart ecosystem settings because both use `pubspec.yaml` and Pub's version constraints.
+
+Use Dart / Flutter support when your repository has:
+
+- pure Dart packages
+- Flutter packages with a `flutter` section
+- Dart or Flutter workspace layouts
+- packages published to `pub.dev`
+
+Dart / Flutter behavior:
+
+- package type is `dart` for pure Dart packages and `flutter` for Flutter packages
+- internal dependency ranges default to `^`
+- `dependencies` and `dev_dependencies` participate in dependency updates
+- `pubspec.lock` can be rewritten directly by default
+- configure `dart pub get` or `flutter pub get` as lockfile commands when you need the Pub solver to refresh files instead of the direct updater
+- built-in publishing targets `pub.dev`
+
+## Python
+
+Python support is centered on `pyproject.toml`. It covers modern PEP 621 projects, Poetry projects, uv workspaces, and standalone packages discovered by scanning for manifests.
+
+Use Python support when your repository has:
+
+- a uv workspace declared under `[tool.uv.workspace]`
+- PEP 621 package metadata under `[project]`
+- Poetry package metadata under `[tool.poetry]`
+- standalone Python packages with `pyproject.toml`
+- internal dependencies that should receive version bumps alongside released workspace packages
+
+Python discovery works in two passes:
+
+1. If the repository root has a `pyproject.toml` with uv workspace members, monochange expands the member globs and reads each member manifest.
+2. monochange then scans for standalone `pyproject.toml` files that were not already included by the uv workspace pass.
+
+When a manifest has both PEP 621 and Poetry metadata, monochange prefers `[project]`. If `[project].dynamic` contains `"version"`, monochange treats the package version as dynamic and does not rewrite the version field.
+
+Python version and dependency behavior:
+
+- package names and dependency names are normalized using Python's PEP 503 style normalization for dependency graph matching
+- PEP 440 versions are parsed into the shared semantic-version model when possible
+- internal dependency ranges default to the `>=` prefix
+- PEP 621 `dependencies` are runtime dependencies
+- PEP 621 `optional-dependencies` are development/optional dependency edges for release-planning purposes
+- Poetry `dependencies` are runtime dependencies, except the special `python` constraint is skipped
+- Poetry dependency groups under `[tool.poetry.group.<name>.dependencies]` are development dependencies
+- release preparation rewrites `pyproject.toml` package versions and matching dependency specifiers while preserving extras such as `httpx[cli]`
+
+Python lockfile behavior is command-based by design:
+
+- `uv.lock` infers `uv lock`
+- `poetry.lock` infers `poetry lock --no-update`
+- unknown Python lockfile names are ignored rather than guessed
+- configuring `[ecosystems.python].lockfile_commands` overrides the inferred commands
+
+Python publishing is external today. Keep package release planning in monochange, but publish with your existing PyPI, uv, Poetry, Hatch, or internal-registry workflow by setting package publishing to `mode = "external"` or by running your own CI step after `mc release`.
+
+Example Python package configuration:
+
+```toml
+[package.api]
+path = "services/api"
+type = "python"
+changelog = true
+
+[ecosystems.python]
+dependency_version_prefix = ">="
+# Optional: override inferred uv/Poetry lockfile commands.
+lockfile_commands = [{ command = "uv lock", cwd = "." }]
+```
+
+## Choosing external publishing
+
+Use `mode = "external"` when an ecosystem or registry is not handled by monochange's built-in publisher, or when your organization needs custom signing, provenance, approval, rate-limit, or private-registry behavior.
+
+For Python, external publishing is currently the expected path:
+
+```toml
+[package.api.publish]
+enabled = true
+mode = "external"
+```
+
+That keeps the package in release planning while leaving upload mechanics to your existing publishing workflow.

--- a/packages/monochange__skill/SKILL.md
+++ b/packages/monochange__skill/SKILL.md
@@ -159,12 +159,12 @@ Release-oriented commands default to markdown output. Use `--format json` for au
 
 ### Lockfile commands
 
-Lockfile refresh is command-driven via `[ecosystems.<name>].lockfile_commands`. monochange infers sensible defaults for Cargo, npm-family, and Dart/Flutter. Explicit configuration overrides inference.
+Lockfile refresh is command-driven via `[ecosystems.<name>].lockfile_commands`. monochange infers sensible defaults for Cargo, npm-family, Dart/Flutter, and Python (`uv lock` / `poetry lock --no-update`). Explicit configuration overrides inference.
 
 ### Publishing and trust
 
 - Package publishing is configured through `publish` on packages and ecosystems.
-- Built-in publishing currently supports only the canonical public registries: `crates.io`, `npm`, `jsr`, and `pub.dev`.
+- Built-in publishing currently supports only the canonical public registries: `crates.io`, `npm`, `jsr`, and `pub.dev`. Python packages are release-planned but PyPI publishing should use `mode = "external"` or custom CI today.
 - `mc publish-readiness` blocks built-in Cargo publishes to crates.io when the current `Cargo.toml` is not publishable: `publish = false`, `publish = [...]` without `crates-io`, missing `description`, or missing both `license` and `license-file`. Workspace-inherited Cargo metadata is accepted.
 - `mc publish-plan --readiness <path>` validates a readiness artifact for the current release record and excludes package ids that are not ready in both the artifact and the fresh local readiness check. Placeholder planning does not accept readiness artifacts.
 - `mc placeholder-publish` exists for first-release bootstrap. It checks whether each managed package already exists in its registry and publishes a placeholder `0.0.0` version only for the missing ones.

--- a/packages/monochange__skill/skills/reference.md
+++ b/packages/monochange__skill/skills/reference.md
@@ -10,6 +10,7 @@ Use it when a repository needs one release-planning model across:
 - npm / pnpm / Bun
 - Deno
 - Dart / Flutter
+- Python
 
 It discovers packages, normalizes dependency relationships, applies package and group rules from `monochange.toml`, reads explicit `.changeset/*.md` files, and turns those inputs into deterministic release plans.
 
@@ -440,7 +441,8 @@ Lockfile refresh is command-driven. monochange infers defaults when not configur
 
 - Cargo: `cargo generate-lockfile`
 - npm-family: detects owned lockfiles and runs the matching command (`npm install --package-lock-only`, `pnpm install --lockfile-only`, `bun install --lockfile-only`)
-- Dart / Flutter: `dart pub get` or `flutter pub get`
+- Dart / Flutter: direct `pubspec.lock` updates by default; configure `dart pub get` or `flutter pub get` when needed
+- Python: `uv.lock` infers `uv lock`, `poetry.lock` infers `poetry lock --no-update`, and unknown Python lockfiles are skipped
 - Deno: no inferred default
 
 Explicit configuration overrides inference:
@@ -469,6 +471,8 @@ Built-in package publishing currently supports only the canonical public registr
 - npm packages → `npm`
 - Deno packages → `jsr`
 - Dart / Flutter packages → `pub.dev`
+
+Python package discovery and release planning are supported, but PyPI publishing is not built in yet. Use `mode = "external"` for Python, private registries, or unsupported publishing flows.
 
 For Cargo, readiness uses the current `Cargo.toml` as a pre-mutation guard. Built-in crates.io publishing is blocked by `publish = false`, by `publish = [...]` when the list omits `crates-io`, by a missing `description`, or by a missing `license`/`license-file`. Workspace-inherited `description`, `license`, and `license-file` values are accepted.
 

--- a/readme.md
+++ b/readme.md
@@ -164,20 +164,21 @@ These are the commands most repositories use after running `mc init`. With the n
 
 <!-- {=projectCapabilityMatrix} -->
 
-| Capability                                                               | Current status                                                                               |
-| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
-| Multi-ecosystem discovery                                                | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter                                                     |
-| Package release planning                                                 | Built in                                                                                     |
-| Grouped/shared versioning                                                | Built in                                                                                     |
-| Dry-run release diff previews                                            | Built in via `mc release --dry-run --diff`                                                   |
-| Durable release history and post-merge tagging                           | Built in via `ReleaseRecord`, `mc release-record`, `mc tag-release`, and `mc repair-release` |
-| Hosted provider releases                                                 | GitHub, GitLab, Gitea                                                                        |
-| Hosted release requests                                                  | GitHub, GitLab, Gitea                                                                        |
-| Built-in registry publishing                                             | `crates.io`, `npm`, `jsr`, `pub.dev`                                                         |
-| GitHub npm trusted-publishing automation                                 | Built in                                                                                     |
-| GitHub trusted-publishing guidance for `crates.io`, `jsr`, and `pub.dev` | Built in, but manual registry enrollment is still required                                   |
-| GitLab trusted-publishing auto-derivation                                | Not built in today                                                                           |
-| Release-retarget sync for hosted releases                                | GitHub first                                                                                 |
+| Capability                                                               | Current status                                                                                |
+| ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| Multi-ecosystem discovery                                                | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, Python                                              |
+| Package release planning                                                 | Built in                                                                                      |
+| Grouped/shared versioning                                                | Built in                                                                                      |
+| Dry-run release diff previews                                            | Built in via `mc release --dry-run --diff`                                                    |
+| Durable release history and post-merge tagging                           | Built in via `ReleaseRecord`, `mc release-record`, `mc tag-release`, and `mc repair-release`  |
+| Hosted provider releases                                                 | GitHub, GitLab, Gitea                                                                         |
+| Hosted release requests                                                  | GitHub, GitLab, Gitea                                                                         |
+| Python release planning                                                  | Built in for discovery, version rewrites, dependency rewrites, and lockfile command inference |
+| Built-in registry publishing                                             | `crates.io`, `npm`, `jsr`, `pub.dev`; use external mode for PyPI and custom registries        |
+| GitHub npm trusted-publishing automation                                 | Built in                                                                                      |
+| GitHub trusted-publishing guidance for `crates.io`, `jsr`, and `pub.dev` | Built in, but manual registry enrollment is still required                                    |
+| GitLab trusted-publishing auto-derivation                                | Not built in today                                                                            |
+| Release-retarget sync for hosted releases                                | GitHub first                                                                                  |
 
 <!-- {/projectCapabilityMatrix} -->
 


### PR DESCRIPTION
## Summary
- add a dedicated ecosystems guide covering Cargo, npm-family, Deno, Dart/Flutter, and Python
- document Python uv, Poetry, and standalone pyproject.toml release-planning behavior
- clarify Python lockfile command inference and current external PyPI publishing flow
- sync shared project, crate, book, and skill documentation blocks

## Validation
- devenv shell docs:update
- devenv shell docs:check
- devenv shell build:book
- mc validate
- git diff --check
- pre-push lint:test and secrets hooks passed