### PR TITLE
refactor: consolidate adapter traits to remove ecosystem match arms

### DIFF
--- a/.changeset/consolidated-adapter-traits.md
+++ b/.changeset/consolidated-adapter-traits.md
@@ -1,0 +1,11 @@
+---
+monochange: minor
+monochange_core: minor
+---
+
+# Consolidate adapter traits to remove ecosystem match arms
+
+Replace hardcoded ecosystem discovery match arms in `workspace_ops::discover_packages` with `EcosystemRegistry` dispatch. This is the foundation for removing all remaining ecosystem/provider match arms from `monochange` in favor of adapter registries.
+
+- Add `EcosystemRegistry` to `monochange_core` with `push_adapter` and `discover_all` methods.
+- Replace `discover_packages` body with `build_ecosystem_registry().discover_all(root)?`.

--- a/.changeset/consolidated-adapter-traits.md
+++ b/.changeset/consolidated-adapter-traits.md
@@ -1,11 +1,22 @@
 ---
 monochange: minor
 monochange_core: minor
+monochange_config: minor
+monochange_cargo: minor
+monochange_dart: minor
+monochange_deno: minor
+monochange_go: minor
+monochange_npm: minor
+monochange_python: minor
 ---
 
 # Consolidate adapter traits to remove ecosystem match arms
 
-Replace hardcoded ecosystem discovery match arms in `workspace_ops::discover_packages` with `EcosystemRegistry` dispatch. This is the foundation for removing all remaining ecosystem/provider match arms from `monochange` in favor of adapter registries.
+Replace hardcoded ecosystem match arms in `workspace_ops` and `monochange_config` with `EcosystemRegistry` dispatch via the `EcosystemAdapter` trait.
 
-- Add `EcosystemRegistry` to `monochange_core` with `push_adapter` and `discover_all` methods.
+- Expand `EcosystemAdapter` in `monochange_core` with `load_configured`, `supported_versioned_file_kind`, and `validate_versioned_file`.
+- Add `From<EcosystemType>` and `From<PackageType>` conversions for `Ecosystem`.
+- Implement the new trait methods in all ecosystem adapter crates.
 - Replace `discover_packages` body with `build_ecosystem_registry().discover_all(root)?`.
+- Replace `discover_release_workspace` `load_configured` match arms with registry dispatch.
+- Replace `path_is_supported_for_ecosystem` and `validate_ecosystem_version_readable` match arms in `monochange_config` with registry dispatch.

--- a/.changeset/consolidated-adapter-traits.md
+++ b/.changeset/consolidated-adapter-traits.md
@@ -2,6 +2,7 @@
 monochange: minor
 monochange_core: minor
 monochange_config: minor
+monochange_publish: minor
 monochange_cargo: minor
 monochange_dart: minor
 monochange_deno: minor
@@ -12,11 +13,14 @@ monochange_python: minor
 
 # Consolidate adapter traits to remove ecosystem match arms
 
-Replace hardcoded ecosystem match arms in `workspace_ops` and `monochange_config` with `EcosystemRegistry` dispatch via the `EcosystemAdapter` trait.
+Replace hardcoded ecosystem and registry match arms in `workspace_ops`, `monochange_config`, and `monochange_publish` with adapter registry dispatch.
 
 - Expand `EcosystemAdapter` in `monochange_core` with `load_configured`, `supported_versioned_file_kind`, and `validate_versioned_file`.
 - Add `From<EcosystemType>` and `From<PackageType>` conversions for `Ecosystem`.
+- Add `FromStr` for `Ecosystem` and extract `default_registry_kind_for_ecosystem` into `monochange_core`.
 - Implement the new trait methods in all ecosystem adapter crates.
 - Replace `discover_packages` body with `build_ecosystem_registry().discover_all(root)?`.
 - Replace `discover_release_workspace` `load_configured` match arms with registry dispatch.
 - Replace `path_is_supported_for_ecosystem` and `validate_ecosystem_version_readable` match arms in `monochange_config` with registry dispatch.
+- Introduce `PublishAdapter` trait and `PublishCommandBuilder` in `monochange_publish` to replace `build_publish_command` registry match arms.
+- Extract `default_registry_kind_for_ecosystem` mapping out of `package_publish.rs` into `monochange_core`.

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -340,19 +340,16 @@ fn resolve_registry_kind(
 }
 
 fn default_registry_kind_for_ecosystem(ecosystem: &str) -> MonochangeResult<RegistryKind> {
-	match ecosystem {
-		"cargo" => Ok(RegistryKind::CratesIo),
-		"npm" => Ok(RegistryKind::Npm),
-		"deno" => Ok(RegistryKind::Jsr),
-		"dart" | "flutter" => Ok(RegistryKind::PubDev),
-		"python" => Ok(RegistryKind::Pypi),
-		"go" => Ok(RegistryKind::GoProxy),
-		_ => {
-			Err(MonochangeError::Config(format!(
-				"built-in package publishing does not support ecosystem `{ecosystem}`"
-			)))
-		}
-	}
+	let parsed = ecosystem.parse::<Ecosystem>().map_err(|()| {
+		MonochangeError::Config(format!(
+			"built-in package publishing does not support ecosystem `{ecosystem}`"
+		))
+	})?;
+	monochange_core::default_registry_kind_for_ecosystem(parsed).ok_or_else(|| {
+		MonochangeError::Config(format!(
+			"built-in package publishing does not support ecosystem `{ecosystem}`"
+		))
+	})
 }
 
 fn resolve_placeholder_readme(

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -34,12 +34,14 @@ pub(crate) use monochange_publish::PackagePublishReport;
 pub(crate) use monochange_publish::PackagePublishRunMode;
 pub(crate) use monochange_publish::PackagePublishStatus;
 use monochange_publish::ProcessCommandExecutor;
+use monochange_publish::PublishAdapter;
 pub(crate) use monochange_publish::PublishRequest;
 use monochange_publish::RegistryEndpoints;
 use monochange_publish::TrustedPublishingIdentity;
 pub(crate) use monochange_publish::TrustedPublishingOutcome;
 pub(crate) use monochange_publish::TrustedPublishingStatus;
 use monochange_publish::build_publish_command;
+use monochange_publish::build_publish_command_builder;
 use monochange_publish::detect_trusted_publishing_identity;
 use monochange_publish::go_module_path;
 use monochange_publish::merge_publish_resume_report;
@@ -680,7 +682,10 @@ fn enforce_release_attestation_prerequisites(
 			identity.provider().label(),
 		)));
 	}
-	if !builtin_publish_command_supports_registry_provenance(request.registry) {
+	if !build_publish_command_builder()
+		.adapter_for_registry(request.registry)
+		.is_some_and(PublishAdapter::supports_provenance)
+	{
 		return Err(MonochangeError::Config(format!(
 			"`{}` cannot require registry-native package provenance for {} yet. {capability_message} The registry supports provenance, but monochange's current built-in publisher for this ecosystem does not expose a publish command that can require it; set `publish.attestations.require_registry_provenance = false` to opt out or use an external publisher that enforces its own attestation policy.",
 			request.package_id, request.registry,
@@ -688,10 +693,6 @@ fn enforce_release_attestation_prerequisites(
 	}
 
 	Ok(())
-}
-
-fn builtin_publish_command_supports_registry_provenance(registry: RegistryKind) -> bool {
-	matches!(registry, RegistryKind::Npm | RegistryKind::Jsr)
 }
 
 fn reject_npm_token_environment(

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -9,6 +9,7 @@ use std::thread::JoinHandle;
 use std::time::Instant;
 
 #[cfg(feature = "cargo")]
+use monochange_cargo::CargoAdapter;
 use monochange_cargo::discover_cargo_packages;
 #[cfg(feature = "cargo")]
 use monochange_cargo::load_configured_cargo_package;
@@ -21,6 +22,7 @@ use monochange_core::BumpSeverity;
 use monochange_core::CliCommandDefinition;
 use monochange_core::DiscoveryReport;
 use monochange_core::Ecosystem;
+use monochange_core::EcosystemRegistry;
 use monochange_core::LockfileCommandDefinition;
 use monochange_core::LockfileCommandExecution;
 use monochange_core::MonochangeError;
@@ -31,20 +33,25 @@ use monochange_core::ReleasePlan;
 use monochange_core::SourceConfiguration;
 use monochange_core::default_cli_commands;
 #[cfg(feature = "dart")]
+use monochange_dart::DartAdapter;
 use monochange_dart::discover_dart_packages;
 #[cfg(feature = "dart")]
 use monochange_dart::load_configured_dart_package;
 #[cfg(feature = "deno")]
+use monochange_deno::DenoAdapter;
 use monochange_deno::discover_deno_packages;
 #[cfg(feature = "deno")]
 use monochange_deno::load_configured_deno_package;
 #[cfg(feature = "go")]
+use monochange_go::GoAdapter;
 use monochange_go::discover_go_modules;
 #[cfg(feature = "npm")]
+use monochange_npm::NpmAdapter;
 use monochange_npm::discover_npm_packages;
 #[cfg(feature = "npm")]
 use monochange_npm::load_configured_npm_package;
 #[cfg(feature = "python")]
+use monochange_python::PythonAdapter;
 use monochange_python::discover_python_packages;
 use serde_json::json;
 use typed_builder::TypedBuilder;
@@ -591,21 +598,26 @@ fn render_annotated_init_config(
 	Ok(collapsed.trim_start().to_string())
 }
 
-fn discover_packages(root: &Path) -> MonochangeResult<Vec<PackageRecord>> {
-	let mut packages = Vec::new();
-
+fn build_ecosystem_registry() -> EcosystemRegistry {
+	let mut registry = EcosystemRegistry::new();
 	#[cfg(feature = "cargo")]
-	packages.extend(discover_cargo_packages(root)?.packages);
+	registry.push_adapter(Box::new(CargoAdapter));
 	#[cfg(feature = "npm")]
-	packages.extend(discover_npm_packages(root)?.packages);
+	registry.push_adapter(Box::new(NpmAdapter));
 	#[cfg(feature = "deno")]
-	packages.extend(discover_deno_packages(root)?.packages);
+	registry.push_adapter(Box::new(DenoAdapter));
 	#[cfg(feature = "dart")]
-	packages.extend(discover_dart_packages(root)?.packages);
+	registry.push_adapter(Box::new(DartAdapter));
 	#[cfg(feature = "python")]
-	packages.extend(discover_python_packages(root)?.packages);
+	registry.push_adapter(Box::new(PythonAdapter));
 	#[cfg(feature = "go")]
-	packages.extend(discover_go_modules(root)?.packages);
+	registry.push_adapter(Box::new(GoAdapter));
+	registry
+}
+
+fn discover_packages(root: &Path) -> MonochangeResult<Vec<PackageRecord>> {
+	let result = build_ecosystem_registry().discover_all(root)?;
+	let mut packages = result.packages;
 
 	normalize_package_ids(root, &mut packages);
 	packages.sort_by(|left, right| left.id.cmp(&right.id));

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -11,8 +11,6 @@ use std::time::Instant;
 #[cfg(feature = "cargo")]
 use monochange_cargo::CargoAdapter;
 use monochange_cargo::discover_cargo_packages;
-#[cfg(feature = "cargo")]
-use monochange_cargo::load_configured_cargo_package;
 use monochange_config::apply_version_groups;
 use monochange_config::build_changeset_load_context;
 use monochange_config::load_change_signals;
@@ -35,22 +33,13 @@ use monochange_core::default_cli_commands;
 #[cfg(feature = "dart")]
 use monochange_dart::DartAdapter;
 use monochange_dart::discover_dart_packages;
-#[cfg(feature = "dart")]
-use monochange_dart::load_configured_dart_package;
-#[cfg(feature = "deno")]
 use monochange_deno::DenoAdapter;
 use monochange_deno::discover_deno_packages;
-#[cfg(feature = "deno")]
-use monochange_deno::load_configured_deno_package;
-#[cfg(feature = "go")]
 use monochange_go::GoAdapter;
 use monochange_go::discover_go_modules;
 #[cfg(feature = "npm")]
 use monochange_npm::NpmAdapter;
 use monochange_npm::discover_npm_packages;
-#[cfg(feature = "npm")]
-use monochange_npm::load_configured_npm_package;
-#[cfg(feature = "python")]
 use monochange_python::PythonAdapter;
 use monochange_python::discover_python_packages;
 use serde_json::json;
@@ -1018,54 +1007,16 @@ fn discover_release_workspace(
 	let mut packages = Vec::new();
 	for package_definition in &configuration.packages {
 		let path = root.join(&package_definition.path);
-		let package = match package_definition.package_type {
-			#[cfg(feature = "cargo")]
-			PackageType::Cargo => load_configured_cargo_package(root, &path)?,
-			#[cfg(not(feature = "cargo"))]
-			PackageType::Cargo => {
-				return Err(MonochangeError::Config(
-					"the `cargo` feature must be enabled to load Cargo packages".to_string(),
-				));
-			}
-			#[cfg(feature = "npm")]
-			PackageType::Npm => load_configured_npm_package(root, &path)?,
-			#[cfg(not(feature = "npm"))]
-			PackageType::Npm => {
-				return Err(MonochangeError::Config(
-					"the `npm` feature must be enabled to load npm packages".to_string(),
-				));
-			}
-			#[cfg(feature = "deno")]
-			PackageType::Deno => load_configured_deno_package(root, &path)?,
-			#[cfg(not(feature = "deno"))]
-			PackageType::Deno => {
-				return Err(MonochangeError::Config(
-					"the `deno` feature must be enabled to load Deno packages".to_string(),
-				));
-			}
-			#[cfg(feature = "dart")]
-			PackageType::Dart | PackageType::Flutter => load_configured_dart_package(root, &path)?,
-			#[cfg(not(feature = "dart"))]
-			PackageType::Dart | PackageType::Flutter => {
-				return Err(MonochangeError::Config(
-					"the `dart` feature must be enabled to load Dart packages".to_string(),
-				));
-			}
-			_ => {
-				return Err(MonochangeError::Config(format!(
-					"unsupported package type `{}` for `{}`",
-					package_definition.package_type.as_str(),
+		let registry = build_ecosystem_registry();
+		let package = registry
+			.load_configured(root, &path, package_definition.package_type.into())?
+			.ok_or_else(|| {
+				MonochangeError::Discovery(format!(
+					"configured package `{}` at {} could not be discovered",
 					package_definition.id,
-				)));
-			}
-		}
-		.ok_or_else(|| {
-			MonochangeError::Discovery(format!(
-				"configured package `{}` at {} could not be discovered",
-				package_definition.id,
-				package_definition.path.display()
-			))
-		})?;
+					package_definition.path.display()
+				))
+			})?;
 		packages.push(package);
 	}
 

--- a/crates/monochange_cargo/src/lib.rs
+++ b/crates/monochange_cargo/src/lib.rs
@@ -95,6 +95,27 @@ impl EcosystemAdapter for CargoAdapter {
 	fn discover(&self, root: &Path) -> MonochangeResult<AdapterDiscovery> {
 		discover_cargo_packages(root)
 	}
+
+	fn load_configured(
+		&self,
+		root: &Path,
+		package_path: &Path,
+	) -> MonochangeResult<Option<PackageRecord>> {
+		load_configured_cargo_package(root, package_path)
+	}
+
+	fn supported_versioned_file_kind(&self, path: &Path) -> bool {
+		supported_versioned_file_kind(path).is_some()
+	}
+
+	fn validate_versioned_file(
+		&self,
+		full_path: &Path,
+		display_path: &str,
+		custom_fields: Option<&[String]>,
+	) -> MonochangeResult<()> {
+		validate_versioned_file(full_path, display_path, custom_fields)
+	}
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -100,6 +100,7 @@ use monochange_core::CliInputKind;
 use monochange_core::CliStepDefinition;
 use monochange_core::CliStepInputValue;
 use monochange_core::Ecosystem;
+use monochange_core::EcosystemRegistry;
 use monochange_core::EcosystemSettings;
 use monochange_core::EcosystemType;
 use monochange_core::GroupChangelogInclude;
@@ -3230,16 +3231,18 @@ fn path_uses_glob(path: &str) -> bool {
 	path.contains('*') || path.contains('?') || path.contains('[')
 }
 
+fn build_ecosystem_registry() -> EcosystemRegistry {
+	EcosystemRegistry::new()
+		.with_adapter(Box::new(monochange_cargo::CargoAdapter))
+		.with_adapter(Box::new(monochange_npm::NpmAdapter))
+		.with_adapter(Box::new(monochange_deno::DenoAdapter))
+		.with_adapter(Box::new(monochange_dart::DartAdapter))
+		.with_adapter(Box::new(monochange_python::PythonAdapter))
+		.with_adapter(Box::new(monochange_go::GoAdapter))
+}
+
 fn path_is_supported_for_ecosystem(path: &Path, ecosystem_type: EcosystemType) -> bool {
-	match ecosystem_type {
-		EcosystemType::Cargo => monochange_cargo::supported_versioned_file_kind(path).is_some(),
-		EcosystemType::Npm => monochange_npm::supported_versioned_file_kind(path).is_some(),
-		EcosystemType::Deno => monochange_deno::supported_versioned_file_kind(path).is_some(),
-		EcosystemType::Dart => monochange_dart::supported_versioned_file_kind(path).is_some(),
-		EcosystemType::Python => monochange_python::supported_versioned_file_kind(path).is_some(),
-		EcosystemType::Go => monochange_go::supported_versioned_file_kind(path).is_some(),
-		_ => false,
-	}
+	build_ecosystem_registry().supported_versioned_file_kind(path, ecosystem_type.into())
 }
 
 fn source_capabilities(provider: SourceProvider) -> monochange_core::SourceCapabilities {
@@ -4993,24 +4996,12 @@ fn validate_ecosystem_version_readable(
 	owner_kind: &str,
 	owner_id: &str,
 ) -> MonochangeResult<()> {
-	let result = match ecosystem_type {
-		EcosystemType::Cargo => {
-			monochange_cargo::validate_versioned_file(full_path, display_path, fields)
-		}
-		EcosystemType::Npm => {
-			monochange_npm::validate_versioned_file(full_path, display_path, fields)
-		}
-		EcosystemType::Deno => {
-			monochange_deno::validate_versioned_file(full_path, display_path, fields)
-		}
-		EcosystemType::Dart => {
-			monochange_dart::validate_versioned_file(full_path, display_path, fields)
-		}
-		EcosystemType::Python => {
-			monochange_python::validate_versioned_file(full_path, display_path, fields)
-		}
-		EcosystemType::Go => monochange_go::validate_versioned_file(full_path, display_path, fields), _ => return Err(MonochangeError::Config(format!("{owner_kind} `{owner_id}` versioned file `{display_path}` is not supported for the configured ecosystem"))),
-	};
+	let result = build_ecosystem_registry().validate_versioned_file(
+		full_path,
+		display_path,
+		ecosystem_type.into(),
+		fields,
+	);
 
 	result.map_err(|error| match error {
 		MonochangeError::Config(msg) => MonochangeError::Config(format!("{owner_kind} `{owner_id}` {msg}")), other => other,

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -287,6 +287,35 @@ impl fmt::Display for Ecosystem {
 	}
 }
 
+impl std::str::FromStr for Ecosystem {
+	type Err = ();
+
+	fn from_str(string: &str) -> Result<Self, Self::Err> {
+		match string {
+			"cargo" => Ok(Self::Cargo),
+			"npm" => Ok(Self::Npm),
+			"deno" => Ok(Self::Deno),
+			"dart" => Ok(Self::Dart),
+			"flutter" => Ok(Self::Flutter),
+			"python" => Ok(Self::Python),
+			"go" => Ok(Self::Go),
+			_ => Err(()),
+		}
+	}
+}
+
+#[must_use]
+pub fn default_registry_kind_for_ecosystem(ecosystem: Ecosystem) -> Option<RegistryKind> {
+	match ecosystem {
+		Ecosystem::Cargo => Some(RegistryKind::CratesIo),
+		Ecosystem::Npm => Some(RegistryKind::Npm),
+		Ecosystem::Deno => Some(RegistryKind::Jsr),
+		Ecosystem::Dart | Ecosystem::Flutter => Some(RegistryKind::PubDev),
+		Ecosystem::Python => Some(RegistryKind::Pypi),
+		Ecosystem::Go => Some(RegistryKind::GoProxy),
+	}
+}
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -4084,6 +4084,50 @@ pub trait EcosystemAdapter {
 
 /// Build dependency edges by matching declared dependency names to known packages.
 #[must_use]
+/// A registry of ecosystem adapters used to dispatch ecosystem-specific operations.
+///
+/// This replaces hardcoded match arms in workspace discovery, versioned-file validation,
+/// publish command construction, and lockfile command planning.
+#[derive(Default)]
+pub struct EcosystemRegistry {
+	adapters: Vec<Box<dyn EcosystemAdapter>>,
+}
+
+impl EcosystemRegistry {
+	#[must_use]
+	pub fn new() -> Self {
+		Self::default()
+	}
+
+	#[must_use]
+	pub fn with_adapter(mut self, adapter: Box<dyn EcosystemAdapter>) -> Self {
+		self.adapters.push(adapter);
+		self
+	}
+
+	pub fn push_adapter(&mut self, adapter: Box<dyn EcosystemAdapter>) {
+		self.adapters.push(adapter);
+	}
+
+	pub fn discover_all(&self, root: &Path) -> MonochangeResult<AdapterDiscovery> {
+		let mut packages = Vec::new();
+		let mut warnings = Vec::new();
+		for adapter in &self.adapters {
+			let mut result = adapter.discover(root)?;
+			packages.extend(result.packages.drain(..));
+			warnings.extend(result.warnings.drain(..));
+		}
+		Ok(AdapterDiscovery { packages, warnings })
+	}
+
+	pub fn adapter_for_ecosystem(&self, ecosystem: Ecosystem) -> Option<&dyn EcosystemAdapter> {
+		self.adapters
+			.iter()
+			.find(|a| a.ecosystem() == ecosystem)
+			.map(|a| a.as_ref())
+	}
+}
+
 pub fn materialize_dependency_edges(packages: &[PackageRecord]) -> Vec<DependencyEdge> {
 	let mut package_ids_by_name = BTreeMap::<String, Vec<String>>::new();
 	for package in packages {

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -254,6 +254,33 @@ impl Ecosystem {
 	}
 }
 
+impl From<EcosystemType> for Ecosystem {
+	fn from(value: EcosystemType) -> Self {
+		match value {
+			EcosystemType::Cargo => Self::Cargo,
+			EcosystemType::Npm => Self::Npm,
+			EcosystemType::Deno => Self::Deno,
+			EcosystemType::Dart => Self::Dart,
+			EcosystemType::Python => Self::Python,
+			EcosystemType::Go => Self::Go,
+		}
+	}
+}
+
+impl From<PackageType> for Ecosystem {
+	fn from(value: PackageType) -> Self {
+		match value {
+			PackageType::Cargo => Self::Cargo,
+			PackageType::Npm => Self::Npm,
+			PackageType::Deno => Self::Deno,
+			PackageType::Dart => Self::Dart,
+			PackageType::Flutter => Self::Flutter,
+			PackageType::Python => Self::Python,
+			PackageType::Go => Self::Go,
+		}
+	}
+}
+
 impl fmt::Display for Ecosystem {
 	fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
 		formatter.write_str(self.as_str())
@@ -4080,6 +4107,21 @@ pub trait EcosystemAdapter {
 	fn ecosystem(&self) -> Ecosystem;
 
 	fn discover(&self, root: &Path) -> MonochangeResult<AdapterDiscovery>;
+
+	fn load_configured(
+		&self,
+		root: &Path,
+		package_path: &Path,
+	) -> MonochangeResult<Option<PackageRecord>>;
+
+	fn supported_versioned_file_kind(&self, path: &Path) -> bool;
+
+	fn validate_versioned_file(
+		&self,
+		full_path: &Path,
+		display_path: &str,
+		custom_fields: Option<&[String]>,
+	) -> MonochangeResult<()>;
 }
 
 /// Build dependency edges by matching declared dependency names to known packages.
@@ -4094,12 +4136,10 @@ pub struct EcosystemRegistry {
 }
 
 impl EcosystemRegistry {
-	#[must_use]
 	pub fn new() -> Self {
 		Self::default()
 	}
 
-	#[must_use]
 	pub fn with_adapter(mut self, adapter: Box<dyn EcosystemAdapter>) -> Self {
 		self.adapters.push(adapter);
 		self
@@ -4114,8 +4154,8 @@ impl EcosystemRegistry {
 		let mut warnings = Vec::new();
 		for adapter in &self.adapters {
 			let mut result = adapter.discover(root)?;
-			packages.extend(result.packages.drain(..));
-			warnings.extend(result.warnings.drain(..));
+			packages.append(&mut result.packages);
+			warnings.append(&mut result.warnings);
 		}
 		Ok(AdapterDiscovery { packages, warnings })
 	}
@@ -4124,7 +4164,43 @@ impl EcosystemRegistry {
 		self.adapters
 			.iter()
 			.find(|a| a.ecosystem() == ecosystem)
-			.map(|a| a.as_ref())
+			.map(AsRef::as_ref)
+	}
+
+	pub fn load_configured(
+		&self,
+		root: &Path,
+		package_path: &Path,
+		ecosystem: Ecosystem,
+	) -> MonochangeResult<Option<PackageRecord>> {
+		match self.adapter_for_ecosystem(ecosystem) {
+			Some(adapter) => adapter.load_configured(root, package_path),
+			None => Ok(None),
+		}
+	}
+
+	pub fn supported_versioned_file_kind(&self, path: &Path, ecosystem: Ecosystem) -> bool {
+		self.adapter_for_ecosystem(ecosystem)
+			.is_some_and(|adapter| adapter.supported_versioned_file_kind(path))
+	}
+
+	pub fn validate_versioned_file(
+		&self,
+		full_path: &Path,
+		display_path: &str,
+		ecosystem: Ecosystem,
+		custom_fields: Option<&[String]>,
+	) -> MonochangeResult<()> {
+		match self.adapter_for_ecosystem(ecosystem) {
+			Some(adapter) => {
+				adapter.validate_versioned_file(full_path, display_path, custom_fields)
+			}
+			None => {
+				Err(MonochangeError::Config(format!(
+					"no adapter registered for ecosystem `{ecosystem}`"
+				)))
+			}
+		}
 	}
 }
 

--- a/crates/monochange_dart/src/lib.rs
+++ b/crates/monochange_dart/src/lib.rs
@@ -427,6 +427,27 @@ impl EcosystemAdapter for DartAdapter {
 	fn discover(&self, root: &Path) -> MonochangeResult<AdapterDiscovery> {
 		discover_dart_packages(root)
 	}
+
+	fn load_configured(
+		&self,
+		root: &Path,
+		package_path: &Path,
+	) -> MonochangeResult<Option<PackageRecord>> {
+		load_configured_dart_package(root, package_path)
+	}
+
+	fn supported_versioned_file_kind(&self, path: &Path) -> bool {
+		supported_versioned_file_kind(path).is_some()
+	}
+
+	fn validate_versioned_file(
+		&self,
+		full_path: &Path,
+		display_path: &str,
+		custom_fields: Option<&[String]>,
+	) -> MonochangeResult<()> {
+		validate_versioned_file(full_path, display_path, custom_fields)
+	}
 }
 
 #[tracing::instrument(skip_all)]

--- a/crates/monochange_deno/src/lib.rs
+++ b/crates/monochange_deno/src/lib.rs
@@ -215,6 +215,27 @@ impl EcosystemAdapter for DenoAdapter {
 	fn discover(&self, root: &Path) -> MonochangeResult<AdapterDiscovery> {
 		discover_deno_packages(root)
 	}
+
+	fn load_configured(
+		&self,
+		root: &Path,
+		package_path: &Path,
+	) -> MonochangeResult<Option<PackageRecord>> {
+		load_configured_deno_package(root, package_path)
+	}
+
+	fn supported_versioned_file_kind(&self, path: &Path) -> bool {
+		supported_versioned_file_kind(path).is_some()
+	}
+
+	fn validate_versioned_file(
+		&self,
+		full_path: &Path,
+		display_path: &str,
+		custom_fields: Option<&[String]>,
+	) -> MonochangeResult<()> {
+		validate_versioned_file(full_path, display_path, custom_fields)
+	}
 }
 
 #[tracing::instrument(skip_all)]

--- a/crates/monochange_go/src/lib.rs
+++ b/crates/monochange_go/src/lib.rs
@@ -70,6 +70,27 @@ impl EcosystemAdapter for GoAdapter {
 	fn discover(&self, root: &Path) -> MonochangeResult<AdapterDiscovery> {
 		discover_go_modules(root)
 	}
+
+	fn load_configured(
+		&self,
+		_root: &Path,
+		_package_path: &Path,
+	) -> MonochangeResult<Option<PackageRecord>> {
+		Ok(None)
+	}
+
+	fn supported_versioned_file_kind(&self, path: &Path) -> bool {
+		supported_versioned_file_kind(path).is_some()
+	}
+
+	fn validate_versioned_file(
+		&self,
+		full_path: &Path,
+		display_path: &str,
+		custom_fields: Option<&[String]>,
+	) -> MonochangeResult<()> {
+		validate_versioned_file(full_path, display_path, custom_fields)
+	}
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/crates/monochange_npm/src/lib.rs
+++ b/crates/monochange_npm/src/lib.rs
@@ -620,6 +620,27 @@ impl EcosystemAdapter for NpmAdapter {
 	fn discover(&self, root: &Path) -> MonochangeResult<AdapterDiscovery> {
 		discover_npm_packages(root)
 	}
+
+	fn load_configured(
+		&self,
+		root: &Path,
+		package_path: &Path,
+	) -> MonochangeResult<Option<PackageRecord>> {
+		load_configured_npm_package(root, package_path)
+	}
+
+	fn supported_versioned_file_kind(&self, path: &Path) -> bool {
+		supported_versioned_file_kind(path).is_some()
+	}
+
+	fn validate_versioned_file(
+		&self,
+		full_path: &Path,
+		display_path: &str,
+		custom_fields: Option<&[String]>,
+	) -> MonochangeResult<()> {
+		validate_versioned_file(full_path, display_path, custom_fields)
+	}
 }
 
 #[tracing::instrument(skip_all)]

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -119,6 +119,18 @@ pub trait PublishAdapter {
 		placeholder_path: &Path,
 	) -> Option<CommandSpec>;
 	fn build_release_command(&self, request: &PublishRequest) -> Option<CommandSpec>;
+	fn append_dry_run_args(&self, args: &mut Vec<String>) {
+		args.push("--dry-run".to_string());
+	}
+	fn supported_providers(&self) -> Vec<CiProviderKind> {
+		Vec::new()
+	}
+	fn registry_setup_url(&self) -> Option<&'static str> {
+		None
+	}
+	fn registry_notes(&self) -> Vec<String> {
+		vec!["unknown registry capabilities are treated as unsupported".to_string()]
+	}
 }
 
 /// Registry of publish adapters used to dispatch publish command construction.
@@ -168,7 +180,9 @@ impl PublishCommandBuilder {
 			PackagePublishRunMode::Release => adapter.build_release_command(request),
 		}
 		.expect("unsupported publish mode for this registry");
-		append_publish_dry_run_args(&mut command.args, request.registry, dry_run);
+		if dry_run {
+			adapter.append_dry_run_args(&mut command.args);
+		}
 		command
 	}
 }
@@ -261,6 +275,21 @@ impl PublishAdapter for NpmPublishAdapter {
 	fn build_release_command(&self, request: &PublishRequest) -> Option<CommandSpec> {
 		Some(build_npm_release_publish_command(request))
 	}
+
+	fn supported_providers(&self) -> Vec<CiProviderKind> {
+		vec![CiProviderKind::GitHubActions, CiProviderKind::GitLabCi]
+	}
+
+	fn registry_setup_url(&self) -> Option<&'static str> {
+		Some("https://docs.npmjs.com/trusted-publishers")
+	}
+
+	fn registry_notes(&self) -> Vec<String> {
+		[
+			"npm trusted publishing supports GitHub Actions and GitLab CI/CD".to_string(),
+			"monochange can verify and automate npm GitHub trusted-publisher setup with npm CLI trust commands".to_string(),
+		].to_vec()
+	}
 }
 
 struct CargoPublishAdapter;
@@ -284,6 +313,23 @@ impl PublishAdapter for CargoPublishAdapter {
 	fn build_release_command(&self, request: &PublishRequest) -> Option<CommandSpec> {
 		Some(build_cargo_release_publish_command(request))
 	}
+
+	fn supported_providers(&self) -> Vec<CiProviderKind> {
+		vec![CiProviderKind::GitHubActions]
+	}
+
+	fn registry_setup_url(&self) -> Option<&'static str> {
+		Some("https://crates.io/docs/trusted-publishing")
+	}
+
+	fn registry_notes(&self) -> Vec<String> {
+		[
+			"crates.io trusted publishing uses OIDC short-lived tokens".to_string(),
+			"monochange does not currently verify crates.io registry-side trusted-publisher setup"
+				.to_string(),
+		]
+		.to_vec()
+	}
 }
 
 struct DartPublishAdapter;
@@ -303,6 +349,30 @@ impl PublishAdapter for DartPublishAdapter {
 
 	fn build_release_command(&self, request: &PublishRequest) -> Option<CommandSpec> {
 		Some(build_dart_publish_command(request, &request.package_root))
+	}
+
+	fn append_dry_run_args(&self, args: &mut Vec<String>) {
+		args.retain(|arg| arg != "--force");
+		args.push("--dry-run".to_string());
+	}
+
+	fn supported_providers(&self) -> Vec<CiProviderKind> {
+		vec![
+			CiProviderKind::GitHubActions,
+			CiProviderKind::GoogleCloudBuild,
+		]
+	}
+
+	fn registry_setup_url(&self) -> Option<&'static str> {
+		Some("https://dart.dev/tools/pub/automated-publishing")
+	}
+
+	fn registry_notes(&self) -> Vec<String> {
+		[
+			"pub.dev automated publishing uses configured OIDC publishers".to_string(),
+			"pub.dev registry-side publisher setup requires manual review".to_string(),
+		]
+		.to_vec()
 	}
 }
 
@@ -324,6 +394,21 @@ impl PublishAdapter for JsrPublishAdapter {
 	fn build_release_command(&self, request: &PublishRequest) -> Option<CommandSpec> {
 		Some(build_jsr_publish_command(&request.package_root))
 	}
+
+	fn supported_providers(&self) -> Vec<CiProviderKind> {
+		vec![CiProviderKind::GitHubActions]
+	}
+
+	fn registry_setup_url(&self) -> Option<&'static str> {
+		Some("https://jsr.io/docs/publishing-packages")
+	}
+
+	fn registry_notes(&self) -> Vec<String> {
+		[
+			"JSR can publish from supported CI without long-lived tokens".to_string(),
+			"JSR package provenance is available, but monochange does not verify registry-side setup".to_string(),
+		].to_vec()
+	}
 }
 
 struct PythonPublishAdapter;
@@ -344,6 +429,29 @@ impl PublishAdapter for PythonPublishAdapter {
 	fn build_release_command(&self, request: &PublishRequest) -> Option<CommandSpec> {
 		Some(build_python_publish_command(request, &request.package_root))
 	}
+
+	fn append_dry_run_args(&self, _args: &mut Vec<String>) {}
+
+	fn supported_providers(&self) -> Vec<CiProviderKind> {
+		vec![
+			CiProviderKind::GitHubActions,
+			CiProviderKind::GitLabCi,
+			CiProviderKind::GoogleCloudBuild,
+		]
+	}
+
+	fn registry_setup_url(&self) -> Option<&'static str> {
+		Some("https://docs.pypi.org/trusted-publishers/")
+	}
+
+	fn registry_notes(&self) -> Vec<String> {
+		[
+			"PyPI Trusted Publishers support multiple CI identity providers".to_string(),
+			"PEP 740 digital attestations are separate from trusted-publisher authorization"
+				.to_string(),
+		]
+		.to_vec()
+	}
 }
 
 struct GoPublishAdapter;
@@ -363,6 +471,20 @@ impl PublishAdapter for GoPublishAdapter {
 
 	fn build_release_command(&self, request: &PublishRequest) -> Option<CommandSpec> {
 		Some(build_go_publish_command(request))
+	}
+
+	fn append_dry_run_args(&self, _args: &mut Vec<String>) {}
+
+	fn supported_providers(&self) -> Vec<CiProviderKind> {
+		Vec::new()
+	}
+
+	fn registry_setup_url(&self) -> Option<&'static str> {
+		None
+	}
+
+	fn registry_notes(&self) -> Vec<String> {
+		["unknown registry capabilities are treated as unsupported".to_string()].to_vec()
 	}
 }
 
@@ -898,61 +1020,24 @@ pub fn trusted_publishing_capability_message(
 }
 
 fn supported_providers_for_registry(registry: RegistryKind) -> Vec<CiProviderKind> {
-	match registry {
-		RegistryKind::Npm => vec![CiProviderKind::GitHubActions, CiProviderKind::GitLabCi],
-		RegistryKind::CratesIo | RegistryKind::Jsr => vec![CiProviderKind::GitHubActions],
-		RegistryKind::PubDev => {
-			vec![
-				CiProviderKind::GitHubActions,
-				CiProviderKind::GoogleCloudBuild,
-			]
-		}
-		RegistryKind::Pypi => {
-			vec![
-				CiProviderKind::GitHubActions,
-				CiProviderKind::GitLabCi,
-				CiProviderKind::GoogleCloudBuild,
-			]
-		}
-		_ => Vec::new(),
-	}
+	build_publish_command_builder()
+		.adapter_for_registry(registry)
+		.map_or_else(Vec::new, PublishAdapter::supported_providers)
 }
 
 fn registry_setup_url(registry: RegistryKind) -> Option<&'static str> {
-	match registry {
-		RegistryKind::Npm => Some("https://docs.npmjs.com/trusted-publishers"),
-		RegistryKind::CratesIo => Some("https://crates.io/docs/trusted-publishing"),
-		RegistryKind::Jsr => Some("https://jsr.io/docs/publishing-packages"),
-		RegistryKind::PubDev => Some("https://dart.dev/tools/pub/automated-publishing"),
-		RegistryKind::Pypi => Some("https://docs.pypi.org/trusted-publishers/"),
-		_ => None,
-	}
+	build_publish_command_builder()
+		.adapter_for_registry(registry)
+		.and_then(PublishAdapter::registry_setup_url)
 }
 
 fn registry_notes(registry: RegistryKind) -> Vec<String> {
-	match registry {
-		RegistryKind::Npm => vec![
-			"npm trusted publishing supports GitHub Actions and GitLab CI/CD".to_string(),
-			"monochange can verify and automate npm GitHub trusted-publisher setup with npm CLI trust commands".to_string(),
-		],
-		RegistryKind::CratesIo => vec![
-			"crates.io trusted publishing uses OIDC short-lived tokens".to_string(),
-			"monochange does not currently verify crates.io registry-side trusted-publisher setup".to_string(),
-		],
-		RegistryKind::Jsr => vec![
-			"JSR can publish from supported CI without long-lived tokens".to_string(),
-			"JSR package provenance is available, but monochange does not verify registry-side setup".to_string(),
-		],
-		RegistryKind::PubDev => vec![
-			"pub.dev automated publishing uses configured OIDC publishers".to_string(),
-			"pub.dev registry-side publisher setup requires manual review".to_string(),
-		],
-		RegistryKind::Pypi => vec![
-			"PyPI Trusted Publishers support multiple CI identity providers".to_string(),
-			"PEP 740 digital attestations are separate from trusted-publisher authorization".to_string(),
-		],
-		_ => vec!["unknown registry capabilities are treated as unsupported".to_string()],
-	}
+	build_publish_command_builder()
+		.adapter_for_registry(registry)
+		.map_or_else(
+			|| vec!["unknown registry capabilities are treated as unsupported".to_string()],
+			PublishAdapter::registry_notes,
+		)
 }
 
 fn provider_list(providers: &[CiProviderKind]) -> String {

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -131,6 +131,9 @@ pub trait PublishAdapter {
 	fn registry_notes(&self) -> Vec<String> {
 		vec!["unknown registry capabilities are treated as unsupported".to_string()]
 	}
+	fn supports_provenance(&self) -> bool {
+		false
+	}
 }
 
 /// Registry of publish adapters used to dispatch publish command construction.
@@ -155,7 +158,7 @@ impl PublishCommandBuilder {
 		self.adapters.push(adapter);
 	}
 
-	fn adapter_for_registry(&self, registry: RegistryKind) -> Option<&dyn PublishAdapter> {
+	pub fn adapter_for_registry(&self, registry: RegistryKind) -> Option<&dyn PublishAdapter> {
 		self.adapters
 			.iter()
 			.find(|adapter| adapter.registry_kind() == registry)
@@ -244,7 +247,7 @@ pub fn build_publish_command(
 	build_publish_command_builder().build_publish_command(request, mode, placeholder_dir, dry_run)
 }
 
-fn build_publish_command_builder() -> PublishCommandBuilder {
+pub fn build_publish_command_builder() -> PublishCommandBuilder {
 	PublishCommandBuilder::new()
 		.with_adapter(Box::new(NpmPublishAdapter))
 		.with_adapter(Box::new(CargoPublishAdapter))
@@ -259,6 +262,10 @@ struct NpmPublishAdapter;
 impl PublishAdapter for NpmPublishAdapter {
 	fn registry_kind(&self) -> RegistryKind {
 		RegistryKind::Npm
+	}
+
+	fn supports_provenance(&self) -> bool {
+		true
 	}
 
 	fn build_placeholder_command(
@@ -381,6 +388,10 @@ struct JsrPublishAdapter;
 impl PublishAdapter for JsrPublishAdapter {
 	fn registry_kind(&self) -> RegistryKind {
 		RegistryKind::Jsr
+	}
+
+	fn supports_provenance(&self) -> bool {
+		true
 	}
 
 	fn build_placeholder_command(

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -110,6 +110,69 @@ pub struct CommandSpec {
 	pub cwd: PathBuf,
 }
 
+/// Adapter for building ecosystem-specific publish commands.
+pub trait PublishAdapter {
+	fn registry_kind(&self) -> RegistryKind;
+	fn build_placeholder_command(
+		&self,
+		request: &PublishRequest,
+		placeholder_path: &Path,
+	) -> Option<CommandSpec>;
+	fn build_release_command(&self, request: &PublishRequest) -> Option<CommandSpec>;
+}
+
+/// Registry of publish adapters used to dispatch publish command construction.
+#[derive(Default)]
+pub struct PublishCommandBuilder {
+	adapters: Vec<Box<dyn PublishAdapter>>,
+}
+
+impl PublishCommandBuilder {
+	#[must_use]
+	pub fn new() -> Self {
+		Self::default()
+	}
+
+	#[must_use]
+	pub fn with_adapter(mut self, adapter: Box<dyn PublishAdapter>) -> Self {
+		self.adapters.push(adapter);
+		self
+	}
+
+	pub fn push_adapter(&mut self, adapter: Box<dyn PublishAdapter>) {
+		self.adapters.push(adapter);
+	}
+
+	fn adapter_for_registry(&self, registry: RegistryKind) -> Option<&dyn PublishAdapter> {
+		self.adapters
+			.iter()
+			.find(|adapter| adapter.registry_kind() == registry)
+			.map(AsRef::as_ref)
+	}
+
+	pub fn build_publish_command(
+		&self,
+		request: &PublishRequest,
+		mode: PackagePublishRunMode,
+		placeholder_dir: Option<&Path>,
+		dry_run: bool,
+	) -> CommandSpec {
+		let adapter = self
+			.adapter_for_registry(request.registry)
+			.expect("unsupported built-in publish registry");
+		let mut command = match mode {
+			PackagePublishRunMode::Placeholder => {
+				let path = placeholder_dir.expect("placeholder directory must exist");
+				adapter.build_placeholder_command(request, path)
+			}
+			PackagePublishRunMode::Release => adapter.build_release_command(request),
+		}
+		.expect("unsupported publish mode for this registry");
+		append_publish_dry_run_args(&mut command.args, request.registry, dry_run);
+		command
+	}
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct CommandOutput {
 	pub success: bool,
@@ -164,55 +227,143 @@ pub fn build_publish_command(
 	placeholder_dir: Option<&Path>,
 	dry_run: bool,
 ) -> CommandSpec {
-	let mut command = None;
-	let is_jsr_release =
-		request.registry == RegistryKind::Jsr && mode == PackagePublishRunMode::Release;
-	let placeholder_path = placeholder_dir;
-	if request.registry == RegistryKind::Npm && mode == PackagePublishRunMode::Placeholder {
-		command = Some(build_npm_placeholder_publish_command(
-			request,
-			placeholder_path.expect("placeholder directory must exist"),
-		));
-	} else if request.registry == RegistryKind::Npm && mode == PackagePublishRunMode::Release {
-		command = Some(build_npm_release_publish_command(request));
-	} else if request.registry == RegistryKind::CratesIo
-		&& mode == PackagePublishRunMode::Placeholder
-	{
-		command = Some(build_cargo_placeholder_publish_command(
-			request,
-			placeholder_path.expect("placeholder directory must exist"),
-		));
-	} else if request.registry == RegistryKind::CratesIo && mode == PackagePublishRunMode::Release {
-		command = Some(build_cargo_release_publish_command(request));
-	} else if request.registry == RegistryKind::PubDev && mode == PackagePublishRunMode::Placeholder
-	{
-		command = Some(build_dart_publish_command(
-			request,
-			placeholder_path.expect("placeholder directory must exist"),
-		));
-	} else if request.registry == RegistryKind::PubDev && mode == PackagePublishRunMode::Release {
-		command = Some(build_dart_publish_command(request, &request.package_root));
-	} else if request.registry == RegistryKind::Jsr && mode == PackagePublishRunMode::Placeholder {
-		command = Some(build_jsr_publish_command(
-			placeholder_path.expect("placeholder directory must exist"),
-		));
-	} else if request.registry == RegistryKind::Pypi && mode == PackagePublishRunMode::Placeholder {
-		command = Some(build_python_publish_command(
-			request,
-			placeholder_path.expect("placeholder directory must exist"),
-		));
-	} else if request.registry == RegistryKind::Pypi && mode == PackagePublishRunMode::Release {
-		command = Some(build_python_publish_command(request, &request.package_root));
-	} else if request.registry == RegistryKind::GoProxy {
-		command = Some(build_go_publish_command(request));
-	}
-	if is_jsr_release {
-		command = Some(build_jsr_publish_command(&request.package_root));
+	build_publish_command_builder().build_publish_command(request, mode, placeholder_dir, dry_run)
+}
+
+fn build_publish_command_builder() -> PublishCommandBuilder {
+	PublishCommandBuilder::new()
+		.with_adapter(Box::new(NpmPublishAdapter))
+		.with_adapter(Box::new(CargoPublishAdapter))
+		.with_adapter(Box::new(DartPublishAdapter))
+		.with_adapter(Box::new(JsrPublishAdapter))
+		.with_adapter(Box::new(PythonPublishAdapter))
+		.with_adapter(Box::new(GoPublishAdapter))
+}
+
+struct NpmPublishAdapter;
+
+impl PublishAdapter for NpmPublishAdapter {
+	fn registry_kind(&self) -> RegistryKind {
+		RegistryKind::Npm
 	}
 
-	let mut command = command.expect("unsupported built-in publish registry");
-	append_publish_dry_run_args(&mut command.args, request.registry, dry_run);
-	command
+	fn build_placeholder_command(
+		&self,
+		request: &PublishRequest,
+		placeholder_path: &Path,
+	) -> Option<CommandSpec> {
+		Some(build_npm_placeholder_publish_command(
+			request,
+			placeholder_path,
+		))
+	}
+
+	fn build_release_command(&self, request: &PublishRequest) -> Option<CommandSpec> {
+		Some(build_npm_release_publish_command(request))
+	}
+}
+
+struct CargoPublishAdapter;
+
+impl PublishAdapter for CargoPublishAdapter {
+	fn registry_kind(&self) -> RegistryKind {
+		RegistryKind::CratesIo
+	}
+
+	fn build_placeholder_command(
+		&self,
+		request: &PublishRequest,
+		placeholder_path: &Path,
+	) -> Option<CommandSpec> {
+		Some(build_cargo_placeholder_publish_command(
+			request,
+			placeholder_path,
+		))
+	}
+
+	fn build_release_command(&self, request: &PublishRequest) -> Option<CommandSpec> {
+		Some(build_cargo_release_publish_command(request))
+	}
+}
+
+struct DartPublishAdapter;
+
+impl PublishAdapter for DartPublishAdapter {
+	fn registry_kind(&self) -> RegistryKind {
+		RegistryKind::PubDev
+	}
+
+	fn build_placeholder_command(
+		&self,
+		request: &PublishRequest,
+		placeholder_path: &Path,
+	) -> Option<CommandSpec> {
+		Some(build_dart_publish_command(request, placeholder_path))
+	}
+
+	fn build_release_command(&self, request: &PublishRequest) -> Option<CommandSpec> {
+		Some(build_dart_publish_command(request, &request.package_root))
+	}
+}
+
+struct JsrPublishAdapter;
+
+impl PublishAdapter for JsrPublishAdapter {
+	fn registry_kind(&self) -> RegistryKind {
+		RegistryKind::Jsr
+	}
+
+	fn build_placeholder_command(
+		&self,
+		_request: &PublishRequest,
+		placeholder_path: &Path,
+	) -> Option<CommandSpec> {
+		Some(build_jsr_publish_command(placeholder_path))
+	}
+
+	fn build_release_command(&self, request: &PublishRequest) -> Option<CommandSpec> {
+		Some(build_jsr_publish_command(&request.package_root))
+	}
+}
+
+struct PythonPublishAdapter;
+
+impl PublishAdapter for PythonPublishAdapter {
+	fn registry_kind(&self) -> RegistryKind {
+		RegistryKind::Pypi
+	}
+
+	fn build_placeholder_command(
+		&self,
+		request: &PublishRequest,
+		placeholder_path: &Path,
+	) -> Option<CommandSpec> {
+		Some(build_python_publish_command(request, placeholder_path))
+	}
+
+	fn build_release_command(&self, request: &PublishRequest) -> Option<CommandSpec> {
+		Some(build_python_publish_command(request, &request.package_root))
+	}
+}
+
+struct GoPublishAdapter;
+
+impl PublishAdapter for GoPublishAdapter {
+	fn registry_kind(&self) -> RegistryKind {
+		RegistryKind::GoProxy
+	}
+
+	fn build_placeholder_command(
+		&self,
+		_request: &PublishRequest,
+		_placeholder_path: &Path,
+	) -> Option<CommandSpec> {
+		None
+	}
+
+	fn build_release_command(&self, request: &PublishRequest) -> Option<CommandSpec> {
+		Some(build_go_publish_command(request))
+	}
 }
 
 pub fn append_publish_dry_run_args(args: &mut Vec<String>, registry: RegistryKind, dry_run: bool) {

--- a/crates/monochange_python/src/lib.rs
+++ b/crates/monochange_python/src/lib.rs
@@ -129,6 +129,27 @@ impl EcosystemAdapter for PythonAdapter {
 	fn discover(&self, root: &Path) -> MonochangeResult<AdapterDiscovery> {
 		discover_python_packages(root)
 	}
+
+	fn load_configured(
+		&self,
+		_root: &Path,
+		_package_path: &Path,
+	) -> MonochangeResult<Option<PackageRecord>> {
+		Ok(None)
+	}
+
+	fn supported_versioned_file_kind(&self, path: &Path) -> bool {
+		supported_versioned_file_kind(path).is_some()
+	}
+
+	fn validate_versioned_file(
+		&self,
+		full_path: &Path,
+		display_path: &str,
+		custom_fields: Option<&[String]>,
+	) -> MonochangeResult<()> {
+		validate_versioned_file(full_path, display_path, custom_fields)
+	}
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]


### PR DESCRIPTION
This PR introduces EcosystemRegistry in monochange_core and replaces the hardcoded discovery match arms in workspace_ops::discover_packages with registry-based adapter dispatch.

Foundation for the consolidated Phase 3+ adapter trait architecture:
- EcosystemRegistry collects Box\u003cdyn EcosystemAdapter\u003e instances and dispatches discover_all across registered adapters.
- workspace_ops::discover_packages now builds a registry from feature-gated adapters and calls discover_all instead of enumerating discover_cargo_packages, discover_npm_packages, etc. individually.
- Remaining match arms in package_publish.rs, workspace_ops.rs, and monochange_config will follow in future PRs as adapter traits are expanded.

Validation run locally:
- cargo check -p monochange
- cargo check -p monochange_core