### PR TITLE
feat: add configurable changeset lint rules

### DIFF
--- a/.changeset/configurable-changeset-lints.md
+++ b/.changeset/configurable-changeset-lints.md
@@ -1,0 +1,12 @@
+---
+monochange: feat
+monochange_config: feat
+monochange_core: feat
+"@monochange/skill": patch
+---
+
+#### Configure changeset lint rules
+
+Add configurable changeset lint rules under `[lints.rules]` for summaries, section headings, bump-specific requirements, and changelog-type-specific requirements.
+
+Rules can target built-in or custom changeset types with dynamic ids like `changesets/types/breaking` and `changesets/types/unicorns`, while unknown type ids are rejected during configuration loading.

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -1043,6 +1043,27 @@ Rule configuration supports two forms:
 - simple severity: `"rule-id" = "error"`, `"warning"`, or `"off"`
 - detailed config: `{ level = "error", ...rule_specific_options }`
 
+## Changeset lint rules
+
+Changeset lint rules use the same `[lints.rules]` table as manifest rules. They are evaluated while markdown changesets are loaded by validation and release workflows.
+
+```toml
+[lints.rules]
+"changesets/duplicate" = "error"
+"changesets/no_section_headings" = "error"
+"changesets/summary" = { level = "error", required = true, heading_level = 2, min_length = 12, max_length = 80, forbid_trailing_period = true, forbid_conventional_commit_prefix = true }
+"changesets/bump/major" = { level = "error", required_sections = ["Impact", "Migration"], min_body_chars = 120, require_code_block = true }
+"changesets/types/breaking" = { level = "error", forbidden_headings = ["Breaking", "Breaking changes"], required_sections = ["Impact", "Migration"], required_bump = "major" }
+```
+
+Supported changeset rule ids:
+
+- `changesets/duplicate` — validates that a changeset does not target the same effective package more than once.
+- `changesets/no_section_headings` — rejects headings that duplicate a change type used by that changeset.
+- `changesets/summary` — configures the one-line summary heading. Options: `required`, `heading_level`, `min_length`, `max_length`, `forbid_trailing_period`, `forbid_conventional_commit_prefix`.
+- `changesets/bump/<severity>` — configures rules for `major`, `minor`, or `patch` entries. Options: `required_sections`, `forbidden_headings`, `min_body_chars`, `max_body_chars`, `require_code_block`, `required_bump`.
+- `changesets/types/<type>` — configures rules for a configured changelog type such as `breaking`, `feature`, `fix`, `security`, or a custom type like `unicorns`. It accepts the same scoped options as bump rules. The `<type>` segment must match a configured changelog type.
+
 ## Current rule coverage
 
 Today, built-in manifest lint rules exist for:

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -6,6 +6,7 @@ use miette::LabeledSpan;
 use monochange_core::BumpSeverity;
 use monochange_core::ChangelogDefinition;
 use monochange_core::ChangelogFormat;
+use monochange_core::ChangelogSettings;
 use monochange_core::ChangelogTarget;
 use monochange_core::CliCommandDefinition;
 use monochange_core::CliInputDefinition;
@@ -22,6 +23,11 @@ use monochange_core::PublishState;
 use monochange_core::RegistryKind;
 use monochange_core::ShellConfig;
 use monochange_core::SourceProvider;
+use monochange_core::lint::ChangesetLintSettings;
+use monochange_core::lint::ChangesetScopedLintSettings;
+use monochange_core::lint::ChangesetSummaryLintSettings;
+use monochange_core::lint::LintRuleConfig;
+use monochange_core::lint::LintSeverity;
 use monochange_test_helpers::current_test_name;
 use monochange_test_helpers::snapshot_settings;
 use semver::Version;
@@ -1402,6 +1408,553 @@ fn load_change_signals_parses_explicit_versions_and_infers_bumps() {
 	assert_eq!(target.explicit_version, Some(Version::new(1, 2, 0)));
 	assert_eq!(signal.requested_bump, Some(BumpSeverity::Minor));
 	assert_eq!(signal.explicit_version, Some(Version::new(1, 2, 0)));
+}
+
+#[test]
+fn load_changeset_file_lints_configured_summary_requirements() {
+	let root = fixture_path("config/changeset-lint-summary");
+	let configuration = load_workspace_configuration(&root)
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+	let summary_rule = configuration
+		.lints
+		.rules
+		.get("changesets/summary")
+		.unwrap_or_else(|| panic!("expected changesets/summary rule"));
+	assert_eq!(summary_rule.severity(), LintSeverity::Error);
+	assert!(summary_rule.bool_option("required", false));
+	let packages = vec![PackageRecord::new(
+		Ecosystem::Cargo,
+		"cargo-core",
+		root.join("crates/core/Cargo.toml"),
+		root.clone(),
+		Some(Version::new(1, 0, 0)),
+		PublishState::Public,
+	)];
+
+	let error = load_changeset_file(&root.join("change.md"), &configuration, &packages)
+		.expect_err("summary lint should reject a body that does not start with a heading");
+	let message = error.to_string();
+
+	assert!(
+		message.contains("changeset body must start with a summary heading"),
+		"unexpected error: {message}"
+	);
+}
+
+#[test]
+fn load_changeset_file_lints_configured_bump_and_type_rules() {
+	let root = fixture_path("config/changeset-lint-bump-type");
+	let configuration = load_workspace_configuration(&root)
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+	let packages = vec![PackageRecord::new(
+		Ecosystem::Cargo,
+		"cargo-core",
+		root.join("crates/core/Cargo.toml"),
+		root.clone(),
+		Some(Version::new(1, 0, 0)),
+		PublishState::Public,
+	)];
+
+	let error = load_changeset_file(&root.join("change.md"), &configuration, &packages)
+		.expect_err("type lint should reject a forbidden heading");
+	let message = error.to_string();
+
+	assert!(
+		message.contains("changeset must not use `Breaking` as a heading"),
+		"unexpected error: {message}"
+	);
+}
+
+#[test]
+fn load_changeset_file_lints_configured_custom_type_rule() {
+	let root = fixture_path("config/changeset-lint-custom-type");
+	let configuration = load_workspace_configuration(&root)
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+	assert!(configuration.changelog.types.contains_key("unicorns"));
+	assert!(
+		configuration
+			.lints
+			.rules
+			.contains_key("changesets/types/unicorns")
+	);
+	let packages = vec![PackageRecord::new(
+		Ecosystem::Cargo,
+		"cargo-core",
+		root.join("crates/core/Cargo.toml"),
+		root.clone(),
+		Some(Version::new(1, 0, 0)),
+		PublishState::Public,
+	)];
+
+	let error = load_changeset_file(&root.join("change.md"), &configuration, &packages)
+		.expect_err("custom type lint should reject a missing required section");
+	let message = error.to_string();
+
+	assert!(
+		message.contains("changeset must include a `Rainbow` section"),
+		"unexpected error: {message}"
+	);
+}
+
+#[test]
+fn load_workspace_configuration_rejects_unknown_changeset_type_lint_rule() {
+	let root = fixture_path("config/changeset-lint-unknown-type");
+	let error = load_workspace_configuration(&root)
+		.expect_err("unknown changeset type lint rule should be rejected");
+	let message = error.to_string();
+
+	assert!(
+		message.contains(
+			"[lints.rules].changesets/types/unicorns references an unknown changeset type"
+		),
+		"unexpected error: {message}"
+	);
+}
+
+fn detailed_lint_rule(options: &[(&str, serde_json::Value)]) -> LintRuleConfig {
+	LintRuleConfig::Detailed {
+		level: LintSeverity::Error,
+		options: options
+			.iter()
+			.map(|(key, value)| ((*key).to_string(), value.clone()))
+			.collect(),
+	}
+}
+
+fn changeset_lint_rules(entries: &[(&str, LintRuleConfig)]) -> BTreeMap<String, LintRuleConfig> {
+	entries
+		.iter()
+		.map(|(key, value)| ((*key).to_string(), value.clone()))
+		.collect()
+}
+
+fn raw_change(bump: Option<BumpSeverity>, change_type: Option<&str>) -> crate::RawChangeEntry {
+	crate::RawChangeEntry {
+		package: "cargo-core".to_string(),
+		bump,
+		version: None,
+		reason: None,
+		details: None,
+		change_type: change_type.map(str::to_string),
+		caused_by: Vec::new(),
+	}
+}
+
+fn expect_config_error(result: monochange_core::MonochangeResult<()>, expected: &str) {
+	let error = result.expect_err("expected config error").to_string();
+	assert!(error.contains(expected), "unexpected error: {error}");
+}
+
+#[test]
+fn changeset_lint_rule_parsing_covers_enabled_disabled_and_invalid_options() {
+	let settings = crate::changeset_lint_settings_from_rules(&changeset_lint_rules(&[
+		(
+			"packages/name",
+			LintRuleConfig::Severity(LintSeverity::Error),
+		),
+		(
+			"changesets/duplicate",
+			LintRuleConfig::Severity(LintSeverity::Off),
+		),
+		(
+			"changesets/no_section_headings",
+			LintRuleConfig::Severity(LintSeverity::Error),
+		),
+		(
+			"changesets/summary",
+			detailed_lint_rule(&[
+				("required", serde_json::json!(true)),
+				("heading_level", serde_json::json!(2)),
+				("min_length", serde_json::json!(3)),
+				("max_length", serde_json::json!(80)),
+				("forbid_trailing_period", serde_json::json!(true)),
+				("forbid_conventional_commit_prefix", serde_json::json!(true)),
+			]),
+		),
+		(
+			"changesets/bump/minor",
+			detailed_lint_rule(&[
+				("required_sections", serde_json::json!(["Impact"])),
+				("min_body_chars", serde_json::json!(12)),
+				("max_body_chars", serde_json::json!(200)),
+				("require_code_block", serde_json::json!(true)),
+				("required_bump", serde_json::json!("minor")),
+				("forbidden_headings", serde_json::json!(["Minor"])),
+			]),
+		),
+		(
+			"changesets/types/Feature",
+			detailed_lint_rule(&[("required_sections", serde_json::json!(["Usage"]))]),
+		),
+		(
+			"changesets/unknown",
+			LintRuleConfig::Severity(LintSeverity::Error),
+		),
+	]))
+	.unwrap_or_else(|error| panic!("parse changeset lints: {error}"));
+
+	assert!(settings.no_section_headings);
+	assert!(settings.summary.required);
+	assert_eq!(settings.summary.heading_level, Some(2));
+	assert!(settings.bump.contains_key(&BumpSeverity::Minor));
+	assert!(settings.types.contains_key("Feature"));
+
+	for (rule_id, config, expected) in [
+		(
+			"changesets/bump/mega",
+			LintRuleConfig::Severity(LintSeverity::Error),
+			"uses an unknown bump severity",
+		),
+		(
+			"changesets/types/",
+			LintRuleConfig::Severity(LintSeverity::Error),
+			"must include a type name",
+		),
+		(
+			"changesets/summary",
+			detailed_lint_rule(&[("required", serde_json::json!("yes"))]),
+			"required must be a boolean",
+		),
+		(
+			"changesets/summary",
+			detailed_lint_rule(&[(
+				"forbid_conventional_commit_prefix",
+				serde_json::json!("yes"),
+			)]),
+			"forbid_conventional_commit_prefix must be a boolean",
+		),
+		(
+			"changesets/summary",
+			detailed_lint_rule(&[("heading_level", serde_json::json!("2"))]),
+			"heading_level must be a non-negative integer",
+		),
+		(
+			"changesets/bump/major",
+			detailed_lint_rule(&[("required_sections", serde_json::json!("Impact"))]),
+			"required_sections must be a string array",
+		),
+		(
+			"changesets/bump/major",
+			detailed_lint_rule(&[("required_sections", serde_json::json!([1]))]),
+			"required_sections must be a string array",
+		),
+		(
+			"changesets/bump/major",
+			detailed_lint_rule(&[("required_bump", serde_json::json!(1))]),
+			"required_bump must be a bump severity string",
+		),
+		(
+			"changesets/bump/major",
+			detailed_lint_rule(&[("required_bump", serde_json::json!("mega"))]),
+			"required_bump uses an unknown bump severity",
+		),
+	] {
+		let error =
+			crate::changeset_lint_settings_from_rules(&changeset_lint_rules(&[(rule_id, config)]))
+				.expect_err("invalid lint rule should be rejected")
+				.to_string();
+		assert!(error.contains(expected), "unexpected error: {error}");
+	}
+}
+
+#[test]
+fn changeset_lint_validation_covers_summary_and_scoped_rule_errors() {
+	let changelog = ChangelogSettings::default();
+	let mut valid = ChangesetLintSettings::default();
+	valid.bump.insert(
+		BumpSeverity::Minor,
+		ChangesetScopedLintSettings {
+			required_sections: vec!["Impact".to_string()],
+			min_body_chars: Some(5),
+			max_body_chars: Some(200),
+			require_code_block: false,
+			required_bump: None,
+			forbidden_headings: Vec::new(),
+		},
+	);
+	valid.types.insert(
+		"feat".to_string(),
+		ChangesetScopedLintSettings {
+			required_sections: vec!["Usage".to_string()],
+			min_body_chars: None,
+			max_body_chars: None,
+			require_code_block: false,
+			required_bump: Some(BumpSeverity::Minor),
+			forbidden_headings: vec!["Feature".to_string()],
+		},
+	);
+	crate::validate_changeset_lint_settings(&valid, &changelog)
+		.unwrap_or_else(|error| panic!("valid lint settings: {error}"));
+
+	let invalid_cases = [
+		(
+			ChangesetLintSettings {
+				summary: ChangesetSummaryLintSettings {
+					heading_level: Some(7),
+					..ChangesetSummaryLintSettings::default()
+				},
+				..ChangesetLintSettings::default()
+			},
+			"heading_level must be between 1 and 6",
+		),
+		(
+			ChangesetLintSettings {
+				summary: ChangesetSummaryLintSettings {
+					min_length: Some(20),
+					max_length: Some(10),
+					..ChangesetSummaryLintSettings::default()
+				},
+				..ChangesetLintSettings::default()
+			},
+			"min_length must not exceed max_length",
+		),
+	];
+	for (settings, expected) in invalid_cases {
+		let error = crate::validate_changeset_lint_settings(&settings, &changelog)
+			.expect_err("invalid lint settings should be rejected")
+			.to_string();
+		assert!(error.contains(expected), "unexpected error: {error}");
+	}
+
+	for (scoped, expected) in [
+		(
+			ChangesetScopedLintSettings {
+				min_body_chars: Some(20),
+				max_body_chars: Some(10),
+				..ChangesetScopedLintSettings::default()
+			},
+			"min_body_chars must not exceed max_body_chars",
+		),
+		(
+			ChangesetScopedLintSettings {
+				required_sections: vec![" ".to_string()],
+				..ChangesetScopedLintSettings::default()
+			},
+			"required_sections must not include empty values",
+		),
+		(
+			ChangesetScopedLintSettings {
+				forbidden_headings: vec![String::new()],
+				..ChangesetScopedLintSettings::default()
+			},
+			"forbidden_headings must not include empty values",
+		),
+	] {
+		let mut settings = ChangesetLintSettings::default();
+		settings.bump.insert(BumpSeverity::Patch, scoped);
+		let error = crate::validate_changeset_lint_settings(&settings, &changelog)
+			.expect_err("invalid scoped lint settings should be rejected")
+			.to_string();
+		assert!(error.contains(expected), "unexpected error: {error}");
+	}
+
+	let mut invalid_type_settings = ChangesetLintSettings::default();
+	invalid_type_settings.types.insert(
+		"feat".to_string(),
+		ChangesetScopedLintSettings {
+			required_sections: vec![String::new()],
+			..ChangesetScopedLintSettings::default()
+		},
+	);
+	let error = crate::validate_changeset_lint_settings(&invalid_type_settings, &changelog)
+		.expect_err("invalid type scoped lint settings should be rejected")
+		.to_string();
+	assert!(
+		error.contains("changesets/types/feat.required_sections must not include empty values"),
+		"unexpected error: {error}"
+	);
+}
+
+#[test]
+fn lint_markdown_changeset_covers_summary_type_and_scope_failures() {
+	let path = Path::new("change.md");
+	let changes = [raw_change(Some(BumpSeverity::Minor), Some("Feature"))];
+	let mut settings = ChangesetLintSettings::default();
+	assert!(crate::lint_markdown_changeset("", &changes, &settings, path).is_ok());
+
+	settings.summary.required = true;
+	expect_config_error(
+		crate::lint_markdown_changeset("", &changes, &settings, path),
+		"changeset body must start with a summary heading",
+	);
+	expect_config_error(
+		crate::lint_markdown_changeset("plain summary", &changes, &settings, path),
+		"changeset body must start with a summary heading",
+	);
+
+	settings.summary.heading_level = Some(2);
+	expect_config_error(
+		crate::lint_markdown_changeset("# Wrong level", &changes, &settings, path),
+		"summary heading must use level 2",
+	);
+
+	settings.summary.min_length = Some(20);
+	expect_config_error(
+		crate::lint_markdown_changeset("## Short", &changes, &settings, path),
+		"summary must be at least 20 characters",
+	);
+	settings.summary.min_length = None;
+	settings.summary.max_length = Some(5);
+	expect_config_error(
+		crate::lint_markdown_changeset("## Summary too long", &changes, &settings, path),
+		"summary must be at most 5 characters",
+	);
+	settings.summary.max_length = None;
+	settings.summary.forbid_trailing_period = true;
+	expect_config_error(
+		crate::lint_markdown_changeset("## Summary.", &changes, &settings, path),
+		"summary must not end with a period",
+	);
+	settings.summary.forbid_trailing_period = false;
+	settings.summary.forbid_conventional_commit_prefix = true;
+	expect_config_error(
+		crate::lint_markdown_changeset("## feat(core): add behavior", &changes, &settings, path),
+		"summary must not use a conventional-commit prefix",
+	);
+	assert!(!crate::has_conventional_commit_prefix("Add behavior"));
+
+	settings.summary = ChangesetSummaryLintSettings::default();
+	settings.no_section_headings = true;
+	expect_config_error(
+		crate::lint_markdown_changeset("# Summary\n\n## Feature", &changes, &settings, path),
+		"must not also be used as a heading",
+	);
+	assert!(
+		crate::lint_markdown_changeset("# Summary\n\n## Details", &changes, &settings, path)
+			.is_ok()
+	);
+
+	settings.no_section_headings = false;
+	settings.types.insert(
+		"feature".to_string(),
+		ChangesetScopedLintSettings {
+			required_sections: vec!["Impact".to_string()],
+			..ChangesetScopedLintSettings::default()
+		},
+	);
+	expect_config_error(
+		crate::lint_markdown_changeset("# Summary", &changes, &settings, path),
+		"changeset must include a `Impact` section",
+	);
+	assert!(
+		crate::lint_markdown_changeset("# Summary\n\n## Impact", &changes, &settings, path).is_ok()
+	);
+}
+
+#[test]
+fn lint_markdown_scope_covers_each_configured_requirement() {
+	let path = Path::new("change.md");
+	let body = "# Summary\n\n## Impact\n\n```rust\nlet value = 1;\n```";
+	let change = raw_change(Some(BumpSeverity::Patch), Some("breaking"));
+
+	expect_config_error(
+		crate::lint_markdown_scope(
+			body,
+			&change,
+			&ChangesetScopedLintSettings {
+				required_bump: Some(BumpSeverity::Major),
+				..ChangesetScopedLintSettings::default()
+			},
+			path,
+		),
+		"requires bump `major`, found `patch`",
+	);
+	expect_config_error(
+		crate::lint_markdown_scope(
+			body,
+			&raw_change(None, Some("breaking")),
+			&ChangesetScopedLintSettings {
+				required_bump: Some(BumpSeverity::Major),
+				..ChangesetScopedLintSettings::default()
+			},
+			path,
+		),
+		"requires bump `major`, found `auto`",
+	);
+	expect_config_error(
+		crate::lint_markdown_scope(
+			"# Summary",
+			&change,
+			&ChangesetScopedLintSettings {
+				required_sections: vec!["Impact".to_string()],
+				..ChangesetScopedLintSettings::default()
+			},
+			path,
+		),
+		"changeset must include a `Impact` section",
+	);
+	expect_config_error(
+		crate::lint_markdown_scope(
+			body,
+			&change,
+			&ChangesetScopedLintSettings {
+				forbidden_headings: vec!["Impact".to_string()],
+				..ChangesetScopedLintSettings::default()
+			},
+			path,
+		),
+		"changeset must not use `Impact` as a heading",
+	);
+	assert!(
+		crate::lint_markdown_scope(
+			body,
+			&change,
+			&ChangesetScopedLintSettings {
+				forbidden_headings: vec!["Missing".to_string()],
+				..ChangesetScopedLintSettings::default()
+			},
+			path,
+		)
+		.is_ok()
+	);
+	expect_config_error(
+		crate::lint_markdown_scope(
+			"# Tiny",
+			&change,
+			&ChangesetScopedLintSettings {
+				min_body_chars: Some(20),
+				..ChangesetScopedLintSettings::default()
+			},
+			path,
+		),
+		"body must be at least 20 characters",
+	);
+	expect_config_error(
+		crate::lint_markdown_scope(
+			body,
+			&change,
+			&ChangesetScopedLintSettings {
+				max_body_chars: Some(10),
+				..ChangesetScopedLintSettings::default()
+			},
+			path,
+		),
+		"body must be at most 10 characters",
+	);
+	expect_config_error(
+		crate::lint_markdown_scope(
+			"# Summary\n\n## Impact",
+			&change,
+			&ChangesetScopedLintSettings {
+				require_code_block: true,
+				..ChangesetScopedLintSettings::default()
+			},
+			path,
+		),
+		"must include a fenced code block",
+	);
+	assert!(
+		crate::lint_markdown_scope(
+			"# Summary\n\n~~~text\ncode\n~~~",
+			&change,
+			&ChangesetScopedLintSettings {
+				require_code_block: true,
+				..ChangesetScopedLintSettings::default()
+			},
+			path,
+		)
+		.is_ok()
+	);
 }
 
 #[test]
@@ -5012,8 +5565,8 @@ fn load_workspace_configuration_parses_top_level_lints_and_scopes() {
 			.lints
 			.rules
 			.get("cargo/internal-dependency-workspace")
-			.map(monochange_core::lint::LintRuleConfig::severity),
-		Some(monochange_core::lint::LintSeverity::Error)
+			.map(LintRuleConfig::severity),
+		Some(LintSeverity::Error)
 	);
 	assert_eq!(
 		configuration.lints.include,

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -126,6 +126,10 @@ use monochange_core::VersionedFileDefinition;
 use monochange_core::WorkspaceConfiguration;
 use monochange_core::WorkspaceDefaults;
 use monochange_core::default_cli_commands;
+use monochange_core::lint::ChangesetLintSettings;
+use monochange_core::lint::ChangesetScopedLintSettings;
+use monochange_core::lint::ChangesetSummaryLintSettings;
+use monochange_core::lint::LintRuleConfig;
 use monochange_core::lint::WorkspaceLintSettings;
 use monochange_core::relative_to_root;
 use regex::Regex;
@@ -1208,6 +1212,9 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 	validate_cli(&cli)?;
 	validate_changelog_configuration(&contents, &changelog, &packages, &groups)?;
 	validate_changesets_configuration(&changesets, &packages)?;
+	let changelog = build_changelog_settings(changelog);
+	let changeset_lints = changeset_lint_settings_from_rules(&lints.rules)?;
+	validate_changeset_lint_settings(&changeset_lints, &changelog)?;
 	validate_source_configuration(source.as_ref())?;
 	for (ecosystem_id, ecosystem_settings) in [
 		("cargo", &cargo_ecosystem),
@@ -1248,7 +1255,7 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 			release_title: defaults.release_title,
 			changelog_version_title: defaults.changelog_version_title,
 		},
-		changelog: build_changelog_settings(changelog),
+		changelog,
 		packages,
 		groups,
 		cli,
@@ -1271,6 +1278,7 @@ struct ChangeTypeLookup {
 
 #[derive(Debug)]
 pub struct ChangesetLoadContext<'a> {
+	configuration: &'a WorkspaceConfiguration,
 	package_ids: HashSet<&'a str>,
 	groups_by_id: HashMap<&'a str, &'a GroupDefinition>,
 	package_reference_matches: HashMap<String, Vec<&'a str>>,
@@ -1338,6 +1346,7 @@ pub fn build_changeset_load_context<'a>(
 		);
 	}
 	ChangesetLoadContext {
+		configuration,
 		package_ids,
 		groups_by_id,
 		package_reference_matches,
@@ -1748,6 +1757,9 @@ fn parse_markdown_change_file_with_context(
 			caused_by,
 		});
 	}
+
+	let lint_settings = changeset_lint_settings_from_rules(&context.configuration.lints.rules)?;
+	lint_markdown_changeset(body, &changes, &lint_settings, changes_path)?;
 
 	Ok(RawChangeFile { changes })
 }
@@ -2229,6 +2241,409 @@ fn markdown_change_text(body: &str) -> (Option<String>, Option<String>) {
 			Some(normalized_details)
 		},
 	)
+}
+
+fn changeset_lint_settings_from_rules(
+	rules: &BTreeMap<String, LintRuleConfig>,
+) -> MonochangeResult<ChangesetLintSettings> {
+	let mut settings = ChangesetLintSettings::default();
+	for (rule_id, config) in rules {
+		if !rule_id.starts_with("changesets/") || !config.severity().is_enabled() {
+			continue;
+		}
+		match rule_id.as_str() {
+			"changesets/duplicate" => {}
+			"changesets/no_section_headings" => settings.no_section_headings = true,
+			"changesets/summary" => {
+				settings.summary = changeset_summary_lint_settings_from_rule(rule_id, config)?;
+			}
+			_ => {
+				if let Some(bump) = rule_id.strip_prefix("changesets/bump/") {
+					let Some(bump) = parse_bump_severity(bump) else {
+						return Err(MonochangeError::Config(format!(
+							"[lints.rules].{rule_id} uses an unknown bump severity"
+						)));
+					};
+					settings.bump.insert(
+						bump,
+						changeset_scoped_lint_settings_from_rule(rule_id, config)?,
+					);
+				} else if let Some(change_type) = rule_id.strip_prefix("changesets/types/") {
+					if change_type.trim().is_empty() {
+						return Err(MonochangeError::Config(
+							"[lints.rules].changesets/types/<type> must include a type name"
+								.to_string(),
+						));
+					}
+					settings.types.insert(
+						change_type.to_string(),
+						changeset_scoped_lint_settings_from_rule(rule_id, config)?,
+					);
+				}
+			}
+		}
+	}
+	Ok(settings)
+}
+
+fn changeset_summary_lint_settings_from_rule(
+	rule_id: &str,
+	config: &LintRuleConfig,
+) -> MonochangeResult<ChangesetSummaryLintSettings> {
+	Ok(ChangesetSummaryLintSettings {
+		required: lint_bool_option(rule_id, config, "required")?.unwrap_or(false),
+		heading_level: lint_usize_option(rule_id, config, "heading_level")?,
+		min_length: lint_usize_option(rule_id, config, "min_length")?,
+		max_length: lint_usize_option(rule_id, config, "max_length")?,
+		forbid_trailing_period: lint_bool_option(rule_id, config, "forbid_trailing_period")?
+			.unwrap_or(false),
+		forbid_conventional_commit_prefix: lint_bool_option(
+			rule_id,
+			config,
+			"forbid_conventional_commit_prefix",
+		)?
+		.unwrap_or(false),
+	})
+}
+
+fn changeset_scoped_lint_settings_from_rule(
+	rule_id: &str,
+	config: &LintRuleConfig,
+) -> MonochangeResult<ChangesetScopedLintSettings> {
+	Ok(ChangesetScopedLintSettings {
+		required_sections: lint_string_list_option(rule_id, config, "required_sections")?
+			.unwrap_or_default(),
+		min_body_chars: lint_usize_option(rule_id, config, "min_body_chars")?,
+		max_body_chars: lint_usize_option(rule_id, config, "max_body_chars")?,
+		require_code_block: lint_bool_option(rule_id, config, "require_code_block")?
+			.unwrap_or(false),
+		required_bump: lint_bump_option(rule_id, config, "required_bump")?,
+		forbidden_headings: lint_string_list_option(rule_id, config, "forbidden_headings")?
+			.unwrap_or_default(),
+	})
+}
+
+fn lint_bool_option(
+	rule_id: &str,
+	config: &LintRuleConfig,
+	key: &str,
+) -> MonochangeResult<Option<bool>> {
+	let Some(value) = config.option(key) else {
+		return Ok(None);
+	};
+	value.as_bool().map(Some).ok_or_else(|| {
+		MonochangeError::Config(format!("[lints.rules].{rule_id}.{key} must be a boolean"))
+	})
+}
+
+fn lint_usize_option(
+	rule_id: &str,
+	config: &LintRuleConfig,
+	key: &str,
+) -> MonochangeResult<Option<usize>> {
+	let Some(value) = config.option(key) else {
+		return Ok(None);
+	};
+	let Some(value) = value.as_u64().and_then(|value| usize::try_from(value).ok()) else {
+		return Err(MonochangeError::Config(format!(
+			"[lints.rules].{rule_id}.{key} must be a non-negative integer"
+		)));
+	};
+	Ok(Some(value))
+}
+
+fn lint_string_list_option(
+	rule_id: &str,
+	config: &LintRuleConfig,
+	key: &str,
+) -> MonochangeResult<Option<Vec<String>>> {
+	let Some(value) = config.option(key) else {
+		return Ok(None);
+	};
+	let Some(values) = value.as_array() else {
+		return Err(MonochangeError::Config(format!(
+			"[lints.rules].{rule_id}.{key} must be a string array"
+		)));
+	};
+	let mut strings = Vec::new();
+	for value in values {
+		let Some(value) = value.as_str() else {
+			return Err(MonochangeError::Config(format!(
+				"[lints.rules].{rule_id}.{key} must be a string array"
+			)));
+		};
+		strings.push(value.to_string());
+	}
+	Ok(Some(strings))
+}
+
+fn lint_bump_option(
+	rule_id: &str,
+	config: &LintRuleConfig,
+	key: &str,
+) -> MonochangeResult<Option<BumpSeverity>> {
+	let Some(value) = config.option(key) else {
+		return Ok(None);
+	};
+	let Some(value) = value.as_str() else {
+		return Err(MonochangeError::Config(format!(
+			"[lints.rules].{rule_id}.{key} must be a bump severity string"
+		)));
+	};
+	parse_bump_severity(value).map(Some).ok_or_else(|| {
+		MonochangeError::Config(format!(
+			"[lints.rules].{rule_id}.{key} uses an unknown bump severity"
+		))
+	})
+}
+
+fn lint_markdown_changeset(
+	body: &str,
+	changes: &[RawChangeEntry],
+	settings: &ChangesetLintSettings,
+	changes_path: &Path,
+) -> MonochangeResult<()> {
+	lint_markdown_summary(body, settings, changes_path)?;
+
+	if settings.no_section_headings {
+		lint_markdown_no_section_headings(body, changes, changes_path)?;
+	}
+
+	for change in changes {
+		if let Some(bump) = change.bump
+			&& let Some(scoped) = settings.bump.get(&bump)
+		{
+			lint_markdown_scope(body, change, scoped, changes_path)?;
+		}
+		if let Some(change_type) = &change.change_type
+			&& let Some(scoped) = changeset_type_lint_settings(settings, change_type)
+		{
+			lint_markdown_scope(body, change, scoped, changes_path)?;
+		}
+	}
+
+	Ok(())
+}
+
+fn lint_markdown_no_section_headings(
+	body: &str,
+	changes: &[RawChangeEntry],
+	changes_path: &Path,
+) -> MonochangeResult<()> {
+	let change_types = changes
+		.iter()
+		.filter_map(|change| change.change_type.as_deref())
+		.collect::<BTreeSet<_>>();
+	for change_type in change_types {
+		if markdown_has_heading(body, change_type) {
+			return Err(changeset_lint_error(
+				changes_path,
+				format!("changeset type `{change_type}` must not also be used as a heading"),
+			));
+		}
+	}
+	Ok(())
+}
+
+fn changeset_type_lint_settings<'settings>(
+	settings: &'settings ChangesetLintSettings,
+	change_type: &str,
+) -> Option<&'settings ChangesetScopedLintSettings> {
+	settings.types.get(change_type).or_else(|| {
+		settings.types.iter().find_map(|(configured_type, scoped)| {
+			configured_type
+				.eq_ignore_ascii_case(change_type)
+				.then_some(scoped)
+		})
+	})
+}
+
+fn lint_markdown_summary(
+	body: &str,
+	settings: &ChangesetLintSettings,
+	changes_path: &Path,
+) -> MonochangeResult<()> {
+	let summary_settings = &settings.summary;
+	let Some(first_line) = first_non_empty_line(body) else {
+		if summary_settings.required {
+			return Err(changeset_lint_error(
+				changes_path,
+				"changeset body must start with a summary heading",
+			));
+		}
+		return Ok(());
+	};
+
+	let heading_level = markdown_heading_level(first_line);
+	if summary_settings.required && heading_level.is_none() {
+		return Err(changeset_lint_error(
+			changes_path,
+			"changeset body must start with a summary heading",
+		));
+	}
+	if let (Some(required_level), Some(actual_level)) =
+		(summary_settings.heading_level, heading_level)
+		&& actual_level != required_level
+	{
+		return Err(changeset_lint_error(
+			changes_path,
+			format!(
+				"changeset summary heading must use level {required_level}, found level {actual_level}"
+			),
+		));
+	}
+
+	let summary =
+		markdown_heading_text(first_line).unwrap_or_else(|| first_line.trim().to_string());
+	if let Some(min_length) = summary_settings.min_length
+		&& summary.chars().count() < min_length
+	{
+		return Err(changeset_lint_error(
+			changes_path,
+			format!("changeset summary must be at least {min_length} characters"),
+		));
+	}
+	if let Some(max_length) = summary_settings.max_length
+		&& summary.chars().count() > max_length
+	{
+		return Err(changeset_lint_error(
+			changes_path,
+			format!("changeset summary must be at most {max_length} characters"),
+		));
+	}
+	if summary_settings.forbid_trailing_period && summary.ends_with('.') {
+		return Err(changeset_lint_error(
+			changes_path,
+			"changeset summary must not end with a period",
+		));
+	}
+	if summary_settings.forbid_conventional_commit_prefix
+		&& has_conventional_commit_prefix(&summary)
+	{
+		return Err(changeset_lint_error(
+			changes_path,
+			"changeset summary must not use a conventional-commit prefix",
+		));
+	}
+
+	Ok(())
+}
+
+fn lint_markdown_scope(
+	body: &str,
+	change: &RawChangeEntry,
+	settings: &ChangesetScopedLintSettings,
+	changes_path: &Path,
+) -> MonochangeResult<()> {
+	if let Some(required_bump) = settings.required_bump
+		&& change.bump != Some(required_bump)
+	{
+		let actual = change
+			.bump
+			.map_or_else(|| "auto".to_string(), |bump| bump.to_string());
+		return Err(changeset_lint_error(
+			changes_path,
+			format!(
+				"changeset type `{}` requires bump `{required_bump}`, found `{actual}`",
+				change.change_type.as_deref().unwrap_or("<unknown>")
+			),
+		));
+	}
+
+	for section in &settings.required_sections {
+		if !markdown_has_heading(body, section) {
+			return Err(changeset_lint_error(
+				changes_path,
+				format!("changeset must include a `{section}` section"),
+			));
+		}
+	}
+	for heading in &settings.forbidden_headings {
+		if markdown_has_heading(body, heading) {
+			return Err(changeset_lint_error(
+				changes_path,
+				format!("changeset must not use `{heading}` as a heading"),
+			));
+		}
+	}
+	if let Some(min_body_chars) = settings.min_body_chars
+		&& body.trim().chars().count() < min_body_chars
+	{
+		return Err(changeset_lint_error(
+			changes_path,
+			format!("changeset body must be at least {min_body_chars} characters"),
+		));
+	}
+	if let Some(max_body_chars) = settings.max_body_chars
+		&& body.trim().chars().count() > max_body_chars
+	{
+		return Err(changeset_lint_error(
+			changes_path,
+			format!("changeset body must be at most {max_body_chars} characters"),
+		));
+	}
+	if settings.require_code_block && !markdown_has_code_block(body) {
+		return Err(changeset_lint_error(
+			changes_path,
+			"changeset must include a fenced code block",
+		));
+	}
+
+	Ok(())
+}
+
+fn first_non_empty_line(markdown: &str) -> Option<&str> {
+	markdown.lines().find_map(|line| {
+		let trimmed = line.trim();
+		(!trimmed.is_empty()).then_some(trimmed)
+	})
+}
+
+fn markdown_heading_text(line: &str) -> Option<String> {
+	let level = markdown_heading_level(line)?;
+	let text = line
+		.trim_start()
+		.chars()
+		.skip(level)
+		.collect::<String>()
+		.trim()
+		.trim_end_matches('#')
+		.trim()
+		.to_string();
+	Some(text)
+}
+
+fn markdown_has_heading(markdown: &str, heading: &str) -> bool {
+	markdown.lines().any(|line| {
+		markdown_heading_text(line).is_some_and(|text| text.eq_ignore_ascii_case(heading.trim()))
+	})
+}
+
+fn markdown_has_code_block(markdown: &str) -> bool {
+	markdown.lines().any(|line| {
+		let trimmed = line.trim_start();
+		trimmed.starts_with("```") || trimmed.starts_with("~~~")
+	})
+}
+
+fn has_conventional_commit_prefix(summary: &str) -> bool {
+	let Some((prefix, _)) = summary.split_once(':') else {
+		return false;
+	};
+	let prefix = prefix.trim();
+	let kind = prefix.split('(').next().unwrap_or(prefix);
+	matches!(
+		kind,
+		"build" | "chore" | "ci" | "docs" | "feat" | "fix" | "perf" | "refactor" | "style" | "test"
+	)
+}
+
+fn changeset_lint_error(path: &Path, message: impl Into<String>) -> MonochangeError {
+	MonochangeError::Config(format!(
+		"changeset lint failed for {}: {}",
+		path.display(),
+		message.into()
+	))
 }
 
 fn configured_change_sections<'config>(
@@ -3223,6 +3638,82 @@ fn validate_changesets_configuration(
 				})?;
 			}
 		}
+	}
+	Ok(())
+}
+
+fn validate_changeset_lint_settings(
+	settings: &ChangesetLintSettings,
+	changelog: &ChangelogSettings,
+) -> MonochangeResult<()> {
+	if let Some(level) = settings.summary.heading_level
+		&& !(1..=6).contains(&level)
+	{
+		return Err(MonochangeError::Config(
+			"[lints.rules].changesets/summary.heading_level must be between 1 and 6".to_string(),
+		));
+	}
+	if let (Some(min_length), Some(max_length)) =
+		(settings.summary.min_length, settings.summary.max_length)
+		&& min_length > max_length
+	{
+		return Err(MonochangeError::Config(
+			"[lints.rules].changesets/summary.min_length must not exceed max_length".to_string(),
+		));
+	}
+	for (bump, scoped) in &settings.bump {
+		validate_changeset_scoped_lint_settings(
+			scoped,
+			&format!("[lints.rules].changesets/bump/{bump}"),
+		)?;
+	}
+	for (change_type, scoped) in &settings.types {
+		if !changelog
+			.types
+			.keys()
+			.any(|configured| configured.eq_ignore_ascii_case(change_type))
+		{
+			return Err(MonochangeError::Config(format!(
+				"[lints.rules].changesets/types/{change_type} references an unknown changeset type"
+			)));
+		}
+		validate_changeset_scoped_lint_settings(
+			scoped,
+			&format!("[lints.rules].changesets/types/{change_type}"),
+		)?;
+	}
+	Ok(())
+}
+
+fn validate_changeset_scoped_lint_settings(
+	settings: &ChangesetScopedLintSettings,
+	path: &str,
+) -> MonochangeResult<()> {
+	if let (Some(min_body_chars), Some(max_body_chars)) =
+		(settings.min_body_chars, settings.max_body_chars)
+		&& min_body_chars > max_body_chars
+	{
+		return Err(MonochangeError::Config(format!(
+			"{path}.min_body_chars must not exceed max_body_chars"
+		)));
+	}
+	if settings
+		.required_sections
+		.iter()
+		.any(|section| section.trim().is_empty())
+	{
+		return Err(MonochangeError::Config(format!(
+			"{path}.required_sections must not include empty values"
+		)));
+	}
+	if settings
+		.forbidden_headings
+		.iter()
+		.any(|heading| heading.trim().is_empty())
+	{
+		return Err(MonochangeError::Config(format!(
+			"{path}.forbidden_headings must not include empty values"
+		)));
 	}
 	Ok(())
 }

--- a/crates/monochange_core/src/lint.rs
+++ b/crates/monochange_core/src/lint.rs
@@ -14,6 +14,8 @@ use std::path::PathBuf;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::BumpSeverity;
+
 /// The severity level of a lint.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -478,6 +480,52 @@ pub struct LintScopeConfig {
 	pub presets: Vec<String>,
 	#[serde(default)]
 	pub rules: BTreeMap<String, LintRuleConfig>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct ChangesetSummaryLintSettings {
+	/// Require the first non-empty body line to be a markdown heading.
+	#[serde(default)]
+	pub required: bool,
+	/// Require the summary heading to use this markdown level.
+	#[serde(default)]
+	pub heading_level: Option<usize>,
+	#[serde(default)]
+	pub min_length: Option<usize>,
+	#[serde(default)]
+	pub max_length: Option<usize>,
+	#[serde(default)]
+	pub forbid_trailing_period: bool,
+	#[serde(default)]
+	pub forbid_conventional_commit_prefix: bool,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct ChangesetScopedLintSettings {
+	#[serde(default)]
+	pub required_sections: Vec<String>,
+	#[serde(default)]
+	pub min_body_chars: Option<usize>,
+	#[serde(default)]
+	pub max_body_chars: Option<usize>,
+	#[serde(default)]
+	pub require_code_block: bool,
+	#[serde(default)]
+	pub required_bump: Option<BumpSeverity>,
+	#[serde(default)]
+	pub forbidden_headings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct ChangesetLintSettings {
+	#[serde(default)]
+	pub no_section_headings: bool,
+	#[serde(default)]
+	pub summary: ChangesetSummaryLintSettings,
+	#[serde(default)]
+	pub bump: BTreeMap<BumpSeverity, ChangesetScopedLintSettings>,
+	#[serde(default)]
+	pub types: BTreeMap<String, ChangesetScopedLintSettings>,
 }
 
 /// Top-level workspace lint settings from `monochange.toml`.

--- a/docs/src/reference/linting.md
+++ b/docs/src/reference/linting.md
@@ -54,6 +54,27 @@ Rule configuration supports two forms:
 - simple severity: `"rule-id" = "error"`, `"warning"`, or `"off"`
 - detailed config: `{ level = "error", ...rule_specific_options }`
 
+## Changeset lint rules
+
+Changeset lint rules use the same `[lints.rules]` table as manifest rules. They are evaluated while markdown changesets are loaded by validation and release workflows.
+
+```toml
+[lints.rules]
+"changesets/duplicate" = "error"
+"changesets/no_section_headings" = "error"
+"changesets/summary" = { level = "error", required = true, heading_level = 2, min_length = 12, max_length = 80, forbid_trailing_period = true, forbid_conventional_commit_prefix = true }
+"changesets/bump/major" = { level = "error", required_sections = ["Impact", "Migration"], min_body_chars = 120, require_code_block = true }
+"changesets/types/breaking" = { level = "error", forbidden_headings = ["Breaking", "Breaking changes"], required_sections = ["Impact", "Migration"], required_bump = "major" }
+```
+
+Supported changeset rule ids:
+
+- `changesets/duplicate` — validates that a changeset does not target the same effective package more than once.
+- `changesets/no_section_headings` — rejects headings that duplicate a change type used by that changeset.
+- `changesets/summary` — configures the one-line summary heading. Options: `required`, `heading_level`, `min_length`, `max_length`, `forbid_trailing_period`, `forbid_conventional_commit_prefix`.
+- `changesets/bump/<severity>` — configures rules for `major`, `minor`, or `patch` entries. Options: `required_sections`, `forbidden_headings`, `min_body_chars`, `max_body_chars`, `require_code_block`, `required_bump`.
+- `changesets/types/<type>` — configures rules for a configured changelog type such as `breaking`, `feature`, `fix`, `security`, or a custom type like `unicorns`. It accepts the same scoped options as bump rules. The `<type>` segment must match a configured changelog type.
+
 ## Current rule coverage
 
 Today, built-in manifest lint rules exist for:

--- a/fixtures/tests/config/changeset-lint-bump-type/change.md
+++ b/fixtures/tests/config/changeset-lint-bump-type/change.md
@@ -1,0 +1,21 @@
+---
+core: breaking
+---
+
+## Remove legacy parser
+
+## Impact
+
+Consumers must move to the new parser entry points before upgrading because the old aliases are no longer exported.
+
+## Migration
+
+Replace direct legacy parser imports with the supported parser module.
+
+```rust
+use cargo_core::parser::Parser;
+```
+
+## Breaking
+
+The legacy parser has been removed.

--- a/fixtures/tests/config/changeset-lint-bump-type/crates/core/Cargo.toml
+++ b/fixtures/tests/config/changeset-lint-bump-type/crates/core/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "core"
+version = "1.0.0"

--- a/fixtures/tests/config/changeset-lint-bump-type/monochange.toml
+++ b/fixtures/tests/config/changeset-lint-bump-type/monochange.toml
@@ -1,0 +1,15 @@
+[package.core]
+path = "crates/core"
+type = "cargo"
+
+[changelog.sections.breaking]
+heading = "Breaking changes"
+priority = 100
+
+[changelog.types.breaking]
+section = "breaking"
+bump = "major"
+
+[lints.rules]
+"changesets/bump/major" = { level = "error", required_sections = ["Impact", "Migration"], min_body_chars = 120, require_code_block = true }
+"changesets/types/breaking" = { level = "error", required_bump = "major", forbidden_headings = ["Breaking", "Breaking changes"], required_sections = ["Impact", "Migration"] }

--- a/fixtures/tests/config/changeset-lint-custom-type/change.md
+++ b/fixtures/tests/config/changeset-lint-custom-type/change.md
@@ -1,0 +1,7 @@
+---
+core: unicorns
+---
+
+## Add stable unicorn APIs
+
+This introduces magical behavior without the required lint section.

--- a/fixtures/tests/config/changeset-lint-custom-type/crates/core/Cargo.toml
+++ b/fixtures/tests/config/changeset-lint-custom-type/crates/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "cargo-core"
+version = "1.0.0"
+edition = "2021"

--- a/fixtures/tests/config/changeset-lint-custom-type/monochange.toml
+++ b/fixtures/tests/config/changeset-lint-custom-type/monochange.toml
@@ -1,0 +1,14 @@
+[package.core]
+path = "crates/core"
+type = "cargo"
+
+[changelog.sections.magic]
+heading = "Magic"
+priority = 100
+
+[changelog.types.unicorns]
+section = "magic"
+bump = "minor"
+
+[lints.rules]
+"changesets/types/unicorns" = { level = "error", required_bump = "minor", required_sections = ["Rainbow"] }

--- a/fixtures/tests/config/changeset-lint-summary/change.md
+++ b/fixtures/tests/config/changeset-lint-summary/change.md
@@ -1,0 +1,5 @@
+---
+core: patch
+---
+
+fix: short.

--- a/fixtures/tests/config/changeset-lint-summary/crates/core/Cargo.toml
+++ b/fixtures/tests/config/changeset-lint-summary/crates/core/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "core"
+version = "1.0.0"

--- a/fixtures/tests/config/changeset-lint-summary/monochange.toml
+++ b/fixtures/tests/config/changeset-lint-summary/monochange.toml
@@ -1,0 +1,6 @@
+[package.core]
+path = "crates/core"
+type = "cargo"
+
+[lints.rules]
+"changesets/summary" = { level = "error", required = true, heading_level = 2, min_length = 12, max_length = 80, forbid_trailing_period = true, forbid_conventional_commit_prefix = true }

--- a/fixtures/tests/config/changeset-lint-unknown-type/crates/core/Cargo.toml
+++ b/fixtures/tests/config/changeset-lint-unknown-type/crates/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "cargo-core"
+version = "1.0.0"
+edition = "2021"

--- a/fixtures/tests/config/changeset-lint-unknown-type/monochange.toml
+++ b/fixtures/tests/config/changeset-lint-unknown-type/monochange.toml
@@ -1,0 +1,6 @@
+[package.core]
+path = "crates/core"
+type = "cargo"
+
+[lints.rules]
+"changesets/types/unicorns" = "error"

--- a/packages/monochange__skill/skills/linting.md
+++ b/packages/monochange__skill/skills/linting.md
@@ -52,6 +52,27 @@ Rule configuration supports two forms:
 - simple severity: `"rule-id" = "error"`, `"warning"`, or `"off"`
 - detailed config: `{ level = "error", ...rule_specific_options }`
 
+## Changeset lint rules
+
+Changeset lint rules use the same `[lints.rules]` table as manifest rules. They are evaluated while markdown changesets are loaded by validation and release workflows.
+
+```toml
+[lints.rules]
+"changesets/duplicate" = "error"
+"changesets/no_section_headings" = "error"
+"changesets/summary" = { level = "error", required = true, heading_level = 2, min_length = 12, max_length = 80, forbid_trailing_period = true, forbid_conventional_commit_prefix = true }
+"changesets/bump/major" = { level = "error", required_sections = ["Impact", "Migration"], min_body_chars = 120, require_code_block = true }
+"changesets/types/breaking" = { level = "error", forbidden_headings = ["Breaking", "Breaking changes"], required_sections = ["Impact", "Migration"], required_bump = "major" }
+```
+
+Supported changeset rule ids:
+
+- `changesets/duplicate` — validates that a changeset does not target the same effective package more than once.
+- `changesets/no_section_headings` — rejects headings that duplicate a change type used by that changeset.
+- `changesets/summary` — configures the one-line summary heading. Options: `required`, `heading_level`, `min_length`, `max_length`, `forbid_trailing_period`, `forbid_conventional_commit_prefix`.
+- `changesets/bump/<severity>` — configures rules for `major`, `minor`, or `patch` entries. Options: `required_sections`, `forbidden_headings`, `min_body_chars`, `max_body_chars`, `require_code_block`, `required_bump`.
+- `changesets/types/<type>` — configures rules for a configured changelog type such as `breaking`, `feature`, `fix`, `security`, or a custom type like `unicorns`. It accepts the same scoped options as bump rules. The `<type>` segment must match a configured changelog type.
+
 ## Current rule coverage
 
 Today, built-in manifest lint rules exist for:


### PR DESCRIPTION
## Summary
- add changeset lint rule configuration under existing `[lints.rules]` entries
- support summary, no-section-heading, bump-scoped, and type-scoped changeset lint settings
- validate dynamic `changesets/types/<type>` rule ids against configured changelog types, including custom types
- document changeset lint rule ids and add fixture-backed tests

## Validation
- `cargo test -p monochange_config lints -- --nocapture`
- `cargo test -p monochange_config unknown_changeset_type -- --nocapture`
- `cargo test -p monochange_lint`
- `cargo check --workspace`
- `mc validate`