### PR TITLE
fix: prevent release PR auto-merge loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,7 +350,7 @@ jobs:
           fail-comment: |
             This check fails intentionally so GitHub's normal merge button cannot be used for release PRs.
 
-            After every required check is green, comment `/merge` on this PR or run the `release-pr-merge` workflow. That workflow fast-forwards the release branch and preserves monochange's release history invariants.
+            After every required check is green, run the `release-pr-merge` workflow manually. Maintainers can also post the exact merge command in a PR comment, but automated comments intentionally avoid spelling it out so they cannot trigger the merge workflow.
 
   release-pr:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'monochange'

--- a/.github/workflows/release-pr-merge.yml
+++ b/.github/workflows/release-pr-merge.yml
@@ -31,7 +31,8 @@ jobs:
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
-        contains(github.event.comment.body, '/merge')
+        github.actor != 'github-actions[bot]' &&
+        github.event.comment.body == '/merge'
       )
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Restrict release PR comment-triggered merges to an exact `/merge` comment from a non-bot actor.
- Remove the literal merge command from the manual merge blocker bot comment so that automated comments cannot trigger the merge workflow.

## Why
The merge workflow used `contains(github.event.comment.body, '/merge')`. The manual merge blocker posts an automated comment containing `/merge`, so every release PR blocker comment could trigger the merge workflow without a maintainer explicitly requesting it.

## Immediate mitigation
I disabled the `release-pr-merge` workflow in GitHub Actions to stop the loop while this PR is reviewed/merged. Re-enable it after this fix is on main.

## Validation
- git diff --check