### PR TITLE
fix: clear Nix LD vars when publishing npm packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -201,7 +201,18 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-oidc.outputs.token }}
         run: |
-          "$RUNNER_TEMP/bin/mc" publish ${{ matrix.packages }} \
-            --output "$RUNNER_TEMP/publish-result-${{ matrix.registry }}-${{ matrix.batch }}.json" \
-            --format json
+          if [ "${{ matrix.registry }}" = "npm" ]; then
+            # Nix glibc 2.42's libdl.so.2 requires GLIBC_ABI_DT_X86_64_PLT which
+            # the runner's glibc 2.39 does not provide. Clear the Nix library-path
+            # overrides so pnpm (and its node shebang) use only the system
+            # dynamic linker and system glibc.
+            env -u LD_LIBRARY_PATH -u LD_PRELOAD -u LD_AUDIT -u NIX_LD -u NIX_LD_LIBRARY_PATH \
+              "$RUNNER_TEMP/bin/mc" publish ${{ matrix.packages }} \
+                --output "$RUNNER_TEMP/publish-result-${{ matrix.registry }}-${{ matrix.batch }}.json" \
+                --format json
+          else
+            "$RUNNER_TEMP/bin/mc" publish ${{ matrix.packages }} \
+              --output "$RUNNER_TEMP/publish-result-${{ matrix.registry }}-${{ matrix.batch }}.json" \
+              --format json
+          fi
         shell: devenv shell -- bash -e {0}


### PR DESCRIPTION
## Problem

The `publish` workflow fails with a glibc ABI incompatibility when publishing npm packages:

```
discovery error: package publish failed for @monochange/cli 0.3.0: `pnpm publish --access public` failed: /usr/bin/env: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_ABI_DT_X86_64_PLT' not found (required by /nix/store/...-glibc-2.42-61/lib/libdl.so.2)
```

## Root Cause

The devenv shell sets `LD_LIBRARY_PATH`, `LD_PRELOAD`, `LD_AUDIT`, `NIX_LD`, and `NIX_LD_LIBRARY_PATH` to point at Nix store paths. Nix glibc 2.42's `libdl.so.2` requires the `GLIBC_ABI_DT_X86_64_PLT` symbol version, but the GitHub Actions runner's glibc 2.39 does not provide it.

When `mc publish` shells out to `pnpm publish`, the pnpm binary (resolved from the Nix store via the devenv PATH) has a `#!/usr/bin/env node` shebang. The system `/usr/bin/env` inherits the Nix LD overrides, causing the `libdl` incompatibility.

## Fix

For **npm** publish batches, clear the Nix library-path overrides via `env -u` before invoking `mc publish`. This ensures `pnpm` and its `node` shebang use only the system dynamic linker and system glibc.

For **crates_io** batches, the Nix environment is preserved so `cargo publish` has access to the Rust toolchain.

This mirrors the same pattern already used in `ci.yml` for `oxlint`:

```bash
env -u LD_LIBRARY_PATH -u LD_PRELOAD -u LD_AUDIT -u NIX_LD -u NIX_LD_LIBRARY_PATH node oxlint...
```