### PR TITLE
fix: use release token for release-pr pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,11 +363,12 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
 
       - name: setup
         uses: ./.github/actions/devenv
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
 
       - name: configure git
         env:


### PR DESCRIPTION
## Summary
- Use RELEASE_PR_MERGE_TOKEN for the release-pr job checkout and devenv setup credentials.
- This lets the generated release PR branch include workflow changes when a merged changeset modifies .github/workflows/*.yml.

## Why
The post-merge run failed because git pushed with the default GitHub App token, which cannot create or update workflow files without the workflows permission.

## Validation
- git diff --check