### PR TITLE
ci: use monochange actions v0.5

### DIFF
--- a/.github/workflows/changeset-policy.yml
+++ b/.github/workflows/changeset-policy.yml
@@ -40,6 +40,10 @@ jobs:
           cat > "$bin_dir/mc" <<EOF
           #!/usr/bin/env bash
           set -euo pipefail
+          if [ "\${1:-}" = "--version" ]; then
+            echo "mc local"
+            exit 0
+          fi
           exec "$devenv_bin" shell cargo run --quiet --release --package monochange --bin mc -- "\$@"
           EOF
           chmod +x "$bin_dir/mc"

--- a/.github/workflows/changeset-policy.yml
+++ b/.github/workflows/changeset-policy.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: run changeset policy
         uses: monochange/actions/changeset-policy@v0.5.1
+        env:
+          PATH: ${{ runner.temp }}/monochange-bin:/home/runner/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
         with:
           setup-monochange: "false"
           changed-paths: ${{ steps.changed.outputs.all_changed_files }}

--- a/.github/workflows/changeset-policy.yml
+++ b/.github/workflows/changeset-policy.yml
@@ -35,7 +35,7 @@ jobs:
         uses: tj-actions/changed-files@v46
 
       - name: run changeset policy
-        uses: monochange/actions/changeset-policy@v0.5.0
+        uses: monochange/actions/changeset-policy@v0.5.1
         with:
           setup-monochange: "false"
           changed-paths: ${{ steps.changed.outputs.all_changed_files }}

--- a/.github/workflows/changeset-policy.yml
+++ b/.github/workflows/changeset-policy.yml
@@ -55,7 +55,7 @@ jobs:
         uses: tj-actions/changed-files@v46
 
       - name: run changeset policy
-        uses: monochange/actions/changeset-policy@v0.5.1
+        uses: monochange/actions/changeset-policy@v0.5.2
         env:
           PATH: ${{ runner.temp }}/monochange-bin:/home/runner/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
         with:

--- a/.github/workflows/changeset-policy.yml
+++ b/.github/workflows/changeset-policy.yml
@@ -30,6 +30,20 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: expose monochange on PATH
+        shell: bash
+        run: |
+          set -euo pipefail
+          bin_dir="$RUNNER_TEMP/monochange-bin"
+          mkdir -p "$bin_dir"
+          cat > "$bin_dir/mc" <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          exec devenv shell -- cargo run --quiet --release --package monochange --bin mc -- "$@"
+          EOF
+          chmod +x "$bin_dir/mc"
+          echo "$bin_dir" >> "$GITHUB_PATH"
+
       - name: collect changed files
         id: changed
         uses: tj-actions/changed-files@v46

--- a/.github/workflows/changeset-policy.yml
+++ b/.github/workflows/changeset-policy.yml
@@ -15,11 +15,11 @@ concurrency:
 
 jobs:
   check:
-    if: ${{ !startsWith(github.head_ref, 'monochange/release/') }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
       pull-requests: read
     steps:
       - name: checkout repository
@@ -35,24 +35,8 @@ jobs:
         uses: tj-actions/changed-files@v46
 
       - name: run changeset policy
-        env:
-          PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
-          CHANGED_FILES: ${{ steps.changed.outputs.all_changed_files }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          mapfile -t labels < <(jq -r '.[]' <<<"$PR_LABELS_JSON")
-          args=(step:affected-packages --format json --verify)
-
-          for path in $CHANGED_FILES; do
-            args+=(--changed-paths "$path")
-          done
-
-          for label in "${labels[@]}"; do
-            args+=(--label "$label")
-          done
-
-          devenv shell -- monochange "${args[@]}" | tee policy.raw
-          awk 'BEGIN { capture = 0 } /^\{/ { capture = 1 } capture { print }' policy.raw > policy.json
-          jq -e '.status != "failed"' policy.json >/dev/null
+        uses: monochange/actions/changeset-policy@v0.5.0
+        with:
+          setup-monochange: "false"
+          changed-paths: ${{ steps.changed.outputs.all_changed_files }}
+          labels: ${{ join(github.event.pull_request.labels.*.name, ',') }}

--- a/.github/workflows/changeset-policy.yml
+++ b/.github/workflows/changeset-policy.yml
@@ -44,6 +44,34 @@ jobs:
             echo "mc local"
             exit 0
           fi
+          if [ "\${1:-}" = "affected" ]; then
+            shift
+            translated=("step:affected-packages")
+            while [ "\$#" -gt 0 ]; do
+              case "\$1" in
+                --paths)
+                  shift
+                  for path in \$1; do
+                    translated+=(--changed-paths "\$path")
+                  done
+                  ;;
+                --labels)
+                  shift
+                  IFS=',' read -ra labels <<< "\$1"
+                  for label in "\${labels[@]}"; do
+                    if [ -n "\$label" ]; then
+                      translated+=(--label "\$label")
+                    fi
+                  done
+                  ;;
+                *)
+                  translated+=("\$1")
+                  ;;
+              esac
+              shift || true
+            done
+            exec "$devenv_bin" shell cargo run --quiet --release --package monochange --bin mc -- "\${translated[@]}"
+          fi
           exec "$devenv_bin" shell cargo run --quiet --release --package monochange --bin mc -- "\$@"
           EOF
           chmod +x "$bin_dir/mc"

--- a/.github/workflows/changeset-policy.yml
+++ b/.github/workflows/changeset-policy.yml
@@ -35,13 +35,15 @@ jobs:
         run: |
           set -euo pipefail
           bin_dir="$RUNNER_TEMP/monochange-bin"
+          devenv_bin="$(command -v devenv)"
           mkdir -p "$bin_dir"
-          cat > "$bin_dir/mc" <<'EOF'
+          cat > "$bin_dir/mc" <<EOF
           #!/usr/bin/env bash
           set -euo pipefail
-          exec devenv shell -- cargo run --quiet --release --package monochange --bin mc -- "$@"
+          exec "$devenv_bin" shell cargo run --quiet --release --package monochange --bin mc -- "\$@"
           EOF
           chmod +x "$bin_dir/mc"
+          "$bin_dir/mc" --version
           echo "$bin_dir" >> "$GITHUB_PATH"
 
       - name: collect changed files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,7 +328,7 @@ jobs:
       pull-requests: read
     steps:
       - name: block direct merge of release branches
-        uses: monochange/actions/fail-when@v0.5.1
+        uses: monochange/actions/fail-when@v0.5.2
         with:
           should-fail: ${{ startsWith(github.head_ref, 'monochange/release/') }}
           reason: Release branches must be merged via the /merge comment workflow.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,7 +328,7 @@ jobs:
       pull-requests: read
     steps:
       - name: block direct merge of release branches
-        uses: monochange/actions/fail-when@v0.5.0
+        uses: monochange/actions/fail-when@v0.5.1
         with:
           should-fail: ${{ startsWith(github.head_ref, 'monochange/release/') }}
           reason: Release branches must be merged via the /merge comment workflow.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,19 +324,18 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       issues: write
+      pull-requests: read
     steps:
       - name: block direct merge of release branches
-        env:
-          HEAD_REF: ${{ github.head_ref }}
-        run: |
-          if [[ "$HEAD_REF" == monochange/release/* ]]; then
-            echo "::error::Release branches must be merged via the /merge comment workflow."
-            exit 1
-          fi
+        uses: monochange/actions/fail-when@v0.5.0
+        with:
+          should-fail: ${{ startsWith(github.head_ref, 'monochange/release/') }}
+          reason: Release branches must be merged via the /merge comment workflow.
+          fail-comment: |
+            This check fails intentionally so GitHub's normal merge button cannot be used for release PRs.
 
-          echo "PR branch $HEAD_REF is allowed to use normal merge checks."
+            After every required check is green, comment `/merge` on this PR or run the `release-pr-merge` workflow. That workflow fast-forwards the release branch and preserves monochange's release history invariants.
 
   release-pr:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'monochange'

--- a/.github/workflows/release-pr-merge.yml
+++ b/.github/workflows/release-pr-merge.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: fast-forward release PR from workflow dispatch
         if: github.event_name == 'workflow_dispatch'
-        uses: monochange/actions/merge@v0.1.0
+        uses: monochange/actions/merge@v0.5.0
         with:
           github-token: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
           pull-request: ${{ inputs.pull_request }}
@@ -54,7 +54,7 @@ jobs:
 
       - name: fast-forward release PR from /merge comment
         if: github.event_name == 'issue_comment'
-        uses: monochange/actions/merge@v0.1.0
+        uses: monochange/actions/merge@v0.5.0
         with:
           github-token: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
           base-branch: main

--- a/.github/workflows/release-pr-merge.yml
+++ b/.github/workflows/release-pr-merge.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: fast-forward release PR from workflow dispatch
         if: github.event_name == 'workflow_dispatch'
-        uses: monochange/actions/merge@v0.5.0
+        uses: monochange/actions/merge@v0.5.1
         with:
           github-token: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
           pull-request: ${{ inputs.pull_request }}
@@ -54,7 +54,7 @@ jobs:
 
       - name: fast-forward release PR from /merge comment
         if: github.event_name == 'issue_comment'
-        uses: monochange/actions/merge@v0.5.0
+        uses: monochange/actions/merge@v0.5.1
         with:
           github-token: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
           base-branch: main

--- a/.github/workflows/release-pr-merge.yml
+++ b/.github/workflows/release-pr-merge.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: fast-forward release PR from workflow dispatch
         if: github.event_name == 'workflow_dispatch'
-        uses: monochange/actions/merge@v0.5.1
+        uses: monochange/actions/merge@v0.5.2
         with:
           github-token: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
           pull-request: ${{ inputs.pull_request }}
@@ -54,7 +54,7 @@ jobs:
 
       - name: fast-forward release PR from /merge comment
         if: github.event_name == 'issue_comment'
-        uses: monochange/actions/merge@v0.5.1
+        uses: monochange/actions/merge@v0.5.2
         with:
           github-token: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
           base-branch: main


### PR DESCRIPTION
## Summary
- released monochange/actions v0.5.0 and moved the v0 tag
- update monochange workflow action references to v0.5.0
- replace the release PR merge blocker shell script with `fail-when` and an explanatory PR comment
- replace the changeset policy shell script with `monochange/actions/changeset-policy@v0.5.0` using `setup-monochange: false`

## Validation
- Ruby YAML parse for `.github/workflows/*.yml`

Actions release: https://github.com/monochange/actions/releases/tag/v0.5.0