### PR TITLE
feat: add Forgejo source provider

### DIFF
--- a/.changeset/forgejo-source-provider.md
+++ b/.changeset/forgejo-source-provider.md
@@ -1,0 +1,13 @@
+---
+"monochange": minor
+"monochange_core": minor
+"monochange_config": minor
+"monochange_forgejo": minor
+"monochange_hosting": patch
+"monochange_schema": patch
+"monochange_telemetry": patch
+---
+
+# Add Forgejo source provider
+
+Add Forgejo as a hosted source provider for releases and release pull requests.

--- a/.templates/crates.t.md
+++ b/.templates/crates.t.md
@@ -422,7 +422,7 @@ Reach for this crate when you want to preview or publish GitLab releases and mer
 
 `monochange_hosting` packages the shared git and HTTP plumbing used by hosted source providers.
 
-Reach for this crate when you are implementing GitHub, Gitea, or GitLab release adapters and want one place for release-body rendering, change-request branch naming, JSON requests, and git branch orchestration.
+Reach for this crate when you are implementing GitHub, Gitea, Forgejo, or GitLab release adapters and want one place for release-body rendering, change-request branch naming, JSON requests, and git branch orchestration.
 
 ## Why use it?
 

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -120,8 +120,8 @@ These are the commands most repositories use after running `mc init`. With the n
 | Grouped/shared versioning                                                      | Built in                                                                                                       |
 | Dry-run release diff previews                                                  | Built in via `mc release --dry-run --diff`                                                                     |
 | Durable release history and post-merge tagging                                 | Built in via `ReleaseRecord`, `mc release-record`, `mc tag-release`, and `mc repair-release`                   |
-| Hosted provider releases                                                       | GitHub, GitLab, Gitea                                                                                          |
-| Hosted release requests                                                        | GitHub, GitLab, Gitea                                                                                          |
+| Hosted provider releases                                                       | GitHub, GitLab, Gitea, Forgejo                                                                                 |
+| Hosted release requests                                                        | GitHub, GitLab, Gitea, Forgejo                                                                                 |
 | Python release planning                                                        | Built in for discovery, version rewrites, dependency rewrites, lockfile command inference, and PyPI publishing |
 | Go release planning                                                            | Built in for `go.mod` discovery, dependency rewrites, `go mod tidy` inference, and Go proxy tag publishing     |
 | Built-in registry publishing                                                   | `crates.io`, `npm`, `jsr`, `pub.dev`, `pypi`, Go proxy tags; use external mode for custom registries           |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2045,6 +2045,7 @@ dependencies = [
  "monochange_core",
  "monochange_dart",
  "monochange_deno",
+ "monochange_forgejo",
  "monochange_gitea",
  "monochange_github",
  "monochange_gitlab",
@@ -2160,6 +2161,7 @@ dependencies = [
  "monochange_core",
  "monochange_dart",
  "monochange_deno",
+ "monochange_forgejo",
  "monochange_gitea",
  "monochange_github",
  "monochange_gitlab",
@@ -2247,6 +2249,26 @@ dependencies = [
  "oxc_ast",
  "oxc_parser",
  "oxc_span",
+]
+
+[[package]]
+name = "monochange_forgejo"
+version = "0.3.4"
+dependencies = [
+ "etest",
+ "httpmock",
+ "insta",
+ "monochange_core",
+ "monochange_hosting",
+ "monochange_test_helpers",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "temp-env",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "urlencoding",
 ]
 
 [[package]]
@@ -2355,7 +2377,9 @@ version = "0.0.0"
 dependencies = [
  "insta",
  "insta-cmd",
+ "monochange_config",
  "monochange_core",
+ "monochange_forgejo",
  "monochange_schema",
  "monochange_test_helpers",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ monochange_core = { version = "0.3.4", path = "./crates/monochange_core" }
 monochange_dart = { version = "0.3.4", path = "./crates/monochange_dart" }
 monochange_deno = { version = "0.3.4", path = "./crates/monochange_deno" }
 monochange_ecmascript = { version = "0.3.4", path = "./crates/monochange_ecmascript" }
+monochange_forgejo = { version = "0.3.4", path = "./crates/monochange_forgejo" }
 monochange_gitea = { version = "0.3.4", path = "./crates/monochange_gitea" }
 monochange_github = { version = "0.3.4", path = "./crates/monochange_github" }
 monochange_gitlab = { version = "0.3.4", path = "./crates/monochange_gitlab" }
@@ -126,6 +127,7 @@ cast_precision_loss = "allow"
 cast_sign_loss = "allow"
 expl_impl_clone_on_copy = "allow"
 items_after_statements = "allow"
+indexing_slicing = "deny"
 missing_errors_doc = "allow"
 missing_panics_doc = "allow"
 module_name_repetitions = "allow"

--- a/crates/monochange/Cargo.toml
+++ b/crates/monochange/Cargo.toml
@@ -22,7 +22,7 @@ pkg-fmt = "tgz"
 bin-dir = "{ bin }{ binary-ext }"
 
 [features]
-default = ["cargo", "npm", "deno", "dart", "python", "go", "github", "gitlab", "gitea"]
+default = ["cargo", "npm", "deno", "dart", "python", "go", "github", "gitlab", "gitea", "forgejo"]
 cargo = ["monochange_cargo"]
 npm = ["monochange_npm"]
 deno = ["monochange_deno"]
@@ -32,6 +32,7 @@ go = ["monochange_go"]
 github = ["monochange_github", "monochange_core/http"]
 gitlab = ["monochange_gitlab", "monochange_core/http"]
 gitea = ["monochange_gitea", "monochange_core/http"]
+forgejo = ["monochange_forgejo", "monochange_core/http"]
 
 [dependencies]
 anstyle = { workspace = true, default-features = true }
@@ -46,6 +47,7 @@ monochange_config = { workspace = true }
 monochange_core = { workspace = true }
 monochange_dart = { workspace = true, optional = true }
 monochange_deno = { workspace = true, optional = true }
+monochange_forgejo = { workspace = true, optional = true }
 monochange_gitea = { workspace = true, optional = true }
 monochange_github = { workspace = true, optional = true }
 monochange_gitlab = { workspace = true, optional = true }

--- a/crates/monochange/src/__tests.rs
+++ b/crates/monochange/src/__tests.rs
@@ -11309,6 +11309,62 @@ fn build_source_release_requests_and_change_request_cover_gitea_dispatch() {
 }
 
 #[test]
+fn build_source_release_requests_and_change_request_cover_forgejo_dispatch() {
+	let source = monochange_core::SourceConfiguration {
+		provider: monochange_core::SourceProvider::Forgejo,
+		host: Some("https://codeberg.org".to_string()),
+		api_url: Some("https://codeberg.org/api/v1".to_string()),
+		owner: "ifiokjr".to_string(),
+		repo: "monochange".to_string(),
+		releases: monochange_core::ProviderReleaseSettings::default(),
+		pull_requests: monochange_core::ProviderMergeRequestSettings::default(),
+	};
+	assert_eq!(
+		crate::hosted_sources::hosted_source_adapter(monochange_core::SourceProvider::Forgejo)
+			.provider(),
+		monochange_core::SourceProvider::Forgejo
+	);
+	assert_eq!(
+		crate::tag_url_for_provider(&source, "v1.2.3"),
+		"https://codeberg.org/ifiokjr/monochange/releases/tag/v1.2.3"
+	);
+	assert_eq!(
+		crate::compare_url_for_provider(&source, "v1.2.2", "v1.2.3"),
+		"https://codeberg.org/ifiokjr/monochange/compare/v1.2.2...v1.2.3"
+	);
+	let empty_publish = temp_env::with_var("FORGEJO_TOKEN", Some("token"), || {
+		crate::publish_source_release_requests(&source, &[])
+			.unwrap_or_else(|error| panic!("publish empty Forgejo releases: {error}"))
+	});
+	assert!(empty_publish.is_empty());
+
+	let manifest = sample_release_manifest_for_commit_message(true, true);
+	let requests = crate::build_source_release_requests(&source, &manifest);
+	assert_eq!(requests.len(), 1);
+	assert_eq!(
+		requests[0].provider,
+		monochange_core::SourceProvider::Forgejo
+	);
+	assert_eq!(requests[0].repository, "ifiokjr/monochange");
+	let request = crate::build_source_change_request(&source, &manifest);
+	assert_eq!(request.provider, monochange_core::SourceProvider::Forgejo);
+	assert_eq!(request.repository, "ifiokjr/monochange");
+	assert!(!request.commit_message.subject.is_empty());
+
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let publish_error = temp_env::with_var("FORGEJO_TOKEN", Some("invalid\n"), || {
+		crate::publish_source_change_request(&source, tempdir.path(), &request, &[], true)
+			.err()
+			.unwrap_or_else(|| panic!("expected invalid git repository error"))
+	});
+	assert!(
+		publish_error
+			.to_string()
+			.contains("prepare release pull request branch")
+	);
+}
+
+#[test]
 fn tracked_release_pull_request_paths_include_manifest_path_and_deduplicate() {
 	let manifest = sample_release_manifest_for_commit_message(false, true);
 	let context = CliContext {

--- a/crates/monochange/src/cli_help.rs
+++ b/crates/monochange/src/cli_help.rs
@@ -220,7 +220,7 @@ fn builtin_command_helps() -> Vec<CommandHelp> {
 			description: "Scans the workspace for supported package manifests (Cargo.toml, package.json, \
 				deno.json, pubspec.yaml) and generates a monochange.toml configuration file with \
 				discovered packages, version groups, and default CLI commands.\n\n\
-				Use --provider to scaffold source-control integration (GitHub, GitLab, Gitea) \
+				Use --provider to scaffold source-control integration (GitHub, GitLab, Gitea, Forgejo) \
 				with release automation CLI commands.",
 			usage: "mc init [OPTIONS]",
 			options: &[
@@ -560,7 +560,7 @@ fn builtin_command_helps() -> Vec<CommandHelp> {
 			name: "release-pr",
 			summary: "Open or update a hosted release pull request",
 			description: "Opens (or updates an existing) pull request on the configured source host \
-				(GitHub, GitLab, Gitea) with the prepared release changes. Requires [source] \
+				(GitHub, GitLab, Gitea, Forgejo) with the prepared release changes. Requires [source] \
 				configuration in monochange.toml.",
 			usage: "mc release-pr [OPTIONS]",
 			options: &[

--- a/crates/monochange/src/hosted_sources.rs
+++ b/crates/monochange/src/hosted_sources.rs
@@ -23,9 +23,15 @@ pub(crate) fn hosted_source_adapter(provider: SourceProvider) -> &'static dyn Ho
 		}
 		#[cfg(feature = "gitea")]
 		SourceProvider::Gitea => &monochange_gitea::HOSTED_SOURCE_ADAPTER,
+		#[cfg(feature = "forgejo")]
+		SourceProvider::Forgejo => &monochange_forgejo::HOSTED_SOURCE_ADAPTER,
 		#[cfg(not(feature = "gitea"))]
 		SourceProvider::Gitea => {
 			panic!("the `gitea` feature must be enabled to use Gitea as a source provider")
+		}
+		#[cfg(not(feature = "forgejo"))]
+		SourceProvider::Forgejo => {
+			panic!("the `forgejo` feature must be enabled to use Forgejo as a source provider")
 		}
 	}
 }

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -43,6 +43,8 @@
 //! - expose JSON-first MCP tools for assistant workflows
 //! <!-- {/monochangeCrateDocs} -->
 
+#![allow(clippy::indexing_slicing)]
+
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::ffi::OsString;
@@ -215,6 +217,8 @@ use monochange_core::materialize_dependency_edges;
 use monochange_core::relative_to_root;
 use monochange_core::render_release_notes;
 use monochange_core::render_release_record_block;
+#[cfg(feature = "forgejo")]
+use monochange_forgejo as forgejo_provider;
 #[cfg(feature = "gitea")]
 use monochange_gitea as gitea_provider;
 #[cfg(feature = "github")]

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -241,7 +241,14 @@ pub(crate) fn tag_url_for_provider(source: &SourceConfiguration, tag_name: &str)
 		SourceProvider::GitLab => gitlab_provider::tag_url(source, tag_name),
 		#[cfg(feature = "gitea")]
 		SourceProvider::Gitea => gitea_provider::tag_url(source, tag_name),
-		#[cfg(not(any(feature = "github", feature = "gitlab", feature = "gitea")))]
+		#[cfg(feature = "forgejo")]
+		SourceProvider::Forgejo => forgejo_provider::tag_url(source, tag_name),
+		#[cfg(not(any(
+			feature = "github",
+			feature = "gitlab",
+			feature = "gitea",
+			feature = "forgejo"
+		)))]
 		_ => String::new(),
 	}
 }
@@ -259,7 +266,14 @@ pub(crate) fn compare_url_for_provider(
 		SourceProvider::GitLab => gitlab_provider::compare_url(source, previous_tag, current_tag),
 		#[cfg(feature = "gitea")]
 		SourceProvider::Gitea => gitea_provider::compare_url(source, previous_tag, current_tag),
-		#[cfg(not(any(feature = "github", feature = "gitlab", feature = "gitea")))]
+		#[cfg(feature = "forgejo")]
+		SourceProvider::Forgejo => forgejo_provider::compare_url(source, previous_tag, current_tag),
+		#[cfg(not(any(
+			feature = "github",
+			feature = "gitlab",
+			feature = "gitea",
+			feature = "forgejo"
+		)))]
 		_ => String::new(),
 	}
 }
@@ -1200,7 +1214,14 @@ pub(crate) fn build_source_release_requests(
 		SourceProvider::GitLab => gitlab_provider::build_release_requests(source, manifest),
 		#[cfg(feature = "gitea")]
 		SourceProvider::Gitea => gitea_provider::build_release_requests(source, manifest),
-		#[cfg(not(any(feature = "github", feature = "gitlab", feature = "gitea")))]
+		#[cfg(feature = "forgejo")]
+		SourceProvider::Forgejo => forgejo_provider::build_release_requests(source, manifest),
+		#[cfg(not(any(
+			feature = "github",
+			feature = "gitlab",
+			feature = "gitea",
+			feature = "forgejo"
+		)))]
 		_ => Vec::new(),
 	}
 }
@@ -1216,7 +1237,14 @@ pub(crate) fn build_source_change_request(
 		SourceProvider::GitLab => gitlab_provider::build_release_pull_request_request(source, manifest),
 		#[cfg(feature = "gitea")]
 		SourceProvider::Gitea => gitea_provider::build_release_pull_request_request(source, manifest),
-		#[cfg(not(any(feature = "github", feature = "gitlab", feature = "gitea")))]
+		#[cfg(feature = "forgejo")]
+		SourceProvider::Forgejo => forgejo_provider::build_release_pull_request_request(source, manifest),
+		#[cfg(not(any(
+			feature = "github",
+			feature = "gitlab",
+			feature = "gitea",
+			feature = "forgejo"
+		)))]
 		_ => {
 			unreachable!(
 				"a hosting provider feature must be enabled to build source change requests"
@@ -1238,7 +1266,14 @@ pub(crate) fn publish_source_release_requests(
 		SourceProvider::GitLab => gitlab_provider::publish_release_requests(source, requests),
 		#[cfg(feature = "gitea")]
 		SourceProvider::Gitea => gitea_provider::publish_release_requests(source, requests),
-		#[cfg(not(any(feature = "github", feature = "gitlab", feature = "gitea")))]
+		#[cfg(feature = "forgejo")]
+		SourceProvider::Forgejo => forgejo_provider::publish_release_requests(source, requests),
+		#[cfg(not(any(
+			feature = "github",
+			feature = "gitlab",
+			feature = "gitea",
+			feature = "forgejo"
+		)))]
 		_ => Ok(Vec::new()),
 	}
 }
@@ -1281,7 +1316,22 @@ pub(crate) fn publish_source_change_request(
 				no_verify,
 			)
 		}
-		#[cfg(not(any(feature = "github", feature = "gitlab", feature = "gitea")))]
+		#[cfg(feature = "forgejo")]
+		SourceProvider::Forgejo => {
+			forgejo_provider::publish_release_pull_request(
+				source,
+				root,
+				request,
+				tracked_paths,
+				no_verify,
+			)
+		}
+		#[cfg(not(any(
+			feature = "github",
+			feature = "gitlab",
+			feature = "gitea",
+			feature = "forgejo"
+		)))]
 		_ => {
 			Err(MonochangeError::Config(
 				"no hosting provider feature enabled".to_string(),

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -2118,7 +2118,9 @@ mod workspace_ops_tests {
 		SourceConfiguration {
 			provider,
 			host: match provider {
-				SourceProvider::Gitea => Some("https://codeberg.org".to_string()),
+				SourceProvider::Gitea | SourceProvider::Forgejo => {
+					Some("https://codeberg.org".to_string())
+				}
 				SourceProvider::GitHub | SourceProvider::GitLab => None,
 			},
 			api_url: None,

--- a/crates/monochange/tests/affected.rs
+++ b/crates/monochange/tests/affected.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::ffi::OsString;
 use std::path::Path;
 

--- a/crates/monochange/tests/benchmark_cli_comment.rs
+++ b/crates/monochange/tests/benchmark_cli_comment.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::fs;
 use std::path::Path;
 use std::process::Command;

--- a/crates/monochange/tests/cargo_lockfile_fast_path.rs
+++ b/crates/monochange/tests/cargo_lockfile_fast_path.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::env;
 use std::ffi::OsString;
 use std::fs;

--- a/crates/monochange/tests/changelog_formats.rs
+++ b/crates/monochange/tests/changelog_formats.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::fs;
 
 use insta::assert_snapshot;

--- a/crates/monochange/tests/changeset_context.rs
+++ b/crates/monochange/tests/changeset_context.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::fs;
 use std::path::Path;
 

--- a/crates/monochange/tests/changeset_policy.rs
+++ b/crates/monochange/tests/changeset_policy.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::path::Path;
 
 use rstest::rstest;

--- a/crates/monochange/tests/changeset_target_metadata.rs
+++ b/crates/monochange/tests/changeset_target_metadata.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::fs;
 use std::path::Path;
 

--- a/crates/monochange/tests/cli_help.rs
+++ b/crates/monochange/tests/cli_help.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 //! Integration tests for `mc help` subcommand output.
 
 use insta_cmd::assert_cmd_snapshot;

--- a/crates/monochange/tests/cli_main_binary.rs
+++ b/crates/monochange/tests/cli_main_binary.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::path::PathBuf;
 use std::process::Command;
 

--- a/crates/monochange/tests/cli_output.rs
+++ b/crates/monochange/tests/cli_output.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::fs;
 
 use httpmock::Method::GET;

--- a/crates/monochange/tests/cli_progress.rs
+++ b/crates/monochange/tests/cli_progress.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::path::Path;
 
 use insta::assert_snapshot;

--- a/crates/monochange/tests/cli_step_input_overrides.rs
+++ b/crates/monochange/tests/cli_step_input_overrides.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::fs;
 use std::path::Path;
 

--- a/crates/monochange/tests/cli_step_when.rs
+++ b/crates/monochange/tests/cli_step_when.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::fs;
 use std::path::Path;
 use std::process::Output;

--- a/crates/monochange/tests/github_releases.rs
+++ b/crates/monochange/tests/github_releases.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use rstest::rstest;
 
 mod test_support;

--- a/crates/monochange/tests/hosted_release_benchmarks.rs
+++ b/crates/monochange/tests/hosted_release_benchmarks.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;

--- a/crates/monochange/tests/manifest_formatting.rs
+++ b/crates/monochange/tests/manifest_formatting.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::fs;
 
 use insta::assert_snapshot;

--- a/crates/monochange/tests/pre_stable_versioning.rs
+++ b/crates/monochange/tests/pre_stable_versioning.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use insta::assert_snapshot;
 use rstest::rstest;
 use serde_json::Value;

--- a/crates/monochange/tests/prepared_release_artifacts.rs
+++ b/crates/monochange/tests/prepared_release_artifacts.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::ffi::OsString;
 use std::fs;
 use std::path::Path;

--- a/crates/monochange/tests/release_apply.rs
+++ b/crates/monochange/tests/release_apply.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::fs;
 
 use serde_json::Value;

--- a/crates/monochange/tests/release_group_propagation.rs
+++ b/crates/monochange/tests/release_group_propagation.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use serde_json::Value;
 
 mod test_support;

--- a/crates/monochange/tests/release_notes_and_propagation.rs
+++ b/crates/monochange/tests/release_notes_and_propagation.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::fs;
 
 use insta::assert_snapshot;

--- a/crates/monochange/tests/release_pull_requests.rs
+++ b/crates/monochange/tests/release_pull_requests.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use rstest::rstest;
 
 mod test_support;

--- a/crates/monochange/tests/release_record.rs
+++ b/crates/monochange/tests/release_record.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::fs;
 use std::path::Path;
 

--- a/crates/monochange/tests/snapshots/cli_help__help_init_shows_detailed_help@help_init_shows_detailed_help.snap
+++ b/crates/monochange/tests/snapshots/cli_help__help_init_shows_detailed_help@help_init_shows_detailed_help.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/monochange/tests/cli_help.rs
+assertion_line: 56
 info:
   program: mc
   args:
@@ -21,7 +22,7 @@ exit_code: 0
 
   Scans the workspace for supported package manifests (Cargo.toml, package.json, deno.json, pubspec.yaml) and generates a monochange.toml configuration file with discovered packages, version groups, and default CLI commands.
 
-  Use --provider to scaffold source-control integration (GitHub, GitLab, Gitea) with release automation CLI commands.
+  Use --provider to scaffold source-control integration (GitHub, GitLab, Gitea, Forgejo) with release automation CLI commands.
 
 ▸ Usage
 

--- a/crates/monochange/tests/source_providers.rs
+++ b/crates/monochange/tests/source_providers.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use rstest::rstest;
 
 mod test_support;

--- a/crates/monochange/tests/telemetry.rs
+++ b/crates/monochange/tests/telemetry.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::fs;
 
 use serde_json::Value;

--- a/crates/monochange/tests/test_support.rs
+++ b/crates/monochange/tests/test_support.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::fs;
 use std::path::Path;
 use std::process::Command;

--- a/crates/monochange_config/Cargo.toml
+++ b/crates/monochange_config/Cargo.toml
@@ -20,6 +20,7 @@ monochange_cargo = { workspace = true }
 monochange_core = { workspace = true }
 monochange_dart = { workspace = true }
 monochange_deno = { workspace = true }
+monochange_forgejo = { workspace = true }
 monochange_gitea = { workspace = true }
 monochange_github = { workspace = true }
 monochange_gitlab = { workspace = true }

--- a/crates/monochange_config/src/__tests.rs
+++ b/crates/monochange_config/src/__tests.rs
@@ -3535,6 +3535,8 @@ fn load_workspace_configuration_rejects_open_release_pull_request_without_source
 
 #[test]
 fn load_workspace_configuration_rejects_comment_released_issues_for_unsupported_provider() {
+	assert!(!crate::source_capabilities(SourceProvider::Forgejo).released_issue_comments);
+
 	let root_gitlab = fixture_path("config/rejects-comment-unsupported");
 	let error = load_workspace_configuration(&root_gitlab)
 		.err()

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -3247,6 +3247,7 @@ fn source_capabilities(provider: SourceProvider) -> monochange_core::SourceCapab
 		SourceProvider::GitHub => monochange_github::source_capabilities(),
 		SourceProvider::GitLab => monochange_gitlab::source_capabilities(),
 		SourceProvider::Gitea => monochange_gitea::source_capabilities(),
+		SourceProvider::Forgejo => monochange_forgejo::source_capabilities(),
 	}
 }
 
@@ -3672,6 +3673,7 @@ fn validate_source_configuration(source: Option<&SourceConfiguration>) -> Monoch
 		SourceProvider::GitHub => monochange_github::validate_source_configuration(source),
 		SourceProvider::GitLab => monochange_gitlab::validate_source_configuration(source),
 		SourceProvider::Gitea => monochange_gitea::validate_source_configuration(source),
+		SourceProvider::Forgejo => monochange_forgejo::validate_source_configuration(source),
 	}
 }
 

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -1489,8 +1489,18 @@ fn hosting_provider_kind_as_str_and_display_cover_all_variants() {
 	assert_eq!(HostingProviderKind::GitHub.as_str(), "github");
 	assert_eq!(HostingProviderKind::GitLab.as_str(), "gitlab");
 	assert_eq!(HostingProviderKind::Gitea.as_str(), "gitea");
+	assert_eq!(HostingProviderKind::Forgejo.as_str(), "forgejo");
 	assert_eq!(HostingProviderKind::Bitbucket.as_str(), "bitbucket");
-	assert_eq!(HostingProviderKind::Gitea.to_string(), "gitea");
+	assert_eq!(HostingProviderKind::Forgejo.to_string(), "forgejo");
+}
+
+#[test]
+fn source_provider_as_str_and_display_cover_all_variants() {
+	assert_eq!(SourceProvider::GitHub.as_str(), "github");
+	assert_eq!(SourceProvider::GitLab.as_str(), "gitlab");
+	assert_eq!(SourceProvider::Gitea.as_str(), "gitea");
+	assert_eq!(SourceProvider::Forgejo.as_str(), "forgejo");
+	assert_eq!(SourceProvider::Forgejo.to_string(), "forgejo");
 }
 
 #[test]

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -2650,6 +2650,8 @@ pub enum HostingProviderKind {
 	GitLab,
 	#[serde(rename = "gitea")]
 	Gitea,
+	#[serde(rename = "forgejo")]
+	Forgejo,
 	#[serde(rename = "bitbucket")]
 	Bitbucket,
 }
@@ -2663,6 +2665,7 @@ impl HostingProviderKind {
 			Self::GitHub => "github",
 			Self::GitLab => "gitlab",
 			Self::Gitea => "gitea",
+			Self::Forgejo => "forgejo",
 			Self::Bitbucket => "bitbucket",
 		}
 	}
@@ -3508,6 +3511,8 @@ pub enum SourceProvider {
 	GitLab,
 	#[serde(rename = "gitea")]
 	Gitea,
+	#[serde(rename = "forgejo")]
+	Forgejo,
 }
 
 impl SourceProvider {
@@ -3518,6 +3523,7 @@ impl SourceProvider {
 			Self::GitHub => "github",
 			Self::GitLab => "gitlab",
 			Self::Gitea => "gitea",
+			Self::Forgejo => "forgejo",
 		}
 	}
 }

--- a/crates/monochange_forgejo/Cargo.toml
+++ b/crates/monochange_forgejo/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "monochange_forgejo"
+version = { workspace = true }
+categories = { workspace = true }
+documentation = "https://docs.rs/monochange_forgejo"
+edition = { workspace = true }
+include = ["src/**/*.rs", "Cargo.toml", "readme.md"]
+keywords = ["forgejo", "releases", "versioning", "monorepo"]
+license = { workspace = true }
+readme = "readme.md"
+repository = { workspace = true }
+rust-version = { workspace = true }
+description = "Forgejo release payload rendering and publishing for monochange"
+
+[dependencies]
+monochange_core = { workspace = true }
+monochange_hosting = { workspace = true }
+reqwest = { workspace = true, default-features = true }
+serde = { workspace = true, default-features = true }
+serde_json = { workspace = true, default-features = true }
+tokio = { workspace = true, default-features = true }
+tracing = { workspace = true, default-features = true }
+urlencoding = { workspace = true, default-features = true }
+
+[dev-dependencies]
+etest = { workspace = true, default-features = true }
+httpmock = { workspace = true, default-features = true }
+insta = { workspace = true, default-features = true }
+monochange_test_helpers = { workspace = true }
+temp-env = { workspace = true, default-features = true }
+tempfile = { workspace = true, default-features = true }
+
+[lints]
+workspace = true

--- a/crates/monochange_forgejo/readme.md
+++ b/crates/monochange_forgejo/readme.md
@@ -1,0 +1,38 @@
+# `monochange_forgejo`
+
+<br />
+
+<!-- {=crateReadmeBadgeRow:"monochange_forgejo"} -->
+
+[![Crates.io](https://img.shields.io/badge/crates.io-monochange**forgejo-orange?logo=rust)](https://crates.io/crates/monochange_forgejo) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange**forgejo-1f425f?logo=docs.rs)](https://docs.rs/monochange_forgejo/) [![CI](https://github.com/monochange/monochange/actions/workflows/ci.yml/badge.svg)](https://github.com/monochange/monochange/actions/workflows/ci.yml) [![Coverage](https://codecov.io/gh/monochange/monochange/branch/main/graph/badge.svg?flag=monochange_forgejo)](https://codecov.io/gh/monochange/monochange?flag=monochange_forgejo) [![License](https://img.shields.io/badge/license-Unlicense-blue.svg)](https://opensource.org/license/unlicense)
+
+<!-- {/crateReadmeBadgeRow} -->
+
+<br />
+
+<!-- {=monochangeForgejoCrateDocs} -->
+
+`monochange_forgejo` turns `monochange` release manifests into Forgejo automation requests.
+
+Reach for this crate when you want to preview or publish Forgejo releases and release pull requests using the same structured release data that powers changelog files and release manifests.
+
+## Why use it?
+
+- derive Forgejo release payloads and release-PR bodies from `monochange`'s structured release manifest
+- keep Forgejo automation aligned with changelog rendering and release targets
+- reuse one publishing path for dry-run previews and real repository updates
+
+## Best for
+
+- building Forgejo release automation on top of `mc release`
+- previewing would-be Forgejo releases and release PRs in CI before publishing
+- self-hosted Forgejo instances that need the same release workflow as GitHub or GitLab
+
+## Public entry points
+
+- `build_release_requests(manifest, source)` builds release payloads from prepared release state
+- `build_change_request(manifest, source)` builds a pull-request payload for the release
+- `validate_source_configuration(source)` validates Forgejo-specific source config
+- `source_capabilities()` returns provider feature flags
+
+<!-- {/monochangeForgejoCrateDocs} -->

--- a/crates/monochange_forgejo/src/__tests.rs
+++ b/crates/monochange_forgejo/src/__tests.rs
@@ -1,0 +1,1415 @@
+#![allow(clippy::disallowed_methods)]
+
+use std::path::PathBuf;
+use std::thread;
+
+use httpmock::Method::GET;
+use httpmock::Method::PATCH;
+use httpmock::Method::POST;
+use httpmock::MockServer;
+use insta::assert_snapshot;
+use monochange_core::BumpSeverity;
+use monochange_core::ChangesetContext;
+use monochange_core::ChangesetRevision;
+use monochange_core::CommitMessage;
+use monochange_core::HostedActorRef;
+use monochange_core::HostedActorSourceKind;
+use monochange_core::HostedCommitRef;
+use monochange_core::HostedSourceAdapter;
+use monochange_core::HostedSourceFeatures;
+use monochange_core::HostingCapabilities;
+use monochange_core::HostingProviderKind;
+use monochange_core::MonochangeResult;
+use monochange_core::PreparedChangeset;
+use monochange_core::ProviderMergeRequestSettings;
+use monochange_core::ProviderReleaseNotesSource;
+use monochange_core::ProviderReleaseSettings;
+use monochange_core::ReleaseManifest;
+use monochange_core::ReleaseManifestChangelog;
+use monochange_core::ReleaseManifestPlan;
+use monochange_core::ReleaseManifestPlanDecision;
+use monochange_core::ReleaseManifestTarget;
+use monochange_core::ReleaseNotesDocument;
+use monochange_core::ReleaseNotesSection;
+use monochange_core::ReleaseOwnerKind;
+use monochange_core::SourceCapabilities;
+use monochange_core::SourceChangeRequestOperation;
+use monochange_core::SourceConfiguration;
+use monochange_core::SourceProvider;
+use monochange_core::SourceReleaseOperation;
+use monochange_core::VersionFormat;
+use monochange_hosting::push_body_entries;
+use monochange_test_helpers::git;
+use monochange_test_helpers::git_output;
+use tempfile::tempdir;
+
+use super::*;
+
+fn must_ok<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> T {
+	match result {
+		Ok(value) => value,
+		Err(error) => panic!("{context}: {error}"),
+	}
+}
+
+#[test]
+fn must_ok_panics_on_errors() {
+	assert!(std::panic::catch_unwind(|| must_ok::<(), _>(Err("boom"), "context")).is_err());
+}
+
+#[test]
+fn build_release_requests_uses_forgejo_provider() {
+	let source = sample_source(None, Some("https://codeberg.org".to_string()));
+	let manifest = sample_manifest();
+	let requests = build_release_requests(&source, &manifest);
+	assert_eq!(requests.len(), 1);
+	assert_eq!(
+		requests
+			.first()
+			.unwrap_or_else(|| panic!("expected request"))
+			.provider,
+		SourceProvider::Forgejo,
+	);
+}
+
+#[test]
+fn build_release_requests_falls_back_to_tag_name_when_rendered_title_is_empty() {
+	let source = sample_source(None, Some("https://codeberg.org".to_string()));
+	let mut manifest = sample_manifest();
+	manifest.release_targets.first_mut().unwrap().rendered_title = String::new();
+
+	let requests = build_release_requests(&source, &manifest);
+	let request = requests
+		.first()
+		.unwrap_or_else(|| panic!("expected request"));
+
+	assert_eq!(request.name, "v1.2.0");
+}
+
+#[test]
+fn build_release_pull_request_request_uses_forgejo_provider_and_sanitized_branch() {
+	let source = sample_source(None, Some("https://codeberg.org".to_string()));
+	let manifest = ReleaseManifest {
+		command: "Release PR!".to_string(),
+		..sample_manifest()
+	};
+
+	let request = build_release_pull_request_request(&source, &manifest);
+
+	assert_eq!(request.provider, SourceProvider::Forgejo);
+	assert_eq!(request.repository, "org/monochange");
+	assert_eq!(request.base_branch, "main");
+	assert_eq!(request.head_branch, "monochange/release/release-pr");
+	assert_snapshot!(
+		"build_release_pull_request_request_uses_forgejo_provider_and_sanitized_branch__body",
+		request.body
+	);
+}
+
+#[test]
+fn forgejo_source_capabilities_capture_provider_limits() {
+	assert_eq!(
+		source_capabilities(),
+		SourceCapabilities {
+			draft_releases: true,
+			prereleases: true,
+			generated_release_notes: false,
+			auto_merge_change_requests: false,
+			released_issue_comments: false,
+			requires_host: true,
+		}
+	);
+}
+
+#[test]
+fn hosted_source_adapter_reports_forgejo_features_and_delegates_context_annotation() {
+	let adapter: &dyn HostedSourceAdapter = &HOSTED_SOURCE_ADAPTER;
+	let source = sample_source(None, Some("https://codeberg.org".to_string()));
+	let mut changesets = Vec::new();
+
+	assert_eq!(adapter.provider(), SourceProvider::Forgejo);
+	assert_eq!(adapter.features(), HostedSourceFeatures::default());
+	adapter.annotate_changeset_context(&source, &mut changesets);
+	adapter.enrich_changeset_context(&source, &mut changesets);
+}
+
+#[test]
+fn validate_source_configuration_rejects_missing_host_and_unsupported_features() {
+	let error = validate_source_configuration(&sample_source(None, None))
+		.err()
+		.unwrap_or_else(|| panic!("expected validation error"));
+	assert!(
+		error
+			.to_string()
+			.contains("[source].host must be set for `provider = \"forgejo\"`")
+	);
+
+	let error = validate_source_configuration(&SourceConfiguration {
+		pull_requests: ProviderMergeRequestSettings {
+			auto_merge: true,
+			..ProviderMergeRequestSettings::default()
+		},
+		..sample_source(None, Some("https://codeberg.org".to_string()))
+	})
+	.err()
+	.unwrap_or_else(|| panic!("expected validation error"));
+	assert!(
+		error
+			.to_string()
+			.contains("[source.pull_requests].auto_merge is not supported")
+	);
+
+	let error = validate_source_configuration(&SourceConfiguration {
+		releases: ProviderReleaseSettings {
+			source: ProviderReleaseNotesSource::GitHubGenerated,
+			..ProviderReleaseSettings::default()
+		},
+		..sample_source(None, Some("https://codeberg.org".to_string()))
+	})
+	.err()
+	.unwrap_or_else(|| panic!("expected validation error"));
+	assert!(
+		error
+			.to_string()
+			.contains("provider-generated release notes are not supported")
+	);
+}
+
+#[test]
+fn forgejo_api_base_requires_host_unless_api_url_is_set() {
+	let explicit = sample_source(
+		Some("https://codeberg.example.com/api/v1/".to_string()),
+		Some("https://codeberg.org".to_string()),
+	);
+	assert_eq!(
+		forgejo_api_base(&explicit).unwrap_or_else(|error| panic!("api base: {error}")),
+		"https://codeberg.example.com/api/v1"
+	);
+
+	let host_only = sample_source(None, Some("https://codeberg.org/".to_string()));
+	assert_eq!(
+		forgejo_api_base(&host_only).unwrap_or_else(|error| panic!("api base: {error}")),
+		"https://codeberg.org/api/v1"
+	);
+
+	let error = forgejo_api_base(&sample_source(None, None))
+		.err()
+		.unwrap_or_else(|| panic!("expected missing host error"));
+	assert!(
+		error
+			.to_string()
+			.contains("[source].host must be set for `provider = \"forgejo\"`")
+	);
+}
+
+#[test]
+fn forgejo_token_requires_environment_variable() {
+	temp_env::with_vars([("FORGEJO_TOKEN", Some("token"))], || {
+		assert_eq!(
+			forgejo_token().unwrap_or_else(|error| panic!("token: {error}")),
+			"token"
+		);
+	});
+
+	temp_env::with_vars([("FORGEJO_TOKEN", None::<String>)], || {
+		let error = forgejo_token()
+			.err()
+			.unwrap_or_else(|| panic!("expected missing token error"));
+		assert!(
+			error
+				.to_string()
+				.contains("set `FORGEJO_TOKEN` before running Forgejo automation")
+		);
+	});
+}
+
+#[test]
+fn tag_and_compare_urls_use_trimmed_forgejo_host() {
+	let source = sample_source(None, Some("https://codeberg.org/".to_string()));
+	assert_eq!(
+		tag_url(&source, "v1.2.3"),
+		"https://codeberg.org/org/monochange/releases/tag/v1.2.3"
+	);
+	assert_eq!(
+		compare_url(&source, "v1.2.2", "v1.2.3"),
+		"https://codeberg.org/org/monochange/compare/v1.2.2...v1.2.3"
+	);
+}
+
+#[test]
+fn forgejo_context_annotation_updates_hosts_commits_and_authors() {
+	let source = sample_source(
+		None,
+		Some("https://codeberg.org/org/monochange/subpath".to_string()),
+	);
+	assert_eq!(forgejo_host_name(&source).as_deref(), Some("codeberg.org"));
+	assert_eq!(
+		forgejo_commit_url(&source, "abc1234567890"),
+		"https://codeberg.org/org/monochange/subpath/org/monochange/commit/abc1234567890"
+	);
+	let mut changesets = vec![PreparedChangeset {
+		path: PathBuf::from(".changeset/feature.md"),
+		summary: Some("feature".to_string()),
+		details: None,
+		targets: Vec::new(),
+		context: Some(ChangesetContext {
+			provider: HostingProviderKind::GenericGit,
+			host: None,
+			capabilities: HostingCapabilities::default(),
+			introduced: Some(ChangesetRevision {
+				actor: Some(HostedActorRef {
+					provider: HostingProviderKind::GenericGit,
+					host: None,
+					id: None,
+					login: Some("ifiokjr".to_string()),
+					display_name: Some("Ifiok Jr.".to_string()),
+					url: None,
+					source: HostedActorSourceKind::CommitAuthor,
+				}),
+				commit: Some(HostedCommitRef {
+					provider: HostingProviderKind::GenericGit,
+					host: None,
+					sha: "abc1234567890".to_string(),
+					short_sha: "abc1234".to_string(),
+					url: None,
+					authored_at: None,
+					committed_at: None,
+					author_name: None,
+					author_email: None,
+				}),
+				review_request: None,
+			}),
+			last_updated: None,
+			related_issues: Vec::new(),
+		}),
+	}];
+
+	annotate_changeset_context(&source, &mut changesets);
+	enrich_changeset_context(&source, &mut changesets);
+
+	let context = changesets
+		.first()
+		.and_then(|changeset| changeset.context.as_ref())
+		.unwrap_or_else(|| panic!("expected changeset context"));
+	assert_eq!(context.provider, HostingProviderKind::Forgejo);
+	assert_eq!(context.host.as_deref(), Some("codeberg.org"));
+	assert_eq!(
+		context
+			.introduced
+			.as_ref()
+			.and_then(|revision| revision.commit.as_ref())
+			.and_then(|commit| commit.url.as_deref()),
+		Some("https://codeberg.org/org/monochange/subpath/org/monochange/commit/abc1234567890")
+	);
+	assert_eq!(
+		context
+			.introduced
+			.as_ref()
+			.and_then(|revision| revision.actor.as_ref())
+			.map(|actor| (actor.provider, actor.host.clone())),
+		Some((
+			HostingProviderKind::Forgejo,
+			Some("codeberg.org".to_string())
+		))
+	);
+}
+
+#[test]
+fn forgejo_context_annotation_handles_empty_hosts_and_missing_context_entries() {
+	let source = sample_source(None, Some(String::new()));
+	assert_eq!(forgejo_host_name(&source), None);
+	let mut changesets = vec![
+		PreparedChangeset {
+			path: PathBuf::from(".changeset/no-context.md"),
+			summary: None,
+			details: None,
+			targets: Vec::new(),
+			context: None,
+		},
+		PreparedChangeset {
+			path: PathBuf::from(".changeset/partial.md"),
+			summary: Some("partial".to_string()),
+			details: None,
+			targets: Vec::new(),
+			context: Some(ChangesetContext {
+				provider: HostingProviderKind::GenericGit,
+				host: None,
+				capabilities: HostingCapabilities::default(),
+				introduced: Some(ChangesetRevision {
+					actor: None,
+					commit: None,
+					review_request: None,
+				}),
+				last_updated: None,
+				related_issues: Vec::new(),
+			}),
+		},
+	];
+
+	annotate_changeset_context(&source, &mut changesets);
+
+	assert!(
+		changesets
+			.first()
+			.and_then(|changeset| changeset.context.as_ref())
+			.is_none()
+	);
+	let context = changesets
+		.get(1)
+		.and_then(|changeset| changeset.context.as_ref())
+		.unwrap_or_else(|| panic!("expected partial context"));
+	assert_eq!(context.provider, HostingProviderKind::Forgejo);
+	assert_eq!(context.host, None);
+}
+
+#[test]
+fn auth_headers_reject_invalid_forgejo_tokens() {
+	let error = auth_headers("bad\nvalue")
+		.err()
+		.unwrap_or_else(|| panic!("expected invalid header error"));
+	assert!(
+		error
+			.to_string()
+			.contains("invalid Forgejo token header value")
+	);
+}
+
+#[test]
+fn forgejo_json_helpers_cover_not_found_and_status_errors() {
+	let server = MockServer::start();
+	let optional_success = server.mock(|when, then| {
+		when.method(GET).path("/optional-success");
+		then.status(200).body(r#"{"ok":true}"#);
+	});
+	let missing = server.mock(|when, then| {
+		when.method(GET).path("/missing");
+		then.status(404);
+	});
+	let get_success = server.mock(|when, then| {
+		when.method(GET).path("/get-success");
+		then.status(200).body(r#"{"ok":true}"#);
+	});
+	let failing_get = server.mock(|when, then| {
+		when.method(GET).path("/fail-get");
+		then.status(500);
+	});
+	let failing_post = server.mock(|when, then| {
+		when.method(POST).path("/fail-post");
+		then.status(500);
+	});
+	let failing_patch = server.mock(|when, then| {
+		when.method(PATCH).path("/fail-patch");
+		then.status(500);
+	});
+	let invalid_optional = server.mock(|when, then| {
+		when.method(GET).path("/invalid-optional");
+		then.status(200).body("not json");
+	});
+	let invalid_get = server.mock(|when, then| {
+		when.method(GET).path("/invalid-get");
+		then.status(200).body("not json");
+	});
+	let invalid_post = server.mock(|when, then| {
+		when.method(POST).path("/invalid-post");
+		then.status(200).body("not json");
+	});
+	let invalid_patch = server.mock(|when, then| {
+		when.method(PATCH).path("/invalid-patch");
+		then.status(200).body("not json");
+	});
+	let client = Client::builder()
+		.build()
+		.expect("failed to build Forgejo HTTP client");
+	let base = server.base_url();
+	let headers = auth_headers("token").unwrap_or_else(|error| panic!("headers: {error}"));
+
+	let runtime = tokio::runtime::Builder::new_current_thread()
+		.enable_all()
+		.build()
+		.expect("failed to build Forgejo runtime");
+	runtime.block_on(async {
+		let optional_value = get_optional_json::<serde_json::Value>(
+			&client,
+			&headers,
+			&format!("{base}/optional-success"),
+			"Forgejo",
+		)
+		.await
+		.unwrap_or_else(|error| panic!("optional success json: {error}"));
+		assert_eq!(
+			optional_value.and_then(|value| value.get("ok").cloned()),
+			Some(serde_json::json!(true))
+		);
+
+		let missing_value = get_optional_json::<serde_json::Value>(
+			&client,
+			&headers,
+			&format!("{base}/missing"),
+			"Forgejo",
+		)
+		.await
+		.unwrap_or_else(|error| panic!("optional json: {error}"));
+		assert_eq!(missing_value, None);
+
+		let send_error =
+			get_optional_json::<serde_json::Value>(&client, &headers, "http://", "Forgejo")
+				.await
+				.err()
+				.unwrap_or_else(|| panic!("expected optional get send error"));
+		assert!(send_error.to_string().contains("Forgejo API GET"));
+
+		let invalid_optional_error = get_optional_json::<serde_json::Value>(
+			&client,
+			&headers,
+			&format!("{base}/invalid-optional"),
+			"Forgejo",
+		)
+		.await
+		.err()
+		.unwrap_or_else(|| panic!("expected optional invalid json error"));
+		assert!(
+			invalid_optional_error
+				.to_string()
+				.contains("Forgejo API GET")
+		);
+
+		let get_value = get_json::<serde_json::Value>(
+			&client,
+			&headers,
+			&format!("{base}/get-success"),
+			"Forgejo",
+		)
+		.await
+		.unwrap_or_else(|error| panic!("get success json: {error}"));
+		assert_eq!(get_value.get("ok").cloned(), Some(serde_json::json!(true)));
+
+		let get_send_error = get_json::<serde_json::Value>(&client, &headers, "http://", "Forgejo")
+			.await
+			.err()
+			.unwrap_or_else(|| panic!("expected get send error"));
+		assert!(get_send_error.to_string().contains("Forgejo API GET"));
+
+		let get_error = get_json::<serde_json::Value>(
+			&client,
+			&headers,
+			&format!("{base}/fail-get"),
+			"Forgejo",
+		)
+		.await
+		.err()
+		.unwrap_or_else(|| panic!("expected get error"));
+		assert!(get_error.to_string().contains("Forgejo API GET"));
+
+		let invalid_get_error = get_json::<serde_json::Value>(
+			&client,
+			&headers,
+			&format!("{base}/invalid-get"),
+			"Forgejo",
+		)
+		.await
+		.err()
+		.unwrap_or_else(|| panic!("expected invalid get json error"));
+		assert!(invalid_get_error.to_string().contains("Forgejo API GET"));
+
+		let post_send_error = post_json::<_, serde_json::Value>(
+			&client,
+			&headers,
+			"http://",
+			&serde_json::json!({}),
+			"Forgejo",
+		)
+		.await
+		.err()
+		.unwrap_or_else(|| panic!("expected post send error"));
+		assert!(post_send_error.to_string().contains("Forgejo API POST"));
+
+		let post_error = post_json::<_, serde_json::Value>(
+			&client,
+			&headers,
+			&format!("{base}/fail-post"),
+			&serde_json::json!({"tag_name": "v1.2.3"}),
+			"Forgejo",
+		)
+		.await
+		.err()
+		.unwrap_or_else(|| panic!("expected post error"));
+		assert!(post_error.to_string().contains("Forgejo API POST"));
+
+		let invalid_post_error = post_json::<_, serde_json::Value>(
+			&client,
+			&headers,
+			&format!("{base}/invalid-post"),
+			&serde_json::json!({"tag_name": "v1.2.3"}),
+			"Forgejo",
+		)
+		.await
+		.err()
+		.unwrap_or_else(|| panic!("expected invalid post json error"));
+		assert!(invalid_post_error.to_string().contains("Forgejo API POST"));
+
+		let patch_send_error = patch_json::<_, serde_json::Value>(
+			&client,
+			&headers,
+			"http://",
+			&serde_json::json!({}),
+			"Forgejo",
+		)
+		.await
+		.err()
+		.unwrap_or_else(|| panic!("expected patch send error"));
+		assert!(patch_send_error.to_string().contains("Forgejo API PATCH"));
+
+		let patch_error = patch_json::<_, serde_json::Value>(
+			&client,
+			&headers,
+			&format!("{base}/fail-patch"),
+			&serde_json::json!({"name": "v1.2.3"}),
+			"Forgejo",
+		)
+		.await
+		.err()
+		.unwrap_or_else(|| panic!("expected patch error"));
+		assert!(patch_error.to_string().contains("Forgejo API PATCH"));
+
+		let invalid_patch_error = patch_json::<_, serde_json::Value>(
+			&client,
+			&headers,
+			&format!("{base}/invalid-patch"),
+			&serde_json::json!({"name": "v1.2.3"}),
+			"Forgejo",
+		)
+		.await
+		.err()
+		.unwrap_or_else(|| panic!("expected invalid patch json error"));
+		assert!(
+			invalid_patch_error
+				.to_string()
+				.contains("Forgejo API PATCH")
+		);
+	});
+
+	optional_success.assert();
+	missing.assert();
+	get_success.assert();
+	failing_get.assert();
+	failing_post.assert();
+	failing_patch.assert();
+	invalid_optional.assert();
+	invalid_get.assert();
+	invalid_post.assert();
+	invalid_patch.assert();
+}
+
+#[test]
+fn release_pull_request_branch_and_body_helpers_cover_sanitization_and_formatting() {
+	assert_eq!(
+		release_pull_request_branch("monochange/release/", "Release PR!"),
+		"monochange/release/release-pr"
+	);
+	assert_eq!(
+		release_pull_request_branch("monochange/release/", "!!!"),
+		"monochange/release/release"
+	);
+
+	let mut lines = Vec::new();
+	push_body_entries(
+		&mut lines,
+		&[
+			"plain entry".to_string(),
+			"- existing bullet".to_string(),
+			"# heading".to_string(),
+			"first line\nsecond line".to_string(),
+		],
+	);
+	assert_eq!(
+		lines,
+		vec![
+			"- plain entry".to_string(),
+			"- existing bullet".to_string(),
+			"# heading".to_string(),
+			"first line".to_string(),
+			"second line".to_string(),
+		]
+	);
+}
+
+#[test]
+fn release_body_supports_generated_notes_and_minimal_fallback() {
+	let generated_source = SourceConfiguration {
+		releases: ProviderReleaseSettings {
+			source: ProviderReleaseNotesSource::GitHubGenerated,
+			..ProviderReleaseSettings::default()
+		},
+		..sample_source(None, Some("https://codeberg.org".to_string()))
+	};
+	let manifest = sample_manifest();
+	let target = manifest
+		.release_targets
+		.first()
+		.unwrap_or_else(|| panic!("expected release target"));
+	assert_eq!(release_body(&generated_source, &manifest, target), None);
+
+	let manifest = sample_manifest_without_changelog();
+	let target = manifest
+		.release_targets
+		.first()
+		.unwrap_or_else(|| panic!("expected release target"));
+	let body = release_body(
+		&sample_source(None, Some("https://codeberg.org".to_string())),
+		&manifest,
+		target,
+	)
+	.unwrap_or_else(|| panic!("expected release body"));
+	assert_snapshot!(
+		"release_body_supports_generated_notes_and_minimal_fallback__minimal_body",
+		body
+	);
+}
+
+#[test]
+fn release_pull_request_body_uses_minimal_notes_when_changelog_is_missing() {
+	let manifest = sample_manifest_without_changelog();
+	let body = release_pull_request_body(&manifest);
+
+	assert_snapshot!(
+		"release_pull_request_body_uses_minimal_notes_when_changelog_is_missing__body",
+		body
+	);
+}
+
+#[test]
+fn publish_release_requests_creates_release_via_forgejo_api() {
+	let server = MockServer::start();
+	let lookup = server.mock(|when, then| {
+		when.method(GET)
+			.path("/api/v1/repos/org/monochange/releases/tags/v1.2.0");
+		then.status(404);
+	});
+	let create = server.mock(|when, then| {
+		when.method(POST)
+			.path("/api/v1/repos/org/monochange/releases");
+		then.status(201)
+			.header("content-type", "application/json")
+			.body(r#"{"html_url":"https://codeberg.org/org/monochange/releases/tag/v1.2.0"}"#);
+	});
+	let source = sample_source(
+		Some(format!("{}/api/v1", server.base_url())),
+		Some("https://codeberg.org".to_string()),
+	);
+	let requests = build_release_requests(&source, &sample_manifest());
+
+	let outcomes = with_forgejo_env(Some("token"), || {
+		publish_release_requests(&source, &requests)
+			.unwrap_or_else(|error| panic!("publish release: {error}"))
+	});
+
+	lookup.assert();
+	create.assert();
+	assert_eq!(
+		outcomes
+			.first()
+			.unwrap_or_else(|| panic!("expected outcome"))
+			.operation,
+		SourceReleaseOperation::Created,
+	);
+}
+
+#[test]
+fn publish_release_requests_updates_existing_release_via_forgejo_api() {
+	let server = MockServer::start();
+	let lookup = server.mock(|when, then| {
+		when.method(GET)
+			.path("/api/v1/repos/org/monochange/releases/tags/v1.2.0");
+		then.status(200)
+			.header("content-type", "application/json")
+			.body(r#"{"html_url":"https://codeberg.org/org/monochange/releases/tag/v1.2.0"}"#);
+	});
+	let update = server.mock(|when, then| {
+		when.method(PATCH)
+			.path("/api/v1/repos/org/monochange/releases/tags/v1.2.0");
+		then.status(200)
+			.header("content-type", "application/json")
+			.body(r#"{"html_url":"https://codeberg.org/org/monochange/releases/tag/v1.2.0"}"#);
+	});
+	let source = sample_source(
+		Some(format!("{}/api/v1", server.base_url())),
+		Some("https://codeberg.org".to_string()),
+	);
+	let requests = build_release_requests(&source, &sample_manifest());
+
+	let outcomes = with_forgejo_env(Some("token"), || {
+		publish_release_requests(&source, &requests)
+			.unwrap_or_else(|error| panic!("publish release: {error}"))
+	});
+
+	lookup.assert();
+	update.assert();
+	assert_eq!(
+		outcomes
+			.first()
+			.unwrap_or_else(|| panic!("expected outcome"))
+			.operation,
+		SourceReleaseOperation::Updated,
+	);
+}
+
+#[test]
+fn publish_release_requests_reports_forgejo_api_errors() {
+	let server = MockServer::start();
+	let lookup = server.mock(|when, then| {
+		when.method(GET)
+			.path("/api/v1/repos/org/monochange/releases/tags/v1.2.0");
+		then.status(500);
+	});
+	let source = sample_source(
+		Some(format!("{}/api/v1", server.base_url())),
+		Some("https://codeberg.org".to_string()),
+	);
+	let requests = build_release_requests(&source, &sample_manifest());
+
+	let error = with_forgejo_env(Some("token"), || {
+		publish_release_requests(&source, &requests)
+	})
+	.err()
+	.unwrap_or_else(|| panic!("expected publish error"));
+
+	lookup.assert();
+	assert!(error.to_string().contains("Forgejo API GET"));
+}
+
+#[test]
+fn publish_release_requests_reports_create_and_update_api_errors() {
+	for existing in [false, true] {
+		let server = MockServer::start();
+		let lookup = server.mock(|when, then| {
+			when.method(GET)
+				.path("/api/v1/repos/org/monochange/releases/tags/v1.2.0");
+			if existing {
+				then.status(200)
+					.header("content-type", "application/json")
+					.body(
+						r#"{"html_url":"https://codeberg.org/org/monochange/releases/tag/v1.2.0"}"#,
+					);
+			} else {
+				then.status(404);
+			}
+		});
+		let write = server.mock(|when, then| {
+			when.method(if existing { PATCH } else { POST })
+				.path(if existing {
+					"/api/v1/repos/org/monochange/releases/tags/v1.2.0"
+				} else {
+					"/api/v1/repos/org/monochange/releases"
+				});
+			then.status(500);
+		});
+		let source = sample_source(
+			Some(format!("{}/api/v1", server.base_url())),
+			Some("https://codeberg.org".to_string()),
+		);
+		let requests = build_release_requests(&source, &sample_manifest());
+
+		let error = with_forgejo_env(Some("token"), || {
+			publish_release_requests(&source, &requests)
+		})
+		.err()
+		.unwrap_or_else(|| panic!("expected release publish error"));
+
+		lookup.assert();
+		write.assert();
+		assert!(error.to_string().contains(if existing {
+			"Forgejo API PATCH"
+		} else {
+			"Forgejo API POST"
+		}));
+	}
+}
+
+#[test]
+fn publish_release_pull_request_reports_label_api_errors() {
+	let server = MockServer::start();
+	let list = server.mock(|when, then| {
+		when.method(GET)
+			.path("/api/v1/repos/org/monochange/pulls")
+			.query_param("state", "open")
+			.query_param("head", "org:monochange/release/release")
+			.query_param("base", "main");
+		then.status(200)
+			.header("content-type", "application/json")
+			.body("[]");
+	});
+	let create = server.mock(|when, then| {
+		when.method(POST).path("/api/v1/repos/org/monochange/pulls");
+		then.status(201)
+			.header("content-type", "application/json")
+			.body(r#"{"number":9,"html_url":"https://codeberg.org/org/monochange/pulls/9"}"#);
+	});
+	let labels = server.mock(|when, then| {
+		when.method(POST)
+			.path("/api/v1/repos/org/monochange/issues/9/labels");
+		then.status(500);
+	});
+	let (_tempdir, repo) = seed_git_repository();
+	let source = sample_source(
+		Some(format!("{}/api/v1", server.base_url())),
+		Some("https://codeberg.org".to_string()),
+	);
+	let request = build_release_pull_request_request(&source, &sample_manifest());
+
+	let error = with_forgejo_env(Some("token"), || {
+		publish_release_pull_request(
+			&source,
+			&repo,
+			&request,
+			&[PathBuf::from("release.txt")],
+			false,
+		)
+	})
+	.err()
+	.unwrap_or_else(|| panic!("expected label error"));
+
+	list.assert();
+	create.assert();
+	labels.assert();
+	assert!(error.to_string().contains("Forgejo API POST"));
+}
+
+#[test]
+fn publish_release_pull_request_create_branch_is_covered_without_etest() {
+	let server = MockServer::start();
+	let list = server.mock(|when, then| {
+		when.method(GET)
+			.path("/api/v1/repos/org/monochange/pulls")
+			.query_param("state", "open")
+			.query_param("head", "org:monochange/release/release")
+			.query_param("base", "main");
+		then.status(200)
+			.header("content-type", "application/json")
+			.body("[]");
+	});
+	let create = server.mock(|when, then| {
+		when.method(POST).path("/api/v1/repos/org/monochange/pulls");
+		then.status(201)
+			.header("content-type", "application/json")
+			.body(r#"{"number":7,"html_url":"https://codeberg.org/org/monochange/pulls/7"}"#);
+	});
+	let labels = server.mock(|when, then| {
+		when.method(POST)
+			.path("/api/v1/repos/org/monochange/issues/7/labels");
+		then.status(200)
+			.header("content-type", "application/json")
+			.body("[]");
+	});
+	let (_tempdir, repo) = seed_git_repository();
+	let source = sample_source(
+		Some(format!("{}/api/v1", server.base_url())),
+		Some("https://codeberg.org".to_string()),
+	);
+	let request = build_release_pull_request_request(&source, &sample_manifest());
+
+	let outcome = with_forgejo_env(Some("token"), || {
+		publish_release_pull_request(
+			&source,
+			&repo,
+			&request,
+			&[PathBuf::from("release.txt")],
+			false,
+		)
+		.unwrap_or_else(|error| panic!("publish pull request: {error}"))
+	});
+
+	list.assert();
+	create.assert();
+	labels.assert();
+	assert_eq!(outcome.operation, SourceChangeRequestOperation::Created);
+	assert_eq!(outcome.number, 7);
+}
+
+#[test]
+fn publish_release_pull_request_reports_commit_and_push_failures() {
+	let server = MockServer::start();
+	let _list = server.mock(|when, then| {
+		when.method(GET)
+			.path("/api/v1/repos/org/monochange/pulls")
+			.query_param("state", "open")
+			.query_param("head", "org:monochange/release/release")
+			.query_param("base", "main");
+		then.status(200)
+			.header("content-type", "application/json")
+			.body("[]");
+	});
+	let (_tempdir, repo) = seed_git_repository();
+	let source = sample_source(
+		Some(format!("{}/api/v1", server.base_url())),
+		Some("https://codeberg.org".to_string()),
+	);
+	let mut request = build_release_pull_request_request(&source, &sample_manifest());
+	request.commit_message.subject = "release\0notes".to_string();
+
+	let commit_error = with_forgejo_env(Some("token"), || {
+		publish_release_pull_request(
+			&source,
+			&repo,
+			&request,
+			&[PathBuf::from("release.txt")],
+			false,
+		)
+	})
+	.err()
+	.unwrap_or_else(|| panic!("expected commit error"));
+	assert!(
+		commit_error
+			.to_string()
+			.contains("commit release pull request changes")
+	);
+
+	let (_tempdir, repo) = seed_git_repository();
+	git(&repo, &["remote", "remove", "origin"]);
+	let request = build_release_pull_request_request(&source, &sample_manifest());
+	let push_error = with_forgejo_env(Some("token"), || {
+		publish_release_pull_request(
+			&source,
+			&repo,
+			&request,
+			&[PathBuf::from("release.txt")],
+			false,
+		)
+	})
+	.err()
+	.unwrap_or_else(|| panic!("expected push error"));
+	assert!(
+		push_error
+			.to_string()
+			.contains("push release pull request branch")
+	);
+}
+
+#[etest::etest(skip=env::var_os("PRE_COMMIT").is_some())]
+fn publish_release_pull_request_creates_pull_request_and_labels() {
+	let server = MockServer::start();
+	let list = server.mock(|when, then| {
+		when.method(GET)
+			.path("/api/v1/repos/org/monochange/pulls")
+			.query_param("state", "open")
+			.query_param("head", "org:monochange/release/release")
+			.query_param("base", "main");
+		then.status(200)
+			.header("content-type", "application/json")
+			.body("[]");
+	});
+	let create = server.mock(|when, then| {
+		when.method(POST).path("/api/v1/repos/org/monochange/pulls");
+		then.status(201)
+			.header("content-type", "application/json")
+			.body(r#"{"number":12,"html_url":"https://codeberg.org/org/monochange/pulls/12"}"#);
+	});
+	let labels = server.mock(|when, then| {
+		when.method(POST)
+			.path("/api/v1/repos/org/monochange/issues/12/labels");
+		then.status(200)
+			.header("content-type", "application/json")
+			.body("[]");
+	});
+	let (_tempdir, repo) = seed_git_repository();
+	let source = sample_source(
+		Some(format!("{}/api/v1", server.base_url())),
+		Some("https://codeberg.org".to_string()),
+	);
+	let mut request = build_release_pull_request_request(&source, &sample_manifest());
+	request.commit_message.body = Some("release body".to_string());
+
+	let outcome = with_forgejo_env(Some("token"), || {
+		publish_release_pull_request(
+			&source,
+			&repo,
+			&request,
+			&[PathBuf::from("release.txt")],
+			false,
+		)
+		.unwrap_or_else(|error| panic!("publish pull request: {error}"))
+	});
+
+	list.assert();
+	create.assert();
+	labels.assert();
+	assert_eq!(outcome.operation, SourceChangeRequestOperation::Created);
+	assert!(
+		!git_output(
+			&repo,
+			&["rev-parse", "--verify", "monochange/release/release"]
+		)
+		.trim()
+		.is_empty()
+	);
+	let commit_body = git_output(&repo, &["log", "-1", "--pretty=%B"]);
+	assert!(commit_body.contains("release body"));
+}
+
+#[etest::etest(skip=env::var_os("PRE_COMMIT").is_some())]
+fn git_commit_paths_reports_io_and_non_noop_failures() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let missing = tempdir.path().join("missing");
+	let io_error = git_commit_paths(
+		&missing,
+		&CommitMessage {
+			subject: "chore(release): prepare release".to_string(),
+			body: None,
+		},
+		"commit release pull request changes",
+		false,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected missing worktree error"));
+	assert!(
+		io_error
+			.to_string()
+			.contains("failed to commit release pull request changes")
+	);
+
+	let repo = tempdir.path().join("repo-error");
+	git(tempdir.path(), &["init", repo.to_string_lossy().as_ref()]);
+	git(&repo, &["config", "user.name", "monochange Tests"]);
+	git(&repo, &["config", "user.email", "monochange@example.com"]);
+	let hooks_dir = repo.join(".git/hooks");
+	std::fs::write(hooks_dir.join("pre-commit"), "#!/bin/sh\nexit 1\n")
+		.unwrap_or_else(|error| panic!("write hook: {error}"));
+	std::fs::set_permissions(
+		hooks_dir.join("pre-commit"),
+		std::os::unix::fs::PermissionsExt::from_mode(0o755),
+	)
+	.unwrap_or_else(|error| panic!("chmod hook: {error}"));
+	std::fs::write(repo.join("release.txt"), "initial\n")
+		.unwrap_or_else(|error| panic!("write release file: {error}"));
+	git(&repo, &["add", "release.txt"]);
+	let error = git_commit_paths(
+		&repo,
+		&CommitMessage {
+			subject: "chore(release): prepare release".to_string(),
+			body: None,
+		},
+		"commit release pull request changes",
+		false,
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected pre-commit hook failure"));
+	assert!(
+		error
+			.to_string()
+			.contains("failed to commit release pull request changes")
+	);
+}
+
+#[etest::etest(skip=env::var_os("PRE_COMMIT").is_some())]
+fn git_commit_paths_treats_clean_worktrees_as_already_committed() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let repo = tempdir.path().join("repo");
+	git(tempdir.path(), &["init", repo.to_string_lossy().as_ref()]);
+	git(&repo, &["config", "user.name", "monochange Tests"]);
+	git(&repo, &["config", "user.email", "monochange@example.com"]);
+	std::fs::write(repo.join("release.txt"), "initial\n")
+		.unwrap_or_else(|error| panic!("write release file: {error}"));
+	git(&repo, &["add", "release.txt"]);
+	git(&repo, &["commit", "-m", "initial"]);
+
+	git_commit_paths(
+		&repo,
+		&CommitMessage {
+			subject: "chore(release): prepare release".to_string(),
+			body: None,
+		},
+		"commit release pull request changes",
+		false,
+	)
+	.unwrap_or_else(|error| panic!("commit paths: {error}"));
+
+	assert_eq!(
+		git_output(&repo, &["rev-list", "--count", "HEAD"]).trim(),
+		"1"
+	);
+}
+
+#[etest::etest(skip=env::var_os("PRE_COMMIT").is_some())]
+fn git_checkout_branch_is_noop_when_branch_is_already_checked_out() {
+	let tempdir = must_ok(tempdir(), "tempdir");
+	let repo = tempdir.path().join("repo");
+	git(tempdir.path(), &["init", repo.to_string_lossy().as_ref()]);
+	git(&repo, &["config", "user.name", "monochange Tests"]);
+	git(&repo, &["config", "user.email", "monochange@example.com"]);
+	must_ok(
+		std::fs::write(repo.join("release.txt"), "initial\n"),
+		"write release file",
+	);
+	git(&repo, &["add", "release.txt"]);
+	git(&repo, &["commit", "-m", "initial"]);
+
+	must_ok(
+		git_checkout_branch(&repo, "monochange/release/release", "test context"),
+		"checkout branch",
+	);
+	must_ok(
+		git_checkout_branch(&repo, "monochange/release/release", "test context"),
+		"repeat checkout branch",
+	);
+
+	assert_eq!(
+		git_output(&repo, &["rev-parse", "--abbrev-ref", "HEAD"]).trim(),
+		"monochange/release/release"
+	);
+}
+
+#[test]
+fn publish_pull_request_updates_existing_pull_request() {
+	let server = MockServer::start();
+	let list = server.mock(|when, then| {
+		when.method(GET)
+			.path("/api/v1/repos/org/monochange/pulls")
+			.query_param("state", "open")
+			.query_param("head", "org:monochange/release/release")
+			.query_param("base", "main");
+		then.status(200)
+			.header("content-type", "application/json")
+			.body(r#"[{"number":12,"html_url":"https://codeberg.org/org/monochange/pulls/12","title":"old title","body":"old body","base":{"ref":"main"},"head":{"sha":"old-sha"},"labels":[]}]"#);
+	});
+	let update = server.mock(|when, then| {
+		when.method(PATCH)
+			.path("/api/v1/repos/org/monochange/pulls/12");
+		then.status(200)
+			.header("content-type", "application/json")
+			.body(r#"{"number":12,"html_url":"https://codeberg.org/org/monochange/pulls/12"}"#);
+	});
+	let labels = server.mock(|when, then| {
+		when.method(POST)
+			.path("/api/v1/repos/org/monochange/issues/12/labels");
+		then.status(200)
+			.header("content-type", "application/json")
+			.body("[]");
+	});
+	let request = build_release_pull_request_request(
+		&sample_source(
+			Some(format!("{}/api/v1", server.base_url())),
+			Some("https://codeberg.org".to_string()),
+		),
+		&sample_manifest(),
+	);
+	let client = Client::builder()
+		.build()
+		.expect("failed to build Forgejo HTTP client");
+	let headers = auth_headers("token").unwrap_or_else(|error| panic!("headers: {error}"));
+
+	let runtime = tokio::runtime::Builder::new_current_thread()
+		.enable_all()
+		.build()
+		.expect("failed to build Forgejo runtime");
+	let outcome = runtime
+		.block_on(publish_pull_request(
+			&client,
+			&headers,
+			&format!("{}/api/v1", server.base_url()),
+			&request,
+		))
+		.unwrap_or_else(|error| panic!("update pull request: {error}"));
+
+	list.assert();
+	update.assert();
+	labels.assert();
+	assert_eq!(outcome.operation, SourceChangeRequestOperation::Updated);
+}
+
+#[test]
+fn join_existing_pull_request_lookup_reports_panicked_thread() {
+	let error = join_existing_pull_request_lookup(thread::spawn(
+		|| -> MonochangeResult<Option<ForgejoExistingPullRequest>> {
+			panic!("boom");
+		},
+	))
+	.err()
+	.unwrap_or_else(|| panic!("expected join error"));
+	assert!(
+		error
+			.to_string()
+			.contains("failed to join Forgejo pull request lookup thread")
+	);
+}
+
+#[etest::etest(skip=env::var_os("PRE_COMMIT").is_some())]
+fn publish_release_pull_request_skips_push_when_existing_pull_request_matches_local_head() {
+	let server = MockServer::start();
+	let (_tempdir, repo) = seed_git_repository();
+	let source = sample_source(
+		Some(format!("{}/api/v1", server.base_url())),
+		Some("https://codeberg.org".to_string()),
+	);
+	let request = build_release_pull_request_request(&source, &sample_manifest());
+
+	git(&repo, &["checkout", "-B", &request.head_branch]);
+	git(&repo, &["add", "-A", "--", "release.txt"]);
+	git(&repo, &["commit", "-m", "prepare release branch"]);
+	git(&repo, &["push", "-u", "origin", &request.head_branch]);
+	let head_commit = git_output(&repo, &["rev-parse", "HEAD"]).trim().to_string();
+	let labels = request
+		.labels
+		.iter()
+		.map(|label| format!(r#"{{"name":{label:?}}}"#))
+		.collect::<Vec<_>>()
+		.join(",");
+	let list = server.mock(|when, then| {
+		when.method(GET)
+			.path("/api/v1/repos/org/monochange/pulls")
+			.query_param("state", "open")
+			.query_param("head", "org:monochange/release/release")
+			.query_param("base", "main");
+			then.status(200)
+				.header("content-type", "application/json")
+				.body(format!(
+					r#"[{{"number":12,"html_url":"https://codeberg.org/org/monochange/pulls/12","title":{title:?},"body":{body:?},"base":{{"ref":{base:?}}},"head":{{"sha":{head:?}}},"labels":[{labels}]}}]"#,
+					title = request.title,
+					body = request.body,
+					base = request.base_branch,
+					labels = labels,
+					head = head_commit,
+				));
+		});
+	git(
+		&repo,
+		&[
+			"remote",
+			"set-url",
+			"origin",
+			"/definitely/missing/forgejo-origin.git",
+		],
+	);
+
+	let outcome = with_forgejo_env(Some("token"), || {
+		publish_release_pull_request(
+			&source,
+			&repo,
+			&request,
+			&[PathBuf::from("release.txt")],
+			false,
+		)
+		.unwrap_or_else(|error| panic!("publish pull request: {error}"))
+	});
+
+	list.assert();
+	assert_eq!(outcome.operation, SourceChangeRequestOperation::Skipped);
+	assert_eq!(outcome.number, 12);
+}
+
+fn sample_source(api_url: Option<String>, host: Option<String>) -> SourceConfiguration {
+	SourceConfiguration {
+		provider: SourceProvider::Forgejo,
+		owner: "org".to_string(),
+		repo: "monochange".to_string(),
+		host,
+		api_url,
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+	}
+}
+
+fn sample_manifest() -> ReleaseManifest {
+	ReleaseManifest {
+		command: "release".to_string(),
+		dry_run: true,
+		version: Some("1.2.0".to_string()),
+		group_version: Some("1.2.0".to_string()),
+		release_targets: vec![ReleaseManifestTarget {
+			id: "sdk".to_string(),
+			kind: ReleaseOwnerKind::Group,
+			version: "1.2.0".to_string(),
+			tag: true,
+			release: true,
+			version_format: VersionFormat::Primary,
+			tag_name: "v1.2.0".to_string(),
+			rendered_title: "test title".to_string(),
+			rendered_changelog_title: "test changelog title".to_string(),
+			members: vec!["core".to_string(), "app".to_string()],
+		}],
+		package_publications: vec![],
+		released_packages: vec!["workflow-core".to_string(), "workflow-app".to_string()],
+		changed_files: vec![PathBuf::from("Cargo.toml")],
+		changesets: Vec::new(),
+		changelogs: vec![ReleaseManifestChangelog {
+			owner_id: "sdk".to_string(),
+			owner_kind: ReleaseOwnerKind::Group,
+			path: PathBuf::from("changelog.md"),
+			format: monochange_core::ChangelogFormat::Monochange,
+			notes: ReleaseNotesDocument {
+				title: "1.2.0".to_string(),
+				summary: vec!["Grouped release for `sdk`.".to_string()],
+				sections: vec![ReleaseNotesSection {
+					title: "Features".to_string(),
+					collapsed: false,
+					entries: vec!["add forgejo publishing".to_string()],
+				}],
+			},
+			rendered:
+				"## 1.2.0\n\nGrouped release for `sdk`.\n\n### Features\n\n- add forgejo publishing"
+					.to_string(),
+		}],
+		deleted_changesets: Vec::new(),
+		plan: ReleaseManifestPlan {
+			workspace_root: PathBuf::from("."),
+			decisions: vec![ReleaseManifestPlanDecision {
+				package: "core".to_string(),
+				bump: BumpSeverity::Minor,
+				trigger: "changeset".to_string(),
+				planned_version: Some("1.2.0".to_string()),
+				reasons: vec!["add provider automation".to_string()],
+				upstream_sources: vec!["sdk".to_string()],
+			}],
+			groups: Vec::new(),
+			warnings: Vec::new(),
+			unresolved_items: Vec::new(),
+			compatibility_evidence: Vec::new(),
+		},
+	}
+}
+
+fn sample_manifest_without_changelog() -> ReleaseManifest {
+	let mut manifest = sample_manifest();
+	manifest.changelogs.clear();
+	manifest
+}
+
+fn with_forgejo_env<R>(token: Option<&str>, action: impl FnOnce() -> R) -> R {
+	temp_env::with_vars([("FORGEJO_TOKEN", token)], action)
+}
+
+fn seed_git_repository() -> (tempfile::TempDir, PathBuf) {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let bare = tempdir.path().join("origin.git");
+	let repo = tempdir.path().join("repo");
+	git(
+		tempdir.path(),
+		&[
+			"init",
+			"--bare",
+			"--initial-branch=main",
+			bare.to_string_lossy().as_ref(),
+		],
+	);
+	git(
+		tempdir.path(),
+		&[
+			"init",
+			"--initial-branch=main",
+			repo.to_string_lossy().as_ref(),
+		],
+	);
+	git(&repo, &["config", "user.name", "monochange Tests"]);
+	git(&repo, &["config", "user.email", "monochange@example.com"]);
+	git(&repo, &["config", "commit.gpgsign", "false"]);
+	std::fs::write(repo.join("release.txt"), "before\n")
+		.unwrap_or_else(|error| panic!("write release file: {error}"));
+	git(&repo, &["add", "release.txt"]);
+	git(&repo, &["commit", "-m", "initial"]);
+	git(
+		&repo,
+		&["remote", "add", "origin", bare.to_string_lossy().as_ref()],
+	);
+	git(&repo, &["push", "-u", "origin", "main"]);
+	std::fs::write(repo.join("release.txt"), "after\n")
+		.unwrap_or_else(|error| panic!("update release file: {error}"));
+	(tempdir, repo)
+}

--- a/crates/monochange_forgejo/src/lib.rs
+++ b/crates/monochange_forgejo/src/lib.rs
@@ -1,0 +1,852 @@
+//! # `monochange_forgejo`
+//!
+//! <!-- {=monochangeForgejoCrateDocs|trim|linePrefix:"//! ":true} -->
+//! `monochange_forgejo` turns `monochange` release manifests into Forgejo automation requests.
+//!
+//! Reach for this crate when you want to preview or publish Forgejo releases and release pull requests using the same structured release data that powers changelog files and release manifests.
+//!
+//! ## Why use it?
+//!
+//! - derive Forgejo release payloads and release-PR bodies from `monochange`'s structured release manifest
+//! - keep Forgejo automation aligned with changelog rendering and release targets
+//! - reuse one publishing path for dry-run previews and real repository updates
+//!
+//! ## Best for
+//!
+//! - building Forgejo release automation on top of `mc release`
+//! - previewing would-be Forgejo releases and release PRs in CI before publishing
+//! - self-hosted Forgejo instances that need the same release workflow as GitHub or GitLab
+//!
+//! ## Public entry points
+//!
+//! - `build_release_requests(manifest, source)` builds release payloads from prepared release state
+//! - `build_change_request(manifest, source)` builds a pull-request payload for the release
+//! - `validate_source_configuration(source)` validates Forgejo-specific source config
+//! - `source_capabilities()` returns provider feature flags
+//! <!-- {/monochangeForgejoCrateDocs} -->
+
+use std::env;
+use std::path::Path;
+use std::path::PathBuf;
+
+use monochange_core::CommitMessage;
+use monochange_core::HostedSourceAdapter;
+use monochange_core::HostedSourceFeatures;
+use monochange_core::HostingCapabilities;
+use monochange_core::HostingProviderKind;
+use monochange_core::MonochangeError;
+use monochange_core::MonochangeResult;
+use monochange_core::PreparedChangeset;
+use monochange_core::ProviderReleaseNotesSource;
+use monochange_core::ReleaseManifest;
+use monochange_core::SourceCapabilities;
+use monochange_core::SourceChangeRequest;
+use monochange_core::SourceChangeRequestOperation;
+use monochange_core::SourceChangeRequestOutcome;
+use monochange_core::SourceConfiguration;
+use monochange_core::SourceProvider;
+use monochange_core::SourceReleaseOperation;
+use monochange_core::SourceReleaseOutcome;
+use monochange_core::SourceReleaseRequest;
+use monochange_core::git::git_head_commit;
+use monochange_hosting::git_checkout_branch;
+use monochange_hosting::git_commit_paths;
+use monochange_hosting::git_push_branch;
+use monochange_hosting::git_stage_paths;
+use monochange_hosting::release_body;
+use monochange_hosting::release_pull_request_body;
+use monochange_hosting::release_pull_request_branch;
+use reqwest::Client;
+use reqwest::StatusCode;
+use reqwest::header::AUTHORIZATION;
+use reqwest::header::CONTENT_TYPE;
+use reqwest::header::HeaderMap;
+use reqwest::header::HeaderValue;
+use serde::Deserialize;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use tokio::runtime::Builder as RuntimeBuilder;
+use urlencoding::encode;
+
+/// Return the hosted-source capabilities supported by the Forgejo provider.
+#[must_use]
+pub const fn source_capabilities() -> SourceCapabilities {
+	SourceCapabilities {
+		draft_releases: true,
+		prereleases: true,
+		generated_release_notes: false,
+		auto_merge_change_requests: false,
+		released_issue_comments: false,
+		requires_host: true,
+	}
+}
+
+/// Shared Forgejo hosted-source adapter instance used by the workspace.
+pub static HOSTED_SOURCE_ADAPTER: ForgejoHostedSourceAdapter = ForgejoHostedSourceAdapter;
+
+/// Hosted-source adapter for Forgejo repositories.
+pub struct ForgejoHostedSourceAdapter;
+
+impl HostedSourceAdapter for ForgejoHostedSourceAdapter {
+	fn provider(&self) -> SourceProvider {
+		SourceProvider::Forgejo
+	}
+
+	fn features(&self) -> HostedSourceFeatures {
+		HostedSourceFeatures {
+			batched_changeset_context_lookup: false,
+			released_issue_comments: false,
+			release_retarget_sync: false,
+		}
+	}
+
+	fn annotate_changeset_context(
+		&self,
+		source: &SourceConfiguration,
+		changesets: &mut [PreparedChangeset],
+	) {
+		annotate_changeset_context(source, changesets);
+	}
+
+	fn enrich_changeset_context(
+		&self,
+		source: &SourceConfiguration,
+		changesets: &mut [PreparedChangeset],
+	) {
+		enrich_changeset_context(source, changesets);
+	}
+}
+
+/// Return the hosting metadata features available from Forgejo changeset context.
+#[must_use]
+pub const fn forgejo_hosting_capabilities() -> HostingCapabilities {
+	HostingCapabilities {
+		commit_web_urls: true,
+		actor_profiles: false,
+		review_request_lookup: false,
+		related_issues: false,
+		issue_comments: false,
+	}
+}
+
+/// Extract the host name used for rendered Forgejo links.
+#[must_use]
+pub fn forgejo_host_name(source: &SourceConfiguration) -> Option<String> {
+	let host = forgejo_host(source)
+		.trim_start_matches("https://")
+		.trim_start_matches("http://")
+		.split('/')
+		.next()
+		.unwrap_or_default()
+		.trim();
+	if host.is_empty() {
+		None
+	} else {
+		Some(host.to_string())
+	}
+}
+
+/// Build a web URL for a commit on the configured Forgejo repository.
+#[must_use]
+pub fn forgejo_commit_url(source: &SourceConfiguration, sha: &str) -> String {
+	format!(
+		"{}/{}/{}/commit/{sha}",
+		forgejo_host(source).trim_end_matches('/'),
+		source.owner,
+		source.repo
+	)
+}
+
+/// Apply Forgejo provider metadata and commit URLs to prepared changesets.
+pub fn annotate_changeset_context(
+	source: &SourceConfiguration,
+	changesets: &mut [PreparedChangeset],
+) {
+	let host = forgejo_host_name(source);
+	let capabilities = forgejo_hosting_capabilities();
+
+	for changeset in changesets {
+		let Some(context) = changeset.context.as_mut() else {
+			continue;
+		};
+
+		context.provider = HostingProviderKind::Forgejo;
+		context.host.clone_from(&host);
+		context.capabilities = capabilities.clone();
+
+		for revision in [&mut context.introduced, &mut context.last_updated] {
+			let Some(revision) = revision.as_mut() else {
+				continue;
+			};
+
+			if let Some(commit) = revision.commit.as_mut() {
+				commit.provider = HostingProviderKind::Forgejo;
+				commit.host.clone_from(&host);
+				commit.url = Some(forgejo_commit_url(source, &commit.sha));
+			}
+
+			if let Some(actor) = revision.actor.as_mut() {
+				actor.provider = HostingProviderKind::Forgejo;
+				actor.host.clone_from(&host);
+			}
+		}
+	}
+}
+
+/// Enrich changeset context for Forgejo-backed workspaces.
+///
+/// Forgejo currently exposes only local annotations, so this delegates to
+/// [`annotate_changeset_context`].
+#[tracing::instrument(skip_all)]
+pub fn enrich_changeset_context(
+	source: &SourceConfiguration,
+	changesets: &mut [PreparedChangeset],
+) {
+	annotate_changeset_context(source, changesets);
+}
+
+/// Validate that a source configuration is compatible with the Forgejo provider.
+#[must_use = "the validation result must be checked"]
+pub fn validate_source_configuration(source: &SourceConfiguration) -> MonochangeResult<()> {
+	if source.host.as_deref().is_none_or(str::is_empty) {
+		return Err(MonochangeError::Config(
+			"[source].host must be set for `provider = \"forgejo\"`".to_string(),
+		));
+	}
+	if source.releases.generate_notes
+		|| matches!(
+			source.releases.source,
+			ProviderReleaseNotesSource::GitHubGenerated
+		) {
+		return Err(MonochangeError::Config(
+			"provider-generated release notes are not supported for `provider = \"forgejo\"`; use `source = \"monochange\"`"
+				.to_string(),
+		));
+	}
+	if source.pull_requests.auto_merge {
+		return Err(MonochangeError::Config(
+			"[source.pull_requests].auto_merge is not supported for `provider = \"forgejo\"`"
+				.to_string(),
+		));
+	}
+	Ok(())
+}
+
+#[derive(Debug, Serialize)]
+struct ForgejoReleasePayload<'a> {
+	tag_name: &'a str,
+	name: &'a str,
+	body: Option<&'a str>,
+	draft: bool,
+	prerelease: bool,
+	target_commitish: &'a str,
+}
+
+#[derive(Debug, Serialize)]
+struct ForgejoPullRequestPayload<'a> {
+	title: &'a str,
+	head: &'a str,
+	base: &'a str,
+	body: &'a str,
+}
+
+#[derive(Debug, Serialize)]
+struct ForgejoPullRequestUpdatePayload<'a> {
+	title: &'a str,
+	body: &'a str,
+	base: &'a str,
+}
+
+#[derive(Debug, Serialize)]
+struct ForgejoLabelsPayload<'a> {
+	labels: &'a [String],
+}
+
+#[derive(Debug, Deserialize)]
+struct ForgejoReleaseResponse {
+	html_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ForgejoPullRequestResponse {
+	number: u64,
+	html_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ForgejoExistingPullRequestLabel {
+	name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ForgejoExistingPullRequestBase {
+	#[serde(rename = "ref")]
+	ref_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ForgejoExistingPullRequestHead {
+	sha: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ForgejoExistingPullRequest {
+	number: u64,
+	html_url: Option<String>,
+	title: String,
+	body: Option<String>,
+	base: ForgejoExistingPullRequestBase,
+	head: ForgejoExistingPullRequestHead,
+	#[serde(default)]
+	labels: Vec<ForgejoExistingPullRequestLabel>,
+}
+
+fn forgejo_host(source: &SourceConfiguration) -> &str {
+	source
+		.host
+		.as_deref()
+		.unwrap_or("https://forgejo.com")
+		.trim_end_matches('/')
+}
+
+/// Build the public release URL for a tag on the configured Forgejo repository.
+#[must_use]
+pub fn tag_url(source: &SourceConfiguration, tag_name: &str) -> String {
+	let host = forgejo_host(source);
+	format!(
+		"{host}/{}/{}/releases/tag/{tag_name}",
+		source.owner, source.repo
+	)
+}
+
+/// Build the comparison URL between two tags on the configured Forgejo repository.
+#[must_use]
+pub fn compare_url(source: &SourceConfiguration, previous_tag: &str, current_tag: &str) -> String {
+	let host = forgejo_host(source);
+	format!(
+		"{host}/{}/{}/compare/{previous_tag}...{current_tag}",
+		source.owner, source.repo
+	)
+}
+
+/// Convert releasable targets into provider-specific Forgejo release requests.
+#[must_use]
+pub fn build_release_requests(
+	source: &SourceConfiguration,
+	manifest: &ReleaseManifest,
+) -> Vec<SourceReleaseRequest> {
+	manifest
+		.release_targets
+		.iter()
+		.filter(|target| target.release)
+		.map(|target| {
+			SourceReleaseRequest {
+				provider: SourceProvider::Forgejo,
+				repository: format!("{}/{}", source.owner, source.repo),
+				owner: source.owner.clone(),
+				repo: source.repo.clone(),
+				target_id: target.id.clone(),
+				target_kind: target.kind,
+				tag_name: target.tag_name.clone(),
+				name: if target.rendered_title.is_empty() {
+					target.tag_name.clone()
+				} else {
+					target.rendered_title.clone()
+				},
+				body: release_body(source, manifest, target),
+				draft: source.releases.draft,
+				prerelease: source.releases.prerelease,
+				generate_release_notes: source.releases.generate_notes,
+			}
+		})
+		.collect()
+}
+
+/// Build the release pull request request for the configured Forgejo repository.
+#[must_use]
+pub fn build_release_pull_request_request(
+	source: &SourceConfiguration,
+	manifest: &ReleaseManifest,
+) -> SourceChangeRequest {
+	let repository = format!("{}/{}", source.owner, source.repo);
+	let title = source.pull_requests.title.clone();
+	SourceChangeRequest {
+		provider: SourceProvider::Forgejo,
+		repository: repository.clone(),
+		owner: source.owner.clone(),
+		repo: source.repo.clone(),
+		base_branch: source.pull_requests.base.clone(),
+		head_branch: release_pull_request_branch(
+			&source.pull_requests.branch_prefix,
+			&manifest.command,
+		),
+		title: title.clone(),
+		body: release_pull_request_body(manifest),
+		labels: source.pull_requests.labels.clone(),
+		auto_merge: source.pull_requests.auto_merge,
+		commit_message: CommitMessage {
+			subject: title,
+			body: None,
+		},
+	}
+}
+
+/// Publish or update all planned Forgejo releases for a manifest.
+#[tracing::instrument(skip_all)]
+#[must_use = "the publish result must be checked"]
+#[allow(clippy::disallowed_methods)]
+pub fn publish_release_requests(
+	source: &SourceConfiguration,
+	requests: &[SourceReleaseRequest],
+) -> MonochangeResult<Vec<SourceReleaseOutcome>> {
+	let runtime = RuntimeBuilder::new_current_thread()
+		.enable_all()
+		.build()
+		.expect("failed to build Forgejo runtime");
+	runtime.block_on(async {
+		let client = Client::builder()
+			.build()
+			.expect("failed to build Forgejo HTTP client");
+		let token = forgejo_token()?;
+		let headers = auth_headers(&token)?;
+		let api_base = forgejo_api_base(source)?;
+		let mut outcomes = Vec::with_capacity(requests.len());
+		for request in requests {
+			outcomes.push(
+				publish_release_request(&client, &headers, &api_base, source, request).await?,
+			);
+		}
+		Ok(outcomes)
+	})
+}
+
+/// Commit, push, and publish the release pull request against Forgejo.
+#[must_use = "the pull request result must be checked"]
+#[allow(clippy::disallowed_methods)]
+pub fn publish_release_pull_request(
+	source: &SourceConfiguration,
+	root: &Path,
+	request: &SourceChangeRequest,
+	tracked_paths: &[PathBuf],
+	no_verify: bool,
+) -> MonochangeResult<SourceChangeRequestOutcome> {
+	let lookup_source = source.clone();
+	let lookup_request = request.clone();
+	let existing_pull_request = std::thread::spawn(move || {
+		let runtime = RuntimeBuilder::new_current_thread()
+			.enable_all()
+			.build()
+			.expect("failed to build Forgejo runtime");
+		runtime.block_on(async {
+			let client = Client::builder()
+				.build()
+				.expect("failed to build Forgejo HTTP client");
+			let token = forgejo_token()?;
+			let headers = auth_headers(&token)?;
+			let api_base = forgejo_api_base(&lookup_source)?;
+			lookup_existing_pull_request(&client, &headers, &api_base, &lookup_request).await
+		})
+	});
+	git_checkout_branch(
+		root,
+		&request.head_branch,
+		"prepare release pull request branch",
+	)?;
+	git_stage_paths(root, tracked_paths, "stage release pull request files")?;
+	git_commit_paths(
+		root,
+		&request.commit_message,
+		"commit release pull request changes",
+		no_verify,
+	)?;
+	let head_commit = git_head_commit(root)?;
+	let existing = join_existing_pull_request_lookup(existing_pull_request)?;
+	let head_matches_existing = existing
+		.as_ref()
+		.and_then(|pull_request| pull_request.head.sha.as_deref())
+		== Some(head_commit.as_str());
+	if !head_matches_existing {
+		git_push_branch(
+			root,
+			&request.head_branch,
+			"push release pull request branch",
+			no_verify,
+		)?;
+	}
+
+	let runtime = RuntimeBuilder::new_current_thread()
+		.enable_all()
+		.build()
+		.expect("failed to build Forgejo runtime");
+	runtime.block_on(async {
+		let client = Client::builder()
+			.build()
+			.expect("failed to build Forgejo HTTP client");
+		let token = forgejo_token()?;
+		let headers = auth_headers(&token)?;
+		let api_base = forgejo_api_base(source)?;
+		publish_pull_request_with_existing(
+			&client,
+			&headers,
+			&api_base,
+			request,
+			existing.as_ref(),
+			&head_commit,
+		)
+		.await
+	})
+}
+
+async fn publish_release_request(
+	client: &Client,
+	headers: &HeaderMap,
+	api_base: &str,
+	source: &SourceConfiguration,
+	request: &SourceReleaseRequest,
+) -> MonochangeResult<SourceReleaseOutcome> {
+	let lookup_url = format!(
+		"{api_base}/repos/{}/{}/releases/tags/{}",
+		request.owner,
+		request.repo,
+		encode(&request.tag_name)
+	);
+	let existing =
+		get_optional_json::<ForgejoReleaseResponse>(client, headers, &lookup_url, "Forgejo")
+			.await?;
+	let response: ForgejoReleaseResponse = if existing.is_some() {
+		let update_url = format!(
+			"{api_base}/repos/{}/{}/releases/tags/{}",
+			request.owner,
+			request.repo,
+			encode(&request.tag_name)
+		);
+		patch_json(
+			client,
+			headers,
+			&update_url,
+			&ForgejoReleasePayload {
+				tag_name: &request.tag_name,
+				name: &request.name,
+				body: request.body.as_deref(),
+				draft: request.draft,
+				prerelease: request.prerelease,
+				target_commitish: &source.pull_requests.base,
+			},
+			"Forgejo",
+		)
+		.await?
+	} else {
+		let create_url = format!(
+			"{api_base}/repos/{}/{}/releases",
+			request.owner, request.repo
+		);
+		post_json(
+			client,
+			headers,
+			&create_url,
+			&ForgejoReleasePayload {
+				tag_name: &request.tag_name,
+				name: &request.name,
+				body: request.body.as_deref(),
+				draft: request.draft,
+				prerelease: request.prerelease,
+				target_commitish: &source.pull_requests.base,
+			},
+			"Forgejo",
+		)
+		.await?
+	};
+	Ok(SourceReleaseOutcome {
+		provider: SourceProvider::Forgejo,
+		repository: request.repository.clone(),
+		tag_name: request.tag_name.clone(),
+		operation: if existing.is_some() {
+			SourceReleaseOperation::Updated
+		} else {
+			SourceReleaseOperation::Created
+		},
+		url: response.html_url,
+	})
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+async fn publish_pull_request(
+	client: &Client,
+	headers: &HeaderMap,
+	api_base: &str,
+	request: &SourceChangeRequest,
+) -> MonochangeResult<SourceChangeRequestOutcome> {
+	let existing = lookup_existing_pull_request(client, headers, api_base, request).await?;
+	publish_pull_request_with_existing(client, headers, api_base, request, existing.as_ref(), "")
+		.await
+}
+
+async fn publish_pull_request_with_existing(
+	client: &Client,
+	headers: &HeaderMap,
+	api_base: &str,
+	request: &SourceChangeRequest,
+	existing: Option<&ForgejoExistingPullRequest>,
+	head_commit: &str,
+) -> MonochangeResult<SourceChangeRequestOutcome> {
+	let labels_match = existing.is_some_and(|pull_request| {
+		request.labels.iter().all(|label| {
+			pull_request
+				.labels
+				.iter()
+				.any(|existing_label| existing_label.name == *label)
+		})
+	});
+	let content_matches = existing.is_some_and(|pull_request| {
+		pull_request.title == request.title
+			&& pull_request.body.as_deref().unwrap_or_default() == request.body
+			&& pull_request.base.ref_name == request.base_branch
+	});
+	let head_matches_existing =
+		existing.and_then(|pull_request| pull_request.head.sha.as_deref()) == Some(head_commit);
+	let response: ForgejoPullRequestResponse = match existing {
+		Some(existing_pr) if content_matches => {
+			ForgejoPullRequestResponse {
+				number: existing_pr.number,
+				html_url: existing_pr.html_url.clone(),
+			}
+		}
+		Some(existing_pr) => {
+			let update_url = format!(
+				"{api_base}/repos/{}/{}/pulls/{}",
+				request.owner, request.repo, existing_pr.number
+			);
+			let update_payload = ForgejoPullRequestUpdatePayload {
+				title: &request.title,
+				body: &request.body,
+				base: &request.base_branch,
+			};
+
+			patch_json(client, headers, &update_url, &update_payload, "Forgejo").await?
+		}
+		None => {
+			let create_url = format!("{api_base}/repos/{}/{}/pulls", request.owner, request.repo);
+			let payload = ForgejoPullRequestPayload {
+				title: &request.title,
+				head: &request.head_branch,
+				base: &request.base_branch,
+				body: &request.body,
+			};
+
+			post_json(client, headers, &create_url, &payload, "Forgejo").await?
+		}
+	};
+	if !request.labels.is_empty() && !labels_match {
+		let labels_url = format!(
+			"{api_base}/repos/{}/{}/issues/{}/labels",
+			request.owner, request.repo, response.number
+		);
+		let _: serde_json::Value = post_json(
+			client,
+			headers,
+			&labels_url,
+			&ForgejoLabelsPayload {
+				labels: &request.labels,
+			},
+			"Forgejo",
+		)
+		.await?;
+	}
+	Ok(SourceChangeRequestOutcome {
+		provider: SourceProvider::Forgejo,
+		repository: request.repository.clone(),
+		number: response.number,
+		head_branch: request.head_branch.clone(),
+		operation: match existing {
+			None => SourceChangeRequestOperation::Created,
+			Some(_) if content_matches && labels_match && head_matches_existing => {
+				SourceChangeRequestOperation::Skipped
+			}
+			Some(_) => SourceChangeRequestOperation::Updated,
+		},
+		url: response.html_url,
+	})
+}
+
+async fn lookup_existing_pull_request(
+	client: &Client,
+	headers: &HeaderMap,
+	api_base: &str,
+	request: &SourceChangeRequest,
+) -> MonochangeResult<Option<ForgejoExistingPullRequest>> {
+	let list_url = format!(
+		"{api_base}/repos/{}/{}/pulls?state=open&head={}:{}&base={}",
+		request.owner,
+		request.repo,
+		encode(&request.owner),
+		encode(&request.head_branch),
+		encode(&request.base_branch),
+	);
+	Ok(
+		get_json::<Vec<ForgejoExistingPullRequest>>(client, headers, &list_url, "Forgejo")
+			.await?
+			.into_iter()
+			.next(),
+	)
+}
+
+fn join_existing_pull_request_lookup(
+	handle: std::thread::JoinHandle<MonochangeResult<Option<ForgejoExistingPullRequest>>>,
+) -> MonochangeResult<Option<ForgejoExistingPullRequest>> {
+	handle.join().map_err(|_| {
+		MonochangeError::Config("failed to join Forgejo pull request lookup thread".to_string())
+	})?
+}
+
+async fn get_optional_json<T>(
+	client: &Client,
+	headers: &HeaderMap,
+	url: &str,
+	provider: &str,
+) -> MonochangeResult<Option<T>>
+where
+	T: DeserializeOwned,
+{
+	let response = client
+		.get(url)
+		.headers(headers.clone())
+		.send()
+		.await
+		.map_err(|error| {
+			MonochangeError::Config(format!("{provider} API GET `{url}` failed: {error}"))
+		})?;
+	let status = response.status();
+	if status == StatusCode::NOT_FOUND {
+		return Ok(None);
+	}
+	if !status.is_success() {
+		return Err(MonochangeError::Config(format!(
+			"{provider} API GET `{url}` failed with status {status}"
+		)));
+	}
+	response.json::<T>().await.map(Some).map_err(|error| {
+		MonochangeError::Config(format!("{provider} API GET `{url}` failed: {error}"))
+	})
+}
+async fn get_json<T>(
+	client: &Client,
+	headers: &HeaderMap,
+	url: &str,
+	provider: &str,
+) -> MonochangeResult<T>
+where
+	T: DeserializeOwned,
+{
+	let response = client
+		.get(url)
+		.headers(headers.clone())
+		.send()
+		.await
+		.map_err(|error| {
+			MonochangeError::Config(format!("{provider} API GET `{url}` failed: {error}"))
+		})?;
+	let status = response.status();
+	if !status.is_success() {
+		return Err(MonochangeError::Config(format!(
+			"{provider} API GET `{url}` failed with status {status}"
+		)));
+	}
+	response.json::<T>().await.map_err(|error| {
+		MonochangeError::Config(format!("{provider} API GET `{url}` failed: {error}"))
+	})
+}
+
+async fn post_json<Body, JsonResponse>(
+	client: &Client,
+	headers: &HeaderMap,
+	url: &str,
+	body: &Body,
+	provider: &str,
+) -> MonochangeResult<JsonResponse>
+where
+	Body: Serialize + ?Sized,
+	JsonResponse: DeserializeOwned,
+{
+	let response = client
+		.post(url)
+		.headers(headers.clone())
+		.json(body)
+		.send()
+		.await
+		.map_err(|error| {
+			MonochangeError::Config(format!("{provider} API POST `{url}` failed: {error}"))
+		})?;
+	let status = response.status();
+	if !status.is_success() {
+		return Err(MonochangeError::Config(format!(
+			"{provider} API POST `{url}` failed with status {status}"
+		)));
+	}
+	response.json::<JsonResponse>().await.map_err(|error| {
+		MonochangeError::Config(format!("{provider} API POST `{url}` failed: {error}"))
+	})
+}
+
+async fn patch_json<Body, JsonResponse>(
+	client: &Client,
+	headers: &HeaderMap,
+	url: &str,
+	body: &Body,
+	provider: &str,
+) -> MonochangeResult<JsonResponse>
+where
+	Body: Serialize + ?Sized,
+	JsonResponse: DeserializeOwned,
+{
+	let response = client
+		.patch(url)
+		.headers(headers.clone())
+		.json(body)
+		.send()
+		.await
+		.map_err(|error| {
+			MonochangeError::Config(format!("{provider} API PATCH `{url}` failed: {error}"))
+		})?;
+	let status = response.status();
+	if !status.is_success() {
+		return Err(MonochangeError::Config(format!(
+			"{provider} API PATCH `{url}` failed with status {status}"
+		)));
+	}
+	response.json::<JsonResponse>().await.map_err(|error| {
+		MonochangeError::Config(format!("{provider} API PATCH `{url}` failed: {error}"))
+	})
+}
+
+fn forgejo_token() -> MonochangeResult<String> {
+	env::var("FORGEJO_TOKEN").map_err(|_| {
+		MonochangeError::Config("set `FORGEJO_TOKEN` before running Forgejo automation".to_string())
+	})
+}
+
+fn forgejo_api_base(source: &SourceConfiguration) -> MonochangeResult<String> {
+	if let Some(api_url) = &source.api_url {
+		return Ok(api_url.trim_end_matches('/').to_string());
+	}
+	let host = source.host.as_deref().ok_or_else(|| {
+		MonochangeError::Config(
+			"[source].host must be set for `provider = \"forgejo\"`".to_string(),
+		)
+	})?;
+	Ok(format!("{}/api/v1", host.trim_end_matches('/')))
+}
+
+fn auth_headers(token: &str) -> MonochangeResult<HeaderMap> {
+	let mut headers = HeaderMap::new();
+	headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+	headers.insert(
+		AUTHORIZATION,
+		HeaderValue::from_str(&format!("token {token}")).map_err(|error| {
+			MonochangeError::Config(format!("invalid Forgejo token header value: {error}"))
+		})?,
+	);
+	Ok(headers)
+}
+
+#[cfg(test)]
+mod __tests;

--- a/crates/monochange_forgejo/src/snapshots/monochange_forgejo____tests__build_release_pull_request_request_uses_forgejo_provider_and_sanitized_branch__body.snap
+++ b/crates/monochange_forgejo/src/snapshots/monochange_forgejo____tests__build_release_pull_request_request_uses_forgejo_provider_and_sanitized_branch__body.snap
@@ -1,0 +1,23 @@
+---
+source: crates/monochange_forgejo/src/__tests.rs
+assertion_line: 99
+expression: request.body
+---
+## Prepared release
+
+- command: `Release PR!`
+- group `sdk` -> `v1.2.0`
+
+## Release notes
+
+### sdk 1.2.0
+
+Grouped release for `sdk`.
+
+### Features
+
+- add forgejo publishing
+
+## Changed files
+
+- Cargo.toml

--- a/crates/monochange_forgejo/src/snapshots/monochange_forgejo____tests__release_body_supports_generated_notes_and_minimal_fallback__minimal_body.snap
+++ b/crates/monochange_forgejo/src/snapshots/monochange_forgejo____tests__release_body_supports_generated_notes_and_minimal_fallback__minimal_body.snap
@@ -1,0 +1,10 @@
+---
+source: crates/monochange_forgejo/src/__tests.rs
+assertion_line: 484
+expression: body
+---
+Release target `sdk`
+
+Members: core, app
+
+- add provider automation

--- a/crates/monochange_forgejo/src/snapshots/monochange_forgejo____tests__release_pull_request_body_uses_minimal_notes_when_changelog_is_missing__body.snap
+++ b/crates/monochange_forgejo/src/snapshots/monochange_forgejo____tests__release_pull_request_body_uses_minimal_notes_when_changelog_is_missing__body.snap
@@ -1,0 +1,23 @@
+---
+source: crates/monochange_forgejo/src/__tests.rs
+assertion_line: 495
+expression: body
+---
+## Prepared release
+
+- command: `release`
+- group `sdk` -> `v1.2.0`
+
+## Release notes
+
+### sdk 1.2.0
+
+Release target `sdk`
+
+Members: core, app
+
+- add provider automation
+
+## Changed files
+
+- Cargo.toml

--- a/crates/monochange_github/tests/env_wrappers.rs
+++ b/crates/monochange_github/tests/env_wrappers.rs
@@ -54,7 +54,10 @@ fn publish_release_requests_reads_github_env_configuration() {
 			}],
 		)
 		.unwrap_or_else(|error| panic!("publish releases: {error}"));
-		assert_eq!(outcomes[0].operation, GitHubReleaseOperation::Created);
+		let outcome = outcomes
+			.first()
+			.unwrap_or_else(|| panic!("missing release outcome"));
+		assert_eq!(outcome.operation, GitHubReleaseOperation::Created);
 	});
 
 	release_lookup.assert();

--- a/crates/monochange_hosting/readme.md
+++ b/crates/monochange_hosting/readme.md
@@ -14,7 +14,7 @@
 
 `monochange_hosting` packages the shared git and HTTP plumbing used by hosted source providers.
 
-Reach for this crate when you are implementing GitHub, Gitea, or GitLab release adapters and want one place for release-body rendering, change-request branch naming, JSON requests, and git branch orchestration.
+Reach for this crate when you are implementing GitHub, Gitea, Forgejo, or GitLab release adapters and want one place for release-body rendering, change-request branch naming, JSON requests, and git branch orchestration.
 
 ## Why use it?
 

--- a/crates/monochange_hosting/src/lib.rs
+++ b/crates/monochange_hosting/src/lib.rs
@@ -5,7 +5,7 @@
 //! <!-- {=monochangeHostingCrateDocs|trim|linePrefix:"//! ":true} -->
 //! `monochange_hosting` packages the shared git and HTTP plumbing used by hosted source providers.
 //!
-//! Reach for this crate when you are implementing GitHub, Gitea, or GitLab release adapters and want one place for release-body rendering, change-request branch naming, JSON requests, and git branch orchestration.
+//! Reach for this crate when you are implementing GitHub, Gitea, Forgejo, or GitLab release adapters and want one place for release-body rendering, change-request branch naming, JSON requests, and git branch orchestration.
 //!
 //! ## Why use it?
 //!

--- a/crates/monochange_integration_tests/Cargo.toml
+++ b/crates/monochange_integration_tests/Cargo.toml
@@ -10,7 +10,9 @@ description = "Internal integration tests for monochange crates"
 [dev-dependencies]
 insta = { workspace = true, features = ["redactions"] }
 insta-cmd = { workspace = true }
+monochange_config = { workspace = true }
 monochange_core = { workspace = true }
+monochange_forgejo = { workspace = true }
 monochange_schema = { workspace = true }
 monochange_test_helpers = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/monochange_integration_tests/tests/forgejo_provider.rs
+++ b/crates/monochange_integration_tests/tests/forgejo_provider.rs
@@ -1,0 +1,149 @@
+use std::path::Path;
+use std::process::Command;
+
+use insta::assert_json_snapshot;
+use insta::assert_snapshot;
+use insta_cmd::get_cargo_bin;
+use monochange_core::ProviderMergeRequestSettings;
+use monochange_core::ProviderReleaseNotesSource;
+use monochange_core::ProviderReleaseSettings;
+use monochange_core::SourceConfiguration;
+use monochange_core::SourceProvider;
+
+fn fixture_path(relative: &str) -> std::path::PathBuf {
+	Path::new(env!("CARGO_MANIFEST_DIR"))
+		.join("../../fixtures/tests")
+		.join(relative)
+}
+
+fn forgejo_source() -> SourceConfiguration {
+	SourceConfiguration {
+		provider: SourceProvider::Forgejo,
+		owner: "org".to_string(),
+		repo: "monochange".to_string(),
+		host: Some("https://codeberg.org".to_string()),
+		api_url: Some("https://codeberg.org/api/v1".to_string()),
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+	}
+}
+
+#[test]
+fn forgejo_fixture_loads_and_validates_source_configuration() {
+	let configuration =
+		monochange_config::load_workspace_configuration(&fixture_path("source/forgejo"))
+			.unwrap_or_else(|error| panic!("load forgejo fixture: {error}"));
+	let source = configuration
+		.source
+		.unwrap_or_else(|| panic!("forgejo fixture should configure [source]"));
+
+	assert_eq!(source.provider, SourceProvider::Forgejo);
+	assert_eq!(source.host.as_deref(), Some("https://codeberg.org"));
+	assert_eq!(
+		source.releases.source,
+		ProviderReleaseNotesSource::Monochange
+	);
+	assert_eq!(source.pull_requests.base, "main");
+	assert_json_snapshot!(serde_json::json!({
+		"provider": source.provider,
+		"owner": &source.owner,
+		"repo": &source.repo,
+		"host": &source.host,
+		"api_url": &source.api_url,
+		"release_notes_source": source.releases.source,
+		"pull_request_base": &source.pull_requests.base,
+	}), @r###"
+	{
+	  "api_url": null,
+	  "host": "https://codeberg.org",
+	  "owner": "org",
+	  "provider": "forgejo",
+	  "pull_request_base": "main",
+	  "release_notes_source": "monochange",
+	  "repo": "monochange"
+	}
+	"###);
+	monochange_forgejo::validate_source_configuration(&source)
+		.unwrap_or_else(|error| panic!("validate forgejo source: {error}"));
+}
+
+#[test]
+fn forgejo_cli_validate_accepts_fixture_configuration() {
+	let output = Command::new(get_cargo_bin("mc"))
+		.env("NO_COLOR", "1")
+		.env_remove("RUST_LOG")
+		.current_dir(fixture_path("source/forgejo"))
+		.arg("validate")
+		.output()
+		.unwrap_or_else(|error| panic!("run mc validate: {error}"));
+
+	assert!(
+		output.status.success(),
+		"mc validate failed\nstdout:\n{}\nstderr:\n{}",
+		String::from_utf8_lossy(&output.stdout),
+		String::from_utf8_lossy(&output.stderr)
+	);
+}
+
+#[test]
+fn forgejo_urls_use_configured_host_and_gitea_compatible_routes() {
+	let source = forgejo_source();
+
+	assert_json_snapshot!(serde_json::json!({
+		"tag": monochange_forgejo::tag_url(&source, "v1.2.3"),
+		"compare": monochange_forgejo::compare_url(&source, "v1.2.2", "v1.2.3"),
+		"commit": monochange_forgejo::forgejo_commit_url(&source, "abc123"),
+		"host_name": monochange_forgejo::forgejo_host_name(&source),
+	}), @r###"
+	{
+	  "commit": "https://codeberg.org/org/monochange/commit/abc123",
+	  "compare": "https://codeberg.org/org/monochange/compare/v1.2.2...v1.2.3",
+	  "host_name": "codeberg.org",
+	  "tag": "https://codeberg.org/org/monochange/releases/tag/v1.2.3"
+	}
+	"###);
+}
+
+#[test]
+fn forgejo_rejects_unsupported_source_features() {
+	let mut generated_notes = forgejo_source();
+	generated_notes.releases.generate_notes = true;
+	assert_snapshot!(
+		monochange_forgejo::validate_source_configuration(&generated_notes)
+			.unwrap_err()
+			.to_string(),
+		@"config error: provider-generated release notes are not supported for `provider = \"forgejo\"`; use `source = \"monochange\"`"
+	);
+
+	let mut auto_merge = forgejo_source();
+	auto_merge.pull_requests.auto_merge = true;
+	assert_snapshot!(
+		monochange_forgejo::validate_source_configuration(&auto_merge)
+			.unwrap_err()
+			.to_string(),
+		@"config error: [source.pull_requests].auto_merge is not supported for `provider = \"forgejo\"`"
+	);
+}
+
+#[test]
+fn forgejo_capabilities_match_hosted_support_without_trusted_publishing_claims() {
+	assert_json_snapshot!(monochange_forgejo::source_capabilities(), @r###"
+	{
+	  "draft_releases": true,
+	  "prereleases": true,
+	  "generated_release_notes": false,
+	  "auto_merge_change_requests": false,
+	  "released_issue_comments": false,
+	  "requires_host": true
+	}
+	"###);
+	assert_json_snapshot!(monochange_forgejo::forgejo_hosting_capabilities(), @r###"
+	{
+	  "commitWebUrls": true,
+	  "actorProfiles": false,
+	  "reviewRequestLookup": false,
+	  "relatedIssues": false,
+	  "issueComments": false
+	}
+	"###);
+}

--- a/crates/monochange_schema/src/lib.rs
+++ b/crates/monochange_schema/src/lib.rs
@@ -16,16 +16,18 @@ pub const CURRENT_SCHEMA_VERSION_TEXT: &str = extract_major_minor(env!("CARGO_PK
 
 const fn extract_major_minor(version: &str) -> &str {
 	let bytes = version.as_bytes();
+	let mut remaining = bytes;
 	let mut index = 0;
 	let mut dots = 0;
 
-	while index < bytes.len() {
-		if bytes[index] == b'.' {
+	while let Some((byte, rest)) = remaining.split_first() {
+		if *byte == b'.' {
 			dots += 1;
 			if dots == 2 {
 				break;
 			}
 		}
+		remaining = rest;
 		index += 1;
 	}
 

--- a/crates/monochange_telemetry/src/lib.rs
+++ b/crates/monochange_telemetry/src/lib.rs
@@ -364,22 +364,22 @@ mod tests {
 
 		let events = read_events(&path);
 		assert_eq!(events.len(), 1);
-		let event = &events[0];
-		assert_eq!(event["body"]["string_value"], "command_run");
-		assert_eq!(event["resource"]["service.name"], "monochange");
-		assert_eq!(event["scope"]["name"], TELEMETRY_SCOPE_NAME);
-		assert_eq!(event["scope"]["version"], TELEMETRY_SCOPE_VERSION);
-		assert_eq!(event["severity_text"], "INFO");
-		assert!(event["time_unix_nano"].as_u64().is_some());
-		assert_eq!(event["attributes"]["command_name"], "validate");
-		assert_eq!(event["attributes"]["command_source"], "configured");
-		assert_eq!(event["attributes"]["dry_run"], false);
-		assert_eq!(event["attributes"]["show_diff"], false);
-		assert_eq!(event["attributes"]["progress_format"], "auto");
-		assert_eq!(event["attributes"]["step_count"], 1);
-		assert_eq!(event["attributes"]["duration_ms"], 42);
-		assert_eq!(event["attributes"]["outcome"], "success");
-		assert!(event["attributes"]["error_kind"].is_null());
+		let event = event_at(&events, 0);
+		assert_eq!(json_str(event, "/body/string_value"), "command_run");
+		assert_eq!(json_str(event, "/resource/service.name"), "monochange");
+		assert_eq!(json_str(event, "/scope/name"), TELEMETRY_SCOPE_NAME);
+		assert_eq!(json_str(event, "/scope/version"), TELEMETRY_SCOPE_VERSION);
+		assert_eq!(json_str(event, "/severity_text"), "INFO");
+		assert!(json_value(event, "/time_unix_nano").as_u64().is_some());
+		assert_eq!(json_str(event, "/attributes/command_name"), "validate");
+		assert_eq!(json_str(event, "/attributes/command_source"), "configured");
+		assert!(!json_bool(event, "/attributes/dry_run"));
+		assert!(!json_bool(event, "/attributes/show_diff"));
+		assert_eq!(json_str(event, "/attributes/progress_format"), "auto");
+		assert_eq!(json_u64(event, "/attributes/step_count"), 1);
+		assert_eq!(json_u64(event, "/attributes/duration_ms"), 42);
+		assert_eq!(json_str(event, "/attributes/outcome"), "success");
+		assert!(json_value(event, "/attributes/error_kind").is_null());
 	}
 
 	#[test]
@@ -417,15 +417,15 @@ mod tests {
 
 		let events = read_events(&state_home.join("monochange").join("telemetry.jsonl"));
 		assert_eq!(events.len(), 1);
-		let event = &events[0];
-		assert_eq!(event["body"]["string_value"], "command_step");
-		assert_eq!(event["attributes"]["command_name"], "step:validate");
-		assert_eq!(event["attributes"]["step_index"], 3);
-		assert_eq!(event["attributes"]["step_kind"], "Validate");
-		assert_eq!(event["attributes"]["skipped"], true);
-		assert_eq!(event["attributes"]["duration_ms"], 7);
-		assert_eq!(event["attributes"]["outcome"], "skipped");
-		assert_eq!(event["attributes"]["error_kind"], "config_error");
+		let event = event_at(&events, 0);
+		assert_eq!(json_str(event, "/body/string_value"), "command_step");
+		assert_eq!(json_str(event, "/attributes/command_name"), "step:validate");
+		assert_eq!(json_u64(event, "/attributes/step_index"), 3);
+		assert_eq!(json_str(event, "/attributes/step_kind"), "Validate");
+		assert!(json_bool(event, "/attributes/skipped"));
+		assert_eq!(json_u64(event, "/attributes/duration_ms"), 7);
+		assert_eq!(json_str(event, "/attributes/outcome"), "skipped");
+		assert_eq!(json_str(event, "/attributes/error_kind"), "config_error");
 		assert!(!event.to_string().contains("/tmp/repo"));
 	}
 
@@ -597,6 +597,47 @@ mod tests {
 			outcome: TelemetryOutcome::Success,
 			error: None,
 		}
+	}
+
+	fn event_at(events: &[serde_json::Value], index: usize) -> &serde_json::Value {
+		events
+			.get(index)
+			.unwrap_or_else(|| panic!("missing telemetry event {index}"))
+	}
+
+	fn json_value<'event>(
+		event: &'event serde_json::Value,
+		pointer: &str,
+	) -> &'event serde_json::Value {
+		event
+			.pointer(pointer)
+			.unwrap_or_else(|| panic!("missing json pointer {pointer} in {event}"))
+	}
+
+	fn json_str<'event>(event: &'event serde_json::Value, pointer: &str) -> &'event str {
+		json_value(event, pointer)
+			.as_str()
+			.unwrap_or_else(|| panic!("json pointer {pointer} is not a string in {event}"))
+	}
+
+	fn json_bool(event: &serde_json::Value, pointer: &str) -> bool {
+		json_value(event, pointer)
+			.as_bool()
+			.unwrap_or_else(|| panic!("json pointer {pointer} is not a bool in {event}"))
+	}
+
+	#[test]
+	#[should_panic(expected = "is not an unsigned integer")]
+	fn json_u64_reports_type_mismatches() {
+		let event = serde_json::json!({ "value": "not a number" });
+
+		let _ = json_u64(&event, "/value");
+	}
+
+	fn json_u64(event: &serde_json::Value, pointer: &str) -> u64 {
+		json_value(event, pointer).as_u64().unwrap_or_else(|| {
+			panic!("json pointer {pointer} is not an unsigned integer in {event}")
+		})
 	}
 
 	fn read_events(path: &Path) -> Vec<serde_json::Value> {

--- a/crates/monochange_telemetry/tests/local_jsonl.rs
+++ b/crates/monochange_telemetry/tests/local_jsonl.rs
@@ -45,11 +45,42 @@ fn public_api_writes_sanitized_command_and_step_jsonl_events() {
 
 	let events = read_jsonl_events(&telemetry_file);
 	assert_eq!(events.len(), 2);
-	assert_eq!(events[0]["body"]["string_value"], "command_step");
-	assert_eq!(events[0]["attributes"]["error_kind"], "config_error");
-	assert_eq!(events[1]["body"]["string_value"], "command_run");
-	assert_eq!(events[1]["attributes"]["dry_run"], true);
-	assert_eq!(events[1]["attributes"]["progress_format"], "auto");
+	let step_event = events
+		.first()
+		.unwrap_or_else(|| panic!("missing step telemetry event"));
+	let command_event = events
+		.get(1)
+		.unwrap_or_else(|| panic!("missing command telemetry event"));
+	assert_eq!(
+		step_event
+			.pointer("/body/string_value")
+			.and_then(Value::as_str),
+		Some("command_step")
+	);
+	assert_eq!(
+		step_event
+			.pointer("/attributes/error_kind")
+			.and_then(Value::as_str),
+		Some("config_error")
+	);
+	assert_eq!(
+		command_event
+			.pointer("/body/string_value")
+			.and_then(Value::as_str),
+		Some("command_run")
+	);
+	assert_eq!(
+		command_event
+			.pointer("/attributes/dry_run")
+			.and_then(Value::as_bool),
+		Some(true)
+	);
+	assert_eq!(
+		command_event
+			.pointer("/attributes/progress_format")
+			.and_then(Value::as_str),
+		Some("auto")
+	);
 
 	let rendered =
 		serde_json::to_string(&events).unwrap_or_else(|error| panic!("render json: {error}"));

--- a/docs/src/guide/13-ci-and-publishing.md
+++ b/docs/src/guide/13-ci-and-publishing.md
@@ -61,8 +61,8 @@ Keeping those layers separate is important. Package publication and hosted-relea
 | Grouped/shared versioning                                                      | Built in                                                                                                       |
 | Dry-run release diff previews                                                  | Built in via `mc release --dry-run --diff`                                                                     |
 | Durable release history and post-merge tagging                                 | Built in via `ReleaseRecord`, `mc release-record`, `mc tag-release`, and `mc repair-release`                   |
-| Hosted provider releases                                                       | GitHub, GitLab, Gitea                                                                                          |
-| Hosted release requests                                                        | GitHub, GitLab, Gitea                                                                                          |
+| Hosted provider releases                                                       | GitHub, GitLab, Gitea, Forgejo                                                                                 |
+| Hosted release requests                                                        | GitHub, GitLab, Gitea, Forgejo                                                                                 |
 | Python release planning                                                        | Built in for discovery, version rewrites, dependency rewrites, lockfile command inference, and PyPI publishing |
 | Go release planning                                                            | Built in for `go.mod` discovery, dependency rewrites, `go mod tidy` inference, and Go proxy tag publishing     |
 | Built-in registry publishing                                                   | `crates.io`, `npm`, `jsr`, `pub.dev`, `pypi`, Go proxy tags; use external mode for custom registries           |

--- a/fixtures/tests/source/forgejo/.changeset/feature.md
+++ b/fixtures/tests/source/forgejo/.changeset/feature.md
@@ -1,0 +1,5 @@
+---
+core: patch
+---
+
+#### add gitea fixture coverage

--- a/fixtures/tests/source/forgejo/Cargo.toml
+++ b/fixtures/tests/source/forgejo/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[workspace.package]
+version = "1.0.0"
+
+[workspace.dependencies]
+workflow-core = { path = "./crates/core", version = "1.0.0" }

--- a/fixtures/tests/source/forgejo/crates/core/CHANGELOG.md
+++ b/fixtures/tests/source/forgejo/crates/core/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/fixtures/tests/source/forgejo/crates/core/Cargo.toml
+++ b/fixtures/tests/source/forgejo/crates/core/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "workflow-core"
+version = { workspace = true }
+edition = "2021"
+description = "Fixture package for forgejo provider integration tests"
+license = "MIT"
+repository = "https://codeberg.org/org/monochange"

--- a/fixtures/tests/source/forgejo/monochange.toml
+++ b/fixtures/tests/source/forgejo/monochange.toml
@@ -1,0 +1,39 @@
+[defaults]
+package_type = "cargo"
+changelog = "{{ path }}/CHANGELOG.md"
+
+[package.core]
+path = "crates/core"
+tag = true
+release = true
+
+[source]
+provider = "forgejo"
+owner = "org"
+repo = "monochange"
+host = "https://codeberg.org"
+
+[source.releases]
+source = "monochange"
+
+[source.pull_requests]
+base = "main"
+branch_prefix = "monochange/release"
+labels = ["release"]
+
+[ecosystems.cargo]
+enabled = true
+
+[cli.release-pr]
+
+[[cli.release-pr.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
+[[cli.release-pr.steps]]
+type = "PrepareRelease"
+
+[[cli.release-pr.steps]]
+type = "OpenReleaseRequest"

--- a/monochange.toml
+++ b/monochange.toml
@@ -287,6 +287,9 @@ path = "crates/monochange_gitlab"
 [package.monochange_gitea]
 path = "crates/monochange_gitea"
 
+[package.monochange_forgejo]
+path = "crates/monochange_forgejo"
+
 [package.monochange_hosting]
 path = "crates/monochange_hosting"
 
@@ -409,6 +412,7 @@ packages = [
 	"monochange_dart",
 	"monochange_deno",
 	"monochange_ecmascript",
+	"monochange_forgejo",
 	"monochange_gitea",
 	"monochange_github",
 	"monochange_gitlab",

--- a/readme.md
+++ b/readme.md
@@ -171,8 +171,8 @@ These are the commands most repositories use after running `mc init`. With the n
 | Grouped/shared versioning                                                      | Built in                                                                                                       |
 | Dry-run release diff previews                                                  | Built in via `mc release --dry-run --diff`                                                                     |
 | Durable release history and post-merge tagging                                 | Built in via `ReleaseRecord`, `mc release-record`, `mc tag-release`, and `mc repair-release`                   |
-| Hosted provider releases                                                       | GitHub, GitLab, Gitea                                                                                          |
-| Hosted release requests                                                        | GitHub, GitLab, Gitea                                                                                          |
+| Hosted provider releases                                                       | GitHub, GitLab, Gitea, Forgejo                                                                                 |
+| Hosted release requests                                                        | GitHub, GitLab, Gitea, Forgejo                                                                                 |
 | Python release planning                                                        | Built in for discovery, version rewrites, dependency rewrites, lockfile command inference, and PyPI publishing |
 | Go release planning                                                            | Built in for `go.mod` discovery, dependency rewrites, `go mod tidy` inference, and Go proxy tag publishing     |
 | Built-in registry publishing                                                   | `crates.io`, `npm`, `jsr`, `pub.dev`, `pypi`, Go proxy tags; use external mode for custom registries           |


### PR DESCRIPTION
## Summary
- add Forgejo as a first-class hosted source provider using Gitea-compatible release and change-request behavior
- wire Forgejo through configuration, CLI dispatch, artifacts, docs, templates, and release planning
- add Forgejo fixtures and integration coverage while keeping trusted publishing unsupported

## Validation
- cargo fmt --all -- --check
- cargo test -q -p monochange_forgejo publish_release
- cargo test -q -p monochange_integration_tests --test forgejo_provider
- cargo test -q -p monochange --lib build_source_release_requests_and_change_request_cover_forgejo_dispatch
- cargo check -q --no-default-features
- cargo llvm-cov test --workspace --all-features --all-targets --no-report
- cargo llvm-cov report --lcov --output-path target/coverage/lcov.info
- node scripts/check-patch-coverage.mjs --base origin/main --target 100
- pre-push lint:test hook (lint:all + test:all)
