### PR TITLE
fix(release-pr): diagnose large commit messages

### DIFF
--- a/.changeset/release-pr-commit-file-message.md
+++ b/.changeset/release-pr-commit-file-message.md
@@ -1,0 +1,8 @@
+---
+"monochange": patch
+"monochange_core": patch
+"monochange_github": patch
+"monochange_hosting": patch
+---
+
+Commit generated release pull request messages from a temporary file and include detailed commit diagnostics when git cannot create the release commit.

--- a/crates/monochange/src/git_support.rs
+++ b/crates/monochange/src/git_support.rs
@@ -1,19 +1,20 @@
+#[cfg(test)]
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command as ProcessCommand;
+#[cfg(test)]
 use std::process::Stdio;
 
 use monochange_core::CommitMessage;
 use monochange_core::MonochangeError;
 use monochange_core::MonochangeResult;
 use monochange_core::git::git_command_output;
-use monochange_core::git::git_commit_message_text;
-use monochange_core::git::git_commit_paths_stdin_command;
 use monochange_core::git::git_error_detail;
 use monochange_core::git::git_stage_paths_command;
 use monochange_core::git::git_stderr_trimmed;
 use monochange_core::git::git_stdout_trimmed;
+use monochange_core::git::run_git_commit_message;
 
 #[must_use = "the tag commit result must be checked"]
 pub(crate) fn resolve_git_tag_commit(root: &Path, tag_name: &str) -> MonochangeResult<String> {
@@ -283,11 +284,7 @@ pub(crate) fn git_commit_paths(
 	message: &CommitMessage,
 	no_verify: bool,
 ) -> MonochangeResult<()> {
-	run_git_process_with_stdin(
-		git_commit_paths_stdin_command(root, no_verify),
-		git_commit_message_text(message).as_bytes(),
-		"failed to create release commit",
-	)
+	run_git_commit_message(root, message, "create release commit", no_verify)
 }
 
 #[must_use = "the HEAD commit result must be checked"]
@@ -309,6 +306,7 @@ pub(crate) fn run_git_process(
 	handle_git_process_output(&output, error_message)
 }
 
+#[cfg(test)]
 pub(crate) fn run_git_process_with_stdin(
 	mut command: ProcessCommand,
 	input: &[u8],

--- a/crates/monochange_core/Cargo.toml
+++ b/crates/monochange_core/Cargo.toml
@@ -21,6 +21,7 @@ reqwest = { workspace = true, optional = true, default-features = true }
 semver = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
+tempfile = { workspace = true, default-features = true }
 thiserror = { workspace = true, default-features = true }
 tracing = { workspace = true, default-features = true }
 
@@ -31,7 +32,6 @@ proptest = { workspace = true, default-features = true }
 rstest = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
 similar-asserts = { workspace = true, default-features = true }
-tempfile = { workspace = true, default-features = true }
 
 [lints]
 workspace = true

--- a/crates/monochange_core/src/git.rs
+++ b/crates/monochange_core/src/git.rs
@@ -1,8 +1,13 @@
+use std::fmt::Display;
+use std::fmt::Write as FmtWrite;
+use std::io::Write as IoWrite;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 use std::process::Output;
 use std::process::Stdio;
+
+use tempfile::NamedTempFile;
 
 use crate::CommitMessage;
 use crate::MonochangeError;
@@ -123,6 +128,18 @@ pub fn git_commit_paths_stdin_command(root: &Path, no_verify: bool) -> Command {
 	command
 }
 
+/// Build a `git commit` command that reads the message from `message_file`.
+#[must_use]
+pub fn git_commit_file_command(root: &Path, message_file: &Path, no_verify: bool) -> Command {
+	let mut command = git_command(root);
+	command.arg("commit");
+	if no_verify {
+		command.arg("--no-verify");
+	}
+	command.arg("--file").arg(message_file);
+	command
+}
+
 /// Build a force-with-lease push command for `branch`.
 #[must_use]
 pub fn git_push_branch_command(root: &Path, branch: &str, no_verify: bool) -> Command {
@@ -225,6 +242,110 @@ pub fn run_command(mut command: Command, action: &str) -> MonochangeResult<()> {
 	Ok(())
 }
 
+/// Run a `git commit` command with a commit message stored in a temporary file.
+#[must_use = "the commit command result must be checked"]
+pub fn run_git_commit_message(
+	root: &Path,
+	message: &CommitMessage,
+	action: &str,
+	no_verify: bool,
+) -> MonochangeResult<()> {
+	run_git_commit_message_with_io(
+		root,
+		message,
+		action,
+		no_verify,
+		|message_file, message_text| message_file.write_all(message_text.as_bytes()),
+		flush_git_commit_message_file,
+	)
+}
+
+fn flush_git_commit_message_file(message_file: &mut NamedTempFile) -> std::io::Result<()> {
+	message_file.as_file_mut().sync_all()
+}
+
+fn run_git_commit_message_with_io<WriteMessage, FlushMessage>(
+	root: &Path,
+	message: &CommitMessage,
+	action: &str,
+	no_verify: bool,
+	write_message: WriteMessage,
+	flush_message: FlushMessage,
+) -> MonochangeResult<()>
+where
+	WriteMessage: FnOnce(&mut NamedTempFile, &str) -> std::io::Result<()>,
+	FlushMessage: FnOnce(&mut NamedTempFile) -> std::io::Result<()>,
+{
+	let message_text = git_commit_message_text(message);
+	let mut message_file =
+		NamedTempFile::new_in(git_commit_message_temp_dir(root)).map_err(|error| {
+			git_commit_create_temp_file_error(
+				root,
+				message,
+				&message_text,
+				action,
+				no_verify,
+				error,
+			)
+		})?;
+	write_message(&mut message_file, &message_text).map_err(|error| {
+		git_commit_write_temp_file_error(
+			root,
+			message,
+			&message_text,
+			action,
+			no_verify,
+			message_file.path(),
+			error,
+		)
+	})?;
+	flush_message(&mut message_file).map_err(|error| {
+		git_commit_flush_temp_file_error(
+			root,
+			message,
+			&message_text,
+			action,
+			no_verify,
+			message_file.path(),
+			error,
+		)
+	})?;
+
+	let mut command = git_commit_file_command(root, message_file.path(), no_verify);
+	let output = command.output().map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to {action}: {error}\n{}",
+			git_commit_message_diagnostics(
+				root,
+				message,
+				&message_text,
+				action,
+				"spawning git commit with --file",
+				no_verify,
+				Some(message_file.path()),
+			)
+		))
+	})?;
+
+	if output.status.success() || git_reports_nothing_to_commit(&output) {
+		return Ok(());
+	}
+
+	Err(MonochangeError::Config(format!(
+		"failed to {action}: {}\n{}",
+		git_error_detail(&output),
+		git_commit_message_diagnostics(
+			root,
+			message,
+			&message_text,
+			action,
+			"executing git commit with --file",
+			no_verify,
+			Some(message_file.path()),
+		)
+	)))
+}
+
 /// Run a commit command and treat `nothing to commit` as success.
 #[must_use = "the commit command result must be checked"]
 pub fn run_commit_command_allow_nothing_to_commit(
@@ -245,8 +366,151 @@ pub fn run_commit_command_allow_nothing_to_commit(
 	)))
 }
 
+fn git_commit_message_temp_dir(root: &Path) -> &Path {
+	root.parent().unwrap_or(root)
+}
+
+fn git_commit_create_temp_file_error(
+	root: &Path,
+	message: &CommitMessage,
+	message_text: &str,
+	action: &str,
+	no_verify: bool,
+	error: impl Display,
+) -> MonochangeError {
+	MonochangeError::Io(format!(
+		"failed to {action}: could not create temporary git commit message file: {error}\n{}",
+		git_commit_message_diagnostics(
+			root,
+			message,
+			message_text,
+			action,
+			"creating temporary commit message file",
+			no_verify,
+			None,
+		)
+	))
+}
+
+fn git_commit_write_temp_file_error(
+	root: &Path,
+	message: &CommitMessage,
+	message_text: &str,
+	action: &str,
+	no_verify: bool,
+	message_file: &Path,
+	error: impl Display,
+) -> MonochangeError {
+	MonochangeError::Io(format!(
+		"failed to {action}: could not write temporary git commit message file {}: {error}\n{}",
+		message_file.display(),
+		git_commit_message_diagnostics(
+			root,
+			message,
+			message_text,
+			action,
+			"writing temporary commit message file",
+			no_verify,
+			Some(message_file),
+		)
+	))
+}
+
+fn git_commit_flush_temp_file_error(
+	root: &Path,
+	message: &CommitMessage,
+	message_text: &str,
+	action: &str,
+	no_verify: bool,
+	message_file: &Path,
+	error: impl Display,
+) -> MonochangeError {
+	MonochangeError::Io(format!(
+		"failed to {action}: could not flush temporary git commit message file {}: {error}\n{}",
+		message_file.display(),
+		git_commit_message_diagnostics(
+			root,
+			message,
+			message_text,
+			action,
+			"flushing temporary commit message file",
+			no_verify,
+			Some(message_file),
+		)
+	))
+}
+
+fn git_commit_message_diagnostics(
+	root: &Path,
+	message: &CommitMessage,
+	message_text: &str,
+	action: &str,
+	phase: &str,
+	no_verify: bool,
+	message_file: Option<&Path>,
+) -> String {
+	let body = message.body.as_deref().unwrap_or("");
+	let message_file = message_file.map_or_else(
+		|| "<not yet created>".to_string(),
+		|path| path.display().to_string(),
+	);
+	let mut diagnostics = String::new();
+	let _ = writeln!(diagnostics, "git commit diagnostics:");
+	let _ = writeln!(diagnostics, "  action: {action}");
+	let _ = writeln!(diagnostics, "  phase: {phase}");
+	let _ = writeln!(diagnostics, "  repository: {}", root.display());
+	let _ = writeln!(
+		diagnostics,
+		"  command: git commit --file <temporary-message-file>"
+	);
+	let _ = writeln!(diagnostics, "  temporary message file: {message_file}");
+	let _ = writeln!(diagnostics, "  no_verify: {no_verify}");
+	let _ = writeln!(diagnostics, "  subject bytes: {}", message.subject.len());
+	let _ = writeln!(diagnostics, "  body bytes: {}", body.len());
+	let _ = writeln!(diagnostics, "  full message bytes: {}", message_text.len());
+	let _ = writeln!(diagnostics, "  subject: {}", message.subject);
+	if message.body.is_some() {
+		let _ = writeln!(diagnostics, "  body preview: {}", preview_text(body));
+	} else {
+		let _ = writeln!(diagnostics, "  body preview: <none>");
+	}
+	let _ = writeln!(
+		diagnostics,
+		"  full message preview: {}",
+		preview_text(message_text)
+	);
+	let _ = writeln!(diagnostics, "suggested manual commit approaches:");
+	let _ = writeln!(
+		diagnostics,
+		"  - write the commit message to a file and run `git commit --file <message-file>` from the repository root"
+	);
+	let _ = writeln!(
+		diagnostics,
+		"  - if a hook is failing, rerun the same command locally and inspect the hook output"
+	);
+	let _ = writeln!(
+		diagnostics,
+		"  - avoid passing very large release records with repeated `--message`/`-m` arguments because OS argv limits can reject them before git starts"
+	);
+	diagnostics
+}
+
+fn preview_text(text: &str) -> String {
+	const PREVIEW_CHARS: usize = 240;
+	let mut chars = text.chars();
+	let preview = chars.by_ref().take(PREVIEW_CHARS).collect::<String>();
+	if chars.next().is_some() {
+		format!("{}…", preview.replace('\n', "\\n"))
+	} else {
+		preview.replace('\n', "\\n")
+	}
+}
+
 #[cfg(test)]
 mod tests {
+	use std::fs;
+	use std::io;
+
 	use super::*;
 
 	#[test]
@@ -305,13 +569,33 @@ mod tests {
 
 	fn temp_path_with_git() -> tempfile::TempDir {
 		let directory = tempdir("create PATH dir");
-		std::fs::write(directory.path().join(git_executable_name()), "")
+		fs::write(directory.path().join(git_executable_name()), "")
 			.unwrap_or_else(|error| panic!("write git shim: {error}"));
 		directory
 	}
 
 	fn tempdir(context: &str) -> tempfile::TempDir {
 		tempfile::tempdir().unwrap_or_else(|error| panic!("{context}: {error}"))
+	}
+
+	fn git(root: &Path, args: &[&str]) {
+		let status = git_command(root)
+			.args(args)
+			.status()
+			.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
+		assert!(status.success(), "git {args:?} failed with {status}");
+	}
+
+	fn git_stdout(root: &Path, args: &[&str]) -> String {
+		let output = git_command(root)
+			.args(args)
+			.output()
+			.unwrap_or_else(|error| panic!("git {args:?}: {error}"));
+		assert!(
+			output.status.success(),
+			"git {args:?} failed with {output:?}"
+		);
+		String::from_utf8_lossy(&output.stdout).to_string()
 	}
 
 	#[test]
@@ -349,5 +633,191 @@ mod tests {
 			.collect::<Vec<_>>();
 
 		assert_eq!(args, vec!["commit", "--no-verify", "--file", "-"]);
+	}
+
+	#[test]
+	fn git_commit_file_command_reads_message_from_file() {
+		let command = git_commit_file_command(Path::new("."), Path::new("message.txt"), true);
+		let args = command
+			.get_args()
+			.map(|arg| arg.to_string_lossy().into_owned())
+			.collect::<Vec<_>>();
+
+		assert_eq!(args, vec!["commit", "--no-verify", "--file", "message.txt"]);
+	}
+
+	#[test]
+	fn git_commit_temp_file_error_helpers_include_phase_diagnostics() {
+		let message = CommitMessage {
+			subject: "chore(release): prepare release".to_string(),
+			body: None,
+		};
+		let message_text = git_commit_message_text(&message);
+		let message_file = Path::new("message.txt");
+
+		let create_error = git_commit_create_temp_file_error(
+			Path::new("repo"),
+			&message,
+			&message_text,
+			"commit release pull request changes",
+			true,
+			"disk unavailable",
+		)
+		.to_string();
+		let write_error = git_commit_write_temp_file_error(
+			Path::new("repo"),
+			&message,
+			&message_text,
+			"commit release pull request changes",
+			true,
+			message_file,
+			"write failed",
+		)
+		.to_string();
+		let flush_error = git_commit_flush_temp_file_error(
+			Path::new("repo"),
+			&message,
+			&message_text,
+			"commit release pull request changes",
+			true,
+			message_file,
+			"flush failed",
+		)
+		.to_string();
+
+		assert!(create_error.contains("phase: creating temporary commit message file"));
+		assert!(create_error.contains("temporary message file: <not yet created>"));
+		assert!(create_error.contains("body preview: <none>"));
+		assert!(create_error.contains("no_verify: true"));
+		assert!(write_error.contains("phase: writing temporary commit message file"));
+		assert!(write_error.contains("temporary message file: message.txt"));
+		assert!(flush_error.contains("phase: flushing temporary commit message file"));
+		assert!(flush_error.contains("temporary message file: message.txt"));
+	}
+
+	#[test]
+	fn preview_text_truncates_long_multiline_messages() {
+		let preview = preview_text(&format!("{}\nsecond line", "a".repeat(260)));
+
+		assert!(preview.ends_with('…'));
+		assert!(!preview.contains('\n'));
+	}
+
+	#[test]
+	fn run_git_commit_message_reports_create_temp_file_diagnostics() {
+		let tempdir = tempdir("create parent");
+		let missing_nested_root = tempdir.path().join("missing-parent").join("repo");
+		let error = run_git_commit_message(
+			&missing_nested_root,
+			&CommitMessage {
+				subject: "chore(release): prepare release".to_string(),
+				body: Some("release body".to_string()),
+			},
+			"commit release pull request changes",
+			false,
+		)
+		.err()
+		.unwrap_or_else(|| panic!("expected commit failure"))
+		.to_string();
+
+		assert!(error.contains("could not create temporary git commit message file"));
+		assert!(error.contains("phase: creating temporary commit message file"));
+		assert!(error.contains("temporary message file: <not yet created>"));
+	}
+
+	#[test]
+	fn run_git_commit_message_reports_write_and_flush_diagnostics() {
+		let tempdir = tempdir("create repo");
+		let root = tempdir.path();
+		let message = CommitMessage {
+			subject: "chore(release): prepare release".to_string(),
+			body: Some("release body".to_string()),
+		};
+
+		let write_error = run_git_commit_message_with_io(
+			root,
+			&message,
+			"commit release pull request changes",
+			false,
+			|_, _| Err(io::Error::other("write failed")),
+			flush_git_commit_message_file,
+		)
+		.err()
+		.unwrap_or_else(|| panic!("expected write failure"))
+		.to_string();
+		let flush_error = run_git_commit_message_with_io(
+			root,
+			&message,
+			"commit release pull request changes",
+			false,
+			|_, _| Ok(()),
+			|_| Err(io::Error::other("flush failed")),
+		)
+		.err()
+		.unwrap_or_else(|| panic!("expected flush failure"))
+		.to_string();
+
+		assert!(write_error.contains("could not write temporary git commit message file"));
+		assert!(write_error.contains("phase: writing temporary commit message file"));
+		assert!(write_error.contains("temporary message file:"));
+		assert!(flush_error.contains("could not flush temporary git commit message file"));
+		assert!(flush_error.contains("phase: flushing temporary commit message file"));
+		assert!(flush_error.contains("temporary message file:"));
+	}
+
+	#[test]
+	fn run_git_commit_message_commits_large_message_from_file() {
+		let tempdir = tempdir("create repo");
+		let root = tempdir.path();
+		git(root, &["init"]);
+		git(root, &["config", "user.name", "monochange Tests"]);
+		git(root, &["config", "user.email", "monochange@example.com"]);
+		fs::write(root.join("release.txt"), "release\n")
+			.unwrap_or_else(|error| panic!("write release file: {error}"));
+		git(root, &["add", "release.txt"]);
+
+		let body = "release target metadata\n".repeat(30_000);
+		run_git_commit_message(
+			root,
+			&CommitMessage {
+				subject: "chore(release): prepare release".to_string(),
+				body: Some(body.clone()),
+			},
+			"commit release pull request changes",
+			false,
+		)
+		.unwrap_or_else(|error| panic!("commit: {error}"));
+
+		let message = git_stdout(root, &["log", "-1", "--pretty=%B"]);
+		assert!(message.starts_with("chore(release): prepare release\n\n"));
+		assert!(message.contains("release target metadata"));
+		assert!(message.len() >= body.len());
+	}
+
+	#[test]
+	fn run_git_commit_message_reports_message_diagnostics_when_git_cannot_start() {
+		let tempdir = tempdir("create parent");
+		let missing = tempdir.path().join("missing");
+		let error = run_git_commit_message(
+			&missing,
+			&CommitMessage {
+				subject: "chore(release): prepare release".to_string(),
+				body: Some("release body".to_string()),
+			},
+			"commit release pull request changes",
+			false,
+		)
+		.err()
+		.unwrap_or_else(|| panic!("expected commit failure"));
+		let error = error.to_string();
+
+		assert!(error.contains("failed to commit release pull request changes"));
+		assert!(error.contains("phase: spawning git commit with --file"));
+		assert!(error.contains("command: git commit --file <temporary-message-file>"));
+		assert!(error.contains("subject: chore(release): prepare release"));
+		assert!(error.contains("body bytes: 12"));
+		assert!(error.contains("full message bytes: 45"));
+		assert!(error.contains("write the commit message to a file"));
+		assert!(error.contains("avoid passing very large release records"));
 	}
 }

--- a/crates/monochange_github/src/lib.rs
+++ b/crates/monochange_github/src/lib.rs
@@ -135,14 +135,13 @@ use monochange_core::SourceReleaseOutcome;
 use monochange_core::SourceReleaseRequest;
 use monochange_core::git::git_checkout_branch_command;
 use monochange_core::git::git_command_output;
-use monochange_core::git::git_commit_paths_command;
 use monochange_core::git::git_current_branch;
 use monochange_core::git::git_error_detail;
 use monochange_core::git::git_head_commit;
 use monochange_core::git::git_push_branch_command;
 use monochange_core::git::git_stage_paths_command;
 use monochange_core::git::run_command;
-use monochange_core::git::run_commit_command_allow_nothing_to_commit;
+use monochange_core::git::run_git_commit_message;
 use octocrab::Octocrab;
 use regex::Regex;
 use serde::Deserialize;
@@ -1823,9 +1822,11 @@ fn git_path_is_ignored(root: &Path, path: &Path) -> MonochangeResult<bool> {
 }
 
 fn git_commit_paths(root: &Path, message: &CommitMessage, no_verify: bool) -> MonochangeResult<()> {
-	run_commit_command_allow_nothing_to_commit(
-		git_commit_paths_command(root, message, no_verify),
+	run_git_commit_message(
+		root,
+		message,
 		"commit release pull request changes",
+		no_verify,
 	)
 }
 

--- a/crates/monochange_hosting/src/lib.rs
+++ b/crates/monochange_hosting/src/lib.rs
@@ -40,12 +40,11 @@ use monochange_core::ReleaseManifestTarget;
 use monochange_core::ReleaseOwnerKind;
 use monochange_core::SourceConfiguration;
 use monochange_core::git::git_checkout_branch_command;
-use monochange_core::git::git_commit_paths_command;
 use monochange_core::git::git_current_branch;
 use monochange_core::git::git_push_branch_command;
 use monochange_core::git::git_stage_paths_command;
 use monochange_core::git::run_command;
-use monochange_core::git::run_commit_command_allow_nothing_to_commit;
+use monochange_core::git::run_git_commit_message;
 use reqwest::blocking::Client;
 use reqwest::header::HeaderMap;
 use serde::Serialize;
@@ -397,10 +396,7 @@ pub fn git_commit_paths(
 	context: &str,
 	no_verify: bool,
 ) -> MonochangeResult<()> {
-	run_commit_command_allow_nothing_to_commit(
-		git_commit_paths_command(root, message, no_verify),
-		context,
-	)
+	run_git_commit_message(root, message, context, no_verify)
 }
 
 /// Push the release branch to `origin` with `--force-with-lease`.


### PR DESCRIPTION
## Summary
- commit release PR changes with git commit --file so large generated release messages never enter argv or stdin pipe handling
- add contextual diagnostics for release commit failures, including phase, repository, no_verify, message byte counts, previews, temporary file path, and manual recovery suggestions
- route CLI, GitHub, and shared hosting release commit paths through the safer diagnostic helper

## Validation
- cargo fmt --check
- cargo test -p monochange_core git::tests::run_git_commit_message
- cargo test -p monochange_core git::tests::git_commit_file_command_reads_message_from_file
- cargo test -p monochange git_support::tests::git_commit_paths_allows_large_release_message
- cargo check -p monochange -p monochange_core -p monochange_github -p monochange_hosting
- cargo clippy -p monochange -p monochange_core -p monochange_hosting -p monochange_github --all-targets -- -D warnings
- git diff --check
- mc step:affected-packages --format json --verify --changed-paths <changed files>
- DEVENV_ROOT=/Users/ifiokjr/.pi/agent/worktrees/root/root/Users/ifiokjr/Developer/projects/monochange/monochange/worktrees/fix-release-pr-commit-arg-limit coverage:patch

## Coverage
- Patch coverage: 0/0 (100.00%); no executable changed lines were found in the coverage report after coverage:all produced target/coverage/lcov.info.