### PR TITLE
fix: remove indexing slicing allowances

### DIFF
--- a/.changeset/remove-indexing-slicing-allowances.md
+++ b/.changeset/remove-indexing-slicing-allowances.md
@@ -1,0 +1,7 @@
+---
+monochange: patch
+---
+
+# Remove indexing/slicing lint allowances
+
+Remove crate-level `clippy::indexing_slicing` allowances and replace production indexing/slicing call sites with safe accessors.

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,4 +2,6 @@ disallowed-methods = [
 	{ path = "std::result::Result::expect", reason = "hides errors; use `unwrap_or_else(|error| panic!(...))`" },
 ]
 
+allow-indexing-slicing-in-tests = true
 msrv = "1.90.0"
+suppress-restriction-lint-in-const = true

--- a/crates/monochange/src/changelog.rs
+++ b/crates/monochange/src/changelog.rs
@@ -988,11 +988,11 @@ fn aggregate_group_release_note_changes(changes: Vec<ReleaseNoteChange>) -> Vec<
 			context: change.context.clone(),
 		};
 		if let Some(index) = indexes.get(&key).copied() {
-			let entry = &mut aggregated[index];
-			if !entry
-				.package_labels
-				.iter()
-				.any(|label| label == &change.package_name)
+			if let Some(entry) = aggregated.get_mut(index)
+				&& !entry
+					.package_labels
+					.iter()
+					.any(|label| label == &change.package_name)
 			{
 				entry.package_labels.push(change.package_name.clone());
 				entry.package_name = entry.package_labels.join(", ");
@@ -1126,8 +1126,9 @@ fn format_group_labeled_entry(change: &ReleaseNoteChange, rendered: &str) -> Str
 	if change.package_labels.len() == 1
 		&& !rendered.contains('\n')
 		&& let Some(entry) = rendered.strip_prefix("- ")
+		&& let Some(package_label) = change.package_labels.first()
 	{
-		return format!("- **{}**: {}", change.package_labels[0], entry);
+		return format!("- **{package_label}**: {entry}");
 	}
 	let labels = change
 		.package_labels

--- a/crates/monochange/src/cli_progress.rs
+++ b/crates/monochange/src/cli_progress.rs
@@ -479,9 +479,10 @@ impl CliProgressReporter {
 		let spinner_frames = self.symbols.spinner_frames;
 		let handle = thread::spawn(move || {
 			thread::sleep(SPINNER_DELAY);
-			let mut frame_index = 0;
-			while !stop_flag.load(Ordering::Relaxed) {
-				let frame = spinner_frames[frame_index % spinner_frames.len()];
+			for frame in spinner_frames.iter().copied().cycle() {
+				if stop_flag.load(Ordering::Relaxed) {
+					break;
+				}
 				with_stderr_lock(&writer_lock, || {
 					eprint!(
 						"\r\u{1b}[2K{} {}",
@@ -492,7 +493,6 @@ impl CliProgressReporter {
 				});
 				rendered_flag.store(true, Ordering::Relaxed);
 				thread::sleep(SPINNER_TICK);
-				frame_index += 1;
 			}
 		});
 		self.active_spinner = Some(SpinnerState {
@@ -832,7 +832,7 @@ mod tests {
 
 		reporter.command_started();
 		reporter.step_started(0, &step);
-		thread::sleep(SPINNER_TICK + Duration::from_millis(20));
+		thread::sleep(SPINNER_DELAY + SPINNER_TICK + Duration::from_millis(20));
 		reporter.step_finished(
 			0,
 			&step,

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -698,7 +698,10 @@ pub(crate) fn execute_cli_command_with_options(
 					..
 				} => {
 					let build_file_diffs = context.show_diff
-						|| steps_reference_release_file_diffs(&cli_command.steps[step_index + 1..]);
+						|| cli_command
+							.steps
+							.get(step_index + 1..)
+							.is_some_and(steps_reference_release_file_diffs);
 					let prepared_execution = if let Some(loaded) =
 						maybe_load_prepared_release_execution(
 							root,
@@ -1278,12 +1281,13 @@ fn parse_template_as_boolean(value: &serde_json::Value, condition: &str) -> Mono
 		serde_json::Value::String(value) => parse_string_as_boolean(value, condition),
 		serde_json::Value::Null => Ok(false),
 		serde_json::Value::Array(values) => {
-			if values.len() == 1 {
-				parse_template_as_boolean(&values[0], condition)
-			} else {
-				Err(MonochangeError::Config(format!(
-					"`when` condition `{condition}` is not a scalar boolean value"
-				)))
+			match values.as_slice() {
+				[value] => parse_template_as_boolean(value, condition),
+				_ => {
+					Err(MonochangeError::Config(format!(
+						"`when` condition `{condition}` is not a scalar boolean value"
+					)))
+				}
 			}
 		}
 		serde_json::Value::Object(_) => {

--- a/crates/monochange/src/jq_filter.rs
+++ b/crates/monochange/src/jq_filter.rs
@@ -129,8 +129,8 @@ fn evaluate_path(value: &Value, path: &str) -> Vec<Value> {
 	let mut current = vec![value.clone()];
 	let chars = path.chars().collect::<Vec<_>>();
 	let mut index = 1;
-	while index < chars.len() {
-		match chars[index] {
+	while let Some(character) = chars.get(index).copied() {
+		match character {
 			'.' => index += 1,
 			'[' if chars.get(index + 1) == Some(&']') => {
 				current = current
@@ -145,17 +145,16 @@ fn evaluate_path(value: &Value, path: &str) -> Vec<Value> {
 				index += 2;
 			}
 			'[' => {
-				let Some(end) = chars[index..]
-					.iter()
-					.position(|character| *character == ']')
+				let Some(end) = chars
+					.get(index..)
+					.and_then(|remaining| remaining.iter().position(|character| *character == ']'))
 				else {
 					return Vec::new();
 				};
 				let end = index + end;
-				let Ok(array_index) = chars[index + 1..end]
-					.iter()
-					.collect::<String>()
-					.parse::<usize>()
+				let Some(array_index) = chars
+					.get(index + 1..end)
+					.and_then(|range| range.iter().collect::<String>().parse::<usize>().ok())
 				else {
 					return Vec::new();
 				};
@@ -172,13 +171,20 @@ fn evaluate_path(value: &Value, path: &str) -> Vec<Value> {
 			}
 			_ => {
 				let start = index;
-				while index < chars.len() && is_field_character(chars[index]) {
+				while chars
+					.get(index)
+					.is_some_and(|character| is_field_character(*character))
+				{
 					index += 1;
 				}
 				if start == index {
 					return Vec::new();
 				}
-				let field = chars[start..index].iter().collect::<String>();
+				let field = chars
+					.iter()
+					.skip(start)
+					.take(index - start)
+					.collect::<String>();
 				current = current
 					.into_iter()
 					.filter_map(|candidate| {
@@ -256,9 +262,11 @@ fn split_top_level_and(expression: &str) -> Vec<&str> {
 			'(' | '[' => depth += 1,
 			')' | ']' => depth = depth.saturating_sub(1),
 			'a' if depth == 0 && expression[index..].starts_with("and") => {
-				let before = index == 0 || bytes[index - 1].is_ascii_whitespace();
+				let before =
+					index == 0 || bytes.get(index - 1).is_some_and(u8::is_ascii_whitespace);
 				let after_index = index + 3;
-				let after = after_index >= bytes.len() || bytes[after_index].is_ascii_whitespace();
+				let after = after_index >= bytes.len()
+					|| bytes.get(after_index).is_some_and(u8::is_ascii_whitespace);
 				if before && after {
 					parts.push(&expression[start..index]);
 					start = after_index;

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -43,8 +43,6 @@
 //! - expose JSON-first MCP tools for assistant workflows
 //! <!-- {/monochangeCrateDocs} -->
 
-#![allow(clippy::indexing_slicing)]
-
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::ffi::OsString;

--- a/crates/monochange/src/mcp.rs
+++ b/crates/monochange/src/mcp.rs
@@ -113,25 +113,21 @@ fn parse_frame(frame_str: &str) -> monochange_analysis::ChangeFrame {
 	}
 
 	// Try parsing as branch range: "main...feature"
-	if frame_str.contains("...") {
-		let parts: Vec<&str> = frame_str.split("...").collect();
-		if parts.len() == 2 {
-			return ChangeFrame::BranchRange {
-				base: parts[0].to_string(),
-				head: parts[1].to_string(),
-			};
-		}
+	if let Some((base, head)) = frame_str.split_once("...") {
+		return ChangeFrame::BranchRange {
+			base: base.to_string(),
+			head: head.to_string(),
+		};
 	}
 
 	// Try parsing as PR format: "pr:target,source"
-	if let Some(stripped) = frame_str.strip_prefix("pr:") {
-		let parts: Vec<&str> = stripped.split(',').collect();
-		if parts.len() == 2 {
-			return ChangeFrame::PullRequest {
-				target: parts[0].to_string(),
-				pr_branch: parts[1].to_string(),
-			};
-		}
+	if let Some(stripped) = frame_str.strip_prefix("pr:")
+		&& let Some((target, pr_branch)) = stripped.split_once(',')
+	{
+		return ChangeFrame::PullRequest {
+			target: target.to_string(),
+			pr_branch: pr_branch.to_string(),
+		};
 	}
 
 	// Default to working directory
@@ -962,6 +958,7 @@ mod __tests {
 	use super::PathParam;
 	use super::json_error_result;
 	use super::json_result;
+	use super::parse_frame;
 	use super::resolve_root;
 
 	macro_rules! assert_readable_json_snapshot {
@@ -1040,6 +1037,25 @@ mod __tests {
 
 	fn fixture_path(relative: &str) -> PathBuf {
 		monochange_test_helpers::fs::fixture_path_from(env!("CARGO_MANIFEST_DIR"), relative)
+	}
+
+	#[test]
+	fn parse_frame_supports_named_range_and_pull_request_inputs() {
+		assert_eq!(parse_frame("working"), ChangeFrame::WorkingDirectory);
+		assert_eq!(
+			parse_frame("main...feature/indexing"),
+			ChangeFrame::BranchRange {
+				base: "main".to_string(),
+				head: "feature/indexing".to_string(),
+			}
+		);
+		assert_eq!(
+			parse_frame("pr:main,fix/indexing"),
+			ChangeFrame::PullRequest {
+				target: "main".to_string(),
+				pr_branch: "fix/indexing".to_string(),
+			}
+		);
 	}
 
 	fn setup_analysis_workspace() -> tempfile::TempDir {

--- a/crates/monochange/src/publish_rate_limits.rs
+++ b/crates/monochange/src/publish_rate_limits.rs
@@ -139,10 +139,11 @@ pub(crate) fn plan_publish_rate_limits_for_requests(
 	let mut batches = Vec::new();
 
 	for (registry, requests) in requests_by_registry {
-		let policy = &policies[&registry];
-		let window = plan_window(policy, requests.len());
-		batches.extend(plan_batches(policy, &requests));
-		windows.push(window);
+		if let Some(policy) = policies.get(&registry) {
+			let window = plan_window(policy, requests.len());
+			batches.extend(plan_batches(policy, &requests));
+			windows.push(window);
+		}
 	}
 
 	windows.sort_by(|left, right| {

--- a/crates/monochange/tests/affected.rs
+++ b/crates/monochange/tests/affected.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use std::ffi::OsString;
 use std::path::Path;
 
@@ -156,7 +154,7 @@ fn affected_with_verify_flag_exits_zero_when_covered() {
 	);
 }
 
-#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+#[etest::etest]
 fn affected_since_flag_detects_changes_from_git_revision() {
 	let mut settings = snapshot_settings();
 	settings.set_snapshot_suffix(current_test_name());
@@ -177,7 +175,7 @@ fn affected_since_flag_detects_changes_from_git_revision() {
 	assert_readable_json_snapshot!(json);
 }
 
-#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+#[etest::etest]
 fn affected_since_flag_detects_changeset_added_after_revision() {
 	let mut settings = snapshot_settings();
 	settings.set_snapshot_suffix(current_test_name());
@@ -198,7 +196,7 @@ fn affected_since_flag_detects_changeset_added_after_revision() {
 	assert_readable_json_snapshot!(json);
 }
 
-#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+#[etest::etest]
 fn affected_since_takes_priority_over_changed_paths_with_warning() {
 	let tempdir = setup_scenario_workspace("affected/since-base");
 	let root = tempdir.path();

--- a/crates/monochange/tests/benchmark_cli_comment.rs
+++ b/crates/monochange/tests/benchmark_cli_comment.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use std::fs;
 use std::path::Path;
 use std::process::Command;

--- a/crates/monochange/tests/cargo_lockfile_fast_path.rs
+++ b/crates/monochange/tests/cargo_lockfile_fast_path.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use std::env;
 use std::ffi::OsString;
 use std::fs;

--- a/crates/monochange/tests/changelog_formats.rs
+++ b/crates/monochange/tests/changelog_formats.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use std::fs;
 
 use insta::assert_snapshot;

--- a/crates/monochange/tests/changeset_context.rs
+++ b/crates/monochange/tests/changeset_context.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use std::fs;
 use std::path::Path;
 

--- a/crates/monochange/tests/changeset_policy.rs
+++ b/crates/monochange/tests/changeset_policy.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use std::path::Path;
 
 use rstest::rstest;

--- a/crates/monochange/tests/changeset_target_metadata.rs
+++ b/crates/monochange/tests/changeset_target_metadata.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use std::fs;
 use std::path::Path;
 

--- a/crates/monochange/tests/cli_help.rs
+++ b/crates/monochange/tests/cli_help.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 //! Integration tests for `mc help` subcommand output.
 
 use insta_cmd::assert_cmd_snapshot;

--- a/crates/monochange/tests/cli_main_binary.rs
+++ b/crates/monochange/tests/cli_main_binary.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use std::path::PathBuf;
 use std::process::Command;
 

--- a/crates/monochange/tests/cli_output.rs
+++ b/crates/monochange/tests/cli_output.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use std::fs;
 
 use httpmock::Method::GET;

--- a/crates/monochange/tests/cli_progress.rs
+++ b/crates/monochange/tests/cli_progress.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use std::path::Path;
 
 use insta::assert_snapshot;
@@ -60,18 +58,23 @@ fn normalized_progress_events(stderr: &str) -> Vec<Value> {
 	let mut normalized = Vec::with_capacity(events.len());
 	let mut index = 0;
 	while index < events.len() {
-		if events[index].get("event").and_then(Value::as_str) != Some("command_output") {
-			normalized.push(events[index].clone());
+		let Some(event) = events.get(index) else {
+			break;
+		};
+		if event.get("event").and_then(Value::as_str) != Some("command_output") {
+			normalized.push(event.clone());
 			index += 1;
 			continue;
 		}
 		let start = index;
-		while index < events.len()
-			&& events[index].get("event").and_then(Value::as_str) == Some("command_output")
-		{
+		while events.get(index).is_some_and(|event| {
+			event.get("event").and_then(Value::as_str) == Some("command_output")
+		}) {
 			index += 1;
 		}
-		let mut output_events = events[start..index].to_vec();
+		let mut output_events = events
+			.get(start..index)
+			.map_or_else(Vec::new, <[_]>::to_vec);
 		output_events.sort_by(|left, right| {
 			let left_key = (
 				left.get("stepIndex")

--- a/crates/monochange/tests/cli_step_input_overrides.rs
+++ b/crates/monochange/tests/cli_step_input_overrides.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use std::fs;
 use std::path::Path;
 

--- a/crates/monochange/tests/cli_step_when.rs
+++ b/crates/monochange/tests/cli_step_when.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use std::fs;
 use std::path::Path;
 use std::process::Output;

--- a/crates/monochange/tests/github_releases.rs
+++ b/crates/monochange/tests/github_releases.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use rstest::rstest;
 
 mod test_support;

--- a/crates/monochange/tests/hosted_release_benchmarks.rs
+++ b/crates/monochange/tests/hosted_release_benchmarks.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;

--- a/crates/monochange/tests/manifest_formatting.rs
+++ b/crates/monochange/tests/manifest_formatting.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use std::fs;
 
 use insta::assert_snapshot;

--- a/crates/monochange/tests/pre_stable_versioning.rs
+++ b/crates/monochange/tests/pre_stable_versioning.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use insta::assert_snapshot;
 use rstest::rstest;
 use serde_json::Value;
@@ -60,13 +58,14 @@ fn pre_stable_release_json_scenarios_match_snapshot(
 }
 
 fn find_decision<'a>(json: &'a Value, package_name_fragment: &str) -> &'a Value {
-	json["plan"]["decisions"]
-		.as_array()
+	json.pointer("/plan/decisions")
+		.and_then(Value::as_array)
 		.unwrap_or_else(|| panic!("decisions array"))
 		.iter()
 		.find(|decision| {
-			decision["package"]
-				.as_str()
+			decision
+				.get("package")
+				.and_then(Value::as_str)
 				.is_some_and(|package| package.contains(package_name_fragment))
 		})
 		.unwrap_or_else(|| panic!("expected decision for {package_name_fragment}"))
@@ -78,14 +77,32 @@ fn pre_stable_major_bump_keeps_expected_decisions() {
 	let json = run_json_command(tempdir.path(), "release", Some("2026-04-06"));
 
 	let core_decision = find_decision(&json, "core");
-	assert_eq!(core_decision["bump"], "major");
-	assert_eq!(core_decision["plannedVersion"], "0.2.0");
-	assert_eq!(core_decision["trigger"], "direct-change");
+	assert_eq!(
+		core_decision.get("bump").and_then(Value::as_str),
+		Some("major")
+	);
+	assert_eq!(
+		core_decision.get("plannedVersion").and_then(Value::as_str),
+		Some("0.2.0")
+	);
+	assert_eq!(
+		core_decision.get("trigger").and_then(Value::as_str),
+		Some("direct-change")
+	);
 
 	let app_decision = find_decision(&json, "app");
-	assert_eq!(app_decision["bump"], "patch");
-	assert_eq!(app_decision["plannedVersion"], "0.1.1");
-	assert_eq!(app_decision["trigger"], "transitive-dependency");
+	assert_eq!(
+		app_decision.get("bump").and_then(Value::as_str),
+		Some("patch")
+	);
+	assert_eq!(
+		app_decision.get("plannedVersion").and_then(Value::as_str),
+		Some("0.1.1")
+	);
+	assert_eq!(
+		app_decision.get("trigger").and_then(Value::as_str),
+		Some("transitive-dependency")
+	);
 }
 
 #[test]
@@ -94,8 +111,14 @@ fn pre_stable_minor_bump_keeps_expected_decisions() {
 	let json = run_json_command(tempdir.path(), "release", Some("2026-04-06"));
 
 	let core_decision = find_decision(&json, "core");
-	assert_eq!(core_decision["bump"], "minor");
-	assert_eq!(core_decision["plannedVersion"], "0.1.1");
+	assert_eq!(
+		core_decision.get("bump").and_then(Value::as_str),
+		Some("minor")
+	);
+	assert_eq!(
+		core_decision.get("plannedVersion").and_then(Value::as_str),
+		Some("0.1.1")
+	);
 }
 
 #[test]
@@ -104,6 +127,12 @@ fn stable_major_bump_keeps_expected_decisions() {
 	let json = run_json_command(tempdir.path(), "release", Some("2026-04-06"));
 
 	let core_decision = find_decision(&json, "core");
-	assert_eq!(core_decision["bump"], "major");
-	assert_eq!(core_decision["plannedVersion"], "2.0.0");
+	assert_eq!(
+		core_decision.get("bump").and_then(Value::as_str),
+		Some("major")
+	);
+	assert_eq!(
+		core_decision.get("plannedVersion").and_then(Value::as_str),
+		Some("2.0.0")
+	);
 }

--- a/crates/monochange/tests/prepared_release_artifacts.rs
+++ b/crates/monochange/tests/prepared_release_artifacts.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use std::ffi::OsString;
 use std::fs;
 use std::path::Path;

--- a/crates/monochange/tests/release_apply.rs
+++ b/crates/monochange/tests/release_apply.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use std::fs;
 
 use serde_json::Value;

--- a/crates/monochange/tests/release_group_propagation.rs
+++ b/crates/monochange/tests/release_group_propagation.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use serde_json::Value;
 
 mod test_support;

--- a/crates/monochange/tests/release_notes_and_propagation.rs
+++ b/crates/monochange/tests/release_notes_and_propagation.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use std::fs;
 
 use insta::assert_snapshot;

--- a/crates/monochange/tests/release_pull_requests.rs
+++ b/crates/monochange/tests/release_pull_requests.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use rstest::rstest;
 
 mod test_support;

--- a/crates/monochange/tests/release_record.rs
+++ b/crates/monochange/tests/release_record.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use std::fs;
 use std::path::Path;
 
@@ -24,7 +22,7 @@ use test_support::monochange_command;
 use test_support::setup_fixture;
 use test_support::snapshot_settings;
 
-#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+#[etest::etest]
 fn release_record_command_reports_record_from_tag_as_json() {
 	let mut settings = snapshot_settings();
 	settings.set_snapshot_suffix(current_test_name());
@@ -48,7 +46,7 @@ fn release_record_command_reports_record_from_tag_as_json() {
 	assert_readable_json_snapshot!(parsed);
 }
 
-#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+#[etest::etest]
 fn release_record_command_walks_first_parent_ancestry_from_head() {
 	let mut settings = snapshot_settings();
 	settings.set_snapshot_suffix(current_test_name());
@@ -81,7 +79,7 @@ fn release_record_command_walks_first_parent_ancestry_from_head() {
 	);
 }
 
-#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+#[etest::etest]
 fn release_record_command_reports_unresolved_refs() {
 	let mut settings = snapshot_settings();
 	settings.set_snapshot_suffix(current_test_name());
@@ -97,7 +95,7 @@ fn release_record_command_reports_unresolved_refs() {
 	);
 }
 
-#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+#[etest::etest]
 fn release_record_command_reports_missing_record_in_history() {
 	let mut settings = snapshot_settings();
 	settings.set_snapshot_suffix(current_test_name());
@@ -113,7 +111,7 @@ fn release_record_command_reports_missing_record_in_history() {
 	);
 }
 
-#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+#[etest::etest]
 fn release_record_command_fails_loudly_on_malformed_record_in_ancestry() {
 	let mut settings = snapshot_settings();
 	settings.set_snapshot_suffix(current_test_name());
@@ -138,7 +136,7 @@ fn release_record_command_fails_loudly_on_malformed_record_in_ancestry() {
 	);
 }
 
-#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+#[etest::etest]
 fn release_record_command_reports_unsupported_schema_version() {
 	let mut settings = snapshot_settings();
 	settings.set_snapshot_suffix(current_test_name());
@@ -177,7 +175,7 @@ fn release_record_command_reports_unsupported_schema_version() {
 	);
 }
 
-#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+#[etest::etest]
 fn tag_release_command_creates_and_pushes_declared_tags() {
 	let mut settings = snapshot_settings();
 	settings.set_snapshot_suffix(current_test_name());
@@ -213,7 +211,7 @@ fn tag_release_command_creates_and_pushes_declared_tags() {
 	);
 }
 
-#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+#[etest::etest]
 fn tag_release_command_is_idempotent_when_tags_already_exist() {
 	let mut settings = snapshot_settings();
 	settings.set_snapshot_suffix(current_test_name());
@@ -244,7 +242,7 @@ fn tag_release_command_is_idempotent_when_tags_already_exist() {
 	);
 }
 
-#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+#[etest::etest]
 fn tag_release_command_rejects_descendant_refs_that_are_not_release_commits() {
 	let mut settings = snapshot_settings();
 	settings.set_snapshot_suffix(current_test_name());
@@ -264,7 +262,7 @@ fn tag_release_command_rejects_descendant_refs_that_are_not_release_commits() {
 	);
 }
 
-#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+#[etest::etest]
 fn tag_release_command_json_snapshots_entire_report() {
 	let mut settings = snapshot_settings();
 	settings.set_snapshot_suffix(current_test_name());
@@ -309,7 +307,7 @@ fn tag_release_command_json_snapshots_entire_report() {
 	assert_readable_json_snapshot!(parsed);
 }
 
-#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+#[etest::etest]
 fn tag_release_command_dry_run_reports_planned_tags_without_creating_them() {
 	let mut settings = snapshot_settings();
 	settings.set_snapshot_suffix(current_test_name());
@@ -341,7 +339,7 @@ fn tag_release_command_dry_run_reports_planned_tags_without_creating_them() {
 	);
 }
 
-#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+#[etest::etest]
 fn tag_release_command_reports_when_no_tags_are_declared() {
 	let mut settings = snapshot_settings();
 	settings.set_snapshot_suffix(current_test_name());
@@ -371,7 +369,7 @@ fn tag_release_command_reports_when_no_tags_are_declared() {
 	);
 }
 
-#[etest::etest(skip=std::env::var_os("PRE_COMMIT").is_some())]
+#[etest::etest]
 fn tag_release_command_rejects_existing_tags_that_point_elsewhere() {
 	let mut settings = snapshot_settings();
 	settings.set_snapshot_suffix(current_test_name());

--- a/crates/monochange/tests/source_providers.rs
+++ b/crates/monochange/tests/source_providers.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use rstest::rstest;
 
 mod test_support;

--- a/crates/monochange/tests/telemetry.rs
+++ b/crates/monochange/tests/telemetry.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use std::fs;
 
 use serde_json::Value;

--- a/crates/monochange/tests/test_support.rs
+++ b/crates/monochange/tests/test_support.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-
 use std::fs;
 use std::path::Path;
 use std::process::Command;


### PR DESCRIPTION
## Summary
- remove `#![allow(clippy::indexing_slicing)]` from monochange tests and crate root
- add Clippy configuration for test/const restriction lint handling
- replace production indexing/slicing call sites with safe accessors
- keep snapshot-backed git integration tests active during pre-push so snapshot relevance checks stay green

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -q --workspace --all-targets --all-features`
- `cargo test -q --workspace --all-features`
- `devenv shell mc validate`
- pre-push `lint:test` hook passed during push