### PR TITLE
fix: generate publish readiness before package publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,12 +76,22 @@ jobs:
             --packages-dir packages
         shell: devenv shell -- bash -e {0}
 
+      - name: check publish readiness
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-oidc.outputs.token }}
+        run: |
+          mc publish-readiness \
+            --from HEAD \
+            --output "$RUNNER_TEMP/publish-readiness.json" \
+            --format json
+        shell: devenv shell -- bash -e {0}
+
       - name: plan publish batches
         id: publish_plan
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-oidc.outputs.token }}
         run: |
-          report="$(mc publish-plan --format json)"
+          report="$(mc publish-plan --readiness "$RUNNER_TEMP/publish-readiness.json" --format json)"
           echo "report<<EOF" >> "$GITHUB_OUTPUT"
           echo "$report" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
@@ -136,6 +146,42 @@ jobs:
         uses: rust-lang/crates-io-auth-action@v1
         id: crates-oidc
 
+      - name: download release assets
+        if: matrix.registry == 'npm' && startsWith( needs.plan.outputs.tag , 'v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.plan.outputs.tag }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/release-assets"
+          gh release download "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "monochange-*-${RELEASE_TAG}.tar.gz" \
+            --pattern "monochange-*-${RELEASE_TAG}.zip" \
+            --dir "$RUNNER_TEMP/release-assets"
+
+      - name: populate cli npm packages with release binaries
+        if: matrix.registry == 'npm'
+        env:
+          RELEASE_TAG: ${{ needs.plan.outputs.tag }}
+        run: |
+          node scripts/npm/build-packages.mjs \
+            --release-tag "$RELEASE_TAG" \
+            --assets-dir "$RUNNER_TEMP/release-assets"
+          node scripts/npm/populate-packages.mjs \
+            --packages-dir packages
+        shell: devenv shell -- bash -e {0}
+
+      - name: check publish readiness for batch
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-oidc.outputs.token }}
+        run: |
+          mc publish-readiness \
+            --from HEAD \
+            ${{ matrix.packages }} \
+            --output "$RUNNER_TEMP/publish-readiness.json" \
+            --format json
+        shell: devenv shell -- bash -e {0}
+
       - name: wait for rate-limit window
         if: matrix.wait_seconds > 0
         run: |
@@ -145,5 +191,9 @@ jobs:
       - name: publish batch ${{ matrix.batch }} of ${{ matrix.total_batches }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-oidc.outputs.token }}
-        run: mc publish ${{ matrix.packages }} --format json
+        run: |
+          mc publish ${{ matrix.packages }} \
+            --readiness "$RUNNER_TEMP/publish-readiness.json" \
+            --output "$RUNNER_TEMP/publish-result-${{ matrix.registry }}-${{ matrix.batch }}.json" \
+            --format json
         shell: devenv shell -- bash -e {0}


### PR DESCRIPTION
## Problem

The publish workflow now reaches `mc publish`, but every publish matrix job fails with:

```text
config error: `PublishPackages` requires `--readiness <PATH>` when publishing; run `mc publish-readiness --from HEAD --output <PATH>` first
```

Failed job: https://github.com/monochange/monochange/actions/runs/25188257189/job/73851739153

The workflow runs `mc publish-plan` and then `mc publish` directly. Current monochange publishing intentionally requires a readiness artifact for real package publishing so registry/readiness checks are explicit and tied to the release record and selected package set.

## Fix

- Generate a plan-wide readiness artifact in the `plan` job before `mc publish-plan`.
- Pass that artifact to `mc publish-plan --readiness ...` so planning only includes ready publish work.
- In each publish matrix job, generate a per-batch readiness artifact using the exact `${{ matrix.packages }}` package selection.
- Pass the per-batch artifact to `mc publish --readiness ...`.
- Re-populate npm CLI packages with release binaries inside npm publish jobs before readiness/publish, so the npm package checkout is publishable in the job that actually publishes it.

## Validation

- `git diff --check`
- Ruby YAML parse of `.github/workflows/publish.yml`
- pre-push hook completed successfully, including lint/test and 2103 Rust tests
