### PR TITLE
fix: run publish plan in devenv shell

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,6 +101,7 @@ jobs:
 
           echo "Publish plan:"
           echo "$report" | jq '.publishRateLimits'
+        shell: devenv shell -- bash -e {0}
 
   publish:
     needs: plan


### PR DESCRIPTION
## Problem

The publish workflow failed in the `plan publish batches` step with:

```
mc: command not found
```

Failed run: https://github.com/monochange/monochange/actions/runs/25185219013/job/73840626560

The workflow runs `.github/actions/devenv` with its default `activate: false`, so devenv-provided tools are not added globally to subsequent steps. Neighboring steps that need local project tools already opt into:

```yaml
shell: devenv shell -- bash -e {0}
```

but `plan publish batches` used the default shell while calling `mc publish-plan`.

## Fix

Run `plan publish batches` inside the devenv shell so `mc` is available on PATH.