### PR TITLE
fix: sync documented workflow commands

### DIFF
--- a/.changeset/documentation-sync-audit.md
+++ b/.changeset/documentation-sync-audit.md
@@ -1,0 +1,7 @@
+---
+monochange: patch
+---
+
+# Sync documented workflow commands with generated config
+
+Fix the generated `mc init` configuration so it no longer defines the reserved `[cli.validate]` command, restores the documented provider `release-pr` workflow command, and syncs the repository workflow examples with the config-defined commands documented in the README and guides.

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -607,7 +607,7 @@ The binary no longer ships a hidden default workflow set for commands such as `d
 
 `mc validate` remains a hardcoded binary command for normal preflight checks. The matching immutable step form is also available as `mc step:validate`. Do not define `[cli.validate]` or any `[cli.step:*]` command in `monochange.toml`; those names are reserved for built-in commands.
 
-Commands like `commit-release` combine `PrepareRelease` with later stateful steps such as `CommitRelease` and `OpenReleaseRequest`. Keep them as explicit `[cli.*]` workflow commands when you want a durable, named release process.
+Commands like `commit-release` combine `PrepareRelease` with later stateful steps such as `CommitRelease`. Provider request workflows such as `release-pr` can add `OpenReleaseRequest`. Keep both as explicit `[cli.*]` workflow commands when you want a durable, named release process.
 
 Current `PrepareRelease` behavior:
 

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -1082,7 +1082,7 @@ fn init_writes_detected_packages_groups_and_default_cli_commands() {
 	assert!(config.contains("[package.core]"));
 	assert!(config.contains("[package.web]"));
 	assert!(config.contains("[group.main]"));
-	assert!(config.contains("[cli.validate]"));
+	assert!(!config.contains("[cli.validate]"));
 	assert!(config.contains("[cli.discover]"));
 	assert!(config.contains("[cli.change]"));
 	assert!(config.contains("[cli.release]"));
@@ -1094,6 +1094,29 @@ fn init_writes_detected_packages_groups_and_default_cli_commands() {
 	assert!(config.contains("type = \"CreateChangeFile\""));
 	assert!(config.contains("type = \"PlaceholderPublish\""));
 	assert!(config.contains("type = \"PublishPackages\""));
+
+	load_workspace_configuration(tempdir.path())
+		.unwrap_or_else(|error| panic!("generated config should parse: {error}"));
+}
+
+#[test]
+fn init_writes_configuration_that_validates_in_empty_workspace() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+
+	run_cli(
+		tempdir.path(),
+		[OsString::from("mc"), OsString::from("init")],
+	)
+	.unwrap_or_else(|error| panic!("init output: {error}"));
+	let config = fs::read_to_string(tempdir.path().join("monochange.toml"))
+		.unwrap_or_else(|error| panic!("config: {error}"));
+
+	assert!(!config.contains("[cli.validate]"));
+	run_cli(
+		tempdir.path(),
+		[OsString::from("mc"), OsString::from("validate")],
+	)
+	.unwrap_or_else(|error| panic!("generated config should validate: {error}"));
 }
 
 #[test]
@@ -11859,6 +11882,10 @@ fn init_with_provider_writes_source_section_and_commit_release_command() {
 		"expected [cli.commit-release] command"
 	);
 	assert!(
+		config.contains("[cli.release-pr]"),
+		"expected [cli.release-pr] command"
+	);
+	assert!(
 		config.contains("type = \"PrepareRelease\""),
 		"expected PrepareRelease step"
 	);
@@ -11870,6 +11897,8 @@ fn init_with_provider_writes_source_section_and_commit_release_command() {
 		config.contains("type = \"OpenReleaseRequest\""),
 		"expected OpenReleaseRequest step"
 	);
+	load_workspace_configuration(tempdir.path())
+		.unwrap_or_else(|error| panic!("generated provider config should parse: {error}"));
 }
 
 #[test]

--- a/crates/monochange/src/monochange.init.toml
+++ b/crates/monochange/src/monochange.init.toml
@@ -741,13 +741,14 @@ ignored_paths = []
 #
 # Each [cli.<name>] table becomes a top-level `mc <name>` command.
 #
-# monochange starts from its built-in default command set. If you redefine a
-# built-in command like [cli.release], your definition fully replaces the
-# default for that command. You can delete unchanged built-in command tables
-# from your real monochange.toml and keep only the overrides you care about.
+# Workflow names such as `discover`, `change`, `release`, and `publish` come
+# from these generated tables. You can edit or delete them like any other
+# configuration. The underlying steps are always available directly as
+# immutable `mc step:*` commands.
 #
-# Reserved names that cannot be used include built-in commands such as
-# "analyze", "init", "mcp", "help", and "version"
+# Reserved names that cannot be used include hardcoded commands such as
+# "agent", "agents", "analyze", "check", "fix", "help", "init", "lint",
+# "lsp", "mcp", "skill", "skills", "subagents", "validate", and "version".
 #
 # Fields:
 #   help_text — description shown in `mc --help`
@@ -832,10 +833,6 @@ ignored_paths = []
 # CLI inputs are available as {{ inputs.name }} in command templates.
 {% endraw -%}
 
-[cli.validate]
-help_text = "Validate monochange configuration and changesets"
-steps = [{ name = "validate workspace", type = "Validate" }]
-
 [cli.discover]
 help_text = "Discover packages across supported ecosystems"
 inputs = [
@@ -849,6 +846,7 @@ inputs = [
 	{ name = "package", type = "string_list", required = true },
 	{ name = "bump", type = "choice", choices = ["none", "patch", "minor", "major"], default = "patch" },
 	{ name = "reason", type = "string", required = true },
+	{ name = "version", type = "string" },
 	{ name = "type", type = "string" },
 	{ name = "caused_by", type = "string_list" },
 	{ name = "details", type = "string" },
@@ -933,14 +931,23 @@ steps = [{ name = "retarget release", type = "RetargetRelease" }]
 {% if provider %}
 
 [cli.commit-release]
-help_text = "Prepare a release, commit it, and open or update a release PR"
+help_text = "Prepare a release and create a local release commit"
 inputs = [
 	{ name = "format", type = "choice", choices = ["text", "json"], default = "text" },
 ]
 steps = [
 	{ type = "PrepareRelease" },
 	{ type = "CommitRelease" },
-	{ type = "OpenReleaseRequest" },
+]
+
+[cli.release-pr]
+help_text = "Prepare a release and open a release pull request"
+inputs = [
+	{ name = "format", type = "choice", choices = ["text", "json", "markdown"], default = "markdown" },
+]
+steps = [
+	{ type = "PrepareRelease", name = "plan release" },
+	{ type = "OpenReleaseRequest", name = "open release PR" },
 ]
 
 [cli.publish-release]

--- a/docs/agents/changeset-quality.md
+++ b/docs/agents/changeset-quality.md
@@ -25,25 +25,25 @@ For any change that adds, removes, or modifies a CLI command or flag:
 
 The goal is to highlight the differences, not duplicate unchanged context.
 
-Example headline for a renamed flag:
+Example headline for a streamlined invocation:
 
-> #### rename `--changed-path` to `--changed-paths`
+> #### allow one `mc affected --changed-paths` flag to accept several paths
 
 Example body:
 
 > **Before:**
 >
 > ```bash
-> mc verify --changed-path src/lib.rs --changed-path crates/core/src/main.rs
+> mc affected --changed-paths src/lib.rs --changed-paths crates/core/src/main.rs
 > ```
 >
 > **After:**
 >
 > ```bash
-> mc verify --changed-paths src/lib.rs crates/core/src/main.rs
+> mc affected --changed-paths src/lib.rs crates/core/src/main.rs
 > ```
 >
-> `--changed-path` is kept as a hidden alias for one release cycle.
+> Repeated `--changed-paths` flags continue to work for compatibility.
 
 When the invocation is unchanged but the output changes, prefer a structure like this:
 
@@ -71,9 +71,9 @@ When the invocation is unchanged but the output changes, prefer a structure like
 
 When a command is **removed**, explain what users should do instead:
 
-> #### remove `mc deploy` command
+> #### remove legacy deployment workflow command
 >
-> Use your CI platform's native deployment triggers (e.g. a GitHub Actions `workflow_run` event on the release workflow) instead of the `Deploy` workflow step.
+> Use your CI platform's native deployment triggers (e.g. a GitHub Actions `workflow_run` event on the release workflow) instead of the legacy deployment wrapper.
 
 ## Library API changes
 

--- a/docs/src/guide/06-release-planning.md
+++ b/docs/src/guide/06-release-planning.md
@@ -224,7 +224,7 @@ The binary no longer ships a hidden default workflow set for commands such as `d
 
 `mc validate` remains a hardcoded binary command for normal preflight checks. The matching immutable step form is also available as `mc step:validate`. Do not define `[cli.validate]` or any `[cli.step:*]` command in `monochange.toml`; those names are reserved for built-in commands.
 
-Commands like `commit-release` combine `PrepareRelease` with later stateful steps such as `CommitRelease` and `OpenReleaseRequest`. Keep them as explicit `[cli.*]` workflow commands when you want a durable, named release process.
+Commands like `commit-release` combine `PrepareRelease` with later stateful steps such as `CommitRelease`. Provider request workflows such as `release-pr` can add `OpenReleaseRequest`. Keep both as explicit `[cli.*]` workflow commands when you want a durable, named release process.
 
 Current `PrepareRelease` behavior:
 

--- a/monochange.toml
+++ b/monochange.toml
@@ -656,7 +656,9 @@ verified_commits = true
 #
 # Each [cli.<name>] table becomes a top-level `mc <name>` command.
 #
-# Reserved names that cannot be used: "init", "help", "version"
+# Reserved names that cannot be used include hardcoded commands such as
+# "agent", "agents", "analyze", "check", "fix", "help", "init", "lint",
+# "lsp", "mcp", "skill", "skills", "subagents", "validate", and "version".
 #
 # Fields:
 #   help_text — description shown in `mc --help`
@@ -698,6 +700,81 @@ verified_commits = true
 # Command templates can also use {{ inputs.name }} for CLI inputs.
 # {{ version }}, {{ group_version }}, {{ released_packages }}, {{changed_files}}, {{ changesets }}
 
+[cli.discover]
+help_text = "Discover packages across supported ecosystems"
+inputs = [
+	{ name = "format", type = "choice", choices = ["text", "json"], default = "text" },
+]
+steps = [{ name = "discover packages", type = "Discover" }]
+
+[cli.change]
+help_text = "Create a change file for one or more packages"
+inputs = [
+	{ name = "package", type = "string_list", required = true },
+	{ name = "bump", type = "choice", choices = ["none", "patch", "minor", "major"], default = "patch" },
+	{ name = "reason", type = "string", required = true },
+	{ name = "version", type = "string" },
+	{ name = "type", type = "string" },
+	{ name = "caused_by", type = "string_list" },
+	{ name = "details", type = "string" },
+	{ name = "output", type = "path" },
+]
+steps = [{ name = "create change file", type = "CreateChangeFile" }]
+
+[cli.versions]
+help_text = "Display planned package and group versions from discovered change files"
+inputs = [
+	{ name = "format", type = "choice", choices = ["text", "markdown", "json"], default = "text" },
+]
+steps = [{ name = "display versions", type = "DisplayVersions" }]
+
+[cli.placeholder-publish]
+help_text = "Publish placeholder package versions for missing registry packages"
+inputs = [
+	{ name = "format", type = "choice", choices = ["text", "markdown", "json"], default = "text" },
+	{ name = "package", type = "string_list" },
+]
+steps = [{ name = "publish placeholder packages", type = "PlaceholderPublish" }]
+
+[cli.publish-plan]
+help_text = "Plan package-registry publish work against known ecosystem rate limits"
+inputs = [
+	{ name = "format", type = "choice", choices = ["text", "markdown", "json"], default = "text" },
+	{ name = "mode", type = "choice", choices = ["publish", "placeholder"], default = "publish" },
+	{ name = "package", type = "string_list" },
+	{ name = "readiness", type = "path", help_text = "JSON artifact from mc publish-readiness; limits publish plans to ready package work" },
+	{ name = "ci", type = "choice", choices = ["github-actions", "gitlab-ci"] },
+]
+steps = [{ name = "plan publish rate limits", type = "PlanPublishRateLimits" }]
+
+[cli.affected]
+help_text = "Evaluate pull-request changeset policy"
+inputs = [
+	{ name = "format", type = "choice", choices = ["text", "json"], default = "text" },
+	{ name = "changed_paths", type = "string_list", required = true },
+	{ name = "label", type = "string_list" },
+]
+steps = [{ name = "evaluate affected packages", type = "AffectedPackages" }]
+
+[cli.diagnostics]
+help_text = "Show changeset diagnostics and context"
+inputs = [
+	{ name = "format", type = "choice", choices = ["text", "json"], default = "text" },
+	{ name = "changeset", type = "string_list", help_text = "changeset path(s), e.g. .changeset/feature.md (omit for all changesets)" },
+]
+steps = [{ name = "diagnose changesets", type = "DiagnoseChangesets" }]
+
+[cli.repair-release]
+help_text = "Repair a recent release by moving its release tags to a later commit"
+inputs = [
+	{ name = "from", type = "string", help_text = "tag or commit-ish used to locate the release record", required = true },
+	{ name = "target", type = "string", help_text = "commit-ish the release set should move to", default = "HEAD" },
+	{ name = "force", type = "boolean", help_text = "allow non-descendant retargets", default = false },
+	{ name = "sync_provider", type = "boolean", help_text = "sync hosted release state after tag movement (disable with --sync-provider=false)", default = true },
+	{ name = "format", type = "choice", choices = ["text", "json"], default = "text" },
+]
+steps = [{ name = "retarget release", type = "RetargetRelease" }]
+
 [cli.release]
 help_text = "Prepare a release from discovered change files"
 inputs = [
@@ -730,6 +807,16 @@ steps = [
 	{ type = "Command", name = "refresh shared markdown", command = "mdt update" },
 	{ type = "CommitRelease", name = "create release commit", inputs = { no_verify = "{{ inputs.no_verify }}" } },
 	{ type = "OpenReleaseRequest", name = "create the pr", inputs = { no_verify = "{{ inputs.no_verify }}" } },
+]
+
+[cli.commit-release]
+help_text = "Prepare a release and create a local release commit"
+inputs = [
+	{ name = "format", type = "choice", choices = ["text", "json"], default = "text" },
+]
+steps = [
+	{ type = "PrepareRelease" },
+	{ type = "CommitRelease" },
 ]
 
 [cli.publish-release]


### PR DESCRIPTION
## Summary
- sync documented workflow commands with generated/root configuration
- stop generating reserved [cli.validate] config and validate generated init output
- restore the provider-generated release-pr workflow used by generated GitHub release automation

## Validation
- devenv shell fix:all
- devenv shell test:all
- devenv shell docs:check
- devenv shell mc validate
- cargo fmt --all -- --check
- git diff --check
- ad-hoc markdown mc command/flag scanner
- temp-repo mc init + mc validate
- temp-repo mc init --provider github + mc validate + mc release-pr --help