### PR TITLE
feat(ci): resolve git identity from token for release PR commits

### DIFF
--- a/.changeset/github-noreply-email.md
+++ b/.changeset/github-noreply-email.md
@@ -1,5 +1,5 @@
 ---
-main: patch
+main: none
 ---
 
 # Resolve git identity from token for release PR commits

--- a/.changeset/github-noreply-email.md
+++ b/.changeset/github-noreply-email.md
@@ -1,0 +1,7 @@
+---
+main: patch
+---
+
+# Resolve git identity from token for release PR commits
+
+The `release-pr` workflow now queries the GitHub API for the authenticated user's `id`, `login`, and `name`, then constructs the standard GitHub noreply email (`{id}+{login}@users.noreply.github.com`) for `git config user.email`. This replaces the previous hardcoded `github-actions[bot]` identity, so release PR commits are properly attributed to the account that owns the `RELEASE_PR_MERGE_TOKEN`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,9 +356,16 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: configure git
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          set -euo pipefail
+          user_info="$(gh api user --jq '{id: .id, login: .login, name: .name}')"
+          user_id="$(echo "$user_info" | jq -r '.id')"
+          user_login="$(echo "$user_info" | jq -r '.login')"
+          user_name="$(echo "$user_info" | jq -r '.name // .login')"
+          git config user.name "$user_name"
+          git config user.email "${user_id}+${user_login}@users.noreply.github.com"
         shell: devenv shell -- bash -e {0}
 
       - name: refresh tags from origin


### PR DESCRIPTION
## Summary

The \`release-pr\` job previously hardcoded the git identity to `github-actions[bot]`:

- **name:** `github-actions[bot]`
- **email:** `41898282+github-actions[bot]@users.noreply.github.com`

This meant release PR commits were always authored by the generic bot, regardless of which token was used to push.

## Change

The \`configure git\` step now calls the GitHub API (`gh api user`) to dynamically resolve the authenticated user's profile from the token:

1. **Fetches** \`id\`, \`login\`, and \`name\` via the REST API
2. **Constructs** the standard noreply email: `{id}+{login}@users.noreply.github.com`
3. **Sets** `user.name` to the display `name` (falling back to `login` if empty)

This ensures release PR commits are properly attributed to the account that owns the `RELEASE_PR_MERGE_TOKEN`, producing verified commits with the correct identity.

## Usage

No action required. The next time the `release-pr` job runs on `main`, the commits will automatically use the token owner's identity.
