### PR TITLE
feat: add migration audit command

### DIFF
--- a/.changeset/migration-audit-command.md
+++ b/.changeset/migration-audit-command.md
@@ -1,0 +1,5 @@
+---
+"monochange": minor
+---
+
+Add `mc migrate audit` to report legacy release tooling, changelog providers, and CI migration signals before moving a repository to monochange.

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -70,6 +70,160 @@ where
 }
 
 #[test]
+fn migrate_audit_reports_legacy_release_tooling() {
+	let tempdir = setup_fixture("migration-audit/legacy-release-workflow");
+	let output = run_cli(
+		tempdir.path(),
+		[
+			OsString::from("mc"),
+			OsString::from("migrate"),
+			OsString::from("audit"),
+		],
+	)
+	.unwrap_or_else(|error| panic!("migration audit: {error}"));
+
+	assert!(output.contains("migration audit: migration-needed"));
+	assert!(output.contains("legacy-release-tool knope at knope.toml"));
+	assert!(output.contains("ci-workflow changesets at .github/workflows/release.yml"));
+	assert!(output.contains("Plan trusted publishing per package"));
+
+	let json_output = run_cli(
+		tempdir.path(),
+		[
+			OsString::from("mc"),
+			OsString::from("migrate"),
+			OsString::from("audit"),
+			OsString::from("--format"),
+			OsString::from("json"),
+		],
+	)
+	.unwrap_or_else(|error| panic!("migration audit json: {error}"));
+	let parsed: serde_json::Value = serde_json::from_str(&json_output)
+		.unwrap_or_else(|error| panic!("parse migration audit json: {error}"));
+
+	assert_eq!(parsed["status"], serde_json::json!("migration-needed"));
+	assert!(parsed["signals"].as_array().is_some_and(|signals| {
+		signals.iter().any(|signal| {
+			signal["tool"] == serde_json::json!("knope")
+				&& signal["path"] == serde_json::json!("knope.toml")
+		})
+	}));
+	assert!(parsed["recommendations"].as_array().is_some_and(|items| {
+		items
+			.iter()
+			.any(|item| item["id"] == serde_json::json!("audit-changelogs"))
+	}));
+}
+
+#[test]
+fn migrate_audit_reports_ready_workspace_and_quiet_mode() {
+	let tempdir = setup_fixture("migration-audit/ready-monochange");
+	let output = run_cli(
+		tempdir.path(),
+		[
+			OsString::from("mc"),
+			OsString::from("migrate"),
+			OsString::from("audit"),
+			OsString::from("--format"),
+			OsString::from("markdown"),
+		],
+	)
+	.unwrap_or_else(|error| panic!("migration audit ready: {error}"));
+
+	assert!(output.contains("migration audit: ready"));
+	assert!(output.contains("monochange-config monochange at monochange.toml"));
+	assert!(output.contains("- no migration-specific recommendations detected"));
+
+	let quiet_output = run_cli(
+		tempdir.path(),
+		[
+			OsString::from("mc"),
+			OsString::from("--quiet"),
+			OsString::from("migrate"),
+			OsString::from("audit"),
+		],
+	)
+	.unwrap_or_else(|error| panic!("migration audit quiet: {error}"));
+	assert_eq!(quiet_output, "");
+
+	let empty_tempdir = setup_fixture("migration-audit/empty-workspace");
+	let empty_output = run_cli(
+		empty_tempdir.path(),
+		[
+			OsString::from("mc"),
+			OsString::from("migrate"),
+			OsString::from("audit"),
+		],
+	)
+	.unwrap_or_else(|error| panic!("migration audit empty: {error}"));
+	assert!(empty_output.contains("- none detected"));
+	assert!(empty_output.contains("Generate monochange configuration"));
+}
+
+#[test]
+fn migrate_audit_reports_fixture_read_errors() {
+	let package_json_dir = setup_fixture("migration-audit/unreadable-package-json");
+	fs::rename(
+		package_json_dir.path().join("package-json-dir"),
+		package_json_dir.path().join("package.json"),
+	)
+	.unwrap_or_else(|error| panic!("rename package.json directory fixture: {error}"));
+	let package_error = run_cli(
+		package_json_dir.path(),
+		[
+			OsString::from("mc"),
+			OsString::from("migrate"),
+			OsString::from("audit"),
+		],
+	)
+	.unwrap_err();
+	assert!(package_error.to_string().contains("failed to read"));
+	assert!(package_error.to_string().contains("package.json"));
+
+	let workflow_root_file = setup_fixture("migration-audit/unreadable-workflow-root");
+	fs::rename(
+		workflow_root_file.path().join(".github/workflows-file"),
+		workflow_root_file.path().join(".github/workflows"),
+	)
+	.unwrap_or_else(|error| panic!("rename workflows file fixture: {error}"));
+	let workflow_root_error = run_cli(
+		workflow_root_file.path(),
+		[
+			OsString::from("mc"),
+			OsString::from("migrate"),
+			OsString::from("audit"),
+		],
+	)
+	.unwrap_err();
+	assert!(
+		workflow_root_error
+			.to_string()
+			.contains(".github/workflows")
+	);
+
+	let workflow_file_dir = setup_fixture("migration-audit/unreadable-workflow-file");
+	fs::rename(
+		workflow_file_dir
+			.path()
+			.join(".github/workflows/release-yml-dir"),
+		workflow_file_dir
+			.path()
+			.join(".github/workflows/release.yml"),
+	)
+	.unwrap_or_else(|error| panic!("rename workflow directory fixture: {error}"));
+	let workflow_file_error = run_cli(
+		workflow_file_dir.path(),
+		[
+			OsString::from("mc"),
+			OsString::from("migrate"),
+			OsString::from("audit"),
+		],
+	)
+	.unwrap_err();
+	assert!(workflow_file_error.to_string().contains("release.yml"));
+}
+
+#[test]
 fn verify_release_branch_step_reports_matching_branch() {
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	fs::write(

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -205,6 +205,7 @@ When provided, the generated config includes:\n\
 			.subcommand(build_skill_subcommand())
 			.subcommand(build_subagents_subcommand())
 			.subcommand(build_analyze_subcommand())
+			.subcommand(build_migrate_subcommand())
 			.subcommand(build_release_record_subcommand())
 			.subcommand(build_publish_readiness_subcommand())
 			.subcommand(build_publish_bootstrap_subcommand())
@@ -394,6 +395,34 @@ Analysis notes:
 				.default_value("markdown")
 				.value_parser(["text", "json", "markdown", "md"])
 				.help("Output format"),
+		)
+}
+
+pub(crate) fn build_migrate_subcommand() -> Command {
+	Command::new("migrate")
+		.about("Audit release automation before migrating to monochange")
+		.subcommand_required(true)
+		.arg_required_else_help(true)
+		.subcommand(
+			Command::new("audit")
+				.about("Report existing release tools, changelog providers, and CI migration work")
+				.after_help(
+					r"Examples:
+  mc migrate audit
+  mc migrate audit --format json
+
+Audit notes:
+  - Looks for known release tools such as knope, Changesets, release-please, semantic-release, and cargo-release.
+  - Scans GitHub Actions workflows for legacy release actions and commands.
+  - Reports changelog providers and trusted-publishing migration recommendations.",
+				)
+				.arg(
+					Arg::new("format")
+						.long("format")
+						.help("Output format")
+						.default_value("text")
+						.value_parser(["text", "json", "markdown", "md"]),
+				),
 		)
 }
 

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -137,6 +137,7 @@ pub(crate) use git_support::run_git_capture;
 pub(crate) use git_support::run_git_process;
 #[cfg(test)]
 pub(crate) use git_support::run_git_status;
+use migration_audit::run_migration_command;
 use minijinja::Environment;
 use minijinja::UndefinedBehavior;
 #[cfg(feature = "cargo")]
@@ -299,6 +300,7 @@ mod interactive;
 mod lint;
 mod lint_check_reporter;
 mod mcp;
+mod migration_audit;
 mod package_publish;
 mod prepared_release_cache;
 mod publish_bootstrap;
@@ -874,6 +876,7 @@ where
 				format,
 			)
 		}
+		Some(("migrate", migrate_matches)) => run_migration_command(root, quiet, migrate_matches),
 		Some(("mcp", _)) => run_mcp_command_with(quiet, mcp::run_server),
 		Some(("release-record", release_record_matches)) => {
 			let from = release_record_matches

--- a/crates/monochange/src/migration_audit.rs
+++ b/crates/monochange/src/migration_audit.rs
@@ -1,0 +1,466 @@
+use std::fmt::Write as _;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::Path;
+
+use clap::ArgMatches;
+use monochange_core::MonochangeError;
+use monochange_core::MonochangeResult;
+use serde::Serialize;
+
+use crate::OutputFormat;
+use crate::parse_output_format;
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum MigrationAuditStatus {
+	Ready,
+	MigrationNeeded,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct MigrationAuditReport {
+	pub status: MigrationAuditStatus,
+	pub root: String,
+	pub signals: Vec<MigrationAuditSignal>,
+	pub recommendations: Vec<MigrationAuditRecommendation>,
+	pub next_steps: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct MigrationAuditSignal {
+	pub kind: String,
+	pub tool: String,
+	pub path: String,
+	pub message: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct MigrationAuditRecommendation {
+	pub id: String,
+	pub title: String,
+	pub detail: String,
+}
+
+pub(crate) fn run_migration_command(
+	root: &Path,
+	quiet: bool,
+	migrate_matches: &ArgMatches,
+) -> MonochangeResult<String> {
+	if quiet {
+		return Ok(String::new());
+	}
+	let audit_matches = migrate_matches
+		.subcommand_matches("audit")
+		.unwrap_or(migrate_matches);
+	let format = audit_matches
+		.get_one::<String>("format")
+		.map_or(Ok(OutputFormat::Text), |value| parse_output_format(value))?;
+	run_migration_audit(root, format)
+}
+
+pub(crate) fn run_migration_audit(root: &Path, format: OutputFormat) -> MonochangeResult<String> {
+	let report = audit_migration(root)?;
+	Ok(render_migration_audit_report(&report, format))
+}
+
+pub(crate) fn audit_migration(root: &Path) -> MonochangeResult<MigrationAuditReport> {
+	let mut signals = Vec::new();
+
+	add_path_signal(
+		root,
+		&mut signals,
+		"monochange-config",
+		"monochange",
+		"monochange.toml",
+		"monochange configuration already exists",
+	);
+	add_path_signal(
+		root,
+		&mut signals,
+		"legacy-release-tool",
+		"knope",
+		"knope.toml",
+		"knope configuration detected",
+	);
+	add_path_signal(
+		root,
+		&mut signals,
+		"legacy-release-tool",
+		"knope",
+		".knope.toml",
+		"knope configuration detected",
+	);
+	add_path_signal(
+		root,
+		&mut signals,
+		"legacy-changeset-tool",
+		"changesets",
+		".changeset/config.json",
+		"Changesets configuration detected; audit frontmatter and changelog settings before reusing files with monochange",
+	);
+	add_path_signal(
+		root,
+		&mut signals,
+		"legacy-release-tool",
+		"release-please",
+		"release-please-config.json",
+		"release-please configuration detected",
+	);
+	add_path_signal(
+		root,
+		&mut signals,
+		"legacy-release-tool",
+		"release-please",
+		".release-please-manifest.json",
+		"release-please manifest detected",
+	);
+	for path in [
+		".releaserc",
+		".releaserc.json",
+		".releaserc.yml",
+		".releaserc.yaml",
+		".releaserc.js",
+		"release.config.js",
+	] {
+		add_path_signal(
+			root,
+			&mut signals,
+			"legacy-release-tool",
+			"semantic-release",
+			path,
+			"semantic-release configuration detected",
+		);
+	}
+	add_path_signal(
+		root,
+		&mut signals,
+		"legacy-release-tool",
+		"cargo-release",
+		"release.toml",
+		"cargo-release configuration detected",
+	);
+	add_path_signal(
+		root,
+		&mut signals,
+		"changelog-provider",
+		"mdt",
+		"mdt.toml",
+		"mdt changelog provider detected; compare generated changelogs with monochange changelog sections",
+	);
+	for path in ["CHANGELOG.md", "changelog.md"] {
+		add_path_signal(
+			root,
+			&mut signals,
+			"changelog-file",
+			"markdown-changelog",
+			path,
+			"existing changelog detected",
+		);
+	}
+
+	detect_package_json_release_tools(root, &mut signals)?;
+	detect_workflow_release_tools(root, &mut signals)?;
+	signals.sort_by(|left, right| {
+		left.path
+			.cmp(&right.path)
+			.then_with(|| left.tool.cmp(&right.tool))
+			.then_with(|| left.kind.cmp(&right.kind))
+	});
+	signals.dedup();
+
+	let recommendations = build_recommendations(&signals);
+	let status = if migration_signals(&signals).next().is_some() {
+		MigrationAuditStatus::MigrationNeeded
+	} else {
+		MigrationAuditStatus::Ready
+	};
+
+	Ok(MigrationAuditReport {
+		status,
+		root: root.display().to_string(),
+		signals,
+		recommendations,
+		next_steps: next_steps(),
+	})
+}
+
+fn add_path_signal(
+	root: &Path,
+	signals: &mut Vec<MigrationAuditSignal>,
+	kind: &str,
+	tool: &str,
+	relative_path: &str,
+	message: &str,
+) {
+	if root.join(relative_path).exists() {
+		push_signal(signals, kind, tool, relative_path, message);
+	}
+}
+
+fn detect_package_json_release_tools(
+	root: &Path,
+	signals: &mut Vec<MigrationAuditSignal>,
+) -> MonochangeResult<()> {
+	let path = root.join("package.json");
+	let Some(contents) = optional_read_to_string(&path)? else {
+		return Ok(());
+	};
+
+	for (needle, tool, message) in [
+		(
+			"@changesets/cli",
+			"changesets",
+			"package.json references the Changesets CLI",
+		),
+		(
+			"changeset",
+			"changesets",
+			"package.json references Changesets",
+		),
+		(
+			"release-please",
+			"release-please",
+			"package.json references release-please",
+		),
+		(
+			"semantic-release",
+			"semantic-release",
+			"package.json references semantic-release",
+		),
+		("knope", "knope", "package.json references knope"),
+	] {
+		if contents.contains(needle) {
+			push_signal(signals, "package-script", tool, "package.json", message);
+		}
+	}
+
+	Ok(())
+}
+
+fn detect_workflow_release_tools(
+	root: &Path,
+	signals: &mut Vec<MigrationAuditSignal>,
+) -> MonochangeResult<()> {
+	let workflows = root.join(".github/workflows");
+	let entries = match fs::read_dir(&workflows) {
+		Ok(entries) => entries,
+		Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+		Err(error) => {
+			return Err(MonochangeError::Io(format!(
+				"failed to read {}: {error}",
+				workflows.display()
+			)));
+		}
+	};
+
+	for entry in entries.flatten() {
+		let path = entry.path();
+		if !is_workflow_file(&path) {
+			continue;
+		}
+		let contents = fs::read_to_string(&path).map_err(|error| {
+			MonochangeError::Io(format!("failed to read {}: {error}", path.display()))
+		})?;
+		let relative_path = path
+			.strip_prefix(root)
+			.unwrap_or(path.as_path())
+			.to_string_lossy()
+			.replace('\\', "/");
+
+		for (needle, tool, message) in [
+			(
+				"changesets/action",
+				"changesets",
+				"GitHub Actions workflow uses the Changesets action",
+			),
+			(
+				"release-please",
+				"release-please",
+				"GitHub Actions workflow references release-please",
+			),
+			(
+				"semantic-release",
+				"semantic-release",
+				"GitHub Actions workflow references semantic-release",
+			),
+			("knope", "knope", "GitHub Actions workflow references knope"),
+			(
+				"cargo release",
+				"cargo-release",
+				"GitHub Actions workflow references cargo-release",
+			),
+		] {
+			if contents.contains(needle) {
+				push_signal(signals, "ci-workflow", tool, &relative_path, message);
+			}
+		}
+	}
+
+	Ok(())
+}
+
+fn is_workflow_file(path: &Path) -> bool {
+	path.extension()
+		.and_then(|extension| extension.to_str())
+		.is_some_and(|extension| matches!(extension, "yml" | "yaml"))
+}
+
+fn optional_read_to_string(path: &Path) -> MonochangeResult<Option<String>> {
+	match fs::read_to_string(path) {
+		Ok(contents) => Ok(Some(contents)),
+		Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+		Err(error) => {
+			Err(MonochangeError::Io(format!(
+				"failed to read {}: {error}",
+				path.display()
+			)))
+		}
+	}
+}
+
+fn push_signal(
+	signals: &mut Vec<MigrationAuditSignal>,
+	kind: &str,
+	tool: &str,
+	path: &str,
+	message: &str,
+) {
+	signals.push(MigrationAuditSignal {
+		kind: kind.to_string(),
+		tool: tool.to_string(),
+		path: path.to_string(),
+		message: message.to_string(),
+	});
+}
+
+fn migration_signals(
+	signals: &[MigrationAuditSignal],
+) -> impl Iterator<Item = &MigrationAuditSignal> {
+	signals
+		.iter()
+		.filter(|signal| signal.kind != "monochange-config" && signal.kind != "changelog-file")
+}
+
+fn build_recommendations(signals: &[MigrationAuditSignal]) -> Vec<MigrationAuditRecommendation> {
+	let has_monochange = signals
+		.iter()
+		.any(|signal| signal.kind == "monochange-config");
+	let has_legacy_release_tool = signals.iter().any(|signal| {
+		matches!(
+			signal.kind.as_str(),
+			"legacy-release-tool" | "legacy-changeset-tool" | "package-script" | "ci-workflow"
+		)
+	});
+	let has_changelog = signals.iter().any(|signal| {
+		matches!(
+			signal.kind.as_str(),
+			"changelog-provider" | "changelog-file"
+		)
+	});
+	let has_ci = signals.iter().any(|signal| signal.kind == "ci-workflow");
+
+	let mut recommendations = Vec::new();
+	if !has_monochange {
+		recommendations.push(MigrationAuditRecommendation {
+			id: "generate-config".to_string(),
+			title: "Generate monochange configuration".to_string(),
+			detail: "Run `mc init --provider github` or create `monochange.toml` manually, then review package groups, changelog sections, and publish settings.".to_string(),
+		});
+	}
+	if has_legacy_release_tool {
+		recommendations.push(MigrationAuditRecommendation {
+			id: "translate-release-tooling".to_string(),
+			title: "Translate existing release automation".to_string(),
+			detail: "Map legacy release rules, package ordering, tag formats, and release notes into monochange release commands before removing old tooling.".to_string(),
+		});
+	}
+	if has_changelog {
+		recommendations.push(MigrationAuditRecommendation {
+			id: "audit-changelogs".to_string(),
+			title: "Audit changelog ownership".to_string(),
+			detail: "Compare existing changelog files and providers with monochange changelog recommendations so releases do not produce duplicate or divergent notes.".to_string(),
+		});
+	}
+	if has_ci {
+		recommendations.push(MigrationAuditRecommendation {
+			id: "replace-ci-workflows".to_string(),
+			title: "Replace release workflows incrementally".to_string(),
+			detail: "Update CI to run `mc check`, release planning, `mc publish-readiness`, and trusted publishing setup before deleting the legacy workflow.".to_string(),
+		});
+	}
+	if has_legacy_release_tool || !has_monochange {
+		recommendations.push(MigrationAuditRecommendation {
+			id: "trusted-publishing-checklist".to_string(),
+			title: "Plan trusted publishing per package".to_string(),
+			detail: "Prefer trusted publishers for registries that support them and record repository, workflow, and environment context in each package publish configuration.".to_string(),
+		});
+	}
+
+	recommendations
+}
+
+fn next_steps() -> Vec<String> {
+	vec![
+		"Run `mc discover --format json` and compare discovered packages with existing release tooling.".to_string(),
+		"Draft or update `monochange.toml` with package groups, changelog sections, and publish settings.".to_string(),
+		"Dry-run release planning and publishing before removing legacy automation.".to_string(),
+	]
+}
+
+fn render_migration_audit_report(report: &MigrationAuditReport, format: OutputFormat) -> String {
+	match format {
+		OutputFormat::Json => serde_json::to_string_pretty(report).unwrap_or_default(),
+		OutputFormat::Markdown | OutputFormat::Text => render_text_report(report),
+	}
+}
+
+fn render_text_report(report: &MigrationAuditReport) -> String {
+	let mut output = String::new();
+	let _ = writeln!(output, "migration audit: {}", status_label(&report.status));
+	let _ = writeln!(output, "root: {}", report.root);
+	output.push('\n');
+	output.push_str("signals:\n");
+	if report.signals.is_empty() {
+		output.push_str("- none detected\n");
+	} else {
+		for signal in &report.signals {
+			let _ = writeln!(
+				output,
+				"- {} {} at {}: {}",
+				signal.kind, signal.tool, signal.path, signal.message
+			);
+		}
+	}
+
+	output.push('\n');
+	output.push_str("recommendations:\n");
+	if report.recommendations.is_empty() {
+		output.push_str("- no migration-specific recommendations detected\n");
+	} else {
+		for recommendation in &report.recommendations {
+			let _ = writeln!(
+				output,
+				"- {}: {}",
+				recommendation.title, recommendation.detail
+			);
+		}
+	}
+
+	output.push('\n');
+	output.push_str("next steps:\n");
+	for step in &report.next_steps {
+		let _ = writeln!(output, "- {step}");
+	}
+	output
+}
+
+fn status_label(status: &MigrationAuditStatus) -> &'static str {
+	match status {
+		MigrationAuditStatus::Ready => "ready",
+		MigrationAuditStatus::MigrationNeeded => "migration-needed",
+	}
+}

--- a/crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_prints_help.snap
+++ b/crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_prints_help.snap
@@ -21,6 +21,7 @@ Commands:
   skill                          Install the monochange skill bundle into the current project with the skills CLI
   subagents                      Generate repo-local monochange subagents and agent guidance files
   analyze                        Analyze semantic changes for one package across main, head, and optional release baselines
+  migrate                        Audit release automation before migrating to monochange
   release-record                 Inspect the monochange release record associated with a tag or commit
   publish-readiness              Check package registry publishing readiness without publishing packages
   publish-bootstrap              Publish first-time placeholder package versions for a release record

--- a/fixtures/tests/migration-audit/legacy-release-workflow/.changeset/config.json
+++ b/fixtures/tests/migration-audit/legacy-release-workflow/.changeset/config.json
@@ -1,0 +1,4 @@
+{
+  "changelog": ["@changesets/changelog-github", { "repo": "monochange/example" }],
+  "commit": false
+}

--- a/fixtures/tests/migration-audit/legacy-release-workflow/.github/workflows/release.yml
+++ b/fixtures/tests/migration-audit/legacy-release-workflow/.github/workflows/release.yml
@@ -1,0 +1,13 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: changesets/action@v1
+      - run: knope release

--- a/fixtures/tests/migration-audit/legacy-release-workflow/changelog.md
+++ b/fixtures/tests/migration-audit/legacy-release-workflow/changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release.

--- a/fixtures/tests/migration-audit/legacy-release-workflow/knope.toml
+++ b/fixtures/tests/migration-audit/legacy-release-workflow/knope.toml
@@ -1,0 +1,2 @@
+[packages.core]
+versioned_files = ["packages/core/package.json"]

--- a/fixtures/tests/migration-audit/legacy-release-workflow/mdt.toml
+++ b/fixtures/tests/migration-audit/legacy-release-workflow/mdt.toml
@@ -1,0 +1,2 @@
+[changelog]
+path = "changelog.md"

--- a/fixtures/tests/migration-audit/legacy-release-workflow/package.json
+++ b/fixtures/tests/migration-audit/legacy-release-workflow/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "legacy-release-workflow",
+  "private": true,
+  "scripts": {
+    "release": "changeset version && knope release"
+  },
+  "devDependencies": {
+    "@changesets/cli": "^2.29.0"
+  }
+}

--- a/fixtures/tests/migration-audit/ready-monochange/.github/workflows/notes.txt
+++ b/fixtures/tests/migration-audit/ready-monochange/.github/workflows/notes.txt
@@ -1,0 +1,1 @@
+release notes that should not be treated as a workflow

--- a/fixtures/tests/migration-audit/ready-monochange/monochange.toml
+++ b/fixtures/tests/migration-audit/ready-monochange/monochange.toml
@@ -1,0 +1,3 @@
+[packages]
+
+[commands]

--- a/fixtures/tests/migration-audit/unreadable-package-json/package-json-dir/README.md
+++ b/fixtures/tests/migration-audit/unreadable-package-json/package-json-dir/README.md
@@ -1,0 +1,1 @@
+This directory intentionally occupies the package.json path.

--- a/fixtures/tests/migration-audit/unreadable-workflow-file/.github/workflows/release-yml-dir/README.md
+++ b/fixtures/tests/migration-audit/unreadable-workflow-file/.github/workflows/release-yml-dir/README.md
@@ -1,0 +1,1 @@
+This directory intentionally occupies a workflow file path.

--- a/fixtures/tests/migration-audit/unreadable-workflow-root/.github/workflows-file
+++ b/fixtures/tests/migration-audit/unreadable-workflow-root/.github/workflows-file
@@ -1,0 +1,1 @@
+This file intentionally blocks reading .github/workflows as a directory.


### PR DESCRIPTION
## Summary
- add `mc migrate audit` to report legacy release tooling, changelog providers, and CI migration signals
- support text, markdown, and JSON audit output for planning migrations to monochange
- add fixture-based CLI coverage and update the top-level help snapshot

## Validation
- `devenv shell cargo fmt --all`
- `devenv shell cargo test -p monochange migrate_audit_reports_legacy_release_tooling`
- `devenv shell cargo clippy -p monochange --all-targets -- -D warnings`
- push hook `lint and test`

Related to #319.