### PR TITLE
ci: use npm trusted publishing

### DIFF
--- a/.changeset/npm-trusted-publishing.md
+++ b/.changeset/npm-trusted-publishing.md
@@ -1,0 +1,25 @@
+---
+monochange: patch
+---
+
+#### publish CLI npm packages with trusted publishing
+
+monochange's own CLI npm package workflow now publishes without `NODE_AUTH_TOKEN` or `NPM_TOKEN`. The publish job keeps the protected `publisher` environment and `id-token: write` permission so npm can use GitHub OIDC trusted publishing and produce provenance for the CLI packages.
+
+**Before:**
+
+```yaml
+- name: publish cli npm packages
+  env:
+    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  run: node scripts/npm/publish-packages.mjs --packages-dir packages
+```
+
+**After:**
+
+```yaml
+- name: publish cli npm packages
+  run: node scripts/npm/publish-packages.mjs --packages-dir packages
+```
+
+The publish script rejects long-lived npm token environment variables and verifies it is running from `monochange/monochange`'s `publish.yml` workflow with GitHub Actions OIDC context before invoking `npm publish --provenance`.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,8 +74,6 @@ jobs:
         shell: devenv shell -- bash -e {0}
 
       - name: publish cli npm packages
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           node scripts/npm/publish-packages.mjs \
             --packages-dir packages

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -868,6 +868,21 @@ The monochange repository itself can dogfood this model by:
 
 - declaring `[source]`, `[source.releases]`, and `[source.pull_requests]` in `monochange.toml`
 - running a real `changeset-policy` GitHub Actions workflow that shells into `mc step:affected-packages`
+- publishing the CLI npm packages from `.github/workflows/publish.yml` with the protected `publisher` environment and `id-token: write`, without `NODE_AUTH_TOKEN` or `NPM_TOKEN`
+
+For monochange's own npm packages, register every package under the GitHub trusted-publishing context `monochange/monochange`, workflow file `publish.yml`, and environment `publisher` before the first tokenless publish:
+
+- `@monochange/cli`
+- `@monochange/cli-darwin-arm64`
+- `@monochange/cli-darwin-x64`
+- `@monochange/cli-linux-arm64-gnu`
+- `@monochange/cli-linux-arm64-musl`
+- `@monochange/cli-linux-x64-gnu`
+- `@monochange/cli-linux-x64-musl`
+- `@monochange/cli-win32-arm64-msvc`
+- `@monochange/cli-win32-x64-msvc`
+
+After publishing, verify npm provenance from the package page or with npm's provenance metadata for the released version. The expected publisher identity is the `publish.yml` workflow in `monochange/monochange`; a run that lacks npm trusted-publishing setup should fail instead of falling back to a long-lived registry token.
 
 <!-- {/githubAutomationDogfoodNotes} -->
 

--- a/docs/src/guide/08-github-automation.md
+++ b/docs/src/guide/08-github-automation.md
@@ -344,6 +344,21 @@ The monochange repository itself can dogfood this model by:
 
 - declaring `[source]`, `[source.releases]`, and `[source.pull_requests]` in `monochange.toml`
 - running a real `changeset-policy` GitHub Actions workflow that shells into `mc step:affected-packages`
+- publishing the CLI npm packages from `.github/workflows/publish.yml` with the protected `publisher` environment and `id-token: write`, without `NODE_AUTH_TOKEN` or `NPM_TOKEN`
+
+For monochange's own npm packages, register every package under the GitHub trusted-publishing context `monochange/monochange`, workflow file `publish.yml`, and environment `publisher` before the first tokenless publish:
+
+- `@monochange/cli`
+- `@monochange/cli-darwin-arm64`
+- `@monochange/cli-darwin-x64`
+- `@monochange/cli-linux-arm64-gnu`
+- `@monochange/cli-linux-arm64-musl`
+- `@monochange/cli-linux-x64-gnu`
+- `@monochange/cli-linux-x64-musl`
+- `@monochange/cli-win32-arm64-msvc`
+- `@monochange/cli-win32-x64-msvc`
+
+After publishing, verify npm provenance from the package page or with npm's provenance metadata for the released version. The expected publisher identity is the `publish.yml` workflow in `monochange/monochange`; a run that lacks npm trusted-publishing setup should fail instead of falling back to a long-lived registry token.
 
 <!-- {/githubAutomationDogfoodNotes} -->
 

--- a/scripts/npm/publish-packages.mjs
+++ b/scripts/npm/publish-packages.mjs
@@ -18,6 +18,19 @@ export const PLATFORM_PACKAGE_DIRS = [
 
 export const CLI_PACKAGE_DIR = "monochange__cli";
 
+export const TRUSTED_PUBLISHING_REPOSITORY = "monochange/monochange";
+export const TRUSTED_PUBLISHING_WORKFLOW = "publish.yml";
+
+export const FORBIDDEN_NPM_TOKEN_ENV_KEYS = [
+	"NODE_AUTH_TOKEN",
+	"NPM_TOKEN",
+	"NPM_AUTH_TOKEN",
+	"NPM_CONFIG_TOKEN",
+	"NPM_CONFIG__AUTH_TOKEN",
+	"npm_config_token",
+	"npm_config__authToken",
+];
+
 let _spawnSync = nodeSpawnSync;
 
 export function _setSpawnSync(fn) {
@@ -51,6 +64,7 @@ export function run(command, args, options = {}) {
 		encoding: "utf8",
 		stdio: options.stdio ?? "pipe",
 		cwd: options.cwd,
+		env: options.env,
 	});
 
 	if (result.status !== 0) {
@@ -83,7 +97,55 @@ export function hasBinary(dir) {
 	return entries.some((entry) => entry.startsWith("monochange"));
 }
 
-export function publishPackage(dir) {
+export function assertTrustedPublishingContext(env = process.env) {
+	const configuredTokenKeys = FORBIDDEN_NPM_TOKEN_ENV_KEYS.filter((key) => env[key]);
+	if (configuredTokenKeys.length > 0) {
+		throw new Error(
+			`Refusing to publish npm packages with long-lived npm token environment variables: ${configuredTokenKeys.join(", ")}. ` +
+				"Remove npm token credentials so npm trusted publishing can use GitHub OIDC.",
+		);
+	}
+
+	const workflowRef = env.GITHUB_WORKFLOW_REF ?? "";
+	const expectedWorkflowPath = `${TRUSTED_PUBLISHING_REPOSITORY}/.github/workflows/${TRUSTED_PUBLISHING_WORKFLOW}@`;
+	const missing = [];
+
+	if (env.GITHUB_ACTIONS !== "true") {
+		missing.push("GITHUB_ACTIONS=true");
+	}
+	if (env.GITHUB_REPOSITORY !== TRUSTED_PUBLISHING_REPOSITORY) {
+		missing.push(`GITHUB_REPOSITORY=${TRUSTED_PUBLISHING_REPOSITORY}`);
+	}
+	if (!workflowRef.startsWith(expectedWorkflowPath)) {
+		missing.push(`GITHUB_WORKFLOW_REF=${expectedWorkflowPath}<ref>`);
+	}
+	if (!env.ACTIONS_ID_TOKEN_REQUEST_URL) {
+		missing.push("ACTIONS_ID_TOKEN_REQUEST_URL");
+	}
+	if (!env.ACTIONS_ID_TOKEN_REQUEST_TOKEN) {
+		missing.push("ACTIONS_ID_TOKEN_REQUEST_TOKEN");
+	}
+
+	if (missing.length > 0) {
+		throw new Error(
+			"Cannot publish npm packages without the trusted-publishing GitHub Actions context. " +
+				`Expected repository ${TRUSTED_PUBLISHING_REPOSITORY}, workflow ${TRUSTED_PUBLISHING_WORKFLOW}, environment publisher, and OIDC token permissions. ` +
+				`Missing or mismatched: ${missing.join(", ")}.`,
+		);
+	}
+}
+
+export function npmPublishEnv(env = process.env) {
+	const publishEnv = { ...env };
+	for (const key of FORBIDDEN_NPM_TOKEN_ENV_KEYS) {
+		delete publishEnv[key];
+	}
+	publishEnv.NPM_CONFIG_PROVENANCE = "true";
+	return publishEnv;
+}
+
+export function publishPackage(dir, options = {}) {
+	const env = options.env ?? process.env;
 	const pkg = packageMetadata(dir);
 	if (hasBinary(dir) === false) {
 		throw new Error(
@@ -92,19 +154,22 @@ export function publishPackage(dir) {
 		);
 	}
 
+	assertTrustedPublishingContext(env);
+
 	if (packageExists(pkg.name, pkg.version)) {
 		console.log(`Skipping ${pkg.name}@${pkg.version}; already published.`);
 		return;
 	}
 
-	console.log(`Publishing ${pkg.name}@${pkg.version}...`);
+	console.log(`Publishing ${pkg.name}@${pkg.version} with npm trusted publishing...`);
 	run("npm", ["publish", "--access", "public", "--provenance"], {
 		cwd: dir,
 		stdio: "inherit",
+		env: npmPublishEnv(env),
 	});
 }
 
-export function main(argv = process.argv.slice(2)) {
+export function main(argv = process.argv.slice(2), options = {}) {
 	const args = parseArgs(argv);
 	if (!args["packages-dir"]) {
 		throw new Error("usage: publish-packages.mjs --packages-dir <dir>");
@@ -112,11 +177,12 @@ export function main(argv = process.argv.slice(2)) {
 
 	const packagesDir = resolve(args["packages-dir"]);
 
+	const env = options.env ?? process.env;
 	for (const dirName of PLATFORM_PACKAGE_DIRS) {
-		publishPackage(join(packagesDir, dirName));
+		publishPackage(join(packagesDir, dirName), { env });
 	}
 
-	publishPackage(join(packagesDir, CLI_PACKAGE_DIR));
+	publishPackage(join(packagesDir, CLI_PACKAGE_DIR), { env });
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {

--- a/scripts/npm/tests/publish-packages.test.mjs
+++ b/scripts/npm/tests/publish-packages.test.mjs
@@ -8,12 +8,14 @@ import {
 	CLI_PACKAGE_DIR,
 	hasBinary,
 	main as publishMain,
+	npmPublishEnv,
 	packageExists,
 	packageMetadata,
 	parseArgs,
 	PLATFORM_PACKAGE_DIRS,
 	publishPackage,
 	run,
+	assertTrustedPublishingContext,
 } from "../publish-packages.mjs";
 
 function makeSandbox() {
@@ -21,6 +23,17 @@ function makeSandbox() {
 	const sandbox = join(base, `test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	mkdirSync(sandbox, { recursive: true });
 	return sandbox;
+}
+
+function trustedPublishingEnv(overrides = {}) {
+	return {
+		GITHUB_ACTIONS: "true",
+		GITHUB_REPOSITORY: "monochange/monochange",
+		GITHUB_WORKFLOW_REF: "monochange/monochange/.github/workflows/publish.yml@refs/tags/v1.0.0",
+		ACTIONS_ID_TOKEN_REQUEST_URL: "https://token.actions.example/request",
+		ACTIONS_ID_TOKEN_REQUEST_TOKEN: "oidc-request-token",
+		...overrides,
+	};
 }
 
 afterEach(() => {
@@ -157,6 +170,36 @@ describe("hasBinary", () => {
 	});
 });
 
+describe("trusted publishing context", () => {
+	test("accepts the monochange publish workflow OIDC context", () => {
+		assert.doesNotThrow(() => assertTrustedPublishingContext(trustedPublishingEnv()));
+	});
+
+	test("rejects long-lived npm token environment variables", () => {
+		assert.throws(
+			() => assertTrustedPublishingContext(trustedPublishingEnv({ NODE_AUTH_TOKEN: "secret" })),
+			{
+				message: /long-lived npm token environment variables: NODE_AUTH_TOKEN/,
+			},
+		);
+	});
+
+	test("rejects missing GitHub OIDC context", () => {
+		assert.throws(() => assertTrustedPublishingContext({}), {
+			message: /Cannot publish npm packages without the trusted-publishing GitHub Actions context/,
+		});
+	});
+
+	test("removes npm token variables from publish environment", () => {
+		const env = npmPublishEnv(
+			trustedPublishingEnv({ NODE_AUTH_TOKEN: "secret", NPM_TOKEN: "secret" }),
+		);
+		assert.equal(env.NODE_AUTH_TOKEN, undefined);
+		assert.equal(env.NPM_TOKEN, undefined);
+		assert.equal(env.NPM_CONFIG_PROVENANCE, "true");
+	});
+});
+
 describe("publishPackage", () => {
 	test("throws when no binary is present", () => {
 		const sandbox = makeSandbox();
@@ -200,7 +243,7 @@ describe("publishPackage", () => {
 			}),
 		);
 		_setSpawnSync(() => ({ status: 0, stdout: '"1.0.0"' }));
-		publishPackage(sandbox);
+		publishPackage(sandbox, { env: trustedPublishingEnv() });
 	});
 
 	test("publishes when binary present and package not on npm", () => {
@@ -215,18 +258,21 @@ describe("publishPackage", () => {
 			}),
 		);
 		let publishCalled = false;
-		_setSpawnSync((cmd, args) => {
+		let publishOptions;
+		_setSpawnSync((cmd, args, options) => {
 			if (args[0] === "view") {
 				return { status: 1, stderr: "not found" };
 			}
 			if (args[0] === "publish") {
 				publishCalled = true;
+				publishOptions = options;
 				return { status: 0, stdout: "" };
 			}
 			return { status: 0, stdout: "" };
 		});
-		publishPackage(sandbox);
+		publishPackage(sandbox, { env: trustedPublishingEnv() });
 		assert.equal(publishCalled, true);
+		assert.equal(publishOptions.env.NPM_CONFIG_PROVENANCE, "true");
 	});
 });
 
@@ -264,7 +310,7 @@ describe("main", () => {
 			return { status: 0, stdout: "" };
 		});
 
-		publishMain(["--packages-dir", sandbox]);
+		publishMain(["--packages-dir", sandbox], { env: trustedPublishingEnv() });
 
 		assert.equal(publishedOrder.length, PLATFORM_PACKAGE_DIRS.length + 1);
 	});


### PR DESCRIPTION
## Summary

- remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from monochange's CLI npm package publish step
- make `scripts/npm/publish-packages.mjs` reject long-lived npm token environment variables and require the GitHub Actions OIDC context for `monochange/monochange`'s `publish.yml` workflow
- document the npm trusted-publishing setup checklist for monochange's CLI npm packages and add a changeset

Closes #309.

## Validation

- `node --test scripts/npm/tests/publish-packages.test.mjs`
- `dprint check .github/workflows/publish.yml scripts/npm/publish-packages.mjs scripts/npm/tests/publish-packages.test.mjs docs/src/guide/08-github-automation.md .templates/guides.t.md .changeset/npm-trusted-publishing.md`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml")'`
- `docs:check`
- `git diff --check`
- `mc validate`
