### PR TITLE
feat: add initial changelog headers

### DIFF
--- a/.changeset/changelog-initial-headers.md
+++ b/.changeset/changelog-initial-headers.md
@@ -1,0 +1,11 @@
+---
+monochange: minor
+monochange_config: minor
+monochange_core: minor
+---
+
+# Add initial changelog headers
+
+Changelog targets now support `initial_header` in `[defaults.changelog]`, `[package.<id>.changelog]`, and `[group.<id>.changelog]`. monochange renders the header only when creating a changelog from empty content, preserving existing preambles on later releases.
+
+When no custom header is configured, the selected changelog format provides a built-in default header.

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -5,6 +5,7 @@
 		"dist/**",
 		"coverage/**",
 		"node_modules/**",
-		"pnpm-lock.yaml"
+		"pnpm-lock.yaml",
+		"fixtures/**"
 	]
 }

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
-All notable changes to the `main` release group will be documented in this file.
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
 
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 

--- a/crates/monochange/changelog.md
+++ b/crates/monochange/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
-All notable changes to `monochange` will be documented in this file.
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
 
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 

--- a/crates/monochange/src/changelog.rs
+++ b/crates/monochange/src/changelog.rs
@@ -131,10 +131,23 @@ pub(crate) fn build_changelog_updates(
 			&changes,
 		);
 		let rendered = render_release_notes(changelog_target.format, &document);
+		let initial_header = render_package_initial_changelog_header(
+			context,
+			changelog_target,
+			&package_id,
+			package,
+			group_definition,
+			planned_version,
+		);
+		let next_changelog = append_changelog_section(
+			&changelog_target.path,
+			&rendered,
+			Some(initial_header.as_str()),
+		)?;
 		updates.push(ChangelogUpdate {
 			file: FileUpdate {
 				path: changelog_target.path.clone(),
-				content: append_changelog_section(&changelog_target.path, &rendered)?.into_bytes(),
+				content: next_changelog.into_bytes(),
 			},
 			owner_id: package_id,
 			owner_kind: ReleaseOwnerKind::Package,
@@ -193,10 +206,23 @@ pub(crate) fn build_changelog_updates(
 			&changes,
 		);
 		let rendered = render_release_notes(changelog_target.format, &document);
+		let initial_header = render_group_initial_changelog_header(
+			context,
+			changelog_target,
+			planned_group,
+			group_definition,
+			planned_version,
+			&member_ids,
+		);
+		let next_changelog = append_changelog_section(
+			&changelog_target.path,
+			&rendered,
+			Some(initial_header.as_str()),
+		)?;
 		updates.push(ChangelogUpdate {
 			file: FileUpdate {
 				path: changelog_target.path.clone(),
-				content: append_changelog_section(&changelog_target.path, &rendered)?.into_bytes(),
+				content: next_changelog.into_bytes(),
 			},
 			owner_id: planned_group.group_id.clone(),
 			owner_kind: ReleaseOwnerKind::Group,
@@ -209,7 +235,120 @@ pub(crate) fn build_changelog_updates(
 	Ok(dedup_changelog_updates(updates))
 }
 
-fn append_changelog_section(path: &Path, section: &str) -> MonochangeResult<String> {
+fn default_initial_changelog_header(format: ChangelogFormat) -> &'static str {
+	if format == ChangelogFormat::KeepAChangelog {
+		return monochange_core::DEFAULT_INITIAL_CHANGELOG_HEADER_KEEP_A_CHANGELOG;
+	}
+
+	monochange_core::DEFAULT_INITIAL_CHANGELOG_HEADER_MONOCHANGE
+}
+
+fn render_package_initial_changelog_header(
+	context: ChangelogBuildContext<'_>,
+	changelog_target: &ChangelogTarget,
+	owner_id: &str,
+	package: &PackageRecord,
+	group_definition: Option<&monochange_core::GroupDefinition>,
+	planned_version: &semver::Version,
+) -> String {
+	let mut metadata = initial_changelog_header_metadata(context, changelog_target);
+	let package_dir = package
+		.manifest_path
+		.parent()
+		.unwrap_or(package.manifest_path.as_path());
+	let package_path = monochange_core::normalize_path(package_dir)
+		.strip_prefix(monochange_core::normalize_path(context.root))
+		.map_or_else(|_| package_dir.to_path_buf(), Path::to_path_buf);
+	metadata.insert("package", package.name.clone());
+	metadata.insert("package_id", owner_id.to_string());
+	metadata.insert("package_name", package.name.clone());
+	metadata.insert("package_path", package_path.to_string_lossy().to_string());
+	metadata.insert("release_owner", owner_id.to_string());
+	metadata.insert("release_owner_kind", "package".to_string());
+	metadata.insert("version", planned_version.to_string());
+	metadata.insert("new_version", planned_version.to_string());
+	metadata.insert(
+		"current_version",
+		package
+			.current_version
+			.as_ref()
+			.map(ToString::to_string)
+			.unwrap_or_default(),
+	);
+	if let Some(group) = group_definition {
+		metadata.insert("group", group.id.clone());
+		metadata.insert("group_id", group.id.clone());
+		metadata.insert("group_name", group.id.clone());
+	}
+	render_initial_changelog_header(changelog_target, &metadata)
+}
+
+fn render_group_initial_changelog_header(
+	context: ChangelogBuildContext<'_>,
+	changelog_target: &ChangelogTarget,
+	planned_group: &monochange_core::PlannedVersionGroup,
+	group_definition: Option<&monochange_core::GroupDefinition>,
+	planned_version: &semver::Version,
+	member_ids: &[String],
+) -> String {
+	let mut metadata = initial_changelog_header_metadata(context, changelog_target);
+	let group_id =
+		group_definition.map_or_else(|| planned_group.group_id.clone(), |group| group.id.clone());
+	metadata.insert("group", group_id.clone());
+	metadata.insert("group_id", group_id.clone());
+	metadata.insert("group_name", group_id.clone());
+	metadata.insert("member_count", member_ids.len().to_string());
+	metadata.insert("members", member_ids.join(", "));
+	metadata.insert("release_owner", group_id);
+	metadata.insert("release_owner_kind", "group".to_string());
+	metadata.insert("version", planned_version.to_string());
+	metadata.insert("new_version", planned_version.to_string());
+	render_initial_changelog_header(changelog_target, &metadata)
+}
+
+fn initial_changelog_header_metadata(
+	context: ChangelogBuildContext<'_>,
+	changelog_target: &ChangelogTarget,
+) -> BTreeMap<&'static str, String> {
+	let config_path = context.configuration.root_path.join("monochange.toml");
+	let changelog_path = root_relative(context.root, &changelog_target.path);
+	let workspace_root = monochange_core::normalize_path(context.root);
+	let mut metadata = BTreeMap::new();
+	metadata.insert("monochange_version", env!("CARGO_PKG_VERSION").to_string());
+	metadata.insert("config_path", config_path.to_string_lossy().to_string());
+	metadata.insert(
+		"monochange_config_path",
+		config_path.to_string_lossy().to_string(),
+	);
+	metadata.insert(
+		"workspace_root",
+		workspace_root.to_string_lossy().to_string(),
+	);
+	metadata.insert(
+		"changelog_path",
+		changelog_path.to_string_lossy().to_string(),
+	);
+	metadata.insert("changelog_format", format!("{:?}", changelog_target.format));
+	metadata
+}
+
+fn render_initial_changelog_header(
+	changelog_target: &ChangelogTarget,
+	metadata: &BTreeMap<&'static str, String>,
+) -> String {
+	let template = changelog_target
+		.initial_header
+		.as_deref()
+		.filter(|header| !header.trim().is_empty())
+		.unwrap_or_else(|| default_initial_changelog_header(changelog_target.format));
+	render_message_template(template, metadata)
+}
+
+fn append_changelog_section(
+	path: &Path,
+	section: &str,
+	initial_header: Option<&str>,
+) -> MonochangeResult<String> {
 	let current = if path.exists() {
 		fs::read_to_string(path).map_err(|error| {
 			MonochangeError::Io(format!("failed to read {}: {error}", path.display()))
@@ -220,7 +359,13 @@ fn append_changelog_section(path: &Path, section: &str) -> MonochangeResult<Stri
 
 	let current = current.trim_end();
 	if current.is_empty() {
-		return Ok(format!("{section}\n"));
+		let Some(initial_header) = initial_header
+			.map(str::trim)
+			.filter(|header| !header.is_empty())
+		else {
+			return Ok(format!("{section}\n"));
+		};
+		return Ok(format!("{initial_header}\n\n{section}\n"));
 	}
 
 	let Some(offset) = current
@@ -1262,6 +1407,7 @@ mod tests {
 			changelog: Some(ChangelogTarget {
 				path: PathBuf::from(format!("packages/{config_id}/CHANGELOG.md")),
 				format: ChangelogFormat::Monochange,
+				initial_header: None,
 			}),
 			excluded_changelog_types: Vec::new(),
 			empty_update_message: None,
@@ -1285,6 +1431,7 @@ mod tests {
 			changelog: Some(ChangelogTarget {
 				path: PathBuf::from("groups/sdk/CHANGELOG.md"),
 				format: ChangelogFormat::Monochange,
+				initial_header: None,
 			}),
 			changelog_include: include,
 			excluded_changelog_types: Vec::new(),
@@ -1354,18 +1501,205 @@ mod tests {
 	}
 
 	#[test]
+	fn initial_changelog_header_renders_custom_template_and_format_default() {
+		let mut metadata = BTreeMap::new();
+		metadata.insert("package_name", "workflow-core".to_string());
+		metadata.insert("monochange_version", "1.2.3".to_string());
+
+		let custom = ChangelogTarget {
+			path: PathBuf::from("CHANGELOG.md"),
+			format: ChangelogFormat::Monochange,
+			initial_header: Some(
+				"# {{ package_name }}\n\nGenerated by {{ monochange_version }}".to_string(),
+			),
+		};
+		assert_eq!(
+			render_initial_changelog_header(&custom, &metadata),
+			"# workflow-core\n\nGenerated by 1.2.3"
+		);
+
+		let format_default = ChangelogTarget {
+			path: PathBuf::from("CHANGELOG.md"),
+			format: ChangelogFormat::KeepAChangelog,
+			initial_header: None,
+		};
+		assert!(
+			render_initial_changelog_header(&format_default, &metadata)
+				.contains("Keep a Changelog")
+		);
+	}
+
+	#[test]
+	fn build_changelog_updates_writes_package_and_group_initial_headers() {
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let root = tempdir.path();
+		let package_a = sample_package_record(root, "pkg-a", "pkg-a");
+		let package_b = sample_package_record(root, "pkg-b", "pkg-b");
+		let package_a_id = package_a.id.clone();
+		let other_package_id = package_b.id.clone();
+		let packages = vec![package_a, package_b];
+
+		let mut configuration = empty_configuration(root);
+		configuration.packages = vec![
+			sample_package_definition("pkg-a"),
+			sample_package_definition("pkg-b"),
+		];
+		configuration.groups = vec![sample_group_definition(GroupChangelogInclude::All)];
+
+		let plan = ReleasePlan {
+			workspace_root: root.to_path_buf(),
+			decisions: vec![sample_decision(&package_a_id, None)],
+			groups: vec![sample_group(vec![package_a_id.clone(), other_package_id])],
+			warnings: Vec::new(),
+			unresolved_items: Vec::new(),
+			compatibility_evidence: Vec::new(),
+		};
+		let package_changelog_path = root.join("packages/pkg-a/CHANGELOG.md");
+		let group_changelog_path = root.join("groups/sdk/CHANGELOG.md");
+		let changelog_targets = (
+			BTreeMap::from([(
+				package_a_id,
+				ChangelogTarget {
+					path: package_changelog_path.clone(),
+					format: ChangelogFormat::Monochange,
+					initial_header: Some("# {{ package_name }} changelog".to_string()),
+				},
+			)]),
+			BTreeMap::from([(
+				"sdk".to_string(),
+				ChangelogTarget {
+					path: group_changelog_path.clone(),
+					format: ChangelogFormat::Monochange,
+					initial_header: Some("# {{ group_name }} changelog".to_string()),
+				},
+			)]),
+		);
+
+		let updates = build_changelog_updates(ChangelogBuildContext {
+			root,
+			configuration: &configuration,
+			packages: &packages,
+			plan: &plan,
+			change_signals: &[],
+			changesets: &[],
+			changelog_targets: &changelog_targets,
+			release_targets: &[],
+		})
+		.unwrap_or_else(|error| panic!("build changelog updates: {error}"));
+
+		let package_update = updates
+			.iter()
+			.find(|update| update.file.path == package_changelog_path)
+			.unwrap_or_else(|| panic!("missing package changelog update"));
+		assert!(
+			String::from_utf8_lossy(&package_update.file.content).starts_with("# pkg-a changelog")
+		);
+
+		let group_update = updates
+			.iter()
+			.find(|update| update.file.path == group_changelog_path)
+			.unwrap_or_else(|| panic!("missing group changelog update"));
+		assert!(String::from_utf8_lossy(&group_update.file.content).starts_with("# sdk changelog"));
+	}
+
+	#[test]
+	fn build_changelog_updates_reports_package_and_group_append_errors() {
+		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let root = tempdir.path();
+		let package_a = sample_package_record(root, "pkg-a", "pkg-a");
+		let package_a_id = package_a.id.clone();
+		let packages = vec![package_a];
+
+		let mut configuration = empty_configuration(root);
+		configuration.packages = vec![sample_package_definition("pkg-a")];
+		configuration.groups = vec![sample_group_definition(GroupChangelogInclude::All)];
+
+		let bad_changelog_path = root.join("invalid-utf8-changelog.md");
+		fs::write(&bad_changelog_path, [0xff])
+			.unwrap_or_else(|error| panic!("write invalid changelog file: {error}"));
+
+		let package_plan = ReleasePlan {
+			workspace_root: root.to_path_buf(),
+			decisions: vec![sample_decision(&package_a_id, None)],
+			groups: Vec::new(),
+			warnings: Vec::new(),
+			unresolved_items: Vec::new(),
+			compatibility_evidence: Vec::new(),
+		};
+		let package_error = build_changelog_updates(ChangelogBuildContext {
+			root,
+			configuration: &configuration,
+			packages: &packages,
+			plan: &package_plan,
+			change_signals: &[],
+			changesets: &[],
+			changelog_targets: &(
+				BTreeMap::from([(
+					package_a_id.clone(),
+					ChangelogTarget {
+						path: bad_changelog_path.clone(),
+						format: ChangelogFormat::Monochange,
+						initial_header: None,
+					},
+				)]),
+				BTreeMap::new(),
+			),
+			release_targets: &[],
+		});
+		assert!(package_error.is_err());
+
+		let group_plan = ReleasePlan {
+			workspace_root: root.to_path_buf(),
+			decisions: vec![sample_decision(&package_a_id, Some("sdk"))],
+			groups: vec![sample_group(vec![package_a_id.clone()])],
+			warnings: Vec::new(),
+			unresolved_items: Vec::new(),
+			compatibility_evidence: Vec::new(),
+		};
+		let group_error = build_changelog_updates(ChangelogBuildContext {
+			root,
+			configuration: &configuration,
+			packages: &packages,
+			plan: &group_plan,
+			change_signals: &[],
+			changesets: &[],
+			changelog_targets: &(
+				BTreeMap::new(),
+				BTreeMap::from([(
+					"sdk".to_string(),
+					ChangelogTarget {
+						path: bad_changelog_path,
+						format: ChangelogFormat::Monochange,
+						initial_header: None,
+					},
+				)]),
+			),
+			release_targets: &[],
+		});
+		assert!(group_error.is_err());
+	}
+
+	#[test]
 	fn changelog_file_helpers_append_and_deduplicate_updates() {
 		let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 		let changelog_path = tempdir.path().join("CHANGELOG.md");
 
-		let first = append_changelog_section(&changelog_path, "## 1.0.0\n- initial")
-			.unwrap_or_else(|error| panic!("append first changelog section: {error}"));
-		assert_eq!(first, "## 1.0.0\n- initial\n");
+		let first =
+			append_changelog_section(&changelog_path, "## 1.0.0\n- initial", Some("# Changelog"))
+				.unwrap_or_else(|error| panic!("append first changelog section: {error}"));
+		assert_eq!(first, "# Changelog\n\n## 1.0.0\n- initial\n");
+
+		let without_header_path = tempdir.path().join("without-header.md");
+		let without_header =
+			append_changelog_section(&without_header_path, "## 1.0.0\n- initial", None)
+				.unwrap_or_else(|error| panic!("append changelog section without header: {error}"));
+		assert_eq!(without_header, "## 1.0.0\n- initial\n");
 
 		fs::write(&changelog_path, "# Changelog\n\n## 0.9.0\n- older\n")
 			.unwrap_or_else(|error| panic!("write existing changelog: {error}"));
-		let appended = append_changelog_section(&changelog_path, "## 1.0.0\n- latest")
-			.unwrap_or_else(|error| panic!("append second changelog section: {error}"));
+		let appended =
+			append_changelog_section(&changelog_path, "## 1.0.0\n- latest", Some("# Ignored"))
+				.unwrap_or_else(|error| panic!("append second changelog section: {error}"));
 		assert_eq!(
 			appended,
 			"# Changelog\n\n## 1.0.0\n- latest\n\n## 0.9.0\n- older\n"

--- a/crates/monochange/src/changesets.rs
+++ b/crates/monochange/src/changesets.rs
@@ -850,6 +850,7 @@ pub(crate) fn resolve_changelog_targets(
 			ChangelogTarget {
 				path: resolve_config_path(&configuration.root_path, &changelog_path.path),
 				format: changelog_path.format,
+				initial_header: changelog_path.initial_header.clone(),
 			},
 		);
 	}
@@ -862,6 +863,7 @@ pub(crate) fn resolve_changelog_targets(
 			ChangelogTarget {
 				path: resolve_config_path(&configuration.root_path, &changelog_path.path),
 				format: changelog_path.format,
+				initial_header: changelog_path.initial_header.clone(),
 			},
 		);
 	}

--- a/crates/monochange/src/monochange.init.toml
+++ b/crates/monochange/src/monochange.init.toml
@@ -64,10 +64,16 @@ warn_on_group_mismatch = true
 #   false                          → disable changelogs by default
 #   "{{ path }}/changelog.md"      → pattern where {{ path }} is replaced with each package path
 #
-# As a table, you can set both path and format:
+# As a table, you can set path, format, and the initial header used when
+# monochange creates a changelog from empty content:
 #   [defaults.changelog]
 #   path = "{{ path }}/changelog.md"
 #   format = "keep_a_changelog"
+#   initial_header = """
+#   # Changelog
+#
+#   All notable changes to this project will be documented in this file.
+#   """
 {% endraw -%}
 #
 # Supported formats: "monochange" (default), "keep_a_changelog"
@@ -77,6 +83,13 @@ warn_on_group_mismatch = true
 # path = "{{ path }}/changelog.md"
 {% endraw -%}
 # format = "keep_a_changelog"
+# initial_header = """
+# # Changelog
+#
+# All notable changes to this project will be documented in this file.
+#
+# This changelog is managed by [monochange](https://github.com/monochange/monochange).
+# """
 
 # Default changelog configuration. When [changelog] is not specified,
 # built-in defaults provide standard sections (Major, Breaking Change, Added,
@@ -249,7 +262,8 @@ warn_on_group_mismatch = true
 #   type                    — "cargo", "npm", "deno", "dart", "flutter", "python"
 #                             (not needed when defaults.package_type is set)
 #   changelog               — true, false, "path/to/changelog.md", or a table
-#                             with { path, format }; overrides [defaults.changelog]
+#                             with { path, format, initial_header }; overrides
+#                             [defaults.changelog]
 #   excluded_changelog_types — list of changelog type keys to exclude from this target
 #   empty_update_message    — per-package fallback text for transitive bumps
 #   versioned_files         — additional files to update with the new version

--- a/crates/monochange/tests/snapshots/changelog_formats__app@defaults_keep_a.snap
+++ b/crates/monochange/tests/snapshots/changelog_formats__app@defaults_keep_a.snap
@@ -1,7 +1,15 @@
 ---
 source: crates/monochange/tests/changelog_formats.rs
+assertion_line: 40
 expression: app_changelog
 ---
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## 1.1.0 ([DATE])
 
 ### Changed

--- a/crates/monochange/tests/snapshots/changelog_formats__app@defaults_then_package_override.snap
+++ b/crates/monochange/tests/snapshots/changelog_formats__app@defaults_then_package_override.snap
@@ -1,7 +1,14 @@
 ---
 source: crates/monochange/tests/changelog_formats.rs
+assertion_line: 40
 expression: app_changelog
 ---
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## 1.1.0 ([DATE])
 
 - No package-specific changes were recorded; `workflow-app` was updated to 1.1.0 as part of group `sdk`.

--- a/crates/monochange/tests/snapshots/changelog_formats__core@defaults_keep_a.snap
+++ b/crates/monochange/tests/snapshots/changelog_formats__core@defaults_keep_a.snap
@@ -1,7 +1,15 @@
 ---
 source: crates/monochange/tests/changelog_formats.rs
+assertion_line: 39
 expression: core_changelog
 ---
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## 1.1.0 ([DATE])
 
 ### Changed

--- a/crates/monochange/tests/snapshots/changelog_formats__core@defaults_then_package_override.snap
+++ b/crates/monochange/tests/snapshots/changelog_formats__core@defaults_then_package_override.snap
@@ -1,7 +1,15 @@
 ---
 source: crates/monochange/tests/changelog_formats.rs
+assertion_line: 39
 expression: core_changelog
 ---
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## 1.1.0 ([DATE])
 
 ### Changed

--- a/crates/monochange/tests/snapshots/changelog_formats__group@defaults_keep_a.snap
+++ b/crates/monochange/tests/snapshots/changelog_formats__group@defaults_keep_a.snap
@@ -1,7 +1,15 @@
 ---
 source: crates/monochange/tests/changelog_formats.rs
+assertion_line: 41
 expression: group_changelog
 ---
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## 1.1.0 ([DATE])
 
 Grouped release for `sdk`.

--- a/crates/monochange/tests/snapshots/changelog_formats__group@defaults_then_package_override.snap
+++ b/crates/monochange/tests/snapshots/changelog_formats__group@defaults_then_package_override.snap
@@ -1,7 +1,14 @@
 ---
 source: crates/monochange/tests/changelog_formats.rs
+assertion_line: 41
 expression: group_changelog
 ---
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## 1.1.0 ([DATE])
 
 Grouped release for `sdk`.

--- a/crates/monochange/tests/snapshots/changelog_formats__release_group_alert_snapshots_match_expected_output@alert_multi_packages.snap
+++ b/crates/monochange/tests/snapshots/changelog_formats__release_group_alert_snapshots_match_expected_output@alert_multi_packages.snap
@@ -1,7 +1,14 @@
 ---
 source: crates/monochange/tests/changelog_formats.rs
+assertion_line: 66
 expression: group_changelog
 ---
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## 1.1.0 ([DATE])
 
 Grouped release for `sdk`.

--- a/crates/monochange/tests/snapshots/changelog_formats__release_group_alert_snapshots_match_expected_output@alert_multiline.snap
+++ b/crates/monochange/tests/snapshots/changelog_formats__release_group_alert_snapshots_match_expected_output@alert_multiline.snap
@@ -1,7 +1,14 @@
 ---
 source: crates/monochange/tests/changelog_formats.rs
+assertion_line: 66
 expression: group_changelog
 ---
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## 1.1.0 ([DATE])
 
 Grouped release for `sdk`.

--- a/crates/monochange/tests/snapshots/changelog_formats__release_uses_linked_keep_a_changelog_titles_without_double_wrapping.snap
+++ b/crates/monochange/tests/snapshots/changelog_formats__release_uses_linked_keep_a_changelog_titles_without_double_wrapping.snap
@@ -1,7 +1,15 @@
 ---
 source: crates/monochange/tests/changelog_formats.rs
+assertion_line: 85
 expression: core_changelog
 ---
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [1.1.0](https://github.com/ifiokjr/monochange/releases/tag/v1.1.0) (2026-04-06)
 
 ### Changed

--- a/crates/monochange/tests/snapshots/release_notes_and_propagation__custom_empty_update_message_on_package_overrides_default@custom_empty_update_message_on_package_overrides_default.snap
+++ b/crates/monochange/tests/snapshots/release_notes_and_propagation__custom_empty_update_message_on_package_overrides_default@custom_empty_update_message_on_package_overrides_default.snap
@@ -2,6 +2,12 @@
 source: crates/monochange/tests/release_notes_and_propagation.rs
 expression: changelog
 ---
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## 1.1.0 ([DATE])
 
 Grouped release for `sdk`.

--- a/crates/monochange_analysis/changelog.md
+++ b/crates/monochange_analysis/changelog.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added

--- a/crates/monochange_cargo/changelog.md
+++ b/crates/monochange_cargo/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
-All notable changes to `monochange_cargo` will be documented in this file.
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
 
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 

--- a/crates/monochange_config/changelog.md
+++ b/crates/monochange_config/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
-All notable changes to `monochange_config` will be documented in this file.
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
 
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -321,6 +321,7 @@ fn load_workspace_configuration_parses_package_group_and_cli_command_declaration
 		Some(ChangelogTarget {
 			path: PathBuf::from("crates/core/changelog.md"),
 			format: ChangelogFormat::Monochange,
+			initial_header: None,
 		})
 	);
 	assert_eq!(
@@ -629,6 +630,7 @@ fn load_workspace_configuration_uses_defaults_changelog_pattern_when_package_cha
 		Some(ChangelogTarget {
 			path: PathBuf::from("crates/core/changelog.md"),
 			format: ChangelogFormat::Monochange,
+			initial_header: None,
 		})
 	);
 }
@@ -657,6 +659,7 @@ fn load_workspace_configuration_supports_package_changelog_true_false_and_string
 		Some(ChangelogTarget {
 			path: PathBuf::from("crates/core/CHANGELOG.md"),
 			format: ChangelogFormat::Monochange,
+			initial_header: None,
 		})
 	);
 	assert_eq!(app.changelog, None);
@@ -665,6 +668,7 @@ fn load_workspace_configuration_supports_package_changelog_true_false_and_string
 		Some(ChangelogTarget {
 			path: PathBuf::from("docs/tool-release-notes.md"),
 			format: ChangelogFormat::Monochange,
+			initial_header: None,
 		})
 	);
 }
@@ -694,6 +698,7 @@ fn load_workspace_configuration_supports_changelog_format_tables_and_overrides()
 		Some(ChangelogTarget {
 			path: PathBuf::from("crates/core/CHANGELOG.md"),
 			format: ChangelogFormat::KeepAChangelog,
+			initial_header: Some("Default {{ release_owner }} changelog".to_string()),
 		})
 	);
 	assert_eq!(
@@ -701,6 +706,7 @@ fn load_workspace_configuration_supports_changelog_format_tables_and_overrides()
 		Some(ChangelogTarget {
 			path: PathBuf::from("docs/app-release-notes.md"),
 			format: ChangelogFormat::Monochange,
+			initial_header: Some("App {{ package_name }} changelog".to_string()),
 		})
 	);
 	assert_eq!(
@@ -708,6 +714,7 @@ fn load_workspace_configuration_supports_changelog_format_tables_and_overrides()
 		Some(ChangelogTarget {
 			path: PathBuf::from("docs/group-release-notes.md"),
 			format: ChangelogFormat::KeepAChangelog,
+			initial_header: Some("Default {{ release_owner }} changelog".to_string()),
 		})
 	);
 }
@@ -4065,6 +4072,7 @@ fn raw_changelog_config_resolves_package_and_group_paths() {
 		enabled: Some(false),
 		path: Some("group/CHANGELOG.md".to_string()),
 		format: None,
+		initial_header: None,
 		include: None,
 	});
 	assert!(detailed_disabled.is_disabled());
@@ -4078,6 +4086,7 @@ fn raw_changelog_config_resolves_package_and_group_paths() {
 		enabled: Some(true),
 		path: None,
 		format: None,
+		initial_header: Some("Header".to_string()),
 		include: Some(crate::RawGroupChangelogInclude::Mode(
 			"group-only".to_string(),
 		)),

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -270,6 +270,8 @@ struct RawChangelogTable {
 	#[serde(default)]
 	format: Option<ChangelogFormat>,
 	#[serde(default)]
+	initial_header: Option<String>,
+	#[serde(default)]
 	include: Option<RawGroupChangelogInclude>,
 }
 
@@ -591,6 +593,19 @@ impl RawChangelogConfig {
 		match self {
 			Self::Legacy(_) => None,
 			Self::Detailed(table) => table.include.as_ref(),
+		}
+	}
+
+	fn initial_header(&self) -> Option<String> {
+		match self {
+			Self::Legacy(_) => None,
+			Self::Detailed(table) => {
+				table
+					.initial_header
+					.as_ref()
+					.filter(|header| !header.trim().is_empty())
+					.cloned()
+			}
 		}
 	}
 
@@ -1018,13 +1033,17 @@ fn build_package_definitions(
 					definition.resolve_for_package(&package.path, false).map(|path| ChangelogTarget {
 						path,
 						format: definition.format().unwrap_or(default_changelog_format),
+						initial_header: definition
+							.initial_header()
+							.or_else(|| default_package_changelog.and_then(RawChangelogConfig::initial_header)),
 					})
 				})
 				.or_else(|| {
-					default_package_changelog.as_ref().and_then(|definition| {
+					default_package_changelog.and_then(|definition| {
 						definition.resolve_for_package(&package.path, true).map(|path| ChangelogTarget {
 							path,
 							format: definition.format().unwrap_or(default_changelog_format),
+							initial_header: definition.initial_header(),
 						})
 					})
 				});
@@ -1098,6 +1117,7 @@ fn build_group_definitions(
 	contents: &str,
 	groups: BTreeMap<String, RawGroupDefinition>,
 	default_changelog_format: ChangelogFormat,
+	default_changelog_initial_header: Option<&str>,
 ) -> MonochangeResult<Vec<GroupDefinition>> {
 	groups
 		.into_iter()
@@ -1108,6 +1128,9 @@ fn build_group_definitions(
 					Some(path) => Some(ChangelogTarget {
 						path,
 						format: definition.format().unwrap_or(default_changelog_format),
+						initial_header: definition
+							.initial_header()
+							.or_else(|| default_changelog_initial_header.map(str::to_string)),
 					}),
 					None if definition.is_disabled() => None,
 					None => {
@@ -1236,7 +1259,16 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		&python_ecosystem,
 		&go_ecosystem,
 	)?;
-	let groups = build_group_definitions(&contents, group, default_changelog_format)?;
+	let default_changelog_initial_header = defaults
+		.changelog
+		.as_ref()
+		.and_then(RawChangelogConfig::initial_header);
+	let groups = build_group_definitions(
+		&contents,
+		group,
+		default_changelog_format,
+		default_changelog_initial_header.as_deref(),
+	)?;
 	let source = resolve_source_configuration(source);
 
 	validate_cli(&cli)?;

--- a/crates/monochange_core/changelog.md
+++ b/crates/monochange_core/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
-All notable changes to `monochange_core` will be documented in this file.
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
 
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -1751,6 +1751,7 @@ fn sample_workspace_configuration() -> WorkspaceConfiguration {
 				changelog: Some(ChangelogTarget {
 					path: PathBuf::from("crates/monochange/changelog.md"),
 					format: ChangelogFormat::Monochange,
+					initial_header: None,
 				}),
 				excluded_changelog_types: Vec::new(),
 				empty_update_message: None,
@@ -1772,6 +1773,7 @@ fn sample_workspace_configuration() -> WorkspaceConfiguration {
 				changelog: Some(ChangelogTarget {
 					path: PathBuf::from("crates/monochange_core/changelog.md"),
 					format: ChangelogFormat::Monochange,
+					initial_header: None,
 				}),
 				excluded_changelog_types: Vec::new(),
 				empty_update_message: None,
@@ -1811,6 +1813,7 @@ fn sample_workspace_configuration() -> WorkspaceConfiguration {
 			changelog: Some(ChangelogTarget {
 				path: PathBuf::from("changelog.md"),
 				format: ChangelogFormat::Monochange,
+				initial_header: None,
 			}),
 			changelog_include: GroupChangelogInclude::All,
 			excluded_changelog_types: Vec::new(),

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -85,6 +85,11 @@ pub const DEFAULT_CHANGELOG_VERSION_TITLE_PRIMARY: &str =
 /// Default changelog version title for namespaced versioning (markdown-linked when source configured).
 pub const DEFAULT_CHANGELOG_VERSION_TITLE_NAMESPACED: &str = "{% if tag_url %}{{ id }} [{{ version }}]({{ tag_url }}){% else %}{{ id }} {{ version }}{% endif %} ({{ date }})";
 
+/// Default initial changelog header for the `monochange` changelog format.
+pub const DEFAULT_INITIAL_CHANGELOG_HEADER_MONOCHANGE: &str = "# Changelog\n\nAll notable changes to this project will be documented in this file.\n\nThis changelog is managed by [monochange](https://github.com/monochange/monochange).";
+/// Default initial changelog header for the `keep_a_changelog` changelog format.
+pub const DEFAULT_INITIAL_CHANGELOG_HEADER_KEEP_A_CHANGELOG: &str = "# Changelog\n\nAll notable changes to this project will be documented in this file.\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),\nand this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).";
+
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum MonochangeError {
@@ -1037,6 +1042,8 @@ pub struct ChangelogTarget {
 	pub path: PathBuf,
 	#[serde(default)]
 	pub format: ChangelogFormat,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub initial_header: Option<String>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/crates/monochange_dart/changelog.md
+++ b/crates/monochange_dart/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
-All notable changes to `monochange_dart` will be documented in this file.
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
 
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 

--- a/crates/monochange_deno/changelog.md
+++ b/crates/monochange_deno/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
-All notable changes to `monochange_deno` will be documented in this file.
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
 
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 

--- a/crates/monochange_ecmascript/changelog.md
+++ b/crates/monochange_ecmascript/changelog.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added

--- a/crates/monochange_gitea/changelog.md
+++ b/crates/monochange_gitea/changelog.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added

--- a/crates/monochange_github/changelog.md
+++ b/crates/monochange_github/changelog.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added

--- a/crates/monochange_gitlab/changelog.md
+++ b/crates/monochange_gitlab/changelog.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added

--- a/crates/monochange_graph/changelog.md
+++ b/crates/monochange_graph/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
-All notable changes to `monochange_graph` will be documented in this file.
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
 
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 

--- a/crates/monochange_hosting/changelog.md
+++ b/crates/monochange_hosting/changelog.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added

--- a/crates/monochange_lint/changelog.md
+++ b/crates/monochange_lint/changelog.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Breaking Change

--- a/crates/monochange_lint_testing/changelog.md
+++ b/crates/monochange_lint_testing/changelog.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## [0.2.0](https://github.com/ifiokjr/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added

--- a/crates/monochange_linting/changelog.md
+++ b/crates/monochange_linting/changelog.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added

--- a/crates/monochange_npm/changelog.md
+++ b/crates/monochange_npm/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
-All notable changes to `monochange_npm` will be documented in this file.
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
 
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 

--- a/crates/monochange_semver/changelog.md
+++ b/crates/monochange_semver/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
-All notable changes to `monochange_semver` will be documented in this file.
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
 
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 

--- a/crates/monochange_test_helpers/changelog.md
+++ b/crates/monochange_test_helpers/changelog.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## monochange_test_helpers [0.0.1](https://github.com/ifiokjr/monochange/releases/tag/monochange_test_helpers/v0.0.1) (2026-04-13)
 
 ### Fixes

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -91,6 +91,23 @@ Optional package fields:
 
 A package-level `changelog` value overrides the default for that package.
 
+The table form also accepts `initial_header`. monochange renders this Markdown only when a changelog file is created from empty content. Existing changelog preambles are preserved and are not rewritten on later releases. If `initial_header` is omitted or blank, monochange uses the selected format's built-in header: `keep_a_changelog` gets the Keep a Changelog/SemVer preamble, and `monochange` gets the monochange-managed preamble. Package and group changelog tables can override the default header.
+
+```toml
+[defaults.changelog]
+path = "{{ path }}/changelog.md"
+format = "keep_a_changelog"
+initial_header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+"""
+```
+
+`initial_header` templates can use release context such as `{{ monochange_version }}`, `{{ config_path }}`, `{{ monochange_config_path }}`, `{{ workspace_root }}`, `{{ changelog_path }}`, `{{ changelog_format }}`, `{{ package }}`, `{{ package_name }}`, `{{ package_id }}`, `{{ package_path }}`, `{{ group }}`, `{{ group_name }}`, `{{ group_id }}`, `{{ member_count }}`, `{{ members }}`, `{{ release_owner }}`, `{{ release_owner_kind }}`, `{{ version }}`, `{{ new_version }}`, and `{{ current_version }}`.
+
 `empty_update_message` lets changelog targets render a readable fallback entry when a version update is required but no direct release notes were recorded for that target. This is especially useful for grouped packages that keep their own changelog entries even when only another member of the group changed.
 
 `empty_update_message` can be set on:

--- a/dprint.json
+++ b/dprint.json
@@ -42,6 +42,8 @@
 		".devenv/**",
 		".tmp-node/**",
 		"**/fixtures",
+		"**/fixtures/**",
+		"fixtures/**",
 		"**/snapshots",
 		"**/target",
 		"**/node_modules",

--- a/fixtures/tests/config/changelog-format-tables/monochange.toml
+++ b/fixtures/tests/config/changelog-format-tables/monochange.toml
@@ -4,6 +4,7 @@ package_type = "cargo"
 [defaults.changelog]
 path = "{{ path }}/CHANGELOG.md"
 format = "keep_a_changelog"
+initial_header = "Default {{ release_owner }} changelog"
 
 [package.core]
 path = "crates/core"
@@ -14,6 +15,7 @@ path = "crates/app"
 [package.app.changelog]
 path = "docs/app-release-notes.md"
 format = "monochange"
+initial_header = "App {{ package_name }} changelog"
 
 [group.sdk]
 packages = ["core", "app"]

--- a/monochange.toml
+++ b/monochange.toml
@@ -50,15 +50,28 @@ package_type = "cargo"
 #   false                 → disable changelogs by default
 #   "{{ path }}/changelog.md" → pattern where {{ path }} is replaced with each package path
 #
-# As a table, you can set both path and format:
+# As a table, you can set path, format, and the initial header used when
+# monochange creates a changelog from empty content:
 #   [defaults.changelog]
 #   path = "{{ path }}/changelog.md"
 #   format = "keep_a_changelog"
+#   initial_header = """
+#   # Changelog
+#
+#   All notable changes to this project will be documented in this file.
+#   """
 #
 # Supported formats: "monochange" (default), "keep_a_changelog"
 [defaults.changelog]
 path = "{{ path }}/changelog.md"
 format = "keep_a_changelog"
+initial_header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+"""
 
 # Whether conflicting explicit versions from multiple changesets should fail
 # validation/planning instead of warning and using the highest semver version.

--- a/packages/monochange__cli-darwin-arm64/changelog.md
+++ b/packages/monochange__cli-darwin-arm64/changelog.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Changed

--- a/packages/monochange__cli-darwin-x64/changelog.md
+++ b/packages/monochange__cli-darwin-x64/changelog.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Changed

--- a/packages/monochange__cli-linux-arm64-gnu/changelog.md
+++ b/packages/monochange__cli-linux-arm64-gnu/changelog.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Changed

--- a/packages/monochange__cli-linux-arm64-musl/changelog.md
+++ b/packages/monochange__cli-linux-arm64-musl/changelog.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Changed

--- a/packages/monochange__cli-linux-x64-gnu/changelog.md
+++ b/packages/monochange__cli-linux-x64-gnu/changelog.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Changed

--- a/packages/monochange__cli-linux-x64-musl/changelog.md
+++ b/packages/monochange__cli-linux-x64-musl/changelog.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Changed

--- a/packages/monochange__cli-win32-arm64-msvc/changelog.md
+++ b/packages/monochange__cli-win32-arm64-msvc/changelog.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Changed

--- a/packages/monochange__cli-win32-x64-msvc/changelog.md
+++ b/packages/monochange__cli-win32-x64-msvc/changelog.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Changed

--- a/packages/monochange__cli/changelog.md
+++ b/packages/monochange__cli/changelog.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## [0.2.0](https://github.com/monochange/monochange/releases/tag/v0.2.0) (2026-04-21)
 
 ### Added

--- a/packages/monochange__skill/changelog.md
+++ b/packages/monochange__skill/changelog.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
 ## @monochange/skill [0.1.0](https://github.com/monochange/monochange/releases/tag/@monochange/skill/v0.1.0) (2026-04-13)
 
 ### Breaking changes


### PR DESCRIPTION
## Summary
- add configurable initial changelog headers for defaults, packages, and groups
- render format-specific default preambles only when creating empty changelogs
- update docs, snapshots, project changelog headers, and coverage tests

## Validation
- rebased on latest origin/main
- mc affected equivalent: `mc step:affected-packages --since $(git merge-base HEAD origin/main)` => monochange, monochange_config, monochange_core
- `devenv shell fix:all` passed
- `RUST_TEST_THREADS=1 devenv shell coverage:all && devenv shell coverage:patch` passed at 100% patch coverage
- `cargo fmt --all`
- `cargo test -q -p monochange build_changelog_updates --lib`
- `docs:check`
- `mc validate`
- `git diff --check`