### PR TITLE
fix: add retry loop to attestation asset download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,10 +119,24 @@ jobs:
           mkdir -p "$asset_dir"
 
           echo "Downloading all release assets for attestation..."
-          gh release download "$RELEASE_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --pattern 'monochange-*' \
-            --dir "$asset_dir"
+          for attempt in 1 2 3 4 5; do
+            if gh release download "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern 'monochange-*' \
+              --dir "$asset_dir" 2>/dev/null; then
+              break
+            fi
+            echo "Release $RELEASE_TAG not yet available (attempt $attempt/5), retrying in 10s..."
+            sleep 10
+          done
+
+          # Verify we actually got files
+          shopt -s nullglob
+          archives=("$asset_dir"/*)
+          if [ ${#archives[@]} -eq 0 ]; then
+            echo "::error::No release archives downloaded for $RELEASE_TAG after 5 attempts" >&2
+            exit 1
+          fi
 
           echo "Downloaded release archives for attestation:"
           for archive in "$asset_dir"/*; do


### PR DESCRIPTION
## Problem

The `attest_assets` job fails with `release not found` when running `gh release download`. This happens because the GitHub API has a brief propagation delay after the `upload_assets` matrix completes — the release assets exist but aren't immediately available via the API.

## Fix

- Added a retry loop (5 attempts, 10s apart) around `gh release download` to handle eventual consistency
- Added a post-download verification that checks files were actually downloaded and fails with a clear error if not

This matches the pattern already used in the verification step below.