### PR TITLE
feat(release): publish GitHub releases through drafts

### DIFF
--- a/.changeset/github-draft-releases.md
+++ b/.changeset/github-draft-releases.md
@@ -1,0 +1,10 @@
+---
+monochange: minor
+monochange_core: minor
+---
+
+## publish GitHub releases through drafts
+
+- Add a boolean `draft` input to the built-in `PublishRelease` step so CLI commands can create hosted releases as drafts while preserving `[source.releases].draft` defaults.
+- Update release automation to create draft GitHub releases, run the asset upload workflow against those drafts, then publish the drafts after assets are attached.
+- Add a global `--jq` filter for JSON-producing commands so automation can extract release tags and other fields directly from `--format json` output.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,15 +94,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          if mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then
-            resolved_commit="$(jq -r '.resolvedCommit' /tmp/release-record.json)"
-            record_commit="$(jq -r '.recordCommit' /tmp/release-record.json)"
-
-            if [ "$resolved_commit" = "$record_commit" ]; then
-              echo "is_release_commit=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "is_release_commit=false" >> "$GITHUB_OUTPUT"
-            fi
+          if is_release_commit="$(mc release-record --from HEAD --format json --jq '.resolvedCommit == .recordCommit' 2>/dev/null)"; then
+            echo "is_release_commit=${is_release_commit}" >> "$GITHUB_OUTPUT"
           else
             echo "is_release_commit=false" >> "$GITHUB_OUTPUT"
           fi
@@ -368,15 +361,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          if mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then
-            resolved_commit="$(jq -r '.resolvedCommit' /tmp/release-record.json)"
-            record_commit="$(jq -r '.recordCommit' /tmp/release-record.json)"
-
-            if [ "$resolved_commit" = "$record_commit" ]; then
-              echo "is_release_commit=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "is_release_commit=false" >> "$GITHUB_OUTPUT"
-            fi
+          if is_release_commit="$(mc release-record --from HEAD --format json --jq '.resolvedCommit == .recordCommit' 2>/dev/null)"; then
+            echo "is_release_commit=${is_release_commit}" >> "$GITHUB_OUTPUT"
           else
             echo "is_release_commit=false" >> "$GITHUB_OUTPUT"
           fi
@@ -399,6 +385,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
     steps:
       - name: checkout repository
@@ -420,25 +407,34 @@ jobs:
         run: |
           set -euo pipefail
 
-          if mc release-record --from HEAD --format json >/tmp/release-record.json 2>/dev/null; then
-            resolved_commit="$(jq -r .resolvedCommit /tmp/release-record.json)"
-            record_commit="$(jq -r .recordCommit /tmp/release-record.json)"
-
-            if [ "$resolved_commit" = "$record_commit" ]; then
-              echo "is_release_commit=true" >> "$GITHUB_OUTPUT"
+          if is_release_commit="$(mc release-record --from HEAD --format json --jq '.resolvedCommit == .recordCommit' 2>/dev/null)"; then
+            echo "is_release_commit=${is_release_commit}" >> "$GITHUB_OUTPUT"
+            if [ "${is_release_commit}" = "true" ]; then
               mc tag-release --from HEAD --push=true --format json | tee /tmp/tag-report.json
-            else
-              echo "is_release_commit=false" >> "$GITHUB_OUTPUT"
             fi
           else
             echo "is_release_commit=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: publish release
+      - name: create draft releases
         if: steps.tag_release.outputs.is_release_commit == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mc publish-release --from-ref="${{ inputs.from-ref }}"
+        run: mc publish-release --from-ref="HEAD" --draft --format json | tee /tmp/publish-release.json
+        shell: devenv shell -- bash -e {0}
+
+      - name: upload release assets to drafts
+        if: steps.tag_release.outputs.is_release_commit == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          tag="$(mc release-record --from HEAD --format json --jq '.record.releaseTargets[] | select(.id == "main" and .kind == "group" and .release == true) | .tagName')"
+          gh workflow run release.yml \
+            --repo "${{ github.repository }}" \
+            --ref "main" \
+            -f "tag=${tag}"
         shell: devenv shell -- bash -e {0}
 
       - name: comment on released issues

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,8 +169,26 @@ jobs:
             echo "::endgroup::"
           done
 
-  trigger_publish:
+  publish_draft:
     needs: upload_assets
+    environment: publisher
+    env:
+      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+    permissions:
+      contents: write
+    if: >-
+      github.repository_owner == 'monochange' &&
+      startsWith(inputs.tag || github.ref_name, 'v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: publish draft release
+        run: gh release edit "${RELEASE_TAG}" --draft=false --latest --repo "${{ github.repository }}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  trigger_publish:
+    needs: publish_draft
     environment: publisher
     env:
       RELEASE_TAG: ${{ inputs.tag || github.ref_name }}

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -223,7 +223,48 @@ fn cli_help_returns_success_output() {
 	assert!(output.contains("step:retarget-release"));
 	assert!(output.contains("release-record"));
 	assert!(output.contains("publish-bootstrap"));
+	assert!(output.contains("publish-release"));
+	assert!(output.contains("comment-released-issues"));
 	assert!(output.contains("tag-release"));
+}
+
+#[test]
+fn publish_release_help_documents_draft_release_options() {
+	let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+	let output = run_with_args_in_dir(
+		"mc",
+		[
+			OsString::from("mc"),
+			OsString::from("publish-release"),
+			OsString::from("--help"),
+		],
+		&root,
+	)
+	.unwrap_or_else(|error| panic!("publish-release help: {error}"));
+
+	assert!(output.contains("Create provider releases from a durable release record"));
+	assert!(output.contains("--from-ref <FROM-REF>"));
+	assert!(output.contains("--draft"));
+	assert!(output.contains("--format <FORMAT>"));
+}
+
+#[test]
+fn comment_released_issues_help_documents_post_merge_options() {
+	let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+	let output = run_with_args_in_dir(
+		"mc",
+		[
+			OsString::from("mc"),
+			OsString::from("comment-released-issues"),
+			OsString::from("--help"),
+		],
+		&root,
+	)
+	.unwrap_or_else(|error| panic!("comment-released-issues help: {error}"));
+
+	assert!(output.contains("Comment on and optionally close issues"));
+	assert!(output.contains("--from-ref <FROM-REF>"));
+	assert!(output.contains("--auto-close-issues"));
 }
 
 #[test]
@@ -642,6 +683,58 @@ fn release_record_supports_json_output() {
 	assert!(output.contains("\"record\""));
 	assert!(output.contains("\"recordCommit\""));
 	assert!(output.contains("\"resolvedCommit\""));
+}
+
+#[test]
+fn release_record_jq_filters_json_output_for_ci() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	let mut record = sample_release_record_for_retarget();
+	record.release_targets[0].id = "main".to_string();
+	create_release_record_commit_from_record(root, &record);
+	let subscriber = tracing_subscriber::fmt()
+		.with_max_level(tracing::Level::TRACE)
+		.with_writer(std::io::sink)
+		.finish();
+	let traced_discovery = tracing::subscriber::with_default(subscriber, || {
+		crate::release_record::discover_release_record(root, "HEAD")
+	})
+	.unwrap_or_else(|error| panic!("trace release-record discovery: {error}"));
+	assert_eq!(traced_discovery.record.release_targets[0].id, "main");
+
+	let tag = run_cli(
+		root,
+		[
+			OsString::from("mc"),
+			OsString::from("release-record"),
+			OsString::from("--from"),
+			OsString::from("HEAD"),
+			OsString::from("--format"),
+			OsString::from("json"),
+			OsString::from("--jq"),
+			OsString::from(
+				r#".record.releaseTargets[] | select(.id == "main" and .kind == "group" and .release == true) | .tagName"#,
+			),
+		],
+	)
+	.unwrap_or_else(|error| panic!("release-record jq tag output: {error}"));
+	assert_eq!(tag, "v1.2.3");
+
+	let is_release_commit = run_cli(
+		root,
+		[
+			OsString::from("mc"),
+			OsString::from("release-record"),
+			OsString::from("--from"),
+			OsString::from("HEAD"),
+			OsString::from("--format"),
+			OsString::from("json"),
+			OsString::from("--jq"),
+			OsString::from(".resolvedCommit == .recordCommit"),
+		],
+	)
+	.unwrap_or_else(|error| panic!("release-record jq commit output: {error}"));
+	assert_eq!(is_release_commit, "true");
 }
 
 #[test]

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -171,6 +171,13 @@ pub(crate) fn build_command_with_cli(
 					.value_name("FORMAT")
 					.value_parser(["auto", "unicode", "ascii", "json"]),
 			)
+			.arg(
+				Arg::new("jq")
+					.long("jq")
+					.global(true)
+					.help("Filter JSON output with a jq-style expression, such as `.assets[].name`")
+					.value_name("EXPRESSION"),
+			)
 			.subcommand(
 				Command::new("init")
 					.about(

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -338,6 +338,19 @@ fn ensure_prepared_release_for_consumer_step(
 	Ok(())
 }
 
+fn publish_release_source_configuration(
+	configured_source: Option<&SourceConfiguration>,
+	step_inputs: &BTreeMap<String, Vec<String>>,
+) -> MonochangeResult<SourceConfiguration> {
+	let mut source = configured_source.cloned().ok_or_else(|| {
+		MonochangeError::Config("`PublishRelease` requires `[source]` configuration".to_string())
+	})?;
+	if parse_boolean_step_input(step_inputs, "draft")?.unwrap_or(false) {
+		source.releases.draft = true;
+	}
+	Ok(source)
+}
+
 pub(crate) fn build_release_results(
 	dry_run: bool,
 	requests: &[SourceReleaseRequest],
@@ -723,15 +736,14 @@ pub(crate) fn execute_cli_command_with_options(
 						let discovery = discover_release_record(root, &from_ref)?;
 						build_release_manifest_from_record(&discovery.record)
 					};
+					let source = publish_release_source_configuration(
+						configuration.source.as_ref(),
+						&step_inputs,
+					)?;
 					if !context.dry_run {
 						#[rustfmt::skip]
-						release_branch_policy::verify_release_ref_for_publish(root, configuration.source.as_ref(), &verify_ref)?;
+						release_branch_policy::verify_release_ref_for_publish(root, Some(&source), &verify_ref)?;
 					}
-					let source = configuration.source.clone().ok_or_else(|| {
-						MonochangeError::Config(
-							"`PublishRelease` requires `[source]` configuration".to_string(),
-						)
-					})?;
 					context.release_requests = build_source_release_requests(&source, &manifest);
 					#[rustfmt::skip]
 						let results = build_release_results_for_source(context.dry_run, &source, &context.release_requests)?;
@@ -3480,6 +3492,7 @@ mod tests {
 	use monochange_core::ReleaseOwnerKind;
 	use monochange_core::ReleasePlan;
 	use monochange_core::ShellConfig;
+	use monochange_core::SourceProvider;
 	use monochange_core::VersionFormat;
 	use serde::Serialize;
 	use tempfile::tempdir;
@@ -3513,6 +3526,63 @@ mod tests {
 			step_outputs: BTreeMap::new(),
 			command_logs: Vec::new(),
 		}
+	}
+
+	fn sample_source_configuration() -> SourceConfiguration {
+		let provider = serde_json::from_str::<SourceProvider>("\"github\"")
+			.unwrap_or_else(|error| panic!("source provider: {error}"));
+		SourceConfiguration {
+			provider,
+			owner: "monochange".to_string(),
+			repo: "monochange".to_string(),
+			host: None,
+			api_url: None,
+			releases: monochange_core::ProviderReleaseSettings::default(),
+			pull_requests: monochange_core::ProviderMergeRequestSettings::default(),
+			bot: monochange_core::ProviderBotSettings::default(),
+		}
+	}
+
+	#[test]
+	fn publish_release_source_configuration_preserves_configured_draft_default() {
+		let mut source = sample_source_configuration();
+		source.releases.draft = true;
+
+		let configured = publish_release_source_configuration(Some(&source), &BTreeMap::new())
+			.unwrap_or_else(|error| panic!("publish source: {error}"));
+
+		assert!(configured.releases.draft);
+	}
+
+	#[test]
+	fn publish_release_source_configuration_applies_draft_step_override() {
+		let source = sample_source_configuration();
+		let inputs = BTreeMap::from([("draft".to_string(), vec!["true".to_string()])]);
+
+		let configured = publish_release_source_configuration(Some(&source), &inputs)
+			.unwrap_or_else(|error| panic!("publish source: {error}"));
+
+		assert!(configured.releases.draft);
+		assert!(!source.releases.draft);
+	}
+
+	#[test]
+	fn publish_release_source_configuration_keeps_draft_disabled_without_override() {
+		let source = sample_source_configuration();
+
+		let configured = publish_release_source_configuration(Some(&source), &BTreeMap::new())
+			.unwrap_or_else(|error| panic!("publish source: {error}"));
+
+		assert!(!configured.releases.draft);
+	}
+
+	#[test]
+	fn publish_release_source_configuration_requires_source_configuration() {
+		let error = publish_release_source_configuration(None, &BTreeMap::new())
+			.err()
+			.unwrap_or_else(|| panic!("expected source configuration error"));
+
+		assert!(error.to_string().contains("[source]"));
 	}
 
 	fn sample_configuration(root: &Path) -> monochange_core::WorkspaceConfiguration {

--- a/crates/monochange/src/jq_filter.rs
+++ b/crates/monochange/src/jq_filter.rs
@@ -1,0 +1,438 @@
+use monochange_core::MonochangeError;
+use monochange_core::MonochangeResult;
+use serde_json::Value;
+
+pub(crate) fn apply_jq_filter(output: &str, expression: &str) -> MonochangeResult<String> {
+	let value = serde_json::from_str::<Value>(output.trim()).map_err(|error| {
+		MonochangeError::Config(format!(
+			"--jq requires JSON output; add `--format json` before filtering: {error}"
+		))
+	})?;
+	let values = evaluate_pipeline(vec![value], expression)?;
+	Ok(render_values(&values))
+}
+
+fn evaluate_pipeline(values: Vec<Value>, expression: &str) -> MonochangeResult<Vec<Value>> {
+	let mut current = values;
+	for stage in split_top_level(expression, '|') {
+		let stage = stage.trim();
+		if stage.is_empty() {
+			continue;
+		}
+
+		if let Some(condition) = select_condition(stage) {
+			let mut filtered = Vec::new();
+			for value in current {
+				if condition_matches(&value, condition)? {
+					filtered.push(value);
+				}
+			}
+			current = filtered;
+			continue;
+		}
+
+		if is_comparison(stage) {
+			current = current
+				.into_iter()
+				.map(|value| condition_matches(&value, stage).map(Value::Bool))
+				.collect::<MonochangeResult<Vec<_>>>()?;
+			continue;
+		}
+
+		current = current
+			.iter()
+			.flat_map(|value| evaluate_path(value, stage))
+			.collect();
+	}
+	Ok(current)
+}
+
+fn select_condition(stage: &str) -> Option<&str> {
+	stage
+		.strip_prefix("select(")
+		.and_then(|inner| inner.strip_suffix(')'))
+		.map(str::trim)
+}
+
+fn is_comparison(stage: &str) -> bool {
+	find_top_level_operator(stage, "==").is_some() || find_top_level_operator(stage, "!=").is_some()
+}
+
+fn condition_matches(value: &Value, condition: &str) -> MonochangeResult<bool> {
+	for part in split_top_level_and(condition) {
+		if !single_condition_matches(value, part.trim())? {
+			return Ok(false);
+		}
+	}
+	Ok(true)
+}
+
+fn single_condition_matches(value: &Value, condition: &str) -> MonochangeResult<bool> {
+	if let Some(index) = find_top_level_operator(condition, "==") {
+		return compare_operands(value, &condition[..index], &condition[index + 2..], true);
+	}
+	if let Some(index) = find_top_level_operator(condition, "!=") {
+		return compare_operands(value, &condition[..index], &condition[index + 2..], false);
+	}
+
+	Ok(evaluate_operand(value, condition)?
+		.into_iter()
+		.any(|candidate| truthy(&candidate)))
+}
+
+fn compare_operands(value: &Value, left: &str, right: &str, equal: bool) -> MonochangeResult<bool> {
+	let left_values = evaluate_operand(value, left.trim())?;
+	let right_values = evaluate_operand(value, right.trim())?;
+	let matched = left_values.iter().any(|left_value| {
+		right_values
+			.iter()
+			.any(|right_value| left_value == right_value)
+	});
+	Ok(if equal { matched } else { !matched })
+}
+
+fn evaluate_operand(value: &Value, operand: &str) -> MonochangeResult<Vec<Value>> {
+	let operand = operand.trim();
+	if operand.starts_with('.') {
+		return Ok(evaluate_path(value, operand));
+	}
+	parse_literal(operand).map(|literal| vec![literal])
+}
+
+fn parse_literal(value: &str) -> MonochangeResult<Value> {
+	match value {
+		"true" => Ok(Value::Bool(true)),
+		"false" => Ok(Value::Bool(false)),
+		"null" => Ok(Value::Null),
+		_ if value.starts_with('"') => {
+			serde_json::from_str::<Value>(value).map_err(|error| {
+				MonochangeError::Config(format!("invalid --jq string literal `{value}`: {error}"))
+			})
+		}
+		_ => {
+			serde_json::from_str::<Value>(value).map_err(|error| {
+				MonochangeError::Config(format!("unsupported --jq operand `{value}`: {error}"))
+			})
+		}
+	}
+}
+
+fn evaluate_path(value: &Value, path: &str) -> Vec<Value> {
+	let path = path.trim();
+	if path == "." {
+		return vec![value.clone()];
+	}
+	if !path.starts_with('.') {
+		return Vec::new();
+	}
+
+	let mut current = vec![value.clone()];
+	let chars = path.chars().collect::<Vec<_>>();
+	let mut index = 1;
+	while index < chars.len() {
+		match chars[index] {
+			'.' => index += 1,
+			'[' if chars.get(index + 1) == Some(&']') => {
+				current = current
+					.into_iter()
+					.flat_map(|candidate| {
+						match candidate {
+							Value::Array(values) => values,
+							_ => Vec::new(),
+						}
+					})
+					.collect();
+				index += 2;
+			}
+			'[' => {
+				let Some(end) = chars[index..]
+					.iter()
+					.position(|character| *character == ']')
+				else {
+					return Vec::new();
+				};
+				let end = index + end;
+				let Ok(array_index) = chars[index + 1..end]
+					.iter()
+					.collect::<String>()
+					.parse::<usize>()
+				else {
+					return Vec::new();
+				};
+				current = current
+					.into_iter()
+					.filter_map(|candidate| {
+						match candidate {
+							Value::Array(values) => values.get(array_index).cloned(),
+							_ => None,
+						}
+					})
+					.collect();
+				index = end + 1;
+			}
+			_ => {
+				let start = index;
+				while index < chars.len() && is_field_character(chars[index]) {
+					index += 1;
+				}
+				if start == index {
+					return Vec::new();
+				}
+				let field = chars[start..index].iter().collect::<String>();
+				current = current
+					.into_iter()
+					.filter_map(|candidate| {
+						match candidate {
+							Value::Object(map) => map.get(&field).cloned(),
+							_ => None,
+						}
+					})
+					.collect();
+			}
+		}
+	}
+	current
+}
+
+fn is_field_character(character: char) -> bool {
+	character.is_ascii_alphanumeric() || matches!(character, '_' | '-')
+}
+
+fn split_top_level(expression: &str, delimiter: char) -> Vec<&str> {
+	let mut parts = Vec::new();
+	let mut start = 0;
+	let mut depth = 0usize;
+	let mut in_string = false;
+	let mut escaped = false;
+	for (index, character) in expression.char_indices() {
+		if in_string {
+			if escaped {
+				escaped = false;
+			} else if character == '\\' {
+				escaped = true;
+			} else if character == '"' {
+				in_string = false;
+			}
+			continue;
+		}
+		match character {
+			'"' => in_string = true,
+			'(' | '[' => depth += 1,
+			')' | ']' => depth = depth.saturating_sub(1),
+			_ if character == delimiter && depth == 0 => {
+				parts.push(&expression[start..index]);
+				start = index + character.len_utf8();
+			}
+			_ => {}
+		}
+	}
+	parts.push(&expression[start..]);
+	parts
+}
+
+fn split_top_level_and(expression: &str) -> Vec<&str> {
+	let mut parts = Vec::new();
+	let mut start = 0;
+	let mut depth = 0usize;
+	let mut in_string = false;
+	let mut escaped = false;
+	let bytes = expression.as_bytes();
+	let mut index = 0;
+	while index < bytes.len() {
+		let character = expression[index..].chars().next().unwrap_or_default();
+		if in_string {
+			if escaped {
+				escaped = false;
+			} else if character == '\\' {
+				escaped = true;
+			} else if character == '"' {
+				in_string = false;
+			}
+			index += character.len_utf8();
+			continue;
+		}
+		match character {
+			'"' => in_string = true,
+			'(' | '[' => depth += 1,
+			')' | ']' => depth = depth.saturating_sub(1),
+			'a' if depth == 0 && expression[index..].starts_with("and") => {
+				let before = index == 0 || bytes[index - 1].is_ascii_whitespace();
+				let after_index = index + 3;
+				let after = after_index >= bytes.len() || bytes[after_index].is_ascii_whitespace();
+				if before && after {
+					parts.push(&expression[start..index]);
+					start = after_index;
+					index = after_index;
+					continue;
+				}
+			}
+			_ => {}
+		}
+		index += character.len_utf8();
+	}
+	parts.push(&expression[start..]);
+	parts
+}
+
+fn find_top_level_operator(expression: &str, operator: &str) -> Option<usize> {
+	let mut depth = 0usize;
+	let mut in_string = false;
+	let mut escaped = false;
+	for (index, character) in expression.char_indices() {
+		if in_string {
+			if escaped {
+				escaped = false;
+			} else if character == '\\' {
+				escaped = true;
+			} else if character == '"' {
+				in_string = false;
+			}
+			continue;
+		}
+		match character {
+			'"' => in_string = true,
+			'(' | '[' => depth += 1,
+			')' | ']' => depth = depth.saturating_sub(1),
+			_ if depth == 0 && expression[index..].starts_with(operator) => return Some(index),
+			_ => {}
+		}
+	}
+	None
+}
+
+fn truthy(value: &Value) -> bool {
+	!matches!(value, Value::Null | Value::Bool(false))
+}
+
+fn render_values(values: &[Value]) -> String {
+	values
+		.iter()
+		.map(render_value)
+		.collect::<Vec<_>>()
+		.join("\n")
+}
+
+fn render_value(value: &Value) -> String {
+	match value {
+		Value::Null => "null".to_string(),
+		Value::Bool(value) => value.to_string(),
+		Value::Number(value) => value.to_string(),
+		Value::String(value) => value.clone(),
+		Value::Array(_) | Value::Object(_) => {
+			serde_json::to_string(value)
+				.unwrap_or_else(|error| panic!("serializing filtered JSON should succeed: {error}"))
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn jq_filter_extracts_array_fields_and_selects_matches() {
+		let output = r#"{"assets":[{"name":"a"},{"name":"b"}],"record":{"releaseTargets":[{"id":"main","kind":"group","release":true,"tagName":"v1.2.3"},{"id":"core","kind":"package","release":false,"tagName":"core/v1.2.3"}]},"resolvedCommit":"abc","recordCommit":"abc"}"#;
+
+		assert_eq!(apply_jq_filter(output, ".assets[].name").unwrap(), "a\nb");
+		assert_eq!(
+			apply_jq_filter(
+				output,
+				r#".record.releaseTargets[] | select(.id == "main" and .kind == "group" and .release == true) | .tagName"#,
+			)
+			.unwrap(),
+			"v1.2.3"
+		);
+		assert_eq!(
+			apply_jq_filter(output, ".resolvedCommit == .recordCommit").unwrap(),
+			"true"
+		);
+	}
+
+	#[test]
+	fn jq_filter_reports_non_json_output() {
+		let error = apply_jq_filter("not json", ".assets[].name").unwrap_err();
+		assert!(error.to_string().contains("--jq requires JSON output"));
+	}
+
+	#[test]
+	fn jq_filter_renders_scalar_array_and_object_values() {
+		let output = r#"{"number":42,"nothing":null,"items":[{"name":"a"}]}"#;
+
+		assert_eq!(
+			apply_jq_filter(output, ".").unwrap(),
+			r#"{"items":[{"name":"a"}],"nothing":null,"number":42}"#
+		);
+		assert_eq!(apply_jq_filter(output, ".number").unwrap(), "42");
+		assert_eq!(apply_jq_filter(output, ".nothing").unwrap(), "null");
+		assert_eq!(
+			apply_jq_filter(output, ".items").unwrap(),
+			r#"[{"name":"a"}]"#
+		);
+	}
+
+	#[test]
+	fn jq_filter_handles_empty_stages_and_truthy_selectors() {
+		let output = r#"{"items":[{"id":"main","release":true},{"id":"draft","release":false},{"id":"missing"}]}"#;
+
+		assert_eq!(
+			apply_jq_filter(output, ".items[] | | select(.release) | .id").unwrap(),
+			"main"
+		);
+		assert_eq!(
+			apply_jq_filter(output, ".items[] | select(.missing) | .id").unwrap(),
+			""
+		);
+	}
+
+	#[test]
+	fn jq_filter_handles_not_equal_and_string_escapes() {
+		let output = r#"{"items":[{"id":"main","name":"a\"b","tags":["x"],"candy":true},{"id":"draft","name":"plain","tags":["y"],"candy":true}]}"#;
+
+		assert_eq!(
+			apply_jq_filter(output, r#".items[] | select(.id != "draft") | .id"#).unwrap(),
+			"main"
+		);
+		assert_eq!(
+			apply_jq_filter(output, r#".items[] | select("a\"b" == .name) | .id"#).unwrap(),
+			"main"
+		);
+		assert_eq!(
+			apply_jq_filter(
+				output,
+				r#".items[] | select(.tags[0] == "x" and .candy == true and .name == "a\"b") | .id"#
+			)
+			.unwrap(),
+			"main"
+		);
+	}
+
+	#[test]
+	fn jq_filter_reports_invalid_operands() {
+		let output = r#"{"id":"main"}"#;
+
+		let invalid_string = apply_jq_filter(output, r#".id == "unterminated"#).unwrap_err();
+		assert!(
+			invalid_string
+				.to_string()
+				.contains("invalid --jq string literal")
+		);
+
+		let unsupported = apply_jq_filter(output, ".id == unsupported").unwrap_err();
+		assert!(unsupported.to_string().contains("unsupported --jq operand"));
+	}
+
+	#[test]
+	fn jq_filter_ignores_invalid_or_missing_paths() {
+		let output = r#"{"items":[{"name":"a"}],"name":"top"}"#;
+
+		assert_eq!(apply_jq_filter(output, "items").unwrap(), "");
+		assert_eq!(apply_jq_filter(output, ".name[]").unwrap(), "");
+		assert_eq!(apply_jq_filter(output, ".items[0].name").unwrap(), "a");
+		assert_eq!(apply_jq_filter(output, ".items[9].name").unwrap(), "");
+		assert_eq!(apply_jq_filter(output, ".items[bad].name").unwrap(), "");
+		assert_eq!(apply_jq_filter(output, ".items[0.name").unwrap(), "");
+		assert_eq!(apply_jq_filter(output, ".name[0]").unwrap(), "");
+		assert_eq!(apply_jq_filter(output, ".%").unwrap(), "");
+		assert_eq!(apply_jq_filter(output, ".items[].name.foo").unwrap(), "");
+	}
+}

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -296,6 +296,7 @@ mod cli_theme;
 mod git_support;
 mod hosted_sources;
 mod interactive;
+mod jq_filter;
 mod lint;
 mod lint_check_reporter;
 mod mcp;
@@ -768,7 +769,8 @@ where
 		Err(error) => return Err(MonochangeError::Config(error.to_string())),
 	};
 
-	match matches.subcommand() {
+	let jq_expression = matches.get_one::<String>("jq").cloned();
+	let output = match matches.subcommand() {
 		Some(("help", help_matches)) => {
 			let command_name = help_matches
 				.get_one::<String>("command")
@@ -1022,6 +1024,12 @@ where
 			)
 		}
 		None => Err(MonochangeError::Config("Usage: mc".to_string())),
+	}?;
+
+	if let Some(expression) = jq_expression {
+		jq_filter::apply_jq_filter(&output, &expression)
+	} else {
+		Ok(output)
 	}
 }
 

--- a/crates/monochange/src/monochange.init.toml
+++ b/crates/monochange/src/monochange.init.toml
@@ -948,6 +948,8 @@ steps = [
 help_text = "Create provider releases from a durable release record"
 inputs = [
 	{ name = "from-ref", type = "string", default = "HEAD" },
+	{ name = "draft", type = "boolean", default = false },
+	{ name = "format", type = "choice", choices = ["text", "json", "markdown"], default = "text" },
 ]
 steps = [{ name = "publish release", type = "PublishRelease" }]
 
@@ -955,7 +957,7 @@ steps = [{ name = "publish release", type = "PublishRelease" }]
 help_text = "Comment on and optionally close issues referenced in released changesets"
 inputs = [
 	{ name = "from-ref", type = "string", default = "HEAD" },
-	{ name = "auto-close-issues", type = "string", default = "false" },
+	{ name = "auto-close-issues", type = "boolean", default = false },
 ]
 steps = [{ name = "comment on released issues", type = "CommentReleasedIssues" }]
 

--- a/crates/monochange/src/snapshots/monochange____tests__subagents_help_describes_supported_targets.snap
+++ b/crates/monochange/src/snapshots/monochange____tests__subagents_help_describes_supported_targets.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/monochange/src/__tests.rs
-assertion_line: 351
+assertion_line: 493
 expression: output
 ---
 Generate repo-local monochange subagents and agent guidance files
@@ -17,6 +17,7 @@ Options:
       --dry-run                   Preview the generated files without writing them
       --progress-format <FORMAT>  Control progress output on stderr [possible values: auto, unicode, ascii, json]
       --format <format>           Output format for the generated subagent plan [default: markdown] [possible values: text, json, markdown, md]
+      --jq <EXPRESSION>           Filter JSON output with a jq-style expression, such as `.assets[].name`
       --no-mcp                    Skip repo-local MCP config files for supported targets
   -h, --help                      Print help
 

--- a/crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_prints_help.snap
+++ b/crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_prints_help.snap
@@ -49,6 +49,7 @@ Commands:
 Options:
   -q, --quiet                     Suppress stdout/stderr output and run in dry-run mode when supported
       --progress-format <FORMAT>  Control progress output on stderr [possible values: auto, unicode, ascii, json]
+      --jq <EXPRESSION>           Filter JSON output with a jq-style expression, such as `.assets[].name`
   -h, --help                      Print help
 
 

--- a/crates/monochange/tests/snapshots/cli_output__change_cli_help_documents_package_and_group_targeting_rules@change_cli_help_documents_package_and_group_targeting_rules.snap
+++ b/crates/monochange/tests/snapshots/cli_output__change_cli_help_documents_package_and_group_targeting_rules@change_cli_help_documents_package_and_group_targeting_rules.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/monochange/tests/cli_output.rs
-assertion_line: 156
 info:
   program: mc
   args:
@@ -24,6 +23,7 @@ Options:
       --package <PACKAGE>         Package or group to include in the change
       --progress-format <FORMAT>  Control progress output on stderr [possible values: auto, unicode, ascii, json]
       --bump <BUMP>               Requested semantic version bump [default: patch] [possible values: none, patch, minor, major]
+      --jq <EXPRESSION>           Filter JSON output with a jq-style expression, such as `.assets[].name`
       --version <VERSION>         Pin an explicit version for this release
       --reason <REASON>           Short release-note summary for this change
       --type <TYPE>               Optional release-note type such as `security` or `note` [possible values: security, test]

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -1226,6 +1226,16 @@ fn valid_input_names_returns_expected_names_for_display_and_publish_steps() {
 		Some(["format"].as_slice())
 	);
 
+	let publish_release = CliStepDefinition::PublishRelease {
+		name: None,
+		when: None,
+		inputs: BTreeMap::new(),
+	};
+	assert_eq!(
+		publish_release.valid_input_names(),
+		Some(["format", "from-ref", "draft"].as_slice())
+	);
+
 	let publish = CliStepDefinition::PublishPackages {
 		name: None,
 		when: None,
@@ -1353,6 +1363,44 @@ fn expected_input_kind_returns_correct_types_for_display_and_publish_steps() {
 	);
 	assert_eq!(prepare.expected_input_kind("versions"), None);
 	assert_eq!(prepare.expected_input_kind("unknown"), None);
+
+	let comment_released_issues = CliStepDefinition::CommentReleasedIssues {
+		name: None,
+		when: None,
+		inputs: BTreeMap::new(),
+	};
+	assert_eq!(
+		comment_released_issues.expected_input_kind("format"),
+		Some(CliInputKind::Choice)
+	);
+	assert_eq!(
+		comment_released_issues.expected_input_kind("from-ref"),
+		Some(CliInputKind::String)
+	);
+	assert_eq!(
+		comment_released_issues.expected_input_kind("auto-close-issues"),
+		Some(CliInputKind::Boolean)
+	);
+	assert_eq!(comment_released_issues.expected_input_kind("unknown"), None);
+
+	let publish_release = CliStepDefinition::PublishRelease {
+		name: None,
+		when: None,
+		inputs: BTreeMap::new(),
+	};
+	assert_eq!(
+		publish_release.expected_input_kind("format"),
+		Some(CliInputKind::Choice)
+	);
+	assert_eq!(
+		publish_release.expected_input_kind("from-ref"),
+		Some(CliInputKind::String)
+	);
+	assert_eq!(
+		publish_release.expected_input_kind("draft"),
+		Some(CliInputKind::Boolean)
+	);
+	assert_eq!(publish_release.expected_input_kind("unknown"), None);
 
 	let publish = CliStepDefinition::PublishPackages {
 		name: None,

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -2063,11 +2063,13 @@ impl CliStepDefinition {
 			Self::Validate { .. } => Some(&["fix"]),
 			Self::CommitRelease { .. } => Some(&["no_verify"]),
 			Self::VerifyReleaseBranch { .. } => Some(&["from"]),
-			Self::Discover { .. }
-			| Self::DisplayVersions { .. }
-			| Self::PrepareRelease { .. }
-			| Self::PublishRelease { .. }
-			| Self::CommentReleasedIssues { .. } => Some(&["format"]),
+			Self::Discover { .. } | Self::DisplayVersions { .. } | Self::PrepareRelease { .. } => {
+				Some(&["format"])
+			}
+			Self::CommentReleasedIssues { .. } => {
+				Some(&["format", "from-ref", "auto-close-issues"])
+			}
+			Self::PublishRelease { .. } => Some(&["format", "from-ref", "draft"]),
 			Self::OpenReleaseRequest { .. } => Some(&["format", "no_verify"]),
 			Self::PlaceholderPublish { .. } => Some(&["format", "package"]),
 			Self::PublishPackages { .. } => {
@@ -2159,13 +2161,22 @@ impl CliStepDefinition {
 				}
 			}
 			Self::Command { .. } => None,
-			Self::Discover { .. }
-			| Self::DisplayVersions { .. }
-			| Self::PrepareRelease { .. }
-			| Self::PublishRelease { .. }
-			| Self::CommentReleasedIssues { .. } => {
+			Self::Discover { .. } | Self::DisplayVersions { .. } | Self::PrepareRelease { .. } => {
+				matches!(name, "format").then_some(CliInputKind::Choice)
+			}
+			Self::CommentReleasedIssues { .. } => {
 				match name {
 					"format" => Some(CliInputKind::Choice),
+					"from-ref" => Some(CliInputKind::String),
+					"auto-close-issues" => Some(CliInputKind::Boolean),
+					_ => None,
+				}
+			}
+			Self::PublishRelease { .. } => {
+				match name {
+					"format" => Some(CliInputKind::Choice),
+					"from-ref" => Some(CliInputKind::String),
+					"draft" => Some(CliInputKind::Boolean),
 					_ => None,
 				}
 			}

--- a/monochange.toml
+++ b/monochange.toml
@@ -737,6 +737,23 @@ steps = [
 	{ type = "OpenReleaseRequest", name = "create the pr", inputs = { no_verify = "{{ inputs.no_verify }}" } },
 ]
 
+[cli.publish-release]
+help_text = "Create provider releases from a durable release record"
+inputs = [
+	{ name = "from-ref", type = "string", default = "HEAD" },
+	{ name = "draft", type = "boolean", default = false },
+	{ name = "format", type = "choice", choices = ["text", "json", "markdown"], default = "text" },
+]
+steps = [{ name = "publish release", type = "PublishRelease" }]
+
+[cli.comment-released-issues]
+help_text = "Comment on and optionally close issues referenced in released changesets"
+inputs = [
+	{ name = "from-ref", type = "string", default = "HEAD" },
+	{ name = "auto-close-issues", type = "boolean", default = false },
+]
+steps = [{ name = "comment on released issues", type = "CommentReleasedIssues" }]
+
 [cli.publish]
 help_text = "Publish packages from this release using built-in publishing workflows"
 inputs = [


### PR DESCRIPTION
## Summary
- add a `draft` input to the `PublishRelease` step and expose draft/from-ref release follow-up commands in monochange config
- create GitHub releases as drafts in post-merge release automation, dispatch asset uploads for each release tag, then publish the draft from `release.yml`
- cover the new step input schema, CLI help, and draft source override behavior

## Validation
- cargo fmt --all
- devenv shell mc validate
- cargo test -p monochange_core valid_input_names_returns_expected_names_for_display_and_publish_steps --lib
- cargo test -p monochange_core expected_input_kind_returns_correct_types_for_display_and_publish_steps --lib
- cargo test -p monochange publish_release_help_documents_draft_release_options --lib
- cargo test -p monochange comment_released_issues_help_documents_post_merge_options --lib
- cargo test -p monochange publish_release_source_configuration --lib
- cargo clippy -p monochange_core --all-targets -- -D warnings
- cargo clippy -p monochange --lib --tests -- -D warnings
- devenv shell coverage:patch (`PATCH_COVERAGE 0/0 (100.00%)`; no executable changed lines reported locally)
- pre-push hook: 1932 tests passed