### PR TITLE
refactor: move JSR placeholder manifests into monochange_deno

### DIFF
--- a/.changeset/move-deno-placeholder-manifest.md
+++ b/.changeset/move-deno-placeholder-manifest.md
@@ -1,0 +1,8 @@
+---
+monochange: patch
+monochange_deno: minor
+---
+
+# Move JSR placeholder manifests into monochange_deno
+
+Move JSR placeholder `deno.json` and `mod.ts` generation out of `monochange::package_publish` and into `monochange_deno`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,6 +2232,7 @@ dependencies = [
  "insta",
  "monochange_core",
  "monochange_ecmascript",
+ "monochange_publish",
  "rstest",
  "semver",
  "serde",

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -18,6 +18,7 @@ use monochange_core::PublishRegistry;
 use monochange_core::RegistryKind;
 use monochange_core::SourceConfiguration;
 use monochange_core::WorkspaceConfiguration;
+use monochange_deno::write_jsr_placeholder_manifest;
 use monochange_github::format_manual_trust_context;
 use monochange_github::resolve_github_trust_context;
 use monochange_github::trust_list_contains_context;
@@ -55,7 +56,6 @@ use monochange_publish::resume_publish_requests;
 use monochange_publish::trusted_publishing_capability_message;
 use monochange_publish::trusted_publishing_capability_message_for_builtin;
 use reqwest::blocking::Client;
-use serde_json::Value as JsonValue;
 use tempfile::TempDir;
 use toml::Value as TomlValue;
 use urlencoding::encode;
@@ -1047,49 +1047,6 @@ fn write_dart_placeholder_manifest(
 	})
 }
 
-fn write_jsr_placeholder_manifest(
-	dir: &Path,
-	request: &PublishRequest,
-	source: Option<&SourceConfiguration>,
-) -> MonochangeResult<()> {
-	let mut manifest = serde_json::Map::new();
-	manifest.insert(
-		"name".to_string(),
-		JsonValue::String(request.package_name.clone()),
-	);
-	manifest.insert(
-		"version".to_string(),
-		JsonValue::String(request.version.clone()),
-	);
-	manifest.insert(
-		"exports".to_string(),
-		JsonValue::Object(
-			[(".".to_string(), JsonValue::String("./mod.ts".to_string()))]
-				.into_iter()
-				.collect(),
-		),
-	);
-	if let Some(source) = source {
-		manifest.insert(
-			"repository".to_string(),
-			JsonValue::String(format!(
-				"https://github.com/{}/{}",
-				source.owner, source.repo
-			)),
-		);
-	}
-	fs::write(
-		dir.join("deno.json"),
-		JsonValue::Object(manifest).to_string(),
-	)
-	.map_err(|error| {
-		MonochangeError::Io(format!("failed to write placeholder deno.json: {error}"))
-	})?;
-	fs::write(dir.join("mod.ts"), "export {};\n").map_err(|error| {
-		MonochangeError::Io(format!("failed to write placeholder mod.ts: {error}"))
-	})
-}
-
 fn write_python_placeholder_manifest(
 	dir: &Path,
 	request: &PublishRequest,
@@ -1282,6 +1239,7 @@ mod tests {
 	use monochange_publish::write_publish_report_artifact;
 	use monochange_test_helpers::git;
 	use semver::Version;
+	use serde_json::Value as JsonValue;
 	use temp_env::with_vars;
 
 	use super::*;

--- a/crates/monochange_deno/Cargo.toml
+++ b/crates/monochange_deno/Cargo.toml
@@ -16,6 +16,7 @@ description = "Deno workspace and package discovery for monochange"
 glob = { workspace = true, default-features = true }
 monochange_core = { workspace = true }
 monochange_ecmascript = { workspace = true }
+monochange_publish = { workspace = true }
 semver = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }

--- a/crates/monochange_deno/src/lib.rs
+++ b/crates/monochange_deno/src/lib.rs
@@ -54,7 +54,9 @@ use monochange_core::MonochangeResult;
 use monochange_core::PackageDependency;
 use monochange_core::PackageRecord;
 use monochange_core::PublishState;
+use monochange_core::SourceConfiguration;
 use monochange_core::normalize_path;
+use monochange_publish::PublishRequest;
 use semver::Version;
 use serde_json::Value;
 use walkdir::DirEntry;
@@ -83,6 +85,45 @@ pub fn supported_versioned_file_kind(path: &Path) -> Option<DenoVersionedFileKin
 		}
 		_ => None,
 	}
+}
+
+pub fn write_jsr_placeholder_manifest(
+	dir: &Path,
+	request: &PublishRequest,
+	source: Option<&SourceConfiguration>,
+) -> MonochangeResult<()> {
+	let mut manifest = serde_json::Map::new();
+	manifest.insert(
+		"name".to_string(),
+		Value::String(request.package_name.clone()),
+	);
+	manifest.insert(
+		"version".to_string(),
+		Value::String(request.version.clone()),
+	);
+	manifest.insert(
+		"exports".to_string(),
+		Value::Object(
+			[(".".to_string(), Value::String("./mod.ts".to_string()))]
+				.into_iter()
+				.collect(),
+		),
+	);
+	if let Some(source) = source {
+		manifest.insert(
+			"repository".to_string(),
+			Value::String(format!(
+				"https://github.com/{}/{}",
+				source.owner, source.repo
+			)),
+		);
+	}
+	fs::write(dir.join("deno.json"), Value::Object(manifest).to_string()).map_err(|error| {
+		MonochangeError::Io(format!("failed to write placeholder deno.json: {error}"))
+	})?;
+	fs::write(dir.join("mod.ts"), "export {};\n").map_err(|error| {
+		MonochangeError::Io(format!("failed to write placeholder mod.ts: {error}"))
+	})
 }
 
 fn rewrite_dependency_reference(text: &str, package_name: &str, version: &str) -> String {

--- a/docs/plans/monochange-crate-boundaries-audit.md
+++ b/docs/plans/monochange-crate-boundaries-audit.md
@@ -145,7 +145,7 @@ The top-level `monochange` crate should only register adapters and call `monocha
 2. Extract Cargo readiness blockers into `monochange_cargo`. ✅
 3. Extract GitHub trust context into `monochange_github`. ✅
 4. Move npm trusted-publishing command helpers and npm placeholder manifest generation into `monochange_npm`.
-5. Extract remaining placeholder manifest generation per ecosystem, starting with Go proxy placeholders in `monochange_go`.
+5. Extract remaining placeholder manifest generation per ecosystem, continuing with JSR/Deno placeholders in `monochange_deno`.
 6. Extract registry existence checks per ecosystem or route them through publish adapters.
 7. Delete top-level ecosystem/provider match arms from `package_publish.rs` and reduce it to CLI glue or remove it entirely.
 
@@ -508,3 +508,7 @@ The latest `origin/main` moved ecosystem constants and versioned-file validation
 ### 2026-05-08: Go placeholder boundary follow-up
 
 After the npm helper extraction, the next focused follow-up moves Go placeholder `go.mod` generation into `monochange_go`. This keeps Go module bootstrap formatting with the Go ecosystem adapter while `package_publish.rs` still owns the temporary-directory orchestration until `PublishAdapter` exists.
+
+### 2026-05-09: JSR placeholder boundary follow-up
+
+After the npm and Go placeholder extractions, the next focused follow-up moves JSR placeholder `deno.json` and `mod.ts` generation into `monochange_deno`. This keeps Deno/JSR package scaffold rules with the Deno ecosystem adapter while `package_publish.rs` still owns temporary-directory orchestration until `PublishAdapter` exists.


### PR DESCRIPTION
Move JSR placeholder `deno.json` and `mod.ts` generation out of `monochange::package_publish` and into `monochange_deno`.

This continues the Phase 2 publish boundary cleanup after the npm and Go placeholder extractions. The top-level publish module still owns temporary-directory orchestration until `PublishAdapter` exists.

Validation run locally:

- `cargo check -p monochange_deno -p monochange`
- `cargo clippy -p monochange_deno -p monochange --all-targets -- -D warnings`
- `dprint fmt`