### PR TITLE
fix: harden release pipeline and remove npm publish from populate script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,6 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'monochange'
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    environment: publisher
     permissions:
       contents: write
       pull-requests: write
@@ -431,20 +430,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: mc publish-release --from-ref="HEAD" --draft --format json | tee /tmp/publish-release.json
-        shell: devenv shell -- bash -e {0}
-
-      - name: upload release assets to drafts
-        if: steps.tag_release.outputs.is_release_commit == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          tag="$(mc release-record --from HEAD --format json --jq '.record.releaseTargets[] | select(.id == "main" and .kind == "group" and .release == true) | .tagName')"
-          gh workflow run release.yml \
-            --repo "${{ github.repository }}" \
-            --ref "main" \
-            -f "tag=${tag}"
         shell: devenv shell -- bash -e {0}
 
       - name: comment on released issues

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,12 +73,6 @@ jobs:
             --assets-dir "$RUNNER_TEMP/release-assets"
         shell: devenv shell -- bash -e {0}
 
-      - name: publish cli npm packages
-        run: |
-          node scripts/npm/publish-packages.mjs \
-            --packages-dir packages
-        shell: devenv shell -- bash -e {0}
-
       - name: plan publish batches
         id: publish_plan
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,6 +71,8 @@ jobs:
           node scripts/npm/build-packages.mjs \
             --release-tag "$RELEASE_TAG" \
             --assets-dir "$RUNNER_TEMP/release-assets"
+          node scripts/npm/populate-packages.mjs \
+            --packages-dir packages
         shell: devenv shell -- bash -e {0}
 
       - name: plan publish batches

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ packages/monochange__cli-win32-x64-msvc/bin/
 packages/monochange__cli-win32-arm64-msvc/bin/
 packages/.tmp/
 .tmp-test-build-packages/
-.tmp-test-publish-packages/
+.tmp-test-populate-packages/
 **/dist/**
 node_modules/
 

--- a/docs/agents/release-checklist.md
+++ b/docs/agents/release-checklist.md
@@ -1,0 +1,88 @@
+# Release prerequisites checklist
+
+A pre-release verification list for agents working on the monochange repository. Run every item before cutting a release. Fix any blockers before proceeding.
+
+## 1. Placeholder publishing
+
+New crates that do not yet exist on their target registry must be placeholder-published before the main release can succeed. Crates.io rejects publications when the crate name is completely unknown; a placeholder version (typically `0.0.0`) reserves the name and lets subsequent real versions through.
+
+- [ ] Identify every package in `monochange.toml` whose registry entry does not yet exist. Run `cargo search <crate>` for each cargo package, and `npm view <pkg> version` for each npm package. Anything that returns "not found" needs a placeholder.
+- [ ] For each missing crate, verify its `Cargo.toml` does **not** have `publish = false`. If it does, the crate is intentionally private and should also have `tag = false, release = false, changelog = false` in `monochange.toml`.
+- [ ] Run `mc placeholder-publish` to publish placeholder versions for every missing package. This step is manual and must happen **before** the release PR is merged.
+- [ ] Verify placeholders landed: re-run the registry search for each crate.
+
+**Why it matters.** If a new crate is in the release group (`tag = true`, `release = true`) but has no registry entry, the publish job will fail partway through. crates.io will 404 on the crate name, and the remaining batches never execute.
+
+## 2. Group and package consistency
+
+- [ ] Every package in a release group (`tag = true` / `release = true`) must be publishable on its registry. Packages with `publish = false` in their manifest should have `tag = false`, `release = false`, and `changelog = false` in `monochange.toml`, and should ideally not be members of a release group at all.
+- [ ] Run `mc validate` and confirm no warnings about group members that contradict their package manifests.
+- [ ] Check that `defaults.include_private` in `monochange.toml` is set correctly (currently `false`), and that no private package accidentally appears in a release group.
+
+## 3. Batched publisher readiness
+
+- [ ] Run `mc publish-plan --mode publish --format json` locally and inspect the output. Confirm that:
+  - Every expected package appears in the plan.
+  - Crate batches respect crates.io rate limits (1 new crate / 5 min, or OIDC-provenance batch limits).
+  - npm platform packages are **excluded** from the `mc publish-plan` output if they are no longer published by this script (npm publishing is now handled by `mc publish`).
+- [ ] If crates.io OIDC trusted publishing is used (which it should be), confirm the publish job runs in the `publisher` environment with `id-token: write` permission.
+- [ ] Confirm the publish matrix gracefully handles zero batches (no packages to publish) without failing the workflow.
+
+## 4. CI workflow flow verification
+
+```text
+push to main → ci.yml (release-pr) → manual merge → release-pr-merge.yml
+  → push to main → ci.yml (release-post-merge: tag + draft release)
+  → tag push → release.yml (cross-compile, upload assets, draft release)
+  → publish.yml (build npm packages, plan batches, publish cargo batches)
+```
+
+- [ ] Verify each step above is present and triggered by the correct event.
+- [ ] Confirm `mc release-record --from HEAD` correctly detects a release commit after merge (the `release-post-merge` job gates on this).
+- [ ] Confirm tag push triggers `release.yml` automatically (`on: push: tags: "v*"`).
+- [ ] Verify concurrency groups prevent duplicate runs without silently canceling important work.
+
+## 5. npm publishing flow
+
+npm packages are handled differently from cargo crates. Platform-specific npm packages (`@monochange/cli-darwin-arm64`, etc.) and the main CLI wrapper (`@monochange/cli`) are built and populated by `scripts/npm/populate-packages.mjs` inside the `publish.yml` **plan** job. They are now published by `mc publish` alongside cargo crates in the **publish** job.
+
+- [ ] Confirm `scripts/npm/build-packages.mjs` runs **before** `scripts/npm/populate-packages.mjs` so binaries are populated.
+- [ ] Confirm `scripts/npm/populate-packages.mjs` validates binary presence before populate.
+- [ ] Verify that `mc publish-plan` does **not** re-include npm packages in its batch output for a second publish attempt. If `mc publish-plan` cannot filter by ecosystem, pass `--package` flags to exclude npm packages from the cargo publish.
+
+## 6. Trusted publishing and OIDC
+
+- [ ] crates.io: the `publish.yml` workflow uses `rust-lang/crates-io-auth-action@v1` for OIDC. Confirm the `publisher` environment has `id-token: write` permission and no additional restrictions that block the OIDC flow.
+- [ ] npm: trusted publishing relies on GitHub Actions OIDC. Confirm the `publish` job has `id-token: write` permission.
+- [ ] Confirm no long-lived `CARGO_REGISTRY_TOKEN`, `NODE_AUTH_TOKEN`, or `NPM_TOKEN` secrets are set in the repository or environment. These would bypass OIDC and lose provenance benefits.
+
+## 7. Environment gates
+
+- [ ] The `publisher` GitHub environment should require approval **only** for jobs that actually publish (the `publish.yml` publish job).
+- [ ] The `ci.yml` `release-pr` job should **not** use the `publisher` environment. It only creates a PR and does not publish anything.
+- [ ] Verify the `release-pr-merge.yml` workflow's `RELEASE_PR_MERGE_TOKEN` secret is available outside the `publisher` environment (it uses `secrets.RELEASE_PR_MERGE_TOKEN` directly, not through an environment).
+
+## 8. Changeset and version validation
+
+- [ ] Run `mc validate` and fix any errors or warnings.
+- [ ] Run `lint:monochange` (devenv script) and fix any lint errors.
+- [ ] Check that every changeset targeting a new package uses `major` (not `patch`) for the first release of that package.
+- [ ] Verify the `main` group's `version_format = "primary"` is set — only one package or group may use `"primary"` and it produces the top-level `vX.Y.Z` tag.
+- [ ] Verify `versioned_files` in the group entry covers all files that need version bumps (currently `Cargo.toml` with `workspace.package.version`).
+
+## 9. Asset build and attestation
+
+- [ ] `release.yml` cross-compiles for all targets in the matrix. Verify the target list matches what npm platform packages expect (`darwin-arm64`, `darwin-x64`, `linux-arm64-gnu`, `linux-arm64-musl`, `linux-x64-gnu`, `linux-x64-musl`, `win32-x64-msvc`, `win32-arm64-msvc`).
+- [ ] Verify `taiki-e/upload-rust-binary-action` is configured with `archive: "$bin-$target-$tag"` — the download step in `publish.yml` matches this pattern (`monochange-*-${RELEASE_TAG}.tar.gz` / `.zip`).
+- [ ] Build attestations (`actions/attest-build-provenance@v3`) and verification steps exist and pass.
+
+## 10. Post-release verification
+
+- [ ] Confirm the GitHub Release is non-draft and marked as latest.
+- [ ] Confirm all cross-compiled binaries appear as release assets.
+- [ ] Confirm crate versions are live on crates.io (`cargo search monochange`).
+- [ ] Confirm npm packages are live on npmjs.com (`npm view @monochange/cli version`).
+- [ ] Confirm tags exist in the repo for each release target.
+- [ ] Confirm `mc release-record --from HEAD` shows the release record as resolved.
+- [ ] Confirm issues referenced in changesets received close/comment notifications.
+- [ ] Confirm docs deployed to GitHub Pages (if applicable).

--- a/monochange.toml
+++ b/monochange.toml
@@ -300,6 +300,9 @@ path = "crates/monochange_linting"
 
 [package.monochange_lint_testing]
 path = "crates/monochange_lint_testing"
+tag = false
+release = false
+changelog = false
 
 [package."@monochange/skill"]
 path = "packages/monochange__skill"

--- a/scripts/npm/populate-packages.mjs
+++ b/scripts/npm/populate-packages.mjs
@@ -79,14 +79,6 @@ export function packageMetadata(dir) {
 	return JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
 }
 
-export function packageExists(name, version) {
-	const result = _spawnSync("npm", ["view", `${name}@${version}`, "version", "--json"], {
-		encoding: "utf8",
-		stdio: "pipe",
-	});
-	return result.status === 0;
-}
-
 export function hasBinary(dir) {
 	const binDir = join(dir, "bin");
 	if (!existsSync(binDir)) {
@@ -135,54 +127,35 @@ export function assertTrustedPublishingContext(env = process.env) {
 	}
 }
 
-export function npmPublishEnv(env = process.env) {
-	const publishEnv = { ...env };
-	for (const key of FORBIDDEN_NPM_TOKEN_ENV_KEYS) {
-		delete publishEnv[key];
-	}
-	publishEnv.NPM_CONFIG_PROVENANCE = "true";
-	return publishEnv;
-}
-
-export function publishPackage(dir, options = {}) {
-	const env = options.env ?? process.env;
-	const pkg = packageMetadata(dir);
-	if (hasBinary(dir) === false) {
-		throw new Error(
-			`Cannot publish ${pkg.name}@${pkg.version}: no binary found in ${join(dir, "bin")}. ` +
-				"Run build-packages.mjs first to populate platform binaries.",
-		);
-	}
-
-	assertTrustedPublishingContext(env);
-
-	if (packageExists(pkg.name, pkg.version)) {
-		console.log(`Skipping ${pkg.name}@${pkg.version}; already published.`);
-		return;
-	}
-
-	console.log(`Publishing ${pkg.name}@${pkg.version} with npm trusted publishing...`);
-	run("npm", ["publish", "--access", "public", "--provenance"], {
-		cwd: dir,
-		stdio: "inherit",
-		env: npmPublishEnv(env),
-	});
-}
-
-export function main(argv = process.argv.slice(2), options = {}) {
+export function main(argv = process.argv.slice(2)) {
 	const args = parseArgs(argv);
 	if (!args["packages-dir"]) {
-		throw new Error("usage: publish-packages.mjs --packages-dir <dir>");
+		throw new Error("usage: populate-packages.mjs --packages-dir <dir>");
 	}
 
 	const packagesDir = resolve(args["packages-dir"]);
 
-	const env = options.env ?? process.env;
 	for (const dirName of PLATFORM_PACKAGE_DIRS) {
-		publishPackage(join(packagesDir, dirName), { env });
+		const dir = join(packagesDir, dirName);
+		const pkg = packageMetadata(dir);
+		if (hasBinary(dir) === false) {
+			throw new Error(
+				`Cannot populate ${pkg.name}@${pkg.version}: no binary found in ${join(dir, "bin")}. ` +
+					"Run build-packages.mjs first to populate platform binaries.",
+			);
+		}
+		console.log(`Populated ${pkg.name}@${pkg.version}`);
 	}
 
-	publishPackage(join(packagesDir, CLI_PACKAGE_DIR), { env });
+	const cliDir = join(packagesDir, CLI_PACKAGE_DIR);
+	const cliPkg = packageMetadata(cliDir);
+	if (hasBinary(cliDir) === false) {
+		throw new Error(
+			`Cannot populate ${cliPkg.name}@${cliPkg.version}: no binary found in ${join(cliDir, "bin")}. ` +
+				"Run build-packages.mjs first to populate platform binaries.",
+		);
+	}
+	console.log(`Populated ${cliPkg.name}@${cliPkg.version}`);
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {

--- a/scripts/npm/tests/populate-packages.test.mjs
+++ b/scripts/npm/tests/populate-packages.test.mjs
@@ -7,19 +7,16 @@ import {
 	_setSpawnSync,
 	CLI_PACKAGE_DIR,
 	hasBinary,
-	main as publishMain,
-	npmPublishEnv,
-	packageExists,
+	main as populateMain,
 	packageMetadata,
 	parseArgs,
 	PLATFORM_PACKAGE_DIRS,
-	publishPackage,
 	run,
 	assertTrustedPublishingContext,
-} from "../publish-packages.mjs";
+} from "../populate-packages.mjs";
 
 function makeSandbox() {
-	const base = join(process.cwd(), ".tmp-test-publish-packages");
+	const base = join(process.cwd(), ".tmp-test-populate-packages");
 	const sandbox = join(base, `test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	mkdirSync(sandbox, { recursive: true });
 	return sandbox;
@@ -109,18 +106,6 @@ describe("packageMetadata", () => {
 	});
 });
 
-describe("packageExists", () => {
-	test("returns true when npm view succeeds", () => {
-		_setSpawnSync(() => ({ status: 0, stdout: '"1.0.0"' }));
-		assert.equal(packageExists("@monochange/test", "1.0.0"), true);
-	});
-
-	test("returns false when npm view fails", () => {
-		_setSpawnSync(() => ({ status: 1, stderr: "not found" }));
-		assert.equal(packageExists("@monochange/test", "99.0.0"), false);
-	});
-});
-
 describe("hasBinary", () => {
 	test("returns false when bin directory does not exist", () => {
 		const sandbox = makeSandbox();
@@ -189,101 +174,15 @@ describe("trusted publishing context", () => {
 			message: /Cannot publish npm packages without the trusted-publishing GitHub Actions context/,
 		});
 	});
-
-	test("removes npm token variables from publish environment", () => {
-		const env = npmPublishEnv(
-			trustedPublishingEnv({ NODE_AUTH_TOKEN: "secret", NPM_TOKEN: "secret" }),
-		);
-		assert.equal(env.NODE_AUTH_TOKEN, undefined);
-		assert.equal(env.NPM_TOKEN, undefined);
-		assert.equal(env.NPM_CONFIG_PROVENANCE, "true");
-	});
-});
-
-describe("publishPackage", () => {
-	test("throws when no binary is present", () => {
-		const sandbox = makeSandbox();
-		writeFileSync(
-			join(sandbox, "package.json"),
-			JSON.stringify({
-				name: "@monochange/cli-darwin-arm64",
-				version: "1.0.0",
-			}),
-		);
-		assert.throws(() => publishPackage(sandbox), { message: /no binary found/ });
-	});
-
-	test("error message includes package name and version", () => {
-		const sandbox = makeSandbox();
-		writeFileSync(
-			join(sandbox, "package.json"),
-			JSON.stringify({
-				name: "@monochange/cli-darwin-arm64",
-				version: "3.2.1",
-			}),
-		);
-		try {
-			publishPackage(sandbox);
-			assert.unreachable("should have thrown");
-		} catch (err) {
-			assert.match(err.message, /@monochange\/cli-darwin-arm64@3\.2\.1/);
-			assert.match(err.message, /build-packages\.mjs/);
-		}
-	});
-
-	test("skips publishing when package already exists on npm", () => {
-		const sandbox = makeSandbox();
-		mkdirSync(join(sandbox, "bin"));
-		writeFileSync(join(sandbox, "bin", "monochange"), "");
-		writeFileSync(
-			join(sandbox, "package.json"),
-			JSON.stringify({
-				name: "@monochange/cli-darwin-arm64",
-				version: "1.0.0",
-			}),
-		);
-		_setSpawnSync(() => ({ status: 0, stdout: '"1.0.0"' }));
-		publishPackage(sandbox, { env: trustedPublishingEnv() });
-	});
-
-	test("publishes when binary present and package not on npm", () => {
-		const sandbox = makeSandbox();
-		mkdirSync(join(sandbox, "bin"));
-		writeFileSync(join(sandbox, "bin", "monochange"), "");
-		writeFileSync(
-			join(sandbox, "package.json"),
-			JSON.stringify({
-				name: "@monochange/cli-darwin-arm64",
-				version: "1.0.0",
-			}),
-		);
-		let publishCalled = false;
-		let publishOptions;
-		_setSpawnSync((cmd, args, options) => {
-			if (args[0] === "view") {
-				return { status: 1, stderr: "not found" };
-			}
-			if (args[0] === "publish") {
-				publishCalled = true;
-				publishOptions = options;
-				return { status: 0, stdout: "" };
-			}
-			return { status: 0, stdout: "" };
-		});
-		publishPackage(sandbox, { env: trustedPublishingEnv() });
-		assert.equal(publishCalled, true);
-		assert.equal(publishOptions.env.NPM_CONFIG_PROVENANCE, "true");
-	});
 });
 
 describe("main", () => {
 	test("throws when --packages-dir is missing", () => {
-		assert.throws(() => publishMain([]), { message: /usage:/ });
+		assert.throws(() => populateMain([]), { message: /usage:/ });
 	});
 
-	test("publishes all platform packages then the cli package", () => {
+	test("populates all platform packages then the cli package", () => {
 		const sandbox = makeSandbox();
-		const publishedOrder = [];
 
 		for (const dirName of [...PLATFORM_PACKAGE_DIRS, CLI_PACKAGE_DIR]) {
 			const pkgDir = join(sandbox, dirName);
@@ -299,20 +198,7 @@ describe("main", () => {
 			);
 		}
 
-		_setSpawnSync((cmd, args) => {
-			if (args[0] === "view") {
-				return { status: 1, stderr: "not found" };
-			}
-			if (args[0] === "publish") {
-				publishedOrder.push(args[0]);
-				return { status: 0, stdout: "" };
-			}
-			return { status: 0, stdout: "" };
-		});
-
-		publishMain(["--packages-dir", sandbox], { env: trustedPublishingEnv() });
-
-		assert.equal(publishedOrder.length, PLATFORM_PACKAGE_DIRS.length + 1);
+		populateMain(["--packages-dir", sandbox]);
 	});
 });
 


### PR DESCRIPTION
## Changes

- **Fix `monochange_lint_testing` config**: add `tag = false`, `release = false`, `changelog = false` to match its `publish = false` in Cargo.toml
- **Remove duplicate `release.yml` trigger from `ci.yml`**: the 'upload release assets to drafts' step ran `gh workflow run release.yml` which raced with the tag-push trigger (same concurrency group, `cancel-in-progress: true`). The tag push already triggers `release.yml` reliably via `on: push: tags: "v*"`.
- **Remove `publisher` environment from `release-pr` job in `ci.yml`**: this job only creates a release PR and doesn't publish anything. Having it in the `publisher` environment meant every push to main created a deployment that could require manual approval, blocking the automated release-PR refresh.
- **Rename `publish-packages.mjs` → `populate-packages.mjs`**: remove all npm publish logic (`publishPackage`, `packageExists`, `npmPublishEnv`), keep only binary validation and population. NPM publishing is now handled entirely by `mc publish` via the batched publish plan.
- **Remove 'publish cli npm packages' step from `publish.yml`**: `mc publish` handles npm publishing alongside cargo crates.
- **Add release prerequisites checklist** doc for agents (`docs/agents/release-checklist.md`)

## Test plan

- [x] 34/34 unit tests pass for `populate-packages.mjs`
- [ ] CI checks pass on this PR
- [ ] `mc validate` passes with the `monochange_lint_testing` config fix
- [ ] Verify no duplicate `release.yml` triggers on next release