### PR TITLE
fix: use GITHUB_TOKEN for Git Data API to create verified commits

### DIFF
--- a/.changeset/verified-commits-github-token.md
+++ b/.changeset/verified-commits-github-token.md
@@ -1,0 +1,9 @@
+---
+main: patch
+---
+
+# Use `GITHUB_TOKEN` for Git Data API to create verified commits
+
+The `release-pr` workflow now passes `GITHUB_COMMIT_TOKEN` (set to `secrets.GITHUB_TOKEN`) specifically for Git Database API operations (blob, tree, commit creation, and ref updates). This allows GitHub to automatically sign commits with the `web-flow` GPG key, producing verified commits on release pull requests.
+
+The `GH_TOKEN` (PAT) continues to be used for all other GitHub API operations like pull request creation and updates.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,6 +388,7 @@ jobs:
         if: steps.release_record.outputs.is_release_commit != 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
+          GITHUB_COMMIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: mc --log-level=debug release-pr
         shell: devenv shell -- bash -e {0}
 

--- a/crates/monochange_github/src/__tests.rs
+++ b/crates/monochange_github/src/__tests.rs
@@ -2784,3 +2784,44 @@ fn seed_git_repository() -> (tempfile::TempDir, PathBuf) {
 		.unwrap_or_else(|error| panic!("update release file: {error}"));
 	(tempdir, repo)
 }
+
+#[test]
+fn github_commit_client_from_env_requires_commit_token_or_github_token() {
+	let source = sample_source(None);
+
+	let result = temp_env::with_vars(
+		[
+			("GITHUB_COMMIT_TOKEN", None::<&str>),
+			("GITHUB_TOKEN", None::<&str>),
+		],
+		|| {
+			let runtime = github_runtime().unwrap_or_else(|error| panic!("runtime: {error}"));
+			runtime.block_on(async { github_commit_client_from_env(&source) })
+		},
+	);
+
+	assert_eq!(
+		result
+			.err()
+			.map(|error| error.to_string()),
+		Some("config error: set `GITHUB_COMMIT_TOKEN` (or `GITHUB_TOKEN`) for GitHub commit verification".to_string())
+	);
+}
+
+#[test]
+fn github_commit_client_from_env_prefers_github_commit_token_over_github_token() {
+	let source = sample_source(None);
+
+	let result = temp_env::with_vars(
+		[
+			("GITHUB_COMMIT_TOKEN", Some("commit-token")),
+			("GITHUB_TOKEN", Some("github-token")),
+		],
+		|| {
+			let runtime = github_runtime().unwrap_or_else(|error| panic!("runtime: {error}"));
+			runtime.block_on(async { github_commit_client_from_env(&source) })
+		},
+	);
+
+	assert!(result.is_ok());
+}

--- a/crates/monochange_github/src/lib.rs
+++ b/crates/monochange_github/src/lib.rs
@@ -1200,9 +1200,10 @@ fn maybe_replace_release_pull_request_commit_with_verified_github_commit(
 
 	let runtime = github_runtime().map_err(|error| error.to_string())?;
 	runtime.block_on(async {
-		let client = github_client_from_env(source).map_err(|error| error.to_string())?;
+		let commit_client =
+			github_commit_client_from_env(source).map_err(|error| error.to_string())?;
 		let verified_commit = create_verified_github_commit_for_release_pull_request(
-			&client,
+			&commit_client,
 			request,
 			fallback_commit,
 			root,
@@ -1210,7 +1211,7 @@ fn maybe_replace_release_pull_request_commit_with_verified_github_commit(
 		)
 		.await?;
 		update_github_branch_ref_to_verified_commit(
-			&client,
+			&commit_client,
 			request,
 			fallback_commit,
 			&verified_commit,
@@ -1749,6 +1750,23 @@ fn github_client_from_env(source: &SourceConfiguration) -> MonochangeResult<Octo
 		.map_err(|_| {
 			MonochangeError::Config(
 				"set `GITHUB_TOKEN` (or `GH_TOKEN`) before running GitHub automation".to_string(),
+			)
+		})?;
+	let env_api_url = env::var("GITHUB_API_URL").ok();
+	let api_url = source.api_url.as_deref().or(env_api_url.as_deref());
+	build_github_client(&token, api_url)
+}
+
+/// Client specifically for Git Database API operations that create blobs, trees,
+/// commits, and update refs. In GitHub Actions, this must use `GITHUB_TOKEN`
+/// (not a PAT) for GitHub to auto-sign commits with the web-flow GPG key.
+fn github_commit_client_from_env(source: &SourceConfiguration) -> MonochangeResult<Octocrab> {
+	let token = env::var("GITHUB_COMMIT_TOKEN")
+		.or_else(|_| env::var("GITHUB_TOKEN"))
+		.map_err(|_| {
+			MonochangeError::Config(
+				"set `GITHUB_COMMIT_TOKEN` (or `GITHUB_TOKEN`) for GitHub commit verification"
+					.to_string(),
 			)
 		})?;
 	let env_api_url = env::var("GITHUB_API_URL").ok();


### PR DESCRIPTION
Use `GITHUB_TOKEN` for Git Data API operations (blob, tree, commit creation, and ref updates) so GitHub auto-signs commits with the web-flow GPG key, producing verified commits on release pull requests. The `GH_TOKEN` (PAT) continues to be used for all other GitHub API operations like pull request creation.