### PR TITLE
refactor: move Go placeholder manifests into monochange_go

### DIFF
--- a/.changeset/move-go-placeholder-manifest.md
+++ b/.changeset/move-go-placeholder-manifest.md
@@ -1,0 +1,8 @@
+---
+monochange: patch
+monochange_go: minor
+---
+
+# Move Go placeholder manifests into monochange_go
+
+Move Go placeholder `go.mod` generation out of `monochange::package_publish` and into `monochange_go`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,6 +2342,7 @@ dependencies = [
  "glob",
  "insta",
  "monochange_core",
+ "monochange_publish",
  "monochange_test_helpers",
  "regex",
  "rstest",

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -22,6 +22,7 @@ use monochange_github::format_manual_trust_context;
 use monochange_github::resolve_github_trust_context;
 use monochange_github::trust_list_contains_context;
 use monochange_github::verify_github_trust_context;
+use monochange_go::write_go_placeholder_manifest;
 use monochange_npm::build_npm_trust_command;
 use monochange_npm::build_npm_trust_list_command;
 use monochange_npm::render_npm_trust_command;
@@ -893,18 +894,6 @@ fn build_placeholder_directory(
 	manifest_result.expect("unsupported built-in publish registry")?;
 
 	Ok(tempdir)
-}
-
-fn write_go_placeholder_manifest(dir: &Path, request: &PublishRequest) -> MonochangeResult<()> {
-	let contents = format!(
-		"module {}
-
-go 1.22
-",
-		go_module_path(request)
-	);
-	fs::write(dir.join("go.mod"), contents)
-		.map_err(|error| MonochangeError::Io(format!("failed to write go.mod: {error}")))
 }
 
 fn write_cargo_placeholder_manifest(

--- a/crates/monochange_go/Cargo.toml
+++ b/crates/monochange_go/Cargo.toml
@@ -15,6 +15,7 @@ description = "Go ecosystem adapter for monochange — discovers Go modules and 
 [dependencies]
 glob = { workspace = true, default-features = true }
 monochange_core = { workspace = true }
+monochange_publish = { workspace = true }
 regex = { workspace = true, default-features = true }
 semver = { workspace = true, default-features = true }
 tracing = { workspace = true, default-features = true }

--- a/crates/monochange_go/src/lib.rs
+++ b/crates/monochange_go/src/lib.rs
@@ -46,6 +46,8 @@ use monochange_core::PackageRecord;
 use monochange_core::PublishState;
 use monochange_core::ShellConfig;
 use monochange_core::normalize_path;
+use monochange_publish::PublishRequest;
+use monochange_publish::go_module_path;
 use semver::Version;
 use walkdir::DirEntry;
 use walkdir::WalkDir;
@@ -113,6 +115,18 @@ pub fn default_lockfile_commands(package: &PackageRecord) -> Vec<LockfileCommand
 		cwd: manifest_dir,
 		shell: ShellConfig::None,
 	}]
+}
+
+pub fn write_go_placeholder_manifest(dir: &Path, request: &PublishRequest) -> MonochangeResult<()> {
+	let contents = format!(
+		"module {}
+
+go 1.22
+",
+		go_module_path(request)
+	);
+	fs::write(dir.join("go.mod"), contents)
+		.map_err(|error| MonochangeError::Io(format!("failed to write go.mod: {error}")))
 }
 
 /// Update a `go.mod` file's require directives for cross-module dependencies.

--- a/docs/plans/monochange-crate-boundaries-audit.md
+++ b/docs/plans/monochange-crate-boundaries-audit.md
@@ -145,7 +145,7 @@ The top-level `monochange` crate should only register adapters and call `monocha
 2. Extract Cargo readiness blockers into `monochange_cargo`. ✅
 3. Extract GitHub trust context into `monochange_github`. ✅
 4. Move npm trusted-publishing command helpers and npm placeholder manifest generation into `monochange_npm`.
-5. Extract remaining placeholder manifest generation per ecosystem.
+5. Extract remaining placeholder manifest generation per ecosystem, starting with Go proxy placeholders in `monochange_go`.
 6. Extract registry existence checks per ecosystem or route them through publish adapters.
 7. Delete top-level ecosystem/provider match arms from `package_publish.rs` and reduce it to CLI glue or remove it entirely.
 
@@ -504,3 +504,7 @@ Current `package_publish.rs` is about 5.7k lines. #419 moves npm trusted-publish
 ### 2026-05-08: ecosystem constants and validation moved down
 
 The latest `origin/main` moved ecosystem constants and versioned-file validation out of `monochange_core` and delegated them to ecosystem crates. That change reinforces the same boundary direction as the publish work: ecosystem-owned file formats and validation should stay in `monochange_cargo`, `monochange_npm`, `monochange_dart`, `monochange_deno`, `monochange_python`, and `monochange_go`, while the top-level crate should compose those crates rather than reimplementing their rules.
+
+### 2026-05-08: Go placeholder boundary follow-up
+
+After the npm helper extraction, the next focused follow-up moves Go placeholder `go.mod` generation into `monochange_go`. This keeps Go module bootstrap formatting with the Go ecosystem adapter while `package_publish.rs` still owns the temporary-directory orchestration until `PublishAdapter` exists.


### PR DESCRIPTION
Stacked on #419.

Move Go placeholder `go.mod` generation out of `monochange::package_publish` and into `monochange_go`. The top-level publish module still owns temporary-directory orchestration until `PublishAdapter` exists.

Validation run locally:

- `cargo check -p monochange_go -p monochange`
- `cargo clippy -p monochange_go -p monochange --all-targets -- -D warnings`
- `dprint fmt`