### PR TITLE
ci: use cherry-pick merge action

### DIFF
--- a/.github/workflows/release-pr-merge.yml
+++ b/.github/workflows/release-pr-merge.yml
@@ -40,7 +40,7 @@ jobs:
       checks: read
       statuses: read
     steps:
-      - name: fast-forward release PR from workflow dispatch
+      - name: cherry-pick release PR from workflow dispatch
         if: github.event_name == 'workflow_dispatch'
         uses: monochange/actions/merge@v0
         with:
@@ -48,17 +48,19 @@ jobs:
           pull-request: ${{ inputs.pull_request }}
           base-branch: main
           head-branch-prefix: monochange/release/
+          merge-method: cherry-pick
           required-failing-check: release-pr-manual-merge-blocker
           require-green-checks: "false"
           comment: ${{ inputs.comment }}
 
-      - name: fast-forward release PR from /merge comment
+      - name: cherry-pick release PR from /merge comment
         if: github.event_name == 'issue_comment'
         uses: monochange/actions/merge@v0
         with:
           github-token: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
           base-branch: main
           head-branch-prefix: monochange/release/
+          merge-method: cherry-pick
           required-failing-check: release-pr-manual-merge-blocker
           require-green-checks: "false"
           comment: always


### PR DESCRIPTION
## Summary

Switch the release PR merge workflow to the new cherry-pick merge mode from `monochange/actions@v0.7.0`.

This keeps the existing release PR workflow shape, but passes:

```yaml
merge-method: cherry-pick
```

That means the merge action will replay each release PR commit onto `main` with `git cherry-pick -x` instead of fast-forwarding `main` to the PR head SHA. The important effect is that the pushed `main` commits get fresh SHAs, so checks run again on `main` instead of carrying over the intentionally failing PR-only blocker check from the original PR head.

## Related

- Actions release: https://github.com/monochange/actions/releases/tag/v0.7.0
- Actions PR: https://github.com/monochange/actions/pull/26

## Verification

- Workflow-only change.
- No local code tests were run.
