### PR TITLE
feat: add first-class PyPI publishing

### DIFF
--- a/.changeset/ecosystem-documentation.md
+++ b/.changeset/ecosystem-documentation.md
@@ -8,4 +8,4 @@ monochange_python: patch
 
 The documentation now includes a dedicated ecosystem guide that compares Cargo, npm-family, Deno, Dart / Flutter, and Python support across discovery, manifest updates, lockfile handling, and built-in registry publishing. Python is documented as a supported release-planning ecosystem with uv workspace discovery, Poetry and PEP 621 `pyproject.toml` parsing, Python dependency normalization, manifest version rewrites, internal dependency rewrites, and inferred `uv lock` / `poetry lock --no-update` lockfile commands.
 
-The guide also clarifies the current publishing boundary: Python packages participate in monochange release planning, but PyPI publication remains external for now and should use `mode = "external"` or custom CI until built-in PyPI publishing exists.
+The guide also clarifies ecosystem publishing boundaries, including canonical public registry support and the external-mode escape hatch for private registries or custom publication flows.

--- a/.changeset/feat-python-pypi-publishing.md
+++ b/.changeset/feat-python-pypi-publishing.md
@@ -1,0 +1,8 @@
+---
+"@monochange/cli": minor
+monochange: minor
+monochange_config: minor
+monochange_core: minor
+---
+
+Add first-class PyPI publishing support for Python packages, including PyPI as the built-in Python registry, placeholder package generation, `uv build` / `uv publish` command generation, PyPI JSON API publication checks, trusted-publisher setup guidance, and rate-limit planning coverage.

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -107,25 +107,25 @@ These are the commands most repositories use after running `mc init`. With the n
 
 <!-- {/projectCommandAutomationMatrix} -->
 
-`mc publish-readiness` performs non-mutating registry checks before `mc publish`. For built-in Cargo publishes to crates.io it also verifies current manifest publishability: `publish = false` blocks publishing, `publish = [...]` must include `crates-io`, `description` must be set, and either `license` or `license-file` must be set. Workspace-inherited Cargo metadata is accepted, and already-published versions remain non-blocking when the readiness artifact still matches the current package set. `mc publish-plan --readiness <path>` validates the same artifact for planning and limits rate-limit batches to package ids that are ready in both the artifact and the fresh local readiness check. If readiness shows missing first-time registry packages, run `mc publish-bootstrap --from HEAD --output .monochange/bootstrap-result.json`, then rerun readiness before real publishing. Python packages participate in discovery and release planning, but PyPI publishing should use `mode = "external"` or a custom CI command today.
+`mc publish-readiness` performs non-mutating registry checks before `mc publish`. For built-in Cargo publishes to crates.io it also verifies current manifest publishability: `publish = false` blocks publishing, `publish = [...]` must include `crates-io`, `description` must be set, and either `license` or `license-file` must be set. Workspace-inherited Cargo metadata is accepted, and already-published versions remain non-blocking when the readiness artifact still matches the current package set. `mc publish-plan --readiness <path>` validates the same artifact for planning and limits rate-limit batches to package ids that are ready in both the artifact and the fresh local readiness check. If readiness shows missing first-time registry packages, run `mc publish-bootstrap --from HEAD --output .monochange/bootstrap-result.json`, then rerun readiness before real publishing. Python packages support built-in PyPI publishing with `uv build` and `uv publish`; keep `mode = "external"` for private registries or custom Python publication flows.
 
 <!-- {@projectCapabilityMatrix} -->
 
-| Capability                                                               | Current status                                                                                |
-| ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
-| Multi-ecosystem discovery                                                | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, Python                                              |
-| Package release planning                                                 | Built in                                                                                      |
-| Grouped/shared versioning                                                | Built in                                                                                      |
-| Dry-run release diff previews                                            | Built in via `mc release --dry-run --diff`                                                    |
-| Durable release history and post-merge tagging                           | Built in via `ReleaseRecord`, `mc release-record`, `mc tag-release`, and `mc repair-release`  |
-| Hosted provider releases                                                 | GitHub, GitLab, Gitea                                                                         |
-| Hosted release requests                                                  | GitHub, GitLab, Gitea                                                                         |
-| Python release planning                                                  | Built in for discovery, version rewrites, dependency rewrites, and lockfile command inference |
-| Built-in registry publishing                                             | `crates.io`, `npm`, `jsr`, `pub.dev`; use external mode for PyPI and custom registries        |
-| GitHub npm trusted-publishing automation                                 | Built in                                                                                      |
-| GitHub trusted-publishing guidance for `crates.io`, `jsr`, and `pub.dev` | Built in, but manual registry enrollment is still required                                    |
-| GitLab trusted-publishing auto-derivation                                | Not built in today                                                                            |
-| Release-retarget sync for hosted releases                                | GitHub first                                                                                  |
+| Capability                                                                     | Current status                                                                                                 |
+| ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| Multi-ecosystem discovery                                                      | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, Python                                                               |
+| Package release planning                                                       | Built in                                                                                                       |
+| Grouped/shared versioning                                                      | Built in                                                                                                       |
+| Dry-run release diff previews                                                  | Built in via `mc release --dry-run --diff`                                                                     |
+| Durable release history and post-merge tagging                                 | Built in via `ReleaseRecord`, `mc release-record`, `mc tag-release`, and `mc repair-release`                   |
+| Hosted provider releases                                                       | GitHub, GitLab, Gitea                                                                                          |
+| Hosted release requests                                                        | GitHub, GitLab, Gitea                                                                                          |
+| Python release planning                                                        | Built in for discovery, version rewrites, dependency rewrites, lockfile command inference, and PyPI publishing |
+| Built-in registry publishing                                                   | `crates.io`, `npm`, `jsr`, `pub.dev`, `pypi`; use external mode for custom registries                          |
+| GitHub npm trusted-publishing automation                                       | Built in                                                                                                       |
+| GitHub trusted-publishing guidance for `crates.io`, `jsr`, `pub.dev`, and PyPI | Built in, but manual registry enrollment is still required                                                     |
+| GitLab trusted-publishing auto-derivation                                      | Not built in today                                                                                             |
+| Release-retarget sync for hosted releases                                      | GitHub first                                                                                                   |
 
 <!-- {/projectCapabilityMatrix} -->
 

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -6412,6 +6412,7 @@ fn retarget_release_succeeds_end_to_end_without_provider_sync() {
 		.unwrap_or_else(|error| panic!("write second release file: {error}"));
 	git_in_temp_repo(&repo, &["add", "release.txt"]);
 	git_in_temp_repo(&repo, &["commit", "-m", "second"]);
+	let target_commit = git_output_in_temp_repo(&repo, &["rev-parse", "HEAD"]);
 	let discovery = monochange_core::ReleaseRecordDiscovery {
 		input_ref: "v1.2.3".to_string(),
 		resolved_commit: record_commit.clone(),
@@ -6419,8 +6420,9 @@ fn retarget_release_succeeds_end_to_end_without_provider_sync() {
 		distance: 0,
 		record: sample_release_record_for_retarget(),
 	};
-	let result = crate::retarget_release(&repo, &discovery, "HEAD", false, false, false, None)
-		.unwrap_or_else(|error| panic!("retarget release: {error}"));
+	let result =
+		crate::retarget_release(&repo, &discovery, &target_commit, false, false, false, None)
+			.unwrap_or_else(|error| panic!("retarget release: {error}"));
 	assert_eq!(result.git_tag_results.len(), 1);
 }
 

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -2808,6 +2808,10 @@ jobs:
 			manual_setup_url(&sample_request(RegistryKind::Jsr)),
 			"https://jsr.io/@scope/pkg".to_string()
 		);
+		assert_eq!(
+			manual_setup_url(&sample_request(RegistryKind::Pypi)),
+			"https://pypi.org/manage/project/pkg/settings/publishing/".to_string()
+		);
 		assert_eq!(trust_docs_url(RegistryKind::Npm), NPM_TRUST_DOCS_URL);
 		assert_eq!(
 			trust_docs_url(RegistryKind::CratesIo),
@@ -2815,6 +2819,7 @@ jobs:
 		);
 		assert_eq!(trust_docs_url(RegistryKind::PubDev), DART_TRUST_DOCS_URL);
 		assert_eq!(trust_docs_url(RegistryKind::Jsr), JSR_TRUST_DOCS_URL);
+		assert_eq!(trust_docs_url(RegistryKind::Pypi), PYPI_TRUST_DOCS_URL);
 	}
 
 	#[test]
@@ -3136,6 +3141,10 @@ jobs:
 			when.method(GET).path("/missing");
 			then.status(404);
 		});
+		server.mock(|when, then| {
+			when.method(GET).path("/missing/json");
+			then.status(404);
+		});
 		let client = Client::builder().build().expect("http client:");
 		let endpoints = RegistryEndpoints {
 			npm_registry: server.base_url(),
@@ -3151,6 +3160,13 @@ jobs:
 			..request
 		};
 		assert!(!registry_version_exists(&client, &endpoints, &request).expect("missing:"));
+		let pypi_request = PublishRequest {
+			package_name: "missing".to_string(),
+			..sample_request(RegistryKind::Pypi)
+		};
+		assert!(
+			!registry_version_exists(&client, &endpoints, &pypi_request).expect("PyPI missing:")
+		);
 	}
 
 	#[test]
@@ -3774,6 +3790,57 @@ jobs:
 				.join("example_pkg_name")
 				.join("__init__.py")
 				.is_file()
+		);
+
+		let digit_request = PublishRequest {
+			package_name: "123-pkg".to_string(),
+			..sample_request(RegistryKind::Pypi)
+		};
+		let digit_python = build_placeholder_directory(tempdir.path(), &digit_request, None)
+			.expect("digit Python placeholder:");
+		assert!(
+			digit_python
+				.path()
+				.join("src")
+				.join("placeholder_123_pkg")
+				.join("__init__.py")
+				.is_file()
+		);
+	}
+
+	#[test]
+	fn python_placeholder_manifest_writers_report_io_errors() {
+		let request = sample_request(RegistryKind::Pypi);
+		let tempdir = tempfile::tempdir().expect("tempdir:");
+		fs::create_dir(tempdir.path().join("pyproject.toml")).expect("create pyproject dir");
+		let error = write_python_placeholder_manifest(tempdir.path(), &request, None)
+			.expect_err("pyproject write should fail");
+		assert!(
+			error
+				.to_string()
+				.contains("failed to write placeholder pyproject.toml")
+		);
+
+		let tempdir = tempfile::tempdir().expect("tempdir:");
+		fs::write(tempdir.path().join("src"), "not a directory").expect("write src file");
+		let error = write_python_placeholder_manifest(tempdir.path(), &request, None)
+			.expect_err("package directory create should fail");
+		assert!(
+			error
+				.to_string()
+				.contains("failed to create placeholder Python package")
+		);
+
+		let tempdir = tempfile::tempdir().expect("tempdir:");
+		let module_dir = tempdir.path().join("src").join("pkg");
+		fs::create_dir_all(&module_dir).expect("create module dir");
+		fs::create_dir(module_dir.join("__init__.py")).expect("create init dir");
+		let error = write_python_placeholder_manifest(tempdir.path(), &request, None)
+			.expect_err("module write should fail");
+		assert!(
+			error
+				.to_string()
+				.contains("failed to write placeholder Python package module")
 		);
 	}
 

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -41,6 +41,8 @@ const CRATES_TRUST_DOCS_URL: &str = "https://crates.io/docs/trusted-publishing";
 const DART_TRUST_DOCS_URL: &str = "https://dart.dev/tools/pub/automated-publishing";
 #[cfg(test)]
 const JSR_TRUST_DOCS_URL: &str = "https://jsr.io/docs/publishing-packages";
+#[cfg(test)]
+const PYPI_TRUST_DOCS_URL: &str = "https://docs.pypi.org/trusted-publishers/";
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -171,6 +173,7 @@ pub(crate) struct RegistryEndpoints {
 	pub(crate) crates_io_index: String,
 	pub(crate) pub_dev_api: String,
 	pub(crate) jsr_base: String,
+	pub(crate) pypi_api: String,
 }
 
 impl RegistryEndpoints {
@@ -186,6 +189,8 @@ impl RegistryEndpoints {
 				.unwrap_or_else(|_| "https://pub.dev/api".to_string()),
 			jsr_base: env::var("MONOCHANGE_JSR_BASE_URL")
 				.unwrap_or_else(|_| "https://jsr.io".to_string()),
+			pypi_api: env::var("MONOCHANGE_PYPI_API_URL")
+				.unwrap_or_else(|_| "https://pypi.org/pypi".to_string()),
 		}
 	}
 }
@@ -568,6 +573,7 @@ fn default_registry_kind_for_ecosystem(ecosystem: &str) -> MonochangeResult<Regi
 		"npm" => Ok(RegistryKind::Npm),
 		"deno" => Ok(RegistryKind::Jsr),
 		"dart" | "flutter" => Ok(RegistryKind::PubDev),
+		"python" => Ok(RegistryKind::Pypi),
 		_ => {
 			Err(MonochangeError::Config(format!(
 				"built-in package publishing does not support ecosystem `{ecosystem}`"
@@ -1102,6 +1108,13 @@ fn build_publish_command(
 		command = Some(build_jsr_publish_command(
 			placeholder_path.expect("placeholder directory must exist"),
 		));
+	} else if request.registry == RegistryKind::Pypi && mode == PackagePublishRunMode::Placeholder {
+		command = Some(build_python_publish_command(
+			request,
+			placeholder_path.expect("placeholder directory must exist"),
+		));
+	} else if request.registry == RegistryKind::Pypi && mode == PackagePublishRunMode::Release {
+		command = Some(build_python_publish_command(request, &request.package_root));
 	}
 	if is_jsr_release {
 		command = Some(build_jsr_publish_command(&request.package_root));
@@ -1114,6 +1127,10 @@ fn build_publish_command(
 
 fn append_publish_dry_run_args(args: &mut Vec<String>, registry: RegistryKind, dry_run: bool) {
 	if !dry_run {
+		return;
+	}
+
+	if registry == RegistryKind::Pypi {
 		return;
 	}
 
@@ -1216,6 +1233,22 @@ fn build_jsr_publish_command(cwd: &Path) -> CommandSpec {
 	}
 }
 
+fn build_python_publish_command(request: &PublishRequest, cwd: &Path) -> CommandSpec {
+	let trusted_publishing = if request.trusted_publishing.enabled {
+		"always"
+	} else {
+		"never"
+	};
+	let script = format!(
+		"uv build --out-dir dist && uv publish --trusted-publishing {trusted_publishing} dist/*"
+	);
+	CommandSpec {
+		program: "sh".to_string(),
+		args: vec!["-c".to_string(), script],
+		cwd: cwd.to_path_buf(),
+	}
+}
+
 fn build_placeholder_directory(
 	root: &Path,
 	request: &PublishRequest,
@@ -1246,6 +1279,12 @@ fn build_placeholder_directory(
 		));
 	} else if request.registry == RegistryKind::PubDev {
 		manifest_result = Some(write_dart_placeholder_manifest(
+			tempdir_path,
+			request,
+			source,
+		));
+	} else if request.registry == RegistryKind::Pypi {
+		manifest_result = Some(write_python_placeholder_manifest(
 			tempdir_path,
 			request,
 			source,
@@ -1542,6 +1581,63 @@ fn write_jsr_placeholder_manifest(
 	})
 }
 
+fn write_python_placeholder_manifest(
+	dir: &Path,
+	request: &PublishRequest,
+	source: Option<&SourceConfiguration>,
+) -> MonochangeResult<()> {
+	let module_name = python_placeholder_module_name(&request.package_name);
+	let project_urls = source.map(|source| {
+		format!(
+			"\n[project.urls]\nRepository = \"https://github.com/{}/{}\"\n",
+			source.owner, source.repo
+		)
+	});
+	let pyproject = format!(
+		"[build-system]\nrequires = [\"hatchling\"]\nbuild-backend = \"hatchling.build\"\n\n[project]\nname = \"{}\"\nversion = \"{}\"\ndescription = \"Placeholder package for {}\"\nreadme = \"README.md\"\nrequires-python = \">=3.8\"\n{}\n[tool.hatch.build.targets.wheel]\npackages = [\"src/{}\"]\n",
+		request.package_name,
+		request.version,
+		request.package_name,
+		project_urls.unwrap_or_default(),
+		module_name,
+	);
+	fs::write(dir.join("pyproject.toml"), pyproject).map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to write placeholder pyproject.toml: {error}"
+		))
+	})?;
+	let package_dir = dir.join("src").join(&module_name);
+	fs::create_dir_all(&package_dir).map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to create placeholder Python package: {error}"
+		))
+	})?;
+	fs::write(
+		package_dir.join("__init__.py"),
+		"\"\"\"Placeholder package published by monochange.\"\"\"\n",
+	)
+	.map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to write placeholder Python package module: {error}"
+		))
+	})
+}
+
+fn python_placeholder_module_name(package_name: &str) -> String {
+	let mut module = String::new();
+	for character in package_name.chars() {
+		if character.is_ascii_alphanumeric() || character == '_' {
+			module.push(character.to_ascii_lowercase());
+		} else {
+			module.push('_');
+		}
+	}
+	if module.is_empty() || module.starts_with(|character: char| character.is_ascii_digit()) {
+		module.insert_str(0, "placeholder_");
+	}
+	module
+}
+
 fn placeholder_tempdir_error(error: &std::io::Error) -> MonochangeError {
 	MonochangeError::Io(format!("failed to create placeholder tempdir: {error}"))
 }
@@ -1614,6 +1710,32 @@ fn registry_version_exists(
 						version.get("version").and_then(JsonValue::as_str)
 							== Some(request.version.as_str())
 					})
+			});
+		return Ok(exists);
+	}
+
+	if request.registry == RegistryKind::Pypi {
+		let url = format!(
+			"{}/{}/json",
+			endpoints.pypi_api.trim_end_matches('/'),
+			encode(&request.package_name)
+		);
+		let response = client.get(url).send().map_err(http_error("PyPI lookup"))?;
+		if response.status() == StatusCode::NOT_FOUND {
+			return Ok(false);
+		}
+		let response = response
+			.error_for_status()
+			.map_err(http_error("PyPI lookup"))?;
+		let json = response
+			.json::<JsonValue>()
+			.map_err(http_error("PyPI decode"))?;
+		let exists = json
+			.get("releases")
+			.and_then(JsonValue::as_object)
+			.is_some_and(|releases| {
+				request.placeholder && !releases.is_empty()
+					|| releases.contains_key(&request.version)
 			});
 		return Ok(exists);
 	}
@@ -1823,6 +1945,11 @@ fn manual_setup_url(request: &PublishRequest) -> String {
 		format!("https://pub.dev/packages/{}/admin", request.package_name)
 	} else if request.registry == RegistryKind::Jsr {
 		format!("https://jsr.io/{}", request.package_name)
+	} else if request.registry == RegistryKind::Pypi {
+		format!(
+			"https://pypi.org/manage/project/{}/settings/publishing/",
+			request.package_name
+		)
 	} else {
 		format!(
 			"https://www.npmjs.com/package/{}/access",
@@ -1839,6 +1966,8 @@ fn trust_docs_url(registry: RegistryKind) -> &'static str {
 		DART_TRUST_DOCS_URL
 	} else if registry == RegistryKind::Jsr {
 		JSR_TRUST_DOCS_URL
+	} else if registry == RegistryKind::Pypi {
+		PYPI_TRUST_DOCS_URL
 	} else {
 		NPM_TRUST_DOCS_URL
 	}) as _
@@ -1916,6 +2045,8 @@ mod tests {
 				Ecosystem::Npm
 			} else if registry == RegistryKind::PubDev {
 				Ecosystem::Dart
+			} else if registry == RegistryKind::Pypi {
+				Ecosystem::Python
 			} else {
 				Ecosystem::Deno
 			},
@@ -1990,6 +2121,7 @@ mod tests {
 			crates_io_index: base_url.to_string(),
 			pub_dev_api: base_url.to_string(),
 			jsr_base: base_url.to_string(),
+			pypi_api: base_url.to_string(),
 		}
 	}
 
@@ -2536,6 +2668,32 @@ jobs:
 			false,
 		);
 		assert_eq!(jsr_release.cwd, PathBuf::from("/workspace/pkg"));
+		let pypi_placeholder = build_publish_command(
+			&sample_request(RegistryKind::Pypi),
+			PackagePublishRunMode::Placeholder,
+			Some(&tempdir),
+			false,
+		);
+		assert_eq!(pypi_placeholder.program, "sh");
+		assert_eq!(pypi_placeholder.cwd, tempdir.path());
+		assert!(
+			render_command(&pypi_placeholder).contains("uv publish --trusted-publishing never")
+		);
+		let pypi_release_request = PublishRequest {
+			trusted_publishing: TrustedPublishingSettings {
+				enabled: true,
+				..TrustedPublishingSettings::default()
+			},
+			..sample_request(RegistryKind::Pypi)
+		};
+		let pypi_release = build_publish_command(
+			&pypi_release_request,
+			PackagePublishRunMode::Release,
+			None,
+			false,
+		);
+		assert_eq!(pypi_release.cwd, PathBuf::from("/workspace/pkg"));
+		assert!(render_command(&pypi_release).contains("uv publish --trusted-publishing always"));
 	}
 
 	#[test]
@@ -2574,6 +2732,14 @@ jobs:
 			true,
 		);
 		assert_eq!(jsr.args.last(), Some(&"--dry-run".to_string()));
+
+		let pypi = build_publish_command(
+			&sample_request(RegistryKind::Pypi),
+			PackagePublishRunMode::Placeholder,
+			Some(&tempdir),
+			true,
+		);
+		assert!(!render_command(&pypi).contains("--dry-run"));
 	}
 
 	#[test]
@@ -2714,6 +2880,12 @@ jobs:
 				"versions": { "1.2.3": {} }
 			}));
 		});
+		server.mock(|when, then| {
+			when.method(GET).path("/pkg/json");
+			then.status(200).json_body_obj(&serde_json::json!({
+				"releases": { "1.2.3": [] }
+			}));
+		});
 		let client = Client::builder().build().expect("http client:");
 		let endpoints = RegistryEndpoints {
 			npm_registry: server.base_url(),
@@ -2721,6 +2893,7 @@ jobs:
 			crates_io_index: server.base_url(),
 			pub_dev_api: server.base_url(),
 			jsr_base: server.base_url(),
+			pypi_api: server.base_url(),
 		};
 
 		assert!(
@@ -2738,6 +2911,10 @@ jobs:
 		assert!(
 			registry_version_exists(&client, &endpoints, &sample_request(RegistryKind::Jsr))
 				.expect("jsr exists:")
+		);
+		assert!(
+			registry_version_exists(&client, &endpoints, &sample_request(RegistryKind::Pypi))
+				.expect("PyPI exists:")
 		);
 	}
 
@@ -2770,6 +2947,12 @@ jobs:
 				"versions": { "1.0.0": {} }
 			}));
 		});
+		server.mock(|when, then| {
+			when.method(GET).path("/pkg/json");
+			then.status(200).json_body_obj(&serde_json::json!({
+				"releases": { "1.0.0": [] }
+			}));
+		});
 		let client = Client::builder().build().expect("http client:");
 		let endpoints = sample_endpoints(&server.base_url());
 		let placeholder = |registry| {
@@ -2795,6 +2978,10 @@ jobs:
 		assert!(
 			registry_version_exists(&client, &endpoints, &placeholder(RegistryKind::Jsr))
 				.expect("jsr placeholder exists:")
+		);
+		assert!(
+			registry_version_exists(&client, &endpoints, &placeholder(RegistryKind::Pypi))
+				.expect("PyPI placeholder exists:")
 		);
 	}
 
@@ -2956,6 +3143,7 @@ jobs:
 			crates_io_index: server.base_url(),
 			pub_dev_api: server.base_url(),
 			jsr_base: server.base_url(),
+			pypi_api: server.base_url(),
 		};
 		let request = sample_request(RegistryKind::Npm);
 		let request = PublishRequest {
@@ -3542,7 +3730,7 @@ jobs:
 	}
 
 	#[test]
-	fn write_placeholder_directory_builds_npm_jsr_and_dart_scaffolds() {
+	fn write_placeholder_directory_builds_npm_jsr_dart_and_python_scaffolds() {
 		let tempdir = tempfile::tempdir().expect("tempdir:");
 		let npm = build_placeholder_directory(
 			tempdir.path(),
@@ -3567,6 +3755,26 @@ jobs:
 		)
 		.expect("jsr placeholder:");
 		assert!(jsr.path().join("deno.json").is_file());
+
+		let python_request = PublishRequest {
+			package_name: "Example-Pkg.Name".to_string(),
+			..sample_request(RegistryKind::Pypi)
+		};
+		let python =
+			build_placeholder_directory(tempdir.path(), &python_request, Some(&sample_source()))
+				.expect("Python placeholder:");
+		let pyproject =
+			fs::read_to_string(python.path().join("pyproject.toml")).expect("read pyproject.toml");
+		assert!(pyproject.contains("name = \"Example-Pkg.Name\""));
+		assert!(pyproject.contains("packages = [\"src/example_pkg_name\"]"));
+		assert!(
+			python
+				.path()
+				.join("src")
+				.join("example_pkg_name")
+				.join("__init__.py")
+				.is_file()
+		);
 	}
 
 	#[test]
@@ -4293,6 +4501,7 @@ version = "1.2.3"
 			crates_io_index: server.base_url(),
 			pub_dev_api: server.base_url(),
 			jsr_base: server.base_url(),
+			pypi_api: server.base_url(),
 		};
 		let request = PublishRequest {
 			mode: PublishMode::External,

--- a/crates/monochange/src/publish_rate_limits.rs
+++ b/crates/monochange/src/publish_rate_limits.rs
@@ -23,6 +23,7 @@ const CRATES_IO_SOURCE: &str = "https://github.com/rust-lang/crates.io";
 const NPM_TRUST_DOCS: &str = "https://docs.npmjs.com/trusted-publishers";
 const PUB_DEV_AUTOMATED_PUBLISHING: &str = "https://dart.dev/tools/pub/automated-publishing";
 const JSR_PUBLISHING_DOCS: &str = "https://jsr.io/docs/publishing-packages";
+const PYPI_TRUSTED_PUBLISHERS_DOCS: &str = "https://docs.pypi.org/trusted-publishers/";
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub(crate) enum PublishRateLimitMode {
@@ -365,6 +366,20 @@ fn registry_policies() -> Vec<RegistryRateLimitPolicy> {
 				notes: "official automation docs; limit itself is enforced operationally but not clearly enumerated on this page".to_string(),
 			}],
 		},
+		RegistryRateLimitPolicy {
+			registry: RegistryKind::Pypi,
+			operation: RateLimitOperation::Publish,
+			limit: None,
+			window_seconds: None,
+			confidence: RateLimitConfidence::Low,
+			notes: "PyPI does not publish a precise package publish quota; use sequential CI publishing with retries".to_string(),
+			evidence: vec![RateLimitEvidence {
+				title: "PyPI trusted publishers documentation".to_string(),
+				url: PYPI_TRUSTED_PUBLISHERS_DOCS.to_string(),
+				kind: RateLimitEvidenceKind::Official,
+				notes: "official trusted-publisher workflow guidance but no exact package publish quota".to_string(),
+			}],
+		},
 	]
 }
 
@@ -449,6 +464,21 @@ mod tests {
 	}
 
 	#[test]
+	fn registry_policies_include_pypi_without_a_fixed_quota() {
+		let pypi = registry_policies()
+			.into_iter()
+			.find(|policy| policy.registry == RegistryKind::Pypi)
+			.expect("PyPI policy should exist");
+
+		assert_eq!(pypi.limit, None);
+		assert_eq!(pypi.window_seconds, None);
+		assert_eq!(pypi.confidence, RateLimitConfidence::Low);
+		assert!(pypi.notes.contains("PyPI does not publish"));
+		let evidence = pypi.evidence.first().expect("PyPI policy evidence");
+		assert_eq!(evidence.url, PYPI_TRUSTED_PUBLISHERS_DOCS);
+	}
+
+	#[test]
 	fn plan_publish_rate_limits_summarizes_pending_publications_and_batches() {
 		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 		let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -527,6 +557,7 @@ mod tests {
 			crates_io_index: server.base_url(),
 			pub_dev_api: server.base_url(),
 			jsr_base: server.base_url(),
+			pypi_api: server.base_url(),
 		};
 		let requests = build_release_plan_requests_with_transport(
 			tempdir.path(),
@@ -790,6 +821,7 @@ mod tests {
 			crates_io_index: server.base_url(),
 			pub_dev_api: server.base_url(),
 			jsr_base: server.base_url(),
+			pypi_api: server.base_url(),
 		};
 		let requests = build_release_plan_requests_with_transport(
 			tempdir.path(),
@@ -859,6 +891,7 @@ mod tests {
 			crates_io_index: server.base_url(),
 			pub_dev_api: server.base_url(),
 			jsr_base: server.base_url(),
+			pypi_api: server.base_url(),
 		};
 		let requests = build_placeholder_plan_requests_with_transport(
 			tempdir.path(),
@@ -939,6 +972,7 @@ mod tests {
 			crates_io_index: server.base_url(),
 			pub_dev_api: server.base_url(),
 			jsr_base: server.base_url(),
+			pypi_api: server.base_url(),
 		};
 		let requests = build_placeholder_plan_requests_with_transport(
 			tempdir.path(),

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -1033,7 +1033,10 @@ type = "python"
 			.map(|definition| definition.path.as_str()),
 		Some("pyproject.toml")
 	);
-	assert!(package.publish.registry.is_none());
+	assert_eq!(
+		package.publish.registry,
+		Some(PublishRegistry::Builtin(RegistryKind::Pypi))
+	);
 }
 
 #[test]

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -814,6 +814,7 @@ fn default_publish_registry_for_ecosystem(
 		EcosystemType::Npm => Some(PublishRegistry::Builtin(RegistryKind::Npm)),
 		EcosystemType::Deno => Some(PublishRegistry::Builtin(RegistryKind::Jsr)),
 		EcosystemType::Dart => Some(PublishRegistry::Builtin(RegistryKind::PubDev)),
+		EcosystemType::Python => Some(PublishRegistry::Builtin(RegistryKind::Pypi)),
 		_ => None,
 	};
 	registry

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -229,6 +229,7 @@ fn publish_mode_and_registry_kind_display_canonical_names() {
 	assert_eq!(RegistryKind::Npm.as_str(), "npm");
 	assert_eq!(RegistryKind::Jsr.as_str(), "jsr");
 	assert_eq!(RegistryKind::PubDev.as_str(), "pub_dev");
+	assert_eq!(RegistryKind::Pypi.as_str(), "pypi");
 }
 
 #[test]

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -1382,6 +1382,7 @@ pub enum RegistryKind {
 	Npm,
 	Jsr,
 	PubDev,
+	Pypi,
 }
 
 impl RegistryKind {
@@ -1393,6 +1394,7 @@ impl RegistryKind {
 			Self::Npm => "npm",
 			Self::Jsr => "jsr",
 			Self::PubDev => "pub_dev",
+			Self::Pypi => "pypi",
 		}
 	}
 }

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -167,8 +167,9 @@ Built-in publishing currently targets only the canonical public registry for eac
 - npm packages → `npm`
 - Deno packages → `jsr`
 - Dart / Flutter packages → `pub.dev`
+- Python packages → `pypi`
 
-Python package discovery and release planning are supported, but built-in PyPI publishing is not available yet. For Python packages, private registries, or any other custom publication flow, set `mode = "external"` and handle publication outside monochange.
+Private registries and custom publication flows are still external. For those packages, set `mode = "external"` and handle publication outside monochange.
 
 ### Placeholder publishing
 
@@ -203,7 +204,7 @@ When `trusted_publishing` is enabled:
 
 - npm packages can be configured automatically with `npm trust github ...`
 - pnpm workspaces use `pnpm exec npm trust ...` and `pnpm publish`, so workspace protocol and catalog dependency handling stays aligned with the workspace manager
-- Cargo, `jsr`, and `pub.dev` currently require manual trusted-publishing setup; monochange reports the setup URL and blocks built-in release publishing until trust is configured
+- Cargo, `jsr`, `pub.dev`, and PyPI currently require manual trusted-publishing setup; monochange reports the setup URL and blocks built-in release publishing until trust is configured
 
 For a GitHub-focused setup guide with exact registry fields, commands, and workflow requirements, see [Trusted publishing and OIDC](./07-trusted-publishing.md). For monorepo workflow and tag-shape recommendations, see [Multi-package publishing patterns](./14-multi-package-publishing.md).
 
@@ -221,7 +222,7 @@ The built-in package publishing flow is intentionally narrow for now:
 
 - no private or custom registry support in `mode = "builtin"`
 - rate-limit planning can batch work and enforce single-window safety, but monochange still does not sleep across windows or requeue later batches automatically
-- manual trusted-publishing setup is still required for `crates.io`, `jsr`, and `pub.dev`
+- manual trusted-publishing setup is still required for `crates.io`, `jsr`, `pub.dev`, and PyPI
 
 If your workflow needs any of those today, keep the package on `mode = "external"` and let your own CI or scripts own publication.
 

--- a/docs/src/guide/07-trusted-publishing.md
+++ b/docs/src/guide/07-trusted-publishing.md
@@ -6,8 +6,9 @@ monochange supports built-in package publishing for the canonical public registr
 - npm packages → `npm`
 - Deno packages → `jsr`
 - Dart / Flutter packages → `pub.dev`
+- Python packages → `pypi`
 
-For those registries, monochange can also manage or verify **trusted publishing** when the registry supports publishing directly from a verified GitHub Actions identity. Python packages are supported for release planning, but PyPI publishing and PyPI trusted-publisher setup are external to monochange today.
+For those registries, monochange can also manage or verify **trusted publishing** when the registry supports publishing directly from a verified GitHub Actions identity. PyPI is supported by the built-in publisher through `uv build` and `uv publish`; PyPI trusted-publisher enrollment is still completed manually in the PyPI project settings.
 
 Different registries use different names for the same general pattern:
 
@@ -30,10 +31,11 @@ The goal is the same in every case:
 | cargo          | crates.io | Trusted Publishing        | Yes                         | Can publish with a temporary token after you finish registry-side setup               |
 | deno           | jsr       | GitHub Actions publishing | Yes                         | Reports the setup URL; repository linking is still manual                             |
 | dart / flutter | pub.dev   | Automated publishing      | Yes                         | Reports the setup URL; admin-page setup is still manual                               |
+| python         | PyPI      | Trusted publishers        | Yes                         | Reports the setup URL; project settings setup is still manual                         |
 
-npm is currently the only ecosystem where monochange performs bulk trusted-publishing setup itself. Use `mode = "external"` for Python/PyPI and for any registry workflow that should stay outside monochange's built-in publisher.
+npm is currently the only ecosystem where monochange performs bulk trusted-publishing setup itself. Use `mode = "external"` for any registry workflow that should stay outside monochange's built-in publisher.
 
-For `crates.io`, `jsr`, and `pub.dev`, monochange reports the setup URL for each package and blocks the next built-in registry publish until the trust configuration has been completed manually. It also preflights the GitHub trusted-publishing context for those registries, surfacing the repository, workflow, and environment it expects when that context can be resolved.
+For `crates.io`, `jsr`, `pub.dev`, and PyPI, monochange reports the setup URL for each package and blocks the next built-in registry publish until the trust configuration has been completed manually. It also preflights the GitHub trusted-publishing context for those registries, surfacing the repository, workflow, and environment it expects when that context can be resolved.
 
 ## monochange configuration
 
@@ -55,6 +57,9 @@ trusted_publishing = true
 trusted_publishing = true
 
 [ecosystems.dart.publish]
+trusted_publishing = true
+
+[ecosystems.python.publish]
 trusted_publishing = true
 
 [package.cli.publish.trusted_publishing]
@@ -444,17 +449,18 @@ In those cases, you can still use the same registry-side trusted-publishing setu
 
 monochange is intentionally conservative here.
 
-Today, npm is the only registry where monochange performs trusted-publishing enrollment itself. For `crates.io`, `jsr`, and `pub.dev`, monochange currently focuses on setup guidance, preflight checks, and actionable diagnostics instead of trying to mutate registry-side trust records automatically.
+Today, npm is the only registry where monochange performs trusted-publishing enrollment itself. For `crates.io`, `jsr`, `pub.dev`, and PyPI, monochange currently focuses on setup guidance, preflight checks, and actionable diagnostics instead of trying to mutate registry-side trust records automatically.
 
 Areas that may become more automated later, where the registry and CI contracts make it safe enough, include:
 
 - **`crates.io`** — stronger preflight validation around explicit workflow filenames, environment alignment, and clearer checks for first-publish bootstrap versus post-bootstrap trusted publishing
 - **`jsr`** — better repository-link diagnostics and package metadata checks before publish, especially when the package already exists but repository-side linking is incomplete
 - **`pub.dev`** — stronger validation that tag patterns, workflow triggers, working directories, and optional environments still match the automated-publishing setup expected by pub.dev
+- **PyPI** — stronger validation that the project trusted-publisher settings match the workflow name, environment, and package path monochange expects before running `uv publish`
 
 Areas that monochange does **not** promise today:
 
-- auto-enrolling registry-side trusted-publisher records for `crates.io`, `jsr`, or `pub.dev`
+- auto-enrolling registry-side trusted-publisher records for `crates.io`, `jsr`, `pub.dev`, or PyPI
 - bypassing browser-confirmed or admin-page-only steps that the registry intentionally keeps manual
 - inferring enough registry-side state to claim a package is fully enrolled when the registry does not expose that state safely or consistently
 

--- a/docs/src/guide/13-ci-and-publishing.md
+++ b/docs/src/guide/13-ci-and-publishing.md
@@ -54,21 +54,21 @@ Keeping those layers separate is important. Package publication and hosted-relea
 
 <!-- {=projectCapabilityMatrix} -->
 
-| Capability                                                               | Current status                                                                                |
-| ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
-| Multi-ecosystem discovery                                                | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, Python                                              |
-| Package release planning                                                 | Built in                                                                                      |
-| Grouped/shared versioning                                                | Built in                                                                                      |
-| Dry-run release diff previews                                            | Built in via `mc release --dry-run --diff`                                                    |
-| Durable release history and post-merge tagging                           | Built in via `ReleaseRecord`, `mc release-record`, `mc tag-release`, and `mc repair-release`  |
-| Hosted provider releases                                                 | GitHub, GitLab, Gitea                                                                         |
-| Hosted release requests                                                  | GitHub, GitLab, Gitea                                                                         |
-| Python release planning                                                  | Built in for discovery, version rewrites, dependency rewrites, and lockfile command inference |
-| Built-in registry publishing                                             | `crates.io`, `npm`, `jsr`, `pub.dev`; use external mode for PyPI and custom registries        |
-| GitHub npm trusted-publishing automation                                 | Built in                                                                                      |
-| GitHub trusted-publishing guidance for `crates.io`, `jsr`, and `pub.dev` | Built in, but manual registry enrollment is still required                                    |
-| GitLab trusted-publishing auto-derivation                                | Not built in today                                                                            |
-| Release-retarget sync for hosted releases                                | GitHub first                                                                                  |
+| Capability                                                                     | Current status                                                                                                 |
+| ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| Multi-ecosystem discovery                                                      | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, Python                                                               |
+| Package release planning                                                       | Built in                                                                                                       |
+| Grouped/shared versioning                                                      | Built in                                                                                                       |
+| Dry-run release diff previews                                                  | Built in via `mc release --dry-run --diff`                                                                     |
+| Durable release history and post-merge tagging                                 | Built in via `ReleaseRecord`, `mc release-record`, `mc tag-release`, and `mc repair-release`                   |
+| Hosted provider releases                                                       | GitHub, GitLab, Gitea                                                                                          |
+| Hosted release requests                                                        | GitHub, GitLab, Gitea                                                                                          |
+| Python release planning                                                        | Built in for discovery, version rewrites, dependency rewrites, lockfile command inference, and PyPI publishing |
+| Built-in registry publishing                                                   | `crates.io`, `npm`, `jsr`, `pub.dev`, `pypi`; use external mode for custom registries                          |
+| GitHub npm trusted-publishing automation                                       | Built in                                                                                                       |
+| GitHub trusted-publishing guidance for `crates.io`, `jsr`, `pub.dev`, and PyPI | Built in, but manual registry enrollment is still required                                                     |
+| GitLab trusted-publishing auto-derivation                                      | Not built in today                                                                                             |
+| Release-retarget sync for hosted releases                                      | GitHub first                                                                                                   |
 
 <!-- {/projectCapabilityMatrix} -->
 
@@ -77,7 +77,7 @@ Keeping those layers separate is important. Package publication and hosted-relea
 The workflow sketches below assume the job already has:
 
 - the `monochange` CLI available as `mc`
-- the native ecosystem toolchain it needs (`npm`/`pnpm`, `cargo`, `deno`, `dart`, `flutter`, `uv`, `poetry`, or your Python publishing tool)
+- the native ecosystem toolchain it needs (`npm`/`pnpm`, `cargo`, `deno`, `dart`, `flutter`, `uv`, `poetry`, or your external publishing tool)
 - repository checkout with enough history for release-record inspection
 
 In the monochange repository itself, that usually means entering the `devenv` shell. In other repositories, it may mean installing `@monochange/cli` or `monochange` explicitly before the publish step.

--- a/docs/src/guide/ecosystems.md
+++ b/docs/src/guide/ecosystems.md
@@ -10,15 +10,15 @@ monochange uses ecosystem adapters to translate native package-manager files int
 
 ## Capability matrix
 
-| Ecosystem      | Package type      | Discovery sources                                                                       | Version and dependency updates                                                             | Lockfile behavior                                                                                                                                       | Built-in registry publishing                                         |
-| -------------- | ----------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| Cargo          | `cargo`           | `Cargo.toml` workspaces and standalone crates                                           | `Cargo.toml` package versions and internal dependency requirements                         | Direct `Cargo.lock` rewrite by default; configure `cargo generate-lockfile`, `cargo check`, or another command when you need package-manager resolution | `crates.io`                                                          |
-| npm-family     | `npm`             | npm workspaces, pnpm workspaces, Bun workspaces, and standalone `package.json` packages | `package.json` versions and dependency ranges                                              | Direct `package-lock.json`, `pnpm-lock.yaml`, `bun.lock`, and `bun.lockb` updates by default; command overrides support package-manager refreshes       | `npm`                                                                |
-| Deno           | `deno`            | Deno workspaces and standalone `deno.json` / `deno.jsonc` packages                      | Deno manifest versions, exports/imports metadata, and dependency references                | Direct `deno.lock` update when possible; no inferred lockfile command                                                                                   | `jsr`                                                                |
-| Dart / Flutter | `dart`, `flutter` | Dart and Flutter workspaces plus standalone `pubspec.yaml` packages                     | `pubspec.yaml` versions and dependency ranges                                              | Direct `pubspec.lock` update by default; configure `dart pub get` or `flutter pub get` when you need full solver refreshes                              | `pub.dev`                                                            |
-| Python         | `python`          | uv workspaces, Poetry projects, and standalone `pyproject.toml` packages                | PEP 621 `[project]` and Poetry `[tool.poetry]` package versions plus dependency specifiers | Does not mutate `uv.lock` or `poetry.lock` directly; infers `uv lock` and `poetry lock --no-update` commands; unknown Python lockfiles are skipped      | Not built in; use `mode = "external"` for PyPI or private registries |
+| Ecosystem      | Package type      | Discovery sources                                                                       | Version and dependency updates                                                             | Lockfile behavior                                                                                                                                       | Built-in registry publishing |
+| -------------- | ----------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| Cargo          | `cargo`           | `Cargo.toml` workspaces and standalone crates                                           | `Cargo.toml` package versions and internal dependency requirements                         | Direct `Cargo.lock` rewrite by default; configure `cargo generate-lockfile`, `cargo check`, or another command when you need package-manager resolution | `crates.io`                  |
+| npm-family     | `npm`             | npm workspaces, pnpm workspaces, Bun workspaces, and standalone `package.json` packages | `package.json` versions and dependency ranges                                              | Direct `package-lock.json`, `pnpm-lock.yaml`, `bun.lock`, and `bun.lockb` updates by default; command overrides support package-manager refreshes       | `npm`                        |
+| Deno           | `deno`            | Deno workspaces and standalone `deno.json` / `deno.jsonc` packages                      | Deno manifest versions, exports/imports metadata, and dependency references                | Direct `deno.lock` update when possible; no inferred lockfile command                                                                                   | `jsr`                        |
+| Dart / Flutter | `dart`, `flutter` | Dart and Flutter workspaces plus standalone `pubspec.yaml` packages                     | `pubspec.yaml` versions and dependency ranges                                              | Direct `pubspec.lock` update by default; configure `dart pub get` or `flutter pub get` when you need full solver refreshes                              | `pub.dev`                    |
+| Python         | `python`          | uv workspaces, Poetry projects, and standalone `pyproject.toml` packages                | PEP 621 `[project]` and Poetry `[tool.poetry]` package versions plus dependency specifiers | Does not mutate `uv.lock` or `poetry.lock` directly; infers `uv lock` and `poetry lock --no-update` commands; unknown Python lockfiles are skipped      | `pypi`                       |
 
-The built-in publishing column is intentionally narrower than release planning. Python packages are fully supported for discovery, changesets, release plans, version rewrites, internal dependency rewrites, and lockfile command inference, but monochange does not publish to PyPI yet.
+The built-in publishing column is intentionally narrower than release planning. It lists only the canonical public registry for each supported ecosystem; private registries and custom publication flows should use `mode = "external"`.
 
 ## Shared behavior across ecosystems
 
@@ -152,7 +152,7 @@ Python lockfile behavior is command-based by design:
 - unknown Python lockfile names are ignored rather than guessed
 - configuring `[ecosystems.python].lockfile_commands` overrides the inferred commands
 
-Python publishing is external today. Keep package release planning in monochange, but publish with your existing PyPI, uv, Poetry, Hatch, or internal-registry workflow by setting package publishing to `mode = "external"` or by running your own CI step after `mc release`.
+Built-in Python publishing targets PyPI. monochange builds Python artifacts with `uv build --out-dir dist` and publishes them with `uv publish`, using `--trusted-publishing always` when trusted publishing is enabled and `--trusted-publishing never` otherwise. Placeholder publishing creates a minimal Hatchling project with a normalized module directory under `src/`.
 
 Example Python package configuration:
 
@@ -162,6 +162,12 @@ path = "services/api"
 type = "python"
 changelog = true
 
+[package.api.publish]
+enabled = true
+mode = "builtin"
+registry = "pypi"
+trusted_publishing = true
+
 [ecosystems.python]
 dependency_version_prefix = ">="
 # Optional: override inferred uv/Poetry lockfile commands.
@@ -170,14 +176,6 @@ lockfile_commands = [{ command = "uv lock", cwd = "." }]
 
 ## Choosing external publishing
 
-Use `mode = "external"` when an ecosystem or registry is not handled by monochange's built-in publisher, or when your organization needs custom signing, provenance, approval, rate-limit, or private-registry behavior.
-
-For Python, external publishing is currently the expected path:
-
-```toml
-[package.api.publish]
-enabled = true
-mode = "external"
-```
+Use `mode = "external"` when an ecosystem or registry is not handled by monochange's built-in publisher, or when your organization needs custom signing, provenance, approval, rate-limit, private-registry behavior, or a Python publishing toolchain other than the built-in `uv build` / `uv publish` flow.
 
 That keeps the package in release planning while leaving upload mechanics to your existing publishing workflow.

--- a/packages/monochange__skill/SKILL.md
+++ b/packages/monochange__skill/SKILL.md
@@ -165,7 +165,7 @@ Lockfile refresh is command-driven via `[ecosystems.<name>].lockfile_commands`. 
 ### Publishing and trust
 
 - Package publishing is configured through `publish` on packages and ecosystems.
-- Built-in publishing currently supports only the canonical public registries: `crates.io`, `npm`, `jsr`, and `pub.dev`. Python packages are release-planned but PyPI publishing should use `mode = "external"` or custom CI today.
+- Built-in publishing currently supports only the canonical public registries: `crates.io`, `npm`, `jsr`, `pub.dev`, and `pypi`. Use `mode = "external"` for private registries or custom publication flows.
 - `mc publish-readiness` blocks built-in Cargo publishes to crates.io when the current `Cargo.toml` is not publishable: `publish = false`, `publish = [...]` without `crates-io`, missing `description`, or missing both `license` and `license-file`. Workspace-inherited Cargo metadata is accepted.
 - `mc publish-plan --readiness <path>` validates a readiness artifact for the current release record and excludes package ids that are not ready in both the artifact and the fresh local readiness check. Placeholder planning does not accept readiness artifacts.
 - `mc publish-bootstrap --from HEAD --output <path>` is the release-scoped first-release bootstrap command. It reads package ids from the release record, runs placeholder publishing, writes a JSON result artifact, and should be followed by a fresh `mc publish-readiness` run.

--- a/readme.md
+++ b/readme.md
@@ -164,21 +164,21 @@ These are the commands most repositories use after running `mc init`. With the n
 
 <!-- {=projectCapabilityMatrix} -->
 
-| Capability                                                               | Current status                                                                                |
-| ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
-| Multi-ecosystem discovery                                                | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, Python                                              |
-| Package release planning                                                 | Built in                                                                                      |
-| Grouped/shared versioning                                                | Built in                                                                                      |
-| Dry-run release diff previews                                            | Built in via `mc release --dry-run --diff`                                                    |
-| Durable release history and post-merge tagging                           | Built in via `ReleaseRecord`, `mc release-record`, `mc tag-release`, and `mc repair-release`  |
-| Hosted provider releases                                                 | GitHub, GitLab, Gitea                                                                         |
-| Hosted release requests                                                  | GitHub, GitLab, Gitea                                                                         |
-| Python release planning                                                  | Built in for discovery, version rewrites, dependency rewrites, and lockfile command inference |
-| Built-in registry publishing                                             | `crates.io`, `npm`, `jsr`, `pub.dev`; use external mode for PyPI and custom registries        |
-| GitHub npm trusted-publishing automation                                 | Built in                                                                                      |
-| GitHub trusted-publishing guidance for `crates.io`, `jsr`, and `pub.dev` | Built in, but manual registry enrollment is still required                                    |
-| GitLab trusted-publishing auto-derivation                                | Not built in today                                                                            |
-| Release-retarget sync for hosted releases                                | GitHub first                                                                                  |
+| Capability                                                                     | Current status                                                                                                 |
+| ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| Multi-ecosystem discovery                                                      | Cargo, npm/pnpm/Bun, Deno, Dart, Flutter, Python                                                               |
+| Package release planning                                                       | Built in                                                                                                       |
+| Grouped/shared versioning                                                      | Built in                                                                                                       |
+| Dry-run release diff previews                                                  | Built in via `mc release --dry-run --diff`                                                                     |
+| Durable release history and post-merge tagging                                 | Built in via `ReleaseRecord`, `mc release-record`, `mc tag-release`, and `mc repair-release`                   |
+| Hosted provider releases                                                       | GitHub, GitLab, Gitea                                                                                          |
+| Hosted release requests                                                        | GitHub, GitLab, Gitea                                                                                          |
+| Python release planning                                                        | Built in for discovery, version rewrites, dependency rewrites, lockfile command inference, and PyPI publishing |
+| Built-in registry publishing                                                   | `crates.io`, `npm`, `jsr`, `pub.dev`, `pypi`; use external mode for custom registries                          |
+| GitHub npm trusted-publishing automation                                       | Built in                                                                                                       |
+| GitHub trusted-publishing guidance for `crates.io`, `jsr`, `pub.dev`, and PyPI | Built in, but manual registry enrollment is still required                                                     |
+| GitLab trusted-publishing auto-derivation                                      | Not built in today                                                                                             |
+| Release-retarget sync for hosted releases                                      | GitHub first                                                                                                   |
 
 <!-- {/projectCapabilityMatrix} -->
 


### PR DESCRIPTION
## Summary
- add PyPI as Python's built-in publish registry and default registry mapping
- add PyPI package/version checks, placeholder package generation, and uv build/publish commands
- document PyPI publishing and manual trusted-publisher enrollment

## Validation
- cargo fmt --all --check
- cargo check --workspace --all-features --all-targets
- cargo test -p monochange --features python package_publish --lib
- cargo test -p monochange --features python publish_rate_limits --lib
- cargo test -p monochange --features python publish_readiness --lib
- cargo test -p monochange_core -p monochange_config
- devenv shell docs:check
- devenv shell build:book
- devenv shell coverage:patch (PATCH_COVERAGE 0/0, 100.00%)
- devenv shell lint:all
- mc validate
- git diff --check