### PR TITLE
feat: add attestation policy

### DIFF
--- a/.changeset/attestation-policy.md
+++ b/.changeset/attestation-policy.md
@@ -1,0 +1,13 @@
+---
+"monochange_core": patch
+"monochange_config": patch
+"monochange": patch
+---
+
+#### add attestation policy configuration
+
+Add first-class package and release attestation policy settings. Package publish settings now support `publish.attestations.require_registry_provenance`, inherited from ecosystem publish settings and overridable per package.
+
+When registry provenance is required, built-in release publishing fails before invoking registry commands unless trusted publishing is enabled, the current CI/OIDC identity is verifiable, the provider/registry capability matrix reports registry-native provenance support, and the built-in publisher can require that provenance. npm release publishes add `--provenance` only when this policy is enabled.
+
+GitHub release asset attestation intent is modeled under `[source.releases.attestations]` with `require_github_artifact_attestations`, which is accepted only for GitHub sources.

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -9122,6 +9122,7 @@ fn create_release_record_commit_with_package_publication(root: &Path, package: &
 		version: "1.2.3".to_string(),
 		mode: monochange_core::PublishMode::Builtin,
 		trusted_publishing: monochange_core::TrustedPublishingSettings::default(),
+		attestations: monochange_core::PublishAttestationSettings::default(),
 	}];
 	create_release_record_commit_from_record(root, &record)
 }

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -12,6 +12,7 @@ use monochange_core::MonochangeError;
 use monochange_core::MonochangeResult;
 use monochange_core::PackagePublicationTarget;
 use monochange_core::PackageRecord;
+use monochange_core::PublishAttestationSettings;
 use monochange_core::PublishMode;
 use monochange_core::PublishRegistry;
 use monochange_core::PublishState;
@@ -125,6 +126,7 @@ pub(crate) struct PublishRequest {
 	pub(crate) version: String,
 	pub(crate) placeholder: bool,
 	pub(crate) trusted_publishing: TrustedPublishingSettings,
+	pub(crate) attestations: PublishAttestationSettings,
 	pub(crate) placeholder_readme: String,
 }
 
@@ -568,6 +570,7 @@ pub(crate) fn build_placeholder_requests(
 				version: PLACEHOLDER_VERSION.to_string(),
 				placeholder: true,
 				trusted_publishing: package_definition.publish.trusted_publishing.clone(),
+				attestations: package_definition.publish.attestations.clone(),
 				placeholder_readme: resolve_placeholder_readme(
 					root,
 					package_definition.publish.placeholder.readme.as_deref(),
@@ -631,6 +634,7 @@ pub(crate) fn build_release_requests(
 			version: publication.version.clone(),
 			placeholder: false,
 			trusted_publishing: publication.trusted_publishing.clone(),
+			attestations: publication.attestations.clone(),
 			placeholder_readme: default_placeholder_readme(&package.name),
 		});
 	}
@@ -936,6 +940,7 @@ fn execute_publish_requests(
 
 		if mode == PackagePublishRunMode::Release {
 			enforce_release_trust_prerequisites(request, source, root, env_map)?;
+			enforce_release_attestation_prerequisites(request, env_map)?;
 		}
 
 		let output = match executor.run(&publish_command) {
@@ -1078,6 +1083,54 @@ fn enforce_release_trust_prerequisites(
 		workflow.as_deref(),
 		environment.as_deref(),
 	)
+}
+
+fn enforce_release_attestation_prerequisites(
+	request: &PublishRequest,
+	env_map: &BTreeMap<String, String>,
+) -> MonochangeResult<()> {
+	if !request.attestations.require_registry_provenance {
+		return Ok(());
+	}
+
+	if !request.trusted_publishing.enabled {
+		return Err(MonochangeError::Config(format!(
+			"`{}` requires registry-native package provenance, but trusted publishing is disabled. Registry provenance is only enforceable for built-in publishing from a verifiable CI/OIDC identity; set `publish.trusted_publishing = true` or set `publish.attestations.require_registry_provenance = false` to opt out.",
+			request.package_id,
+		)));
+	}
+
+	let registry = PublishRegistry::Builtin(request.registry);
+	let identity = detect_trusted_publishing_identity(env_map);
+	let capability_message = trusted_publishing_capability_message(&registry, &identity);
+	if !identity.is_verifiable_by_env() {
+		return Err(MonochangeError::Config(format!(
+			"`{}` requires registry-native package provenance from a verifiable CI/OIDC identity, but the current publishing context is local or unverifiable. {capability_message} Run `mc publish` from the configured CI workflow or set `publish.attestations.require_registry_provenance = false` to opt out.",
+			request.package_id,
+		)));
+	}
+
+	let capability = provider_registry_trust_capability(&registry, identity.provider());
+	if !capability.registry_native_provenance {
+		return Err(MonochangeError::Config(format!(
+			"`{}` cannot require registry-native package provenance for {} from {}. {capability_message} This registry/provider combination does not expose provenance monochange can require; set `publish.attestations.require_registry_provenance = false` to opt out or use an external publisher that enforces its own attestation policy.",
+			request.package_id,
+			request.registry,
+			identity.provider().label(),
+		)));
+	}
+	if !builtin_publish_command_supports_registry_provenance(request.registry) {
+		return Err(MonochangeError::Config(format!(
+			"`{}` cannot require registry-native package provenance for {} yet. {capability_message} The registry supports provenance, but monochange's current built-in publisher for this ecosystem does not expose a publish command that can require it; set `publish.attestations.require_registry_provenance = false` to opt out or use an external publisher that enforces its own attestation policy.",
+			request.package_id, request.registry,
+		)));
+	}
+
+	Ok(())
+}
+
+fn builtin_publish_command_supports_registry_provenance(registry: RegistryKind) -> bool {
+	matches!(registry, RegistryKind::Npm | RegistryKind::Jsr)
 }
 
 fn reject_npm_token_environment(
@@ -1562,13 +1615,17 @@ fn build_npm_placeholder_publish_command(
 }
 
 fn build_npm_release_publish_command(request: &PublishRequest) -> CommandSpec {
+	let mut args = vec![
+		"publish".to_string(),
+		"--access".to_string(),
+		"public".to_string(),
+	];
+	if request.attestations.require_registry_provenance {
+		args.push("--provenance".to_string());
+	}
 	CommandSpec {
 		program: npm_publish_program(request).to_string(),
-		args: vec![
-			"publish".to_string(),
-			"--access".to_string(),
-			"public".to_string(),
-		],
+		args,
 		cwd: request.package_root.clone(),
 	}
 }
@@ -2573,6 +2630,7 @@ mod tests {
 				workflow: None,
 				environment: None,
 			},
+			attestations: PublishAttestationSettings::default(),
 			placeholder_readme: "placeholder".to_string(),
 		}
 	}
@@ -2638,6 +2696,35 @@ mod tests {
 		let mut request = sample_request(registry);
 		request.trusted_publishing.enabled = true;
 		request
+	}
+
+	fn trusted_provenance_request(registry: RegistryKind) -> PublishRequest {
+		let mut request = trusted_request(registry);
+		request.attestations.require_registry_provenance = true;
+		request
+	}
+
+	fn github_oidc_env() -> BTreeMap<String, String> {
+		BTreeMap::from([
+			(
+				"GITHUB_REPOSITORY".to_string(),
+				"monochange/monochange".to_string(),
+			),
+			(
+				"GITHUB_WORKFLOW_REF".to_string(),
+				"monochange/monochange/.github/workflows/publish.yml@refs/heads/main".to_string(),
+			),
+			("GITHUB_ACTIONS".to_string(), "true".to_string()),
+			("GITHUB_JOB".to_string(), "release".to_string()),
+			(
+				GITHUB_ACTIONS_ID_TOKEN_REQUEST_URL.to_string(),
+				"https://token.actions.githubusercontent.com".to_string(),
+			),
+			(
+				GITHUB_ACTIONS_ID_TOKEN_REQUEST_TOKEN.to_string(),
+				"request-token".to_string(),
+			),
+		])
 	}
 
 	fn sample_endpoints(base_url: &str) -> RegistryEndpoints {
@@ -4282,6 +4369,7 @@ jobs:
 				version: "1.0.0".to_string(),
 				mode: PublishMode::Builtin,
 				trusted_publishing: TrustedPublishingSettings::default(),
+				attestations: PublishAttestationSettings::default(),
 			},
 			PackagePublicationTarget {
 				package: "pkg".to_string(),
@@ -4290,6 +4378,7 @@ jobs:
 				version: "1.2.3".to_string(),
 				mode: PublishMode::Builtin,
 				trusted_publishing: TrustedPublishingSettings::default(),
+				attestations: PublishAttestationSettings::default(),
 			},
 		];
 
@@ -4328,6 +4417,7 @@ jobs:
 			version: "1.2.3".to_string(),
 			mode: PublishMode::Builtin,
 			trusted_publishing: TrustedPublishingSettings::default(),
+			attestations: PublishAttestationSettings::default(),
 		}];
 
 		let requests = build_release_requests(&configuration, &[], &publications, &BTreeSet::new())
@@ -4389,6 +4479,7 @@ jobs:
 				version: "1.0.1".to_string(),
 				mode: PublishMode::Builtin,
 				trusted_publishing: TrustedPublishingSettings::default(),
+				attestations: PublishAttestationSettings::default(),
 			},
 			PackagePublicationTarget {
 				package: "disabled".to_string(),
@@ -4397,6 +4488,7 @@ jobs:
 				version: "1.0.1".to_string(),
 				mode: PublishMode::Builtin,
 				trusted_publishing: TrustedPublishingSettings::default(),
+				attestations: PublishAttestationSettings::default(),
 			},
 			PackagePublicationTarget {
 				package: "private".to_string(),
@@ -4405,6 +4497,7 @@ jobs:
 				version: "1.0.1".to_string(),
 				mode: PublishMode::Builtin,
 				trusted_publishing: TrustedPublishingSettings::default(),
+				attestations: PublishAttestationSettings::default(),
 			},
 		];
 
@@ -5080,6 +5173,85 @@ jobs:
 				.to_string()
 				.contains("expected GitHub workflow `release.yml`, but detected `publish.yml`")
 		);
+	}
+
+	#[test]
+	fn trusted_publishing_without_attestation_policy_does_not_request_npm_provenance() {
+		let mut request = trusted_request(RegistryKind::Npm);
+
+		let command = build_npm_release_publish_command(&request);
+		assert!(!command.args.contains(&"--provenance".to_string()));
+
+		request.attestations.require_registry_provenance = true;
+
+		let command = build_npm_release_publish_command(&request);
+		assert!(command.args.contains(&"--provenance".to_string()));
+	}
+
+	#[test]
+	fn enforce_release_attestation_prerequisites_accepts_supported_registry_provenance() {
+		let env_map = github_oidc_env();
+
+		enforce_release_attestation_prerequisites(
+			&trusted_provenance_request(RegistryKind::Npm),
+			&env_map,
+		)
+		.expect("expected npm provenance policy success");
+
+		enforce_release_attestation_prerequisites(
+			&trusted_provenance_request(RegistryKind::Jsr),
+			&env_map,
+		)
+		.expect("expected JSR provenance policy success");
+	}
+
+	#[test]
+	fn enforce_release_attestation_prerequisites_rejects_disabled_trusted_publishing() {
+		let mut request = sample_request(RegistryKind::Npm);
+		request.attestations.require_registry_provenance = true;
+
+		let error = enforce_release_attestation_prerequisites(&request, &github_oidc_env())
+			.expect_err("disabled trusted publishing should reject provenance policy");
+
+		let message = error.to_string();
+		assert!(message.contains("requires registry-native package provenance"));
+		assert!(message.contains("trusted publishing is disabled"));
+	}
+
+	#[test]
+	fn enforce_release_attestation_prerequisites_rejects_local_contexts() {
+		let error = enforce_release_attestation_prerequisites(
+			&trusted_provenance_request(RegistryKind::Npm),
+			&BTreeMap::new(),
+		)
+		.expect_err("local trusted publishing should reject provenance policy");
+
+		let message = error.to_string();
+		assert!(message.contains("local or unverifiable"));
+		assert!(message.contains("No supported CI provider identity was detected"));
+	}
+
+	#[test]
+	fn enforce_release_attestation_prerequisites_rejects_unsupported_registry_provenance() {
+		let error = enforce_release_attestation_prerequisites(
+			&trusted_provenance_request(RegistryKind::CratesIo),
+			&github_oidc_env(),
+		)
+		.expect_err("crates.io should reject registry provenance policy");
+
+		let message = error.to_string();
+		assert!(message.contains("cannot require registry-native package provenance"));
+		assert!(message.contains("registry-native provenance is not available"));
+
+		let error = enforce_release_attestation_prerequisites(
+			&trusted_provenance_request(RegistryKind::Pypi),
+			&github_oidc_env(),
+		)
+		.expect_err("PyPI should reject until the built-in publisher can require attestations");
+
+		let message = error.to_string();
+		assert!(message.contains("registry supports provenance"));
+		assert!(message.contains("built-in publisher"));
 	}
 
 	#[test]
@@ -6111,6 +6283,7 @@ version = "1.2.3"
 				version: "1.2.3".to_string(),
 				mode: PublishMode::Builtin,
 				trusted_publishing: TrustedPublishingSettings::default(),
+				attestations: PublishAttestationSettings::default(),
 			}],
 		);
 
@@ -6177,6 +6350,7 @@ version = "1.2.3"
 				version: "1.2.3".to_string(),
 				mode: PublishMode::Builtin,
 				trusted_publishing: TrustedPublishingSettings::default(),
+				attestations: PublishAttestationSettings::default(),
 			}],
 		);
 		let discovered =
@@ -6437,6 +6611,7 @@ version = "1.2.3"
 			version: "1.2.3".to_string(),
 			mode: PublishMode::Builtin,
 			trusted_publishing: TrustedPublishingSettings::default(),
+			attestations: PublishAttestationSettings::default(),
 		};
 		let configuration =
 			sample_configuration(&[("pkg", monochange_core::PackageType::Npm, true)]);

--- a/crates/monochange/src/publish_bootstrap.rs
+++ b/crates/monochange/src/publish_bootstrap.rs
@@ -295,6 +295,7 @@ fn yes_no(value: bool) -> &'static str {
 mod tests {
 	use monochange_core::Ecosystem;
 	use monochange_core::PackagePublicationTarget;
+	use monochange_core::PublishAttestationSettings;
 	use monochange_core::PublishMode;
 	use monochange_core::PublishRegistry;
 	use monochange_core::RegistryKind;
@@ -311,6 +312,7 @@ mod tests {
 			version: "1.2.3".to_string(),
 			mode: PublishMode::Builtin,
 			trusted_publishing: TrustedPublishingSettings::default(),
+			attestations: PublishAttestationSettings::default(),
 		}];
 		let selected = BTreeSet::from(["core".to_string(), "docs".to_string()]);
 
@@ -356,6 +358,7 @@ mod tests {
 			version: "1.2.3".to_string(),
 			mode: PublishMode::Builtin,
 			trusted_publishing: TrustedPublishingSettings::default(),
+			attestations: PublishAttestationSettings::default(),
 		}];
 
 		assert_eq!(

--- a/crates/monochange/src/publish_rate_limits.rs
+++ b/crates/monochange/src/publish_rate_limits.rs
@@ -404,6 +404,7 @@ mod tests {
 	use httpmock::Method::GET;
 	use httpmock::MockServer;
 	use monochange_core::PackagePublicationTarget;
+	use monochange_core::PublishAttestationSettings;
 	use monochange_core::PublishMode;
 	use monochange_core::PublishRegistry;
 	use monochange_core::TrustedPublishingSettings;
@@ -464,6 +465,7 @@ mod tests {
 			version: Version::new(1, 0, 0).to_string(),
 			placeholder: false,
 			trusted_publishing: TrustedPublishingSettings::default(),
+			attestations: PublishAttestationSettings::default(),
 			placeholder_readme: String::new(),
 		}
 	}
@@ -521,6 +523,7 @@ mod tests {
 					version: Version::new(1, 0, 0).to_string(),
 					mode: PublishMode::Builtin,
 					trusted_publishing: TrustedPublishingSettings::default(),
+					attestations: PublishAttestationSettings::default(),
 				},
 				PackagePublicationTarget {
 					package: "docs".to_string(),
@@ -529,6 +532,7 @@ mod tests {
 					version: Version::new(1, 0, 0).to_string(),
 					mode: PublishMode::Builtin,
 					trusted_publishing: TrustedPublishingSettings::default(),
+					attestations: PublishAttestationSettings::default(),
 				},
 				PackagePublicationTarget {
 					package: "web".to_string(),
@@ -537,6 +541,7 @@ mod tests {
 					version: Version::new(1, 0, 0).to_string(),
 					mode: PublishMode::Builtin,
 					trusted_publishing: TrustedPublishingSettings::default(),
+					attestations: PublishAttestationSettings::default(),
 				},
 			],
 			version: None,
@@ -721,6 +726,7 @@ mod tests {
 				version: Version::new(1, 0, 1).to_string(),
 				mode: PublishMode::Builtin,
 				trusted_publishing: TrustedPublishingSettings::default(),
+				attestations: PublishAttestationSettings::default(),
 			},
 			PackagePublicationTarget {
 				package: "private".to_string(),
@@ -729,6 +735,7 @@ mod tests {
 				version: Version::new(1, 0, 1).to_string(),
 				mode: PublishMode::Builtin,
 				trusted_publishing: TrustedPublishingSettings::default(),
+				attestations: PublishAttestationSettings::default(),
 			},
 			PackagePublicationTarget {
 				package: "docs".to_string(),
@@ -737,6 +744,7 @@ mod tests {
 				version: Version::new(1, 0, 1).to_string(),
 				mode: PublishMode::Builtin,
 				trusted_publishing: TrustedPublishingSettings::default(),
+				attestations: PublishAttestationSettings::default(),
 			},
 		];
 		let requests = package_publish::build_release_requests(
@@ -786,6 +794,7 @@ mod tests {
 					version: Version::new(1, 0, 0).to_string(),
 					mode: PublishMode::Builtin,
 					trusted_publishing: TrustedPublishingSettings::default(),
+					attestations: PublishAttestationSettings::default(),
 				},
 				PackagePublicationTarget {
 					package: "docs".to_string(),
@@ -794,6 +803,7 @@ mod tests {
 					version: Version::new(1, 0, 0).to_string(),
 					mode: PublishMode::Builtin,
 					trusted_publishing: TrustedPublishingSettings::default(),
+					attestations: PublishAttestationSettings::default(),
 				},
 				PackagePublicationTarget {
 					package: "web".to_string(),
@@ -802,6 +812,7 @@ mod tests {
 					version: Version::new(1, 0, 0).to_string(),
 					mode: PublishMode::Builtin,
 					trusted_publishing: TrustedPublishingSettings::default(),
+					attestations: PublishAttestationSettings::default(),
 				},
 			],
 			version: None,
@@ -1159,6 +1170,7 @@ mod tests {
 					version: Version::new(1, 0, 0).to_string(),
 					placeholder: false,
 					trusted_publishing: TrustedPublishingSettings::default(),
+					attestations: PublishAttestationSettings::default(),
 					placeholder_readme: String::new(),
 				}
 			})

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -177,6 +177,7 @@ pub(crate) fn build_package_publication_targets(
 				version: version.to_string(),
 				mode: package_definition.publish.mode,
 				trusted_publishing: package_definition.publish.trusted_publishing.clone(),
+				attestations: package_definition.publish.attestations.clone(),
 			})
 		})
 		.collect::<Vec<_>>();
@@ -1977,6 +1978,7 @@ mod tests {
 					version: "1.2.0".to_string(),
 					mode: PublishMode::Builtin,
 					trusted_publishing: monochange_core::TrustedPublishingSettings::default(),
+					attestations: monochange_core::PublishAttestationSettings::default(),
 				},
 				PackagePublicationTarget {
 					package: "web".to_string(),
@@ -1985,6 +1987,7 @@ mod tests {
 					version: "2.0.1".to_string(),
 					mode: PublishMode::External,
 					trusted_publishing: monochange_core::TrustedPublishingSettings::default(),
+					attestations: monochange_core::PublishAttestationSettings::default(),
 				},
 			]
 		);
@@ -2024,6 +2027,7 @@ mod tests {
 				version: "1.2.3".to_string(),
 				mode: PublishMode::Builtin,
 				trusted_publishing: monochange_core::TrustedPublishingSettings::default(),
+				attestations: monochange_core::PublishAttestationSettings::default(),
 			}],
 			dry_run: false,
 		};

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -2967,6 +2967,116 @@ trusted_publishing = false
 }
 
 #[test]
+fn load_workspace_configuration_inherits_publish_attestation_policy() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	std::fs::create_dir_all(root.join("packages/web"))
+		.unwrap_or_else(|error| panic!("create web package: {error}"));
+	std::fs::create_dir_all(root.join("packages/legacy"))
+		.unwrap_or_else(|error| panic!("create legacy package: {error}"));
+	std::fs::write(
+		root.join("packages/web/package.json"),
+		r#"{ "name": "web", "version": "1.0.0" }"#,
+	)
+	.unwrap_or_else(|error| panic!("write web manifest: {error}"));
+	std::fs::write(
+		root.join("packages/legacy/package.json"),
+		r#"{ "name": "legacy", "version": "1.0.0" }"#,
+	)
+	.unwrap_or_else(|error| panic!("write legacy manifest: {error}"));
+	std::fs::write(
+		root.join("monochange.toml"),
+		r#"
+[ecosystems.npm.publish.attestations]
+require_registry_provenance = true
+
+[package.web]
+path = "packages/web"
+type = "npm"
+
+[package.legacy]
+path = "packages/legacy"
+type = "npm"
+
+[package.legacy.publish.attestations]
+require_registry_provenance = false
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write monochange.toml: {error}"));
+
+	let configuration =
+		load_workspace_configuration(root).unwrap_or_else(|error| panic!("configuration: {error}"));
+	let web = configuration
+		.package_by_id("web")
+		.unwrap_or_else(|| panic!("expected web package"));
+	let legacy = configuration
+		.package_by_id("legacy")
+		.unwrap_or_else(|| panic!("expected legacy package"));
+
+	assert!(web.publish.attestations.require_registry_provenance);
+	assert!(!legacy.publish.attestations.require_registry_provenance);
+	assert!(web.publish.enabled);
+}
+
+#[test]
+fn load_workspace_configuration_rejects_github_release_attestations_for_other_sources() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	std::fs::write(
+		root.join("monochange.toml"),
+		r#"
+[source]
+provider = "gitlab"
+owner = "monochange"
+repo = "monochange"
+
+[source.releases.attestations]
+require_github_artifact_attestations = true
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write monochange.toml: {error}"));
+
+	let error = load_workspace_configuration(root)
+		.expect_err("GitHub release attestations should reject GitLab source");
+
+	assert!(error.to_string().contains(
+		"[source.releases.attestations].require_github_artifact_attestations requires [source].provider = \"github\""
+	));
+}
+
+#[test]
+fn load_workspace_configuration_parses_release_attestation_policy() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	std::fs::write(
+		root.join("monochange.toml"),
+		r#"
+[source]
+provider = "github"
+owner = "monochange"
+repo = "monochange"
+
+[source.releases.attestations]
+require_github_artifact_attestations = true
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write monochange.toml: {error}"));
+
+	let configuration =
+		load_workspace_configuration(root).unwrap_or_else(|error| panic!("configuration: {error}"));
+	let source = configuration
+		.source
+		.unwrap_or_else(|| panic!("expected source config"));
+
+	assert!(
+		source
+			.releases
+			.attestations
+			.require_github_artifact_attestations
+	);
+}
+
+#[test]
 fn load_workspace_configuration_merges_trusted_publishing_details() {
 	let root = fixture_path("config/publish-trusted-publishing-overrides");
 	let configuration = load_workspace_configuration(&root)

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -113,6 +113,7 @@ use monochange_core::PackageType;
 use monochange_core::ProviderBotSettings;
 use monochange_core::ProviderMergeRequestSettings;
 use monochange_core::ProviderReleaseSettings;
+use monochange_core::PublishAttestationSettings;
 use monochange_core::PublishMode;
 use monochange_core::PublishRegistry;
 use monochange_core::PublishSettings;
@@ -392,9 +393,17 @@ struct RawPublishSettings {
 	#[serde(default)]
 	trusted_publishing: Option<RawTrustedPublishingSettings>,
 	#[serde(default)]
+	attestations: RawPublishAttestationSettings,
+	#[serde(default)]
 	rate_limits: RawPublishRateLimitSettings,
 	#[serde(default)]
 	placeholder: RawPlaceholderSettings,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct RawPublishAttestationSettings {
+	#[serde(default)]
+	require_registry_provenance: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -858,6 +867,17 @@ fn normalize_trusted_publishing_settings(
 	settings
 }
 
+fn normalize_publish_attestation_settings(
+	base: Option<&PublishAttestationSettings>,
+	raw: &RawPublishAttestationSettings,
+) -> PublishAttestationSettings {
+	let mut settings = base.cloned().unwrap_or_default();
+	if let Some(require_registry_provenance) = raw.require_registry_provenance {
+		settings.require_registry_provenance = require_registry_provenance;
+	}
+	settings
+}
+
 fn normalize_publish_settings(
 	contents: &str,
 	base: Option<&PublishSettings>,
@@ -885,6 +905,10 @@ fn normalize_publish_settings(
 	settings.trusted_publishing = normalize_trusted_publishing_settings(
 		base.map(|settings| &settings.trusted_publishing),
 		raw.trusted_publishing,
+	);
+	settings.attestations = normalize_publish_attestation_settings(
+		base.map(|settings| &settings.attestations),
+		&raw.attestations,
 	);
 	if let Some(enforce) = raw.rate_limits.enforce {
 		settings.rate_limits.enforce = enforce;
@@ -3531,6 +3555,17 @@ fn validate_source_configuration(source: Option<&SourceConfiguration>) -> Monoch
 	{
 		return Err(MonochangeError::Config(
 			"[source.releases].branches must not include empty values".to_string(),
+		));
+	}
+	if source
+		.releases
+		.attestations
+		.require_github_artifact_attestations
+		&& source.provider != SourceProvider::GitHub
+	{
+		return Err(MonochangeError::Config(
+			"[source.releases.attestations].require_github_artifact_attestations requires [source].provider = \"github\""
+				.to_string(),
 		));
 	}
 	if source

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -1446,6 +1446,32 @@ pub struct TrustedPublishingSettings {
 	pub environment: Option<String>,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct PublishAttestationSettings {
+	#[serde(default)]
+	pub require_registry_provenance: bool,
+}
+
+impl PublishAttestationSettings {
+	#[must_use]
+	pub fn is_default(&self) -> bool {
+		self == &Self::default()
+	}
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct ReleaseAttestationSettings {
+	#[serde(default)]
+	pub require_github_artifact_attestations: bool,
+}
+
+impl ReleaseAttestationSettings {
+	#[must_use]
+	pub fn is_default(&self) -> bool {
+		self == &Self::default()
+	}
+}
+
 impl Default for TrustedPublishingSettings {
 	fn default() -> Self {
 		Self {
@@ -1468,6 +1494,11 @@ pub struct PublishSettings {
 	pub registry: Option<PublishRegistry>,
 	#[serde(default)]
 	pub trusted_publishing: TrustedPublishingSettings,
+	#[serde(
+		default,
+		skip_serializing_if = "PublishAttestationSettings::is_default"
+	)]
+	pub attestations: PublishAttestationSettings,
 	#[serde(default)]
 	pub rate_limits: PublishRateLimitSettings,
 	#[serde(default)]
@@ -1481,6 +1512,7 @@ impl Default for PublishSettings {
 			mode: PublishMode::default(),
 			registry: None,
 			trusted_publishing: TrustedPublishingSettings::default(),
+			attestations: PublishAttestationSettings::default(),
 			rate_limits: PublishRateLimitSettings::default(),
 			placeholder: PlaceholderSettings::default(),
 		}
@@ -2483,6 +2515,11 @@ pub struct PackagePublicationTarget {
 	pub mode: PublishMode,
 	#[serde(default)]
 	pub trusted_publishing: TrustedPublishingSettings,
+	#[serde(
+		default,
+		skip_serializing_if = "PublishAttestationSettings::is_default"
+	)]
+	pub attestations: PublishAttestationSettings,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
@@ -3258,6 +3295,11 @@ pub struct ProviderReleaseSettings {
 	pub enforce_for_publish: bool,
 	#[serde(default)]
 	pub enforce_for_commit: bool,
+	#[serde(
+		default,
+		skip_serializing_if = "ReleaseAttestationSettings::is_default"
+	)]
+	pub attestations: ReleaseAttestationSettings,
 }
 
 impl Default for ProviderReleaseSettings {
@@ -3272,6 +3314,7 @@ impl Default for ProviderReleaseSettings {
 			enforce_for_tags: true,
 			enforce_for_publish: true,
 			enforce_for_commit: false,
+			attestations: ReleaseAttestationSettings::default(),
 		}
 	}
 }

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -146,6 +146,9 @@ trusted_publishing = true
 workflow = "publish.yml"
 environment = "publisher"
 
+[ecosystems.npm.publish.attestations]
+require_registry_provenance = true
+
 [package.web.publish]
 mode = "builtin"
 
@@ -162,11 +165,12 @@ Supported fields:
 - `mode` — `builtin` or `external`
 - `registry` — public registry override for the package ecosystem
 - `trusted_publishing` — `true`/`false` or a table with `enabled`, `repository`, `workflow`, and `environment`
+- `attestations.require_registry_provenance` — require registry-native package provenance when the selected registry/provider capability supports it
 - `rate_limits.enforce` — block built-in publish runs when the selected package set exceeds a known single registry window
 - `placeholder.readme` — inline placeholder README content
 - `placeholder.readme_file` — workspace-relative file to use as placeholder README content
 
-Inheritance flows from `[ecosystems.<name>.publish]` to matching packages, and package-level values override the inherited ecosystem defaults. Configure shared trusted-publishing policy and context on the ecosystem, then use package-level publish settings for opt-outs or package-specific workflows.
+Inheritance flows from `[ecosystems.<name>.publish]` to matching packages, and package-level values override the inherited ecosystem defaults. Configure shared trusted-publishing, attestation, and context policy on the ecosystem, then use package-level publish settings for opt-outs or package-specific workflows.
 
 Built-in publishing currently targets only the canonical public registry for each supported ecosystem:
 
@@ -219,6 +223,30 @@ When `trusted_publishing` is enabled:
 - npm packages can be configured automatically with `npm trust github ...`
 - pnpm workspaces use `pnpm exec npm trust ...` and `pnpm publish`, so workspace protocol and catalog dependency handling stays aligned with the workspace manager
 - Cargo, `jsr`, `pub.dev`, and PyPI currently require manual trusted-publishing setup; monochange reports the setup URL and blocks built-in release publishing until trust is configured
+
+### Attestation policy
+
+`publish.attestations.require_registry_provenance` is separate from `publish.trusted_publishing`. Trusted publishing must be enabled first, then the attestation policy tells monochange to require registry-native package provenance where the selected registry and CI provider support it.
+
+```toml
+[ecosystems.npm.publish]
+trusted_publishing = true
+
+[ecosystems.npm.publish.attestations]
+require_registry_provenance = true
+
+[package.legacy.publish.attestations]
+require_registry_provenance = false
+```
+
+monochange currently treats npm provenance and JSR package provenance as enforceable built-in registry provenance. PyPI PEP 740 attestations are modeled in the capability matrix, but `require_registry_provenance` is rejected for PyPI until the built-in Python publisher exposes a publish command that can require uploading those attestations. `crates.io`, `pub.dev`, Go proxy publishing, and custom registries are also rejected when this requirement is enabled because monochange cannot verify equivalent registry-native package attestations for those flows.
+
+GitHub release asset attestations are a separate release policy under `[source.releases.attestations]` and are valid only for the GitHub source provider:
+
+```toml
+[source.releases.attestations]
+require_github_artifact_attestations = true
+```
 
 For a GitHub-focused setup guide with exact registry fields, commands, and workflow requirements, see [Trusted publishing and OIDC](./07-trusted-publishing.md). For monorepo workflow and tag-shape recommendations, see [Multi-package publishing patterns](./14-multi-package-publishing.md).
 

--- a/docs/src/guide/07-trusted-publishing.md
+++ b/docs/src/guide/07-trusted-publishing.md
@@ -56,6 +56,9 @@ provider = "github"
 owner = "ifiokjr"
 repo = "monochange"
 
+[source.releases.attestations]
+require_github_artifact_attestations = true
+
 [ecosystems.npm.publish]
 trusted_publishing = true
 
@@ -63,11 +66,17 @@ trusted_publishing = true
 workflow = "publish.yml"
 environment = "publisher"
 
+[ecosystems.npm.publish.attestations]
+require_registry_provenance = true
+
 [ecosystems.cargo.publish]
 trusted_publishing = true
 
 [ecosystems.deno.publish]
 trusted_publishing = true
+
+[ecosystems.deno.publish.attestations]
+require_registry_provenance = true
 
 [ecosystems.dart.publish]
 trusted_publishing = true
@@ -93,6 +102,53 @@ monochange resolves the GitHub trust context from:
 - otherwise GitHub Actions runtime values such as `GITHUB_REPOSITORY`, `GITHUB_WORKFLOW_REF`, and `GITHUB_JOB`
 
 If your workflow filename or environment cannot be inferred reliably, set them explicitly in `monochange.toml`.
+
+## Attestation and provenance policy
+
+Trusted publishing and attestations answer different questions:
+
+- **trusted publishing** decides which CI/OIDC identity may publish a package
+- **registry-native package provenance** records where a published package came from in registries that support it, such as npm provenance, JSR provenance, and PyPI PEP 740 attestations
+- **GitHub release artifact attestations** cover release assets uploaded to GitHub Releases and are separate from package-registry provenance
+
+Trusted publishing does not automatically require registry provenance. Enable provenance explicitly for registries where you want monochange to enforce it:
+
+```toml
+[ecosystems.npm.publish]
+trusted_publishing = true
+
+[ecosystems.npm.publish.attestations]
+require_registry_provenance = true
+```
+
+Packages inherit `publish.attestations` from their ecosystem publish settings. Package-level settings can override or opt out:
+
+```toml
+[package.legacy.publish.attestations]
+require_registry_provenance = false
+```
+
+When `publish.attestations.require_registry_provenance = true`, built-in release publishing fails before invoking the registry command unless all of these are true:
+
+1. `publish.trusted_publishing = true` is effective for the package.
+2. The current environment exposes a verifiable CI/OIDC identity.
+3. The provider/registry capability matrix says registry-native provenance is available for that identity.
+
+Today this is enforceable for npm trusted publishing and JSR publishing from supported OIDC contexts. The capability matrix records PyPI PEP 740 attestations as registry-native provenance, but monochange rejects `require_registry_provenance` for PyPI until the built-in Python publisher exposes a publish command that can require uploading those attestations. It also rejects `crates.io`, `pub.dev`, Go proxy publication, and custom registries because those flows do not expose registry-native package provenance that monochange can require without creating false assurance.
+
+For GitHub release assets, keep the policy under `[source.releases.attestations]`:
+
+```toml
+[source]
+provider = "github"
+owner = "ifiokjr"
+repo = "monochange"
+
+[source.releases.attestations]
+require_github_artifact_attestations = true
+```
+
+This setting is accepted only for the GitHub source provider. It records that release assets are expected to be covered by GitHub Artifact Attestations; the workflow that builds/uploads assets must still grant `attestations: write` and run the GitHub attestation action for the uploaded subjects.
 
 ## GitHub Actions baseline
 


### PR DESCRIPTION
## Summary

- add package publish attestation settings with ecosystem-to-package inheritance
- enforce registry provenance policy before built-in release publish commands when the registry/provider/publisher path can support it
- add GitHub release asset attestation policy under `[source.releases.attestations]`
- document trusted publishing vs registry provenance vs GitHub artifact attestations

Closes #315.

## Validation

- `cargo fmt --check`
- `cargo check -p monochange_core -p monochange_config -p monochange --lib`
- `cargo test -p monochange package_publish --lib`
- `cargo test -p monochange_config attestation --lib`
- `cargo test -p monochange_core --lib`
- `cargo test -p monochange_config --lib`
- `cargo clippy -p monochange_core -p monochange_config -p monochange --lib -- -D warnings`
- `dprint check`
- `docs:check`
- `mc validate`
- `git diff --check`
