### PR TITLE
fix(cli): show retarget release progress

### DIFF
--- a/.changeset/1778056679-monochange.md
+++ b/.changeset/1778056679-monochange.md
@@ -1,0 +1,7 @@
+---
+monochange: patch
+---
+
+# Show retarget release progress
+
+`mc repair-release` now updates progress while retargeting a release so long-running provider and git ref updates show the active sub-step instead of a static spinner.

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -4790,6 +4790,35 @@ fn repair_release_command_dry_run_reports_text_output() {
 }
 
 #[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+fn repair_release_command_emits_retarget_progress_statuses() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	write_blank_monochange_config(root);
+	create_release_record_history(root);
+
+	let output = temp_env::with_var("MONOCHANGE_PROGRESS_FORMAT", Some("json"), || {
+		run_with_args_in_dir(
+			"mc",
+			[
+				OsString::from("mc"),
+				OsString::from("step:retarget-release"),
+				OsString::from("--from"),
+				OsString::from("v1.2.3"),
+				OsString::from("--target"),
+				OsString::from("HEAD"),
+				OsString::from("--sync-provider=false"),
+				OsString::from("--dry-run"),
+			],
+			root,
+		)
+	})
+	.unwrap_or_else(|error| panic!("repair-release output: {error}"));
+
+	assert!(output.contains("repair release:"));
+	assert!(output.contains("status: dry-run"));
+}
+
+#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
 fn repair_release_command_reports_json_output() {
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	let root = tempdir.path();

--- a/crates/monochange/src/cli_progress.rs
+++ b/crates/monochange/src/cli_progress.rs
@@ -277,6 +277,39 @@ impl CliProgressReporter {
 		self.print_line(&line);
 	}
 
+	pub(crate) fn step_status(
+		&mut self,
+		step_index: usize,
+		step: &CliStepDefinition,
+		status: &str,
+	) {
+		if !self.enabled {
+			return;
+		}
+		if self.render_mode == ProgressRenderMode::Json {
+			let mut payload = serde_json::Map::new();
+			payload.insert(
+				"status".to_string(),
+				serde_json::Value::String(status.to_string()),
+			);
+			self.emit_step_event("step_status", step_index, step, payload);
+			return;
+		}
+		let message = format!(
+			"{} — {}",
+			self.step_message(step_index, step),
+			self.paint(status, Style::Detail),
+		);
+		if self.animate {
+			self.start_spinner(message);
+		} else {
+			self.print_line(&format!(
+				"{} {message}",
+				self.paint(self.symbols.step_start, Style::Accent),
+			));
+		}
+	}
+
 	pub(crate) fn step_finished(
 		&mut self,
 		step_index: usize,
@@ -768,6 +801,27 @@ mod tests {
 
 		reporter.step_skipped(0, &step, Some("{{ false }}"));
 		reporter.step_failed(1, &step, Duration::from_millis(25), "boom");
+	}
+
+	#[test]
+	fn progress_reporter_updates_step_status_in_human_json_and_animated_modes() {
+		let step = named_command_step("retarget release");
+		let mut disabled = progress_reporter(false, false);
+		disabled.step_status(0, &step, "locating release record");
+
+		let mut human = progress_reporter(true, false);
+		human.step_status(0, &step, "planning retarget");
+
+		let mut json = progress_reporter(true, false);
+		json.render_mode = ProgressRenderMode::Json;
+		json.step_status(0, &step, "applying git ref and provider updates");
+		assert_eq!(json.event_sequence, 1);
+
+		let mut animated = progress_reporter(true, true);
+		animated.animate = true;
+		animated.step_status(0, &step, "syncing provider metadata");
+		assert!(animated.active_spinner.is_some());
+		animated.stop_spinner();
 	}
 
 	#[test]

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -979,12 +979,47 @@ pub(crate) fn execute_cli_command_with_options(
 					let force = parse_boolean_step_input(&step_inputs, "force")?.unwrap_or(false);
 					let sync_provider =
 						parse_boolean_step_input(&step_inputs, "sync_provider")?.unwrap_or(true);
+					if show_progress {
+						progress.step_status(
+							step_index,
+							step,
+							&format!("locating release record for {from}"),
+						);
+					}
+					let phase_started_at = Instant::now();
 					let discovery = discover_release_record(root, &from)?;
+					step_phase_timings.push(StepPhaseTiming {
+						label: "locate release record".to_string(),
+						duration: phase_started_at.elapsed(),
+					});
+					if show_progress {
+						progress.step_status(
+							step_index,
+							step,
+							&format!(
+								"resolving source provider for {}",
+								discovery.resolved_commit
+							),
+						);
+					}
+					let phase_started_at = Instant::now();
 					let source = inferred_retarget_source_configuration(
 						configuration.source.as_ref(),
 						&discovery,
 						sync_provider,
 					);
+					step_phase_timings.push(StepPhaseTiming {
+						label: "resolve source provider".to_string(),
+						duration: phase_started_at.elapsed(),
+					});
+					if show_progress {
+						progress.step_status(
+							step_index,
+							step,
+							&format!("planning retarget to {target}"),
+						);
+					}
+					let phase_started_at = Instant::now();
 					let plan = plan_release_retarget(
 						root,
 						&discovery,
@@ -994,7 +1029,23 @@ pub(crate) fn execute_cli_command_with_options(
 						context.dry_run,
 						source.as_ref(),
 					)?;
+					step_phase_timings.push(StepPhaseTiming {
+						label: "plan retarget".to_string(),
+						duration: phase_started_at.elapsed(),
+					});
+					if show_progress {
+						progress.step_status(
+							step_index,
+							step,
+							"applying git ref and provider updates",
+						);
+					}
+					let phase_started_at = Instant::now();
 					let result = execute_release_retarget(root, source.as_ref(), &plan)?;
+					step_phase_timings.push(StepPhaseTiming {
+						label: "apply retarget".to_string(),
+						duration: phase_started_at.elapsed(),
+					});
 					context.retarget_report = Some(build_retarget_release_report(
 						&from,
 						&target,

--- a/devenv.nix
+++ b/devenv.nix
@@ -30,6 +30,7 @@ in
       rustup
       shfmt
       unzip
+      zip
     ]
     ++ lib.optionals stdenv.isDarwin [
       coreutils


### PR DESCRIPTION
## Summary
- update retarget release progress while each sub-step runs
- include phase timings for locate/resolve/plan/apply retarget work
- add regression coverage for human, JSON, and animated progress output
- provide zip in the devenv shell so Vitest archive tests run without host tools

## Validation
- MONOCHANGE_PATCH_COVERAGE_BASE=origin/main MONOCHANGE_PATCH_COVERAGE_HEAD=HEAD devenv shell coverage:patch → PATCH_COVERAGE 96/96 (100.00%)
- devenv shell cargo fmt
- devenv shell cargo check -p monochange
- devenv shell cargo test -p monochange cli_progress --lib
- devenv shell cargo test -p monochange repair_release_command_dry_run_reports_text_output --lib
- devenv shell cargo test -p monochange repair_release_command_emits_retarget_progress_statuses --lib
- pre-push lint:test passed during push