### PR TITLE
fix: grant attest_assets contents:write to access draft release downloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
     timeout-minutes: 20
     permissions:
       attestations: write
-      contents: read
+      contents: write
       id-token: write
     env:
       RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
@@ -119,16 +119,10 @@ jobs:
           mkdir -p "$asset_dir"
 
           echo "Downloading all release assets for attestation..."
-          for attempt in 1 2 3 4 5; do
-            if gh release download "$RELEASE_TAG" \
-              --repo "$GITHUB_REPOSITORY" \
-              --pattern 'monochange-*' \
-              --dir "$asset_dir" 2>/dev/null; then
-              break
-            fi
-            echo "Release $RELEASE_TAG not yet available (attempt $attempt/5), retrying in 10s..."
-            sleep 10
-          done
+          gh release download "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern 'monochange-*' \
+            --dir "$asset_dir"
 
           # Verify we actually got files
           shopt -s nullglob


### PR DESCRIPTION
## Problem

The `release.yml` workflow's `attest_assets` job repeatedly failed with:

```
Release v0.3.0 not yet available (attempt 1/5), retrying in 10s...
...
```

The job had `contents: read` permission but was trying to download assets from a **draft release** created by `taiki-e/upload-rust-binary-action`. GitHub's API only makes draft releases visible to tokens with write access (`contents: write`).

The 5-attempt retry loop was ineffective because the permission denial was permanent — not a transient race condition.

## Fix

- Changed `attest_assets` job permissions from `contents: read` to `contents: write`
- Removed the retry loop around `gh release download` since the underlying issue is permissions, not timing

## References

- Failed run: https://github.com/monochange/monochange/actions/runs/25179699138