### PR TITLE
ci: attest release archives

### DIFF
--- a/.changeset/release-asset-attestations.md
+++ b/.changeset/release-asset-attestations.md
@@ -1,0 +1,36 @@
+---
+monochange: patch
+---
+
+#### attest GitHub release archives before publishing downstream packages
+
+monochange's own GitHub release asset workflow now runs from tag or manual dispatch events instead of draft release creation events. This makes the workflow compatible with GitHub immutable releases, where assets should exist before the release is finalized and draft `release.created` events are not a reliable trigger.
+
+**Before:**
+
+```yaml
+on:
+  release:
+    types: [created]
+```
+
+The workflow uploaded CLI archives and checksum files, but did not create first-class GitHub artifact attestations for the uploaded `.tar.gz` and `.zip` archives.
+
+**After:**
+
+```yaml
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+```
+
+The release asset job now requests the minimum attestation permissions, downloads each uploaded archive back from the release, creates GitHub build-provenance attestations for those archive subjects, and verifies the attestations before triggering downstream package publishing.
+
+Users can verify a published archive with:
+
+```bash
+gh attestation verify monochange-x86_64-unknown-linux-gnu-v1.2.3.tar.gz \
+  --repo monochange/monochange
+```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,13 @@
 name: "release"
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag (e.g. v0.1.0). Must start with `v` and have a matching GitHub release."
+        description: "Release tag (e.g. v0.1.0). Must start with `v`."
         required: true
         type: string
       checkout_ref:
@@ -15,7 +16,7 @@ on:
         type: boolean
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.tag || github.event.release.tag_name }}
+  group: ${{ github.workflow }}-${{ inputs.tag || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -24,12 +25,14 @@ jobs:
       CARGO_PROFILE_RELEASE_LTO: true
       CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
       CARGO_PROFILE_RELEASE_STRIP: symbols
-      RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name }}
+      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
     permissions:
+      attestations: write
       contents: write
+      id-token: write
     if: >-
       github.repository_owner == 'monochange' &&
-      startsWith(inputs.tag || github.event.release.tag_name, 'v')
+      startsWith(inputs.tag || github.ref_name, 'v')
     strategy:
       fail-fast: false
       matrix:
@@ -91,16 +94,91 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           checksum: sha256,sha512
 
+      - name: download uploaded archives for attestation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TARGET: ${{ matrix.target }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          asset_dir="$RUNNER_TEMP/release-asset-attestations/$RELEASE_TARGET"
+          mkdir -p "$asset_dir"
+
+          downloaded=0
+          for asset in \
+            "monochange-${RELEASE_TARGET}-${RELEASE_TAG}.tar.gz" \
+            "monochange-${RELEASE_TARGET}-${RELEASE_TAG}.zip"; do
+            if gh release view "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json assets \
+              --jq '.assets[].name' | grep -Fx "$asset" >/dev/null; then
+              gh release download "$RELEASE_TAG" \
+                --repo "$GITHUB_REPOSITORY" \
+                --pattern "$asset" \
+                --dir "$asset_dir"
+              downloaded=$((downloaded + 1))
+            fi
+          done
+
+          if [ "$downloaded" -eq 0 ]; then
+            echo "No release archives found for $RELEASE_TARGET and $RELEASE_TAG" >&2
+            gh release view "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json assets \
+              --jq '.assets[].name' >&2
+            exit 1
+          fi
+
+          echo "Downloaded release archives for attestation:"
+          for archive in "$asset_dir"/*; do
+            echo "$archive"
+            shasum -a 256 "$archive"
+          done
+
+      - name: attest release archives
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: ${{ runner.temp }}/release-asset-attestations/${{ matrix.target }}/*
+
+      - name: verify release archive attestations
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TARGET: ${{ matrix.target }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          for archive in "$RUNNER_TEMP/release-asset-attestations/$RELEASE_TARGET"/*; do
+            echo "::group::Verify attestation for $(basename "$archive")"
+            verified=false
+            for attempt in 1 2 3 4 5; do
+              if gh attestation verify "$archive" --repo "$GITHUB_REPOSITORY"; then
+                verified=true
+                break
+              fi
+
+              echo "Attestation not available yet for $(basename "$archive") on attempt $attempt; retrying..."
+              sleep 10
+            done
+
+            if [ "$verified" != true ]; then
+              echo "Failed to verify attestation for $archive" >&2
+              exit 1
+            fi
+            echo "::endgroup::"
+          done
+
   trigger_publish:
     needs: upload_assets
     environment: publisher
     env:
-      RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name }}
+      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
     permissions:
       actions: write
     if: >-
       github.repository_owner == 'monochange' &&
-      startsWith(inputs.tag || github.event.release.tag_name, 'v')
+      startsWith(inputs.tag || github.ref_name, 'v')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/docs/src/guide/08-github-automation.md
+++ b/docs/src/guide/08-github-automation.md
@@ -259,6 +259,15 @@ monochange now includes a release workflow modeled around long-running release P
 
 That split keeps tag creation on the default branch side of the merge and lets downstream automation consume the exact durable release metadata that monochange stored in git history.
 
+For release asset workflows, prefer tag or manual dispatch triggers over draft `release.created` triggers. Draft releases do not reliably emit `release.created`, and immutable releases need every archive to be uploaded and attested before the release is finalized. A hardened GitHub release asset job should request `contents: write`, `id-token: write`, and `attestations: write`, upload the `.tar.gz` and `.zip` archives, then attest the archive files directly instead of treating checksum files as a substitute.
+
+After a release finishes, verify an archive with GitHub's attestation CLI:
+
+```bash
+gh attestation verify monochange-x86_64-unknown-linux-gnu-v1.2.3.tar.gz \
+  --repo monochange/monochange
+```
+
 For release repair, GitHub is also the first provider with hosted-release retarget sync support. monochange uses the durable release record plus tag names from that record to keep the hosted release view aligned with moved tags.
 
 ## GitHub Actions policy workflow


### PR DESCRIPTION
## Summary

- Switch the release asset workflow from draft `release.created` events to tag/manual dispatch triggers for immutable-release compatibility.
- Add GitHub artifact attestation permissions and attest every uploaded CLI `.tar.gz` / `.zip` archive before downstream package publishing is triggered.
- Document release archive attestation verification with `gh attestation verify`.

Closes #308.

## Validation

- `dprint check .github/workflows/release.yml docs/src/guide/08-github-automation.md .changeset/release-asset-attestations.md`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
- `git diff --check`
- `mc validate`

## Changeset

Added `.changeset/release-asset-attestations.md`.

## Risk and rollout

This changes release asset workflow triggering: release archives now build on `v*` tag pushes or manual dispatch instead of draft release creation. The existing manual `tag` input remains available, archive names are unchanged, and downstream `publish.yml` still receives the release tag after all matrix uploads and attestation verification complete.
