### PR TITLE
feat: rename public release record field from v to schemaVersion

### DIFF
--- a/.changeset/simplify-schema-version.md
+++ b/.changeset/simplify-schema-version.md
@@ -1,0 +1,32 @@
+---
+"monochange_schema": major
+"monochange": minor
+"monochange_core": minor
+"monochange_test_helpers": minor
+---
+
+# Rename public release record field from `v` to `schemaVersion`
+
+All public durable schemas now use `schemaVersion` (a `"major.minor"` string) instead of `v`:
+
+- `monochange_schema` release record shape: field name changed from `v` to `schemaVersion`
+- `monochange_core` parsing: handles legacy `v` and integer `schemaVersion` via normalization
+- Integration tests, JSON schemas, and snapshots updated accordingly
+
+## Before
+
+```json
+{
+	"v": "0.1",
+	"kind": "monochange.releaseRecord"
+}
+```
+
+## After
+
+```json
+{
+	"schemaVersion": "0.1",
+	"kind": "monochange.releaseRecord"
+}
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,7 +2483,7 @@ dependencies = [
 
 [[package]]
 name = "monochange_schema"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "insta",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ monochange_linting = { version = "0.4.0", path = "./crates/monochange_linting" }
 monochange_npm = { version = "0.4.0", path = "./crates/monochange_npm" }
 monochange_publish = { version = "0.4.0", path = "./crates/monochange_publish" }
 monochange_python = { version = "0.4.0", path = "./crates/monochange_python" }
-monochange_schema = { version = "0.0.0", path = "./crates/monochange_schema" }
+monochange_schema = { version = "0.1.0", path = "./crates/monochange_schema" }
 monochange_semver = { version = "0.4.0", path = "./crates/monochange_semver" }
 monochange_telemetry = { version = "0.4.0", path = "./crates/monochange_telemetry" }
 monochange_test_helpers = { version = "0.4.0", path = "./crates/monochange_test_helpers" }

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -4689,7 +4689,7 @@ fn text_release_record_discovery_renders_targets_packages_and_provider() {
 
 fn sample_release_record_for_discovery_text() -> monochange_core::ReleaseRecord {
 	monochange_core::ReleaseRecord {
-		schema_version: monochange_core::RELEASE_RECORD_SCHEMA_VERSION,
+		schema_version: monochange_core::RELEASE_RECORD_SCHEMA_VERSION.to_string(),
 		kind: monochange_core::RELEASE_RECORD_KIND.to_string(),
 		created_at: "2026-04-07T08:00:00Z".to_string(),
 		command: "release-pr".to_string(),
@@ -4729,7 +4729,7 @@ fn text_release_record_discovery_omits_empty_sections() {
 		record_commit: "abc1234567890".to_string(),
 		distance: 2,
 		record: monochange_core::ReleaseRecord {
-			schema_version: monochange_core::RELEASE_RECORD_SCHEMA_VERSION,
+			schema_version: monochange_core::RELEASE_RECORD_SCHEMA_VERSION.to_string(),
 			kind: monochange_core::RELEASE_RECORD_KIND.to_string(),
 			created_at: "2026-04-07T08:00:00Z".to_string(),
 			command: "release-pr".to_string(),
@@ -10103,7 +10103,7 @@ fn create_release_record_commit_from_record(
 
 fn sample_release_record_for_retarget() -> monochange_core::ReleaseRecord {
 	monochange_core::ReleaseRecord {
-		schema_version: monochange_core::RELEASE_RECORD_SCHEMA_VERSION,
+		schema_version: monochange_core::RELEASE_RECORD_SCHEMA_VERSION.to_string(),
 		kind: monochange_core::RELEASE_RECORD_KIND.to_string(),
 		created_at: "2026-04-07T08:00:00Z".to_string(),
 		command: "release-pr".to_string(),
@@ -13152,7 +13152,7 @@ fn build_release_manifest_from_record_populates_manifest_from_release_record() {
 	use monochange_core::ReleaseRecordTarget;
 
 	let record = ReleaseRecord {
-		schema_version: 1,
+		schema_version: monochange_core::RELEASE_RECORD_SCHEMA_VERSION.to_string(),
 		kind: "monochange.releaseRecord".to_string(),
 		created_at: "2024-01-01T00:00:00Z".to_string(),
 		command: "release-pr".to_string(),
@@ -13234,7 +13234,7 @@ fn build_release_manifest_from_record_preserves_changelog_metadata() {
 		rendered: "## main 1.0.0\n\n- Preserve release notes".to_string(),
 	};
 	let record = ReleaseRecord {
-		schema_version: 1,
+		schema_version: monochange_core::RELEASE_RECORD_SCHEMA_VERSION.to_string(),
 		kind: "monochange.releaseRecord".to_string(),
 		created_at: "2024-01-01T00:00:00Z".to_string(),
 		command: "publish-release".to_string(),
@@ -13331,7 +13331,7 @@ branches = ["release/*"]
 
 	// Write a release record block into a file and commit it
 	let record = monochange_core::ReleaseRecord {
-		schema_version: 1,
+		schema_version: monochange_core::RELEASE_RECORD_SCHEMA_VERSION.to_string(),
 		kind: "monochange.releaseRecord".to_string(),
 		created_at: "2024-01-01T00:00:00Z".to_string(),
 		command: "release-pr".to_string(),
@@ -13475,7 +13475,7 @@ repo = "monochange"
 		.unwrap_or_else(|error| panic!("git commit: {error}"));
 
 	let record = monochange_core::ReleaseRecord {
-		schema_version: 1,
+		schema_version: monochange_core::RELEASE_RECORD_SCHEMA_VERSION.to_string(),
 		kind: "monochange.releaseRecord".to_string(),
 		created_at: "2024-01-01T00:00:00Z".to_string(),
 		command: "release-pr".to_string(),

--- a/crates/monochange/src/__tests__/package_publish_tests.rs
+++ b/crates/monochange/src/__tests__/package_publish_tests.rs
@@ -301,7 +301,7 @@ fn sample_configuration(
 
 fn commit_release_record(root: &Path, publications: Vec<PackagePublicationTarget>) {
 	let record = ReleaseRecord {
-		schema_version: monochange_core::RELEASE_RECORD_SCHEMA_VERSION,
+		schema_version: monochange_core::RELEASE_RECORD_SCHEMA_VERSION.to_string(),
 		kind: monochange_core::RELEASE_RECORD_KIND.to_string(),
 		created_at: "2026-04-14T08:00:00Z".to_string(),
 		command: "release-pr".to_string(),

--- a/crates/monochange/src/__tests__/snapshots/monochange__tests__release_record_file_snapshot.snap
+++ b/crates/monochange/src/__tests__/snapshots/monochange__tests__release_record_file_snapshot.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/monochange/src/__tests.rs
+source: crates/monochange/src/__tests__/lib_tests.rs
 expression: value
 ---
 {
@@ -34,7 +34,7 @@ expression: value
     "monochange",
     "monochange_core"
   ],
-  "schemaVersion": 1,
+  "schemaVersion": "0.0",
   "updatedChangelogs": [],
   "version": "1.2.3"
 }

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -1092,7 +1092,7 @@ pub(crate) fn build_release_record(
 	manifest: &ReleaseManifest,
 ) -> ReleaseRecord {
 	ReleaseRecord {
-		schema_version: monochange_core::RELEASE_RECORD_SCHEMA_VERSION,
+		schema_version: monochange_core::RELEASE_RECORD_SCHEMA_VERSION.to_string(),
 		kind: monochange_core::RELEASE_RECORD_KIND.to_string(),
 		created_at: resolve_release_datetime()
 			.and_utc()

--- a/crates/monochange/src/release_record.rs
+++ b/crates/monochange/src/release_record.rs
@@ -84,16 +84,9 @@ pub fn discover_release_record(
 					record,
 				});
 			}
-			Err(monochange_core::ReleaseRecordError::UnsupportedSchemaVersion(version)) => {
-				return Err(MonochangeError::Discovery(format!(
-					"release record in commit {} uses unsupported schemaVersion {}",
-					crate::short_commit_sha(&commit),
-					version
-				)));
-			}
 			Err(monochange_core::ReleaseRecordError::UnsupportedSchemaVersionValue(version)) => {
 				return Err(MonochangeError::Discovery(format!(
-					"release record in commit {} uses unsupported schema version {}; upgrade monochange to read this record",
+					"release record in commit {} uses unsupported schemaVersion {} (upgrade monochange to read this record)",
 					crate::short_commit_sha(&commit),
 					version
 				)));

--- a/crates/monochange/tests/release_record.rs
+++ b/crates/monochange/tests/release_record.rs
@@ -795,7 +795,7 @@ fn git_command(root: &Path, args: &[&str]) -> Option<String> {
 
 fn sample_release_record() -> ReleaseRecord {
 	ReleaseRecord {
-		schema_version: monochange_core::RELEASE_RECORD_SCHEMA_VERSION,
+		schema_version: monochange_core::RELEASE_RECORD_SCHEMA_VERSION.to_string(),
 		kind: monochange_core::RELEASE_RECORD_KIND.to_string(),
 		created_at: "2026-04-07T08:00:00Z".to_string(),
 		command: "release-pr".to_string(),

--- a/crates/monochange/tests/snapshots/release_record__release_record_command_reports_record_from_tag_as_json@release_record_command_reports_record_from_tag_as_json.snap
+++ b/crates/monochange/tests/snapshots/release_record__release_record_command_reports_record_from_tag_as_json@release_record_command_reports_record_from_tag_as_json.snap
@@ -44,7 +44,7 @@ expression: redacted
       "monochange",
       "monochange_core"
     ],
-    "schemaVersion": 1,
+    "schemaVersion": "[SCHEMA_VERSION]",
     "updatedChangelogs": [
       "crates/monochange/CHANGELOG.md"
     ],

--- a/crates/monochange/tests/snapshots/release_record__release_record_command_reports_unsupported_schema_version@release_record_command_reports_unsupported_schema_version.snap
+++ b/crates/monochange/tests/snapshots/release_record__release_record_command_reports_unsupported_schema_version@release_record_command_reports_unsupported_schema_version.snap
@@ -2,4 +2,4 @@
 source: crates/monochange/tests/release_record.rs
 expression: "String::from_utf8(output.stderr).unwrap_or_else(|error|\npanic!(\"stderr utf8: {error}\"))"
 ---
-discovery error: release record in commit [SHA] uses unsupported schema version 0.2; upgrade monochange to read this record
+discovery error: release record in commit [SHA] uses unsupported schemaVersion 0.2 (upgrade monochange to read this record)

--- a/crates/monochange_core/src/__tests__/lib_tests.rs
+++ b/crates/monochange_core/src/__tests__/lib_tests.rs
@@ -2385,6 +2385,12 @@ fn parse_release_record_json_normalizes_integer_schema_version() {
 }
 
 #[test]
+fn parse_release_record_json_rejects_non_object() {
+	let error = crate::parse_release_record_json("[]").expect_err("expected error for non-object");
+	assert!(matches!(error, ReleaseRecordError::MissingKind));
+}
+
+#[test]
 fn parse_release_record_json_normalizes_legacy_v_field() {
 	let schema_version = monochange_schema::CURRENT_SCHEMA_VERSION_TEXT;
 	let kind = RELEASE_RECORD_KIND;

--- a/crates/monochange_core/src/__tests__/lib_tests.rs
+++ b/crates/monochange_core/src/__tests__/lib_tests.rs
@@ -1902,20 +1902,20 @@ fn release_record_block_roundtrips_with_reserved_markers() {
 }
 
 #[test]
-fn render_release_record_block_writes_current_schema_v_header() {
+fn render_release_record_block_writes_current_schema_version_header() {
 	let record = sample_release_record();
 	let rendered = crate::render_release_record_block(&record)
 		.unwrap_or_else(|error| panic!("render release record: {error}"));
 
 	assert!(rendered.contains(&format!(
-		r#""v": "{}""#,
+		r#""schemaVersion": "{}""#,
 		monochange_schema::CURRENT_SCHEMA_VERSION_TEXT
 	)));
-	assert!(!rendered.contains("\"schemaVersion\""));
+	assert!(!rendered.contains("\"v\""));
 }
 
 #[test]
-fn parse_release_record_block_accepts_current_schema_v_header() {
+fn parse_release_record_block_accepts_current_schema_version_header() {
 	let schema_version = monochange_schema::CURRENT_SCHEMA_VERSION_TEXT;
 	let current = format!(
 		r#"{RELEASE_RECORD_HEADING}
@@ -1923,7 +1923,7 @@ fn parse_release_record_block_accepts_current_schema_v_header() {
 {RELEASE_RECORD_START_MARKER}
 ```json
 {{
-  "v": "{schema_version}",
+  "schemaVersion": "{schema_version}",
   "kind": "{RELEASE_RECORD_KIND}",
   "createdAt": "2026-04-06T12:00:00Z",
   "command": "release-pr",
@@ -1943,14 +1943,14 @@ fn parse_release_record_block_accepts_current_schema_v_header() {
 }
 
 #[test]
-fn parse_release_record_block_rejects_future_schema_v_header() {
+fn parse_release_record_block_rejects_future_schema_version_header() {
 	let future = format!(
 		r#"{RELEASE_RECORD_HEADING}
 
 {RELEASE_RECORD_START_MARKER}
 ```json
 {{
-  "v": "9.0",
+  "schemaVersion": "9.0",
   "kind": "{RELEASE_RECORD_KIND}",
   "createdAt": "2026-04-06T12:00:00Z",
   "command": "release-pr",
@@ -2025,7 +2025,7 @@ fn parse_release_record_block_rejects_unsupported_kind() {
 {start}
 ```json
 {{
-  "v": "{schema_version}",
+  "schemaVersion": "{schema_version}",
   "kind": "monochange.otherRecord",
   "createdAt": "2026-04-06T12:00:00Z",
   "command": "release-pr",
@@ -2050,7 +2050,7 @@ fn parse_release_record_json_rejects_unsupported_kind() {
 	let schema_version = monochange_schema::CURRENT_SCHEMA_VERSION_TEXT;
 	let invalid_kind = format!(
 		r#"{{
-  "v": "{schema_version}",
+  "schemaVersion": "{schema_version}",
   "kind": "monochange.otherRecord",
   "createdAt": "2026-04-06T12:00:00Z",
   "command": "release-pr",
@@ -2080,7 +2080,7 @@ fn parse_release_record_block_rejects_unsupported_schema_version() {
 {start}
 ```json
 {{
-  "v": "0.2",
+  "schemaVersion": "0.2",
   "kind": "{kind}",
   "createdAt": "2026-04-06T12:00:00Z",
   "command": "release-pr",
@@ -2113,7 +2113,7 @@ fn parse_release_record_block_ignores_unknown_fields() {
 {start}
 ```json
 {{
-  "v": "{schema_version}",
+  "schemaVersion": "{schema_version}",
   "kind": "{kind}",
   "createdAt": "2026-04-06T12:00:00Z",
   "command": "release-pr",
@@ -2134,7 +2134,7 @@ fn parse_release_record_block_ignores_unknown_fields() {
 
 fn sample_release_record() -> ReleaseRecord {
 	ReleaseRecord {
-		schema_version: RELEASE_RECORD_SCHEMA_VERSION,
+		schema_version: RELEASE_RECORD_SCHEMA_VERSION.to_string(),
 		kind: RELEASE_RECORD_KIND.to_string(),
 		created_at: "2026-04-06T12:00:00Z".to_string(),
 		command: "release-pr".to_string(),
@@ -2194,14 +2194,14 @@ fn render_release_record_block_rejects_unsupported_kind() {
 #[test]
 fn render_release_record_block_rejects_unsupported_schema_version() {
 	let mut record = sample_release_record();
-	record.schema_version = 2;
+	record.schema_version = "0.2".to_string();
 
 	let error = crate::render_release_record_block(&record)
 		.err()
 		.unwrap_or_else(|| panic!("expected unsupported schema render error"));
 	assert!(matches!(
 		error,
-		ReleaseRecordError::UnsupportedSchemaVersion(2)
+		ReleaseRecordError::UnsupportedSchemaVersionValue(version) if version == "0.2"
 	));
 }
 
@@ -2224,7 +2224,7 @@ fn parse_release_record_block_rejects_missing_kind() {
 {RELEASE_RECORD_START_MARKER}
 ```json
 {{
-  "v": "{schema_version}",
+  "schemaVersion": "{schema_version}",
   "createdAt": "2026-04-06T12:00:00Z",
   "command": "release-pr",
   "releaseTargets": [],

--- a/crates/monochange_core/src/__tests__/lib_tests.rs
+++ b/crates/monochange_core/src/__tests__/lib_tests.rs
@@ -2362,6 +2362,48 @@ fn parse_release_record_block_ignores_unknown_fields() {
 	assert!(parsed.release_targets.is_empty());
 }
 
+#[test]
+fn parse_release_record_json_normalizes_integer_schema_version() {
+	let kind = RELEASE_RECORD_KIND;
+	let json_text = format!(
+		r#"{{
+  "schemaVersion": 1,
+  "kind": "{kind}",
+  "createdAt": "2026-04-06T12:00:00Z",
+  "command": "release-pr",
+  "releaseTargets": [],
+  "releasedPackages": [],
+  "changedFiles": []
+}}"#
+	);
+	let parsed = crate::parse_release_record_json(&json_text)
+		.unwrap_or_else(|error| panic!("parse release record with integer schemaVersion: {error}"));
+	assert_eq!(
+		parsed.schema_version,
+		monochange_schema::CURRENT_SCHEMA_VERSION_TEXT
+	);
+}
+
+#[test]
+fn parse_release_record_json_normalizes_legacy_v_field() {
+	let schema_version = monochange_schema::CURRENT_SCHEMA_VERSION_TEXT;
+	let kind = RELEASE_RECORD_KIND;
+	let json_text = format!(
+		r#"{{
+  "v": "{schema_version}",
+  "kind": "{kind}",
+  "createdAt": "2026-04-06T12:00:00Z",
+  "command": "release-pr",
+  "releaseTargets": [],
+  "releasedPackages": [],
+  "changedFiles": []
+}}"#
+	);
+	let parsed = crate::parse_release_record_json(&json_text)
+		.unwrap_or_else(|error| panic!("parse release record with legacy v: {error}"));
+	assert_eq!(parsed.schema_version, schema_version);
+}
+
 fn sample_release_record() -> ReleaseRecord {
 	ReleaseRecord {
 		schema_version: RELEASE_RECORD_SCHEMA_VERSION.to_string(),

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -3036,8 +3036,8 @@ pub struct ReleaseManifest {
 	pub plan: ReleaseManifestPlan,
 }
 
-/// Current supported `ReleaseRecord` schema version.
-pub const RELEASE_RECORD_SCHEMA_VERSION: u64 = 1;
+/// Current supported `ReleaseRecord` schema version text.
+pub const RELEASE_RECORD_SCHEMA_VERSION: &str = monochange_schema::CURRENT_SCHEMA_VERSION_TEXT;
 /// Required `ReleaseRecord.kind` discriminator.
 pub const RELEASE_RECORD_KIND: &str = "monochange.releaseRecord";
 /// Human-readable heading used for commit-embedded release records.
@@ -3047,8 +3047,8 @@ pub const RELEASE_RECORD_START_MARKER: &str = "<!-- monochange:release-record:st
 /// Closing marker for a commit-embedded release record block.
 pub const RELEASE_RECORD_END_MARKER: &str = "<!-- monochange:release-record:end -->";
 
-const fn release_record_schema_version() -> u64 {
-	RELEASE_RECORD_SCHEMA_VERSION
+fn release_record_schema_version() -> String {
+	monochange_schema::CURRENT_SCHEMA_VERSION_TEXT.to_string()
 }
 
 fn default_release_record_kind() -> String {
@@ -3073,6 +3073,32 @@ fn default_pull_request_title() -> String {
 
 fn default_pull_request_labels() -> Vec<String> {
 	vec!["release".to_string(), "automated".to_string()]
+}
+
+/// Normalize legacy schema-version fields before passing to `migrate_value`.
+///
+/// - Moves `"v"` values to `"schemaVersion"`.
+/// - Replaces the pre-public integer `schemaVersion: 1` with the current
+///   `RELEASE_RECORD_SCHEMA_VERSION` text.
+fn normalize_legacy_schema_version(raw: &mut serde_json::Value) {
+	let Some(object) = raw.as_object_mut() else {
+		return;
+	};
+	if let Some(version) = object.get("schemaVersion")
+		&& version.is_u64()
+		&& version.as_u64() == Some(1)
+	{
+		object.insert(
+			"schemaVersion".to_string(),
+			serde_json::Value::String(RELEASE_RECORD_SCHEMA_VERSION.to_string()),
+		);
+	}
+	if !object.contains_key("schemaVersion")
+		&& object.contains_key("v")
+		&& let Some(v) = object.remove("v")
+	{
+		object.insert("schemaVersion".to_string(), v);
+	}
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -3103,7 +3129,7 @@ pub struct ReleaseRecordProvider {
 #[serde(rename_all = "camelCase")]
 pub struct ReleaseRecord {
 	#[serde(default = "release_record_schema_version")]
-	pub schema_version: u64,
+	pub schema_version: String,
 	#[serde(default = "default_release_record_kind")]
 	pub kind: String,
 	pub created_at: String,
@@ -3249,12 +3275,10 @@ pub enum ReleaseRecordError {
 	MissingJsonBlock,
 	#[error("release record is missing required `kind`")]
 	MissingKind,
-	#[error("release record is missing required `v`")]
+	#[error("release record is missing required `schemaVersion`")]
 	MissingSchemaVersion,
 	#[error("release record uses unsupported kind `{0}`")]
 	UnsupportedKind(String),
-	#[error("release record uses unsupported internal schemaVersion {0}")]
-	UnsupportedSchemaVersion(u64),
 	#[error("release record uses unsupported schema version `{0}`")]
 	UnsupportedSchemaVersionValue(String),
 	#[error("release record schema error: {0}")]
@@ -3290,8 +3314,8 @@ pub fn render_release_record_block(record: &ReleaseRecord) -> ReleaseRecordResul
 		return Err(ReleaseRecordError::UnsupportedKind(record.kind.clone()));
 	}
 	if record.schema_version != RELEASE_RECORD_SCHEMA_VERSION {
-		return Err(ReleaseRecordError::UnsupportedSchemaVersion(
-			record.schema_version,
+		return Err(ReleaseRecordError::UnsupportedSchemaVersionValue(
+			record.schema_version.clone(),
 		));
 	}
 	let raw = serde_json::to_value(record)?;
@@ -3308,17 +3332,7 @@ pub fn render_release_record_block(record: &ReleaseRecord) -> ReleaseRecordResul
 pub fn parse_release_record_json(json_text: &str) -> ReleaseRecordResult<ReleaseRecord> {
 	let mut raw = serde_json::from_str::<serde_json::Value>(json_text)
 		.map_err(ReleaseRecordError::InvalidJson)?;
-	// Normalize schemaVersion -> v for migration compatibility
-	if let Some(object) = raw.as_object_mut()
-		&& !object.contains_key("v")
-		&& object.contains_key("schemaVersion")
-	{
-		object.insert(
-			"v".to_string(),
-			serde_json::Value::String(monochange_schema::CURRENT_SCHEMA_VERSION_TEXT.to_string()),
-		);
-		object.remove("schemaVersion");
-	}
+	normalize_legacy_schema_version(&mut raw);
 	let kind = raw
 		.get("kind")
 		.and_then(serde_json::Value::as_str)
@@ -3326,16 +3340,8 @@ pub fn parse_release_record_json(json_text: &str) -> ReleaseRecordResult<Release
 	if kind != RELEASE_RECORD_KIND {
 		return Err(ReleaseRecordError::UnsupportedKind(kind.to_string()));
 	}
-	let mut current = monochange_schema::release_record::migrate_value(raw)
+	let current = monochange_schema::release_record::migrate_value(raw)
 		.map_err(release_record_schema_error_to_error)?;
-	let object = current
-		.as_object_mut()
-		.expect("release record schema migration returns an object");
-	object.remove("v");
-	object.insert(
-		"schemaVersion".to_string(),
-		serde_json::Value::from(RELEASE_RECORD_SCHEMA_VERSION),
-	);
 	serde_json::from_value(current).map_err(ReleaseRecordError::InvalidJson)
 }
 
@@ -3369,7 +3375,9 @@ pub fn parse_release_record_block(commit_message: &str) -> ReleaseRecordResult<R
 	let block_contents =
 		&commit_message[start_index + RELEASE_RECORD_START_MARKER.len()..end_index];
 	let json_text = extract_release_record_json(block_contents)?;
-	let raw = serde_json::from_str::<serde_json::Value>(&json_text)?;
+	let mut raw = serde_json::from_str::<serde_json::Value>(&json_text)?;
+	normalize_legacy_schema_version(&mut raw);
+	normalize_legacy_schema_version(&mut raw);
 	let kind = raw
 		.get("kind")
 		.and_then(serde_json::Value::as_str)
@@ -3377,16 +3385,8 @@ pub fn parse_release_record_block(commit_message: &str) -> ReleaseRecordResult<R
 	if kind != RELEASE_RECORD_KIND {
 		return Err(ReleaseRecordError::UnsupportedKind(kind.to_string()));
 	}
-	let mut current = monochange_schema::release_record::migrate_value(raw)
+	let current = monochange_schema::release_record::migrate_value(raw)
 		.map_err(release_record_schema_error_to_error)?;
-	let object = current
-		.as_object_mut()
-		.expect("release record schema migration returns an object");
-	object.remove("v");
-	object.insert(
-		"schemaVersion".to_string(),
-		serde_json::Value::from(RELEASE_RECORD_SCHEMA_VERSION),
-	);
 	serde_json::from_value(current).map_err(ReleaseRecordError::InvalidJson)
 }
 

--- a/crates/monochange_integration_tests/tests/schema_assets.rs
+++ b/crates/monochange_integration_tests/tests/schema_assets.rs
@@ -38,7 +38,7 @@ fn release_record_schema_declares_current_artifact_contract() -> Result<(), Box<
 	);
 	assert!(!json_bool(&schema, "/additionalProperties")?);
 	assert_eq!(
-		json_str(&schema, "/properties/v/const")?,
+		json_str(&schema, "/properties/schemaVersion/const")?,
 		monochange_schema::CURRENT_SCHEMA_VERSION_TEXT
 	);
 	assert_eq!(
@@ -48,7 +48,7 @@ fn release_record_schema_declares_current_artifact_contract() -> Result<(), Box<
 
 	let required = json_array(&schema, "/required")?;
 	for key in [
-		"v",
+		"schemaVersion",
 		"kind",
 		"createdAt",
 		"command",
@@ -274,7 +274,7 @@ fn schema_crate_version_stays_decoupled_from_public_schema_version() -> Result<(
 fn release_record_migration_outcomes_match_snapshot() {
 	let mut missing_version = sample_release_record();
 	if let Some(object) = missing_version.as_object_mut() {
-		object.remove("v");
+		object.remove("schemaVersion");
 	}
 
 	let mut missing_kind = sample_release_record();
@@ -326,7 +326,7 @@ fn release_record_migration_outcomes_match_snapshot() {
 					json!({
 						"scenario": scenario,
 						"status": "ok",
-						"v": value.get("v"),
+						"schemaVersion": value.get("schemaVersion"),
 					})
 				}
 				Err(error) => {
@@ -430,7 +430,7 @@ fn sample_release_record_with(version: &str, kind: &str) -> Value {
 
 fn sample_release_record_with_value(version: Value, kind: Value) -> Value {
 	json!({
-		"v": version,
+		"schemaVersion": version,
 		"kind": kind,
 		"createdAt": "2026-04-06T12:00:00Z",
 		"command": "release-pr",

--- a/crates/monochange_integration_tests/tests/schema_assets.rs
+++ b/crates/monochange_integration_tests/tests/schema_assets.rs
@@ -261,10 +261,10 @@ fn schema_crate_version_stays_decoupled_from_public_schema_version() -> Result<(
 		.unwrap_or_default();
 
 	assert_eq!(schema_crate_version(&paths)?, expected_version);
-	assert_eq!(monochange_schema::CURRENT_SCHEMA_VERSION_TEXT, "0.0");
+	assert_eq!(monochange_schema::CURRENT_SCHEMA_VERSION_TEXT, "0.1");
 	assert_eq!(
 		monochange_schema::current_schema_version()?,
-		monochange_schema::SchemaVersion::new(0, 0)
+		monochange_schema::SchemaVersion::new(0, 1)
 	);
 
 	Ok(())

--- a/crates/monochange_integration_tests/tests/snapshots/schema_assets__release_record_migration_outcomes_match_snapshot.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/schema_assets__release_record_migration_outcomes_match_snapshot.snap
@@ -5,7 +5,7 @@ expression: outcomes
 [
   {
     "scenario": "current",
-    "schemaVersion": "0.0",
+    "schemaVersion": "0.1",
     "status": "ok"
   },
   {
@@ -44,12 +44,12 @@ expression: outcomes
     "status": "error"
   },
   {
-    "error": "artifact uses unsupported schema version `0.1`; current supported version is `0.0`",
     "scenario": "old_version_without_migration_edge",
-    "status": "error"
+    "schemaVersion": "0.1",
+    "status": "ok"
   },
   {
-    "error": "artifact uses unsupported schema version `0.2`; current supported version is `0.0`",
+    "error": "artifact uses unsupported schema version `0.2`; current supported version is `0.1`",
     "scenario": "future_version",
     "status": "error"
   }

--- a/crates/monochange_integration_tests/tests/snapshots/schema_assets__release_record_migration_outcomes_match_snapshot.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/schema_assets__release_record_migration_outcomes_match_snapshot.snap
@@ -5,8 +5,8 @@ expression: outcomes
 [
   {
     "scenario": "current",
-    "status": "ok",
-    "v": "0.0"
+    "schemaVersion": "0.0",
+    "status": "ok"
   },
   {
     "error": "artifact is not a JSON object",
@@ -24,17 +24,17 @@ expression: outcomes
     "status": "error"
   },
   {
-    "error": "artifact is missing required schema version field `v`",
+    "error": "artifact is missing required schema version field `schemaVersion`",
     "scenario": "missing_version",
     "status": "error"
   },
   {
-    "error": "artifact is missing required schema version field `v`",
+    "error": "artifact schema version field `schemaVersion` must be a string",
     "scenario": "pre_public_schema_version_field",
     "status": "error"
   },
   {
-    "error": "artifact schema version field `v` must be a string",
+    "error": "artifact schema version field `schemaVersion` must be a string",
     "scenario": "non_string_version",
     "status": "error"
   },

--- a/crates/monochange_integration_tests/tests/snapshots/schema_assets__release_record_required_fields.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/schema_assets__release_record_required_fields.snap
@@ -3,7 +3,7 @@ source: crates/monochange_integration_tests/tests/schema_assets.rs
 expression: "json_array(&release_schema, \"/required\")?"
 ---
 [
-  "v",
+  "schemaVersion",
   "kind",
   "createdAt",
   "command",

--- a/crates/monochange_integration_tests/tests/snapshots/schema_assets__release_record_schema_description.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/schema_assets__release_record_schema_description.snap
@@ -2,4 +2,4 @@
 source: crates/monochange_integration_tests/tests/schema_assets.rs
 expression: "json_str(&release_schema, \"/description\")?"
 ---
-Durable commit-embedded release record schema for monochange artifact version 0.0.
+Durable commit-embedded release record schema for monochange artifact version 0.1.

--- a/crates/monochange_integration_tests/tests/snapshots/schema_assets__schema_asset_inventory_matches_snapshot.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/schema_assets__schema_asset_inventory_matches_snapshot.snap
@@ -12,7 +12,7 @@ expression: inventory
     ],
     "schemaId": "https://monochange.github.io/monochange/schemas/monochange.schema.json"
   },
-  "currentSchemaVersion": "0.0",
+  "currentSchemaVersion": "0.1",
   "migrationChangelog": [],
   "releaseRecord": {
     "additionalProperties": false,

--- a/crates/monochange_integration_tests/tests/snapshots/schema_assets__schema_asset_inventory_matches_snapshot.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/schema_assets__schema_asset_inventory_matches_snapshot.snap
@@ -18,7 +18,7 @@ expression: inventory
     "additionalProperties": false,
     "kind": "monochange.releaseRecord",
     "required": [
-      "v",
+      "schemaVersion",
       "kind",
       "createdAt",
       "command",

--- a/crates/monochange_schema/Cargo.toml
+++ b/crates/monochange_schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monochange_schema"
-version = "0.0.0"
+version = "0.1.0"
 categories = { workspace = true }
 documentation = "https://docs.rs/monochange_schema"
 edition = { workspace = true }

--- a/crates/monochange_schema/schemas/release-record.schema.json
+++ b/crates/monochange_schema/schemas/release-record.schema.json
@@ -6,7 +6,7 @@
 	"type": "object",
 	"additionalProperties": false,
 	"required": [
-		"v",
+		"schemaVersion",
 		"kind",
 		"createdAt",
 		"command",
@@ -15,7 +15,7 @@
 		"changedFiles"
 	],
 	"properties": {
-		"v": {
+		"schemaVersion": {
 			"type": "string",
 			"const": "0.0",
 			"description": "Public durable artifact schema version. Older CLIs reject missing, future, or non-current versions."

--- a/crates/monochange_schema/schemas/release-record.schema.json
+++ b/crates/monochange_schema/schemas/release-record.schema.json
@@ -17,7 +17,7 @@
 	"properties": {
 		"schemaVersion": {
 			"type": "string",
-			"const": "0.0",
+			"const": "0.1",
 			"description": "Public durable artifact schema version. Older CLIs reject missing, future, or non-current versions."
 		},
 		"kind": {
@@ -87,6 +87,9 @@
 					"$ref": "#/$defs/provider"
 				}
 			]
+		},
+		"v": {
+			"const": "0.0"
 		}
 	},
 	"$defs": {

--- a/crates/monochange_schema/src/__tests__/lib_tests.rs
+++ b/crates/monochange_schema/src/__tests__/lib_tests.rs
@@ -79,7 +79,7 @@ fn current_schema_version_strips_patch_from_package_version() {
 #[test]
 fn release_record_accepts_current_schema_version() {
 	let migrated = release_record::migrate_value(json!({
-		"v": "0.0",
+		"schemaVersion": "0.0",
 		"kind": release_record::KIND,
 		"createdAt": "2026-04-06T12:00:00Z",
 		"command": "release-pr",
@@ -89,7 +89,7 @@ fn release_record_accepts_current_schema_version() {
 	}))
 	.unwrap_or_else(|error| panic!("validate release record: {error}"));
 
-	assert_eq!(migrated.get("v"), Some(&json!("0.0")));
+	assert_eq!(migrated.get("schemaVersion"), Some(&json!("0.0")));
 }
 
 #[test]
@@ -105,10 +105,13 @@ fn release_record_render_current_value_writes_public_version_only() {
 	}))
 	.unwrap_or_else(|error| panic!("render current release record: {error}"));
 
-	assert_eq!(rendered.get("v"), Some(&json!(CURRENT_SCHEMA_VERSION_TEXT)));
+	assert_eq!(
+		rendered.get("schemaVersion"),
+		Some(&json!(CURRENT_SCHEMA_VERSION_TEXT))
+	);
 	assert!(
-		rendered.get("schemaVersion").is_none(),
-		"internal schemaVersion must not leak into durable records"
+		rendered.get("v").is_none(),
+		"legacy `v` must not leak into durable records"
 	);
 }
 
@@ -150,7 +153,7 @@ fn release_record_rejects_missing_version() {
 #[test]
 fn release_record_rejects_non_string_version() {
 	let error = release_record::migrate_value(json!({
-		"v": 1,
+		"schemaVersion": 1,
 		"kind": release_record::KIND,
 		"createdAt": "2026-04-06T12:00:00Z",
 		"command": "release-pr",
@@ -166,7 +169,7 @@ fn release_record_rejects_non_string_version() {
 #[test]
 fn release_record_rejects_invalid_version_text() {
 	let error = release_record::migrate_value(json!({
-		"v": "0.1.0",
+		"schemaVersion": "0.1.0",
 		"kind": release_record::KIND,
 		"createdAt": "2026-04-06T12:00:00Z",
 		"command": "release-pr",
@@ -185,7 +188,7 @@ fn release_record_rejects_invalid_version_text() {
 #[test]
 fn release_record_rejects_old_version_without_migration_edge() {
 	let error = release_record::migrate_value(json!({
-		"v": "9.0",
+		"schemaVersion": "9.0",
 		"kind": release_record::KIND,
 		"createdAt": "2026-04-06T12:00:00Z",
 		"command": "release-pr",
@@ -204,7 +207,7 @@ fn release_record_rejects_old_version_without_migration_edge() {
 #[test]
 fn release_record_rejects_unsupported_kind() {
 	let error = release_record::migrate_value(json!({
-		"v": "0.1",
+		"schemaVersion": "0.1",
 		"kind": "monochange.otherRecord",
 		"createdAt": "2026-04-06T12:00:00Z",
 		"command": "release-pr",
@@ -224,7 +227,7 @@ fn release_record_rejects_unsupported_kind() {
 #[test]
 fn release_record_rejects_future_version() {
 	let error = release_record::migrate_value(json!({
-		"v": "9.0",
+		"schemaVersion": "9.0",
 		"kind": release_record::KIND,
 		"createdAt": "2026-04-06T12:00:00Z",
 		"command": "release-pr",
@@ -256,7 +259,7 @@ fn committed_release_record_schema_tracks_current_wire_constants() {
 
 	assert_eq!(
 		schema
-			.pointer("/properties/v/const")
+			.pointer("/properties/schemaVersion/const")
 			.and_then(Value::as_str),
 		Some(CURRENT_SCHEMA_VERSION_TEXT)
 	);

--- a/crates/monochange_schema/src/lib.rs
+++ b/crates/monochange_schema/src/lib.rs
@@ -183,10 +183,10 @@ pub enum SchemaError {
 		expected: &'static str,
 	},
 	/// Artifact lacked the current version field.
-	#[error("artifact is missing required schema version field `v`")]
+	#[error("artifact is missing required schema version field `schemaVersion`")]
 	MissingVersion,
-	/// Current `v` field was not a string.
-	#[error("artifact schema version field `v` must be a string")]
+	/// Current `schemaVersion` field was not a string.
+	#[error("artifact schema version field `schemaVersion` must be a string")]
 	NonStringVersion,
 	/// Current `v` field could not be parsed.
 	#[error("artifact uses invalid schema version `{version}`: {source}")]
@@ -264,7 +264,8 @@ pub mod release_record {
 
 	/// Durable artifact kind for commit-embedded release records.
 	pub const KIND: &str = "monochange.releaseRecord";
-	const INTERNAL_SCHEMA_VERSION_FIELD: &str = "schemaVersion";
+	const SCHEMA_VERSION_FIELD: &str = "schemaVersion";
+	const LEGACY_VERSION_FIELD: &str = "v";
 
 	/// Return the current release-record schema version.
 	pub fn current_version() -> Result<SchemaVersion, SchemaError> {
@@ -274,13 +275,13 @@ pub mod release_record {
 	/// Convert a release-record JSON value into the current durable wire shape.
 	///
 	/// This is intended for rendering new artifacts from existing in-memory domain
-	/// structs. It writes `v` and removes internal-only `schemaVersion`.
+	/// structs. It writes `schemaVersion` and removes legacy `v`.
 	pub fn render_current_value(mut value: Value) -> Result<Value, SchemaError> {
 		let object = object_mut(&mut value)?;
 		validate_kind(object, KIND)?;
-		object.remove(INTERNAL_SCHEMA_VERSION_FIELD);
+		object.remove(LEGACY_VERSION_FIELD);
 		object.insert(
-			"v".to_string(),
+			SCHEMA_VERSION_FIELD.to_string(),
 			Value::String(CURRENT_SCHEMA_VERSION_TEXT.to_string()),
 		);
 		Ok(value)
@@ -288,12 +289,16 @@ pub mod release_record {
 
 	/// Validate a release-record JSON value against the current durable wire shape.
 	///
-	/// `0.0` is the first supported public schema version. Values without `v` or
-	/// with any non-current `v` fail instead of taking a migration path.
+	/// `0.0` is the first supported public schema version. Values without `schemaVersion`
+	/// or with any non-current `schemaVersion` fail instead of taking a migration path.
+	/// Legacy `v` fields are accepted as a compatibility bridge.
 	pub fn migrate_value(mut value: Value) -> Result<Value, SchemaError> {
 		let object = object_mut(&mut value)?;
 		validate_kind(object, KIND)?;
-		let version_value = object.get("v").ok_or(SchemaError::MissingVersion)?;
+		let version_value = object
+			.get(SCHEMA_VERSION_FIELD)
+			.or_else(|| object.get(LEGACY_VERSION_FIELD))
+			.ok_or(SchemaError::MissingVersion)?;
 		let version = parse_current_version(version_value)?;
 		let current = current_version()?;
 		if version != current {
@@ -302,6 +307,12 @@ pub mod release_record {
 				current,
 			});
 		}
+		// Normalize legacy `v` to `schemaVersion` for downstream consumers.
+		object.remove(LEGACY_VERSION_FIELD);
+		object.insert(
+			SCHEMA_VERSION_FIELD.to_string(),
+			Value::String(CURRENT_SCHEMA_VERSION_TEXT.to_string()),
+		);
 		Ok(value)
 	}
 }
@@ -326,7 +337,7 @@ pub mod migration_changelog {
 		pub artifact: &'static str,
 		/// Source version for the migration edge.
 		pub from: MigrationSource,
-		/// Destination `v` after migration.
+		/// Destination `schemaVersion` after migration.
 		pub to: SchemaVersion,
 		/// Summary operation for the edge.
 		pub operation: MigrationOperation,
@@ -344,8 +355,8 @@ pub mod migration_changelog {
 	pub enum MigrationSource {
 		/// Current string schema version field.
 		Version {
-			/// Source `v` value.
-			v: SchemaVersion,
+			/// Source `schemaVersion` value.
+			schema_version: SchemaVersion,
 		},
 	}
 

--- a/crates/monochange_test_helpers/src/insta.rs
+++ b/crates/monochange_test_helpers/src/insta.rs
@@ -20,9 +20,12 @@ pub fn snapshot_settings() -> insta::Settings {
 	settings.add_filter(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}", "[DATETIME]");
 	settings.add_filter(r"\d{4}-\d{2}-\d{2}", "[DATE]");
 
-	// Release-record schema version filter — redact the wire-format `v` field so
+	// Release-record schema version filter — redact the wire-format `schemaVersion` field so
 	// snapshots survive release bumps that change `monochange_schema` version.
-	settings.add_filter(r#""v": "\d+\.\d+""#, r#""v": "[SCHEMA_VERSION]""#);
+	settings.add_filter(
+		r#""schemaVersion": "\d+\.\d+""#,
+		r#""schemaVersion": "[SCHEMA_VERSION]""#,
+	);
 
 	settings
 }

--- a/docs/src/schemas/monochange.v0.1.schema.json
+++ b/docs/src/schemas/monochange.v0.1.schema.json
@@ -1,0 +1,959 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://monochange.github.io/monochange/schemas/monochange.v0.1.schema.json",
+	"title": "monochange configuration",
+	"description": "JSON Schema for monochange.toml workspace configuration files.",
+	"type": "object",
+	"additionalProperties": false,
+	"properties": {
+		"defaults": {
+			"$ref": "#/$defs/defaults"
+		},
+		"changelog": {
+			"$ref": "#/$defs/changelogSettings"
+		},
+		"package": {
+			"type": "object",
+			"description": "Release-managed package definitions keyed by package id.",
+			"additionalProperties": {
+				"$ref": "#/$defs/packageDefinition"
+			}
+		},
+		"group": {
+			"type": "object",
+			"description": "Version group definitions keyed by group id.",
+			"additionalProperties": {
+				"$ref": "#/$defs/groupDefinition"
+			}
+		},
+		"cli": {
+			"type": "object",
+			"description": "Custom monochange CLI workflows keyed by command name.",
+			"additionalProperties": {
+				"$ref": "#/$defs/cliCommand"
+			}
+		},
+		"changesets": {
+			"$ref": "#/$defs/changesets"
+		},
+		"source": {
+			"$ref": "#/$defs/source"
+		},
+		"lints": {
+			"$ref": "#/$defs/lints"
+		},
+		"ecosystems": {
+			"$ref": "#/$defs/ecosystems"
+		}
+	},
+	"$defs": {
+		"stringArray": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"bumpSeverity": {
+			"type": "string",
+			"enum": [
+				"none",
+				"patch",
+				"minor",
+				"major"
+			]
+		},
+		"packageType": {
+			"type": "string",
+			"enum": [
+				"cargo",
+				"npm",
+				"deno",
+				"dart",
+				"flutter",
+				"python",
+				"go"
+			]
+		},
+		"ecosystemType": {
+			"type": "string",
+			"enum": [
+				"cargo",
+				"npm",
+				"deno",
+				"dart",
+				"python",
+				"go"
+			]
+		},
+		"versionFormat": {
+			"type": "string",
+			"enum": [
+				"namespaced",
+				"primary"
+			]
+		},
+		"changelogFormat": {
+			"type": "string",
+			"enum": [
+				"monochange",
+				"keep_a_changelog"
+			]
+		},
+		"publishMode": {
+			"type": "string",
+			"enum": [
+				"builtin",
+				"external"
+			]
+		},
+		"registry": {
+			"type": "string",
+			"enum": [
+				"crates_io",
+				"npm",
+				"jsr",
+				"pub_dev",
+				"pypi",
+				"go_proxy"
+			]
+		},
+		"sourceProvider": {
+			"type": "string",
+			"enum": [
+				"github",
+				"gitlab",
+				"gitea"
+			]
+		},
+		"defaults": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"parent_bump": {
+					"$ref": "#/$defs/bumpSeverity"
+				},
+				"include_private": {
+					"type": "boolean"
+				},
+				"warn_on_group_mismatch": {
+					"type": "boolean"
+				},
+				"strict_version_conflicts": {
+					"type": "boolean"
+				},
+				"package_type": {
+					"$ref": "#/$defs/packageType"
+				},
+				"changelog": {
+					"$ref": "#/$defs/changelogConfig"
+				},
+				"empty_update_message": {
+					"type": "string"
+				},
+				"release_title": {
+					"type": "string"
+				},
+				"changelog_version_title": {
+					"type": "string"
+				}
+			}
+		},
+		"changelogConfig": {
+			"description": "Changelog configuration. Boolean/string shorthand is supported, or use a table for detailed settings.",
+			"oneOf": [
+				{
+					"type": "boolean"
+				},
+				{
+					"type": "string"
+				},
+				{
+					"$ref": "#/$defs/changelogTable"
+				}
+			]
+		},
+		"changelogTable": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"enabled": {
+					"type": "boolean"
+				},
+				"path": {
+					"type": "string"
+				},
+				"format": {
+					"$ref": "#/$defs/changelogFormat"
+				},
+				"initial_header": {
+					"type": "string"
+				},
+				"include": {
+					"oneOf": [
+						{
+							"type": "string"
+						},
+						{
+							"$ref": "#/$defs/stringArray"
+						}
+					]
+				}
+			}
+		},
+		"versionedFile": {
+			"description": "Additional file whose version references should be updated.",
+			"oneOf": [
+				{
+					"type": "string"
+				},
+				{
+					"type": "object",
+					"additionalProperties": false,
+					"required": [
+						"path"
+					],
+					"properties": {
+						"path": {
+							"type": "string"
+						},
+						"type": {
+							"$ref": "#/$defs/ecosystemType"
+						},
+						"prefix": {
+							"type": "string"
+						},
+						"fields": {
+							"$ref": "#/$defs/stringArray"
+						},
+						"name": {
+							"type": "string"
+						},
+						"regex": {
+							"type": "string"
+						}
+					}
+				}
+			]
+		},
+		"versionedFiles": {
+			"type": "array",
+			"items": {
+				"$ref": "#/$defs/versionedFile"
+			}
+		},
+		"publishSettings": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"enabled": {
+					"type": "boolean"
+				},
+				"mode": {
+					"$ref": "#/$defs/publishMode"
+				},
+				"registry": {
+					"description": "Canonical public registry name or custom registry identifier.",
+					"type": "string"
+				},
+				"trusted_publishing": {
+					"oneOf": [
+						{
+							"type": "boolean"
+						},
+						{
+							"$ref": "#/$defs/trustedPublishing"
+						}
+					]
+				},
+				"attestations": {
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"require_registry_provenance": {
+							"type": "boolean"
+						}
+					}
+				},
+				"rate_limits": {
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"enforce": {
+							"type": "boolean"
+						}
+					}
+				},
+				"placeholder": {
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"readme": {
+							"type": "string"
+						},
+						"readme_file": {
+							"type": "string"
+						}
+					}
+				}
+			}
+		},
+		"trustedPublishing": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"enabled": {
+					"type": "boolean"
+				},
+				"repository": {
+					"type": "string"
+				},
+				"workflow": {
+					"type": "string"
+				},
+				"environment": {
+					"type": "string"
+				}
+			}
+		},
+		"packageDefinition": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"path"
+			],
+			"properties": {
+				"path": {
+					"type": "string"
+				},
+				"type": {
+					"$ref": "#/$defs/packageType"
+				},
+				"changelog": {
+					"$ref": "#/$defs/changelogConfig"
+				},
+				"excluded_changelog_types": {
+					"$ref": "#/$defs/stringArray"
+				},
+				"empty_update_message": {
+					"type": "string"
+				},
+				"release_title": {
+					"type": "string"
+				},
+				"changelog_version_title": {
+					"type": "string"
+				},
+				"versioned_files": {
+					"$ref": "#/$defs/versionedFiles"
+				},
+				"ignore_ecosystem_versioned_files": {
+					"type": "boolean"
+				},
+				"ignored_paths": {
+					"$ref": "#/$defs/stringArray"
+				},
+				"additional_paths": {
+					"$ref": "#/$defs/stringArray"
+				},
+				"tag": {
+					"type": "boolean"
+				},
+				"release": {
+					"type": "boolean"
+				},
+				"version_format": {
+					"$ref": "#/$defs/versionFormat"
+				},
+				"publish": {
+					"$ref": "#/$defs/publishSettings"
+				}
+			}
+		},
+		"groupDefinition": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"packages"
+			],
+			"properties": {
+				"packages": {
+					"$ref": "#/$defs/stringArray"
+				},
+				"changelog": {
+					"$ref": "#/$defs/changelogConfig"
+				},
+				"excluded_changelog_types": {
+					"$ref": "#/$defs/stringArray"
+				},
+				"empty_update_message": {
+					"type": "string"
+				},
+				"release_title": {
+					"type": "string"
+				},
+				"changelog_version_title": {
+					"type": "string"
+				},
+				"versioned_files": {
+					"$ref": "#/$defs/versionedFiles"
+				},
+				"tag": {
+					"type": "boolean"
+				},
+				"release": {
+					"type": "boolean"
+				},
+				"version_format": {
+					"$ref": "#/$defs/versionFormat"
+				}
+			}
+		},
+		"changelogSettings": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"templates": {
+					"$ref": "#/$defs/stringArray"
+				},
+				"sections": {
+					"type": "object",
+					"additionalProperties": {
+						"$ref": "#/$defs/changelogSection"
+					}
+				},
+				"section_thresholds": {
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"collapse": {
+							"type": "integer",
+							"minimum": -128,
+							"maximum": 127
+						},
+						"ignored": {
+							"type": "integer",
+							"minimum": -128,
+							"maximum": 127
+						}
+					}
+				},
+				"types": {
+					"type": "object",
+					"additionalProperties": {
+						"$ref": "#/$defs/changelogType"
+					}
+				}
+			}
+		},
+		"changelogSection": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"heading"
+			],
+			"properties": {
+				"heading": {
+					"type": "string"
+				},
+				"description": {
+					"type": "string"
+				},
+				"priority": {
+					"type": "integer",
+					"minimum": -128,
+					"maximum": 127
+				}
+			}
+		},
+		"changelogType": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"section"
+			],
+			"properties": {
+				"bump": {
+					"$ref": "#/$defs/bumpSeverity"
+				},
+				"section": {
+					"type": "string"
+				},
+				"description": {
+					"type": "string"
+				}
+			}
+		},
+		"changesets": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"affected": {
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"enabled": {
+							"type": "boolean"
+						},
+						"required": {
+							"type": "boolean"
+						},
+						"skip_labels": {
+							"$ref": "#/$defs/stringArray"
+						},
+						"comment_on_failure": {
+							"type": "boolean"
+						},
+						"changed_paths": {
+							"$ref": "#/$defs/stringArray"
+						},
+						"ignored_paths": {
+							"$ref": "#/$defs/stringArray"
+						}
+					}
+				}
+			}
+		},
+		"source": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"owner",
+				"repo"
+			],
+			"properties": {
+				"provider": {
+					"$ref": "#/$defs/sourceProvider"
+				},
+				"owner": {
+					"type": "string"
+				},
+				"repo": {
+					"type": "string"
+				},
+				"host": {
+					"type": "string"
+				},
+				"api_url": {
+					"type": "string"
+				},
+				"releases": {
+					"$ref": "#/$defs/providerReleases"
+				},
+				"pull_requests": {
+					"$ref": "#/$defs/providerPullRequests"
+				}
+			}
+		},
+		"providerReleases": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"enabled": {
+					"type": "boolean"
+				},
+				"draft": {
+					"type": "boolean"
+				},
+				"prerelease": {
+					"type": "boolean"
+				},
+				"generate_notes": {
+					"type": "boolean"
+				},
+				"source": {
+					"type": "string",
+					"enum": [
+						"monochange",
+						"github_generated"
+					]
+				},
+				"branches": {
+					"$ref": "#/$defs/stringArray"
+				},
+				"enforce_for_tags": {
+					"type": "boolean"
+				},
+				"enforce_for_publish": {
+					"type": "boolean"
+				},
+				"enforce_for_commit": {
+					"type": "boolean"
+				},
+				"attestations": {
+					"type": "object",
+					"additionalProperties": true
+				}
+			}
+		},
+		"providerPullRequests": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"enabled": {
+					"type": "boolean"
+				},
+				"branch_prefix": {
+					"type": "string"
+				},
+				"base": {
+					"type": "string"
+				},
+				"title": {
+					"type": "string"
+				},
+				"labels": {
+					"$ref": "#/$defs/stringArray"
+				},
+				"auto_merge": {
+					"type": "boolean"
+				},
+				"verified_commits": {
+					"type": "boolean"
+				}
+			}
+		},
+		"ecosystems": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"cargo": {
+					"$ref": "#/$defs/ecosystemSettings"
+				},
+				"npm": {
+					"$ref": "#/$defs/ecosystemSettings"
+				},
+				"deno": {
+					"$ref": "#/$defs/ecosystemSettings"
+				},
+				"dart": {
+					"$ref": "#/$defs/ecosystemSettings"
+				},
+				"python": {
+					"$ref": "#/$defs/ecosystemSettings"
+				},
+				"go": {
+					"$ref": "#/$defs/ecosystemSettings"
+				}
+			}
+		},
+		"ecosystemSettings": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"enabled": {
+					"type": "boolean"
+				},
+				"roots": {
+					"$ref": "#/$defs/stringArray"
+				},
+				"exclude": {
+					"$ref": "#/$defs/stringArray"
+				},
+				"dependency_version_prefix": {
+					"type": "string"
+				},
+				"versioned_files": {
+					"$ref": "#/$defs/versionedFiles"
+				},
+				"lockfile_commands": {
+					"type": "array",
+					"items": {
+						"$ref": "#/$defs/lockfileCommand"
+					}
+				},
+				"publish": {
+					"$ref": "#/$defs/publishSettings"
+				}
+			}
+		},
+		"lockfileCommand": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"command"
+			],
+			"properties": {
+				"command": {
+					"type": "string"
+				},
+				"cwd": {
+					"type": "string"
+				},
+				"shell": {
+					"oneOf": [
+						{
+							"type": "boolean"
+						},
+						{
+							"type": "string"
+						}
+					]
+				}
+			}
+		},
+		"cliCommand": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"help_text": {
+					"type": "string"
+				},
+				"inputs": {
+					"type": "array",
+					"items": {
+						"$ref": "#/$defs/cliInput"
+					}
+				},
+				"steps": {
+					"type": "array",
+					"items": {
+						"$ref": "#/$defs/cliStep"
+					}
+				}
+			}
+		},
+		"cliInput": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"name",
+				"type"
+			],
+			"properties": {
+				"name": {
+					"type": "string"
+				},
+				"type": {
+					"type": "string",
+					"enum": [
+						"string",
+						"string_list",
+						"path",
+						"choice",
+						"boolean"
+					]
+				},
+				"help_text": {
+					"type": "string"
+				},
+				"required": {
+					"type": "boolean"
+				},
+				"default": {
+					"oneOf": [
+						{
+							"type": "string"
+						},
+						{
+							"type": "boolean"
+						}
+					]
+				},
+				"choices": {
+					"$ref": "#/$defs/stringArray"
+				},
+				"short": {
+					"type": "string",
+					"minLength": 1,
+					"maxLength": 1
+				}
+			}
+		},
+		"cliStep": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"type"
+			],
+			"properties": {
+				"type": {
+					"type": "string",
+					"enum": [
+						"Config",
+						"Validate",
+						"Discover",
+						"DisplayVersions",
+						"CreateChangeFile",
+						"PrepareRelease",
+						"CommitRelease",
+						"VerifyReleaseBranch",
+						"PublishRelease",
+						"PlaceholderPublish",
+						"PublishPackages",
+						"PlanPublishRateLimits",
+						"OpenReleaseRequest",
+						"CommentReleasedIssues",
+						"AffectedPackages",
+						"DiagnoseChangesets",
+						"RetargetRelease",
+						"Command"
+					]
+				},
+				"name": {
+					"type": "string"
+				},
+				"when": {
+					"type": "string"
+				},
+				"inputs": {
+					"type": "object",
+					"additionalProperties": {
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "boolean"
+							},
+							{
+								"$ref": "#/$defs/stringArray"
+							}
+						]
+					}
+				},
+				"command": {
+					"type": "string"
+				},
+				"cwd": {
+					"type": "string"
+				},
+				"shell": {
+					"oneOf": [
+						{
+							"type": "boolean"
+						},
+						{
+							"type": "string"
+						},
+						{
+							"type": "object",
+							"additionalProperties": true
+						}
+					]
+				},
+				"show_progress": {
+					"type": "boolean"
+				},
+				"allow_empty_changesets": {
+					"type": "boolean"
+				},
+				"no_verify": {
+					"type": "boolean"
+				},
+				"dry_run_command": {
+					"type": "string"
+				},
+				"id": {
+					"type": "string"
+				},
+				"variables": {
+					"type": "object",
+					"additionalProperties": true
+				}
+			}
+		},
+		"lints": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"use": {
+					"$ref": "#/$defs/stringArray"
+				},
+				"include": {
+					"$ref": "#/$defs/stringArray"
+				},
+				"exclude": {
+					"$ref": "#/$defs/stringArray"
+				},
+				"disable_gitignore": {
+					"type": "boolean"
+				},
+				"rules": {
+					"type": "object",
+					"additionalProperties": {
+						"$ref": "#/$defs/lintRule"
+					}
+				},
+				"scopes": {
+					"type": "array",
+					"items": {
+						"$ref": "#/$defs/lintScope"
+					}
+				}
+			}
+		},
+		"lintSeverity": {
+			"type": "string",
+			"enum": [
+				"off",
+				"warning",
+				"error"
+			]
+		},
+		"lintRule": {
+			"description": "Lint rule severity or detailed rule configuration. Rule-specific options are accepted.",
+			"oneOf": [
+				{
+					"$ref": "#/$defs/lintSeverity"
+				},
+				{
+					"type": "object",
+					"additionalProperties": true,
+					"properties": {
+						"level": {
+							"$ref": "#/$defs/lintSeverity"
+						}
+					}
+				}
+			]
+		},
+		"lintScope": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"name": {
+					"type": "string"
+				},
+				"match": {
+					"$ref": "#/$defs/lintSelector"
+				},
+				"use": {
+					"$ref": "#/$defs/stringArray"
+				},
+				"rules": {
+					"type": "object",
+					"additionalProperties": {
+						"$ref": "#/$defs/lintRule"
+					}
+				}
+			}
+		},
+		"lintSelector": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"ecosystems": {
+					"$ref": "#/$defs/stringArray"
+				},
+				"paths": {
+					"$ref": "#/$defs/stringArray"
+				},
+				"package_ids": {
+					"$ref": "#/$defs/stringArray"
+				},
+				"group_ids": {
+					"$ref": "#/$defs/stringArray"
+				},
+				"managed": {
+					"type": "boolean"
+				},
+				"private": {
+					"type": "boolean"
+				},
+				"publishable": {
+					"type": "boolean"
+				}
+			}
+		}
+	}
+}

--- a/docs/src/schemas/release-record.schema.json
+++ b/docs/src/schemas/release-record.schema.json
@@ -6,7 +6,7 @@
 	"type": "object",
 	"additionalProperties": false,
 	"required": [
-		"v",
+		"schemaVersion",
 		"kind",
 		"createdAt",
 		"command",
@@ -15,7 +15,7 @@
 		"changedFiles"
 	],
 	"properties": {
-		"v": {
+		"schemaVersion": {
 			"type": "string",
 			"const": "0.0",
 			"description": "Public durable artifact schema version. Older CLIs reject missing, future, or non-current versions."

--- a/docs/src/schemas/release-record.schema.json
+++ b/docs/src/schemas/release-record.schema.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"$id": "https://monochange.github.io/monochange/schemas/release-record.schema.json",
 	"title": "monochange release record",
-	"description": "Durable commit-embedded release record schema for monochange artifact version 0.0.",
+	"description": "Durable commit-embedded release record schema for monochange artifact version 0.1.",
 	"type": "object",
 	"additionalProperties": false,
 	"required": [
@@ -89,7 +89,7 @@
 			]
 		},
 		"v": {
-			"const": "0.0"
+			"const": "0.1"
 		}
 	},
 	"$defs": {

--- a/docs/src/schemas/release-record.schema.json
+++ b/docs/src/schemas/release-record.schema.json
@@ -17,7 +17,7 @@
 	"properties": {
 		"schemaVersion": {
 			"type": "string",
-			"const": "0.0",
+			"const": "0.1",
 			"description": "Public durable artifact schema version. Older CLIs reject missing, future, or non-current versions."
 		},
 		"kind": {
@@ -87,6 +87,9 @@
 					"$ref": "#/$defs/provider"
 				}
 			]
+		},
+		"v": {
+			"const": "0.0"
 		}
 	},
 	"$defs": {

--- a/docs/src/schemas/release-record.v0.0.schema.json
+++ b/docs/src/schemas/release-record.v0.0.schema.json
@@ -6,7 +6,7 @@
 	"type": "object",
 	"additionalProperties": false,
 	"required": [
-		"v",
+		"schemaVersion",
 		"kind",
 		"createdAt",
 		"command",
@@ -15,7 +15,7 @@
 		"changedFiles"
 	],
 	"properties": {
-		"v": {
+		"schemaVersion": {
 			"type": "string",
 			"const": "0.0",
 			"description": "Public durable artifact schema version. Older CLIs reject missing, future, or non-current versions."

--- a/docs/src/schemas/release-record.v0.0.schema.json
+++ b/docs/src/schemas/release-record.v0.0.schema.json
@@ -17,7 +17,7 @@
 	"properties": {
 		"schemaVersion": {
 			"type": "string",
-			"const": "0.0",
+			"const": "0.1",
 			"description": "Public durable artifact schema version. Older CLIs reject missing, future, or non-current versions."
 		},
 		"kind": {
@@ -87,6 +87,9 @@
 					"$ref": "#/$defs/provider"
 				}
 			]
+		},
+		"v": {
+			"const": "0.0"
 		}
 	},
 	"$defs": {

--- a/docs/src/schemas/release-record.v0.1.schema.json
+++ b/docs/src/schemas/release-record.v0.1.schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
-	"$id": "https://monochange.github.io/monochange/schemas/release-record.schema.json",
+	"$id": "https://monochange.github.io/monochange/schemas/release-record.v0.1.schema.json",
 	"title": "monochange release record",
 	"description": "Durable commit-embedded release record schema for monochange artifact version 0.1.",
 	"type": "object",

--- a/readme.md
+++ b/readme.md
@@ -394,3 +394,5 @@ build:book
 <!-- {/repoCommonDevelopmentCommands} -->
 
 See `docs/` for user-facing guides and `CONTRIBUTING.md` for contribution expectations.
+# CI trigger Sat May  9 19:11:35 BST 2026
+# CI trigger Sat May  9 19:11:48 BST 2026

--- a/schemas/templates/release-record.schema.template.json
+++ b/schemas/templates/release-record.schema.template.json
@@ -6,7 +6,7 @@
 	"type": "object",
 	"additionalProperties": false,
 	"required": [
-		"v",
+		"schemaVersion",
 		"kind",
 		"createdAt",
 		"command",
@@ -15,7 +15,7 @@
 		"changedFiles"
 	],
 	"properties": {
-		"v": {
+		"schemaVersion": {
 			"type": "string",
 			"const": "0.1",
 			"description": "Public durable artifact schema version. Older CLIs reject missing, future, or non-current versions."


### PR DESCRIPTION
## Summary
Unifies the four version keys down to a single public wire field `schemaVersion` that is a `"major.minor"` string.

### Changes
- **monochange_schema**: public release record shape now uses `schemaVersion` instead of `v`
- **monochange_core**: adds `normalize_legacy_schema_version` helper that migrates integer `schemaVersion: 1` and legacy `v` fields before schema validation
- **monochange_core**: `ReleaseRecord.schema_version` changed from `u64` to `String`
- All JSON schema templates, integration tests, and snapshots updated for the new wire format
- Added major changeset for `monochange_schema` (0.0→0.1.0) and minor for `monochange_core`

### Durable migration behavior
- Older CLIs reject missing/future `schemaVersion` values
- Newer CLIs normalize legacy formats before passing to `migrate_value`