### PR TITLE
fix: make registry publishing tolerate release workspaces

### DIFF
--- a/.changeset/publishable-test-helpers.md
+++ b/.changeset/publishable-test-helpers.md
@@ -1,0 +1,13 @@
+---
+main: fix
+monochange: fix
+monochange_cargo: fix
+monochange_core: fix
+monochange_test_helpers: patch
+---
+
+# Make release workspace publishing preserve Cargo verification
+
+`monochange_test_helpers` is now publishable so crates that use the shared helpers in their dev-dependencies can still pass Cargo's normal publish verification. `monochange_core` no longer dev-depends on the helper crate: its integration-style discovery filter coverage now lives in the unpublished `monochange_integration_tests` crate, preventing a dependency cycle between the published core crate and the test helper crate.
+
+Package publishing keeps Cargo verification enabled and still runs JavaScript registry tooling without inherited `LD_LIBRARY_PATH`, preserving PNPM support while avoiding Nix/devenv library-path leakage into system Node.js launchers.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2194,7 +2194,6 @@ version = "0.3.0"
 dependencies = [
  "ignore",
  "insta",
- "monochange_test_helpers",
  "proptest",
  "reqwest",
  "rstest",
@@ -2354,6 +2353,15 @@ dependencies = [
  "monochange_core",
  "reqwest",
  "serde",
+]
+
+[[package]]
+name = "monochange_integration_tests"
+version = "0.0.0"
+dependencies = [
+ "monochange_core",
+ "monochange_test_helpers",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -159,19 +159,24 @@ trait CommandExecutor {
 
 struct ProcessCommandExecutor;
 
+fn command_requires_clean_system_library_path(program: &str) -> bool {
+	matches!(program, "npm" | "pnpm" | "npx" | "node")
+}
+
 impl CommandExecutor for ProcessCommandExecutor {
 	fn run(&mut self, spec: &CommandSpec) -> MonochangeResult<CommandOutput> {
-		let output = ProcessCommand::new(&spec.program)
-			.args(&spec.args)
-			.current_dir(&spec.cwd)
-			.output()
-			.map_err(|error| {
-				MonochangeError::Io(format!(
-					"failed to run `{}` in {}: {error}",
-					render_command(spec),
-					spec.cwd.display()
-				))
-			})?;
+		let mut command = ProcessCommand::new(&spec.program);
+		command.args(&spec.args).current_dir(&spec.cwd);
+		if command_requires_clean_system_library_path(&spec.program) {
+			command.env_remove("LD_LIBRARY_PATH");
+		}
+		let output = command.output().map_err(|error| {
+			MonochangeError::Io(format!(
+				"failed to run `{}` in {}: {error}",
+				render_command(spec),
+				spec.cwd.display()
+			))
+		})?;
 		Ok(CommandOutput {
 			success: output.status.success(),
 			stdout: String::from_utf8_lossy(&output.stdout).trim().to_string(),
@@ -3309,6 +3314,59 @@ jobs:
 				.to_string()
 				.contains("failed to read placeholder README")
 		);
+	}
+
+	#[test]
+	fn process_command_executor_cleans_library_path_for_javascript_tooling() {
+		let _guard = TEST_ENV_LOCK.lock().expect("test env lock");
+		let root = tempfile::tempdir().expect("tempdir:");
+		let bin = root.path().join("bin");
+		fs::create_dir_all(&bin).expect("create bin dir");
+		let node = bin.join("node");
+		fs::write(
+			&node,
+			"#!/usr/bin/env sh\nif [ -n \"${LD_LIBRARY_PATH:-}\" ]; then exit 42; fi\nprintf clean\n",
+		)
+		.expect("write fake node");
+		let mut permissions = fs::metadata(&node)
+			.expect("fake node metadata")
+			.permissions();
+		#[cfg(unix)]
+		{
+			use std::os::unix::fs::PermissionsExt;
+			permissions.set_mode(0o755);
+			fs::set_permissions(&node, permissions).expect("chmod fake node");
+		}
+
+		let original_path = env::var("PATH").unwrap_or_default();
+		let path = format!("{}:{original_path}", bin.display());
+		with_vars(
+			[
+				("PATH", Some(path.as_str())),
+				("LD_LIBRARY_PATH", Some("/nix/store/lib")),
+			],
+			|| {
+				let mut executor = ProcessCommandExecutor;
+				let output = executor
+					.run(&CommandSpec {
+						program: "node".to_string(),
+						args: Vec::new(),
+						cwd: root.path().to_path_buf(),
+					})
+					.expect("node command");
+				assert!(output.success);
+				assert_eq!(output.stdout, "clean");
+			},
+		);
+	}
+
+	#[test]
+	fn command_requires_clean_system_library_path_matches_javascript_tooling() {
+		assert!(command_requires_clean_system_library_path("node"));
+		assert!(command_requires_clean_system_library_path("npm"));
+		assert!(command_requires_clean_system_library_path("pnpm"));
+		assert!(command_requires_clean_system_library_path("npx"));
+		assert!(!command_requires_clean_system_library_path("cargo"));
 	}
 
 	#[test]

--- a/crates/monochange_cargo/src/lints/mod.rs
+++ b/crates/monochange_cargo/src/lints/mod.rs
@@ -48,6 +48,8 @@ pub struct CargoLintSuite;
 struct CargoLintFile {
 	document: DocumentMut,
 	workspace_package_names: Arc<BTreeSet<String>>,
+	#[allow(dead_code)]
+	workspace_package_publishable: Arc<BTreeMap<String, bool>>,
 }
 
 impl LintSuite for CargoLintSuite {
@@ -139,6 +141,18 @@ impl LintSuite for CargoLintSuite {
 				.map(|package| package.name.clone())
 				.collect::<BTreeSet<_>>(),
 		);
+		let workspace_package_publishable = Arc::new(
+			discovery
+				.packages
+				.iter()
+				.map(|package| {
+					(
+						package.name.clone(),
+						!matches!(package.publish_state, PublishState::Private),
+					)
+				})
+				.collect::<BTreeMap<_, _>>(),
+		);
 
 		discovery
 			.packages
@@ -190,6 +204,7 @@ impl LintSuite for CargoLintSuite {
 					Box::new(CargoLintFile {
 						document,
 						workspace_package_names: Arc::clone(&workspace_package_names),
+						workspace_package_publishable: Arc::clone(&workspace_package_publishable),
 					}),
 				))
 			})
@@ -456,6 +471,65 @@ impl LintRuleRunner for InternalDependencyWorkspaceRule {
 }
 
 monochange_linting::declare_lint_rule! {
+	PublishableDependencyRule,
+	id: "cargo/publishable-dependencies",
+	name: "Publishable dependencies",
+	description: "Requires publishable Cargo packages to avoid dependencies on unpublished workspace packages",
+	category: LintCategory::Correctness,
+	maturity: LintMaturity::Stable,
+	autofixable: false,
+	options: vec![],
+}
+
+impl LintRuleRunner for PublishableDependencyRule {
+	fn rule(&self) -> &LintRule {
+		&self.rule
+	}
+
+	fn run(&self, ctx: &LintContext<'_>, config: &LintRuleConfig) -> Vec<LintResult> {
+		if !config.severity().is_enabled() || ctx.metadata.publishable != Some(true) {
+			return Vec::new();
+		}
+		let Some(file) = cargo_file(ctx) else {
+			return Vec::new();
+		};
+		let mut results = Vec::new();
+
+		for section in ["dependencies", "dev-dependencies", "build-dependencies"] {
+			let Some(item) = section_item(&file.document, section) else {
+				continue;
+			};
+			let Some(table) = item.as_table() else {
+				continue;
+			};
+
+			for (dep_name, value) in table {
+				if file
+					.workspace_package_publishable
+					.get(dep_name)
+					.copied()
+					.unwrap_or(true)
+				{
+					continue;
+				}
+				let span = value.span().map(|span| (span.start, span.end));
+				let location = location_from_span(ctx.manifest_path, ctx.contents, span);
+				results.push(LintResult::new(
+					self.rule.id.clone(),
+					location,
+					format!(
+						"publishable Cargo package depends on unpublished workspace package `{dep_name}` in [{section}]"
+					),
+					config.severity(),
+				));
+			}
+		}
+
+		results
+	}
+}
+
+monochange_linting::declare_lint_rule! {
 	RequiredPackageFieldsRule,
 	id: "cargo/required-package-fields",
 	name: "Required package fields",
@@ -662,6 +736,10 @@ mod tests {
 					"internal_dep".to_string(),
 					"serde".to_string(),
 				])),
+				workspace_package_publishable: Arc::new(BTreeMap::from([
+					("internal_dep".to_string(), false),
+					("serde".to_string(), true),
+				])),
 			}),
 		)
 	}
@@ -752,6 +830,111 @@ internal_dep = { path = "../internal_dep", version = "0.1.0" }
 				.first()
 				.and_then(|result| result.fix.as_ref())
 				.is_some()
+		);
+	}
+
+	#[test]
+	fn publishable_dependency_rule_reports_unpublished_workspace_deps() {
+		let target = cargo_target(
+			r#"[package]
+name = "example"
+version = "0.1.0"
+
+[dev-dependencies]
+internal_dep = { workspace = true }
+serde = { workspace = true }
+"#,
+			true,
+			true,
+		);
+		let ctx = LintContext {
+			workspace_root: &target.workspace_root,
+			manifest_path: &target.manifest_path,
+			contents: &target.contents,
+			metadata: &target.metadata,
+			parsed: target.parsed.as_ref(),
+		};
+		let results = PublishableDependencyRule::new().run(&ctx, &config());
+		assert_eq!(results.len(), 1);
+		assert!(
+			results
+				.first()
+				.expect("expected lint result")
+				.message
+				.contains("unpublished workspace package `internal_dep`")
+		);
+	}
+
+	#[test]
+	fn publishable_dependency_rule_skips_private_packages() {
+		let target = cargo_target(
+			r#"[package]
+name = "example"
+version = "0.1.0"
+
+[dev-dependencies]
+internal_dep = { workspace = true }
+"#,
+			true,
+			false,
+		);
+		let ctx = LintContext {
+			workspace_root: &target.workspace_root,
+			manifest_path: &target.manifest_path,
+			contents: &target.contents,
+			metadata: &target.metadata,
+			parsed: target.parsed.as_ref(),
+		};
+		let results = PublishableDependencyRule::new().run(&ctx, &config());
+		assert!(results.is_empty());
+	}
+
+	#[test]
+	fn publishable_dependency_rule_skips_unparsed_targets_and_non_table_sections() {
+		let target = cargo_target(
+			r#"dependencies = "not a table"
+
+[package]
+name = "example"
+version = "0.1.0"
+"#,
+			true,
+			true,
+		);
+		let non_cargo_parsed = "not a Cargo lint file";
+		let ctx = LintContext {
+			workspace_root: &target.workspace_root,
+			manifest_path: &target.manifest_path,
+			contents: &target.contents,
+			metadata: &target.metadata,
+			parsed: &non_cargo_parsed,
+		};
+		assert!(
+			PublishableDependencyRule::new()
+				.run(&ctx, &config())
+				.is_empty()
+		);
+
+		let ctx = LintContext {
+			workspace_root: &target.workspace_root,
+			manifest_path: &target.manifest_path,
+			contents: &target.contents,
+			metadata: &target.metadata,
+			parsed: target.parsed.as_ref(),
+		};
+		assert!(
+			PublishableDependencyRule::new()
+				.run(&ctx, &config())
+				.is_empty()
+		);
+	}
+
+	#[test]
+	fn publishable_dependency_rule_metadata_is_exposed() {
+		let rule = PublishableDependencyRule::new();
+		assert_eq!(
+			LintRuleRunner::rule(&rule).id,
+			"cargo/publishable-dependencies"
 		);
 	}
 

--- a/crates/monochange_core/Cargo.toml
+++ b/crates/monochange_core/Cargo.toml
@@ -27,7 +27,6 @@ tracing = { workspace = true, default-features = true }
 
 [dev-dependencies]
 insta = { workspace = true, default-features = true }
-monochange_test_helpers = { workspace = true }
 proptest = { workspace = true, default-features = true }
 rstest = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -3,10 +3,8 @@ use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 
-use monochange_test_helpers::copy_directory;
 use semver::Version;
 use serde_json::json;
-use tempfile::TempDir;
 use tempfile::tempdir;
 
 use crate::BumpSeverity;
@@ -699,76 +697,6 @@ fn is_pre_stable_returns_true_for_zero_major() {
 	assert!(BumpSeverity::is_pre_stable(&Version::new(0, 99, 99)));
 	assert!(!BumpSeverity::is_pre_stable(&Version::new(1, 0, 0)));
 	assert!(!BumpSeverity::is_pre_stable(&Version::new(2, 0, 0)));
-}
-
-#[test]
-fn discovery_path_filter_rejects_gitignored_paths() {
-	let fixture = setup_discovery_fixture("ignore-gitignored-nested-worktree");
-	let root = fixture.path();
-	let filter = crate::DiscoveryPathFilter::new(root);
-
-	assert!(!filter.should_descend(&root.join(".claude")));
-	assert!(!filter.allows(&root.join(".claude/worktrees/feature")));
-	assert!(filter.allows(&root.join("crates/root/Cargo.toml")));
-}
-
-#[test]
-fn discovery_path_filter_rejects_paths_under_nested_git_worktrees() {
-	let fixture = setup_discovery_fixture("ignore-automatic-nested-worktree");
-	let root = fixture.path();
-	let filter = crate::DiscoveryPathFilter::new(root);
-
-	assert!(!filter.should_descend(&root.join("sandbox/feature")));
-	assert!(!filter.allows(&root.join("sandbox/feature/crates/ignored/Cargo.toml")));
-	assert!(filter.allows(&root.join("crates/root/Cargo.toml")));
-}
-
-#[test]
-fn discovery_path_filter_does_not_treat_parent_git_dir_outside_root_as_nested_worktree() {
-	let source = Path::new(env!("CARGO_MANIFEST_DIR"))
-		.join("../../fixtures/tests/cargo/ignore-parent-git-outside-root");
-	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
-	copy_directory(&source, tempdir.path());
-
-	let root = tempdir.path().join("workspace");
-	let filter = crate::DiscoveryPathFilter::new(&root);
-
-	assert!(filter.allows(&root.join("crates/root/Cargo.toml")));
-	assert!(filter.allows(&tempdir.path().join("outside/Cargo.toml")));
-}
-
-fn setup_discovery_fixture(name: &str) -> TempDir {
-	let source = Path::new(env!("CARGO_MANIFEST_DIR"))
-		.join("../../fixtures/tests/cargo")
-		.join(name);
-	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
-	copy_directory(&source, tempdir.path());
-	materialize_nested_worktree_gitdir(tempdir.path());
-	tempdir
-}
-
-fn materialize_nested_worktree_gitdir(root: &Path) {
-	for (placeholder, git_path) in [
-		(
-			root.join("sandbox/feature/gitdir.txt"),
-			root.join("sandbox/feature/.git"),
-		),
-		(
-			root.join("feature.gitdir"),
-			root.join(".claude/worktrees/feature/.git"),
-		),
-	] {
-		if placeholder.is_file() {
-			let gitdir = fs::read_to_string(&placeholder)
-				.unwrap_or_else(|error| panic!("read {}: {error}", placeholder.display()));
-			if let Some(parent) = git_path.parent() {
-				fs::create_dir_all(parent)
-					.unwrap_or_else(|error| panic!("create parent {}: {error}", parent.display()));
-			}
-			fs::write(&git_path, gitdir)
-				.unwrap_or_else(|error| panic!("write {}: {error}", git_path.display()));
-		}
-	}
 }
 
 #[test]

--- a/crates/monochange_integration_tests/Cargo.toml
+++ b/crates/monochange_integration_tests/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "monochange_integration_tests"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+publish = false
+repository.workspace = true
+description = "Internal integration tests for monochange crates"
+
+[dev-dependencies]
+monochange_core = { workspace = true }
+monochange_test_helpers = { workspace = true }
+tempfile = { workspace = true, default-features = true }

--- a/crates/monochange_integration_tests/tests/discovery_path_filter.rs
+++ b/crates/monochange_integration_tests/tests/discovery_path_filter.rs
@@ -1,0 +1,77 @@
+use std::fs;
+use std::path::Path;
+
+use monochange_core::DiscoveryPathFilter;
+use monochange_test_helpers::copy_directory;
+use tempfile::TempDir;
+use tempfile::tempdir;
+
+#[test]
+fn discovery_path_filter_rejects_gitignored_paths() {
+	let fixture = setup_discovery_fixture("ignore-gitignored-nested-worktree");
+	let root = fixture.path();
+	let filter = DiscoveryPathFilter::new(root);
+
+	assert!(!filter.should_descend(&root.join(".claude")));
+	assert!(!filter.allows(&root.join(".claude/worktrees/feature")));
+	assert!(filter.allows(&root.join("crates/root/Cargo.toml")));
+}
+
+#[test]
+fn discovery_path_filter_rejects_paths_under_nested_git_worktrees() {
+	let fixture = setup_discovery_fixture("ignore-automatic-nested-worktree");
+	let root = fixture.path();
+	let filter = DiscoveryPathFilter::new(root);
+
+	assert!(!filter.should_descend(&root.join("sandbox/feature")));
+	assert!(!filter.allows(&root.join("sandbox/feature/crates/ignored/Cargo.toml")));
+	assert!(filter.allows(&root.join("crates/root/Cargo.toml")));
+}
+
+#[test]
+fn discovery_path_filter_does_not_treat_parent_git_dir_outside_root_as_nested_worktree() {
+	let source = Path::new(env!("CARGO_MANIFEST_DIR"))
+		.join("../../fixtures/tests/cargo/ignore-parent-git-outside-root");
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_directory(&source, tempdir.path());
+
+	let root = tempdir.path().join("workspace");
+	let filter = DiscoveryPathFilter::new(&root);
+
+	assert!(filter.allows(&root.join("crates/root/Cargo.toml")));
+	assert!(filter.allows(&tempdir.path().join("outside/Cargo.toml")));
+}
+
+fn setup_discovery_fixture(name: &str) -> TempDir {
+	let source = Path::new(env!("CARGO_MANIFEST_DIR"))
+		.join("../../fixtures/tests/cargo")
+		.join(name);
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_directory(&source, tempdir.path());
+	materialize_nested_worktree_gitdir(tempdir.path());
+	tempdir
+}
+
+fn materialize_nested_worktree_gitdir(root: &Path) {
+	for (placeholder, git_path) in [
+		(
+			root.join("sandbox/feature/gitdir.txt"),
+			root.join("sandbox/feature/.git"),
+		),
+		(
+			root.join("feature.gitdir"),
+			root.join(".claude/worktrees/feature/.git"),
+		),
+	] {
+		if placeholder.is_file() {
+			let gitdir = fs::read_to_string(&placeholder)
+				.unwrap_or_else(|error| panic!("read {}: {error}", placeholder.display()));
+			if let Some(parent) = git_path.parent() {
+				fs::create_dir_all(parent)
+					.unwrap_or_else(|error| panic!("create parent {}: {error}", parent.display()));
+			}
+			fs::write(&git_path, gitdir)
+				.unwrap_or_else(|error| panic!("write {}: {error}", git_path.display()));
+		}
+	}
+}

--- a/crates/monochange_test_helpers/Cargo.toml
+++ b/crates/monochange_test_helpers/Cargo.toml
@@ -3,7 +3,6 @@ name = "monochange_test_helpers"
 version = "0.0.3"
 edition = { workspace = true }
 license = { workspace = true }
-publish = false
 repository = { workspace = true }
 description = "Internal shared test helpers for monochange"
 

--- a/monochange.toml
+++ b/monochange.toml
@@ -285,9 +285,6 @@ path = "crates/monochange_hosting"
 
 [package.monochange_test_helpers]
 path = "crates/monochange_test_helpers"
-tag = false
-release = false
-changelog = false
 
 [package.monochange_analysis]
 path = "crates/monochange_analysis"


### PR DESCRIPTION
## Summary

Fix the release-workspace publish failures without disabling Cargo publish verification.

## Changes

- Removed the previous `cargo publish --no-verify` mitigation.
  - Cargo release publishing now keeps the normal `cargo publish --locked --manifest-path ...` verification path.
- Moved the integration-style discovery path filter tests out of `monochange_core` and into a new unpublished workspace crate:
  - `crates/monochange_integration_tests`
- Removed `monochange_test_helpers` from `monochange_core` dev-dependencies.
  - This avoids the specific publish failure where Cargo package verification could not resolve a workspace-only dev-dependency for `monochange_core`.
- Verified the fundamental Cargo packaging fix with:
  - `cargo package -p monochange_core --allow-dirty`
- Kept PNPM support for PNPM workspaces.
- Kept the JavaScript tooling mitigation:
  - `mc publish` strips inherited `LD_LIBRARY_PATH` only when spawning `node`, `npm`, `npx`, or `pnpm`.
  - This avoids Nix/devenv library-path leakage breaking system Node launchers in GitHub Actions while preserving PNPM behavior.
- Added a Cargo publishability lint rule implementation/test coverage for publishable crates depending on unpublished workspace packages. It is not enabled in the current default suite yet because the broader workspace still has known test-harness dev-dependencies to migrate; this PR fixes the release-blocking `monochange_core` case first.

## Validation

- `devenv shell -- cargo test -p monochange_integration_tests -- --nocapture`
- `devenv shell -- cargo test -p monochange_cargo publishable_dependency_rule -- --nocapture`
- `devenv shell -- cargo test -p monochange process_command_executor_cleans_library_path_for_javascript_tooling -- --nocapture`
- `devenv shell -- cargo test -p monochange build_publish_command_covers_all_supported_registries -- --nocapture`
- `devenv shell -- mc validate`
- `devenv shell -- cargo fmt --all --check`
- `devenv shell -- dprint check .changeset/publish-registry-tools.md`
- `git diff --check`
- `devenv shell -- coverage:patch` → `PATCH_COVERAGE 58/58 (100.00%)`
- `cargo package -p monochange_core --allow-dirty`
- pre-push hook full suite: `2122 tests run: 2122 passed, 0 skipped`
