### PR TITLE
fix: rename monochange_telemtry crate to monochange_telemetry

### DIFF
--- a/.changeset/local-telemetry.md
+++ b/.changeset/local-telemetry.md
@@ -1,7 +1,7 @@
 ---
 "@monochange/cli": patch
 "monochange": patch
-"monochange_telemtry": patch
+"monochange_telemetry": patch
 ---
 
 # Add local-only telemetry events

--- a/.templates/crates.t.md
+++ b/.templates/crates.t.md
@@ -682,9 +682,9 @@ Reach for this crate when you are writing integration or fixture-heavy tests tha
 
 <!-- {/monochangeTestHelpersCrateDocs} -->
 
-<!-- {@monochangeTelemtryCrateDocs} -->
+<!-- {@monochangeTelemetryCrateDocs} -->
 
-`monochange_telemtry` provides local-only telemetry primitives for the `monochange` CLI.
+`monochange_telemetry` provides local-only telemetry primitives for the `monochange` CLI.
 
 Reach for this crate when you need the reusable event sink, event payloads, and privacy-preserving error classification that power opt-in local JSONL telemetry. The crate intentionally keeps transport simple: it appends OpenTelemetry-style JSON Lines records to a local file and does not send telemetry over the network.
 
@@ -715,9 +715,9 @@ The crate only accepts low-cardinality command metadata, booleans, counts, durat
 ## Example
 
 ```rust
-use monochange_telemtry::CommandTelemetry;
-use monochange_telemtry::TelemetryOutcome;
-use monochange_telemtry::TelemetrySink;
+use monochange_telemetry::CommandTelemetry;
+use monochange_telemetry::TelemetryOutcome;
+use monochange_telemetry::TelemetrySink;
 use std::time::Duration;
 
 let sink = TelemetrySink::Disabled;
@@ -733,4 +733,4 @@ sink.capture_command(CommandTelemetry {
 });
 ```
 
-<!-- {/monochangeTelemtryCrateDocs} -->
+<!-- {/monochangeTelemetryCrateDocs} -->

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -32,8 +32,8 @@ Use it when your repository has outgrown one-ecosystem release tooling and you w
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__github-orange?logo=rust)](https://crates.io/crates/monochange_github) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__github-1f425f?logo=docs.rs)](https://docs.rs/monochange_github/)
 - `monochange_semver` — merges requested bumps with compatibility-provider evidence.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__semver-orange?logo=rust)](https://crates.io/crates/monochange_semver) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__semver-1f425f?logo=docs.rs)](https://docs.rs/monochange_semver/)
-- `monochange_telemtry` — local-only telemetry event sink and privacy-preserving event schema helpers.
-  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__telemtry-orange?logo=rust)](https://crates.io/crates/monochange_telemtry) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__telemtry-1f425f?logo=docs.rs)](https://docs.rs/monochange_telemtry/)
+- `monochange_telemetry` — local-only telemetry event sink and privacy-preserving event schema helpers.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__telemetry-orange?logo=rust)](https://crates.io/crates/monochange_telemetry) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__telemetry-1f425f?logo=docs.rs)](https://docs.rs/monochange_telemetry/)
 - `monochange_cargo` — Cargo discovery plus Rust semver evidence integration.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__cargo-orange?logo=rust)](https://crates.io/crates/monochange_cargo) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__cargo-1f425f?logo=docs.rs)](https://docs.rs/monochange_cargo/)
 - `monochange_npm` — npm, pnpm, and Bun workspace discovery.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2062,7 +2062,7 @@ dependencies = [
  "monochange_npm",
  "monochange_python",
  "monochange_semver",
- "monochange_telemtry",
+ "monochange_telemetry",
  "monochange_test_helpers",
  "portable-pty",
  "rayon",
@@ -2440,7 +2440,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "monochange_telemtry"
+name = "monochange_telemetry"
 version = "0.2.0"
 dependencies = [
  "monochange_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ monochange_linting = { version = "0.2.0", path = "./crates/monochange_linting" }
 monochange_npm = { version = "0.2.0", path = "./crates/monochange_npm" }
 monochange_python = { version = "0.2.0", path = "./crates/monochange_python" }
 monochange_semver = { version = "0.2.0", path = "./crates/monochange_semver" }
-monochange_telemtry = { version = "0.2.0", path = "./crates/monochange_telemtry" }
+monochange_telemetry = { version = "0.2.0", path = "./crates/monochange_telemetry" }
 monochange_test_helpers = { version = "0.0.2", path = "./crates/monochange_test_helpers" }
 
 [workspace.metadata.bin]

--- a/crates/monochange/Cargo.toml
+++ b/crates/monochange/Cargo.toml
@@ -55,7 +55,7 @@ monochange_lint = { workspace = true }
 monochange_npm = { workspace = true, optional = true }
 monochange_python = { workspace = true, optional = true }
 monochange_semver = { workspace = true }
-monochange_telemtry = { workspace = true }
+monochange_telemetry = { workspace = true }
 rayon = { workspace = true, default-features = true }
 regex = { workspace = true, default-features = true }
 reqwest = { workspace = true, default-features = true, features = ["blocking"] }

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -31,10 +31,10 @@ use monochange_core::SourceChangeRequestOutcome;
 use monochange_core::SourceConfiguration;
 use monochange_core::SourceReleaseOutcome;
 use monochange_core::SourceReleaseRequest;
-use monochange_telemtry::CommandTelemetry;
-use monochange_telemtry::StepTelemetry;
-use monochange_telemtry::TelemetryOutcome;
-use monochange_telemtry::TelemetrySink;
+use monochange_telemetry::CommandTelemetry;
+use monochange_telemetry::StepTelemetry;
+use monochange_telemetry::TelemetryOutcome;
+use monochange_telemetry::TelemetrySink;
 use serde::Serialize;
 
 use crate::cli::command_supports_release_diff_preview;

--- a/crates/monochange_telemetry/Cargo.toml
+++ b/crates/monochange_telemetry/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "monochange_telemtry"
+name = "monochange_telemetry"
 version = { workspace = true }
 authors = { workspace = true }
 categories = { workspace = true }
-documentation = "https://docs.rs/monochange_telemtry"
+documentation = "https://docs.rs/monochange_telemetry"
 edition = { workspace = true }
 homepage = { workspace = true }
 include = ["src/**/*.rs", "tests/**/*.rs", "Cargo.toml", "readme.md"]

--- a/crates/monochange_telemetry/readme.md
+++ b/crates/monochange_telemetry/readme.md
@@ -1,18 +1,18 @@
-# `monochange_telemtry`
+# `monochange_telemetry`
 
 <br />
 
-<!-- {=crateReadmeBadgeRow:"monochange_telemtry"} -->
+<!-- {=crateReadmeBadgeRow:"monochange_telemetry"} -->
 
-[![Crates.io](https://img.shields.io/badge/crates.io-monochange**telemtry-orange?logo=rust)](https://crates.io/crates/monochange_telemtry) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange**telemtry-1f425f?logo=docs.rs)](https://docs.rs/monochange_telemtry/) [![CI](https://github.com/monochange/monochange/actions/workflows/ci.yml/badge.svg)](https://github.com/monochange/monochange/actions/workflows/ci.yml) [![Coverage](https://codecov.io/gh/monochange/monochange/branch/main/graph/badge.svg?flag=monochange_telemtry)](https://codecov.io/gh/monochange/monochange?flag=monochange_telemtry) [![License](https://img.shields.io/badge/license-Unlicense-blue.svg)](https://opensource.org/license/unlicense)
+[![Crates.io](https://img.shields.io/badge/crates.io-monochange**telemetry-orange?logo=rust)](https://crates.io/crates/monochange_telemetry) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange**telemetry-1f425f?logo=docs.rs)](https://docs.rs/monochange_telemetry/) [![CI](https://github.com/monochange/monochange/actions/workflows/ci.yml/badge.svg)](https://github.com/monochange/monochange/actions/workflows/ci.yml) [![Coverage](https://codecov.io/gh/monochange/monochange/branch/main/graph/badge.svg?flag=monochange_telemetry)](https://codecov.io/gh/monochange/monochange?flag=monochange_telemetry) [![License](https://img.shields.io/badge/license-Unlicense-blue.svg)](https://opensource.org/license/unlicense)
 
 <!-- {/crateReadmeBadgeRow} -->
 
 <br />
 
-<!-- {=monochangeTelemtryCrateDocs} -->
+<!-- {=monochangeTelemetryCrateDocs} -->
 
-`monochange_telemtry` provides local-only telemetry primitives for the `monochange` CLI.
+`monochange_telemetry` provides local-only telemetry primitives for the `monochange` CLI.
 
 Reach for this crate when you need the reusable event sink, event payloads, and privacy-preserving error classification that power opt-in local JSONL telemetry. The crate intentionally keeps transport simple: it appends OpenTelemetry-style JSON Lines records to a local file and does not send telemetry over the network.
 
@@ -43,9 +43,9 @@ The crate only accepts low-cardinality command metadata, booleans, counts, durat
 ## Example
 
 ```rust
-use monochange_telemtry::CommandTelemetry;
-use monochange_telemtry::TelemetryOutcome;
-use monochange_telemtry::TelemetrySink;
+use monochange_telemetry::CommandTelemetry;
+use monochange_telemetry::TelemetryOutcome;
+use monochange_telemetry::TelemetrySink;
 use std::time::Duration;
 
 let sink = TelemetrySink::Disabled;
@@ -61,4 +61,4 @@ sink.capture_command(CommandTelemetry {
 });
 ```
 
-<!-- {/monochangeTelemtryCrateDocs} -->
+<!-- {/monochangeTelemetryCrateDocs} -->

--- a/crates/monochange_telemetry/src/lib.rs
+++ b/crates/monochange_telemetry/src/lib.rs
@@ -1,7 +1,7 @@
-//! # `monochange_telemtry`
+//! # `monochange_telemetry`
 //!
-//! <!-- {=monochangeTelemtryCrateDocs|trim|linePrefix:"//! ":true} -->
-//! `monochange_telemtry` provides local-only telemetry primitives for the `monochange` CLI.
+//! <!-- {=monochangeTelemetryCrateDocs|trim|linePrefix:"//! ":true} -->
+//! `monochange_telemetry` provides local-only telemetry primitives for the `monochange` CLI.
 //!
 //! Reach for this crate when you need the reusable event sink, event payloads, and privacy-preserving error classification that power opt-in local JSONL telemetry. The crate intentionally keeps transport simple: it appends OpenTelemetry-style JSON Lines records to a local file and does not send telemetry over the network.
 //!
@@ -32,9 +32,9 @@
 //! ## Example
 //!
 //! ```rust
-//! use monochange_telemtry::CommandTelemetry;
-//! use monochange_telemtry::TelemetryOutcome;
-//! use monochange_telemtry::TelemetrySink;
+//! use monochange_telemetry::CommandTelemetry;
+//! use monochange_telemetry::TelemetryOutcome;
+//! use monochange_telemetry::TelemetrySink;
 //! use std::time::Duration;
 //!
 //! let sink = TelemetrySink::Disabled;
@@ -49,7 +49,7 @@
 //!     error: None,
 //! });
 //! ```
-//! <!-- {/monochangeTelemtryCrateDocs} -->
+//! <!-- {/monochangeTelemetryCrateDocs} -->
 
 use std::collections::BTreeMap;
 use std::env;

--- a/crates/monochange_telemetry/tests/local_jsonl.rs
+++ b/crates/monochange_telemetry/tests/local_jsonl.rs
@@ -1,10 +1,10 @@
 use std::time::Duration;
 
 use monochange_core::MonochangeError;
-use monochange_telemtry::CommandTelemetry;
-use monochange_telemtry::StepTelemetry;
-use monochange_telemtry::TelemetryOutcome;
-use monochange_telemtry::TelemetrySink;
+use monochange_telemetry::CommandTelemetry;
+use monochange_telemetry::StepTelemetry;
+use monochange_telemetry::TelemetryOutcome;
+use monochange_telemetry::TelemetrySink;
 use serde_json::Value;
 
 #[test]

--- a/docs/plans/active/telemetry-research.md
+++ b/docs/plans/active/telemetry-research.md
@@ -159,7 +159,7 @@ Start with a **small internal telemetry abstraction** and defer vendor lock-in.
 
 Recommended first implementation shape:
 
-1. Add a dedicated telemetry crate, `crates/monochange_telemtry`, and import it from the main `monochange` crate.
+1. Add a dedicated telemetry crate, `crates/monochange_telemetry`, and import it from the main `monochange` crate.
 2. Define a `TelemetrySink` trait with a no-op implementation as the default.
 3. Define documented event structs/enums for command, step, discovery, release, and publish events.
 4. Gate all collection behind explicit opt-in configuration and `MC_TELEMETRY`.

--- a/monochange.toml
+++ b/monochange.toml
@@ -268,8 +268,8 @@ path = "crates/monochange_graph"
 [package.monochange_semver]
 path = "crates/monochange_semver"
 
-[package.monochange_telemtry]
-path = "crates/monochange_telemtry"
+[package.monochange_telemetry]
+path = "crates/monochange_telemetry"
 
 [package.monochange_github]
 path = "crates/monochange_github"
@@ -396,7 +396,7 @@ packages = [
 	"monochange_go",
 	"monochange_graph",
 	"monochange_semver",
-	"monochange_telemtry",
+	"monochange_telemetry",
 	"monochange_github",
 	"monochange_gitlab",
 	"monochange_gitea",

--- a/packages/monochange__cli/README.md
+++ b/packages/monochange__cli/README.md
@@ -204,8 +204,8 @@ See [Advanced: Assistant setup and MCP](docs/src/guide/09-assistant-setup.md) fo
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__github-orange?logo=rust)](https://crates.io/crates/monochange_github) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__github-1f425f?logo=docs.rs)](https://docs.rs/monochange_github/)
 - `monochange_semver` — merges requested bumps with compatibility-provider evidence.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__semver-orange?logo=rust)](https://crates.io/crates/monochange_semver) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__semver-1f425f?logo=docs.rs)](https://docs.rs/monochange_semver/)
-- `monochange_telemtry` — local-only telemetry event sink and privacy-preserving event schema helpers.
-  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__telemtry-orange?logo=rust)](https://crates.io/crates/monochange_telemtry) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__telemtry-1f425f?logo=docs.rs)](https://docs.rs/monochange_telemtry/)
+- `monochange_telemetry` — local-only telemetry event sink and privacy-preserving event schema helpers.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__telemetry-orange?logo=rust)](https://crates.io/crates/monochange_telemetry) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__telemetry-1f425f?logo=docs.rs)](https://docs.rs/monochange_telemetry/)
 - `monochange_cargo` — Cargo discovery plus Rust semver evidence integration.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__cargo-orange?logo=rust)](https://crates.io/crates/monochange_cargo) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__cargo-1f425f?logo=docs.rs)](https://docs.rs/monochange_cargo/)
 - `monochange_npm` — npm, pnpm, and Bun workspace discovery.

--- a/readme.md
+++ b/readme.md
@@ -288,8 +288,8 @@ See [Advanced: Assistant setup and MCP](docs/src/guide/09-assistant-setup.md) fo
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__github-orange?logo=rust)](https://crates.io/crates/monochange_github) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__github-1f425f?logo=docs.rs)](https://docs.rs/monochange_github/)
 - `monochange_semver` — merges requested bumps with compatibility-provider evidence.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__semver-orange?logo=rust)](https://crates.io/crates/monochange_semver) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__semver-1f425f?logo=docs.rs)](https://docs.rs/monochange_semver/)
-- `monochange_telemtry` — local-only telemetry event sink and privacy-preserving event schema helpers.
-  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__telemtry-orange?logo=rust)](https://crates.io/crates/monochange_telemtry) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__telemtry-1f425f?logo=docs.rs)](https://docs.rs/monochange_telemtry/)
+- `monochange_telemetry` — local-only telemetry event sink and privacy-preserving event schema helpers.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__telemetry-orange?logo=rust)](https://crates.io/crates/monochange_telemetry) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__telemetry-1f425f?logo=docs.rs)](https://docs.rs/monochange_telemetry/)
 - `monochange_cargo` — Cargo discovery plus Rust semver evidence integration.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__cargo-orange?logo=rust)](https://crates.io/crates/monochange_cargo) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__cargo-1f425f?logo=docs.rs)](https://docs.rs/monochange_cargo/)
 - `monochange_npm` — npm, pnpm, and Bun workspace discovery.


### PR DESCRIPTION
This PR renames the "monochange_telemtry" crate (and folder) to "monochange_telemetry" to fix the spelling typo. All references across the codebase, workspace manifests, templates, and documentation have been updated.