### PR TITLE
feat: expose release tags by target id

### DIFF
--- a/.changeset/1778055969-monochange.md
+++ b/.changeset/1778055969-monochange.md
@@ -1,0 +1,41 @@
+---
+monochange: minor
+"@monochange/cli": minor
+---
+
+# Make tag-release JSON addressable by release target id
+
+`mc tag-release --format json` now includes a flat `tags` object keyed by package or group id, so automation can select the exact release tag it needs without depending on array order or old single-group fields.
+
+Before, workflows had to rely on paths that were either unavailable for this command or too implicit for multi-target releases:
+
+```bash
+tag="$(jq -r '.groupVersion.tag // empty' /tmp/tag-report.json)"
+# or, less explicit:
+tag="$(jq -r '.tagResults[0].tagName // empty' /tmp/tag-report.json)"
+```
+
+After, workflows can read the package or group id directly. For a workspace with `[group.main]`:
+
+```bash
+tag="$(jq -r '.tags.main // empty' /tmp/tag-report.json)"
+```
+
+Example output:
+
+```json
+{
+	"status": "completed",
+	"tagResults": [
+		{
+			"operation": "created",
+			"tagName": "v1.2.3"
+		}
+	],
+	"tags": {
+		"main": "v1.2.3"
+	}
+}
+```
+
+The map is intentionally flat because package ids and group ids share one namespace in monochange configuration, so there is no ambiguity between `.tags.main` as a package id and `.tags.main` as a group id.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,9 +455,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          tag="$(jq -r '.groupVersion.tag // empty' /tmp/tag-report.json)"
+          tag="$(jq -r '.tags.main // empty' /tmp/tag-report.json)"
           if [ -z "$tag" ]; then
-            echo "No tag found in tag-report.json, skipping release trigger"
+            echo "No main group tag found in tag-report.json, skipping release trigger"
             exit 0
           fi
           echo "Triggering release workflow for tag $tag"

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -149,6 +149,43 @@ monochange can promote one prepared release into several source-provider automat
 
 <!-- {/projectGitHubAutomationOverview} -->
 
+<!-- {@projectTagReleaseJsonTagsMap} -->
+
+When a post-merge workflow needs to trigger follow-up release work, prefer `mc tag-release --from HEAD --format json` and read the release tag by package or group id from the top-level `tags` object:
+
+```json
+{
+	"tags": {
+		"main": "v1.2.3",
+		"sdk": "sdk/v1.2.3"
+	}
+}
+```
+
+`name/version` examples such as `sdk/v1.2.3` correspond to a tag template like `{{ name }}/v{{ version }}`.
+
+The `tags` object is intentionally flat because package ids and group ids share the same monochange namespace. A workspace cannot have both a package and a group with the same id, so workflows do not need separate `tags.packages` and `tags.groups` branches or prefixed lookup keys. This makes automation stable and explicit: use `.tags.<id>` for the package or group whose release should drive the next step.
+
+A package or group might not be released in a particular release commit. Handle that by checking whether `tags` has an entry for the id you care about. If there is no tag attached to that id, you can assume that release did not include that package or group and skip that follow-up workflow.
+
+For example, a repository with `[group.main]` can trigger a downstream GitHub release workflow from the main group tag with:
+
+```bash
+mc tag-release --from HEAD --format json >/tmp/tag-report.json
+tag="$(jq -r '.tags.main // empty' /tmp/tag-report.json)"
+
+if [ -z "$tag" ]; then
+  echo "No main group tag found in tag-report.json, skipping release trigger"
+  exit 0
+fi
+
+gh workflow run release.yml --ref "$tag" -f tag="$tag"
+```
+
+Avoid indexing `tagResults[0]` for workflow control. `tagResults` remains the audit log of tag operations, while `tags` is the stable id-addressable map for automation.
+
+<!-- {/projectTagReleaseJsonTagsMap} -->
+
 <!-- {@repoDevEnvironmentSetupCode} -->
 
 ```bash

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -10557,6 +10557,8 @@ fn render_release_tag_report_supports_text_and_json_formats() {
 	assert!(json.contains("\"recordCommit\": "));
 	assert!(json.contains("\"push\": false"));
 	assert!(json.contains("\"status\": \"dry_run\""));
+	assert!(json.contains("\"tags\": {"));
+	assert!(json.contains("\"sdk\": \"v1.2.3\""));
 	assert!(json.contains(&release_commit[..7]));
 }
 
@@ -10574,6 +10576,7 @@ fn create_release_tags_creates_and_pushes_tags_in_process() {
 		.unwrap_or_else(|error| panic!("create release tags: {error}"));
 	assert_eq!(report.status, "completed");
 	assert_eq!(report.tag_results.len(), 1);
+	assert_eq!(report.tags.get("sdk").map(String::as_str), Some("v1.2.3"));
 	assert_eq!(
 		report.tag_results[0].operation,
 		crate::release_record::ReleaseTagOperation::Created

--- a/crates/monochange/src/release_record.rs
+++ b/crates/monochange/src/release_record.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use monochange_core::MonochangeError;
@@ -340,6 +341,7 @@ pub(crate) struct ReleaseTagReport {
 	pub push: bool,
 	pub dry_run: bool,
 	pub tag_results: Vec<ReleaseTagResult>,
+	pub tags: BTreeMap<String, String>,
 	pub status: String,
 }
 
@@ -435,6 +437,8 @@ pub(crate) fn create_release_tags(
 		}
 	}
 
+	let tags = release_tag_map(discovery);
+
 	let status = if dry_run {
 		"dry_run"
 	} else if tag_results.is_empty() {
@@ -456,8 +460,19 @@ pub(crate) fn create_release_tags(
 		push,
 		dry_run,
 		tag_results,
+		tags,
 		status: status.to_string(),
 	})
+}
+
+fn release_tag_map(discovery: &ReleaseRecordDiscovery) -> BTreeMap<String, String> {
+	discovery
+		.record
+		.release_targets
+		.iter()
+		.filter(|target| target.tag)
+		.map(|target| (target.id.clone(), target.tag_name.clone()))
+		.collect()
 }
 
 pub(crate) fn text_release_tag_report(report: &ReleaseTagReport) -> String {

--- a/crates/monochange/tests/release_record.rs
+++ b/crates/monochange/tests/release_record.rs
@@ -263,6 +263,51 @@ fn tag_release_command_rejects_descendant_refs_that_are_not_release_commits() {
 }
 
 #[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+fn tag_release_command_json_snapshots_entire_report() {
+	let mut settings = snapshot_settings();
+	settings.set_snapshot_suffix(current_test_name());
+	let _guard = settings.bind_to_scope();
+
+	let tempdir = setup_release_repo();
+	let repo = tempdir.path();
+	configure_origin_remote(repo);
+	let mut release_record = sample_release_record();
+	release_record.release_targets.push(ReleaseRecordTarget {
+		id: "cli".to_string(),
+		kind: ReleaseOwnerKind::Package,
+		version: "2.0.0".to_string(),
+		version_format: VersionFormat::Namespaced,
+		tag: true,
+		release: true,
+		tag_name: "cli/v2.0.0".to_string(),
+		members: Vec::new(),
+	});
+	commit_release_record(repo, &release_record);
+	git(repo, &["push", "-u", "origin", "HEAD:main"]);
+
+	let output = tag_release_output(
+		repo,
+		&[
+			"--from",
+			"HEAD",
+			"--dry-run",
+			"--push=false",
+			"--format",
+			"json",
+		],
+	);
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	let parsed: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+		panic!("json: {error}\n{}", String::from_utf8_lossy(&output.stdout))
+	});
+	assert_json_snapshot!(parsed);
+}
+
+#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
 fn tag_release_command_dry_run_reports_planned_tags_without_creating_them() {
 	let mut settings = snapshot_settings();
 	settings.set_snapshot_suffix(current_test_name());

--- a/crates/monochange/tests/snapshots/release_record__tag_release_command_json_snapshots_entire_report@tag_release_command_json_snapshots_entire_report.snap
+++ b/crates/monochange/tests/snapshots/release_record__tag_release_command_json_snapshots_entire_report@tag_release_command_json_snapshots_entire_report.snap
@@ -1,25 +1,32 @@
 ---
 source: crates/monochange/tests/release_record.rs
-assertion_line: 200
+assertion_line: 307
 expression: parsed
 ---
 {
   "distance": 0,
-  "dryRun": false,
+  "dryRun": true,
   "from": "HEAD",
-  "push": true,
+  "push": false,
   "recordCommit": "[SHA]",
   "resolvedFromCommit": "[SHA]",
-  "status": "completed",
+  "status": "dry_run",
   "tagResults": [
     {
       "existingCommit": null,
-      "operation": "created",
+      "operation": "planned",
+      "tagName": "cli/v2.0.0",
+      "targetCommit": "[SHA]"
+    },
+    {
+      "existingCommit": null,
+      "operation": "planned",
       "tagName": "v1.2.3",
       "targetCommit": "[SHA]"
     }
   ],
   "tags": {
+    "cli": "cli/v2.0.0",
     "sdk": "v1.2.3"
   }
 }

--- a/docs/src/guide/08-github-automation.md
+++ b/docs/src/guide/08-github-automation.md
@@ -74,6 +74,45 @@ Use `--dry-run` first for `repair-release`. It is a destructive workflow because
 
 If immutable registry artifacts have already been published, prefer cutting a new patch release instead of retargeting the source release.
 
+### Tag-release JSON for follow-up workflows
+
+<!-- {=projectTagReleaseJsonTagsMap} -->
+
+When a post-merge workflow needs to trigger follow-up release work, prefer `mc tag-release --from HEAD --format json` and read the release tag by package or group id from the top-level `tags` object:
+
+```json
+{
+	"tags": {
+		"main": "v1.2.3",
+		"sdk": "sdk/v1.2.3"
+	}
+}
+```
+
+`name/version` examples such as `sdk/v1.2.3` correspond to a tag template like `{{ name }}/v{{ version }}`.
+
+The `tags` object is intentionally flat because package ids and group ids share the same monochange namespace. A workspace cannot have both a package and a group with the same id, so workflows do not need separate `tags.packages` and `tags.groups` branches or prefixed lookup keys. This makes automation stable and explicit: use `.tags.<id>` for the package or group whose release should drive the next step.
+
+A package or group might not be released in a particular release commit. Handle that by checking whether `tags` has an entry for the id you care about. If there is no tag attached to that id, you can assume that release did not include that package or group and skip that follow-up workflow.
+
+For example, a repository with `[group.main]` can trigger a downstream GitHub release workflow from the main group tag with:
+
+```bash
+mc tag-release --from HEAD --format json >/tmp/tag-report.json
+tag="$(jq -r '.tags.main // empty' /tmp/tag-report.json)"
+
+if [ -z "$tag" ]; then
+  echo "No main group tag found in tag-report.json, skipping release trigger"
+  exit 0
+fi
+
+gh workflow run release.yml --ref "$tag" -f tag="$tag"
+```
+
+Avoid indexing `tagResults[0]` for workflow control. `tagResults` remains the audit log of tag operations, while `tags` is the stable id-addressable map for automation.
+
+<!-- {/projectTagReleaseJsonTagsMap} -->
+
 ## Package publishing and trusted publishing
 
 Package publishing is separate from provider release publishing:

--- a/docs/src/guide/13-ci-and-publishing.md
+++ b/docs/src/guide/13-ci-and-publishing.md
@@ -99,6 +99,45 @@ The important current implementation detail is that `mc publish-readiness` can w
 
 If the same post-merge job is responsible for both tags and package publication, run `mc tag-release --from HEAD` immediately after release-commit detection, then run `mc publish-readiness --from HEAD --output <path>`, use `mc publish-bootstrap --from HEAD --output <path>` only when first-time package setup is required, optionally inspect `mc publish-plan --readiness <path>`, and finally run `mc publish --output .monochange/publish-result.json`. Rerun `mc publish-readiness` if CI setup edits publish inputs after the artifact is written. If a registry command fails after some packages were published, fix the cause and rerun `mc publish --resume .monochange/publish-result.json --output .monochange/publish-result.json`; monochange skips completed package versions from the previous result and retries the remaining release work.
 
+### Tag-release JSON for follow-up workflows
+
+<!-- {=projectTagReleaseJsonTagsMap} -->
+
+When a post-merge workflow needs to trigger follow-up release work, prefer `mc tag-release --from HEAD --format json` and read the release tag by package or group id from the top-level `tags` object:
+
+```json
+{
+	"tags": {
+		"main": "v1.2.3",
+		"sdk": "sdk/v1.2.3"
+	}
+}
+```
+
+`name/version` examples such as `sdk/v1.2.3` correspond to a tag template like `{{ name }}/v{{ version }}`.
+
+The `tags` object is intentionally flat because package ids and group ids share the same monochange namespace. A workspace cannot have both a package and a group with the same id, so workflows do not need separate `tags.packages` and `tags.groups` branches or prefixed lookup keys. This makes automation stable and explicit: use `.tags.<id>` for the package or group whose release should drive the next step.
+
+A package or group might not be released in a particular release commit. Handle that by checking whether `tags` has an entry for the id you care about. If there is no tag attached to that id, you can assume that release did not include that package or group and skip that follow-up workflow.
+
+For example, a repository with `[group.main]` can trigger a downstream GitHub release workflow from the main group tag with:
+
+```bash
+mc tag-release --from HEAD --format json >/tmp/tag-report.json
+tag="$(jq -r '.tags.main // empty' /tmp/tag-report.json)"
+
+if [ -z "$tag" ]; then
+  echo "No main group tag found in tag-report.json, skipping release trigger"
+  exit 0
+fi
+
+gh workflow run release.yml --ref "$tag" -f tag="$tag"
+```
+
+Avoid indexing `tagResults[0]` for workflow control. `tagResults` remains the audit log of tag operations, while `tags` is the stable id-addressable map for automation.
+
+<!-- {/projectTagReleaseJsonTagsMap} -->
+
 ### GitHub + npm trusted publishing
 
 Config:

--- a/packages/monochange__cli/README.md
+++ b/packages/monochange__cli/README.md
@@ -148,6 +148,45 @@ monochange can promote one prepared release into several source-provider automat
 
 <!-- {/projectGitHubAutomationOverview} -->
 
+#### Tag-release JSON for follow-up workflows
+
+<!-- {=projectTagReleaseJsonTagsMap} -->
+
+When a post-merge workflow needs to trigger follow-up release work, prefer `mc tag-release --from HEAD --format json` and read the release tag by package or group id from the top-level `tags` object:
+
+```json
+{
+	"tags": {
+		"main": "v1.2.3",
+		"sdk": "sdk/v1.2.3"
+	}
+}
+```
+
+`name/version` examples such as `sdk/v1.2.3` correspond to a tag template like `{{ name }}/v{{ version }}`.
+
+The `tags` object is intentionally flat because package ids and group ids share the same monochange namespace. A workspace cannot have both a package and a group with the same id, so workflows do not need separate `tags.packages` and `tags.groups` branches or prefixed lookup keys. This makes automation stable and explicit: use `.tags.<id>` for the package or group whose release should drive the next step.
+
+A package or group might not be released in a particular release commit. Handle that by checking whether `tags` has an entry for the id you care about. If there is no tag attached to that id, you can assume that release did not include that package or group and skip that follow-up workflow.
+
+For example, a repository with `[group.main]` can trigger a downstream GitHub release workflow from the main group tag with:
+
+```bash
+mc tag-release --from HEAD --format json >/tmp/tag-report.json
+tag="$(jq -r '.tags.main // empty' /tmp/tag-report.json)"
+
+if [ -z "$tag" ]; then
+  echo "No main group tag found in tag-report.json, skipping release trigger"
+  exit 0
+fi
+
+gh workflow run release.yml --ref "$tag" -f tag="$tag"
+```
+
+Avoid indexing `tagResults[0]` for workflow control. `tagResults` remains the audit log of tag operations, while `tags` is the stable id-addressable map for automation.
+
+<!-- {/projectTagReleaseJsonTagsMap} -->
+
 ### Assistant setup and MCP
 
 Assistant tooling is optional.

--- a/readme.md
+++ b/readme.md
@@ -216,6 +216,45 @@ monochange can promote one prepared release into several source-provider automat
 
 <!-- {/projectGitHubAutomationOverview} -->
 
+#### Tag-release JSON for follow-up workflows
+
+<!-- {=projectTagReleaseJsonTagsMap} -->
+
+When a post-merge workflow needs to trigger follow-up release work, prefer `mc tag-release --from HEAD --format json` and read the release tag by package or group id from the top-level `tags` object:
+
+```json
+{
+	"tags": {
+		"main": "v1.2.3",
+		"sdk": "sdk/v1.2.3"
+	}
+}
+```
+
+`name/version` examples such as `sdk/v1.2.3` correspond to a tag template like `{{ name }}/v{{ version }}`.
+
+The `tags` object is intentionally flat because package ids and group ids share the same monochange namespace. A workspace cannot have both a package and a group with the same id, so workflows do not need separate `tags.packages` and `tags.groups` branches or prefixed lookup keys. This makes automation stable and explicit: use `.tags.<id>` for the package or group whose release should drive the next step.
+
+A package or group might not be released in a particular release commit. Handle that by checking whether `tags` has an entry for the id you care about. If there is no tag attached to that id, you can assume that release did not include that package or group and skip that follow-up workflow.
+
+For example, a repository with `[group.main]` can trigger a downstream GitHub release workflow from the main group tag with:
+
+```bash
+mc tag-release --from HEAD --format json >/tmp/tag-report.json
+tag="$(jq -r '.tags.main // empty' /tmp/tag-report.json)"
+
+if [ -z "$tag" ]; then
+  echo "No main group tag found in tag-report.json, skipping release trigger"
+  exit 0
+fi
+
+gh workflow run release.yml --ref "$tag" -f tag="$tag"
+```
+
+Avoid indexing `tagResults[0]` for workflow control. `tagResults` remains the audit log of tag operations, while `tags` is the stable id-addressable map for automation.
+
+<!-- {/projectTagReleaseJsonTagsMap} -->
+
 ### Assistant setup and MCP
 
 Assistant tooling is optional.


### PR DESCRIPTION
## Summary
- add a flat `tags` object to `mc tag-release --format json` keyed by package/group id
- update the CI release trigger to dispatch using `.tags.main`
- update release tag JSON snapshot/tests

## Verification
- `devenv shell fix:format`
- `devenv shell cargo test -p monochange render_release_tag_report_supports_text_and_json_formats`
- `devenv shell cargo test -p monochange create_release_tags_creates_and_pushes_tags_in_process`
- full coverage run via `cargo-llvm-cov llvm-cov test --workspace --all-features --all-targets --no-report`
- `devenv shell coverage:patch` (PATCH_COVERAGE 0/0, 100.00%)