### PR TITLE
feat(cli): expose resolved config step

### DIFF
--- a/.changeset/config-step-template-context.md
+++ b/.changeset/config-step-template-context.md
@@ -1,0 +1,28 @@
+---
+monochange: minor
+monochange_core: minor
+---
+
+# Expose resolved configuration in CLI templates
+
+Configured CLI workflows can now reference the resolved workspace configuration and paths without adding a dedicated setup step. Templates receive `config`, `project_root`, and `config_path` by default, so later steps can read values such as `{{ config.packages.0.id }}` while regular workflow execution stays quiet unless a step intentionally emits output.
+
+The new built-in config step also makes the generated command available for CI and debugging:
+
+```bash
+mc step:config
+```
+
+It prints JSON containing the canonical project root, the `monochange.toml` path, and the resolved configuration:
+
+```json
+{
+	"projectRoot": "/workspace/repo",
+	"configPath": "/workspace/repo/monochange.toml",
+	"config": {
+		"packages": []
+	}
+}
+```
+
+This gives scripts and GitHub Actions a stable command for inspecting the exact configuration that `monochange` loaded while preserving the no-output default for configured workflow steps.

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -2426,6 +2426,94 @@ fn command_versions_reports_planned_versions_without_mutating_files() {
 }
 
 #[test]
+fn command_config_reports_resolved_configuration_json() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	seed_release_fixture(tempdir.path(), None, false);
+
+	let output = run_cli(
+		tempdir.path(),
+		[OsString::from("mc"), OsString::from("step:config")],
+	)
+	.unwrap_or_else(|error| panic!("config output: {error}"));
+	let parsed: serde_json::Value =
+		serde_json::from_str(&output).unwrap_or_else(|error| panic!("config json: {error}"));
+
+	let project_root = tempdir
+		.path()
+		.canonicalize()
+		.unwrap_or_else(|error| panic!("canonical root: {error}"))
+		.display()
+		.to_string();
+	let config_path = tempdir.path().join("monochange.toml").display().to_string();
+
+	assert_eq!(parsed["projectRoot"], serde_json::json!(project_root));
+	assert_eq!(parsed["configPath"], serde_json::json!(config_path));
+	assert_eq!(
+		parsed["config"]["packages"][0]["id"],
+		serde_json::json!("app")
+	);
+}
+
+#[test]
+fn render_config_step_json_falls_back_to_uncanonicalized_root() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	seed_release_fixture(tempdir.path(), None, false);
+	let configuration = load_workspace_configuration(tempdir.path())
+		.unwrap_or_else(|error| panic!("config: {error}"));
+	let missing_root = tempdir.path().join("missing-root");
+
+	let output = crate::render_config_step_json(&missing_root, &configuration);
+	let parsed: serde_json::Value =
+		serde_json::from_str(&output).unwrap_or_else(|error| panic!("config json: {error}"));
+
+	assert_eq!(
+		parsed["projectRoot"],
+		serde_json::json!(missing_root.display().to_string())
+	);
+	assert_eq!(
+		parsed["configPath"],
+		serde_json::json!(missing_root.join("monochange.toml").display().to_string())
+	);
+}
+
+#[test]
+fn template_context_exposes_resolved_config_by_default() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	seed_release_fixture(tempdir.path(), None, false);
+	let mut context = cli_context_for_when_evaluation_tests();
+	context.root = tempdir.path().to_path_buf();
+
+	let template_context = crate::build_cli_template_context(&context, &BTreeMap::new(), None);
+	let project_root = tempdir
+		.path()
+		.canonicalize()
+		.unwrap_or_else(|error| panic!("canonical root: {error}"))
+		.display()
+		.to_string();
+	let config_path = tempdir.path().join("monochange.toml").display().to_string();
+
+	assert_eq!(
+		template_context
+			.get("config")
+			.and_then(|value| value.pointer("/packages/0/id"))
+			.and_then(serde_json::Value::as_str),
+		Some("app")
+	);
+	assert_eq!(
+		template_context
+			.get("project_root")
+			.and_then(serde_json::Value::as_str),
+		Some(project_root.as_str())
+	);
+	assert_eq!(
+		template_context
+			.get("config_path")
+			.and_then(serde_json::Value::as_str),
+		Some(config_path.as_str())
+	);
+}
+
+#[test]
 fn render_interactive_changeset_markdown_uses_natural_summary_heading() {
 	let root = fixture_path("changeset-target-metadata/render-workspace");
 	let configuration =
@@ -10731,6 +10819,15 @@ fn detect_output_format_from_env_args_parses_format_equals() {
 	assert_eq!(
 		crate::detect_output_format_from_env_args(args.into_iter()),
 		crate::OutputFormat::Markdown
+	);
+}
+
+#[test]
+fn detect_output_format_from_env_args_treats_config_step_as_json() {
+	let args: Vec<String> = vec!["monochange".to_string(), "step:config".to_string()];
+	assert_eq!(
+		crate::detect_output_format_from_env_args(args.into_iter()),
+		crate::OutputFormat::Json
 	);
 }
 

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -609,6 +609,14 @@ pub(crate) fn execute_cli_command_with_options(
 		let mut step_phase_timings = Vec::new();
 		let step_result: MonochangeResult<()> = (|| {
 			match step {
+				CliStepDefinition::Config { .. } => {
+					output = if cli_command.name == "step:config" {
+						Some(render_config_step_json(root, configuration))
+					} else {
+						None
+					};
+					Ok(())
+				}
 				CliStepDefinition::Validate { .. } => {
 					let (warnings, mut validation_errors) =
 						lint::collect_workspace_validation_issues(root);
@@ -1282,6 +1290,9 @@ fn step_shows_progress(
 	step: &CliStepDefinition,
 	step_inputs: &BTreeMap<String, Vec<String>>,
 ) -> bool {
+	if matches!(step, CliStepDefinition::Config { .. }) {
+		return false;
+	}
 	if matches!(step, CliStepDefinition::CreateChangeFile { .. })
 		&& step_inputs
 			.get("interactive")
@@ -1663,6 +1674,31 @@ pub(crate) fn build_cli_template_context(
 	variables: Option<&BTreeMap<String, CommandVariable>>,
 ) -> serde_json::Map<String, serde_json::Value> {
 	let mut template_context = serde_json::Map::new();
+
+	let project_root = context
+		.root
+		.canonicalize()
+		.unwrap_or_else(|_| context.root.clone())
+		.display()
+		.to_string();
+	template_context.insert(
+		"project_root".to_string(),
+		serde_json::Value::String(project_root),
+	);
+	template_context.insert(
+		"config_path".to_string(),
+		serde_json::Value::String(
+			monochange_config::config_path(&context.root)
+				.display()
+				.to_string(),
+		),
+	);
+	if let Ok(configuration) = load_workspace_configuration(&context.root) {
+		template_context.insert(
+			"config".to_string(),
+			serde_json::to_value(configuration).unwrap_or(serde_json::Value::Null),
+		);
+	}
 
 	// Core release variables
 	template_context.insert(
@@ -4877,6 +4913,40 @@ path = "crates/core"
 	}
 
 	#[test]
+	fn configured_config_step_uses_generic_completion_without_config_json() {
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let configuration = sample_configuration(tempdir.path());
+		let cli_command = CliCommandDefinition {
+			name: "configured-config".to_string(),
+			help_text: None,
+			inputs: Vec::new(),
+			steps: vec![CliStepDefinition::Config {
+				name: None,
+				when: None,
+				inputs: BTreeMap::new(),
+			}],
+		};
+
+		let output = execute_cli_command_with_options(
+			tempdir.path(),
+			&configuration,
+			&cli_command,
+			ExecuteCliCommandOptions {
+				dry_run: true,
+				quiet: true,
+				show_diff: false,
+				inputs: BTreeMap::new(),
+				prepared_release_path: None,
+				progress_format: ProgressFormat::Auto,
+			},
+		)
+		.unwrap_or_else(|error| panic!("config command: {error}"));
+
+		assert_eq!(output, "command `configured-config` completed (dry-run)");
+		assert!(!output.contains("projectRoot"));
+	}
+
+	#[test]
 	fn execute_cli_command_captures_telemetry_when_step_input_resolution_fails() {
 		let _guard = TEST_ENV_LOCK
 			.lock()
@@ -4918,13 +4988,25 @@ path = "crates/core"
 		);
 
 		let events = read_telemetry_events(&telemetry_path);
-		assert_eq!(events.len(), 2);
-		assert_eq!(events[0]["body"]["string_value"], "command_step");
-		assert_eq!(events[0]["attributes"]["outcome"], "error");
-		assert_eq!(events[0]["attributes"]["error_kind"], "config_error");
-		assert_eq!(events[1]["body"]["string_value"], "command_run");
-		assert_eq!(events[1]["attributes"]["outcome"], "error");
-		assert_eq!(events[1]["attributes"]["error_kind"], "config_error");
+		let step_event = events
+			.iter()
+			.find(|event| {
+				event["body"]["string_value"] == "command_step"
+					&& event["attributes"]["outcome"] == "error"
+			})
+			.unwrap_or_else(|| panic!("expected command_step event: {events:#?}"));
+		let run_event = events
+			.iter()
+			.find(|event| {
+				event["body"]["string_value"] == "command_run"
+					&& event["attributes"]["outcome"] == "error"
+			})
+			.unwrap_or_else(|| panic!("expected command_run event: {events:#?}"));
+
+		assert_eq!(step_event["attributes"]["outcome"], "error");
+		assert_eq!(step_event["attributes"]["error_kind"], "config_error");
+		assert_eq!(run_event["attributes"]["outcome"], "error");
+		assert_eq!(run_event["attributes"]["error_kind"], "config_error");
 	}
 
 	#[test]
@@ -4966,13 +5048,25 @@ path = "crates/core"
 		);
 
 		let events = read_telemetry_events(&telemetry_path);
-		assert_eq!(events.len(), 2);
-		assert_eq!(events[0]["body"]["string_value"], "command_step");
-		assert_eq!(events[0]["attributes"]["outcome"], "error");
-		assert_eq!(events[0]["attributes"]["error_kind"], "config_error");
-		assert_eq!(events[1]["body"]["string_value"], "command_run");
-		assert_eq!(events[1]["attributes"]["outcome"], "error");
-		assert_eq!(events[1]["attributes"]["error_kind"], "config_error");
+		let step_event = events
+			.iter()
+			.find(|event| {
+				event["body"]["string_value"] == "command_step"
+					&& event["attributes"]["outcome"] == "error"
+			})
+			.unwrap_or_else(|| panic!("expected command_step event: {events:#?}"));
+		let run_event = events
+			.iter()
+			.find(|event| {
+				event["body"]["string_value"] == "command_run"
+					&& event["attributes"]["outcome"] == "error"
+			})
+			.unwrap_or_else(|| panic!("expected command_run event: {events:#?}"));
+
+		assert_eq!(step_event["attributes"]["outcome"], "error");
+		assert_eq!(step_event["attributes"]["error_kind"], "config_error");
+		assert_eq!(run_event["attributes"]["outcome"], "error");
+		assert_eq!(run_event["attributes"]["error_kind"], "config_error");
 	}
 
 	#[test]

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -262,6 +262,26 @@ pub(crate) use workspace_ops::render_interactive_changeset_markdown;
 #[cfg(feature = "cargo")]
 pub(crate) use workspace_ops::validate_cargo_workspace_version_groups;
 
+pub(crate) fn render_config_step_json(
+	root: &Path,
+	configuration: &monochange_core::WorkspaceConfiguration,
+) -> String {
+	let project_root = root
+		.canonicalize()
+		.unwrap_or_else(|_| root.to_path_buf())
+		.display()
+		.to_string();
+	let config_path = monochange_config::config_path(root).display().to_string();
+	let output = serde_json::json!({
+		"projectRoot": project_root,
+		"configPath": config_path,
+		"config": configuration,
+	});
+
+	serde_json::to_string_pretty(&output)
+		.unwrap_or_else(|error| panic!("serializing a serde_json::Value failed: {error}"))
+}
+
 pub(crate) fn synthetic_step_command_definition(
 	cli_command_name: &str,
 ) -> MonochangeResult<CliCommandDefinition> {
@@ -667,6 +687,9 @@ pub(crate) fn detect_output_format_from_env_args(
 ) -> OutputFormat {
 	let args: Vec<String> = args.collect();
 	for (i, arg) in args.iter().enumerate() {
+		if arg == "step:config" {
+			return OutputFormat::Json;
+		}
 		if arg == "--format"
 			&& let Some(value) = args.get(i + 1)
 		{

--- a/crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_prints_help.snap
+++ b/crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_prints_help.snap
@@ -30,6 +30,7 @@ Commands:
   mcp                            Start the monochange MCP (Model Context Protocol) server over stdin/stdout
   check                          Validate configuration, changesets, and run manifest lint rules
   help                           Show detailed help for a command
+  step:config                    Run the `step:config` command
   step:validate                  Run the `step:validate` command
   step:discover                  Run the `step:discover` command
   step:display-versions          Run the `step:display-versions` command

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -1785,6 +1785,15 @@ impl<'de> Deserialize<'de> for ShellConfig {
 #[serde(tag = "type", deny_unknown_fields)]
 #[non_exhaustive]
 pub enum CliStepDefinition {
+	/// Expose the resolved `monochange` configuration and workspace root.
+	Config {
+		#[serde(default)]
+		name: Option<String>,
+		#[serde(default)]
+		when: Option<String>,
+		#[serde(default)]
+		inputs: BTreeMap<String, CliStepInputValue>,
+	},
 	/// Validate `monochange` configuration and changesets, and run lint rules
 	/// on package manifests.
 	Validate {
@@ -1983,7 +1992,8 @@ impl CliStepDefinition {
 	#[must_use]
 	pub fn inputs(&self) -> &BTreeMap<String, CliStepInputValue> {
 		match self {
-			Self::Validate { inputs, .. }
+			Self::Config { inputs, .. }
+			| Self::Validate { inputs, .. }
 			| Self::Discover { inputs, .. }
 			| Self::DisplayVersions { inputs, .. }
 			| Self::CreateChangeFile { inputs, .. }
@@ -2007,7 +2017,8 @@ impl CliStepDefinition {
 	#[must_use]
 	pub fn name(&self) -> Option<&str> {
 		match self {
-			Self::Validate { name, .. }
+			Self::Config { name, .. }
+			| Self::Validate { name, .. }
 			| Self::Discover { name, .. }
 			| Self::DisplayVersions { name, .. }
 			| Self::CreateChangeFile { name, .. }
@@ -2037,7 +2048,8 @@ impl CliStepDefinition {
 	#[must_use]
 	pub fn when(&self) -> Option<&str> {
 		match self {
-			Self::Validate { when, .. }
+			Self::Config { when, .. }
+			| Self::Validate { when, .. }
 			| Self::Discover { when, .. }
 			| Self::DisplayVersions { when, .. }
 			| Self::CreateChangeFile { when, .. }
@@ -2072,6 +2084,7 @@ impl CliStepDefinition {
 	#[must_use]
 	pub fn kind_name(&self) -> &'static str {
 		match self {
+			Self::Config { .. } => "Config",
 			Self::Validate { .. } => "Validate",
 			Self::Discover { .. } => "Discover",
 			Self::DisplayVersions { .. } => "DisplayVersions",
@@ -2100,6 +2113,7 @@ impl CliStepDefinition {
 	#[must_use]
 	pub fn valid_input_names(&self) -> Option<&'static [&'static str]> {
 		match self {
+			Self::Config { .. } => Some(&[]),
 			Self::Validate { .. } => Some(&["fix"]),
 			Self::CommitRelease { .. } => Some(&["no_verify"]),
 			Self::VerifyReleaseBranch { .. } => Some(&["from"]),
@@ -2200,7 +2214,7 @@ impl CliStepDefinition {
 					_ => None,
 				}
 			}
-			Self::Command { .. } => None,
+			Self::Config { .. } | Self::Command { .. } => None,
 			Self::Discover { .. } | Self::DisplayVersions { .. } | Self::PrepareRelease { .. } => {
 				matches!(name, "format").then_some(CliInputKind::Choice)
 			}
@@ -3832,6 +3846,11 @@ pub fn default_cli_commands() -> Vec<CliCommandDefinition> {
 #[must_use]
 pub fn all_step_variants() -> Vec<CliStepDefinition> {
 	vec![
+		CliStepDefinition::Config {
+			name: None,
+			when: None,
+			inputs: BTreeMap::new(),
+		},
 		CliStepDefinition::Validate {
 			name: None,
 			when: None,


### PR DESCRIPTION
## Summary
- add a built-in Config CLI step so `mc step:config` is generated
- emit resolved configuration JSON for direct `mc step:config` runs
- expose `config`, `project_root`, and `config_path` in CLI template context by default
- add tests, snapshot coverage, and a changeset

## Validation
- `devenv shell cargo fmt --all`
- `devenv shell cargo check --workspace --all-features`
- `devenv shell cargo test --package monochange config --all-features`
- `devenv shell cargo test --package monochange --test cli_main_binary monochange_binary_prints_help --all-features`
- `devenv shell mc step:affected-packages --verify --changed-paths ...`
- pre-push hook: full test suite passed (2080/2080), doc-tests completed, secrets scan passed

Note: local `fix:all`/`lint:all` initially failed before `pnpm install --frozen-lockfile` because `oxlint`/`oxfmt` were not installed in the worktree node_modules; after installing dependencies, the pre-push validation passed.
