### PR TITLE
ci: limit cargo test build jobs

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -184,6 +184,9 @@ in
     "test:cargo" = {
       exec = ''
         set -euo pipefail
+        if [ -n "''${CI:-}" ]; then
+          export CARGO_BUILD_JOBS="''${CARGO_BUILD_JOBS:-2}"
+        fi
         cargo bin cargo-nextest run --workspace --all-features --no-tests pass
       '';
       description = "Run cargo tests with nextest.";
@@ -192,6 +195,9 @@ in
     "test:cargo:expensive" = {
       exec = ''
         set -euo pipefail
+        if [ -n "''${CI:-}" ]; then
+          export CARGO_BUILD_JOBS="''${CARGO_BUILD_JOBS:-2}"
+        fi
         MONOCHANGE_EXPENSIVE_TESTS=1 cargo bin cargo-nextest run --workspace --all-features --no-tests pass
       '';
       description = "Run cargo tests with the CI-only large-fixture cases enabled.";


### PR DESCRIPTION
## Summary
- cap Cargo build jobs to 2 for CI cargo test scripts
- keep local test scripts using the default Cargo parallelism
- reduce concurrent rust-lld link pressure that caused the main test job to fail with bus errors

## Validation
- `devenv shell lint:format`
- `CI=true CARGO_BUILD_JOBS=2 devenv shell test:cargo:expensive`
- `cargo run -q -p monochange --bin mc -- step:affected-packages --format json --verify --changed-paths devenv.nix`
- `git diff --check`
- pre-push `lint:test` hook