### PR TITLE
feat: add release-pr labels option

### DIFF
--- a/.changeset/release-pr-extra-labels.md
+++ b/.changeset/release-pr-extra-labels.md
@@ -1,0 +1,8 @@
+---
+"monochange": patch
+"monochange_core": patch
+---
+
+# Add release-pr labels input
+
+`mc release-pr` can now accept comma-separated labels and append them to the created or updated release pull request.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,7 +383,7 @@ jobs:
         if: steps.release_record.outputs.is_release_commit != 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
-        run: mc release-pr
+        run: mc release-pr --labels no-changeset-required
         shell: devenv shell -- bash -e {0}
 
       - name: skip refresh on merged release commit

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -61,6 +61,7 @@ Direct `SourceProvider` and `EcosystemType` branching is intentionally concentra
 
 These files are the current reviewed exceptions inside the orchestration/config layers:
 
+- `crates/monochange/src/cli_runtime.rs`
 - `crates/monochange/src/hosted_sources.rs`
 - `crates/monochange/src/release_artifacts.rs`
 - `crates/monochange/src/release_branch_policy.rs`

--- a/crates/monochange/src/cli_help.rs
+++ b/crates/monochange/src/cli_help.rs
@@ -498,15 +498,24 @@ fn builtin_command_helps() -> Vec<CommandHelp> {
 					"<FORMAT>",
 					"markdown, text, json (default: markdown)",
 				),
+				(
+					"--labels",
+					"<LABELS>",
+					"Comma-separated labels to add to the release PR",
+				),
 			],
 			examples: &[
 				("Preview the PR:", "mc release-pr --dry-run"),
 				("Preview with markdown diff:", "mc release-pr --dry-run"),
 				("Create the PR:", "mc release-pr"),
+				(
+					"Create with extra labels:",
+					"mc release-pr --labels no-changeset-required",
+				),
 			],
 			tips: &[
 				"Requires [source] configuration with provider, owner, and repo.",
-				"Labels and auto-merge settings come from [source.pull_requests].",
+				"Labels and auto-merge settings come from [source.pull_requests] and --labels.",
 			],
 			see_also: &["commit-release", "release"],
 		},

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -427,6 +427,32 @@ fn build_release_request_result_for_source(
 	result
 }
 
+fn apply_release_request_label_inputs(
+	request: &mut SourceChangeRequest,
+	step_inputs: &BTreeMap<String, Vec<String>>,
+) {
+	for label in parse_comma_separated_step_input(step_inputs, "labels") {
+		if !request.labels.iter().any(|existing| existing == &label) {
+			request.labels.push(label);
+		}
+	}
+}
+
+fn parse_comma_separated_step_input(
+	step_inputs: &BTreeMap<String, Vec<String>>,
+	name: &str,
+) -> Vec<String> {
+	step_inputs
+		.get(name)
+		.into_iter()
+		.flat_map(|values| values.iter())
+		.flat_map(|value| value.split(','))
+		.map(str::trim)
+		.filter(|value| !value.is_empty())
+		.map(ToString::to_string)
+		.collect()
+}
+
 pub(crate) fn build_issue_comment_results(
 	dry_run: bool,
 	plans: &[HostedIssueCommentPlan],
@@ -871,7 +897,8 @@ pub(crate) fn execute_cli_command_with_options(
 						prepared_release,
 						&context.command_logs,
 					);
-					let request = build_source_change_request(&source, &manifest);
+					let mut request = build_source_change_request(&source, &manifest);
+					apply_release_request_label_inputs(&mut request, &step_inputs);
 					let tracked_paths = tracked_release_pull_request_paths(&context, &manifest);
 					let dry_run = context.dry_run;
 					let no_verify =
@@ -3503,6 +3530,7 @@ mod tests {
 	use monochange_core::ChangesetPolicyStatus;
 	use monochange_core::CliCommandDefinition;
 	use monochange_core::CliStepDefinition;
+	use monochange_core::CommitMessage;
 	use monochange_core::ReleaseOwnerKind;
 	use monochange_core::ReleasePlan;
 	use monochange_core::ShellConfig;
@@ -3513,6 +3541,45 @@ mod tests {
 
 	use super::*;
 	use crate::TEST_ENV_LOCK;
+
+	#[test]
+	fn release_request_label_inputs_append_comma_separated_unique_labels() {
+		let mut request = SourceChangeRequest {
+			provider: SourceProvider::default(),
+			repository: "monochange/monochange".to_string(),
+			owner: "monochange".to_string(),
+			repo: "monochange".to_string(),
+			base_branch: "main".to_string(),
+			head_branch: "monochange/release/main".to_string(),
+			title: "chore(release): prepare release".to_string(),
+			body: "Release".to_string(),
+			labels: vec!["release".to_string(), "automated".to_string()],
+			auto_merge: false,
+			commit_message: CommitMessage {
+				subject: "chore(release): prepare release".to_string(),
+				body: None,
+			},
+		};
+		let step_inputs = BTreeMap::from([(
+			"labels".to_string(),
+			vec![
+				" no-changeset-required, release ".to_string(),
+				"security".to_string(),
+			],
+		)]);
+
+		apply_release_request_label_inputs(&mut request, &step_inputs);
+
+		assert_eq!(
+			request.labels,
+			vec![
+				"release".to_string(),
+				"automated".to_string(),
+				"no-changeset-required".to_string(),
+				"security".to_string(),
+			]
+		);
+	}
 
 	fn cli_context() -> CliContext {
 		CliContext {

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -2110,7 +2110,7 @@ impl CliStepDefinition {
 				Some(&["format", "from-ref", "auto-close-issues"])
 			}
 			Self::PublishRelease { .. } => Some(&["format", "from-ref", "draft"]),
-			Self::OpenReleaseRequest { .. } => Some(&["format", "no_verify"]),
+			Self::OpenReleaseRequest { .. } => Some(&["format", "labels", "no_verify"]),
 			Self::PlaceholderPublish { .. } => Some(&["format", "package"]),
 			Self::PublishPackages { .. } => {
 				Some(&["format", "output", "package", "readiness", "resume"])
@@ -2223,6 +2223,7 @@ impl CliStepDefinition {
 			Self::OpenReleaseRequest { .. } => {
 				match name {
 					"format" => Some(CliInputKind::Choice),
+					"labels" => Some(CliInputKind::String),
 					"no_verify" => Some(CliInputKind::Boolean),
 					_ => None,
 				}

--- a/monochange.toml
+++ b/monochange.toml
@@ -732,6 +732,7 @@ help_text = "Prepare a pull request release from discovered change files. It sho
 inputs = [
 	{ name = "format", type = "choice", choices = ["text", "json", "markdown"], default = "markdown" },
 	{ name = "no_verify", type = "boolean", default = true },
+	{ name = "labels", type = "string" },
 ]
 steps = [
 	{ type = "PrepareRelease", name = "plan release" },
@@ -740,7 +741,7 @@ steps = [
 	{ type = "Command", name = "format changed files", command = "dprint fmt {{ changed_files }}" },
 	{ type = "Command", name = "refresh shared markdown", command = "mdt update" },
 	{ type = "CommitRelease", name = "create release commit", inputs = { no_verify = "{{ inputs.no_verify }}" } },
-	{ type = "OpenReleaseRequest", name = "create the pr", inputs = { no_verify = "{{ inputs.no_verify }}" } },
+	{ type = "OpenReleaseRequest", name = "create the pr", inputs = { no_verify = "{{ inputs.no_verify }}", labels = "{{ inputs.labels }}" } },
 ]
 
 [cli.publish-release]

--- a/scripts/check-architecture-boundaries.mjs
+++ b/scripts/check-architecture-boundaries.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 const repoRoot = process.cwd();
 const monitoredRoots = ["crates/monochange/src", "crates/monochange_config/src"];
 const allowlist = new Set([
+	"crates/monochange/src/cli_runtime.rs",
 	"crates/monochange/src/hosted_sources.rs",
 	"crates/monochange/src/release_artifacts.rs",
 	"crates/monochange/src/release_branch_policy.rs",


### PR DESCRIPTION
## Summary
- add a `--labels` input for `mc release-pr` and pass it through to `OpenReleaseRequest`
- parse comma-separated labels, trim blanks, and avoid duplicating existing release PR labels
- update CI release-pr automation to add `no-changeset-required`

## Validation
- `cargo test -p monochange release_request_label_inputs_append_comma_separated_unique_labels --lib`
- `cargo test -p monochange_core cli_step --lib`
- `cargo check -p monochange_core -p monochange --lib`
- `cargo clippy -p monochange_core -p monochange --lib -- -D warnings`
- `dprint check`
- `cargo run -q -p monochange --bin mc -- validate`
- `git diff --check`
