### PR TITLE
fix: fetch release branch history before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ steps.release_tag.outputs.tag }}
+          fetch-depth: 0
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -123,6 +124,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.plan.outputs.tag }}
+          fetch-depth: 0
 
       - name: setup
         uses: ./.github/actions/devenv


### PR DESCRIPTION
## Problem

The publish workflow matrix jobs all fail inside `mc publish` with:

```
config error: release ref `HEAD` resolves to commit 6ff71c6, which is not reachable from any configured release branch pattern [main]; matching branch refs: none found
```

Failed run/jobs:

- https://github.com/monochange/monochange/actions/runs/25186599311/job/73846394116
- https://github.com/monochange/monochange/actions/runs/25186599311/job/73846394015
- https://github.com/monochange/monochange/actions/runs/25186599311/job/73846394054

The publish jobs check out the release tag as a detached `HEAD`. With the default shallow checkout, the local clone does not contain `origin/main` or enough history for monochange's release-branch policy check to prove that the tag commit is reachable from the configured release branch pattern.

## Fix

Use `fetch-depth: 0` for both checkout steps in `publish.yml` so Actions fetches all branch refs/tags/history before running `mc publish-plan` and `mc publish`. This gives monochange the branch refs it needs to verify the release tag against `[source.releases].branches = ["main"]`.

## Validation

- `git diff --check`