### PR TITLE
ci: use current cli for publish workflow

### DIFF
--- a/.changeset/publish-current-cli.md
+++ b/.changeset/publish-current-cli.md
@@ -1,0 +1,9 @@
+---
+main: fix
+---
+
+# Use the current monochange CLI when publishing release tags
+
+The publish workflow now builds the `mc` binary from the workflow commit before checking out the release tag. Publish jobs still operate on the requested release tag's files and release state, but they execute the current workflow version of `mc` so post-release publishing fixes apply when rerunning publication for an older tag.
+
+The workflow keeps full branch and tag history available after switching to the release tag so publish-time release branch reachability checks still work. The release workflow also dispatches `publish.yml` at the current workflow commit, allowing a fixed publish workflow to publish an older release tag.

--- a/.changeset/publish-current-cli.md
+++ b/.changeset/publish-current-cli.md
@@ -1,5 +1,5 @@
 ---
-main: fix
+main: none
 ---
 
 # Use the current monochange CLI when publishing release tags

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,16 +37,26 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Resolved release tag: $TAG"
 
-      - name: checkout
+      - name: checkout current monochange cli
         uses: actions/checkout@v6
         with:
-          ref: ${{ steps.release_tag.outputs.tag }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
-      - name: setup
+      - name: setup current monochange cli
         uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: build current monochange cli and checkout release tag
+        run: |
+          cargo build --release --package monochange --bin mc
+          mkdir -p "$RUNNER_TEMP/bin"
+          cp target/release/mc "$RUNNER_TEMP/bin/mc"
+          git fetch --force origin "+refs/heads/*:refs/remotes/origin/*"
+          git fetch --tags --force origin "refs/tags/${{ steps.release_tag.outputs.tag }}:refs/tags/${{ steps.release_tag.outputs.tag }}"
+          git checkout --detach "${{ steps.release_tag.outputs.tag }}"
+        shell: devenv shell -- bash -e {0}
 
       - name: get crates oidc auth token
         uses: rust-lang/crates-io-auth-action@v1
@@ -80,7 +90,7 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-oidc.outputs.token }}
         run: |
-          mc publish-readiness \
+          "$RUNNER_TEMP/bin/mc" publish-readiness \
             --from HEAD \
             --output "$RUNNER_TEMP/publish-readiness.json" \
             --format json
@@ -91,7 +101,7 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-oidc.outputs.token }}
         run: |
-          report="$(mc publish-plan --readiness "$RUNNER_TEMP/publish-readiness.json" --format json)"
+          report="$("$RUNNER_TEMP/bin/mc" publish-plan --readiness "$RUNNER_TEMP/publish-readiness.json" --format json)"
           echo "report<<EOF" >> "$GITHUB_OUTPUT"
           echo "$report" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
@@ -130,16 +140,26 @@ jobs:
       matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
     name: publish ${{ matrix.registry }} (${{ matrix.batch }}/${{ matrix.total_batches }})
     steps:
-      - name: checkout
+      - name: checkout current monochange cli
         uses: actions/checkout@v6
         with:
-          ref: ${{ needs.plan.outputs.tag }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
-      - name: setup
+      - name: setup current monochange cli
         uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: build current monochange cli and checkout release tag
+        run: |
+          cargo build --release --package monochange --bin mc
+          mkdir -p "$RUNNER_TEMP/bin"
+          cp target/release/mc "$RUNNER_TEMP/bin/mc"
+          git fetch --force origin "+refs/heads/*:refs/remotes/origin/*"
+          git fetch --tags --force origin "refs/tags/${{ needs.plan.outputs.tag }}:refs/tags/${{ needs.plan.outputs.tag }}"
+          git checkout --detach "${{ needs.plan.outputs.tag }}"
+        shell: devenv shell -- bash -e {0}
 
       - name: get crates oidc auth token
         if: matrix.registry == 'crates_io'
@@ -181,7 +201,7 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-oidc.outputs.token }}
         run: |
-          mc publish ${{ matrix.packages }} \
+          "$RUNNER_TEMP/bin/mc" publish ${{ matrix.packages }} \
             --output "$RUNNER_TEMP/publish-result-${{ matrix.registry }}-${{ matrix.batch }}.json" \
             --format json
         shell: devenv shell -- bash -e {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,10 +56,27 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
-      - name: checkout
+      - name: checkout current workflow ref
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.checkout_ref && github.ref_name || env.RELEASE_TAG }}
+          fetch-depth: 0
+
+      - name: checkout release asset ref
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_ref='${{ inputs.checkout_ref && github.ref_name || env.RELEASE_TAG }}'
+          git fetch --force origin "+refs/heads/*:refs/remotes/origin/*"
+          git fetch --tags --force origin "+refs/tags/*:refs/tags/*"
+
+          if git rev-parse --verify --quiet "refs/tags/$release_ref" >/dev/null; then
+            git checkout --detach "refs/tags/$release_ref"
+          elif git rev-parse --verify --quiet "refs/remotes/origin/$release_ref" >/dev/null; then
+            git checkout --detach "refs/remotes/origin/$release_ref"
+          else
+            git fetch --force origin "$release_ref"
+            git checkout --detach FETCH_HEAD
+          fi
 
       - name: install rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -205,6 +222,7 @@ jobs:
         run: |
           gh workflow run publish.yml \
             --repo "${{ github.repository }}" \
+            --ref "${{ github.sha }}" \
             -f "tag=${{ env.RELEASE_TAG }}"
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- build the current workflow commit's `mc` binary before checking out a release tag
- keep publish/readiness/plan commands operating on the requested release tag checkout
- call the staged current `mc` binary explicitly so publishing older tags picks up workflow/runtime fixes like the removed `PublishPackages --readiness` requirement

## Why
PR #364 removed the readiness requirement, but the publish workflow checks out the release tag before running `mc publish`. Publishing `v0.3.0` therefore executed the `mc` binary from the old tag, which still required `--readiness`.

This keeps the release tag checkout as the working tree for package contents and release state, but uses a current `mc` binary copied to `$RUNNER_TEMP/bin/mc` before switching the checkout to the tag.

## Validation
- `git diff --check`
- Ruby YAML parse for `.github/workflows/publish.yml`
- `devenv shell -- dprint check .github/workflows/publish.yml .changeset/publish-current-cli.md`
- `devenv shell -- pnpm install --frozen-lockfile`
- pre-commit hooks during commit
- pre-push hook: full test suite passed, `2118 tests run: 2118 passed, 0 skipped`
