### PR TITLE
feat: add allow_empty_changesets to PrepareRelease and expose changeset count

### DIFF
--- a/.changeset/allow-empty-changesets.md
+++ b/.changeset/allow-empty-changesets.md
@@ -1,0 +1,10 @@
+---
+monochange: minor
+monochange_core: minor
+---
+
+# Allow `PrepareRelease` to succeed with no changesets
+
+`PrepareRelease` steps in CLI commands now support an `allow_empty_changesets` option. When enabled, missing or empty `.changeset` directories no longer cause errors — instead the step succeeds with an empty release plan, and downstream steps can gate on `number_of_changesets` in their `when` conditions.
+
+This enables `[cli.release-pr]` workflows to run against repos with no pending changes without failing the CI job.

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -1388,6 +1388,7 @@ fn render_cli_commands_toml_handles_release_and_command_step_variants() {
 					"format".to_string(),
 					monochange_core::CliStepInputValue::String("json".to_string()),
 				)]),
+				allow_empty_changesets: false,
 			},
 			monochange_core::CliStepDefinition::Command {
 				show_progress: None,
@@ -2480,6 +2481,38 @@ fn command_release_dry_run_discovers_changesets_without_mutating_files() {
 		original_changelog
 	);
 	assert!(tempdir.path().join(".changeset/feature.md").exists());
+}
+
+#[test]
+fn prepare_release_allows_empty_changesets_when_configured() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	seed_release_fixture(tempdir.path(), None, false);
+	fs::remove_dir_all(tempdir.path().join(".changeset"))
+		.unwrap_or_else(|error| panic!("remove changesets: {error}"));
+
+	let strict_error =
+		crate::prepare_release_execution_with_file_diffs(tempdir.path(), true, false, false)
+			.err()
+			.unwrap_or_else(|| panic!("expected missing changeset error"));
+	assert!(
+		strict_error
+			.to_string()
+			.contains("no markdown changesets found under .changeset")
+	);
+
+	let execution =
+		crate::prepare_release_execution_with_file_diffs(tempdir.path(), true, true, true)
+			.unwrap_or_else(|error| panic!("prepare release execution: {error}"));
+
+	assert_eq!(
+		execution.prepared_release.plan.workspace_root,
+		tempdir.path().to_path_buf()
+	);
+	assert!(execution.prepared_release.changeset_paths.is_empty());
+	assert!(execution.prepared_release.changesets.is_empty());
+	assert!(execution.prepared_release.released_packages.is_empty());
+	assert!(execution.prepared_release.changed_files.is_empty());
+	assert!(execution.file_diffs.is_empty());
 }
 
 #[test]
@@ -4210,6 +4243,37 @@ fn should_execute_cli_step_skips_for_zero_value() {
 }
 
 #[test]
+fn should_execute_cli_step_can_gate_on_number_of_changesets() {
+	let mut context = cli_context_for_when_evaluation_tests();
+	let step_inputs = BTreeMap::new();
+	let step = monochange_core::CliStepDefinition::Command {
+		show_progress: None,
+		name: None,
+		when: Some("{{ number_of_changesets > 0 }}".to_string()),
+		command: "printf hi".to_string(),
+		dry_run_command: None,
+		shell: monochange_core::ShellConfig::default(),
+		id: None,
+		variables: None,
+		inputs: BTreeMap::new(),
+	};
+
+	context.prepared_release = Some(sample_prepared_release_for_cli_render());
+	assert!(
+		!should_execute_cli_step(&step, &context, &step_inputs)
+			.unwrap_or_else(|error| { panic!("when condition: {error}") })
+	);
+
+	let mut prepared = sample_prepared_release_for_cli_render();
+	prepared.changeset_paths = vec![PathBuf::from(".changeset/feature.md")];
+	context.prepared_release = Some(prepared);
+	assert!(
+		should_execute_cli_step(&step, &context, &step_inputs)
+			.unwrap_or_else(|error| { panic!("when condition: {error}") })
+	);
+}
+
+#[test]
 fn should_execute_cli_step_trims_and_treats_1_as_true() {
 	let context = cli_context_for_when_evaluation_tests();
 	let step_inputs = BTreeMap::from([("run".to_string(), vec![" 1 ".to_string()])]);
@@ -5118,6 +5182,18 @@ fn template_context_exposes_manifest_affected_steps_and_custom_variables() {
 			.map(Vec::len),
 		Some(1)
 	);
+	assert_eq!(
+		template_context
+			.get("number_of_changesets")
+			.and_then(serde_json::Value::as_u64),
+		Some(0)
+	);
+	assert_eq!(
+		template_context
+			.get("changeset_count")
+			.and_then(serde_json::Value::as_u64),
+		Some(0)
+	);
 }
 
 #[test]
@@ -5445,6 +5521,7 @@ fn execute_cli_command_source_follow_up_steps_require_source_configuration() {
 				name: None,
 				when: None,
 				inputs: BTreeMap::new(),
+				allow_empty_changesets: false,
 			},
 			monochange_core::CliStepDefinition::CommentReleasedIssues {
 				name: None,
@@ -5484,6 +5561,7 @@ fn execute_cli_command_comment_released_issues_requires_source_configuration() {
 				name: None,
 				when: None,
 				inputs: BTreeMap::new(),
+				allow_empty_changesets: false,
 			},
 			monochange_core::CliStepDefinition::CommentReleasedIssues {
 				name: None,
@@ -5544,6 +5622,7 @@ fn execute_cli_command_publish_and_request_steps_require_source_configuration() 
 					name: None,
 					when: None,
 					inputs: BTreeMap::new(),
+					allow_empty_changesets: false,
 				},
 				step,
 			],
@@ -5617,6 +5696,7 @@ fn execute_cli_command_prepare_release_writes_default_manifest_cache_and_follow_
 			name: None,
 			when: None,
 			inputs: BTreeMap::new(),
+			allow_empty_changesets: false,
 		}],
 	};
 	let render_output = crate::execute_cli_command(
@@ -5641,6 +5721,7 @@ fn execute_cli_command_prepare_release_writes_default_manifest_cache_and_follow_
 				name: None,
 				when: None,
 				inputs: BTreeMap::new(),
+				allow_empty_changesets: false,
 			},
 			monochange_core::CliStepDefinition::PublishRelease {
 				name: None,
@@ -5669,6 +5750,7 @@ fn execute_cli_command_prepare_release_writes_default_manifest_cache_and_follow_
 				name: None,
 				when: None,
 				inputs: BTreeMap::new(),
+				allow_empty_changesets: false,
 			},
 			monochange_core::CliStepDefinition::OpenReleaseRequest {
 				name: None,
@@ -5698,6 +5780,7 @@ fn execute_cli_command_prepare_release_writes_default_manifest_cache_and_follow_
 				name: None,
 				when: None,
 				inputs: BTreeMap::new(),
+				allow_empty_changesets: false,
 			},
 			monochange_core::CliStepDefinition::CommentReleasedIssues {
 				name: None,
@@ -5810,6 +5893,7 @@ fn execute_cli_command_supports_placeholder_and_package_publish_steps() {
 						name: None,
 						when: None,
 						inputs: BTreeMap::new(),
+						allow_empty_changesets: false,
 					},
 					monochange_core::CliStepDefinition::PublishPackages {
 						name: None,
@@ -5889,6 +5973,7 @@ fn execute_cli_command_requires_readiness_for_package_publish_steps_without_matc
 						name: None,
 						when: None,
 						inputs: BTreeMap::new(),
+						allow_empty_changesets: false,
 					},
 					monochange_core::CliStepDefinition::PublishPackages {
 						name: None,
@@ -9662,6 +9747,7 @@ fn apply_runtime_prepare_release_markdown_defaults_promotes_release_format_defau
 			name: None,
 			when: None,
 			inputs: BTreeMap::new(),
+			allow_empty_changesets: false,
 		}],
 	}];
 

--- a/crates/monochange/src/changesets.rs
+++ b/crates/monochange/src/changesets.rs
@@ -10,7 +10,7 @@ pub(crate) fn diagnose_changesets(
 	let discovery = discover_workspace(root)?;
 
 	let changeset_paths = if requested.is_empty() {
-		discover_changeset_paths(root)?
+		discover_changeset_paths(root, false)?
 			.into_iter()
 			.map(|path| root.join(path))
 			.collect::<Vec<_>>()
@@ -203,10 +203,16 @@ fn push_changeset_context_lines(lines: &mut Vec<String>, context: &ChangesetCont
 }
 
 #[must_use = "the discovery result must be checked"]
-pub(crate) fn discover_changeset_paths(root: &Path) -> MonochangeResult<Vec<PathBuf>> {
+pub(crate) fn discover_changeset_paths(
+	root: &Path,
+	allow_empty: bool,
+) -> MonochangeResult<Vec<PathBuf>> {
 	let changeset_dir = root.join(CHANGESET_DIR);
 
 	if !changeset_dir.exists() {
+		if allow_empty {
+			return Ok(Vec::new());
+		}
 		return Err(MonochangeError::Config(format!(
 			"no markdown changesets found under {CHANGESET_DIR}"
 		)));
@@ -226,7 +232,7 @@ pub(crate) fn discover_changeset_paths(root: &Path) -> MonochangeResult<Vec<Path
 
 	changeset_paths.sort();
 
-	if changeset_paths.is_empty() {
+	if changeset_paths.is_empty() && !allow_empty {
 		return Err(MonochangeError::Config(format!(
 			"no markdown changesets found under {CHANGESET_DIR}"
 		)));
@@ -371,7 +377,7 @@ mod diagnostics_tests {
 		assert_eq!(absolute, tempdir.path().join(".changeset/feature.md"));
 
 		let missing_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
-		let missing_error = discover_changeset_paths(missing_dir.path())
+		let missing_error = discover_changeset_paths(missing_dir.path(), false)
 			.err()
 			.unwrap_or_else(|| panic!("expected missing changeset directory error"));
 		assert!(
@@ -383,7 +389,7 @@ mod diagnostics_tests {
 		let empty_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 		fs::create_dir_all(empty_dir.path().join(".changeset"))
 			.unwrap_or_else(|error| panic!("create empty changeset dir: {error}"));
-		let empty_error = discover_changeset_paths(empty_dir.path())
+		let empty_error = discover_changeset_paths(empty_dir.path(), false)
 			.err()
 			.unwrap_or_else(|| panic!("expected empty changeset directory error"));
 		assert!(
@@ -395,7 +401,7 @@ mod diagnostics_tests {
 		let blocked_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 		fs::write(blocked_dir.path().join(".changeset"), "not a directory\n")
 			.unwrap_or_else(|error| panic!("write blocking .changeset file: {error}"));
-		let blocked_error = discover_changeset_paths(blocked_dir.path())
+		let blocked_error = discover_changeset_paths(blocked_dir.path(), false)
 			.err()
 			.unwrap_or_else(|| panic!("expected read_dir error for file-backed .changeset path"));
 		assert!(blocked_error.to_string().contains("failed to read"));

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -673,7 +673,9 @@ pub(crate) fn execute_cli_command_with_options(
 						false,
 					)? {
 						Some(loaded) => loaded.execution,
-						None => prepare_release_execution_with_file_diffs(root, true, false)?,
+						None => {
+							prepare_release_execution_with_file_diffs(root, true, false, false)?
+						}
 					};
 					step_phase_timings.clone_from(&prepared_execution.phase_timings);
 					let rendered_output = render_display_versions_output(
@@ -691,7 +693,10 @@ pub(crate) fn execute_cli_command_with_options(
 					)?);
 					Ok(())
 				}
-				CliStepDefinition::PrepareRelease { .. } => {
+				CliStepDefinition::PrepareRelease {
+					allow_empty_changesets,
+					..
+				} => {
 					let build_file_diffs = context.show_diff
 						|| steps_reference_release_file_diffs(&cli_command.steps[step_index + 1..]);
 					let prepared_execution = if let Some(loaded) =
@@ -705,7 +710,12 @@ pub(crate) fn execute_cli_command_with_options(
 						context.command_logs.push(loaded.message);
 						loaded.execution
 					} else {
-						prepare_release_execution_with_file_diffs(root, dry_run, build_file_diffs)?
+						prepare_release_execution_with_file_diffs(
+							root,
+							dry_run,
+							build_file_diffs,
+							*allow_empty_changesets,
+						)?
 					};
 					step_phase_timings.clone_from(&prepared_execution.phase_timings);
 					context.prepared_file_diffs = prepared_execution.file_diffs;
@@ -1750,6 +1760,14 @@ pub(crate) fn build_cli_template_context(
 					.collect(),
 			),
 		);
+		let number_of_changesets = serde_json::Value::Number(serde_json::Number::from(
+			prepared.changeset_paths.len() as u64,
+		));
+		template_context.insert(
+			"number_of_changesets".to_string(),
+			number_of_changesets.clone(),
+		);
+		template_context.insert("changeset_count".to_string(), number_of_changesets);
 	}
 
 	// Structured release.* namespace
@@ -5204,6 +5222,7 @@ path = "crates/core"
 					name: None,
 					when: None,
 					inputs: BTreeMap::new(),
+					allow_empty_changesets: false,
 				},
 				CliStepDefinition::PlanPublishRateLimits {
 					name: None,

--- a/crates/monochange/src/prepared_release_cache.rs
+++ b/crates/monochange/src/prepared_release_cache.rs
@@ -512,8 +512,9 @@ mod tests {
 	fn save_artifact(root: &Path, dry_run: bool, explicit_path: &Path) -> WorkspaceConfiguration {
 		let configuration = load_workspace_configuration(root)
 			.unwrap_or_else(|error| panic!("load workspace configuration: {error}"));
-		let prepared = crate::prepare_release_execution_with_file_diffs(root, dry_run, false)
-			.unwrap_or_else(|error| panic!("prepare release execution: {error}"));
+		let prepared =
+			crate::prepare_release_execution_with_file_diffs(root, dry_run, false, false)
+				.unwrap_or_else(|error| panic!("prepare release execution: {error}"));
 		save_prepared_release_execution(
 			root,
 			&configuration,
@@ -582,7 +583,7 @@ mod tests {
 		let root = tempdir.path();
 		let configuration = load_workspace_configuration(root)
 			.unwrap_or_else(|error| panic!("load workspace configuration: {error}"));
-		let prepared = crate::prepare_release_execution_with_file_diffs(root, true, false)
+		let prepared = crate::prepare_release_execution_with_file_diffs(root, true, false, false)
 			.unwrap_or_else(|error| panic!("prepare release execution: {error}"));
 		let changed_file = prepared
 			.prepared_release
@@ -664,7 +665,7 @@ mod tests {
 		let artifact_path = explicit_artifact_path(root);
 		let configuration = load_workspace_configuration(root)
 			.unwrap_or_else(|error| panic!("load workspace configuration: {error}"));
-		let prepared = crate::prepare_release_execution_with_file_diffs(root, false, true)
+		let prepared = crate::prepare_release_execution_with_file_diffs(root, false, true, false)
 			.unwrap_or_else(|error| panic!("prepare release execution: {error}"));
 		save_prepared_release_execution(
 			root,
@@ -838,7 +839,7 @@ mod tests {
 		let default_path = default_prepared_release_cache_path(root);
 		let configuration = load_workspace_configuration(root)
 			.unwrap_or_else(|error| panic!("load workspace configuration: {error}"));
-		let prepared = crate::prepare_release_execution_with_file_diffs(root, false, false)
+		let prepared = crate::prepare_release_execution_with_file_diffs(root, false, false, false)
 			.unwrap_or_else(|error| panic!("prepare release execution: {error}"));
 		save_prepared_release_execution(
 			root,
@@ -941,7 +942,7 @@ mod tests {
 		let root = tempdir.path();
 		let configuration = load_workspace_configuration(root)
 			.unwrap_or_else(|error| panic!("load workspace configuration: {error}"));
-		let prepared = crate::prepare_release_execution_with_file_diffs(root, false, false)
+		let prepared = crate::prepare_release_execution_with_file_diffs(root, false, false, false)
 			.unwrap_or_else(|error| panic!("prepare release execution: {error}"));
 
 		let parent_file = root.join("artifact-parent");

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -1555,7 +1555,7 @@ pub fn prepare_release(root: &Path, dry_run: bool) -> MonochangeResult<PreparedR
 	// Building unified diffs for large lockfiles can dominate wall time, so skip
 	// that work here unless a caller explicitly asks for the richer execution
 	// report via `prepare_release_execution`.
-	prepare_release_execution_with_file_diffs(root, dry_run, false)
+	prepare_release_execution_with_file_diffs(root, dry_run, false, false)
 		.map(|execution| execution.prepared_release)
 }
 
@@ -1565,7 +1565,7 @@ pub(crate) fn prepare_release_execution(
 	root: &Path,
 	dry_run: bool,
 ) -> MonochangeResult<PreparedReleaseExecution> {
-	prepare_release_execution_with_file_diffs(root, dry_run, true)
+	prepare_release_execution_with_file_diffs(root, dry_run, true, false)
 }
 
 #[tracing::instrument(skip_all, fields(dry_run, build_file_diffs))]
@@ -1573,6 +1573,7 @@ pub(crate) fn prepare_release_execution_with_file_diffs(
 	root: &Path,
 	dry_run: bool,
 	build_file_diffs: bool,
+	allow_empty_changesets: bool,
 ) -> MonochangeResult<PreparedReleaseExecution> {
 	let mut phase_timings = Vec::new();
 	let configuration =
@@ -1585,9 +1586,38 @@ pub(crate) fn prepare_release_execution_with_file_diffs(
 		})?;
 	let changeset_paths =
 		measure_prepare_phase(&mut phase_timings, "discover changeset paths", || {
-			discover_changeset_paths(root)
+			discover_changeset_paths(root, allow_empty_changesets)
 		})?;
 	tracing::debug!(count = changeset_paths.len(), "discovered changesets");
+
+	if changeset_paths.is_empty() && allow_empty_changesets {
+		return Ok(PreparedReleaseExecution {
+			prepared_release: PreparedRelease {
+				plan: ReleasePlan {
+					workspace_root: root.to_path_buf(),
+					decisions: Vec::new(),
+					groups: Vec::new(),
+					warnings: Vec::new(),
+					unresolved_items: Vec::new(),
+					compatibility_evidence: Vec::new(),
+				},
+				changeset_paths,
+				changesets: Vec::new(),
+				released_packages: Vec::new(),
+				package_publications: Vec::new(),
+				version: None,
+				group_version: None,
+				release_targets: Vec::new(),
+				changed_files: Vec::new(),
+				changelogs: Vec::new(),
+				updated_changelogs: Vec::new(),
+				deleted_changesets: Vec::new(),
+				dry_run,
+			},
+			file_diffs: Vec::new(),
+			phase_timings,
+		});
+	}
 
 	// Build the shared changeset lookup context once.
 	//
@@ -3168,8 +3198,9 @@ cwd = "."
 		fs::write(&config_path, config)
 			.unwrap_or_else(|error| panic!("write monochange.toml: {error}"));
 
-		let prepared = prepare_release_execution_with_file_diffs(fixture.path(), false, false)
-			.unwrap_or_else(|error| panic!("prepare release: {error}"));
+		let prepared =
+			prepare_release_execution_with_file_diffs(fixture.path(), false, false, false)
+				.unwrap_or_else(|error| panic!("prepare release: {error}"));
 
 		assert!(
 			prepared
@@ -3206,8 +3237,9 @@ repo = "monochange"
 		fs::write(&config_path, config)
 			.unwrap_or_else(|error| panic!("write monochange.toml: {error}"));
 
-		let prepared = prepare_release_execution_with_file_diffs(fixture.path(), true, false)
-			.unwrap_or_else(|error| panic!("prepare release: {error}"));
+		let prepared =
+			prepare_release_execution_with_file_diffs(fixture.path(), true, false, false)
+				.unwrap_or_else(|error| panic!("prepare release: {error}"));
 
 		assert!(
 			prepared
@@ -3238,8 +3270,9 @@ repo = "monochange"
 		fs::write(&config_path, config)
 			.unwrap_or_else(|error| panic!("write monochange.toml: {error}"));
 
-		let prepared = prepare_release_execution_with_file_diffs(fixture.path(), false, false)
-			.unwrap_or_else(|error| panic!("prepare release: {error}"));
+		let prepared =
+			prepare_release_execution_with_file_diffs(fixture.path(), false, false, false)
+				.unwrap_or_else(|error| panic!("prepare release: {error}"));
 
 		assert!(
 			prepared

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -940,6 +940,7 @@ fn cli_step_definition_kind_name_covers_all_variants() {
 				name: None,
 				when: None,
 				inputs: BTreeMap::new(),
+				allow_empty_changesets: false,
 			},
 			"PrepareRelease",
 		),
@@ -1056,11 +1057,13 @@ fn cli_step_display_name_prefers_explicit_name_over_kind() {
 		name: Some("plan release".to_string()),
 		when: None,
 		inputs: BTreeMap::new(),
+		allow_empty_changesets: false,
 	};
 	let unnamed = CliStepDefinition::PrepareRelease {
 		name: None,
 		when: None,
 		inputs: BTreeMap::new(),
+		allow_empty_changesets: false,
 	};
 	assert_eq!(named.display_name(), "plan release");
 	assert_eq!(unnamed.display_name(), "PrepareRelease");
@@ -1090,6 +1093,7 @@ fn cli_step_name_returns_explicit_names_for_all_variants() {
 			name: Some(expected.to_string()),
 			when: None,
 			inputs: BTreeMap::new(),
+			allow_empty_changesets: false,
 		},
 		CliStepDefinition::CommitRelease {
 			name: Some(expected.to_string()),
@@ -1361,6 +1365,7 @@ fn expected_input_kind_returns_correct_types_for_display_and_publish_steps() {
 		name: None,
 		when: None,
 		inputs: BTreeMap::new(),
+		allow_empty_changesets: false,
 	};
 	assert_eq!(
 		prepare.expected_input_kind("format"),

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -1850,6 +1850,11 @@ pub enum CliStepDefinition {
 		when: Option<String>,
 		#[serde(default)]
 		inputs: BTreeMap<String, CliStepInputValue>,
+		/// When true, do not error when there are no pending changesets.
+		/// Instead, succeed with zero changesets, allowing downstream steps
+		/// to check `number_of_changesets` in their `when` conditions.
+		#[serde(default)]
+		allow_empty_changesets: bool,
 	},
 	/// Create a local release commit with an embedded durable `ReleaseRecord`.
 	///
@@ -3851,6 +3856,7 @@ pub fn all_step_variants() -> Vec<CliStepDefinition> {
 			name: None,
 			when: None,
 			inputs: BTreeMap::new(),
+			allow_empty_changesets: false,
 		},
 		CliStepDefinition::CommitRelease {
 			name: None,

--- a/monochange.toml
+++ b/monochange.toml
@@ -794,13 +794,13 @@ inputs = [
 	{ name = "no_verify", type = "boolean", default = true },
 ]
 steps = [
-	{ type = "PrepareRelease", name = "plan release" },
-	{ type = "Command", name = "generate cargo lockfile", command = "cargo generate-lockfile" },
-	{ type = "Command", name = "generate pnpm lockfile", command = "pnpm install --lockfile-only" },
-	{ type = "Command", name = "format changed files", command = "dprint fmt {{ changed_files }}" },
-	{ type = "Command", name = "refresh shared markdown", command = "mdt update" },
-	{ type = "CommitRelease", name = "create release commit", inputs = { no_verify = "{{ inputs.no_verify }}" } },
-	{ type = "OpenReleaseRequest", name = "create the pr", inputs = { no_verify = "{{ inputs.no_verify }}" } },
+	{ type = "PrepareRelease", name = "plan release", allow_empty_changesets = true },
+	{ type = "Command", name = "generate cargo lockfile", when = "{{ number_of_changesets > 0 }}", command = "cargo generate-lockfile" },
+	{ type = "Command", name = "generate pnpm lockfile", when = "{{ number_of_changesets > 0 }}", command = "pnpm install --lockfile-only" },
+	{ type = "Command", name = "format changed files", when = "{{ number_of_changesets > 0 }}", command = "dprint fmt {{ changed_files }}" },
+	{ type = "Command", name = "refresh shared markdown", when = "{{ number_of_changesets > 0 }}", command = "mdt update" },
+	{ type = "CommitRelease", name = "create release commit", when = "{{ number_of_changesets > 0 }}", inputs = { no_verify = "{{ inputs.no_verify }}" } },
+	{ type = "OpenReleaseRequest", name = "create the pr", when = "{{ number_of_changesets > 0 }}", inputs = { no_verify = "{{ inputs.no_verify }}" } },
 ]
 
 [cli.commit-release]


### PR DESCRIPTION
## Summary

Adds `allow_empty_changesets` support to `PrepareRelease` so `[cli.release-pr]` gracefully handles repositories with no pending changesets instead of failing.

Closes #344 (alternative to the shell-wrapper approach in #354).

## Changes

### `monochange_core`
- Added `allow_empty_changesets: bool` field to `CliStepDefinition::PrepareRelease` with `#[serde(default)]`, defaulting to `false` (backward compatible).

### `monochange` (workspace ops)
- Updated `discover_changeset_paths(root, allow_empty)` — when `allow_empty` is `true`, a missing or empty `.changeset` directory returns `Ok(Vec::new())` instead of erroring.
- `prepare_release_execution_with_file_diffs` now short-circuits: when `allow_empty_changesets` is `true` and no changesets are found, it returns an empty `PreparedReleaseExecution` instead of failing downstream.

### CLI template context
- Exposes `number_of_changesets` (canonical name) and `changeset_count` (alias) in the template context, computed from `prepared.changeset_paths.len()`.
- Downstream steps can use `when = "{{ number_of_changesets > 0 }}"` to skip when there's nothing to release.

### `monochange.toml`
- `[cli.release-pr]` `PrepareRelease` step now uses `allow_empty_changesets = true`.
- Downstream steps (lockfile generation, formatting, markdown refresh, commit, PR creation) are gated with `when = "{{ number_of_changesets > 0 }}"`.

### Tests
- `prepare_release_allows_empty_changesets_when_configured` — verifies strict mode still errors, and allow mode succeeds with empty state.
- `should_execute_cli_step_can_gate_on_number_of_changesets` — verifies `when` expression gating on `number_of_changesets`.
- Template context assertions for `number_of_changesets` and `changeset_count`.