### PR TITLE
refactor: move Python placeholder manifests into monochange_python

### DIFF
--- a/.changeset/move-python-placeholder-manifest.md
+++ b/.changeset/move-python-placeholder-manifest.md
@@ -1,0 +1,8 @@
+---
+monochange: patch
+monochange_python: minor
+---
+
+# Move Python placeholder manifests into monochange_python
+
+Move PyPI placeholder `pyproject.toml` and module scaffold generation out of `monochange::package_publish` and into `monochange_python`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2468,6 +2468,7 @@ dependencies = [
  "glob",
  "insta",
  "monochange_core",
+ "monochange_publish",
  "monochange_test_helpers",
  "rstest",
  "semver",

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -56,6 +56,7 @@ use monochange_publish::render_command_error;
 use monochange_publish::resume_publish_requests;
 use monochange_publish::trusted_publishing_capability_message;
 use monochange_publish::trusted_publishing_capability_message_for_builtin;
+use monochange_python::write_python_placeholder_manifest;
 use reqwest::blocking::Client;
 use tempfile::TempDir;
 use toml::Value as TomlValue;
@@ -1027,63 +1028,6 @@ fn resolve_cargo_placeholder_license_metadata(
 		.and_then(TomlValue::as_str)
 		.map(ToString::to_string);
 	Ok((workspace_license, workspace_license_file))
-}
-
-fn write_python_placeholder_manifest(
-	dir: &Path,
-	request: &PublishRequest,
-	source: Option<&SourceConfiguration>,
-) -> MonochangeResult<()> {
-	let module_name = python_placeholder_module_name(&request.package_name);
-	let project_urls = source.map(|source| {
-		format!(
-			"\n[project.urls]\nRepository = \"https://github.com/{}/{}\"\n",
-			source.owner, source.repo
-		)
-	});
-	let pyproject = format!(
-		"[build-system]\nrequires = [\"hatchling\"]\nbuild-backend = \"hatchling.build\"\n\n[project]\nname = \"{}\"\nversion = \"{}\"\ndescription = \"Placeholder package for {}\"\nreadme = \"README.md\"\nrequires-python = \">=3.8\"\n{}\n[tool.hatch.build.targets.wheel]\npackages = [\"src/{}\"]\n",
-		request.package_name,
-		request.version,
-		request.package_name,
-		project_urls.unwrap_or_default(),
-		module_name,
-	);
-	fs::write(dir.join("pyproject.toml"), pyproject).map_err(|error| {
-		MonochangeError::Io(format!(
-			"failed to write placeholder pyproject.toml: {error}"
-		))
-	})?;
-	let package_dir = dir.join("src").join(&module_name);
-	fs::create_dir_all(&package_dir).map_err(|error| {
-		MonochangeError::Io(format!(
-			"failed to create placeholder Python package: {error}"
-		))
-	})?;
-	fs::write(
-		package_dir.join("__init__.py"),
-		"\"\"\"Placeholder package published by monochange.\"\"\"\n",
-	)
-	.map_err(|error| {
-		MonochangeError::Io(format!(
-			"failed to write placeholder Python package module: {error}"
-		))
-	})
-}
-
-fn python_placeholder_module_name(package_name: &str) -> String {
-	let mut module = String::new();
-	for character in package_name.chars() {
-		if character.is_ascii_alphanumeric() || character == '_' {
-			module.push(character.to_ascii_lowercase());
-		} else {
-			module.push('_');
-		}
-	}
-	if module.is_empty() || module.starts_with(|character: char| character.is_ascii_digit()) {
-		module.insert_str(0, "placeholder_");
-	}
-	module
 }
 
 fn placeholder_tempdir_error(error: &std::io::Error) -> MonochangeError {

--- a/crates/monochange_python/Cargo.toml
+++ b/crates/monochange_python/Cargo.toml
@@ -15,6 +15,7 @@ description = "Python ecosystem adapter for monochange — discovers uv workspac
 [dependencies]
 glob = { workspace = true, default-features = true }
 monochange_core = { workspace = true }
+monochange_publish = { workspace = true }
 semver = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }
 toml = { workspace = true, default-features = true }

--- a/crates/monochange_python/src/lib.rs
+++ b/crates/monochange_python/src/lib.rs
@@ -43,7 +43,9 @@ use monochange_core::PackageDependency;
 use monochange_core::PackageRecord;
 use monochange_core::PublishState;
 use monochange_core::ShellConfig;
+use monochange_core::SourceConfiguration;
 use monochange_core::normalize_path;
+use monochange_publish::PublishRequest;
 use semver::Version;
 use toml::Value;
 use toml_edit::DocumentMut;
@@ -54,6 +56,63 @@ use walkdir::WalkDir;
 pub const PYPROJECT_FILE: &str = "pyproject.toml";
 pub const UV_LOCK_FILE: &str = "uv.lock";
 pub const POETRY_LOCK_FILE: &str = "poetry.lock";
+
+pub fn write_python_placeholder_manifest(
+	dir: &Path,
+	request: &PublishRequest,
+	source: Option<&SourceConfiguration>,
+) -> MonochangeResult<()> {
+	let module_name = python_placeholder_module_name(&request.package_name);
+	let project_urls = source.map(|source| {
+		format!(
+			"\n[project.urls]\nRepository = \"https://github.com/{}/{}\"\n",
+			source.owner, source.repo
+		)
+	});
+	let pyproject = format!(
+		"[build-system]\nrequires = [\"hatchling\"]\nbuild-backend = \"hatchling.build\"\n\n[project]\nname = \"{}\"\nversion = \"{}\"\ndescription = \"Placeholder package for {}\"\nreadme = \"README.md\"\nrequires-python = \">=3.8\"\n{}\n[tool.hatch.build.targets.wheel]\npackages = [\"src/{}\"]\n",
+		request.package_name,
+		request.version,
+		request.package_name,
+		project_urls.unwrap_or_default(),
+		module_name,
+	);
+	fs::write(dir.join("pyproject.toml"), pyproject).map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to write placeholder pyproject.toml: {error}"
+		))
+	})?;
+	let package_dir = dir.join("src").join(&module_name);
+	fs::create_dir_all(&package_dir).map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to create placeholder Python package: {error}"
+		))
+	})?;
+	fs::write(
+		package_dir.join("__init__.py"),
+		"\"\"\"Placeholder package published by monochange.\"\"\"\n",
+	)
+	.map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to write placeholder Python package module: {error}"
+		))
+	})
+}
+
+fn python_placeholder_module_name(package_name: &str) -> String {
+	let mut module = String::new();
+	for character in package_name.chars() {
+		if character.is_ascii_alphanumeric() || character == '_' {
+			module.push(character.to_ascii_lowercase());
+		} else {
+			module.push('_');
+		}
+	}
+	if module.is_empty() || module.starts_with(|character: char| character.is_ascii_digit()) {
+		module.insert_str(0, "placeholder_");
+	}
+	module
+}
 
 pub struct PythonAdapter;
 

--- a/docs/plans/monochange-crate-boundaries-audit.md
+++ b/docs/plans/monochange-crate-boundaries-audit.md
@@ -56,7 +56,7 @@ Examples of ecosystem/provider leakage in the top-level crate:
 
 - `npm token` environment rejection still lives in `package_publish.rs`; npm trusted-publishing command construction and npm placeholder manifest generation are moving into `monochange_npm`
 - Cargo placeholder manifest generation in `package_publish.rs` (Cargo publish readiness blockers now live in `monochange_cargo`)
-- Cargo and Python placeholder manifest generation in `package_publish.rs`
+- Cargo placeholder manifest generation in `package_publish.rs`
 - top-level orchestration that still hardcodes ecosystem/provider trust setup instead of calling publish/provider adapters
 - trusted publishing capability matrix now lives in `monochange_publish`, while GitHub workflow/environment trust context now lives in `monochange_github`
 
@@ -108,7 +108,8 @@ Provider-specific trust context should move to provider crates:
 | npm placeholder manifest generation                           | `monochange_npm`     | Done in #419 |
 | Go placeholder manifest generation                            | `monochange_go`      | Done in #420 |
 | JSR/Deno placeholder manifest generation                      | `monochange_deno`    | In #423      |
-| Dart placeholder manifest generation                          | `monochange_dart`    | Next         |
+| Dart placeholder manifest generation                          | `monochange_dart`    | In #424      |
+| Python placeholder manifest generation                        | `monochange_python`  | Next         |
 
 **Phase 3: Introduce `PublishAdapter` trait**
 
@@ -148,7 +149,7 @@ The top-level `monochange` crate should only register adapters and call `monocha
 2. Extract Cargo readiness blockers into `monochange_cargo`. ✅
 3. Extract GitHub trust context into `monochange_github`. ✅
 4. Move npm trusted-publishing command helpers and npm placeholder manifest generation into `monochange_npm`.
-5. Extract remaining placeholder manifest generation per ecosystem, continuing with Dart placeholders in `monochange_dart`.
+5. Extract remaining placeholder manifest generation per ecosystem, continuing with Python placeholders in `monochange_python`.
 6. Extract registry existence checks per ecosystem or route them through publish adapters.
 7. Delete top-level ecosystem/provider match arms from `package_publish.rs` and reduce it to CLI glue or remove it entirely.
 
@@ -519,3 +520,7 @@ After the npm and Go placeholder extractions, the next focused follow-up moves J
 ### 2026-05-09: Dart placeholder boundary follow-up
 
 After the JSR placeholder extraction, the next focused follow-up moves pub.dev placeholder `pubspec.yaml` generation into `monochange_dart`. This keeps Dart package scaffold rules with the Dart ecosystem adapter while `package_publish.rs` still owns temporary-directory orchestration until `PublishAdapter` exists.
+
+### 2026-05-09: Python placeholder boundary follow-up
+
+After the Dart placeholder extraction, the next focused follow-up moves PyPI placeholder `pyproject.toml` and module scaffold generation into `monochange_python`. This keeps Python package scaffold rules with the Python ecosystem adapter while `package_publish.rs` still owns temporary-directory orchestration until `PublishAdapter` exists.


### PR DESCRIPTION
Stacked on #424.

Move PyPI placeholder `pyproject.toml` and package module scaffold generation out of `monochange::package_publish` and into `monochange_python`.

This continues the Phase 2 publish boundary cleanup after the Dart placeholder extraction. The top-level publish module still owns temporary-directory orchestration until `PublishAdapter` exists.

Validation run locally:

- `cargo check -p monochange_python -p monochange`
- `cargo clippy -p monochange_python -p monochange --all-targets -- -D warnings`
- `dprint fmt`