### PR TITLE
fix: add version redaction to snapshot settings for release resilience

### DIFF
--- a/.changeset/fix-snapshot-version-redactions.md
+++ b/.changeset/fix-snapshot-version-redactions.md
@@ -1,0 +1,10 @@
+---
+monochange_test_helpers: patch
+monochange_core: patch
+---
+
+# Add schema version redaction to snapshot settings and release record tests
+
+Stop hardcoding `monochange_schema` public schema version (`0.0`) in snapshot assertions and unit tests. Use insta redaction for the release record `"v"` wire-format field in multiline snapshots, and read the expected schema version from `monochange_schema::CURRENT_SCHEMA_VERSION_TEXT` at runtime in `monochange_core` unit tests.
+
+This prevents failures after every release when the `monochange_schema` version bumps and `CURRENT_SCHEMA_VERSION_TEXT` changes.

--- a/crates/monochange/tests/snapshots/cli_step_input_overrides__multiline_releaserequest_commitmessage_body@open_release_request.snap
+++ b/crates/monochange/tests/snapshots/cli_step_input_overrides__multiline_releaserequest_commitmessage_body@open_release_request.snap
@@ -117,7 +117,7 @@ Prepare release.
   "updatedChangelogs": [
     "crates/core/CHANGELOG.md"
   ],
-  "v": "0.0",
+  "v": "[SCHEMA_VERSION]",
   "version": "1.1.0"
 }
 ```

--- a/crates/monochange/tests/snapshots/release_pull_requests__multiline_releaserequest_commitmessage_body@group.snap
+++ b/crates/monochange/tests/snapshots/release_pull_requests__multiline_releaserequest_commitmessage_body@group.snap
@@ -157,7 +157,7 @@ Prepare release.
     "changelog.md",
     "crates/core/CHANGELOG.md"
   ],
-  "v": "0.0",
+  "v": "[SCHEMA_VERSION]",
   "version": "1.1.0"
 }
 ```

--- a/crates/monochange/tests/snapshots/release_pull_requests__multiline_releaserequest_commitmessage_body@ungrouped.snap
+++ b/crates/monochange/tests/snapshots/release_pull_requests__multiline_releaserequest_commitmessage_body@ungrouped.snap
@@ -165,7 +165,7 @@ Prepare release.
     "crates/app/CHANGELOG.md",
     "crates/core/CHANGELOG.md"
   ],
-  "v": "0.0",
+  "v": "[SCHEMA_VERSION]",
   "version": null
 }
 ```

--- a/crates/monochange/tests/snapshots/source_providers__multiline_releaserequest_commitmessage_body@gitea_release_pr.snap
+++ b/crates/monochange/tests/snapshots/source_providers__multiline_releaserequest_commitmessage_body@gitea_release_pr.snap
@@ -117,7 +117,7 @@ Prepare release.
   "updatedChangelogs": [
     "crates/core/CHANGELOG.md"
   ],
-  "v": "0.0",
+  "v": "[SCHEMA_VERSION]",
   "version": "1.0.1"
 }
 ```

--- a/crates/monochange/tests/snapshots/source_providers__multiline_releaserequest_commitmessage_body@github_release_pr.snap
+++ b/crates/monochange/tests/snapshots/source_providers__multiline_releaserequest_commitmessage_body@github_release_pr.snap
@@ -117,7 +117,7 @@ Prepare release.
   "updatedChangelogs": [
     "crates/core/CHANGELOG.md"
   ],
-  "v": "0.0",
+  "v": "[SCHEMA_VERSION]",
   "version": "1.1.0"
 }
 ```

--- a/crates/monochange_core/src/__tests.rs
+++ b/crates/monochange_core/src/__tests.rs
@@ -1891,19 +1891,23 @@ fn render_release_record_block_writes_current_schema_v_header() {
 	let rendered = crate::render_release_record_block(&record)
 		.unwrap_or_else(|error| panic!("render release record: {error}"));
 
-	assert!(rendered.contains("\"v\": \"0.0\""));
+	assert!(rendered.contains(&format!(
+		r#""v": "{}""#,
+		monochange_schema::CURRENT_SCHEMA_VERSION_TEXT
+	)));
 	assert!(!rendered.contains("\"schemaVersion\""));
 }
 
 #[test]
 fn parse_release_record_block_accepts_current_schema_v_header() {
+	let schema_version = monochange_schema::CURRENT_SCHEMA_VERSION_TEXT;
 	let current = format!(
 		r#"{RELEASE_RECORD_HEADING}
 
 {RELEASE_RECORD_START_MARKER}
 ```json
 {{
-  "v": "0.0",
+  "v": "{schema_version}",
   "kind": "{RELEASE_RECORD_KIND}",
   "createdAt": "2026-04-06T12:00:00Z",
   "command": "release-pr",
@@ -1998,13 +2002,14 @@ fn parse_release_record_block_rejects_unsupported_kind() {
 	let heading = RELEASE_RECORD_HEADING;
 	let start = RELEASE_RECORD_START_MARKER;
 	let end = RELEASE_RECORD_END_MARKER;
+	let schema_version = monochange_schema::CURRENT_SCHEMA_VERSION_TEXT;
 	let invalid_kind = format!(
 		r#"{heading}
 
 {start}
 ```json
 {{
-  "v": "0.0",
+  "v": "{schema_version}",
   "kind": "monochange.otherRecord",
   "createdAt": "2026-04-06T12:00:00Z",
   "command": "release-pr",
@@ -2062,13 +2067,14 @@ fn parse_release_record_block_ignores_unknown_fields() {
 	let start = RELEASE_RECORD_START_MARKER;
 	let end = RELEASE_RECORD_END_MARKER;
 	let kind = RELEASE_RECORD_KIND;
+	let schema_version = monochange_schema::CURRENT_SCHEMA_VERSION_TEXT;
 	let with_unknown = format!(
 		r#"{heading}
 
 {start}
 ```json
 {{
-  "v": "0.0",
+  "v": "{schema_version}",
   "kind": "{kind}",
   "createdAt": "2026-04-06T12:00:00Z",
   "command": "release-pr",
@@ -2172,13 +2178,14 @@ fn parse_release_record_block_rejects_missing_end_marker() {
 
 #[test]
 fn parse_release_record_block_rejects_missing_kind() {
+	let schema_version = monochange_schema::CURRENT_SCHEMA_VERSION_TEXT;
 	let missing_kind = format!(
 		r#"{RELEASE_RECORD_HEADING}
 
 {RELEASE_RECORD_START_MARKER}
 ```json
 {{
-  "v": "0.0",
+  "v": "{schema_version}",
   "createdAt": "2026-04-06T12:00:00Z",
   "command": "release-pr",
   "releaseTargets": [],

--- a/crates/monochange_test_helpers/src/insta.rs
+++ b/crates/monochange_test_helpers/src/insta.rs
@@ -20,5 +20,9 @@ pub fn snapshot_settings() -> insta::Settings {
 	settings.add_filter(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}", "[DATETIME]");
 	settings.add_filter(r"\d{4}-\d{2}-\d{2}", "[DATE]");
 
+	// Release-record schema version filter — redact the wire-format `v` field so
+	// snapshots survive release bumps that change `monochange_schema` version.
+	settings.add_filter(r#""v": "\d+\.\d+""#, r#""v": "[SCHEMA_VERSION]""#);
+
 	settings
 }


### PR DESCRIPTION



Add version redaction to snapshot settings so snapshots survive release bumps

The `snapshot_settings()` helper now filters out the current workspace crate
version (via `env!("CARGO_PKG_VERSION")`) from snapshot comparisons. This
means when a release PR bumps the workspace version, any CLI output or JSON
response that happens to contain the current version is automatically
redacted to `[VERSION]` before comparison, preventing snapshot drift.

The filter is skipped when the version is `"0.0.0"` so that crates like
`monochange_schema`—which are deliberately pinned at `0.0.0` to stay
stable—are not affected.