### PR TITLE
fix: add issues:write permission and trigger release workflow from release-post-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,6 +396,7 @@ jobs:
     permissions:
       actions: write
       contents: write
+      issues: write
     steps:
       - name: checkout repository
         uses: actions/checkout@v6
@@ -438,3 +439,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: mc comment-released-issues --from-ref="HEAD" --auto-close-issues
         shell: devenv shell -- bash -e {0}
+
+      - name: trigger release workflow
+        if: steps.tag_release.outputs.is_release_commit == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="$(jq -r '.groupVersion.tag // empty' /tmp/tag-report.json)"
+          if [ -z "$tag" ]; then
+            echo "No tag found in tag-report.json, skipping release trigger"
+            exit 0
+          fi
+          echo "Triggering release workflow for tag $tag"
+          gh workflow run release.yml \
+            --repo "${{ github.repository }}" \
+            -f "tag=$tag"


### PR DESCRIPTION
## Problem

The `release-post-merge` job failed during the v0.3.0 release with two issues:

1. **Missing `issues: write` permission** — The `mc comment-released-issues --auto-close-issues` step got a 403 error when trying to post release comments on tracked issues (e.g., issue #132).

2. **Release workflow not triggered** — The `release.yml` workflow is triggered by tag pushes (`push tags: v*`), but since the release is created as a draft, the tag-push event doesn't reliably trigger the workflow. The `release.yml` never ran for v0.3.0, so no release assets were built or published.

## Changes

1. Added `issues: write` to the `release-post-merge` job permissions block
2. Added a `trigger release workflow` step at the end of `release-post-merge` that explicitly dispatches `release.yml` via `gh workflow run` with the release tag, extracted from the tag-report.json output of `mc tag-release`

This ensures release assets are built and published immediately after the draft release is created, rather than relying on the tag-push event.