### PR TITLE
fix: dispatch publish workflow from release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,7 +222,7 @@ jobs:
         run: |
           gh workflow run publish.yml \
             --repo "${{ github.repository }}" \
-            --ref "${{ github.sha }}" \
+            --ref "${{ env.RELEASE_TAG }}" \
             -f "tag=${{ env.RELEASE_TAG }}"
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- dispatch the publish workflow using the release tag ref instead of the triggering SHA
- fixes GitHub workflow_dispatch failures with `No ref found for` detached release SHAs

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'`