### PR TITLE
refactor: move Cargo placeholder manifests into monochange_cargo

### DIFF
--- a/.changeset/move-cargo-placeholder-manifest.md
+++ b/.changeset/move-cargo-placeholder-manifest.md
@@ -1,0 +1,8 @@
+---
+monochange: patch
+monochange_cargo: minor
+---
+
+# Move Cargo placeholder manifests into monochange_cargo
+
+Move crates.io placeholder `Cargo.toml` and `src/lib.rs` generation out of `monochange::package_publish` and into `monochange_cargo`.

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -1,13 +1,12 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::env;
-use std::fmt::Write as _;
 use std::fs;
 use std::path::Path;
 
 use monochange_cargo::cargo_publish_readiness_blockers;
 use monochange_cargo::publish_blocked_message;
-use monochange_cargo::read_workspace_package_table;
+use monochange_cargo::write_cargo_placeholder_manifest;
 use monochange_core::Ecosystem;
 use monochange_core::MonochangeError;
 use monochange_core::MonochangeResult;
@@ -59,7 +58,6 @@ use monochange_publish::trusted_publishing_capability_message_for_builtin;
 use monochange_python::write_python_placeholder_manifest;
 use reqwest::blocking::Client;
 use tempfile::TempDir;
-use toml::Value as TomlValue;
 use urlencoding::encode;
 
 use crate::PreparedRelease;
@@ -898,138 +896,6 @@ fn build_placeholder_directory(
 	Ok(tempdir)
 }
 
-fn write_cargo_placeholder_manifest(
-	dir: &Path,
-	request: &PublishRequest,
-	root: &Path,
-	source: Option<&SourceConfiguration>,
-) -> MonochangeResult<()> {
-	let contents = fs::read_to_string(&request.manifest_path).map_err(|error| {
-		MonochangeError::Io(format!(
-			"failed to read Cargo manifest {}: {error}",
-			request.manifest_path.display()
-		))
-	})?;
-	let parsed = toml::from_str::<TomlValue>(&contents).map_err(|error| {
-		MonochangeError::Config(format!(
-			"failed to parse {}: {error}",
-			request.manifest_path.display()
-		))
-	})?;
-	let package = parsed
-		.get("package")
-		.and_then(TomlValue::as_table)
-		.ok_or_else(|| {
-			MonochangeError::Config(format!(
-				"{} is missing [package]",
-				request.manifest_path.display()
-			))
-		})?;
-	let (license, license_file) = resolve_cargo_placeholder_license_metadata(package, root)?;
-	let package_license_file = package
-		.get("license-file")
-		.and_then(TomlValue::as_str)
-		.map(ToString::to_string);
-	if license.is_none() && license_file.is_none() {
-		return Err(MonochangeError::Config(format!(
-			"`{}` placeholder publishing requires `package.license` or `package.license-file`",
-			request.package_id
-		)));
-	}
-
-	let description = package
-		.get("description")
-		.and_then(TomlValue::as_str)
-		.unwrap_or("Placeholder crate published by monochange");
-	let edition = package
-		.get("edition")
-		.and_then(TomlValue::as_str)
-		.unwrap_or("2021");
-	let repository = package
-		.get("repository")
-		.and_then(TomlValue::as_str)
-		.map(ToString::to_string)
-		.or_else(|| {
-			source.map(|source| format!("https://github.com/{}/{}", source.owner, source.repo))
-		});
-
-	let mut manifest = format!(
-		"[package]\nname = \"{}\"\nversion = \"{}\"\nedition = \"{}\"\ndescription = \"{}\"\nreadme = \"README.md\"\n",
-		request.package_name, request.version, edition, description
-	);
-	if let Some(license) = license {
-		let _ = writeln!(manifest, "license = \"{license}\"");
-	}
-	if let Some(license_file) = license_file {
-		manifest.push_str("license-file = \"LICENSE\"\n");
-		let source_root = if package_license_file.as_deref() == Some(license_file.as_str()) {
-			request.package_root.as_path()
-		} else {
-			root
-		};
-		let source_path = source_root.join(&license_file);
-		let resolved_source = if source_path.is_absolute() {
-			source_path
-		} else {
-			root.join(source_path)
-		};
-		fs::copy(&resolved_source, dir.join("LICENSE")).map_err(|error| {
-			MonochangeError::Io(format!(
-				"failed to copy placeholder license file {}: {error}",
-				resolved_source.display()
-			))
-		})?;
-	}
-	if let Some(repository) = repository {
-		let _ = writeln!(manifest, "repository = \"{repository}\"");
-	}
-	fs::create_dir_all(dir.join("src")).map_err(|error| {
-		MonochangeError::Io(format!(
-			"failed to create placeholder src directory: {error}"
-		))
-	})?;
-	fs::write(
-		dir.join("src/lib.rs"),
-		"//! Placeholder crate published by monochange.\n",
-	)
-	.map_err(|error| {
-		MonochangeError::Io(format!("failed to write placeholder src/lib.rs: {error}"))
-	})?;
-	fs::write(dir.join("Cargo.toml"), manifest).map_err(|error| {
-		MonochangeError::Io(format!("failed to write placeholder Cargo.toml: {error}"))
-	})
-}
-
-fn resolve_cargo_placeholder_license_metadata(
-	package: &toml::map::Map<String, TomlValue>,
-	root: &Path,
-) -> MonochangeResult<(Option<String>, Option<String>)> {
-	let license = package
-		.get("license")
-		.and_then(TomlValue::as_str)
-		.map(ToString::to_string);
-	let license_file = package
-		.get("license-file")
-		.and_then(TomlValue::as_str)
-		.map(ToString::to_string);
-	if license.is_some() || license_file.is_some() {
-		return Ok((license, license_file));
-	}
-
-	let workspace_package = read_workspace_package_table(root)?;
-	let workspace_license = workspace_package
-		.as_ref()
-		.and_then(|package| package.get("license"))
-		.and_then(TomlValue::as_str)
-		.map(ToString::to_string);
-	let workspace_license_file = workspace_package
-		.as_ref()
-		.and_then(|package| package.get("license-file"))
-		.and_then(TomlValue::as_str)
-		.map(ToString::to_string);
-	Ok((workspace_license, workspace_license_file))
-}
-
 fn placeholder_tempdir_error(error: &std::io::Error) -> MonochangeError {
 	MonochangeError::Io(format!("failed to create placeholder tempdir: {error}"))
 }
@@ -1134,6 +1000,8 @@ mod tests {
 	use httpmock::Method::GET;
 	use httpmock::MockServer;
 	use monochange_cargo::extract_workspace_package_table;
+	use monochange_cargo::read_workspace_package_table;
+	use monochange_cargo::write_cargo_placeholder_manifest;
 	use monochange_core::DependencyKind;
 	use monochange_core::PackageRecord;
 	use monochange_core::PublishAttestationSettings;
@@ -1167,6 +1035,7 @@ mod tests {
 	use semver::Version;
 	use serde_json::Value as JsonValue;
 	use temp_env::with_vars;
+	use toml::Value as TomlValue;
 
 	use super::*;
 	use crate::TEST_ENV_LOCK;

--- a/crates/monochange_cargo/src/lib.rs
+++ b/crates/monochange_cargo/src/lib.rs
@@ -40,6 +40,7 @@ type TomlValue = Value;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::HashSet;
+use std::fmt::Write as _;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
@@ -62,6 +63,7 @@ use monochange_core::PackageDependency;
 use monochange_core::PackageRecord;
 use monochange_core::PublishState;
 use monochange_core::ShellConfig;
+use monochange_core::SourceConfiguration;
 use monochange_core::normalize_path;
 use monochange_semver::CompatibilityProvider;
 use semver::Version;
@@ -1217,6 +1219,138 @@ pub fn read_workspace_package_table(
 	};
 	let parsed = parse_workspace_manifest_value(&workspace_manifest_path, &contents)?;
 	Ok(extract_workspace_package_table(&parsed))
+}
+
+pub fn write_cargo_placeholder_manifest(
+	dir: &Path,
+	request: &PublishRequest,
+	root: &Path,
+	source: Option<&SourceConfiguration>,
+) -> MonochangeResult<()> {
+	let contents = fs::read_to_string(&request.manifest_path).map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to read Cargo manifest {}: {error}",
+			request.manifest_path.display()
+		))
+	})?;
+	let parsed = toml::from_str::<TomlValue>(&contents).map_err(|error| {
+		MonochangeError::Config(format!(
+			"failed to parse {}: {error}",
+			request.manifest_path.display()
+		))
+	})?;
+	let package = parsed
+		.get("package")
+		.and_then(TomlValue::as_table)
+		.ok_or_else(|| {
+			MonochangeError::Config(format!(
+				"{} is missing [package]",
+				request.manifest_path.display()
+			))
+		})?;
+	let (license, license_file) = resolve_cargo_placeholder_license_metadata(package, root)?;
+	let package_license_file = package
+		.get("license-file")
+		.and_then(TomlValue::as_str)
+		.map(ToString::to_string);
+	if license.is_none() && license_file.is_none() {
+		return Err(MonochangeError::Config(format!(
+			"`{}` placeholder publishing requires `package.license` or `package.license-file`",
+			request.package_id
+		)));
+	}
+
+	let description = package
+		.get("description")
+		.and_then(TomlValue::as_str)
+		.unwrap_or("Placeholder crate published by monochange");
+	let edition = package
+		.get("edition")
+		.and_then(TomlValue::as_str)
+		.unwrap_or("2021");
+	let repository = package
+		.get("repository")
+		.and_then(TomlValue::as_str)
+		.map(ToString::to_string)
+		.or_else(|| {
+			source.map(|source| format!("https://github.com/{}/{}", source.owner, source.repo))
+		});
+
+	let mut manifest = format!(
+		"[package]\nname = \"{}\"\nversion = \"{}\"\nedition = \"{}\"\ndescription = \"{}\"\nreadme = \"README.md\"\n",
+		request.package_name, request.version, edition, description
+	);
+	if let Some(license) = license {
+		let _ = writeln!(manifest, "license = \"{license}\"");
+	}
+	if let Some(license_file) = license_file {
+		manifest.push_str("license-file = \"LICENSE\"\n");
+		let source_root = if package_license_file.as_deref() == Some(license_file.as_str()) {
+			request.package_root.as_path()
+		} else {
+			root
+		};
+		let source_path = source_root.join(&license_file);
+		let resolved_source = if source_path.is_absolute() {
+			source_path
+		} else {
+			root.join(source_path)
+		};
+		fs::copy(&resolved_source, dir.join("LICENSE")).map_err(|error| {
+			MonochangeError::Io(format!(
+				"failed to copy placeholder license file {}: {error}",
+				resolved_source.display()
+			))
+		})?;
+	}
+	if let Some(repository) = repository {
+		let _ = writeln!(manifest, "repository = \"{repository}\"");
+	}
+	fs::create_dir_all(dir.join("src")).map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to create placeholder src directory: {error}"
+		))
+	})?;
+	fs::write(
+		dir.join("src/lib.rs"),
+		"//! Placeholder crate published by monochange.\n",
+	)
+	.map_err(|error| {
+		MonochangeError::Io(format!("failed to write placeholder src/lib.rs: {error}"))
+	})?;
+	fs::write(dir.join("Cargo.toml"), manifest).map_err(|error| {
+		MonochangeError::Io(format!("failed to write placeholder Cargo.toml: {error}"))
+	})
+}
+
+pub fn resolve_cargo_placeholder_license_metadata(
+	package: &toml::map::Map<String, TomlValue>,
+	root: &Path,
+) -> MonochangeResult<(Option<String>, Option<String>)> {
+	let license = package
+		.get("license")
+		.and_then(TomlValue::as_str)
+		.map(ToString::to_string);
+	let license_file = package
+		.get("license-file")
+		.and_then(TomlValue::as_str)
+		.map(ToString::to_string);
+	if license.is_some() || license_file.is_some() {
+		return Ok((license, license_file));
+	}
+
+	let workspace_package = read_workspace_package_table(root)?;
+	let workspace_license = workspace_package
+		.as_ref()
+		.and_then(|package| package.get("license"))
+		.and_then(TomlValue::as_str)
+		.map(ToString::to_string);
+	let workspace_license_file = workspace_package
+		.as_ref()
+		.and_then(|package| package.get("license-file"))
+		.and_then(TomlValue::as_str)
+		.map(ToString::to_string);
+	Ok((workspace_license, workspace_license_file))
 }
 
 pub fn maybe_read_workspace_manifest_contents(

--- a/docs/plans/monochange-crate-boundaries-audit.md
+++ b/docs/plans/monochange-crate-boundaries-audit.md
@@ -56,7 +56,7 @@ Examples of ecosystem/provider leakage in the top-level crate:
 
 - `npm token` environment rejection still lives in `package_publish.rs`; npm trusted-publishing command construction and npm placeholder manifest generation are moving into `monochange_npm`
 - Cargo placeholder manifest generation in `package_publish.rs` (Cargo publish readiness blockers now live in `monochange_cargo`)
-- Cargo placeholder manifest generation in `package_publish.rs`
+- Dart, JSR, Python, Go placeholder manifest generation in `package_publish.rs`
 - top-level orchestration that still hardcodes ecosystem/provider trust setup instead of calling publish/provider adapters
 - trusted publishing capability matrix now lives in `monochange_publish`, while GitHub workflow/environment trust context now lives in `monochange_github`
 
@@ -524,3 +524,7 @@ After the JSR placeholder extraction, the next focused follow-up moves pub.dev p
 ### 2026-05-09: Python placeholder boundary follow-up
 
 After the Dart placeholder extraction, the next focused follow-up moves PyPI placeholder `pyproject.toml` and module scaffold generation into `monochange_python`. This keeps Python package scaffold rules with the Python ecosystem adapter while `package_publish.rs` still owns temporary-directory orchestration until `PublishAdapter` exists.
+
+### 2026-05-09: Cargo placeholder boundary follow-up
+
+After the Python placeholder extraction, the final focused follow-up moves crates.io placeholder `Cargo.toml` and `src/lib.rs` generation into `monochange_cargo`. This keeps Cargo crate scaffold rules with the Cargo ecosystem adapter while `package_publish.rs` still owns temporary-directory orchestration until `PublishAdapter` exists.


### PR DESCRIPTION
Move crates.io placeholder `Cargo.toml` and `src/lib.rs` generation out of `monochange::package_publish` and into `monochange_cargo`.

This is the final Phase 2 publish boundary cleanup step after the JSR/Dart/Python placeholder extractions. The top-level publish module still owns temporary-directory orchestration until `PublishAdapter` exists.

Validation run locally:

- `cargo check -p monochange_cargo -p monochange`
- `cargo clippy -p monochange_cargo -p monochange --all-targets -- -D warnings`
- `cargo test -p monochange --lib -- write_cargo_placeholder_manifest`
- `dprint fmt`