### PR TITLE
fix(release): stream commit messages via stdin

### DIFF
--- a/.changeset/fix-git-commit-stdin.md
+++ b/.changeset/fix-git-commit-stdin.md
@@ -1,0 +1,10 @@
+---
+"monochange": patch
+"monochange_core": patch
+---
+
+#### make release commits handle large messages reliably
+
+Release commit creation now streams the generated commit message through standard input instead of passing the full release record as a command-line argument. This avoids operating-system argument length limits for large release records.
+
+Git command spawning now reuses a stable path that contains `git`, and benchmark fixture git commands now use monochange's sanitized git command helper with automatic garbage collection disabled for deterministic synthetic history setup in CI.

--- a/crates/monochange/benches/cli_commands.rs
+++ b/crates/monochange/benches/cli_commands.rs
@@ -354,8 +354,6 @@ fn generate_fixture_with_git_history(
 	num_changesets: usize,
 	num_history_commits: usize,
 ) {
-	use std::process::Command;
-
 	// Create workspace structure first (no git yet).
 	generate_fixture(root, num_packages, num_changesets);
 	// Remove changesets — we'll add them interleaved with history.
@@ -367,9 +365,10 @@ fn generate_fixture_with_git_history(
 
 	// Init git repo.
 	let git = |args: &[&str]| {
-		let output = Command::new("git")
+		let output = monochange_core::git::git_command(root)
+			.arg("-c")
+			.arg("gc.auto=0")
 			.args(args)
-			.current_dir(root)
 			.env("GIT_AUTHOR_NAME", "bench")
 			.env("GIT_AUTHOR_EMAIL", "bench@test")
 			.env("GIT_COMMITTER_NAME", "bench")

--- a/crates/monochange/src/git_support.rs
+++ b/crates/monochange/src/git_support.rs
@@ -1,12 +1,15 @@
+use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command as ProcessCommand;
+use std::process::Stdio;
 
 use monochange_core::CommitMessage;
 use monochange_core::MonochangeError;
 use monochange_core::MonochangeResult;
 use monochange_core::git::git_command_output;
-use monochange_core::git::git_commit_paths_command;
+use monochange_core::git::git_commit_message_text;
+use monochange_core::git::git_commit_paths_stdin_command;
 use monochange_core::git::git_error_detail;
 use monochange_core::git::git_stage_paths_command;
 use monochange_core::git::git_stderr_trimmed;
@@ -280,8 +283,9 @@ pub(crate) fn git_commit_paths(
 	message: &CommitMessage,
 	no_verify: bool,
 ) -> MonochangeResult<()> {
-	run_git_process(
-		git_commit_paths_command(root, message, no_verify),
+	run_git_process_with_stdin(
+		git_commit_paths_stdin_command(root, no_verify),
+		git_commit_message_text(message).as_bytes(),
 		"failed to create release commit",
 	)
 }
@@ -302,8 +306,36 @@ pub(crate) fn run_git_process(
 	let output = command
 		.output()
 		.map_err(|error| MonochangeError::Discovery(format!("{error_message}: {error}")))?;
+	handle_git_process_output(&output, error_message)
+}
+
+pub(crate) fn run_git_process_with_stdin(
+	mut command: ProcessCommand,
+	input: &[u8],
+	error_message: &str,
+) -> MonochangeResult<()> {
+	let mut child = command
+		.stdout(Stdio::piped())
+		.stderr(Stdio::piped())
+		.spawn()
+		.map_err(|error| MonochangeError::Discovery(format!("{error_message}: {error}")))?;
+	if let Some(mut stdin) = child.stdin.take() {
+		stdin
+			.write_all(input)
+			.map_err(|error| MonochangeError::Discovery(format!("{error_message}: {error}")))?;
+	}
+	let output = child
+		.wait_with_output()
+		.map_err(|error| MonochangeError::Discovery(format!("{error_message}: {error}")))?;
+	handle_git_process_output(&output, error_message)
+}
+
+fn handle_git_process_output(
+	output: &std::process::Output,
+	error_message: &str,
+) -> MonochangeResult<()> {
 	if !output.status.success() {
-		let stderr = git_error_detail(&output);
+		let stderr = git_error_detail(output);
 		let detail = [error_message, stderr.as_str()]
 			.into_iter()
 			.filter(|part| !part.is_empty())
@@ -357,6 +389,35 @@ mod tests {
 		git(root, &["config", "user.name", "monochange tests"]);
 		git(root, &["config", "user.email", "monochange@example.com"]);
 		git(root, &["config", "commit.gpgsign", "false"]);
+	}
+
+	#[test]
+	fn git_commit_paths_supports_large_commit_message_bodies() {
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let root = tempdir.path();
+		init_git_repo(root);
+		fs::write(root.join("release.txt"), "release\n")
+			.unwrap_or_else(|error| panic!("write release file: {error}"));
+		git(root, &["add", "release.txt"]);
+		git(root, &["commit", "-m", "initial"]);
+
+		fs::write(root.join("release.txt"), "release\nupdated\n")
+			.unwrap_or_else(|error| panic!("update release file: {error}"));
+		git(root, &["add", "release.txt"]);
+		let body = "release record entry\n".repeat(16_384);
+		git_commit_paths(
+			root,
+			&CommitMessage {
+				subject: "chore(release): prepare release".to_string(),
+				body: Some(body.clone()),
+			},
+			false,
+		)
+		.unwrap_or_else(|error| panic!("git commit paths: {error}"));
+
+		let commit_body = git_output(root, &["log", "-1", "--format=%B"]);
+		assert!(commit_body.contains("chore(release): prepare release"));
+		assert!(commit_body.contains(body.trim_end()));
 	}
 
 	#[test]
@@ -472,6 +533,43 @@ mod tests {
 			.err()
 			.unwrap_or_else(|| panic!("expected failed git process"));
 		assert!(error.to_string().contains("process failure"));
+		assert!(
+			error
+				.to_string()
+				.contains("definitely-not-a-real-git-command")
+		);
+	}
+
+	#[test]
+	fn run_git_process_with_stdin_allows_commands_without_piped_stdin() {
+		let mut command = ProcessCommand::new("git");
+		command.arg("--version");
+
+		run_git_process_with_stdin(command, b"message", "stdin process")
+			.unwrap_or_else(|error| panic!("stdin process should succeed: {error}"));
+	}
+
+	#[test]
+	fn run_git_process_with_stdin_reports_spawn_failures() {
+		let command = ProcessCommand::new("definitely-not-a-real-monochange-test-command");
+
+		let error = run_git_process_with_stdin(command, b"message", "stdin process failure")
+			.err()
+			.unwrap_or_else(|| panic!("expected failed stdin git process"));
+		assert!(error.to_string().contains("stdin process failure"));
+	}
+
+	#[test]
+	fn run_git_process_with_stdin_reports_nonzero_exit_status_details() {
+		let mut command = ProcessCommand::new("git");
+		command
+			.arg("definitely-not-a-real-git-command")
+			.stdin(Stdio::piped());
+
+		let error = run_git_process_with_stdin(command, b"message", "stdin process failure")
+			.err()
+			.unwrap_or_else(|| panic!("expected failed stdin git process"));
+		assert!(error.to_string().contains("stdin process failure"));
 		assert!(
 			error
 				.to_string()

--- a/crates/monochange_core/src/git.rs
+++ b/crates/monochange_core/src/git.rs
@@ -2,16 +2,57 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 use std::process::Output;
+use std::process::Stdio;
 
 use crate::CommitMessage;
 use crate::MonochangeError;
 use crate::MonochangeResult;
+
+fn stable_process_path() -> Option<&'static std::ffi::OsStr> {
+	static PATH: std::sync::OnceLock<Option<std::ffi::OsString>> = std::sync::OnceLock::new();
+	PATH.get_or_init(resolve_stable_process_path).as_deref()
+}
+
+fn resolve_stable_process_path() -> Option<std::ffi::OsString> {
+	resolve_process_path(
+		std::env::var_os("PATH"),
+		option_env!("PATH").map(std::ffi::OsString::from),
+	)
+}
+
+fn resolve_process_path(
+	current: Option<std::ffi::OsString>,
+	fallback: Option<std::ffi::OsString>,
+) -> Option<std::ffi::OsString> {
+	if current.as_deref().is_some_and(path_contains_git) {
+		return current;
+	}
+
+	fallback.filter(|path| path_contains_git(path)).or(current)
+}
+
+fn path_contains_git(path: &std::ffi::OsStr) -> bool {
+	std::env::split_paths(path).any(|entry| entry.join(git_executable_name()).is_file())
+}
+
+#[cfg(windows)]
+fn git_executable_name() -> &'static str {
+	"git.exe"
+}
+
+#[cfg(not(windows))]
+fn git_executable_name() -> &'static str {
+	"git"
+}
 
 /// Build a `git` command scoped to `root` with conflicting git env removed.
 #[must_use]
 pub fn git_command(root: &Path) -> Command {
 	let mut command = Command::new("git");
 	command.current_dir(root);
+	if let Some(path) = stable_process_path() {
+		command.env("PATH", path);
+	}
 
 	for variable in [
 		"GIT_DIR",
@@ -46,6 +87,15 @@ pub fn git_stage_paths_command(root: &Path, tracked_paths: &[PathBuf]) -> Comman
 	command
 }
 
+/// Render a complete git commit message from the supplied monochange commit message.
+#[must_use]
+pub fn git_commit_message_text(message: &CommitMessage) -> String {
+	match &message.body {
+		Some(body) => format!("{}\n\n{}", message.subject, body),
+		None => message.subject.clone(),
+	}
+}
+
 /// Build a `git commit` command for the supplied monochange commit message.
 #[must_use]
 pub fn git_commit_paths_command(root: &Path, message: &CommitMessage, no_verify: bool) -> Command {
@@ -58,6 +108,18 @@ pub fn git_commit_paths_command(root: &Path, message: &CommitMessage, no_verify:
 	if let Some(body) = &message.body {
 		command.arg("--message").arg(body);
 	}
+	command
+}
+
+/// Build a `git commit` command that reads the full commit message from stdin.
+#[must_use]
+pub fn git_commit_paths_stdin_command(root: &Path, no_verify: bool) -> Command {
+	let mut command = git_command(root);
+	command.arg("commit");
+	if no_verify {
+		command.arg("--no-verify");
+	}
+	command.arg("--file").arg("-").stdin(Stdio::piped());
 	command
 }
 
@@ -181,4 +243,111 @@ pub fn run_commit_command_allow_nothing_to_commit(
 		"failed to {action}: {}",
 		git_error_detail(&output)
 	)))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn git_command_reuses_stable_path_for_child_processes() {
+		let command = git_command(Path::new("."));
+		let path = command
+			.get_envs()
+			.find_map(|(key, value)| (key == "PATH").then_some(value))
+			.flatten()
+			.unwrap_or_else(|| panic!("expected PATH override"));
+
+		assert!(path_contains_git(path));
+	}
+
+	#[test]
+	fn resolve_process_path_prefers_current_path_when_it_contains_git() {
+		let current = temp_path_with_git();
+		let fallback = tempdir("create fallback dir");
+
+		let path = resolve_process_path(
+			Some(current.path().as_os_str().to_owned()),
+			Some(fallback.path().as_os_str().to_owned()),
+		)
+		.unwrap_or_else(|| panic!("expected current PATH"));
+
+		assert_eq!(path, current.path().as_os_str());
+	}
+
+	#[test]
+	fn resolve_process_path_uses_fallback_when_current_path_lacks_git() {
+		let current = tempdir("create current dir");
+		let fallback = temp_path_with_git();
+
+		let path = resolve_process_path(
+			Some(current.path().as_os_str().to_owned()),
+			Some(fallback.path().as_os_str().to_owned()),
+		)
+		.unwrap_or_else(|| panic!("expected fallback PATH"));
+
+		assert_eq!(path, fallback.path().as_os_str());
+	}
+
+	#[test]
+	fn resolve_process_path_keeps_current_path_when_no_path_contains_git() {
+		let current = tempdir("create current dir");
+		let fallback = tempdir("create fallback dir");
+
+		let path = resolve_process_path(
+			Some(current.path().as_os_str().to_owned()),
+			Some(fallback.path().as_os_str().to_owned()),
+		)
+		.unwrap_or_else(|| panic!("expected current PATH"));
+
+		assert_eq!(path, current.path().as_os_str());
+	}
+
+	fn temp_path_with_git() -> tempfile::TempDir {
+		let directory = tempdir("create PATH dir");
+		std::fs::write(directory.path().join(git_executable_name()), "")
+			.unwrap_or_else(|error| panic!("write git shim: {error}"));
+		directory
+	}
+
+	fn tempdir(context: &str) -> tempfile::TempDir {
+		tempfile::tempdir().unwrap_or_else(|error| panic!("{context}: {error}"))
+	}
+
+	#[test]
+	fn git_commit_message_text_renders_subject_and_body() {
+		let message = CommitMessage {
+			subject: "chore(release): prepare release".to_string(),
+			body: Some("Prepare release.\n\n<!-- release record -->".to_string()),
+		};
+
+		assert_eq!(
+			git_commit_message_text(&message),
+			"chore(release): prepare release\n\nPrepare release.\n\n<!-- release record -->"
+		);
+	}
+
+	#[test]
+	fn git_commit_message_text_renders_subject_without_body() {
+		let message = CommitMessage {
+			subject: "chore(release): prepare release".to_string(),
+			body: None,
+		};
+
+		assert_eq!(
+			git_commit_message_text(&message),
+			"chore(release): prepare release"
+		);
+	}
+
+	#[test]
+	fn git_commit_paths_stdin_command_reads_message_from_stdin() {
+		let command = git_commit_paths_stdin_command(Path::new("."), true);
+		let args = command
+			.get_args()
+			.map(|arg| arg.to_string_lossy().into_owned())
+			.collect::<Vec<_>>();
+
+		assert_eq!(args, vec!["commit", "--no-verify", "--file", "-"]);
+	}
 }


### PR DESCRIPTION
## Summary

- stream release commit messages through `git commit --file -` instead of `-m` arguments so large release records do not hit OS argument length limits
- keep benchmark synthetic git repositories isolated with monochange's sanitized git command helper and disable git auto-gc while generating history
- add regression coverage for large release commit bodies and stdin-backed git process handling

## Validation

- `cargo test -p monochange_core git_commit --lib`
- `cargo test -p monochange git_support::tests::git_commit_paths_supports_large_commit_message_bodies --lib`
- `cargo test -p monochange git_support::tests::run_git_process_with_stdin --lib`
- `cargo test -p monochange --bench cli_commands -- --test`
- `cargo clippy -p monochange_core --all-targets -- -D warnings`
- `cargo clippy -p monochange --lib --benches -- -D warnings`
- `devenv shell mc validate`
- `devenv shell coverage:all`
- `devenv shell coverage:patch` (`PATCH_COVERAGE 118/118 (100.00%)`)
- push hook: 1896 nextest tests passed
