### PR TITLE
ci: guard release tags against non-main commits

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ inputs.tag || github.run_id }}
   cancel-in-progress: true
 
+env:
+  RELEASE_BRANCH: main
+
 jobs:
   plan:
     environment: publisher
@@ -41,6 +44,26 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ steps.release_tag.outputs.tag }}
+          fetch-depth: 0
+
+      - name: verify release tag is on release branch
+        env:
+          RELEASE_TAG: ${{ steps.release_tag.outputs.tag }}
+        shell: bash
+        run: |
+          git fetch --no-tags origin \
+            "+refs/heads/${RELEASE_BRANCH}:refs/remotes/origin/${RELEASE_BRANCH}"
+
+          tag_commit="$(git rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}")"
+          branch_ref="refs/remotes/origin/${RELEASE_BRANCH}"
+
+          echo "Release tag: ${RELEASE_TAG} (${tag_commit})"
+          echo "Release branch: ${branch_ref} ($(git rev-parse --verify "${branch_ref}"))"
+
+          if ! git merge-base --is-ancestor "${tag_commit}" "${branch_ref}"; then
+            echo "::error::Release tag ${RELEASE_TAG} (${tag_commit}) is not reachable from origin/${RELEASE_BRANCH}."
+            exit 1
+          fi
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -128,6 +151,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.plan.outputs.tag }}
+          fetch-depth: 0
 
       - name: setup
         uses: ./.github/actions/devenv

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ inputs.tag || github.event.release.tag_name }}
   cancel-in-progress: true
 
+env:
+  RELEASE_BRANCH: main
+
 jobs:
   upload_assets:
     env:
@@ -57,6 +60,31 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.checkout_ref && github.ref_name || env.RELEASE_TAG }}
+          fetch-depth: 0
+
+      - name: verify release ref is on release branch
+        shell: bash
+        run: |
+          git fetch --no-tags origin \
+            "+refs/heads/${RELEASE_BRANCH}:refs/remotes/origin/${RELEASE_BRANCH}"
+
+          tag_commit="$(git rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}")"
+          branch_ref="refs/remotes/origin/${RELEASE_BRANCH}"
+          checkout_commit="$(git rev-parse --verify HEAD)"
+
+          echo "Release tag: ${RELEASE_TAG} (${tag_commit})"
+          echo "Release branch: ${branch_ref} ($(git rev-parse --verify "${branch_ref}"))"
+          echo "Checked out commit: ${checkout_commit}"
+
+          if ! git merge-base --is-ancestor "${tag_commit}" "${branch_ref}"; then
+            echo "::error::Release tag ${RELEASE_TAG} (${tag_commit}) is not reachable from origin/${RELEASE_BRANCH}."
+            exit 1
+          fi
+
+          if ! git merge-base --is-ancestor "${checkout_commit}" "${branch_ref}"; then
+            echo "::error::Checked out release source ${checkout_commit} is not reachable from origin/${RELEASE_BRANCH}."
+            exit 1
+          fi
 
       - name: install rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary

- add a hard-coded `main` release branch guard to the release workflow
- reject release asset builds when the tag commit is not reachable from `origin/main`
- reject release asset builds when an override checkout ref is not reachable from `origin/main`
- add the same tag reachability guard before publish planning

Closes #310

## Testing

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/release.yml .github/workflows/publish.yml`
- `git diff --check`
- `actionlint .github/workflows/release.yml .github/workflows/publish.yml`
- locally exercised the guard script with `RELEASE_TAG=v0.2.0`
