### PR TITLE
fix: support windows builds

### DIFF
--- a/.changeset/1778063519-monochange-github.md
+++ b/.changeset/1778063519-monochange-github.md
@@ -1,0 +1,8 @@
+---
+monochange_github:
+  type: fix
+---
+
+# Support verified release commits on Windows
+
+Verified release pull-request commits now build on Windows by avoiding Unix-only file permission APIs outside Unix targets. On Unix platforms, executable files still retain executable Git blob modes; on Windows, regular file blobs use the portable 100644 mode so the GitHub release workflow can compile across macOS, Linux, and Windows.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,21 +75,39 @@ jobs:
 
   build:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: checkout repository
         uses: actions/checkout@v6
 
-      - name: setup
+      - name: setup devenv
+        if: runner.os != 'Windows'
         uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: setup rust
+        if: runner.os == 'Windows'
+        uses: dtolnay/rust-toolchain@stable
+
       - name: build
+        if: runner.os != 'Windows'
         run: build:all
         shell: devenv shell -- bash -e {0}
 
+      - name: build on windows
+        if: runner.os == 'Windows'
+        run: cargo build --workspace --all-features --locked
+
       - name: detect current release commit
+        if: runner.os != 'Windows'
         id: release_record
         run: |
           set -euo pipefail
@@ -102,16 +120,17 @@ jobs:
         shell: devenv shell -- bash -e {0}
 
       - name: check publish builds
-        if: steps.release_record.outputs.is_release_commit != 'true'
+        if: runner.os != 'Windows' && steps.release_record.outputs.is_release_commit != 'true'
         run: publish:check
         shell: devenv shell -- bash -e {0}
 
       - name: skip publish build check on release commit
-        if: steps.release_record.outputs.is_release_commit == 'true'
+        if: runner.os != 'Windows' && steps.release_record.outputs.is_release_commit == 'true'
         run: echo "HEAD is a release commit; skipping publish:check."
         shell: devenv shell -- bash -e {0}
 
       - name: build book
+        if: runner.os != 'Windows'
         run: build:book
         shell: devenv shell -- bash -e {0}
 

--- a/crates/monochange_github/src/__tests.rs
+++ b/crates/monochange_github/src/__tests.rs
@@ -54,6 +54,45 @@ fn must_ok<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> T {
 }
 
 #[test]
+fn git_blob_mode_uses_regular_file_mode() {
+	let directory = must_ok(tempdir(), "create temporary directory");
+	let file_path = directory.path().join("regular.txt");
+	must_ok(std::fs::write(&file_path, "content"), "write regular file");
+	let metadata = must_ok(std::fs::metadata(&file_path), "read regular file metadata");
+
+	assert_eq!(git_blob_mode(&metadata), "100644");
+}
+
+#[cfg(unix)]
+#[test]
+fn git_blob_mode_detects_executable_files() {
+	use std::os::unix::fs::PermissionsExt;
+
+	let directory = must_ok(tempdir(), "create temporary directory");
+	let file_path = directory.path().join("script.sh");
+	must_ok(
+		std::fs::write(&file_path, "#!/usr/bin/env bash\n"),
+		"write executable file",
+	);
+	let mut permissions = must_ok(
+		std::fs::metadata(&file_path),
+		"read executable file metadata",
+	)
+	.permissions();
+	permissions.set_mode(0o755);
+	must_ok(
+		std::fs::set_permissions(&file_path, permissions),
+		"mark file executable",
+	);
+	let metadata = must_ok(
+		std::fs::metadata(&file_path),
+		"read executable file metadata",
+	);
+
+	assert_eq!(git_blob_mode(&metadata), "100755");
+}
+
+#[test]
 fn must_ok_panics_on_errors() {
 	assert!(std::panic::catch_unwind(|| must_ok::<(), _>(Err("boom"), "context")).is_err());
 }

--- a/crates/monochange_github/src/lib.rs
+++ b/crates/monochange_github/src/lib.rs
@@ -1262,8 +1262,6 @@ async fn create_verified_github_commit_for_release_pull_request(
 		None => None,
 	};
 
-	use std::os::unix::fs::PermissionsExt;
-
 	let mut tree_entries = Vec::with_capacity(tracked_paths.len());
 	for path in tracked_paths {
 		let absolute_path = root.join(path);
@@ -1296,11 +1294,7 @@ async fn create_verified_github_commit_for_release_pull_request(
 		} else {
 			let content = std::fs::read_to_string(&absolute_path)
 				.map_err(|e| format!("failed to read file {}: {}", path.display(), e))?;
-			let mode = if metadata.permissions().mode() & 0o100 != 0 {
-				"100755"
-			} else {
-				"100644"
-			};
+			let mode = git_blob_mode(&metadata);
 			(content, mode)
 		};
 
@@ -2101,6 +2095,22 @@ fn push_body_entries(lines: &mut Vec<String>, entries: &[String]) {
 			lines.push(format!("- {trimmed}"));
 		}
 	}
+}
+
+#[cfg(unix)]
+fn git_blob_mode(metadata: &std::fs::Metadata) -> &'static str {
+	use std::os::unix::fs::PermissionsExt;
+
+	if metadata.permissions().mode() & 0o100 != 0 {
+		"100755"
+	} else {
+		"100644"
+	}
+}
+
+#[cfg(not(unix))]
+fn git_blob_mode(_metadata: &std::fs::Metadata) -> &'static str {
+	"100644"
 }
 
 fn minimal_release_body(manifest: &ReleaseManifest, target: &ReleaseManifestTarget) -> String {

--- a/docs/agents/product-rules.md
+++ b/docs/agents/product-rules.md
@@ -1,6 +1,7 @@
 # Product and architecture rules
 
 - Keep `crates/monochange` as the CLI package.
+- monochange has first-class support on all major operating systems: macOS, Linux, and Windows. This is a hard rule for the lifetime of the project; do not add platform-specific behavior without preserving support for all three operating systems.
 - Keep `crates/monochange_core` focused on shared domain types and capability contracts, not adapter implementation details.
 - Put adapter-specific manifest behavior in ecosystem crates.
 - Put provider-specific source automation behavior in source crates (`monochange_github`, `monochange_gitlab`, `monochange_gitea`).


### PR DESCRIPTION
## Summary
- make GitHub verified release commit blob-mode detection compile on Windows
- add macOS, Linux, and Windows coverage to the CI build job, with native Rust setup on Windows instead of devenv
- document first-class macOS, Linux, and Windows support as a permanent agent rule

## Validation
- devenv shell cargo test -p monochange_github git_blob_mode --all-features
- CI= devenv shell build:all
- cargo llvm-cov test -p monochange_github --all-features --no-report git_blob_mode && cargo llvm-cov report --lcov --output-path target/coverage/lcov.info && devenv shell coverage:patch
- git push pre-push hook: lint:test passed, including 2132 tests