### PR TITLE
docs: clarify ecosystem trusted publishing defaults

### DIFF
--- a/.changeset/default-publish-trust.md
+++ b/.changeset/default-publish-trust.md
@@ -1,0 +1,18 @@
+---
+"monochange_config": patch
+"monochange": patch
+---
+
+#### Document ecosystem-level trusted publishing inheritance
+
+Trusted publishing stays an ecosystem-level publish setting that packages inherit by default:
+
+```toml
+[ecosystems.npm.publish]
+trusted_publishing = true
+
+[package.legacy.publish]
+trusted_publishing = false
+```
+
+Use `[ecosystems.<name>.publish.trusted_publishing]` for shared repository, workflow, and environment metadata. Package-level publish settings override the ecosystem defaults for package-specific workflows or opt-outs.

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -2897,6 +2897,76 @@ enforce = true
 }
 
 #[test]
+fn load_workspace_configuration_inherits_ecosystem_publish_trusted_publishing_defaults() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	std::fs::create_dir_all(root.join("packages/web"))
+		.unwrap_or_else(|error| panic!("create web package: {error}"));
+	std::fs::create_dir_all(root.join("packages/legacy"))
+		.unwrap_or_else(|error| panic!("create legacy package: {error}"));
+	std::fs::write(
+		root.join("packages/web/package.json"),
+		r#"{ "name": "web", "version": "1.0.0" }"#,
+	)
+	.unwrap_or_else(|error| panic!("write web manifest: {error}"));
+	std::fs::write(
+		root.join("packages/legacy/package.json"),
+		r#"{ "name": "legacy", "version": "1.0.0" }"#,
+	)
+	.unwrap_or_else(|error| panic!("write legacy manifest: {error}"));
+	std::fs::write(
+		root.join("monochange.toml"),
+		r#"
+[ecosystems.npm.publish.trusted_publishing]
+enabled = true
+repository = "monochange/monochange"
+workflow = "publish.yml"
+environment = "publisher"
+
+[package.web]
+path = "packages/web"
+type = "npm"
+
+[package.legacy]
+path = "packages/legacy"
+type = "npm"
+
+[package.legacy.publish]
+trusted_publishing = false
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write monochange.toml: {error}"));
+
+	let configuration =
+		load_workspace_configuration(root).unwrap_or_else(|error| panic!("configuration: {error}"));
+	let web = configuration
+		.package_by_id("web")
+		.unwrap_or_else(|| panic!("expected web package"));
+	let legacy = configuration
+		.package_by_id("legacy")
+		.unwrap_or_else(|| panic!("expected legacy package"));
+
+	assert!(web.publish.trusted_publishing.enabled);
+	assert_eq!(
+		web.publish.trusted_publishing.repository.as_deref(),
+		Some("monochange/monochange")
+	);
+	assert_eq!(
+		web.publish.trusted_publishing.workflow.as_deref(),
+		Some("publish.yml")
+	);
+	assert_eq!(
+		web.publish.trusted_publishing.environment.as_deref(),
+		Some("publisher")
+	);
+	assert!(!legacy.publish.trusted_publishing.enabled);
+	assert_eq!(
+		legacy.publish.trusted_publishing.workflow.as_deref(),
+		Some("publish.yml")
+	);
+}
+
+#[test]
 fn load_workspace_configuration_merges_trusted_publishing_details() {
 	let root = fixture_path("config/publish-trusted-publishing-overrides");
 	let configuration = load_workspace_configuration(&root)

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -142,11 +142,18 @@ mode = "builtin"
 registry = "npm"
 trusted_publishing = true
 
+[ecosystems.npm.publish.trusted_publishing]
+workflow = "publish.yml"
+environment = "publisher"
+
 [package.web.publish]
 mode = "builtin"
 
 [package.web.publish.placeholder]
 readme_file = "docs/web-placeholder.md"
+
+[package.legacy.publish]
+trusted_publishing = false
 ```
 
 Supported fields:
@@ -159,7 +166,7 @@ Supported fields:
 - `placeholder.readme` — inline placeholder README content
 - `placeholder.readme_file` — workspace-relative file to use as placeholder README content
 
-Inheritance flows from `[ecosystems.<name>.publish]` to matching packages, and package-level values override the inherited defaults.
+Inheritance flows from `[ecosystems.<name>.publish]` to matching packages, and package-level values override the inherited ecosystem defaults. Configure shared trusted-publishing policy and context on the ecosystem, then use package-level publish settings for opt-outs or package-specific workflows.
 
 Built-in publishing currently targets only the canonical public registry for each supported ecosystem:
 
@@ -195,11 +202,16 @@ For each managed package with built-in publishing enabled, monochange:
 [ecosystems.npm.publish]
 trusted_publishing = true
 
-[package.cli.publish.trusted_publishing]
-enabled = true
+[ecosystems.npm.publish.trusted_publishing]
 repository = "owner/repo"
 workflow = "publish.yml"
 environment = "publisher"
+
+[package.cli.publish.trusted_publishing]
+workflow = "publish-cli.yml"
+
+[package.legacy.publish]
+trusted_publishing = false
 ```
 
 When `trusted_publishing` is enabled:

--- a/docs/src/guide/07-trusted-publishing.md
+++ b/docs/src/guide/07-trusted-publishing.md
@@ -48,7 +48,7 @@ For `crates.io`, `jsr`, `pub.dev`, and PyPI, monochange reports the setup URL fo
 
 ## monochange configuration
 
-Start by enabling trusted publishing for the relevant ecosystem or package.
+Start by enabling trusted publishing for the relevant ecosystem. Packages inherit the ecosystem publish setting by default and can override it when needed.
 
 ```toml
 [source]
@@ -58,6 +58,10 @@ repo = "monochange"
 
 [ecosystems.npm.publish]
 trusted_publishing = true
+
+[ecosystems.npm.publish.trusted_publishing]
+workflow = "publish.yml"
+environment = "publisher"
 
 [ecosystems.cargo.publish]
 trusted_publishing = true
@@ -72,9 +76,13 @@ trusted_publishing = true
 trusted_publishing = true
 
 [package.cli.publish.trusted_publishing]
-workflow = "publish.yml"
-environment = "publisher"
+workflow = "publish-cli.yml"
+
+[package.legacy.publish]
+trusted_publishing = false
 ```
+
+Use ecosystem publish settings for the shared trust policy and GitHub context. Use package publish settings only for package-specific workflows, environments, or opt-outs.
 
 monochange resolves the GitHub trust context from:
 
@@ -110,7 +118,7 @@ Use the same environment name in GitHub Actions and in the registry configuratio
 
 Use this sequence when adopting trusted publishing for an existing workspace:
 
-1. Set `publish.trusted_publishing = true` for the target ecosystem or package.
+1. Set `publish.trusted_publishing = true` for the target ecosystem, then override individual packages only when they differ.
 2. Run `mc placeholder-publish --dry-run` to see which packages do not exist yet.
 3. If needed, run `mc placeholder-publish` so the package exists in the registry first.
 4. Complete the registry-side trusted-publishing setup for each package.


### PR DESCRIPTION
## Summary

- Keep trusted publishing defaults scoped to ecosystems rather than workspace defaults.
- Add coverage that packages inherit `[ecosystems.<name>.publish.trusted_publishing]` and can opt out with package-level `trusted_publishing = false`.
- Update docs and the changeset to make the intended inheritance path explicit: ecosystem publish settings → package publish settings.

## Validation

- `cargo fmt --check`
- `cargo test -p monochange_config ecosystem_publish_trusted_publishing --lib`
- `cargo test -p monochange_config --lib`
- `cargo clippy -p monochange_config --all-targets -- -D warnings`
- `dprint check`
- `docs:check`
- `mc validate`
- `git diff --check --cached`
