### PR TITLE
refactor: persistent dedup index and content-hash fast path

### DIFF
--- a/.changeset/persistent-release-index.md
+++ b/.changeset/persistent-release-index.md
@@ -4,9 +4,4 @@ monochange: minor
 
 # Add persistent deduplication index and content-hash fast path for release records
 
-Introduce a JSONL index at `.monochange/local/release-index.jsonl` that survives
-across CLI invocations, eliminating repeated directory scans when checking for
-duplicate release records. A fast path in `validate_release_record_file` now
-compares the `releaseTargets` identity of an existing file against the manifest
-before rebuilding the full `ReleaseRecord`, skipping unnecessary I/O when the
-targets match.
+Introduce a JSONL index at `.monochange/local/release-index.jsonl` that survives across CLI invocations, eliminating repeated directory scans when checking for duplicate release records. A fast path in `validate_release_record_file` now compares the `releaseTargets` identity of an existing file against the manifest before rebuilding the full `ReleaseRecord`, skipping unnecessary I/O when the targets match.

--- a/.changeset/persistent-release-index.md
+++ b/.changeset/persistent-release-index.md
@@ -1,0 +1,12 @@
+---
+monochange: minor
+---
+
+# Add persistent deduplication index and content-hash fast path for release records
+
+Introduce a JSONL index at `.monochange/local/release-index.jsonl` that survives
+across CLI invocations, eliminating repeated directory scans when checking for
+duplicate release records. A fast path in `validate_release_record_file` now
+compares the `releaseTargets` identity of an existing file against the manifest
+before rebuilding the full `ReleaseRecord`, skipping unnecessary I/O when the
+targets match.

--- a/crates/monochange/src/__tests/release_artifacts_tests.rs
+++ b/crates/monochange/src/__tests/release_artifacts_tests.rs
@@ -1,1 +1,0 @@
-fatal: path 'crates/monochange/src/__tests/release_artifacts_tests.rs' exists on disk, but not in 'origin/main'

--- a/crates/monochange/src/__tests/release_artifacts_tests.rs
+++ b/crates/monochange/src/__tests/release_artifacts_tests.rs
@@ -1,0 +1,1 @@
+fatal: path 'crates/monochange/src/__tests/release_artifacts_tests.rs' exists on disk, but not in 'origin/main'

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -13877,13 +13877,25 @@ fn validate_release_record_file_reports_error_when_dedupe_cannot_read_releases_d
 		.unwrap_or_else(|error| panic!("write record: {error}"));
 	assert!(record_path.exists());
 
+	// Mutate the file so the fast path (target identity match) is skipped.
+	let content =
+		fs::read_to_string(&record_path).unwrap_or_else(|error| panic!("read record: {error}"));
+	let mutated = content.replace("pkg-a", "mutated-pkg");
+	fs::write(&record_path, mutated)
+		.unwrap_or_else(|error| panic!("write mutated record: {error}"));
+
+	// Clear both caches so deduplication must scan the directory.
+	let index_path = root.join(".monochange/local/release-index.jsonl");
+	let _ = fs::remove_file(&index_path);
+	crate::release_artifacts::clear_dedup_cache();
+
 	// Remove read permission from the releases directory so dedupe cannot iterate.
 	let releases_dir = root.join(".monochange/releases");
 	let mut permissions = fs::metadata(&releases_dir)
 		.unwrap_or_else(|error| panic!("metadata: {error}"))
 		.permissions();
 	let original_mode = permissions.mode();
-	permissions.set_mode(0o100);
+	permissions.set_mode(0o000);
 	fs::set_permissions(&releases_dir, permissions)
 		.unwrap_or_else(|error| panic!("set permissions: {error}"));
 

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -50,6 +50,10 @@ use crate::render_change_target_markdown;
 use crate::run_with_args;
 use crate::run_with_args_in_dir;
 
+fn clear_dedup_cache() {
+	crate::release_artifacts::DEDUPLICATED_CACHE.with(|cache| cache.borrow_mut().clear());
+}
+
 #[allow(unused_macro_rules)]
 macro_rules! assert_readable_json_snapshot {
 	($value:expr) => {{
@@ -13887,7 +13891,7 @@ fn validate_release_record_file_reports_error_when_dedupe_cannot_read_releases_d
 	// Clear both caches so deduplication must scan the directory.
 	let index_path = root.join(".monochange/local/release-index.jsonl");
 	let _ = fs::remove_file(&index_path);
-	crate::release_artifacts::clear_dedup_cache();
+	clear_dedup_cache();
 
 	// Remove read permission from the releases directory so dedupe cannot iterate.
 	let releases_dir = root.join(".monochange/releases");

--- a/crates/monochange/src/__tests__/release_artifacts_tests.rs
+++ b/crates/monochange/src/__tests__/release_artifacts_tests.rs
@@ -956,3 +956,109 @@ fn write_release_record_file_updates_persistent_index() {
 	let index = load_dedup_index(root);
 	assert!(index.contains(&paths.hash));
 }
+
+#[test]
+fn load_dedup_index_skips_empty_and_invalid_lines() {
+	let tmp = tempdir().unwrap();
+	let root = tmp.path();
+	let index_path = root.join(".monochange/local/release-index.jsonl");
+	fs::create_dir_all(index_path.parent().unwrap()).unwrap();
+	fs::write(
+		&index_path,
+		"\n\n  \nnot-json\n{\"hash\":\"valid\"}\n\n{\"broken\n",
+	)
+	.unwrap();
+
+	let index = load_dedup_index(root);
+	assert_eq!(index.len(), 1);
+	assert!(index.contains("valid"));
+}
+
+#[test]
+#[cfg(unix)]
+fn save_dedup_index_reports_io_errors() {
+	use std::os::unix::fs::PermissionsExt;
+
+	let tmp = tempdir().unwrap();
+	let root = tmp.path();
+
+	// Create a file at the exact path where the directory should be,
+	// so create_dir_all fails.
+	let local_path = root.join(".monochange/local");
+	fs::create_dir_all(local_path.parent().unwrap()).unwrap();
+	fs::write(&local_path, "block").unwrap();
+	let result = save_dedup_index(root, &std::collections::HashSet::new());
+	assert!(result.is_err());
+
+	// Restore directory and make it unwritable.
+	fs::remove_file(&local_path).unwrap();
+	fs::create_dir_all(&local_path).unwrap();
+	let mut permissions = fs::metadata(&local_path).unwrap().permissions();
+	permissions.set_mode(0o000);
+	fs::set_permissions(&local_path, permissions.clone()).unwrap();
+
+	let result = save_dedup_index(root, &std::collections::HashSet::new());
+	assert!(result.is_err());
+
+	// Cleanup: restore permissions so tempdir can be deleted.
+	permissions.set_mode(0o755);
+	let _ = fs::set_permissions(&local_path, permissions);
+}
+
+#[test]
+fn validate_release_record_file_fast_path_detects_missing_id() {
+	let tmp = tempdir().unwrap();
+	let root = tmp.path();
+
+	let manifest = minimal_manifest_with_target("pkg-a", "1.0.0");
+	let path = write_release_record_file(root, None, &manifest).unwrap();
+
+	// Overwrite with a record whose target is missing the `id` field.
+	let mutated = r#"{"schemaVersion":1,"kind":"monochange.releaseRecord","createdAt":"2026-01-01T00:00:00Z","command":"prepare-release","version":"1.0.0","releaseTargets":[{"kind":"npm","version":"1.0.0"}]}"#;
+	fs::write(&path, mutated).unwrap();
+
+	let validated = validate_release_record_file(root, None, &manifest).unwrap();
+	assert_eq!(validated, path);
+
+	// Should have been rewritten with the correct content.
+	let content = fs::read_to_string(&path).unwrap();
+	assert!(content.contains("pkg-a"));
+}
+
+#[test]
+fn validate_release_record_file_fast_path_detects_missing_kind() {
+	let tmp = tempdir().unwrap();
+	let root = tmp.path();
+
+	let manifest = minimal_manifest_with_target("pkg-a", "1.0.0");
+	let path = write_release_record_file(root, None, &manifest).unwrap();
+
+	// Overwrite with a record whose target is missing the `kind` field.
+	let mutated = r#"{"schemaVersion":1,"kind":"monochange.releaseRecord","createdAt":"2026-01-01T00:00:00Z","command":"prepare-release","version":"1.0.0","releaseTargets":[{"id":"pkg-a","version":"1.0.0"}]}"#;
+	fs::write(&path, mutated).unwrap();
+
+	let validated = validate_release_record_file(root, None, &manifest).unwrap();
+	assert_eq!(validated, path);
+
+	let content = fs::read_to_string(&path).unwrap();
+	assert!(content.contains("Package"));
+}
+
+#[test]
+fn validate_release_record_file_fast_path_detects_missing_version() {
+	let tmp = tempdir().unwrap();
+	let root = tmp.path();
+
+	let manifest = minimal_manifest_with_target("pkg-a", "1.0.0");
+	let path = write_release_record_file(root, None, &manifest).unwrap();
+
+	// Overwrite with a record whose target is missing the `version` field.
+	let mutated = r#"{"schemaVersion":1,"kind":"monochange.releaseRecord","createdAt":"2026-01-01T00:00:00Z","command":"prepare-release","version":"1.0.0","releaseTargets":[{"id":"pkg-a","kind":"Package"}]}"#;
+	fs::write(&path, mutated).unwrap();
+
+	let validated = validate_release_record_file(root, None, &manifest).unwrap();
+	assert_eq!(validated, path);
+
+	let content = fs::read_to_string(&path).unwrap();
+	assert!(content.contains("1.0.0"));
+}

--- a/crates/monochange/src/__tests__/release_artifacts_tests.rs
+++ b/crates/monochange/src/__tests__/release_artifacts_tests.rs
@@ -1062,3 +1062,47 @@ fn validate_release_record_file_fast_path_detects_missing_version() {
 	let content = fs::read_to_string(&path).unwrap();
 	assert!(content.contains("1.0.0"));
 }
+
+#[test]
+fn validate_release_record_file_fast_path_detects_mismatched_target_count() {
+	let tmp = tempdir().unwrap();
+	let root = tmp.path();
+
+	let manifest = minimal_manifest_with_target("pkg-a", "1.0.0");
+	let path = write_release_record_file(root, None, &manifest).unwrap();
+
+	// Overwrite with a record that has MORE targets than the manifest.
+	let mutated = r#"{"schemaVersion":1,"kind":"monochange.releaseRecord","createdAt":"2026-01-01T00:00:00Z","command":"prepare-release","version":"1.0.0","releaseTargets":[{"id":"pkg-a","kind":"Package","version":"1.0.0"},{"id":"pkg-b","kind":"Package","version":"2.0.0"}]}"#;
+	fs::write(&path, mutated).unwrap();
+
+	let validated = validate_release_record_file(root, None, &manifest).unwrap();
+	assert_eq!(validated, path);
+
+	// Should have been rewritten because target counts don't match.
+	let content = fs::read_to_string(&path).unwrap();
+	assert!(!content.contains("pkg-b"));
+}
+
+#[test]
+#[cfg(unix)]
+fn validate_release_record_file_fast_path_reports_error_for_unreadable_file() {
+	use std::os::unix::fs::PermissionsExt;
+
+	let tmp = tempdir().unwrap();
+	let root = tmp.path();
+
+	let manifest = minimal_manifest_with_target("pkg-a", "1.0.0");
+	let path = write_release_record_file(root, None, &manifest).unwrap();
+
+	// Make the file unreadable.
+	let mut permissions = fs::metadata(&path).unwrap().permissions();
+	permissions.set_mode(0o000);
+	fs::set_permissions(&path, permissions.clone()).unwrap();
+
+	let result = validate_release_record_file(root, None, &manifest);
+	assert!(result.is_err());
+
+	// Cleanup.
+	permissions.set_mode(0o644);
+	let _ = fs::set_permissions(&path, permissions);
+}

--- a/crates/monochange/src/__tests__/release_artifacts_tests.rs
+++ b/crates/monochange/src/__tests__/release_artifacts_tests.rs
@@ -27,6 +27,41 @@ use monochange_core::WorkspaceDefaults;
 use semver::Version;
 use tempfile::tempdir;
 
+fn minimal_manifest_with_target(id: &str, version: &str) -> ReleaseManifest {
+	ReleaseManifest {
+		command: "prepare-release".to_string(),
+		dry_run: false,
+		version: Some(version.to_string()),
+		group_version: None,
+		release_targets: vec![ReleaseManifestTarget {
+			id: id.to_string(),
+			kind: ReleaseOwnerKind::Package,
+			version: version.to_string(),
+			tag: true,
+			release: true,
+			tag_name: format!("v{version}"),
+			version_format: VersionFormat::Primary,
+			members: vec![],
+			rendered_title: format!("Release {id} {version}"),
+			rendered_changelog_title: format!("{id} {version}"),
+		}],
+		released_packages: vec![],
+		changed_files: vec![],
+		changelogs: vec![],
+		package_publications: vec![],
+		changesets: vec![],
+		deleted_changesets: vec![],
+		plan: ReleaseManifestPlan {
+			workspace_root: PathBuf::from("."),
+			decisions: vec![],
+			groups: vec![],
+			warnings: vec![],
+			unresolved_items: vec![],
+			compatibility_evidence: vec![],
+		},
+	}
+}
+
 use super::*;
 
 fn empty_configuration(root: &Path) -> WorkspaceConfiguration {
@@ -789,4 +824,135 @@ fn release_paths_from_record_produces_same_hash_as_from_manifest() {
 	assert_eq!(from_manifest.hash, from_record.hash);
 	assert_eq!(from_manifest.relative, from_record.relative);
 	assert_eq!(from_manifest.absolute, from_record.absolute);
+}
+
+#[test]
+fn dedup_index_roundtrip() {
+	let tmp = tempdir().unwrap();
+	let root = tmp.path();
+
+	let index = load_dedup_index(root);
+	assert!(index.is_empty());
+
+	let mut set = std::collections::HashSet::new();
+	set.insert("abc123".to_string());
+	set.insert("def456".to_string());
+	save_dedup_index(root, &set).unwrap();
+
+	let loaded = load_dedup_index(root);
+	assert_eq!(loaded.len(), 2);
+	assert!(loaded.contains("abc123"));
+	assert!(loaded.contains("def456"));
+}
+
+#[test]
+fn add_and_remove_from_dedup_index() {
+	let tmp = tempdir().unwrap();
+	let root = tmp.path();
+
+	add_to_dedup_index(root, "hash_a").unwrap();
+	add_to_dedup_index(root, "hash_b").unwrap();
+	let index = load_dedup_index(root);
+	assert_eq!(index.len(), 2);
+
+	remove_from_dedup_index(root, "hash_a").unwrap();
+	let index = load_dedup_index(root);
+	assert_eq!(index.len(), 1);
+	assert!(index.contains("hash_b"));
+}
+
+#[test]
+fn deduplicate_uses_persistent_index_to_skip_scan() {
+	let tmp = tempdir().unwrap();
+	let root = tmp.path();
+
+	let stale_dir = root.join(".monochange/releases/stale");
+	fs::create_dir_all(&stale_dir).unwrap();
+	let stale_record = r#"{
+		"schemaVersion": 1,
+		"kind": "monochange.releaseRecord",
+		"createdAt": "2026-01-01T00:00:00Z",
+		"command": "prepare-release",
+		"version": "1.0.0",
+		"releaseTargets": [
+			{"id":"pkg-a","kind":"Package","version":"1.0.0","tag":true,"release":true,"tag_name":"v1.0.0","version_format":"primary","members":[],"rendered_title":"Release pkg-a 1.0.0","rendered_changelog_title":"pkg-a 1.0.0"}
+		]
+	}"#;
+	fs::write(stale_dir.join("release.json"), stale_record).unwrap();
+
+	let manifest = minimal_manifest_with_target("pkg-b", "2.0.0");
+	let paths = ReleasePaths::from_manifest(root, &manifest);
+	add_to_dedup_index(root, &paths.hash).unwrap();
+
+	let target = ReleaseRecordTarget {
+		id: "pkg-b".to_string(),
+		kind: ReleaseOwnerKind::Package,
+		version: "2.0.0".to_string(),
+		version_format: VersionFormat::Primary,
+		tag: true,
+		release: true,
+		tag_name: "v2.0.0".to_string(),
+		members: vec![],
+	};
+	let result = deduplicate_overlapping_release_records(
+		root,
+		&[target],
+		root.join(".monochange/releases").as_path(),
+	);
+	assert!(result.is_ok());
+	assert!(stale_dir.is_dir());
+}
+
+#[test]
+fn validate_release_record_file_skips_rebuild_when_targets_match() {
+	let tmp = tempdir().unwrap();
+	let root = tmp.path();
+
+	let manifest = minimal_manifest_with_target("pkg-a", "1.0.0");
+	let path = write_release_record_file(root, None, &manifest).unwrap();
+	assert!(path.is_file());
+
+	let first_content = fs::read_to_string(&path).unwrap();
+	let validated = validate_release_record_file(root, None, &manifest).unwrap();
+	assert_eq!(validated, path);
+
+	let second_content = fs::read_to_string(&path).unwrap();
+	assert_eq!(first_content, second_content);
+}
+
+#[test]
+fn validate_release_record_file_rewrites_when_targets_differ() {
+	let tmp = tempdir().unwrap();
+	let root = tmp.path();
+
+	let manifest = minimal_manifest_with_target("pkg-a", "1.0.0");
+	let path = write_release_record_file(root, None, &manifest).unwrap();
+	let first_content = fs::read_to_string(&path).unwrap();
+
+	// Manually mutate the file so its targets no longer match.
+	let mutated = first_content.replace("pkg-a", "pkg-b");
+	fs::write(&path, &mutated).unwrap();
+
+	// Validation should detect the mismatch and rewrite.
+	let validated = validate_release_record_file(root, None, &manifest).unwrap();
+	assert_eq!(validated, path);
+
+	let second_content = fs::read_to_string(&path).unwrap();
+	// The mutated content should have been overwritten back to the original target.
+	assert!(!second_content.contains("pkg-b"));
+	assert!(second_content.contains("pkg-a"));
+}
+
+#[test]
+fn write_release_record_file_updates_persistent_index() {
+	let tmp = tempdir().unwrap();
+	let root = tmp.path();
+
+	let manifest = minimal_manifest_with_target("pkg-a", "1.0.0");
+	let path = write_release_record_file(root, None, &manifest).unwrap();
+	assert!(path.is_file());
+
+	let paths = ReleasePaths::from_manifest(root, &manifest);
+	let index = load_dedup_index(root);
+	assert!(index.contains(&paths.hash));
 }

--- a/crates/monochange/src/__tests__/release_artifacts_tests.rs
+++ b/crates/monochange/src/__tests__/release_artifacts_tests.rs
@@ -913,7 +913,7 @@ fn validate_release_record_file_skips_rebuild_when_targets_match() {
 	assert!(path.is_file());
 
 	let first_content = fs::read_to_string(&path).unwrap();
-	let validated = validate_release_record_file(root, None, &manifest).unwrap();
+	let validated = validate_release_record_file(root, None, &manifest, false).unwrap();
 	assert_eq!(validated, path);
 
 	let second_content = fs::read_to_string(&path).unwrap();
@@ -934,7 +934,7 @@ fn validate_release_record_file_rewrites_when_targets_differ() {
 	fs::write(&path, &mutated).unwrap();
 
 	// Validation should detect the mismatch and rewrite.
-	let validated = validate_release_record_file(root, None, &manifest).unwrap();
+	let validated = validate_release_record_file(root, None, &manifest, true).unwrap();
 	assert_eq!(validated, path);
 
 	let second_content = fs::read_to_string(&path).unwrap();
@@ -1017,7 +1017,7 @@ fn validate_release_record_file_fast_path_detects_missing_id() {
 	let mutated = r#"{"schemaVersion":1,"kind":"monochange.releaseRecord","createdAt":"2026-01-01T00:00:00Z","command":"prepare-release","version":"1.0.0","releaseTargets":[{"kind":"npm","version":"1.0.0"}]}"#;
 	fs::write(&path, mutated).unwrap();
 
-	let validated = validate_release_record_file(root, None, &manifest).unwrap();
+	let validated = validate_release_record_file(root, None, &manifest, true).unwrap();
 	assert_eq!(validated, path);
 
 	// Should have been rewritten with the correct content.
@@ -1037,7 +1037,7 @@ fn validate_release_record_file_fast_path_detects_missing_kind() {
 	let mutated = r#"{"schemaVersion":1,"kind":"monochange.releaseRecord","createdAt":"2026-01-01T00:00:00Z","command":"prepare-release","version":"1.0.0","releaseTargets":[{"id":"pkg-a","version":"1.0.0"}]}"#;
 	fs::write(&path, mutated).unwrap();
 
-	let validated = validate_release_record_file(root, None, &manifest).unwrap();
+	let validated = validate_release_record_file(root, None, &manifest, true).unwrap();
 	assert_eq!(validated, path);
 
 	let content = fs::read_to_string(&path).unwrap();
@@ -1056,7 +1056,7 @@ fn validate_release_record_file_fast_path_detects_missing_version() {
 	let mutated = r#"{"schemaVersion":1,"kind":"monochange.releaseRecord","createdAt":"2026-01-01T00:00:00Z","command":"prepare-release","version":"1.0.0","releaseTargets":[{"id":"pkg-a","kind":"Package"}]}"#;
 	fs::write(&path, mutated).unwrap();
 
-	let validated = validate_release_record_file(root, None, &manifest).unwrap();
+	let validated = validate_release_record_file(root, None, &manifest, true).unwrap();
 	assert_eq!(validated, path);
 
 	let content = fs::read_to_string(&path).unwrap();
@@ -1075,7 +1075,7 @@ fn validate_release_record_file_fast_path_detects_mismatched_target_count() {
 	let mutated = r#"{"schemaVersion":1,"kind":"monochange.releaseRecord","createdAt":"2026-01-01T00:00:00Z","command":"prepare-release","version":"1.0.0","releaseTargets":[{"id":"pkg-a","kind":"Package","version":"1.0.0"},{"id":"pkg-b","kind":"Package","version":"2.0.0"}]}"#;
 	fs::write(&path, mutated).unwrap();
 
-	let validated = validate_release_record_file(root, None, &manifest).unwrap();
+	let validated = validate_release_record_file(root, None, &manifest, true).unwrap();
 	assert_eq!(validated, path);
 
 	// Should have been rewritten because target counts don't match.
@@ -1099,7 +1099,7 @@ fn validate_release_record_file_fast_path_reports_error_for_unreadable_file() {
 	permissions.set_mode(0o000);
 	fs::set_permissions(&path, permissions.clone()).unwrap();
 
-	let result = validate_release_record_file(root, None, &manifest);
+	let result = validate_release_record_file(root, None, &manifest, false);
 	assert!(result.is_err());
 
 	// Cleanup.

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -12,13 +12,8 @@ thread_local! {
 }
 
 thread_local! {
-	static DEDUPLICATED_CACHE: std::cell::RefCell<std::collections::HashSet<(PathBuf, String)>> =
+	pub(crate) static DEDUPLICATED_CACHE: std::cell::RefCell<std::collections::HashSet<(PathBuf, String)>> =
 		std::cell::RefCell::new(std::collections::HashSet::new());
-}
-
-#[cfg(test)]
-pub(crate) fn clear_dedup_cache() {
-	DEDUPLICATED_CACHE.with(|cache| cache.borrow_mut().clear());
 }
 
 /// Path to the persistent deduplication index relative to the workspace root.

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -52,10 +52,9 @@ fn save_dedup_index(
 	index: &std::collections::HashSet<String>,
 ) -> MonochangeResult<()> {
 	let path = root.join(DEDUP_INDEX_PATH);
-	if let Some(parent) = path.parent() {
-		fs::create_dir_all(parent)
-			.map_err(|error| MonochangeError::Io(format!("create dedup index dir: {error}")))?;
-	}
+	let parent = path.parent().unwrap_or(root);
+	fs::create_dir_all(parent)
+		.map_err(|error| MonochangeError::Io(format!("create dedup index dir: {error}")))?;
 	let mut lines = Vec::with_capacity(index.len());
 	for hash in index {
 		lines.push(format!(r#"{{"hash":"{hash}"}}"#));

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -16,6 +16,78 @@ thread_local! {
 		std::cell::RefCell::new(std::collections::HashSet::new());
 }
 
+#[cfg(test)]
+pub(crate) fn clear_dedup_cache() {
+	DEDUPLICATED_CACHE.with(|cache| cache.borrow_mut().clear());
+}
+
+/// Path to the persistent deduplication index relative to the workspace root.
+const DEDUP_INDEX_PATH: &str = ".monochange/local/release-index.jsonl";
+
+/// Load the persistent deduplication index as a set of hashes.
+///
+/// The index is stored as a JSONL file at `.monochange/local/release-index.jsonl`.
+/// Each line is a JSON object with a `hash` field. Missing or unreadable files
+/// are treated as empty indices.
+fn load_dedup_index(root: &Path) -> std::collections::HashSet<String> {
+	let path = root.join(DEDUP_INDEX_PATH);
+	let Ok(content) = fs::read_to_string(&path) else {
+		return std::collections::HashSet::new();
+	};
+	content
+		.lines()
+		.filter_map(|line| {
+			let line = line.trim();
+			if line.is_empty() {
+				return None;
+			}
+			serde_json::from_str::<serde_json::Value>(line)
+				.ok()
+				.and_then(|v| v.get("hash").and_then(|h| h.as_str().map(String::from)))
+		})
+		.collect()
+}
+
+/// Save the persistent deduplication index atomically.
+///
+/// Writes to a temporary file next to the target and renames it into place.
+/// This avoids corrupting the index if the process is interrupted mid-write.
+fn save_dedup_index(
+	root: &Path,
+	index: &std::collections::HashSet<String>,
+) -> MonochangeResult<()> {
+	let path = root.join(DEDUP_INDEX_PATH);
+	if let Some(parent) = path.parent() {
+		fs::create_dir_all(parent)
+			.map_err(|error| MonochangeError::Io(format!("create dedup index dir: {error}")))?;
+	}
+	let mut lines = Vec::with_capacity(index.len());
+	for hash in index {
+		lines.push(format!(r#"{{"hash":"{hash}"}}"#));
+	}
+	lines.sort();
+	let temp = path.with_extension("tmp");
+	fs::write(&temp, lines.join("\n"))
+		.map_err(|error| MonochangeError::Io(format!("write dedup index: {error}")))?;
+	fs::rename(&temp, &path)
+		.map_err(|error| MonochangeError::Io(format!("rename dedup index: {error}")))?;
+	Ok(())
+}
+
+/// Add a hash to the persistent deduplication index.
+fn add_to_dedup_index(root: &Path, hash: &str) -> MonochangeResult<()> {
+	let mut index = load_dedup_index(root);
+	index.insert(hash.to_string());
+	save_dedup_index(root, &index)
+}
+
+/// Remove a hash from the persistent deduplication index.
+fn remove_from_dedup_index(root: &Path, hash: &str) -> MonochangeResult<()> {
+	let mut index = load_dedup_index(root);
+	index.remove(hash);
+	save_dedup_index(root, &index)
+}
+
 pub(crate) fn build_release_targets(
 	configuration: &monochange_core::WorkspaceConfiguration,
 	packages: &[PackageRecord],
@@ -1411,6 +1483,7 @@ pub(crate) fn write_release_record_file(
 	// subsequent PrepareRelease steps (for example during `mc release-pr`)
 	// do not produce a dirty working tree.
 	if paths.absolute.is_file() {
+		add_to_dedup_index(root, &paths.hash).ok();
 		return Ok(paths.absolute);
 	}
 
@@ -1425,6 +1498,7 @@ pub(crate) fn write_release_record_file(
 		.map_err(|error| MonochangeError::Io(format!("create release record dir: {error}")))?;
 	fs::write(&paths.absolute, json)
 		.map_err(|error| MonochangeError::Io(format!("write release record: {error}")))?;
+	add_to_dedup_index(root, &paths.hash)?;
 	Ok(paths.absolute)
 }
 
@@ -1449,14 +1523,65 @@ fn compare_json_strings(json1: &str, json2: &str) -> bool {
 /// on disk after re-running deduplication. Called by `commit_release` to
 /// guard against stale or missing records between `prepare_release` and
 /// `commit_release`.
+///
+/// Performance note: when the file already exists and its `release_targets`
+/// match the manifest, this function skips rebuilding the `ReleaseRecord`
+/// entirely. It only falls back to `build_release_record` when the file is
+/// missing or the targets differ, avoiding the JSON round-trip on the hot
+/// path.
 pub(crate) fn validate_release_record_file(
 	root: &Path,
 	source: Option<&SourceConfiguration>,
 	manifest: &ReleaseManifest,
 	update_release_json: bool,
 ) -> MonochangeResult<PathBuf> {
+	// Compute the expected path from the manifest without building the record.
+	let paths = ReleasePaths::from_manifest(root, manifest);
+
+	// Fast path: if the file exists, verify its release_targets identity
+	// without rebuilding the entire ReleaseRecord.
+	if paths.absolute.is_file() {
+		match fs::read_to_string(&paths.absolute) {
+			Ok(existing_json) => {
+				if let Ok(existing_value) =
+					serde_json::from_str::<serde_json::Value>(&existing_json)
+					&& let Some(existing_targets) = existing_value
+						.get("releaseTargets")
+						.and_then(|v| v.as_array())
+				{
+					let manifest_targets = &manifest.release_targets;
+					if existing_targets.len() == manifest_targets.len() {
+						let all_match = manifest_targets.iter().all(|mt| {
+							existing_targets.iter().any(|et| {
+								let Some(id) = et.get("id").and_then(|v| v.as_str()) else {
+									return false;
+								};
+								let Some(kind) = et.get("kind").and_then(|v| v.as_str()) else {
+									return false;
+								};
+								let Some(version) = et.get("version").and_then(|v| v.as_str())
+								else {
+									return false;
+								};
+								mt.id == id && mt.kind.as_str() == kind && mt.version == version
+							})
+						});
+						if all_match {
+							// Targets match — no need to rebuild or rewrite.
+							add_to_dedup_index(root, &paths.hash).ok();
+							return Ok(paths.absolute);
+						}
+					}
+				}
+			}
+			Err(error) => {
+				return Err(MonochangeError::Io(format!("read release record: {error}")));
+			}
+		}
+	}
+
+	// Slow path: rebuild the record, deduplicate, and validate or rewrite.
 	let record = build_release_record(source, manifest);
-	let paths = ReleasePaths::from_record(root, &record);
 	deduplicate_overlapping_release_records(
 		root,
 		&record.release_targets,
@@ -1512,6 +1637,7 @@ impl ReleasePaths {
 	/// Compute paths from an already-built `ReleaseRecord`.
 	///
 	/// Use this when you have the record in hand to avoid rebuilding it.
+	#[allow(dead_code)]
 	pub fn from_record(root: &Path, record: &ReleaseRecord) -> Self {
 		let hash = release_targets_hash(&record.release_targets);
 		let relative = PathBuf::from(".monochange/releases")
@@ -1623,6 +1749,16 @@ fn deduplicate_overlapping_release_records(
 		return Ok(());
 	}
 
+	let persistent_index = load_dedup_index(root);
+	if persistent_index.contains(&hash) {
+		DEDUPLICATED_CACHE.with(|cache| {
+			cache
+				.borrow_mut()
+				.insert((root.to_path_buf(), hash.clone()));
+		});
+		return Ok(());
+	}
+
 	let new_tags: std::collections::HashSet<(&str, &str)> = release_targets
 		.iter()
 		.map(|target| (target.id.as_str(), target.version.as_str()))
@@ -1659,15 +1795,20 @@ fn deduplicate_overlapping_release_records(
 			.iter()
 			.any(|t| new_tags.contains(&(t.id.as_str(), t.version.as_str())));
 		if has_overlap {
+			let hash_to_remove = release_targets_hash(&existing.release_targets);
 			fs::remove_dir_all(&path).map_err(|error| {
 				MonochangeError::Io(format!("remove stale release record dir: {error}"))
 			})?;
+			remove_from_dedup_index(root, &hash_to_remove).ok();
 		}
 	}
 
 	DEDUPLICATED_CACHE.with(|cache| {
-		cache.borrow_mut().insert((root.to_path_buf(), hash));
+		cache
+			.borrow_mut()
+			.insert((root.to_path_buf(), hash.clone()));
 	});
+	add_to_dedup_index(root, &hash)?;
 
 	Ok(())
 }

--- a/crates/monochange_integration_tests/tests/release_record_artifacts.rs
+++ b/crates/monochange_integration_tests/tests/release_record_artifacts.rs
@@ -1,0 +1,113 @@
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+
+use insta::assert_json_snapshot;
+use insta_cmd::get_cargo_bin;
+use monochange_test_helpers::copy_directory;
+use monochange_test_helpers::git::git;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn fixture_path(relative: &str) -> PathBuf {
+	Path::new(env!("CARGO_MANIFEST_DIR"))
+		.join("../../fixtures/tests")
+		.join(relative)
+}
+
+fn setup_release_fixture() -> TempDir {
+	let tempdir = TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	copy_directory(&fixture_path("release-pr/ungrouped"), root);
+	git(root, &["init"]);
+	git(root, &["config", "user.name", "monochange-tests"]);
+	git(
+		root,
+		&["config", "user.email", "monochange-tests@example.com"],
+	);
+	git(root, &["add", "."]);
+	git(root, &["commit", "-m", "initial"]);
+	tempdir
+}
+
+fn prepare_release(root: &Path) -> Value {
+	let output = Command::new(get_cargo_bin("mc"))
+		.current_dir(root)
+		.env("NO_COLOR", "1")
+		.env_remove("RUST_LOG")
+		.env("MONOCHANGE_RELEASE_DATE", "2026-04-07")
+		.arg("step:prepare-release")
+		.arg("--format")
+		.arg("json")
+		.output()
+		.unwrap_or_else(|error| panic!("run prepare-release: {error}"));
+	assert!(
+		output.status.success(),
+		"prepare-release failed\nstdout:\n{}\nstderr:\n{}",
+		String::from_utf8_lossy(&output.stdout),
+		String::from_utf8_lossy(&output.stderr)
+	);
+	serde_json::from_slice(&output.stdout)
+		.unwrap_or_else(|error| panic!("parse prepare-release json: {error}"))
+}
+
+fn release_record_paths(root: &Path) -> Vec<PathBuf> {
+	let releases_dir = root.join(".monochange/releases");
+	let mut paths = std::fs::read_dir(&releases_dir)
+		.unwrap_or_else(|error| panic!("read {}: {error}", releases_dir.display()))
+		.map(|entry| {
+			entry
+				.unwrap_or_else(|error| panic!("read release entry: {error}"))
+				.path()
+				.join("release.json")
+		})
+		.collect::<Vec<_>>();
+	paths.sort();
+	paths
+}
+
+#[test]
+fn prepare_release_persists_one_record_and_reuses_it_on_later_runs() {
+	let tempdir = setup_release_fixture();
+	let root = tempdir.path();
+
+	let first = prepare_release(root);
+	let first_paths = release_record_paths(root);
+	assert_eq!(first_paths.len(), 1);
+	let first_record = std::fs::read_to_string(&first_paths[0])
+		.unwrap_or_else(|error| panic!("read {}: {error}", first_paths[0].display()));
+	let index_path = root.join(".monochange/local/release-index.jsonl");
+	let first_index = std::fs::read_to_string(&index_path)
+		.unwrap_or_else(|error| panic!("read {}: {error}", index_path.display()));
+
+	let second = prepare_release(root);
+	let second_paths = release_record_paths(root);
+	assert_eq!(second_paths, first_paths);
+	let second_record = std::fs::read_to_string(&second_paths[0])
+		.unwrap_or_else(|error| panic!("read {}: {error}", second_paths[0].display()));
+	let second_index = std::fs::read_to_string(&index_path)
+		.unwrap_or_else(|error| panic!("read {}: {error}", index_path.display()));
+
+	assert_eq!(second_record, first_record);
+	assert_eq!(second_index, first_index);
+	assert!(first_index.contains("1b9c77930352f342"));
+	assert_eq!(
+		first["releaseTargets"], second["releaseTargets"],
+		"repeat prepare-release should compute the same release target identities"
+	);
+	let index_entries = first_index
+		.lines()
+		.map(|line| {
+			serde_json::from_str::<Value>(line)
+				.unwrap_or_else(|error| panic!("parse index line `{line}`: {error}"))
+		})
+		.collect::<Vec<_>>();
+	assert_json_snapshot!(serde_json::json!({
+		"releaseRecordPath": first_paths[0]
+			.strip_prefix(root)
+			.unwrap_or_else(|error| panic!("strip temp root: {error}"))
+			.to_string_lossy(),
+		"index": index_entries,
+		"releaseTargets": first["releaseTargets"],
+	}));
+}

--- a/crates/monochange_integration_tests/tests/snapshots/release_record_artifacts__prepare_release_persists_one_record_and_reuses_it_on_later_runs.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/release_record_artifacts__prepare_release_persists_one_record_and_reuses_it_on_later_runs.snap
@@ -1,0 +1,42 @@
+---
+source: crates/monochange_integration_tests/tests/release_record_artifacts.rs
+expression: "serde_json::json!({\n    \"releaseRecordPath\":\n    first_paths[0].strip_prefix(root).unwrap_or_else(|error|\n    panic!(\"strip temp root: {error}\")).to_string_lossy(), \"index\":\n    index_entries, \"releaseTargets\": first[\"releaseTargets\"],\n})"
+---
+{
+  "index": [
+    {
+      "hash": "1b9c77930352f342"
+    }
+  ],
+  "releaseRecordPath": ".monochange/releases/1b9c77930352f342/release.json",
+  "releaseTargets": [
+    {
+      "id": "app",
+      "kind": "package",
+      "members": [
+        "app"
+      ],
+      "release": true,
+      "renderedChangelogTitle": "app [1.0.1](https://github.com/ifiokjr/monochange/releases/tag/app/v1.0.1) (2026-04-07)",
+      "renderedTitle": "app 1.0.1 (2026-04-07)",
+      "tag": false,
+      "tagName": "app/v1.0.1",
+      "version": "1.0.1",
+      "versionFormat": "namespaced"
+    },
+    {
+      "id": "core",
+      "kind": "package",
+      "members": [
+        "core"
+      ],
+      "release": true,
+      "renderedChangelogTitle": "core [1.1.0](https://github.com/ifiokjr/monochange/releases/tag/core/v1.1.0) (2026-04-07)",
+      "renderedTitle": "core 1.1.0 (2026-04-07)",
+      "tag": true,
+      "tagName": "core/v1.1.0",
+      "version": "1.1.0",
+      "versionFormat": "namespaced"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #430

- Adds a JSONL index at `.monochange/local/release-index.jsonl` that survives across CLI
  invocations, eliminating repeated directory scans when checking for duplicate release
  records.

- Adds a fast path in `validate_release_record_file` that compares the
  `releaseTargets` identity of an existing file against the manifest before
  rebuilding the full `ReleaseRecord`, skipping unnecessary I/O when the targets
  match.
