### PR TITLE
refactor: sort release targets and hash identity fields directly

### DIFF
--- a/.changeset/sort-and-hash-identity-fields.md
+++ b/.changeset/sort-and-hash-identity-fields.md
@@ -1,0 +1,9 @@
+---
+monochange: minor
+---
+
+# Sort release targets and hash identity fields directly
+
+`release_targets_hash` now sorts targets by `(id, kind, version)` before hashing and only feeds identity fields (`id`, `kind`, `version`) into the hasher. Operational flags (`tag`, `release`, `tag_name`, `version_format`, `members`) are excluded from the hash so that path identity matches release identity.
+
+`ReleasePaths::from_manifest` computes the hash directly from the manifest without building the intermediate `ReleaseRecord`, and `write_release_record_file` now checks file existence before doing any expensive work.

--- a/crates/monochange/src/__tests__/release_artifacts_tests.rs
+++ b/crates/monochange/src/__tests__/release_artifacts_tests.rs
@@ -736,7 +736,7 @@ fn release_paths_from_manifest_computes_hash_relative_and_absolute() {
 			compatibility_evidence: vec![],
 		},
 	};
-	let paths = ReleasePaths::from_manifest(&root, None, &manifest);
+	let paths = ReleasePaths::from_manifest(&root, &manifest);
 	assert!(!paths.hash.is_empty());
 	assert_eq!(
 		paths.relative,
@@ -782,7 +782,7 @@ fn release_paths_from_record_produces_same_hash_as_from_manifest() {
 			compatibility_evidence: vec![],
 		},
 	};
-	let from_manifest = ReleasePaths::from_manifest(&root, None, &manifest);
+	let from_manifest = ReleasePaths::from_manifest(&root, &manifest);
 	let record = build_release_record(None, &manifest);
 	let from_record = ReleasePaths::from_record(&root, &record);
 	assert_eq!(from_manifest.hash, from_record.hash);

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -1405,8 +1405,7 @@ pub(crate) fn write_release_record_file(
 	source: Option<&SourceConfiguration>,
 	manifest: &ReleaseManifest,
 ) -> MonochangeResult<PathBuf> {
-	let record = build_release_record(source, manifest);
-	let paths = ReleasePaths::from_record(root, &record);
+	let paths = ReleasePaths::from_manifest(root, manifest);
 
 	// If the record already exists, return it without overwriting so that
 	// subsequent PrepareRelease steps (for example during `mc release-pr`)
@@ -1415,6 +1414,7 @@ pub(crate) fn write_release_record_file(
 		return Ok(paths.absolute);
 	}
 
+	let record = build_release_record(source, manifest);
 	deduplicate_overlapping_release_records(
 		root,
 		&record.release_targets,
@@ -1498,26 +1498,86 @@ impl ReleasePaths {
 	///
 	/// This builds the intermediate `ReleaseRecord` internally, so prefer
 	/// `from_record` when the record is already available.
-	#[allow(dead_code)]
-	pub fn from_manifest(
-		root: &Path,
-		source: Option<&SourceConfiguration>,
-		manifest: &ReleaseManifest,
-	) -> Self {
-		let record = build_release_record(source, manifest);
-		Self::from_record(root, &record)
+	/// Compute paths directly from a `ReleaseManifest`.
+	///
+	/// Unlike `from_record`, this does **not** build the intermediate
+	/// `ReleaseRecord`. The hash is derived from `manifest.release_targets`
+	/// directly so callers can check file existence before doing expensive work.
+	pub fn from_manifest(root: &Path, manifest: &ReleaseManifest) -> Self {
+		let hash = release_targets_hash(&manifest.release_targets);
+		let relative = PathBuf::from(".monochange/releases")
+			.join(&hash)
+			.join("release.json");
+		let absolute = root.join(&relative);
+		Self {
+			hash,
+			relative,
+			absolute,
+		}
 	}
 }
 
-fn release_targets_hash(release_targets: &[ReleaseRecordTarget]) -> String {
+/// Identity-aware hash for a slice of release targets.
+///
+/// The hash is deterministic: targets are sorted by `(id, kind, version)`
+/// before hashing so that manifest order never affects the path.
+///
+/// Fields included in the hash: `id`, `kind`, `version`.
+/// Excluded: `tag`, `release`, `tag_name`, `version_format`, `members`.
+fn release_targets_hash<T: ReleaseTargetIdentity>(release_targets: &[T]) -> String {
 	use std::collections::hash_map::DefaultHasher;
 	use std::hash::Hasher;
 	let mut hasher = DefaultHasher::new();
-	for target in release_targets {
-		hasher.write(target.id.as_bytes());
-		hasher.write(target.version.as_bytes());
+	let mut sorted: Vec<&T> = release_targets.iter().collect();
+	sorted.sort_by(|a, b| {
+		a.id()
+			.cmp(b.id())
+			.then_with(|| a.kind().as_str().cmp(b.kind().as_str()))
+			.then_with(|| a.version().cmp(b.version()))
+	});
+	for target in sorted {
+		hasher.write(target.id().as_bytes());
+		hasher.write(target.kind().as_str().as_bytes());
+		hasher.write(target.version().as_bytes());
 	}
 	format!("{:016x}", hasher.finish())
+}
+
+/// Trait exposing the identity fields that participate in the release-target
+/// hash. Implemented for both `ReleaseManifestTarget` and `ReleaseRecordTarget`
+/// so that `release_targets_hash` can work with either slice type.
+trait ReleaseTargetIdentity {
+	fn id(&self) -> &str;
+	fn kind(&self) -> ReleaseOwnerKind;
+	fn version(&self) -> &str;
+}
+
+impl ReleaseTargetIdentity for ReleaseManifestTarget {
+	fn id(&self) -> &str {
+		&self.id
+	}
+
+	fn kind(&self) -> ReleaseOwnerKind {
+		self.kind
+	}
+
+	fn version(&self) -> &str {
+		&self.version
+	}
+}
+
+impl ReleaseTargetIdentity for ReleaseRecordTarget {
+	fn id(&self) -> &str {
+		&self.id
+	}
+
+	fn kind(&self) -> ReleaseOwnerKind {
+		self.kind
+	}
+
+	fn version(&self) -> &str {
+		&self.version
+	}
 }
 
 fn deduplicate_overlapping_release_records(


### PR DESCRIPTION
Closes #430.

- Sort targets by (id, kind, version) before hashing for deterministic paths regardless of manifest order.
- Hash only identity fields (id, kind, version), excluding operational flags.
- Make `release_targets_hash` generic over both `ReleaseManifestTarget` and `ReleaseRecordTarget`.
- Update `ReleasePaths::from_manifest` to compute hash without building the full `ReleaseRecord`.
- Move file-existence check in `write_release_record_file` before expensive record build.

This removes the JSON allocation in the hash path and enables early-existence checks.
