### PR TITLE
chore: pin crates auth action to Node 24 release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,7 @@ jobs:
         shell: devenv shell -- bash -e {0}
 
       - name: get crates oidc auth token
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@v1.0.4
         id: crates-oidc
 
       - name: download release assets
@@ -164,7 +164,7 @@ jobs:
 
       - name: get crates oidc auth token
         if: matrix.registry == 'crates_io'
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@v1.0.4
         id: crates-oidc
 
       - name: download release assets


### PR DESCRIPTION
## Summary
- Update both publish workflow uses of rust-lang/crates-io-auth-action from v1 to v1.0.4.
- v1.0.4 declares `runs.using: node24`, avoiding the GitHub Actions Node.js 20 deprecation warning.

## Validation
- git diff --check
- Verified upstream `rust-lang/crates-io-auth-action@v1.0.4` action.yml uses Node 24.