### PR TITLE
refactor: move Dart placeholder manifests into monochange_dart

### DIFF
--- a/.changeset/move-dart-placeholder-manifest.md
+++ b/.changeset/move-dart-placeholder-manifest.md
@@ -1,0 +1,8 @@
+---
+monochange: patch
+monochange_dart: minor
+---
+
+# Move Dart placeholder manifests into monochange_dart
+
+Move pub.dev placeholder `pubspec.yaml` generation out of `monochange::package_publish` and into `monochange_dart`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2211,6 +2211,7 @@ dependencies = [
  "insta",
  "monochange_config",
  "monochange_core",
+ "monochange_publish",
  "monochange_test_helpers",
  "rstest",
  "semver",

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -18,6 +18,7 @@ use monochange_core::PublishRegistry;
 use monochange_core::RegistryKind;
 use monochange_core::SourceConfiguration;
 use monochange_core::WorkspaceConfiguration;
+use monochange_dart::write_dart_placeholder_manifest;
 use monochange_deno::write_jsr_placeholder_manifest;
 use monochange_github::format_manual_trust_context;
 use monochange_github::resolve_github_trust_context;
@@ -1026,25 +1027,6 @@ fn resolve_cargo_placeholder_license_metadata(
 		.and_then(TomlValue::as_str)
 		.map(ToString::to_string);
 	Ok((workspace_license, workspace_license_file))
-}
-
-fn write_dart_placeholder_manifest(
-	dir: &Path,
-	request: &PublishRequest,
-	source: Option<&SourceConfiguration>,
-) -> MonochangeResult<()> {
-	let repository =
-		source.map(|source| format!("https://github.com/{}/{}", source.owner, source.repo));
-	let mut rendered = format!(
-		"name: {}\nversion: {}\ndescription: Placeholder package published by monochange.\n",
-		request.package_name, request.version
-	);
-	if let Some(repository) = repository {
-		let _ = writeln!(rendered, "repository: {repository}");
-	}
-	fs::write(dir.join("pubspec.yaml"), rendered).map_err(|error| {
-		MonochangeError::Io(format!("failed to write placeholder pubspec.yaml: {error}"))
-	})
 }
 
 fn write_python_placeholder_manifest(

--- a/crates/monochange_dart/Cargo.toml
+++ b/crates/monochange_dart/Cargo.toml
@@ -15,6 +15,7 @@ description = "Dart and Flutter workspace discovery for monochange"
 [dependencies]
 glob = { workspace = true, default-features = true }
 monochange_core = { workspace = true }
+monochange_publish = { workspace = true }
 semver = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }

--- a/crates/monochange_dart/src/lib.rs
+++ b/crates/monochange_dart/src/lib.rs
@@ -36,6 +36,7 @@ pub mod analysis;
 
 use std::collections::BTreeSet;
 use std::collections::HashSet;
+use std::fmt::Write as _;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
@@ -55,7 +56,9 @@ use monochange_core::PackageDependency;
 use monochange_core::PackageRecord;
 use monochange_core::PublishState;
 use monochange_core::ShellConfig;
+use monochange_core::SourceConfiguration;
 use monochange_core::normalize_path;
+use monochange_publish::PublishRequest;
 use semver::Version;
 use serde_yaml_ng::Mapping;
 use serde_yaml_ng::Value;
@@ -70,6 +73,25 @@ pub const PUBSPEC_FILE: &str = "pubspec.yaml";
 pub enum DartVersionedFileKind {
 	Manifest,
 	Lock,
+}
+
+pub fn write_dart_placeholder_manifest(
+	dir: &Path,
+	request: &PublishRequest,
+	source: Option<&SourceConfiguration>,
+) -> MonochangeResult<()> {
+	let repository =
+		source.map(|source| format!("https://github.com/{}/{}", source.owner, source.repo));
+	let mut rendered = format!(
+		"name: {}\nversion: {}\ndescription: Placeholder package published by monochange.\n",
+		request.package_name, request.version
+	);
+	if let Some(repository) = repository {
+		let _ = writeln!(rendered, "repository: {repository}");
+	}
+	fs::write(dir.join("pubspec.yaml"), rendered).map_err(|error| {
+		MonochangeError::Io(format!("failed to write placeholder pubspec.yaml: {error}"))
+	})
 }
 
 /// Classify a Dart or Flutter versioned file path.

--- a/docs/plans/monochange-crate-boundaries-audit.md
+++ b/docs/plans/monochange-crate-boundaries-audit.md
@@ -56,7 +56,7 @@ Examples of ecosystem/provider leakage in the top-level crate:
 
 - `npm token` environment rejection still lives in `package_publish.rs`; npm trusted-publishing command construction and npm placeholder manifest generation are moving into `monochange_npm`
 - Cargo placeholder manifest generation in `package_publish.rs` (Cargo publish readiness blockers now live in `monochange_cargo`)
-- Dart, JSR, Python, Go placeholder manifest generation in `package_publish.rs`
+- Cargo and Python placeholder manifest generation in `package_publish.rs`
 - top-level orchestration that still hardcodes ecosystem/provider trust setup instead of calling publish/provider adapters
 - trusted publishing capability matrix now lives in `monochange_publish`, while GitHub workflow/environment trust context now lives in `monochange_github`
 
@@ -105,7 +105,10 @@ Provider-specific trust context should move to provider crates:
 | `cargo_publish_readiness_blockers`                            | `monochange_cargo`   | Done in #413 |
 | GitHub trust context resolution and verification              | `monochange_github`  | Done in #417 |
 | npm trusted-publishing command helpers                        | `monochange_npm`     | In #419      |
-| npm placeholder manifest generation                           | `monochange_npm`     | In #419      |
+| npm placeholder manifest generation                           | `monochange_npm`     | Done in #419 |
+| Go placeholder manifest generation                            | `monochange_go`      | Done in #420 |
+| JSR/Deno placeholder manifest generation                      | `monochange_deno`    | In #423      |
+| Dart placeholder manifest generation                          | `monochange_dart`    | Next         |
 
 **Phase 3: Introduce `PublishAdapter` trait**
 
@@ -145,7 +148,7 @@ The top-level `monochange` crate should only register adapters and call `monocha
 2. Extract Cargo readiness blockers into `monochange_cargo`. ✅
 3. Extract GitHub trust context into `monochange_github`. ✅
 4. Move npm trusted-publishing command helpers and npm placeholder manifest generation into `monochange_npm`.
-5. Extract remaining placeholder manifest generation per ecosystem, continuing with JSR/Deno placeholders in `monochange_deno`.
+5. Extract remaining placeholder manifest generation per ecosystem, continuing with Dart placeholders in `monochange_dart`.
 6. Extract registry existence checks per ecosystem or route them through publish adapters.
 7. Delete top-level ecosystem/provider match arms from `package_publish.rs` and reduce it to CLI glue or remove it entirely.
 
@@ -512,3 +515,7 @@ After the npm helper extraction, the next focused follow-up moves Go placeholder
 ### 2026-05-09: JSR placeholder boundary follow-up
 
 After the npm and Go placeholder extractions, the next focused follow-up moves JSR placeholder `deno.json` and `mod.ts` generation into `monochange_deno`. This keeps Deno/JSR package scaffold rules with the Deno ecosystem adapter while `package_publish.rs` still owns temporary-directory orchestration until `PublishAdapter` exists.
+
+### 2026-05-09: Dart placeholder boundary follow-up
+
+After the JSR placeholder extraction, the next focused follow-up moves pub.dev placeholder `pubspec.yaml` generation into `monochange_dart`. This keeps Dart package scaffold rules with the Dart ecosystem adapter while `package_publish.rs` still owns temporary-directory orchestration until `PublishAdapter` exists.


### PR DESCRIPTION
Stacked on #423.

Move pub.dev placeholder `pubspec.yaml` generation out of `monochange::package_publish` and into `monochange_dart`.

This continues the Phase 2 publish boundary cleanup after the JSR/Deno placeholder extraction. The top-level publish module still owns temporary-directory orchestration until `PublishAdapter` exists.

Validation run locally:

- `cargo check -p monochange_dart -p monochange`
- `cargo clippy -p monochange_dart -p monochange --all-targets -- -D warnings`
- `dprint fmt`