### PR TITLE
fix: remove schema versioned file config

### DIFF
--- a/.changeset/schema-version-regex.md
+++ b/.changeset/schema-version-regex.md
@@ -3,6 +3,6 @@
 "monochange_config": patch
 ---
 
-# Manage schema package version with monochange regex
+# Derive schema version from package metadata
 
-The schema crate now exposes a monochange-managed full package version constant and derives the durable schema version from its major/minor components at compile time. Release planning updates the source constant through a regex `versioned_files` rule, keeping the public schema version aligned without a build script.
+The schema crate now derives the durable schema version from its Cargo package version's major/minor components at compile time, keeping the public schema version aligned without a build script.

--- a/monochange.toml
+++ b/monochange.toml
@@ -271,9 +271,6 @@ path = "crates/monochange_graph"
 
 [package.monochange_schema]
 path = "crates/monochange_schema"
-versioned_files = [
-	{ path = "crates/monochange_schema/Cargo.toml", regex = 'version = "(?<version>\d+\.\d+\.\d+)"' },
-]
 
 [package.monochange_semver]
 path = "crates/monochange_semver"


### PR DESCRIPTION
## Summary
- remove the regex versioned_files entry for monochange_schema
- update the pending schema changeset wording to describe package metadata derivation

## Validation
- devenv shell mc validate
- git diff --check