### PR TITLE
fix: fall back to tag_name for release title when rendered_title is empty

### DIFF
--- a/.changeset/draft-release-title-fallback.md
+++ b/.changeset/draft-release-title-fallback.md
@@ -1,0 +1,9 @@
+---
+monochange_github: patch
+monochange_gitlab: patch
+monochange_gitea: patch
+---
+
+# Ensure draft releases use proper title fallback
+
+When a release manifest is reconstructed from git history (e.g. during `release-post-merge`), `rendered_title` may be empty. In that case, `build_release_requests` now falls back to `tag_name` for the release name across all providers (GitHub, GitLab, Gitea). This prevents draft releases from appearing with a generic "Draft" title and ensures they display the actual version tag instead.

--- a/crates/monochange_gitea/src/__tests.rs
+++ b/crates/monochange_gitea/src/__tests.rs
@@ -69,6 +69,20 @@ fn build_release_requests_uses_gitea_provider() {
 }
 
 #[test]
+fn build_release_requests_falls_back_to_tag_name_when_rendered_title_is_empty() {
+	let source = sample_source(None, Some("https://codeberg.org".to_string()));
+	let mut manifest = sample_manifest();
+	manifest.release_targets.first_mut().unwrap().rendered_title = String::new();
+
+	let requests = build_release_requests(&source, &manifest);
+	let request = requests
+		.first()
+		.unwrap_or_else(|| panic!("expected request"));
+
+	assert_eq!(request.name, "v1.2.0");
+}
+
+#[test]
 fn build_release_pull_request_request_uses_gitea_provider_and_sanitized_branch() {
 	let source = sample_source(None, Some("https://codeberg.org".to_string()));
 	let manifest = ReleaseManifest {

--- a/crates/monochange_gitea/src/lib.rs
+++ b/crates/monochange_gitea/src/lib.rs
@@ -353,7 +353,11 @@ pub fn build_release_requests(
 				target_id: target.id.clone(),
 				target_kind: target.kind,
 				tag_name: target.tag_name.clone(),
-				name: target.rendered_title.clone(),
+				name: if target.rendered_title.is_empty() {
+					target.tag_name.clone()
+				} else {
+					target.rendered_title.clone()
+				},
 				body: release_body(source, manifest, target),
 				draft: source.releases.draft,
 				prerelease: source.releases.prerelease,

--- a/crates/monochange_github/src/__tests.rs
+++ b/crates/monochange_github/src/__tests.rs
@@ -519,6 +519,28 @@ fn build_release_requests_fall_back_to_minimal_release_bodies() {
 }
 
 #[test]
+fn build_release_requests_falls_back_to_tag_name_when_rendered_title_is_empty() {
+	let github = SourceConfiguration {
+		provider: SourceProvider::GitHub,
+		host: None,
+		api_url: None,
+		owner: "ifiokjr".to_string(),
+		repo: "monochange".to_string(),
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+	};
+	let mut manifest = sample_manifest();
+	manifest.release_targets.first_mut().unwrap().rendered_title = String::new();
+
+	let requests = build_release_requests(&github, &manifest);
+	let request = requests
+		.first()
+		.unwrap_or_else(|| panic!("expected request"));
+
+	assert_eq!(request.name, "v1.2.0");
+}
+
+#[test]
 fn build_release_pull_request_request_renders_branch_and_body() {
 	let github = SourceConfiguration {
 		provider: SourceProvider::GitHub,

--- a/crates/monochange_github/src/lib.rs
+++ b/crates/monochange_github/src/lib.rs
@@ -635,7 +635,11 @@ pub fn build_release_requests(
 				target_id: target.id.clone(),
 				target_kind: target.kind,
 				tag_name: target.tag_name.clone(),
-				name: target.rendered_title.clone(),
+				name: if target.rendered_title.is_empty() {
+					target.tag_name.clone()
+				} else {
+					target.rendered_title.clone()
+				},
 				body: release_body(source, manifest, target),
 				draft: source.releases.draft,
 				prerelease: source.releases.prerelease,

--- a/crates/monochange_gitlab/src/__tests.rs
+++ b/crates/monochange_gitlab/src/__tests.rs
@@ -70,6 +70,20 @@ fn build_release_requests_uses_gitlab_provider() {
 }
 
 #[test]
+fn build_release_requests_falls_back_to_tag_name_when_rendered_title_is_empty() {
+	let source = sample_source(None);
+	let mut manifest = sample_manifest();
+	manifest.release_targets.first_mut().unwrap().rendered_title = String::new();
+
+	let requests = build_release_requests(&source, &manifest);
+	let request = requests
+		.first()
+		.unwrap_or_else(|| panic!("expected request"));
+
+	assert_eq!(request.name, "v1.2.0");
+}
+
+#[test]
 fn build_release_pull_request_request_uses_gitlab_provider_and_sanitized_branch() {
 	let source = sample_source(None);
 	let manifest = ReleaseManifest {

--- a/crates/monochange_gitlab/src/lib.rs
+++ b/crates/monochange_gitlab/src/lib.rs
@@ -344,7 +344,11 @@ pub fn build_release_requests(
 				target_id: target.id.clone(),
 				target_kind: target.kind,
 				tag_name: target.tag_name.clone(),
-				name: target.rendered_title.clone(),
+				name: if target.rendered_title.is_empty() {
+					target.tag_name.clone()
+				} else {
+					target.rendered_title.clone()
+				},
 				body: release_body(source, manifest, target),
 				draft: source.releases.draft,
 				prerelease: source.releases.prerelease,


### PR DESCRIPTION
## Problem\n\nWhen a release manifest is reconstructed from git history (e.g. during the  job),  is left empty. This causes draft releases to appear with a generic "Draft" title instead of the actual version/tag.\n\n## Fix\n\nIn  across all three providers (GitHub, GitLab, Gitea), release  now falls back to  when  is empty.\n\n## Changes\n\n- \n- \n- 