### PR TITLE
refactor: split crate boundaries

### DIFF
--- a/.changeset/crate-boundaries-refactor.md
+++ b/.changeset/crate-boundaries-refactor.md
@@ -1,0 +1,10 @@
+---
+monochange: patch
+monochange_changelog: patch
+monochange_config: patch
+monochange_publish: patch
+---
+
+# Split crate boundaries for changelog, config, and publish behavior
+
+Move changelog rendering into `monochange_changelog`, shift publish planning and execution helpers into `monochange_publish`, and reduce direct concrete ecosystem/provider dependencies in `monochange_config`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2041,6 +2041,7 @@ dependencies = [
  "minijinja",
  "monochange_analysis",
  "monochange_cargo",
+ "monochange_changelog",
  "monochange_config",
  "monochange_core",
  "monochange_dart",
@@ -2151,6 +2152,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "monochange_changelog"
+version = "0.4.0"
+dependencies = [
+ "minijinja",
+ "monochange_core",
+ "semver",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tracing",
+ "typed-builder",
+]
+
+[[package]]
 name = "monochange_config"
 version = "0.4.0"
 dependencies = [
@@ -2158,17 +2173,7 @@ dependencies = [
  "glob",
  "insta",
  "miette",
- "monochange_cargo",
  "monochange_core",
- "monochange_dart",
- "monochange_deno",
- "monochange_forgejo",
- "monochange_gitea",
- "monochange_github",
- "monochange_gitlab",
- "monochange_go",
- "monochange_npm",
- "monochange_python",
  "monochange_test_helpers",
  "proptest",
  "regex",
@@ -2460,6 +2465,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "urlencoding",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ walkdir = { version = "2", default-features = false }
 monochange = { version = "0.4.0", path = "./crates/monochange" }
 monochange_analysis = { version = "0.4.0", path = "./crates/monochange_analysis" }
 monochange_cargo = { version = "0.4.0", path = "./crates/monochange_cargo" }
+monochange_changelog = { version = "0.4.0", path = "./crates/monochange_changelog" }
 monochange_config = { version = "0.4.0", path = "./crates/monochange_config" }
 monochange_core = { version = "0.4.0", path = "./crates/monochange_core" }
 monochange_dart = { version = "0.4.0", path = "./crates/monochange_dart" }

--- a/crates/monochange/Cargo.toml
+++ b/crates/monochange/Cargo.toml
@@ -43,6 +43,7 @@ inquire = { workspace = true, default-features = true }
 minijinja = { workspace = true, default-features = true }
 monochange_analysis = { workspace = true }
 monochange_cargo = { workspace = true, optional = true }
+monochange_changelog = { workspace = true }
 monochange_config = { workspace = true }
 monochange_core = { workspace = true }
 monochange_dart = { workspace = true, optional = true }

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -12,6 +12,9 @@ use clap::Command;
 use httpmock::Method::GET;
 use httpmock::Method::PATCH;
 use httpmock::MockServer;
+use monochange_changelog::ReleaseNoteChange;
+use monochange_changelog::filter_group_release_note_change;
+use monochange_changelog::group_changelog_include_allows;
 use monochange_config::load_workspace_configuration;
 use monochange_core::BumpSeverity;
 use monochange_core::ChangesetTargetKind;
@@ -10223,23 +10226,23 @@ fn group_changelog_include_allows_expected_member_targets() {
 	let core_only = BTreeSet::from(["core".to_string()]);
 	let core_and_app = BTreeSet::from(["core".to_string(), "app".to_string()]);
 
-	assert!(crate::group_changelog_include_allows(
+	assert!(group_changelog_include_allows(
 		&GroupChangelogInclude::All,
 		&core_only,
 	));
-	assert!(!crate::group_changelog_include_allows(
+	assert!(!group_changelog_include_allows(
 		&GroupChangelogInclude::GroupOnly,
 		&core_only,
 	));
-	assert!(crate::group_changelog_include_allows(
+	assert!(group_changelog_include_allows(
 		&GroupChangelogInclude::Selected(["core".to_string()].into()),
 		&core_only,
 	));
-	assert!(!crate::group_changelog_include_allows(
+	assert!(!group_changelog_include_allows(
 		&GroupChangelogInclude::Selected(["app".to_string()].into()),
 		&core_only,
 	));
-	assert!(!crate::group_changelog_include_allows(
+	assert!(!group_changelog_include_allows(
 		&GroupChangelogInclude::Selected(["core".to_string()].into()),
 		&core_and_app,
 	));
@@ -10251,7 +10254,7 @@ fn filter_group_release_note_change_handles_missing_context_and_direct_group_tar
 	let group = sample_group_definition(GroupChangelogInclude::GroupOnly);
 
 	assert!(
-		crate::filter_group_release_note_change(
+		filter_group_release_note_change(
 			&sample_release_note_change(None),
 			Some(&group),
 			&planned_group,
@@ -10261,7 +10264,7 @@ fn filter_group_release_note_change_handles_missing_context_and_direct_group_tar
 	);
 
 	assert!(
-		crate::filter_group_release_note_change(
+		filter_group_release_note_change(
 			&sample_release_note_change(Some(".changeset/missing.md")),
 			Some(&group),
 			&planned_group,
@@ -10282,7 +10285,7 @@ fn filter_group_release_note_change_handles_missing_context_and_direct_group_tar
 			caused_by: Vec::new(),
 		}],
 	)]);
-	let renamed = crate::filter_group_release_note_change(
+	let renamed = filter_group_release_note_change(
 		&sample_release_note_change(Some(".changeset/group.md")),
 		Some(&group),
 		&planned_group,
@@ -10304,7 +10307,7 @@ fn filter_group_release_note_change_handles_missing_context_and_direct_group_tar
 		}],
 	)]);
 	assert!(
-		crate::filter_group_release_note_change(
+		filter_group_release_note_change(
 			&sample_release_note_change(Some(".changeset/outside.md")),
 			Some(&group),
 			&planned_group,
@@ -10333,7 +10336,7 @@ fn filter_group_release_note_change_respects_member_allowlists() {
 		}],
 	)]);
 	assert!(
-		crate::filter_group_release_note_change(
+		filter_group_release_note_change(
 			&change,
 			Some(&selected_core),
 			&planned_group,
@@ -10366,7 +10369,7 @@ fn filter_group_release_note_change_respects_member_allowlists() {
 		],
 	)]);
 	assert!(
-		crate::filter_group_release_note_change(
+		filter_group_release_note_change(
 			&change,
 			Some(&selected_core),
 			&planned_group,
@@ -10380,8 +10383,8 @@ fn filter_group_release_note_change_respects_member_allowlists() {
 	assert!(message.contains("synchronized group `sdk`"));
 }
 
-fn sample_release_note_change(source_path: Option<&str>) -> crate::ReleaseNoteChange {
-	crate::ReleaseNoteChange {
+fn sample_release_note_change(source_path: Option<&str>) -> ReleaseNoteChange {
+	ReleaseNoteChange {
 		package_id: "core".to_string(),
 		package_name: "core".to_string(),
 		package_labels: Vec::new(),

--- a/crates/monochange/src/changesets.rs
+++ b/crates/monochange/src/changesets.rs
@@ -568,8 +568,8 @@ pub(crate) fn released_package_names(
 	released_packages
 }
 
-pub(crate) type PackageChangelogTargets = BTreeMap<String, ChangelogTarget>;
-pub(crate) type GroupChangelogTargets = BTreeMap<String, ChangelogTarget>;
+pub type PackageChangelogTargets = BTreeMap<String, ChangelogTarget>;
+pub type GroupChangelogTargets = BTreeMap<String, ChangelogTarget>;
 
 pub(crate) fn resolve_changelog_targets(
 	configuration: &monochange_core::WorkspaceConfiguration,

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -61,7 +61,21 @@ use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
 use analyze::render_analyze_report;
-pub(crate) use changelog::*;
+pub(crate) use monochange_changelog::ChangelogBuildContext;
+pub(crate) use monochange_changelog::build_changelog_updates;
+#[cfg(test)]
+pub(crate) use monochange_changelog::render_group_filtered_update_message;
+pub(crate) use monochange_changelog::render_jinja_template;
+#[cfg(test)]
+pub(crate) use monochange_core::ChangelogSettings;
+#[cfg(test)]
+pub(crate) use monochange_core::ChangesetTargetKind;
+#[cfg(test)]
+pub(crate) use monochange_core::ReleaseNotesSection;
+#[cfg(test)]
+pub mod changelog {
+	pub use monochange_changelog::render_message_template;
+}
 pub use changeset_policy::affected_packages;
 pub(crate) use changeset_policy::compute_changed_paths_since;
 pub use changeset_policy::evaluate_changeset_policy;
@@ -138,8 +152,6 @@ pub(crate) use git_support::run_git_process;
 #[cfg(test)]
 pub(crate) use git_support::run_git_status;
 use migration_audit::run_migration_command;
-use minijinja::Environment;
-use minijinja::UndefinedBehavior;
 #[cfg(feature = "cargo")]
 use monochange_cargo::RustSemverProvider;
 use monochange_config::load_changeset_file;
@@ -148,12 +160,10 @@ use monochange_config::resolve_package_reference;
 use monochange_core::BumpSeverity;
 use monochange_core::ChangeSignal;
 use monochange_core::ChangelogFormat;
-use monochange_core::ChangelogSettings;
 use monochange_core::ChangelogTarget;
 use monochange_core::ChangesetContext;
 use monochange_core::ChangesetPolicyEvaluation;
 use monochange_core::ChangesetRevision;
-use monochange_core::ChangesetTargetKind;
 use monochange_core::CliCommandDefinition;
 use monochange_core::CliStepDefinition;
 use monochange_core::CommitMessage;
@@ -163,7 +173,6 @@ use monochange_core::DEFAULT_RELEASE_TITLE_NAMESPACED;
 use monochange_core::DEFAULT_RELEASE_TITLE_PRIMARY;
 use monochange_core::DiscoveryReport;
 use monochange_core::Ecosystem;
-use monochange_core::GroupChangelogInclude;
 
 #[cfg(test)]
 pub(crate) static TEST_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
@@ -171,9 +180,6 @@ use monochange_core::HostedActorRef;
 use monochange_core::HostedActorSourceKind;
 use monochange_core::HostedCommitRef;
 use monochange_core::HostedIssueCommentPlan;
-use monochange_core::HostedIssueRef;
-use monochange_core::HostedIssueRelationshipKind;
-use monochange_core::HostedReviewRequestRef;
 use monochange_core::HostingCapabilities;
 use monochange_core::HostingProviderKind;
 use monochange_core::MonochangeError;
@@ -190,7 +196,6 @@ use monochange_core::ReleaseManifestPlanDecision;
 use monochange_core::ReleaseManifestPlanGroup;
 use monochange_core::ReleaseManifestTarget;
 use monochange_core::ReleaseNotesDocument;
-use monochange_core::ReleaseNotesSection;
 use monochange_core::ReleaseOwnerKind;
 use monochange_core::ReleasePlan;
 use monochange_core::ReleaseRecord;
@@ -213,7 +218,6 @@ use monochange_core::VersionFormat;
 use monochange_core::VersionedFileDefinition;
 use monochange_core::materialize_dependency_edges;
 use monochange_core::relative_to_root;
-use monochange_core::render_release_notes;
 #[cfg(feature = "forgejo")]
 use monochange_forgejo as forgejo_provider;
 #[cfg(feature = "gitea")]
@@ -306,7 +310,6 @@ pub(crate) fn synthetic_step_command_definition(
 }
 
 mod analyze;
-mod changelog;
 mod changeset_policy;
 mod changesets;
 mod cli;
@@ -520,70 +523,6 @@ struct PreparedReleaseExecution {
 struct FileUpdate {
 	path: PathBuf,
 	content: Vec<u8>,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-struct ChangelogUpdate {
-	file: FileUpdate,
-	owner_id: String,
-	owner_kind: ReleaseOwnerKind,
-	format: ChangelogFormat,
-	notes: ReleaseNotesDocument,
-	rendered: String,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-struct ReleaseNoteChange {
-	package_id: String,
-	package_name: String,
-	package_labels: Vec<String>,
-	source_path: Option<String>,
-	summary: String,
-	details: Option<String>,
-	bump: BumpSeverity,
-	change_type: Option<String>,
-	context: Option<String>,
-	changeset_path: Option<String>,
-	change_owner: Option<String>,
-	change_owner_link: Option<String>,
-	review_request: Option<String>,
-	review_request_link: Option<String>,
-	introduced_commit: Option<String>,
-	introduced_commit_link: Option<String>,
-	last_updated_commit: Option<String>,
-	last_updated_commit_link: Option<String>,
-	related_issues: Option<String>,
-	related_issue_links: Option<String>,
-	closed_issues: Option<String>,
-	closed_issue_links: Option<String>,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, Default)]
-struct RenderedChangesetContext {
-	context: String,
-	changeset_path: String,
-	change_owner: Option<String>,
-	change_owner_link: Option<String>,
-	review_request: Option<String>,
-	review_request_link: Option<String>,
-	introduced_commit: Option<String>,
-	introduced_commit_link: Option<String>,
-	last_updated_commit: Option<String>,
-	last_updated_commit_link: Option<String>,
-	related_issues: Option<String>,
-	related_issue_links: Option<String>,
-	closed_issues: Option<String>,
-	closed_issue_links: Option<String>,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
-struct GroupReleaseNoteKey {
-	source_path: Option<String>,
-	summary: String,
-	details: Option<String>,
-	bump: BumpSeverity,
-	change_type: Option<String>,
-	context: Option<String>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+#[cfg(test)]
 use std::env;
+#[cfg(test)]
 use std::fs;
 use std::path::Path;
 
@@ -11,8 +13,8 @@ use monochange_core::Ecosystem;
 use monochange_core::MonochangeError;
 use monochange_core::MonochangeResult;
 use monochange_core::PackagePublicationTarget;
-use monochange_core::PackageRecord;
-use monochange_core::PublishMode;
+#[cfg(test)]
+pub(crate) use monochange_core::PublishMode;
 use monochange_core::PublishRegistry;
 use monochange_core::RegistryKind;
 use monochange_core::SourceConfiguration;
@@ -29,44 +31,67 @@ use monochange_npm::build_npm_trust_list_command;
 use monochange_npm::render_npm_trust_command;
 use monochange_npm::write_npm_placeholder_manifest;
 use monochange_publish::CommandExecutor;
+#[cfg(test)]
+pub(crate) use monochange_publish::PLACEHOLDER_VERSION;
 pub(crate) use monochange_publish::PackagePublishOutcome;
 pub(crate) use monochange_publish::PackagePublishReport;
 pub(crate) use monochange_publish::PackagePublishRunMode;
 pub(crate) use monochange_publish::PackagePublishStatus;
-use monochange_publish::ProcessCommandExecutor;
-use monochange_publish::PublishAdapter;
+use monochange_publish::PlaceholderManifestWriterRegistry;
+#[cfg(test)]
+pub(crate) use monochange_publish::ProcessCommandExecutor;
+use monochange_publish::PublishReadinessRegistry;
 pub(crate) use monochange_publish::PublishRequest;
+use monochange_publish::PublishTrustHandler;
+#[cfg(test)]
 use monochange_publish::RegistryEndpoints;
 use monochange_publish::TrustedPublishingIdentity;
 pub(crate) use monochange_publish::TrustedPublishingOutcome;
 pub(crate) use monochange_publish::TrustedPublishingStatus;
-use monochange_publish::build_publish_command;
+#[cfg(test)]
+use monochange_publish::build_placeholder_directory as build_placeholder_directory_with_writers;
+pub(crate) use monochange_publish::build_placeholder_requests;
+#[cfg(test)]
+pub(crate) use monochange_publish::build_publish_command;
 use monochange_publish::build_publish_command_builder;
+pub(crate) use monochange_publish::build_release_requests;
+#[cfg(test)]
+pub(crate) use monochange_publish::default_registry_kind_for_ecosystem;
 use monochange_publish::detect_trusted_publishing_identity;
-use monochange_publish::go_module_path;
+use monochange_publish::disabled_trust_outcome;
+#[cfg(test)]
+use monochange_publish::enforce_release_attestation_prerequisites as enforce_release_attestation_prerequisites_impl;
+#[cfg(test)]
+use monochange_publish::execute_publish_requests as execute_publish_requests_impl;
+use monochange_publish::execute_publish_requests_with_process;
+#[cfg(test)]
+pub(crate) use monochange_publish::forbidden_npm_token_env_keys;
+use monochange_publish::manual_setup_url;
 use monochange_publish::merge_publish_resume_report;
-use monochange_publish::order_release_requests_by_publish_dependencies;
-use monochange_publish::package_can_be_published;
-use monochange_publish::packages_by_config_id;
 use monochange_publish::provider_registry_trust_capability;
 use monochange_publish::read_publish_report_artifact;
-use monochange_publish::registry_client;
-use monochange_publish::registry_version_exists;
+#[cfg(test)]
+pub(crate) use monochange_publish::registry_version_exists;
+use monochange_publish::reject_npm_token_environment;
 use monochange_publish::render_command;
 use monochange_publish::render_command_error;
+#[cfg(test)]
+pub(crate) use monochange_publish::resolve_placeholder_readme;
+#[cfg(test)]
+pub(crate) use monochange_publish::resolve_registry_kind;
 use monochange_publish::resume_publish_requests;
+use monochange_publish::select_release_publication_targets;
 use monochange_publish::trusted_publishing_capability_message;
 use monochange_publish::trusted_publishing_capability_message_for_builtin;
 use monochange_python::write_python_placeholder_manifest;
+#[cfg(test)]
 use reqwest::blocking::Client;
+#[cfg(test)]
 use tempfile::TempDir;
-use urlencoding::encode;
 
 use crate::PreparedRelease;
 use crate::discover_release_record;
 use crate::discover_workspace;
-
-const PLACEHOLDER_VERSION: &str = "0.0.0";
 
 pub(crate) fn run_placeholder_publish(
 	root: &Path,
@@ -77,20 +102,16 @@ pub(crate) fn run_placeholder_publish(
 	let discovery = discover_workspace(root)?;
 	let requests =
 		build_placeholder_requests(root, configuration, &discovery.packages, selected_packages)?;
-	let env_map = current_env_map();
-	let endpoints = RegistryEndpoints::from_env();
-	let client = registry_client()?;
-	let mut executor = ProcessCommandExecutor;
-	execute_publish_requests(
+	execute_publish_requests_with_process(
 		root,
 		configuration.source.as_ref(),
 		PackagePublishRunMode::Placeholder,
 		dry_run,
 		&requests,
-		&client,
-		&endpoints,
-		&env_map,
-		&mut executor,
+		&build_publish_command_builder(),
+		&placeholder_manifest_writer_registry(),
+		&publish_readiness_registry(),
+		&CliPublishTrustHandler,
 	)
 }
 
@@ -124,25 +145,21 @@ pub(crate) fn run_publish_packages_with_resume(
 	dry_run: bool,
 	resume_path: Option<&Path>,
 ) -> MonochangeResult<PackagePublishReport> {
-	let mut publication_targets =
+	let publication_targets =
 		release_record_package_publications_from_prepared_or_head(root, prepared_release)?;
-
-	if !selected_ecosystems.is_empty() {
-		publication_targets.retain(|t| selected_ecosystems.contains(&t.ecosystem));
-	}
-
-	let mut effective_selected_packages = selected_packages.clone();
-	for group_id in selected_groups {
-		if let Some(group) = configuration.group_by_id(group_id) {
-			effective_selected_packages.extend(group.packages.iter().cloned());
-		}
-	}
+	let selected_targets = select_release_publication_targets(
+		&configuration.groups,
+		&publication_targets,
+		selected_packages,
+		selected_groups,
+		selected_ecosystems,
+	);
 
 	run_publish_packages_with_publications_and_resume(
 		root,
 		configuration,
-		&publication_targets,
-		&effective_selected_packages,
+		&selected_targets.publication_targets,
+		&selected_targets.selected_packages,
 		dry_run,
 		resume_path,
 	)
@@ -198,20 +215,16 @@ fn execute_release_publish_requests(
 	dry_run: bool,
 	requests: &[PublishRequest],
 ) -> MonochangeResult<PackagePublishReport> {
-	let env_map = current_env_map();
-	let endpoints = RegistryEndpoints::from_env();
-	let client = registry_client()?;
-	let mut executor = ProcessCommandExecutor;
-	execute_publish_requests(
+	execute_publish_requests_with_process(
 		root,
 		configuration.source.as_ref(),
 		PackagePublishRunMode::Release,
 		dry_run,
 		requests,
-		&client,
-		&endpoints,
-		&env_map,
-		&mut executor,
+		&build_publish_command_builder(),
+		&placeholder_manifest_writer_registry(),
+		&publish_readiness_registry(),
+		&CliPublishTrustHandler,
 	)
 }
 
@@ -227,177 +240,56 @@ pub(crate) fn release_record_package_publications_from_prepared_or_head(
 		.package_publications)
 }
 
-fn current_env_map() -> BTreeMap<String, String> {
-	env::vars().collect()
-}
+struct CliPublishTrustHandler;
 
-pub(crate) fn build_placeholder_requests(
-	root: &Path,
-	configuration: &WorkspaceConfiguration,
-	packages: &[PackageRecord],
-	selected_packages: &BTreeSet<String>,
-) -> MonochangeResult<Vec<PublishRequest>> {
-	let packages_by_config_id = packages_by_config_id(packages);
-	let mut requests = Vec::new();
+impl PublishTrustHandler for CliPublishTrustHandler {
+	fn trust_outcome_for_skip(
+		&self,
+		request: &PublishRequest,
+		source: Option<&SourceConfiguration>,
+		root: &Path,
+		env_map: &BTreeMap<String, String>,
+	) -> TrustedPublishingOutcome {
+		trust_outcome_for_skip(request, source, root, env_map)
+	}
 
-	for package_definition in &configuration.packages {
-		let package = packages_by_config_id
-			.get(package_definition.id.as_str())
-			.copied();
-		let should_publish =
-			package.is_some_and(|package| package_can_be_published(package_definition, package));
-		if let Some(package) = package.filter(|_| {
-			should_publish
-				&& (selected_packages.is_empty()
-					|| selected_packages.contains(&package_definition.id))
-		}) {
-			requests.push(PublishRequest {
-				package_id: package_definition.id.clone(),
-				package_name: package.name.clone(),
-				ecosystem: package.ecosystem,
-				manifest_path: package.manifest_path.clone(),
-				package_root: package
-					.manifest_path
-					.parent()
-					.unwrap_or(&package.workspace_root)
-					.to_path_buf(),
-				registry: resolve_registry_kind(
-					package_definition.publish.registry.as_ref(),
-					package.ecosystem,
-				)?,
-				package_manager: package.metadata.get("manager").cloned(),
-				package_metadata: package.metadata.clone(),
-				mode: package_definition.publish.mode,
-				version: PLACEHOLDER_VERSION.to_string(),
-				placeholder: true,
-				trusted_publishing: package_definition.publish.trusted_publishing.clone(),
-				attestations: package_definition.publish.attestations.clone(),
-				placeholder_readme: resolve_placeholder_readme(
-					root,
-					package_definition.publish.placeholder.readme.as_deref(),
-					package_definition
-						.publish
-						.placeholder
-						.readme_file
-						.as_deref(),
-					&package.name,
-				)?,
-			});
+	fn planned_trust_outcome(
+		&self,
+		request: &PublishRequest,
+		source: Option<&SourceConfiguration>,
+		root: &Path,
+		env_map: &BTreeMap<String, String>,
+	) -> TrustedPublishingOutcome {
+		planned_trust_outcome(request, source, root, env_map)
+	}
+
+	fn enforce_release_trust_prerequisites(
+		&self,
+		request: &PublishRequest,
+		source: Option<&SourceConfiguration>,
+		root: &Path,
+		env_map: &BTreeMap<String, String>,
+	) -> MonochangeResult<()> {
+		enforce_release_trust_prerequisites(request, source, root, env_map)
+	}
+
+	fn configure_successful_publish_trust(
+		&self,
+		request: &PublishRequest,
+		source: Option<&SourceConfiguration>,
+		root: &Path,
+		env_map: &BTreeMap<String, String>,
+		executor: &mut dyn CommandExecutor,
+	) -> MonochangeResult<TrustedPublishingOutcome> {
+		if request.registry == RegistryKind::Npm {
+			configure_npm_trusted_publishing(request, source, root, env_map, executor)
+		} else {
+			Ok(manual_trust_outcome(request, source, root, env_map))
 		}
 	}
-
-	requests.sort_by(|left, right| left.package_id.cmp(&right.package_id));
-	Ok(requests)
 }
 
-pub(crate) fn build_release_requests(
-	configuration: &WorkspaceConfiguration,
-	packages: &[PackageRecord],
-	publications: &[PackagePublicationTarget],
-	selected_packages: &BTreeSet<String>,
-) -> MonochangeResult<Vec<PublishRequest>> {
-	let packages_by_config_id = packages_by_config_id(packages);
-	let mut requests = Vec::new();
-
-	for publication in publications {
-		if !selected_packages.is_empty() && !selected_packages.contains(&publication.package) {
-			continue;
-		}
-
-		let Some(package_definition) = configuration.package_by_id(&publication.package) else {
-			continue;
-		};
-		let Some(package) = packages_by_config_id
-			.get(publication.package.as_str())
-			.copied()
-		else {
-			continue;
-		};
-
-		if !package_can_be_published(package_definition, package) {
-			continue;
-		}
-
-		requests.push(PublishRequest {
-			package_id: publication.package.clone(),
-			package_name: package.name.clone(),
-			ecosystem: package.ecosystem,
-			manifest_path: package.manifest_path.clone(),
-			package_root: package
-				.manifest_path
-				.parent()
-				.unwrap_or(&package.workspace_root)
-				.to_path_buf(),
-			registry: resolve_registry_kind(publication.registry.as_ref(), package.ecosystem)?,
-			package_manager: package.metadata.get("manager").cloned(),
-			package_metadata: package.metadata.clone(),
-			mode: publication.mode,
-			version: publication.version.clone(),
-			placeholder: false,
-			trusted_publishing: publication.trusted_publishing.clone(),
-			attestations: publication.attestations.clone(),
-			placeholder_readme: default_placeholder_readme(&package.name),
-		});
-	}
-
-	order_release_requests_by_publish_dependencies(packages, requests)
-}
-
-fn resolve_registry_kind(
-	registry: Option<&PublishRegistry>,
-	ecosystem: Ecosystem,
-) -> MonochangeResult<RegistryKind> {
-	match registry {
-		Some(PublishRegistry::Builtin(registry)) => Ok(*registry),
-		Some(PublishRegistry::Custom(name)) => {
-			Err(MonochangeError::Config(format!(
-				"built-in package publishing does not support custom registry `{name}`"
-			)))
-		}
-		None => default_registry_kind_for_ecosystem(ecosystem.as_str()),
-	}
-}
-
-fn default_registry_kind_for_ecosystem(ecosystem: &str) -> MonochangeResult<RegistryKind> {
-	let parsed = ecosystem.parse::<Ecosystem>().map_err(|()| {
-		MonochangeError::Config(format!(
-			"built-in package publishing does not support ecosystem `{ecosystem}`"
-		))
-	})?;
-	monochange_core::default_registry_kind_for_ecosystem(parsed).ok_or_else(|| {
-		MonochangeError::Config(format!(
-			"built-in package publishing does not support ecosystem `{ecosystem}`"
-		))
-	})
-}
-
-fn resolve_placeholder_readme(
-	root: &Path,
-	inline: Option<&str>,
-	file: Option<&Path>,
-	package_name: &str,
-) -> MonochangeResult<String> {
-	if let Some(inline) = inline {
-		return Ok(inline.to_string());
-	}
-	if let Some(file) = file {
-		let path = root.join(file);
-		return fs::read_to_string(&path).map_err(|error| {
-			MonochangeError::Io(format!(
-				"failed to read placeholder README {}: {error}",
-				path.display()
-			))
-		});
-	}
-	Ok(default_placeholder_readme(package_name))
-}
-
-fn default_placeholder_readme(package_name: &str) -> String {
-	format!(
-		"# {package_name}\n\nThis is a placeholder release published by monochange to bootstrap trusted publishing.\n"
-	)
-}
-
+#[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 fn execute_publish_requests(
 	root: &Path,
@@ -410,201 +302,33 @@ fn execute_publish_requests(
 	env_map: &BTreeMap<String, String>,
 	executor: &mut dyn CommandExecutor,
 ) -> MonochangeResult<PackagePublishReport> {
-	let mut outcomes = Vec::new();
-
-	for request in requests {
-		if request.mode == PublishMode::External {
-			outcomes.push(PackagePublishOutcome {
-				package: request.package_id.clone(),
-				ecosystem: request.ecosystem,
-				registry: request.registry.to_string(),
-				version: request.version.clone(),
-				status: PackagePublishStatus::SkippedExternal,
-				message: "package opted out of built-in publishing".to_string(),
-				placeholder: mode == PackagePublishRunMode::Placeholder,
-				trusted_publishing: disabled_trust_outcome(),
-				command: None,
-				stdout: None,
-				stderr: None,
-			});
-			continue;
-		}
-
-		let version_exists = registry_version_exists(client, endpoints, request)?;
-		if version_exists {
-			outcomes.push(PackagePublishOutcome {
-				package: request.package_id.clone(),
-				ecosystem: request.ecosystem,
-				registry: request.registry.to_string(),
-				version: request.version.clone(),
-				status: PackagePublishStatus::SkippedExisting,
-				message: format!(
-					"{} {} already exists on {}",
-					request.package_name, request.version, request.registry
-				),
-				placeholder: mode == PackagePublishRunMode::Placeholder,
-				trusted_publishing: trust_outcome_for_skip(request, source, root, env_map),
-				command: None,
-				stdout: None,
-				stderr: None,
-			});
-			continue;
-		}
-
-		let blockers = if mode == PackagePublishRunMode::Release {
-			cargo_publish_readiness_blockers(root, request)?
-		} else {
-			Vec::new()
-		};
-		if !blockers.is_empty() {
-			let message = publish_blocked_message(request, &blockers);
-
-			if dry_run {
-				outcomes.push(PackagePublishOutcome {
-					package: request.package_id.clone(),
-					ecosystem: request.ecosystem,
-					registry: request.registry.to_string(),
-					version: request.version.clone(),
-					status: PackagePublishStatus::Blocked,
-					message,
-					placeholder: mode == PackagePublishRunMode::Placeholder,
-					trusted_publishing: planned_trust_outcome(request, source, root, env_map),
-					command: None,
-					stdout: None,
-					stderr: None,
-				});
-				continue;
-			}
-
-			return Err(MonochangeError::Config(message));
-		}
-
-		let placeholder_dir = if mode == PackagePublishRunMode::Placeholder {
-			Some(build_placeholder_directory(root, request, source)?)
-		} else {
-			None
-		};
-		let publish_command = build_publish_command(
-			request,
-			mode,
-			placeholder_dir.as_ref().map(TempDir::path),
-			dry_run,
-		);
-
-		if dry_run {
-			outcomes.push(PackagePublishOutcome {
-				package: request.package_id.clone(),
-				ecosystem: request.ecosystem,
-				registry: request.registry.to_string(),
-				version: request.version.clone(),
-				status: PackagePublishStatus::Planned,
-				message: planned_publish_message(mode, request),
-				placeholder: mode == PackagePublishRunMode::Placeholder,
-				trusted_publishing: planned_trust_outcome(request, source, root, env_map),
-				command: None,
-				stdout: None,
-				stderr: None,
-			});
-			continue;
-		}
-
-		if mode == PackagePublishRunMode::Release {
-			enforce_release_trust_prerequisites(request, source, root, env_map)?;
-			enforce_release_attestation_prerequisites(request, env_map)?;
-		}
-
-		let output = match executor.run(&publish_command) {
-			Ok(output) => output,
-			Err(error) => {
-				outcomes.push(failed_publish_outcome(mode, request, error.to_string()));
-				break;
-			}
-		};
-		if !output.success {
-			let mut outcome = failed_publish_outcome(
-				mode,
-				request,
-				format!(
-					"`{}` failed: {}",
-					render_command(&publish_command),
-					render_command_error(&output)
-				),
-			);
-			outcome.command = Some(render_command(&publish_command));
-			outcome.stdout = non_empty_output(output.stdout);
-			outcome.stderr = non_empty_output(output.stderr);
-			outcomes.push(outcome);
-			break;
-		}
-
-		let trusted_publishing = if !request.trusted_publishing.enabled {
-			disabled_trust_outcome()
-		} else if request.registry == RegistryKind::Npm {
-			configure_npm_trusted_publishing(request, source, root, env_map, executor)?
-		} else {
-			manual_trust_outcome(request, source, root, env_map)
-		};
-
-		outcomes.push(PackagePublishOutcome {
-			package: request.package_id.clone(),
-			ecosystem: request.ecosystem,
-			registry: request.registry.to_string(),
-			version: request.version.clone(),
-			status: PackagePublishStatus::Published,
-			message: format!(
-				"published {} {} to {}",
-				request.package_name, request.version, request.registry
-			),
-			placeholder: mode == PackagePublishRunMode::Placeholder,
-			trusted_publishing,
-			command: Some(render_command(&publish_command)),
-			stdout: non_empty_output(output.stdout),
-			stderr: non_empty_output(output.stderr),
-		});
-	}
-
-	Ok(PackagePublishReport {
+	execute_publish_requests_impl(
+		root,
+		source,
 		mode,
 		dry_run,
-		packages: outcomes,
-	})
+		requests,
+		client,
+		endpoints,
+		env_map,
+		executor,
+		&build_publish_command_builder(),
+		&placeholder_manifest_writer_registry(),
+		&publish_readiness_registry(),
+		&CliPublishTrustHandler,
+	)
 }
 
-fn failed_publish_outcome(
-	mode: PackagePublishRunMode,
+#[cfg(test)]
+pub(crate) fn enforce_release_attestation_prerequisites(
 	request: &PublishRequest,
-	message: String,
-) -> PackagePublishOutcome {
-	PackagePublishOutcome {
-		package: request.package_id.clone(),
-		ecosystem: request.ecosystem,
-		registry: request.registry.to_string(),
-		version: request.version.clone(),
-		status: PackagePublishStatus::Failed,
-		message,
-		placeholder: mode == PackagePublishRunMode::Placeholder,
-		trusted_publishing: disabled_trust_outcome(),
-		command: None,
-		stdout: None,
-		stderr: None,
-	}
-}
-
-fn planned_publish_message(mode: PackagePublishRunMode, request: &PublishRequest) -> String {
-	match mode {
-		PackagePublishRunMode::Placeholder => {
-			format!(
-				"would publish placeholder {} {} to {}",
-				request.package_name, request.version, request.registry
-			)
-		}
-		PackagePublishRunMode::Release => {
-			format!(
-				"would publish {} {} to {}",
-				request.package_name, request.version, request.registry
-			)
-		}
-	}
+	env_map: &BTreeMap<String, String>,
+) -> MonochangeResult<()> {
+	enforce_release_attestation_prerequisites_impl(
+		request,
+		env_map,
+		&build_publish_command_builder(),
+	)
 }
 
 fn enforce_release_trust_prerequisites(
@@ -663,87 +387,6 @@ fn enforce_release_trust_prerequisites(
 		workflow.as_deref(),
 		environment.as_deref(),
 	)
-}
-
-fn enforce_release_attestation_prerequisites(
-	request: &PublishRequest,
-	env_map: &BTreeMap<String, String>,
-) -> MonochangeResult<()> {
-	if !request.attestations.require_registry_provenance {
-		return Ok(());
-	}
-
-	if !request.trusted_publishing.enabled {
-		return Err(MonochangeError::Config(format!(
-			"`{}` requires registry-native package provenance, but trusted publishing is disabled. Registry provenance is only enforceable for built-in publishing from a verifiable CI/OIDC identity; set `publish.trusted_publishing = true` or set `publish.attestations.require_registry_provenance = false` to opt out.",
-			request.package_id,
-		)));
-	}
-
-	let registry = PublishRegistry::Builtin(request.registry);
-	let identity = detect_trusted_publishing_identity(env_map);
-	let capability_message = trusted_publishing_capability_message(&registry, &identity);
-	if !identity.is_verifiable_by_env() {
-		return Err(MonochangeError::Config(format!(
-			"`{}` requires registry-native package provenance from a verifiable CI/OIDC identity, but the current publishing context is local or unverifiable. {capability_message} Run `mc publish` from the configured CI workflow or set `publish.attestations.require_registry_provenance = false` to opt out.",
-			request.package_id,
-		)));
-	}
-
-	let capability = provider_registry_trust_capability(&registry, identity.provider());
-	if !capability.registry_native_provenance {
-		return Err(MonochangeError::Config(format!(
-			"`{}` cannot require registry-native package provenance for {} from {}. {capability_message} This registry/provider combination does not expose provenance monochange can require; set `publish.attestations.require_registry_provenance = false` to opt out or use an external publisher that enforces its own attestation policy.",
-			request.package_id,
-			request.registry,
-			identity.provider().label(),
-		)));
-	}
-	if !build_publish_command_builder()
-		.adapter_for_registry(request.registry)
-		.is_some_and(PublishAdapter::supports_provenance)
-	{
-		return Err(MonochangeError::Config(format!(
-			"`{}` cannot require registry-native package provenance for {} yet. {capability_message} The registry supports provenance, but monochange's current built-in publisher for this ecosystem does not expose a publish command that can require it; set `publish.attestations.require_registry_provenance = false` to opt out or use an external publisher that enforces its own attestation policy.",
-			request.package_id, request.registry,
-		)));
-	}
-
-	Ok(())
-}
-
-fn reject_npm_token_environment(
-	request: &PublishRequest,
-	env_map: &BTreeMap<String, String>,
-) -> MonochangeResult<()> {
-	let token_keys = forbidden_npm_token_env_keys(env_map);
-	if token_keys.is_empty() {
-		return Ok(());
-	}
-
-	Err(MonochangeError::Config(format!(
-		"`{}` requires npm trusted publishing, but long-lived npm token environment variables are present: {}. Remove token-based npm credentials and publish from the configured CI/OIDC workflow, or set `publish.trusted_publishing = false` to opt out.",
-		request.package_id,
-		token_keys.join(", "),
-	)))
-}
-
-fn forbidden_npm_token_env_keys(env_map: &BTreeMap<String, String>) -> Vec<String> {
-	env_map
-		.keys()
-		.filter(|key| is_forbidden_npm_token_env_key(key))
-		.cloned()
-		.collect()
-}
-
-fn is_forbidden_npm_token_env_key(key: &str) -> bool {
-	let lowercase_key = key.to_ascii_lowercase();
-	matches!(
-		key,
-		"NPM_TOKEN" | "NODE_AUTH_TOKEN" | "NPM_CONFIG__AUTH_TOKEN" | "npm_config__authToken"
-	) || (lowercase_key.starts_with("npm_config_")
-		&& lowercase_key.contains("auth")
-		&& lowercase_key.contains("token"))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -856,74 +499,77 @@ fn configure_npm_trusted_publishing(
 	})
 }
 
-fn build_placeholder_directory(
+#[cfg(test)]
+pub(crate) fn build_placeholder_directory(
 	root: &Path,
 	request: &PublishRequest,
 	source: Option<&SourceConfiguration>,
 ) -> MonochangeResult<TempDir> {
-	let tempdir = tempfile::tempdir().map_err(|error| placeholder_tempdir_error(&error))?;
-	fs::write(
-		tempdir.path().join("README.md"),
-		&request.placeholder_readme,
+	build_placeholder_directory_with_writers(
+		root,
+		request,
+		source,
+		&placeholder_manifest_writer_registry(),
 	)
-	.map_err(|error| MonochangeError::Io(format!("failed to write placeholder README: {error}")))?;
-
-	let mut manifest_result = None;
-	let is_jsr_registry = request.registry == RegistryKind::Jsr;
-	let tempdir_path = tempdir.path();
-	if request.registry == RegistryKind::Npm {
-		manifest_result = Some(write_npm_placeholder_manifest(
-			tempdir_path,
-			request,
-			source,
-		));
-	} else if request.registry == RegistryKind::CratesIo {
-		manifest_result = Some(write_cargo_placeholder_manifest(
-			tempdir_path,
-			request,
-			root,
-			source,
-		));
-	} else if request.registry == RegistryKind::PubDev {
-		manifest_result = Some(write_dart_placeholder_manifest(
-			tempdir_path,
-			request,
-			source,
-		));
-	} else if request.registry == RegistryKind::Pypi {
-		manifest_result = Some(write_python_placeholder_manifest(
-			tempdir_path,
-			request,
-			source,
-		));
-	} else if request.registry == RegistryKind::GoProxy {
-		manifest_result = Some(write_go_placeholder_manifest(tempdir_path, request));
-	}
-	if is_jsr_registry {
-		manifest_result = Some(write_jsr_placeholder_manifest(
-			tempdir_path,
-			request,
-			source,
-		));
-	}
-	manifest_result.expect("unsupported built-in publish registry")?;
-
-	Ok(tempdir)
 }
 
+#[cfg(test)]
 fn placeholder_tempdir_error(error: &std::io::Error) -> MonochangeError {
 	MonochangeError::Io(format!("failed to create placeholder tempdir: {error}"))
 }
 
-fn disabled_trust_outcome() -> TrustedPublishingOutcome {
-	TrustedPublishingOutcome {
-		status: TrustedPublishingStatus::Disabled,
-		repository: None,
-		workflow: None,
-		environment: None,
-		setup_url: None,
-		message: "trusted publishing disabled".to_string(),
-	}
+fn publish_readiness_registry() -> PublishReadinessRegistry {
+	PublishReadinessRegistry::new().with_checker(
+		RegistryKind::CratesIo,
+		Box::new(|root, request| {
+			let blockers = cargo_publish_readiness_blockers(root, request)?;
+			if blockers.is_empty() {
+				Ok(None)
+			} else {
+				Ok(Some(publish_blocked_message(request, &blockers)))
+			}
+		}),
+	)
+}
+
+fn placeholder_manifest_writer_registry() -> PlaceholderManifestWriterRegistry {
+	PlaceholderManifestWriterRegistry::new()
+		.with_writer(
+			RegistryKind::Npm,
+			Box::new(|placeholder_dir, request, _root, source| {
+				write_npm_placeholder_manifest(placeholder_dir, request, source)
+			}),
+		)
+		.with_writer(
+			RegistryKind::CratesIo,
+			Box::new(|placeholder_dir, request, root, source| {
+				write_cargo_placeholder_manifest(placeholder_dir, request, root, source)
+			}),
+		)
+		.with_writer(
+			RegistryKind::PubDev,
+			Box::new(|placeholder_dir, request, _root, source| {
+				write_dart_placeholder_manifest(placeholder_dir, request, source)
+			}),
+		)
+		.with_writer(
+			RegistryKind::Jsr,
+			Box::new(|placeholder_dir, request, _root, source| {
+				write_jsr_placeholder_manifest(placeholder_dir, request, source)
+			}),
+		)
+		.with_writer(
+			RegistryKind::Pypi,
+			Box::new(|placeholder_dir, request, _root, source| {
+				write_python_placeholder_manifest(placeholder_dir, request, source)
+			}),
+		)
+		.with_writer(
+			RegistryKind::GoProxy,
+			Box::new(|placeholder_dir, request, _root, _source| {
+				write_go_placeholder_manifest(placeholder_dir, request)
+			}),
+		)
 }
 
 fn manual_trust_outcome(
@@ -976,32 +622,6 @@ fn manual_trust_outcome(
 			}
 		}
 	}
-}
-
-fn manual_setup_url(request: &PublishRequest) -> String {
-	if request.registry == RegistryKind::CratesIo {
-		format!("https://crates.io/crates/{}", encode(&request.package_name))
-	} else if request.registry == RegistryKind::PubDev {
-		format!("https://pub.dev/packages/{}/admin", request.package_name)
-	} else if request.registry == RegistryKind::Jsr {
-		format!("https://jsr.io/{}", request.package_name)
-	} else if request.registry == RegistryKind::Pypi {
-		format!(
-			"https://pypi.org/manage/project/{}/settings/publishing/",
-			request.package_name
-		)
-	} else if request.registry == RegistryKind::GoProxy {
-		format!("https://pkg.go.dev/{}", go_module_path(request))
-	} else {
-		format!(
-			"https://www.npmjs.com/package/{}/access",
-			request.package_name
-		)
-	}
-}
-
-fn non_empty_output(output: String) -> Option<String> {
-	(!output.is_empty()).then_some(output)
 }
 
 #[cfg(test)]

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -32,16 +32,11 @@ use monochange_core::SourceConfiguration;
 use monochange_core::default_cli_commands;
 #[cfg(feature = "dart")]
 use monochange_dart::DartAdapter;
-use monochange_dart::discover_dart_packages;
 use monochange_deno::DenoAdapter;
-use monochange_deno::discover_deno_packages;
 use monochange_go::GoAdapter;
-use monochange_go::discover_go_modules;
 #[cfg(feature = "npm")]
 use monochange_npm::NpmAdapter;
-use monochange_npm::discover_npm_packages;
 use monochange_python::PythonAdapter;
-use monochange_python::discover_python_packages;
 use serde_json::json;
 use typed_builder::TypedBuilder;
 
@@ -860,105 +855,9 @@ pub(crate) fn validate_cargo_workspace_version_groups(root: &Path) -> Monochange
 #[must_use = "the discovery result must be checked"]
 pub fn discover_workspace(root: &Path) -> MonochangeResult<DiscoveryReport> {
 	let configuration = load_workspace_configuration(root)?;
-	let mut warnings = Vec::new();
-	let mut packages = Vec::new();
-
-	#[cfg(all(
-		feature = "cargo",
-		feature = "npm",
-		feature = "deno",
-		feature = "dart",
-		feature = "python",
-		feature = "go"
-	))]
-	{
-		let (
-			(cargo_discovery, npm_discovery),
-			(deno_discovery, (dart_discovery, (python_discovery, go_discovery))),
-		) = rayon::join(
-			|| {
-				rayon::join(
-					|| discover_cargo_packages(root),
-					|| discover_npm_packages(root),
-				)
-			},
-			|| {
-				rayon::join(
-					|| discover_deno_packages(root),
-					|| {
-						rayon::join(
-							|| discover_dart_packages(root),
-							|| {
-								rayon::join(
-									|| discover_python_packages(root),
-									|| discover_go_modules(root),
-								)
-							},
-						)
-					},
-				)
-			},
-		);
-		for discovery in [
-			cargo_discovery?,
-			npm_discovery?,
-			deno_discovery?,
-			dart_discovery?,
-			python_discovery?,
-			go_discovery?,
-		] {
-			warnings.extend(discovery.warnings);
-			packages.extend(discovery.packages);
-		}
-	}
-
-	#[cfg(not(all(
-		feature = "cargo",
-		feature = "npm",
-		feature = "deno",
-		feature = "dart",
-		feature = "python",
-		feature = "go"
-	)))]
-	{
-		#[cfg(feature = "cargo")]
-		{
-			let d = discover_cargo_packages(root)?;
-			warnings.extend(d.warnings);
-			packages.extend(d.packages);
-		}
-		#[cfg(feature = "npm")]
-		{
-			let d = discover_npm_packages(root)?;
-			warnings.extend(d.warnings);
-			packages.extend(d.packages);
-		}
-		#[cfg(feature = "deno")]
-		{
-			let d = discover_deno_packages(root)?;
-			warnings.extend(d.warnings);
-			packages.extend(d.packages);
-		}
-		#[cfg(feature = "dart")]
-		{
-			let d = discover_dart_packages(root)?;
-			warnings.extend(d.warnings);
-			packages.extend(d.packages);
-		}
-		#[cfg(feature = "python")]
-		{
-			let d = discover_python_packages(root)?;
-			warnings.extend(d.warnings);
-			packages.extend(d.packages);
-		}
-		#[cfg(feature = "go")]
-		{
-			let d = discover_go_modules(root)?;
-			warnings.extend(d.warnings);
-			packages.extend(d.packages);
-		}
-	}
-
+	let discovery = build_ecosystem_registry().discover_all(root)?;
+	let mut warnings = discovery.warnings;
+	let mut packages = discovery.packages;
 	normalize_package_ids(root, &mut packages);
 	packages.sort_by(|left, right| left.id.cmp(&right.id));
 	packages.dedup_by(|left, right| left.id == right.id);
@@ -1739,6 +1638,23 @@ pub(crate) fn prepare_release_execution_with_file_diffs(
 			.take()
 			.unwrap_or_else(|| panic!("changesets should be available after local planning"))
 	};
+	let changelog_release_targets = release_targets
+		.iter()
+		.map(|target| {
+			monochange_changelog::ReleaseTarget {
+				id: target.id.clone(),
+				kind: target.kind,
+				version: target.version.clone(),
+				tag: target.tag,
+				release: target.release,
+				version_format: target.version_format,
+				tag_name: target.tag_name.clone(),
+				members: target.members.clone(),
+				rendered_title: target.rendered_title.clone(),
+				rendered_changelog_title: target.rendered_changelog_title.clone(),
+			}
+		})
+		.collect::<Vec<_>>();
 	let changelog_updates =
 		measure_prepare_phase(&mut phase_timings, "build changelog updates", || {
 			build_changelog_updates(
@@ -1750,13 +1666,18 @@ pub(crate) fn prepare_release_execution_with_file_diffs(
 					.change_signals(&change_signals)
 					.changesets(&changesets)
 					.changelog_targets(&changelog_targets)
-					.release_targets(&release_targets)
+					.release_targets(&changelog_release_targets)
 					.build(),
 			)
 		})?;
 	let changelog_file_updates = changelog_updates
 		.iter()
-		.map(|update| update.file.clone())
+		.map(|update| {
+			FileUpdate {
+				path: update.file.path.clone(),
+				content: update.file.content.clone(),
+			}
+		})
 		.collect::<Vec<_>>();
 	let base_updates = [
 		manifest_updates.clone(),

--- a/crates/monochange_changelog/Cargo.toml
+++ b/crates/monochange_changelog/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "monochange_changelog"
+version = { workspace = true }
+categories = { workspace = true }
+documentation = "https://docs.rs/monochange_changelog"
+edition = { workspace = true }
+include = ["src/**/*.rs", "Cargo.toml", "readme.md"]
+keywords = ["cli", "changelog", "releases", "versioning", "monorepo"]
+license = { workspace = true }
+readme = "readme.md"
+repository = { workspace = true }
+rust-version = { workspace = true }
+description = "Changelog rendering for monochange"
+
+[dependencies]
+minijinja = { workspace = true, default-features = true }
+monochange_core = { workspace = true }
+semver = { workspace = true, default-features = true }
+serde = { workspace = true, default-features = true }
+serde_json = { workspace = true, default-features = true }
+tracing = { workspace = true, default-features = true }
+typed-builder = { workspace = true, default-features = true }
+
+[dev-dependencies]
+tempfile = { workspace = true, default-features = true }
+
+[lints]
+workspace = true

--- a/crates/monochange_changelog/readme.md
+++ b/crates/monochange_changelog/readme.md
@@ -1,0 +1,3 @@
+# monochange_changelog
+
+Changelog rendering for monochange.

--- a/crates/monochange_changelog/src/__tests__/changelog_tests.rs
+++ b/crates/monochange_changelog/src/__tests__/changelog_tests.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
 
 use monochange_core::ChangeSignal;
 use monochange_core::ChangelogFormat;
@@ -1583,4 +1585,11 @@ fn monochange_format_includes_heading_for_custom_single_section() {
 		markdown.contains("### Features"),
 		"monochange format should include heading for custom single section"
 	);
+}
+
+#[test]
+fn root_relative_renders_workspace_root_as_dot() {
+	let root = Path::new("/workspace");
+
+	assert_eq!(root_relative(root, root), PathBuf::from("."));
 }

--- a/crates/monochange_changelog/src/lib.rs
+++ b/crates/monochange_changelog/src/lib.rs
@@ -1,9 +1,136 @@
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
+use minijinja::Environment;
+use minijinja::UndefinedBehavior;
+use monochange_core::BumpSeverity;
+use monochange_core::ChangeSignal;
+use monochange_core::ChangelogFormat;
+use monochange_core::ChangelogSettings;
+use monochange_core::ChangelogTarget;
+use monochange_core::ChangesetTargetKind;
+use monochange_core::GroupChangelogInclude;
+use monochange_core::HostedActorRef;
+use monochange_core::HostedIssueRef;
+use monochange_core::HostedIssueRelationshipKind;
+use monochange_core::HostedReviewRequestRef;
+#[cfg(test)]
+use monochange_core::HostingCapabilities;
+use monochange_core::MonochangeError;
+use monochange_core::MonochangeResult;
+use monochange_core::PackageRecord;
+use monochange_core::PreparedChangeset;
+use monochange_core::PreparedChangesetTarget;
+use monochange_core::ReleaseNotesDocument;
+use monochange_core::ReleaseNotesSection;
+use monochange_core::ReleaseOwnerKind;
+use monochange_core::ReleasePlan;
+use monochange_core::VersionFormat;
+use monochange_core::relative_to_root;
+use monochange_core::render_release_notes;
 use typed_builder::TypedBuilder;
 
-use super::*;
+pub type PackageChangelogTargets = BTreeMap<String, ChangelogTarget>;
+pub type GroupChangelogTargets = BTreeMap<String, ChangelogTarget>;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ReleaseTarget {
+	pub id: String,
+	pub kind: ReleaseOwnerKind,
+	pub version: String,
+	pub tag: bool,
+	pub release: bool,
+	pub version_format: VersionFormat,
+	pub tag_name: String,
+	pub members: Vec<String>,
+	pub rendered_title: String,
+	pub rendered_changelog_title: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct FileUpdate {
+	pub path: PathBuf,
+	pub content: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ChangelogUpdate {
+	pub file: FileUpdate,
+	pub owner_id: String,
+	pub owner_kind: ReleaseOwnerKind,
+	pub format: ChangelogFormat,
+	pub notes: ReleaseNotesDocument,
+	pub rendered: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ReleaseNoteChange {
+	pub package_id: String,
+	pub package_name: String,
+	pub package_labels: Vec<String>,
+	pub source_path: Option<String>,
+	pub summary: String,
+	pub details: Option<String>,
+	pub bump: BumpSeverity,
+	pub change_type: Option<String>,
+	pub context: Option<String>,
+	pub changeset_path: Option<String>,
+	pub change_owner: Option<String>,
+	pub change_owner_link: Option<String>,
+	pub review_request: Option<String>,
+	pub review_request_link: Option<String>,
+	pub introduced_commit: Option<String>,
+	pub introduced_commit_link: Option<String>,
+	pub last_updated_commit: Option<String>,
+	pub last_updated_commit_link: Option<String>,
+	pub related_issues: Option<String>,
+	pub related_issue_links: Option<String>,
+	pub closed_issues: Option<String>,
+	pub closed_issue_links: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+struct RenderedChangesetContext {
+	context: String,
+	changeset_path: String,
+	change_owner: Option<String>,
+	change_owner_link: Option<String>,
+	review_request: Option<String>,
+	review_request_link: Option<String>,
+	introduced_commit: Option<String>,
+	introduced_commit_link: Option<String>,
+	last_updated_commit: Option<String>,
+	last_updated_commit_link: Option<String>,
+	related_issues: Option<String>,
+	related_issue_links: Option<String>,
+	closed_issues: Option<String>,
+	closed_issue_links: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+struct GroupReleaseNoteKey {
+	source_path: Option<String>,
+	summary: String,
+	details: Option<String>,
+	bump: BumpSeverity,
+	change_type: Option<String>,
+	context: Option<String>,
+}
+
+fn root_relative(root: &Path, path: &Path) -> PathBuf {
+	let relative = relative_to_root(root, path).unwrap_or_else(|| path.to_path_buf());
+	if relative.as_os_str().is_empty() {
+		PathBuf::from(".")
+	} else {
+		relative
+	}
+}
 
 #[derive(Clone, Copy, Debug, TypedBuilder)]
-pub(crate) struct ChangelogBuildContext<'a> {
+pub struct ChangelogBuildContext<'a> {
 	pub root: &'a Path,
 	pub configuration: &'a monochange_core::WorkspaceConfiguration,
 	pub packages: &'a [PackageRecord],
@@ -15,7 +142,7 @@ pub(crate) struct ChangelogBuildContext<'a> {
 }
 
 #[tracing::instrument(skip_all)]
-pub(crate) fn build_changelog_updates(
+pub fn build_changelog_updates(
 	context: ChangelogBuildContext<'_>,
 ) -> MonochangeResult<Vec<ChangelogUpdate>> {
 	let changeset_context_by_path = context
@@ -731,7 +858,7 @@ fn select_empty_update_message<'value>(
 		.unwrap_or(built_in_default)
 }
 
-pub(crate) fn render_jinja_template(
+pub fn render_jinja_template(
 	template: &str,
 	context: &minijinja::Value,
 ) -> MonochangeResult<String> {
@@ -794,7 +921,7 @@ fn render_jinja_template_with_behavior(
 	}
 }
 
-pub(crate) fn render_message_template(template: &str, metadata: &BTreeMap<&str, String>) -> String {
+pub fn render_message_template(template: &str, metadata: &BTreeMap<&str, String>) -> String {
 	let context = minijinja::Value::from_serialize(metadata);
 	render_jinja_template(template, &context).unwrap_or_else(|_| template.to_string())
 }
@@ -918,7 +1045,7 @@ fn group_release_note_changes(
 	changes
 }
 
-pub(crate) fn filter_group_release_note_change(
+pub fn filter_group_release_note_change(
 	change: &ReleaseNoteChange,
 	group_definition: Option<&monochange_core::GroupDefinition>,
 	planned_group: &monochange_core::PlannedVersionGroup,
@@ -954,7 +1081,7 @@ pub(crate) fn filter_group_release_note_change(
 	}
 }
 
-pub(crate) fn group_changelog_include_allows(
+pub fn group_changelog_include_allows(
 	include: &GroupChangelogInclude,
 	in_group_targets: &BTreeSet<String>,
 ) -> bool {
@@ -969,7 +1096,7 @@ pub(crate) fn group_changelog_include_allows(
 	}
 }
 
-pub(crate) fn render_group_filtered_update_message(group_id: &str) -> String {
+pub fn render_group_filtered_update_message(group_id: &str) -> String {
 	format!(
 		"No group-facing notes were recorded for this release. Member packages were updated as part of the synchronized group `{group_id}` version, but their changes are not configured for inclusion in this changelog."
 	)

--- a/crates/monochange_config/Cargo.toml
+++ b/crates/monochange_config/Cargo.toml
@@ -19,17 +19,7 @@ schema = ["dep:schemars", "monochange_core/schema"]
 doc-comment = { workspace = true, default-features = true }
 glob = { workspace = true, default-features = true }
 miette = { workspace = true, default-features = true }
-monochange_cargo = { workspace = true }
 monochange_core = { workspace = true }
-monochange_dart = { workspace = true }
-monochange_deno = { workspace = true }
-monochange_forgejo = { workspace = true }
-monochange_gitea = { workspace = true }
-monochange_github = { workspace = true }
-monochange_gitlab = { workspace = true }
-monochange_go = { workspace = true }
-monochange_npm = { workspace = true }
-monochange_python = { workspace = true }
 regex = { workspace = true, default-features = true }
 schemars = { workspace = true, optional = true }
 semver = { workspace = true, default-features = true }

--- a/crates/monochange_config/src/__tests__/lib_tests.rs
+++ b/crates/monochange_config/src/__tests__/lib_tests.rs
@@ -6490,3 +6490,226 @@ steps = [
 	);
 	assert_eq!(publish_check.steps.len(), 2);
 }
+
+fn source_config_for_provider(provider: SourceProvider) -> monochange_core::SourceConfiguration {
+	monochange_core::SourceConfiguration {
+		provider,
+		owner: "owner".to_string(),
+		repo: "repo".to_string(),
+		host: None,
+		api_url: None,
+		releases: monochange_core::ProviderReleaseSettings::default(),
+		pull_requests: monochange_core::ProviderMergeRequestSettings::default(),
+	}
+}
+
+#[test]
+fn source_provider_capabilities_reject_unsupported_settings() {
+	let gitea_without_host = source_config_for_provider(SourceProvider::Gitea);
+	let error = crate::validate_source_provider_capabilities(&gitea_without_host).unwrap_err();
+	assert!(error.to_string().contains("[source].host must be set"));
+
+	let mut gitlab_with_draft = source_config_for_provider(SourceProvider::GitLab);
+	gitlab_with_draft.releases.draft = true;
+	let error = crate::validate_source_provider_capabilities(&gitlab_with_draft).unwrap_err();
+	assert!(
+		error
+			.to_string()
+			.contains("[source.releases].draft is not supported")
+	);
+
+	let mut gitlab_with_prerelease = source_config_for_provider(SourceProvider::GitLab);
+	gitlab_with_prerelease.releases.prerelease = true;
+	let error = crate::validate_source_provider_capabilities(&gitlab_with_prerelease).unwrap_err();
+	assert!(
+		error
+			.to_string()
+			.contains("[source.releases].prerelease is not supported")
+	);
+
+	let mut gitea_with_notes = source_config_for_provider(SourceProvider::Gitea);
+	gitea_with_notes.host = Some("https://git.example.com".to_string());
+	gitea_with_notes.releases.generate_notes = true;
+	let error = crate::validate_source_provider_capabilities(&gitea_with_notes).unwrap_err();
+	assert!(
+		error
+			.to_string()
+			.contains("provider-generated release notes are not supported")
+	);
+
+	let mut gitea_with_auto_merge = source_config_for_provider(SourceProvider::Gitea);
+	gitea_with_auto_merge.host = Some("https://git.example.com".to_string());
+	gitea_with_auto_merge.pull_requests.auto_merge = true;
+	let error = crate::validate_source_provider_capabilities(&gitea_with_auto_merge).unwrap_err();
+	assert!(
+		error
+			.to_string()
+			.contains("[source.pull_requests].auto_merge is not supported")
+	);
+}
+
+#[test]
+fn validate_ecosystem_version_readable_reports_parse_and_field_errors() {
+	let root = tempdir().unwrap();
+	let unsupported = root.path().join("package.txt");
+	std::fs::write(&unsupported, "version = \"1.0.0\"").unwrap();
+	let error = crate::validate_ecosystem_version_readable(
+		&unsupported,
+		"package.txt",
+		EcosystemType::Npm,
+		None,
+		"package",
+		"pkg",
+	)
+	.unwrap_err();
+	assert!(error.to_string().contains("is not supported for ecosystem"));
+
+	let missing = root.path().join("package.json");
+	let error = crate::validate_ecosystem_version_readable(
+		&missing,
+		"package.json",
+		EcosystemType::Npm,
+		None,
+		"package",
+		"pkg",
+	)
+	.unwrap_err();
+	assert!(error.to_string().contains("failed to read"));
+
+	let bad_json = root.path().join("package.json");
+	std::fs::write(&bad_json, "{").unwrap();
+	let error = crate::validate_ecosystem_version_readable(
+		&bad_json,
+		"package.json",
+		EcosystemType::Npm,
+		None,
+		"package",
+		"pkg",
+	)
+	.unwrap_err();
+	assert!(error.to_string().contains("is not valid JSON"));
+
+	std::fs::write(&bad_json, "{\"version\":\"1.0.0\"}").unwrap();
+	crate::validate_ecosystem_version_readable(
+		&bad_json,
+		"package.json",
+		EcosystemType::Npm,
+		None,
+		"package",
+		"pkg",
+	)
+	.unwrap();
+
+	std::fs::write(&bad_json, "{\"name\":\"pkg\"}").unwrap();
+	let error = crate::validate_ecosystem_version_readable(
+		&bad_json,
+		"package.json",
+		EcosystemType::Npm,
+		None,
+		"package",
+		"pkg",
+	)
+	.unwrap_err();
+	assert!(
+		error
+			.to_string()
+			.contains("does not contain a `version` string field")
+	);
+
+	let bad_yaml = root.path().join("pubspec.yaml");
+	std::fs::write(&bad_yaml, ": bad").unwrap();
+	let error = crate::validate_ecosystem_version_readable(
+		&bad_yaml,
+		"pubspec.yaml",
+		EcosystemType::Dart,
+		None,
+		"package",
+		"pkg",
+	)
+	.unwrap_err();
+	assert!(error.to_string().contains("is not valid YAML"));
+
+	std::fs::write(&bad_yaml, "version: 1.0.0\n").unwrap();
+	crate::validate_ecosystem_version_readable(
+		&bad_yaml,
+		"pubspec.yaml",
+		EcosystemType::Dart,
+		None,
+		"package",
+		"pkg",
+	)
+	.unwrap();
+
+	std::fs::write(&bad_yaml, "name: pkg\n").unwrap();
+	let error = crate::validate_ecosystem_version_readable(
+		&bad_yaml,
+		"pubspec.yaml",
+		EcosystemType::Dart,
+		None,
+		"package",
+		"pkg",
+	)
+	.unwrap_err();
+	assert!(
+		error
+			.to_string()
+			.contains("does not contain a `version` string field")
+	);
+
+	let go_mod = root.path().join("go.mod");
+	std::fs::write(&go_mod, "module example.com/pkg\n").unwrap();
+	crate::validate_ecosystem_version_readable(
+		&go_mod,
+		"go.mod",
+		EcosystemType::Go,
+		None,
+		"package",
+		"pkg",
+	)
+	.unwrap();
+
+	let bad_toml = root.path().join("Cargo.toml");
+	std::fs::write(&bad_toml, "[").unwrap();
+	let error = crate::validate_ecosystem_version_readable(
+		&bad_toml,
+		"Cargo.toml",
+		EcosystemType::Cargo,
+		None,
+		"package",
+		"pkg",
+	)
+	.unwrap_err();
+	assert!(error.to_string().contains("is not valid TOML"));
+
+	std::fs::write(
+		&bad_toml,
+		"[package]\nname = \"pkg\"\nversion = \"1.0.0\"\n",
+	)
+	.unwrap();
+	let fields = vec!["package.version".to_string()];
+	crate::validate_ecosystem_version_readable(
+		&bad_toml,
+		"Cargo.toml",
+		EcosystemType::Cargo,
+		Some(&fields),
+		"package",
+		"pkg",
+	)
+	.unwrap();
+
+	std::fs::write(&bad_toml, "[package]\nname = \"pkg\"\n").unwrap();
+	let error = crate::validate_ecosystem_version_readable(
+		&bad_toml,
+		"Cargo.toml",
+		EcosystemType::Cargo,
+		Some(&fields),
+		"package",
+		"pkg",
+	)
+	.unwrap_err();
+	assert!(
+		error
+			.to_string()
+			.contains("does not contain a `package.version` string field")
+	);
+}

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -100,7 +100,6 @@ use monochange_core::CliInputKind;
 use monochange_core::CliStepDefinition;
 use monochange_core::CliStepInputValue;
 use monochange_core::Ecosystem;
-use monochange_core::EcosystemRegistry;
 use monochange_core::EcosystemSettings;
 use monochange_core::EcosystemType;
 use monochange_core::GroupChangelogInclude;
@@ -112,12 +111,14 @@ use monochange_core::PackageDefinition;
 use monochange_core::PackageRecord;
 use monochange_core::PackageType;
 use monochange_core::ProviderMergeRequestSettings;
+use monochange_core::ProviderReleaseNotesSource;
 use monochange_core::ProviderReleaseSettings;
 use monochange_core::PublishAttestationSettings;
 use monochange_core::PublishMode;
 use monochange_core::PublishRegistry;
 use monochange_core::PublishSettings;
 use monochange_core::RegistryKind;
+use monochange_core::SourceCapabilities;
 use monochange_core::SourceConfiguration;
 use monochange_core::SourceProvider;
 use monochange_core::TrustedPublishingSettings;
@@ -3280,26 +3281,63 @@ fn path_uses_glob(path: &str) -> bool {
 	path.contains('*') || path.contains('?') || path.contains('[')
 }
 
-fn build_ecosystem_registry() -> EcosystemRegistry {
-	EcosystemRegistry::new()
-		.with_adapter(Box::new(monochange_cargo::CargoAdapter))
-		.with_adapter(Box::new(monochange_npm::NpmAdapter))
-		.with_adapter(Box::new(monochange_deno::DenoAdapter))
-		.with_adapter(Box::new(monochange_dart::DartAdapter))
-		.with_adapter(Box::new(monochange_python::PythonAdapter))
-		.with_adapter(Box::new(monochange_go::GoAdapter))
-}
-
 fn path_is_supported_for_ecosystem(path: &Path, ecosystem_type: EcosystemType) -> bool {
-	build_ecosystem_registry().supported_versioned_file_kind(path, ecosystem_type.into())
+	let file_name = path
+		.file_name()
+		.and_then(|name| name.to_str())
+		.unwrap_or_default();
+	match ecosystem_type {
+		EcosystemType::Cargo => {
+			path.extension()
+				.and_then(|extension| extension.to_str())
+				.is_some_and(|extension| extension.eq_ignore_ascii_case("toml"))
+				|| file_name == "Cargo.lock"
+		}
+		EcosystemType::Npm => {
+			matches!(
+				file_name,
+				"package.json" | "package-lock.json" | "pnpm-lock.yaml" | "bun.lock" | "bun.lockb"
+			)
+		}
+		EcosystemType::Deno => matches!(file_name, "deno.json" | "deno.jsonc" | "deno.lock"),
+		EcosystemType::Dart => matches!(file_name, "pubspec.yaml" | "pubspec.yml" | "pubspec.lock"),
+		EcosystemType::Python => matches!(file_name, "pyproject.toml" | "uv.lock" | "poetry.lock"),
+		_ => matches!(file_name, "go.mod" | "go.sum"),
+	}
 }
 
-fn source_capabilities(provider: SourceProvider) -> monochange_core::SourceCapabilities {
+fn source_capabilities(provider: SourceProvider) -> SourceCapabilities {
 	match provider {
-		SourceProvider::GitHub => monochange_github::source_capabilities(),
-		SourceProvider::GitLab => monochange_gitlab::source_capabilities(),
-		SourceProvider::Gitea => monochange_gitea::source_capabilities(),
-		SourceProvider::Forgejo => monochange_forgejo::source_capabilities(),
+		SourceProvider::GitHub => {
+			SourceCapabilities {
+				draft_releases: true,
+				prereleases: true,
+				generated_release_notes: true,
+				auto_merge_change_requests: true,
+				released_issue_comments: true,
+				requires_host: false,
+			}
+		}
+		SourceProvider::GitLab => {
+			SourceCapabilities {
+				draft_releases: false,
+				prereleases: false,
+				generated_release_notes: false,
+				auto_merge_change_requests: false,
+				released_issue_comments: false,
+				requires_host: false,
+			}
+		}
+		SourceProvider::Gitea | SourceProvider::Forgejo => {
+			SourceCapabilities {
+				draft_releases: true,
+				prereleases: true,
+				generated_release_notes: false,
+				auto_merge_change_requests: false,
+				released_issue_comments: false,
+				requires_host: true,
+			}
+		}
 	}
 }
 
@@ -3721,12 +3759,52 @@ fn validate_source_configuration(source: Option<&SourceConfiguration>) -> Monoch
 	if let Some(host) = &source.host {
 		validate_api_url_host(host, source.provider)?;
 	}
-	match source.provider {
-		SourceProvider::GitHub => monochange_github::validate_source_configuration(source),
-		SourceProvider::GitLab => monochange_gitlab::validate_source_configuration(source),
-		SourceProvider::Gitea => monochange_gitea::validate_source_configuration(source),
-		SourceProvider::Forgejo => monochange_forgejo::validate_source_configuration(source),
+	validate_source_provider_capabilities(source)
+}
+
+fn validate_source_provider_capabilities(source: &SourceConfiguration) -> MonochangeResult<()> {
+	let capabilities = source_capabilities(source.provider);
+	if capabilities.requires_host && source.host.as_deref().is_none_or(str::is_empty) {
+		return Err(MonochangeError::Config(format!(
+			"[source].host must be set for `provider = \"{}\"`",
+			source.provider
+		)));
 	}
+	if source.releases.draft && !capabilities.draft_releases {
+		return Err(MonochangeError::Config(format!(
+			"[source.releases].draft is not supported for `provider = \"{}\"`",
+			source.provider
+		)));
+	}
+	if source.releases.prerelease && !capabilities.prereleases {
+		return Err(MonochangeError::Config(format!(
+			"[source.releases].prerelease is not supported for `provider = \"{}\"`",
+			source.provider
+		)));
+	}
+	if source.releases.generate_notes && !capabilities.generated_release_notes {
+		return Err(MonochangeError::Config(format!(
+			"provider-generated release notes are not supported for `provider = \"{}\"`; use `source = \"monochange\"`",
+			source.provider
+		)));
+	}
+	if source.releases.generate_notes
+		&& matches!(
+			source.releases.source,
+			ProviderReleaseNotesSource::Monochange
+		) {
+		return Err(MonochangeError::Config(
+			"[source.releases].generate_notes cannot be true when `source = \"monochange\"`; choose one release-note source"
+				.to_string(),
+		));
+	}
+	if source.pull_requests.auto_merge && !capabilities.auto_merge_change_requests {
+		return Err(MonochangeError::Config(format!(
+			"[source.pull_requests].auto_merge is not supported for `provider = \"{}\"`",
+			source.provider
+		)));
+	}
+	Ok(())
 }
 
 /// Reject `api_url` or `host` values that use insecure schemes. API tokens are
@@ -5045,16 +5123,92 @@ fn validate_ecosystem_version_readable(
 	owner_kind: &str,
 	owner_id: &str,
 ) -> MonochangeResult<()> {
-	let result = build_ecosystem_registry().validate_versioned_file(
-		full_path,
-		display_path,
-		ecosystem_type.into(),
-		fields,
+	if !path_is_supported_for_ecosystem(full_path, ecosystem_type) {
+		return Err(MonochangeError::Config(format!(
+			"{owner_kind} `{owner_id}` versioned file `{display_path}` is not supported for ecosystem `{ecosystem_type:?}`"
+		)));
+	}
+	let contents = fs::read_to_string(full_path).map_err(|error| {
+		MonochangeError::Io(format!("failed to read {}: {error}", full_path.display()))
+	})?;
+	let uses_default_version_field = fields.is_none();
+	let field_names: Vec<&str> = fields.map_or_else(
+		|| vec!["version"],
+		|fields| fields.iter().map(String::as_str).collect(),
 	);
-
-	result.map_err(|error| match error {
-		MonochangeError::Config(msg) => MonochangeError::Config(format!("{owner_kind} `{owner_id}` {msg}")), other => other,
-	})
+	let field_error = |field: &str| {
+		if uses_default_version_field {
+			MonochangeError::Config(format!(
+				"{owner_kind} `{owner_id}` versioned file `{display_path}` does not contain a `version` string field; does not contain a readable version field"
+			))
+		} else {
+			MonochangeError::Config(format!(
+				"{owner_kind} `{owner_id}` versioned file `{display_path}` does not contain a `{field}` string field"
+			))
+		}
+	};
+	let value_is_string = |value: &serde_json::Value, field: &str| {
+		value.get(field).and_then(serde_json::Value::as_str).is_some()
+	};
+	match ecosystem_type {
+		EcosystemType::Npm | EcosystemType::Deno => {
+			let value: serde_json::Value = serde_json::from_str(&contents).map_err(|error| {
+				MonochangeError::Config(format!("{owner_kind} `{owner_id}` `{display_path}` is not valid JSON: {error}"))
+			})?;
+			for field in field_names {
+				if value_is_string(&value, field) {
+					continue;
+				}
+				Err(field_error(field))?;
+			}
+		}
+		EcosystemType::Dart => {
+			let value: serde_yaml_ng::Value = serde_yaml_ng::from_str(&contents).map_err(|error| {
+				MonochangeError::Config(format!("{owner_kind} `{owner_id}` `{display_path}` is not valid YAML: {error}"))
+			})?;
+			for field in field_names {
+				let is_string = value
+					.get(field)
+					.and_then(serde_yaml_ng::Value::as_str)
+					.is_some();
+				if is_string {
+					continue;
+				}
+				Err(field_error(field))?;
+			}
+		}
+		EcosystemType::Cargo => {
+			let value: toml::Value = toml::from_str(&contents).map_err(|error| {
+				MonochangeError::Config(format!(
+					"{owner_kind} `{owner_id}` `{display_path}` is not valid TOML: {error}"
+				))
+			})?;
+			let value_at_path_is_string = |field: &str| {
+				field
+					.split('.')
+					.try_fold(&value, |current, segment| current.get(segment))
+					.and_then(toml::Value::as_str)
+					.is_some()
+			};
+			if uses_default_version_field {
+				let has_version = ["version", "package.version", "workspace.package.version"]
+					.into_iter()
+					.any(value_at_path_is_string);
+				if !has_version {
+					return Err(field_error("version"));
+				}
+			} else {
+				for field in field_names {
+					if value_at_path_is_string(field) {
+						continue;
+					}
+					Err(field_error(field))?;
+				}
+			}
+		}
+		_ => {}
+	}
+	Ok(())
 }
 
 fn validate_changeset_targets(

--- a/crates/monochange_publish/Cargo.toml
+++ b/crates/monochange_publish/Cargo.toml
@@ -17,6 +17,7 @@ monochange_core = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "json"] }
 serde = { workspace = true, default-features = true }
 serde_json = { workspace = true }
+tempfile = { workspace = true }
 urlencoding = { workspace = true }
 
 [lints]

--- a/crates/monochange_publish/src/__tests__/lib_tests.rs
+++ b/crates/monochange_publish/src/__tests__/lib_tests.rs
@@ -1,3 +1,6 @@
+use monochange_core::GroupChangelogInclude;
+use monochange_core::VersionFormat;
+
 use super::*;
 
 fn builtin_provider_registry_trust_capability(
@@ -286,4 +289,157 @@ fn unsupported_builtin_registries_have_no_trusted_publishing_capabilities() {
 		},
 	);
 	assert!(message.contains("supported providers: none"));
+}
+
+fn publication_target(package: &str, ecosystem: Ecosystem) -> PackagePublicationTarget {
+	PackagePublicationTarget {
+		package: package.to_string(),
+		ecosystem,
+		registry: None,
+		version: "1.0.0".to_string(),
+		mode: PublishMode::default(),
+		trusted_publishing: TrustedPublishingSettings::default(),
+		attestations: PublishAttestationSettings::default(),
+	}
+}
+
+fn group_definition(id: &str, packages: &[&str]) -> GroupDefinition {
+	GroupDefinition {
+		id: id.to_string(),
+		packages: packages
+			.iter()
+			.map(|package| (*package).to_string())
+			.collect(),
+		changelog: None,
+		changelog_include: GroupChangelogInclude::default(),
+		excluded_changelog_types: Vec::new(),
+		empty_update_message: None,
+		release_title: None,
+		changelog_version_title: None,
+		versioned_files: Vec::new(),
+		tag: true,
+		release: true,
+		version_format: VersionFormat::default(),
+	}
+}
+
+#[test]
+fn select_release_publication_targets_filters_ecosystems_and_expands_groups() {
+	let groups = vec![
+		group_definition("frontend", &["web", "ui"]),
+		group_definition("docs", &["site"]),
+	];
+	let publication_targets = vec![
+		publication_target("web", Ecosystem::Npm),
+		publication_target("cli", Ecosystem::Cargo),
+		publication_target("docs", Ecosystem::Python),
+	];
+	let selected_packages = BTreeSet::from(["manual".to_string()]);
+	let selected_groups = BTreeSet::from(["frontend".to_string(), "missing".to_string()]);
+	let selected_ecosystems = BTreeSet::from([Ecosystem::Npm, Ecosystem::Cargo]);
+
+	let selected = select_release_publication_targets(
+		&groups,
+		&publication_targets,
+		&selected_packages,
+		&selected_groups,
+		&selected_ecosystems,
+	);
+
+	assert_eq!(selected.publication_targets.len(), 2);
+	assert_eq!(selected.publication_targets[0].package, "web");
+	assert_eq!(selected.publication_targets[1].package, "cli");
+	assert_eq!(
+		selected.selected_packages,
+		BTreeSet::from(["manual".to_string(), "web".to_string(), "ui".to_string()])
+	);
+}
+
+fn sample_publish_request_for_registry(registry: RegistryKind) -> PublishRequest {
+	PublishRequest {
+		package_id: "pkg".to_string(),
+		package_name: "pkg".to_string(),
+		ecosystem: Ecosystem::Npm,
+		manifest_path: PathBuf::from("package.json"),
+		package_root: PathBuf::from("."),
+		registry,
+		package_manager: None,
+		package_metadata: BTreeMap::new(),
+		mode: PublishMode::Builtin,
+		version: "1.0.0".to_string(),
+		placeholder: false,
+		trusted_publishing: TrustedPublishingSettings::default(),
+		attestations: PublishAttestationSettings::default(),
+		placeholder_readme: "placeholder".to_string(),
+	}
+}
+
+#[test]
+fn publish_readiness_registry_push_checker_and_missing_checker_paths() {
+	let request = sample_publish_request_for_registry(RegistryKind::Npm);
+	let root = Path::new(".");
+	let mut registry = PublishReadinessRegistry::new();
+
+	assert_eq!(registry.blocked_message(root, &request).unwrap(), None);
+
+	registry.push_checker(
+		RegistryKind::Npm,
+		Box::new(|_, request| Ok(Some(format!("{} blocked", request.package_name)))),
+	);
+
+	assert_eq!(
+		registry.blocked_message(root, &request).unwrap().as_deref(),
+		Some("pkg blocked")
+	);
+}
+
+#[test]
+fn placeholder_manifest_registry_push_writer_and_directory_builder_write_files() {
+	let request = sample_publish_request_for_registry(RegistryKind::Npm);
+	let root = Path::new(".");
+	let mut registry = PlaceholderManifestWriterRegistry::new();
+
+	registry.push_writer(
+		RegistryKind::Npm,
+		Box::new(|placeholder_dir, request, _, _| {
+			fs::write(
+				placeholder_dir.join("package.json"),
+				format!("{{\"name\":\"{}\"}}", request.package_name),
+			)
+			.map_err(|error| MonochangeError::Io(error.to_string()))
+		}),
+	);
+
+	let tempdir = build_placeholder_directory(root, &request, None, &registry).unwrap();
+
+	assert_eq!(
+		fs::read_to_string(tempdir.path().join("README.md")).unwrap(),
+		"placeholder"
+	);
+	assert_eq!(
+		fs::read_to_string(tempdir.path().join("package.json")).unwrap(),
+		"{\"name\":\"pkg\"}"
+	);
+}
+
+#[test]
+fn default_registry_kind_for_ecosystem_reports_unknown_and_known_ecosystems() {
+	let unknown = default_registry_kind_for_ecosystem("unknown").unwrap_err();
+	assert!(unknown.to_string().contains("ecosystem `unknown`"));
+
+	assert_eq!(
+		default_registry_kind_for_ecosystem("go").unwrap(),
+		RegistryKind::GoProxy
+	);
+}
+
+#[test]
+fn placeholder_tempdir_error_includes_io_error() {
+	let error = std::io::Error::other("no tempdir");
+
+	assert!(
+		placeholder_tempdir_error(&error)
+			.to_string()
+			.contains("failed to create placeholder tempdir: no tempdir")
+	);
 }

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -1,24 +1,64 @@
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::env;
+use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 
 use monochange_core::Ecosystem;
+use monochange_core::GroupDefinition;
 use monochange_core::MonochangeError;
 use monochange_core::MonochangeResult;
+use monochange_core::PackagePublicationTarget;
 use monochange_core::PackageRecord;
 use monochange_core::PublishAttestationSettings;
 use monochange_core::PublishMode;
 use monochange_core::PublishRegistry;
 use monochange_core::PublishState;
 use monochange_core::RegistryKind;
+use monochange_core::SourceConfiguration;
 use monochange_core::TrustedPublishingSettings;
+use monochange_core::WorkspaceConfiguration;
 use reqwest::StatusCode;
 use reqwest::blocking::Client;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::Value as JsonValue;
+use tempfile::TempDir;
 use urlencoding::encode;
+
+pub const PLACEHOLDER_VERSION: &str = "0.0.0";
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct SelectedReleasePublicationTargets {
+	pub publication_targets: Vec<PackagePublicationTarget>,
+	pub selected_packages: BTreeSet<String>,
+}
+
+pub fn select_release_publication_targets(
+	groups: &[GroupDefinition],
+	publication_targets: &[PackagePublicationTarget],
+	selected_packages: &BTreeSet<String>,
+	selected_groups: &BTreeSet<String>,
+	selected_ecosystems: &BTreeSet<Ecosystem>,
+) -> SelectedReleasePublicationTargets {
+	let mut publication_targets = publication_targets.to_vec();
+	if !selected_ecosystems.is_empty() {
+		publication_targets.retain(|target| selected_ecosystems.contains(&target.ecosystem));
+	}
+
+	let mut selected_packages = selected_packages.clone();
+	for group_id in selected_groups {
+		if let Some(group) = groups.iter().find(|group| group.id == *group_id) {
+			selected_packages.extend(group.packages.iter().cloned());
+		}
+	}
+
+	SelectedReleasePublicationTargets {
+		publication_targets,
+		selected_packages,
+	}
+}
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -85,6 +125,169 @@ pub struct PackagePublishReport {
 	pub packages: Vec<PackagePublishOutcome>,
 }
 
+#[must_use]
+pub fn disabled_trust_outcome() -> TrustedPublishingOutcome {
+	TrustedPublishingOutcome {
+		status: TrustedPublishingStatus::Disabled,
+		repository: None,
+		workflow: None,
+		environment: None,
+		setup_url: None,
+		message: "trusted publishing disabled".to_string(),
+	}
+}
+
+#[must_use]
+pub fn failed_publish_outcome(
+	mode: PackagePublishRunMode,
+	request: &PublishRequest,
+	message: String,
+) -> PackagePublishOutcome {
+	PackagePublishOutcome {
+		package: request.package_id.clone(),
+		ecosystem: request.ecosystem,
+		registry: request.registry.to_string(),
+		version: request.version.clone(),
+		status: PackagePublishStatus::Failed,
+		message,
+		placeholder: mode == PackagePublishRunMode::Placeholder,
+		trusted_publishing: disabled_trust_outcome(),
+		command: None,
+		stdout: None,
+		stderr: None,
+	}
+}
+
+#[must_use]
+pub fn planned_publish_message(mode: PackagePublishRunMode, request: &PublishRequest) -> String {
+	match mode {
+		PackagePublishRunMode::Placeholder => {
+			format!(
+				"would publish placeholder {} {} to {}",
+				request.package_name, request.version, request.registry
+			)
+		}
+		PackagePublishRunMode::Release => {
+			format!(
+				"would publish {} {} to {}",
+				request.package_name, request.version, request.registry
+			)
+		}
+	}
+}
+
+#[must_use]
+pub fn non_empty_output(output: String) -> Option<String> {
+	(!output.is_empty()).then_some(output)
+}
+
+pub fn reject_npm_token_environment(
+	request: &PublishRequest,
+	env_map: &BTreeMap<String, String>,
+) -> MonochangeResult<()> {
+	let token_keys = forbidden_npm_token_env_keys(env_map);
+	if token_keys.is_empty() {
+		return Ok(());
+	}
+
+	Err(MonochangeError::Config(format!(
+		"`{}` requires npm trusted publishing, but long-lived npm token environment variables are present: {}. Remove token-based npm credentials and publish from the configured CI/OIDC workflow, or set `publish.trusted_publishing = false` to opt out.",
+		request.package_id,
+		token_keys.join(", "),
+	)))
+}
+
+#[must_use]
+pub fn forbidden_npm_token_env_keys(env_map: &BTreeMap<String, String>) -> Vec<String> {
+	env_map
+		.keys()
+		.filter(|key| is_forbidden_npm_token_env_key(key))
+		.cloned()
+		.collect()
+}
+
+#[must_use]
+pub fn is_forbidden_npm_token_env_key(key: &str) -> bool {
+	let lowercase_key = key.to_ascii_lowercase();
+	matches!(
+		key,
+		"NPM_TOKEN" | "NODE_AUTH_TOKEN" | "NPM_CONFIG__AUTH_TOKEN" | "npm_config__authToken"
+	) || (lowercase_key.starts_with("npm_config_")
+		&& lowercase_key.contains("auth")
+		&& lowercase_key.contains("token"))
+}
+
+pub fn enforce_release_attestation_prerequisites(
+	request: &PublishRequest,
+	env_map: &BTreeMap<String, String>,
+	command_builder: &PublishCommandBuilder,
+) -> MonochangeResult<()> {
+	if !request.attestations.require_registry_provenance {
+		return Ok(());
+	}
+
+	if !request.trusted_publishing.enabled {
+		return Err(MonochangeError::Config(format!(
+			"`{}` requires registry-native package provenance, but trusted publishing is disabled. Registry provenance is only enforceable for built-in publishing from a verifiable CI/OIDC identity; set `publish.trusted_publishing = true` or set `publish.attestations.require_registry_provenance = false` to opt out.",
+			request.package_id,
+		)));
+	}
+
+	let registry = PublishRegistry::Builtin(request.registry);
+	let identity = detect_trusted_publishing_identity(env_map);
+	let capability_message = trusted_publishing_capability_message(&registry, &identity);
+	if !identity.is_verifiable_by_env() {
+		return Err(MonochangeError::Config(format!(
+			"`{}` requires registry-native package provenance from a verifiable CI/OIDC identity, but the current publishing context is local or unverifiable. {capability_message} Run `mc publish` from the configured CI workflow or set `publish.attestations.require_registry_provenance = false` to opt out.",
+			request.package_id,
+		)));
+	}
+
+	let capability = provider_registry_trust_capability(&registry, identity.provider());
+	if !capability.registry_native_provenance {
+		return Err(MonochangeError::Config(format!(
+			"`{}` cannot require registry-native package provenance for {} from {}. {capability_message} This registry/provider combination does not expose provenance monochange can require; set `publish.attestations.require_registry_provenance = false` to opt out or use an external publisher that enforces its own attestation policy.",
+			request.package_id,
+			request.registry,
+			identity.provider().label(),
+		)));
+	}
+	if !command_builder
+		.adapter_for_registry(request.registry)
+		.is_some_and(PublishAdapter::supports_provenance)
+	{
+		return Err(MonochangeError::Config(format!(
+			"`{}` cannot require registry-native package provenance for {} yet. {capability_message} The registry supports provenance, but monochange's current built-in publisher for this ecosystem does not expose a publish command that can require it; set `publish.attestations.require_registry_provenance = false` to opt out or use an external publisher that enforces its own attestation policy.",
+			request.package_id, request.registry,
+		)));
+	}
+
+	Ok(())
+}
+
+#[must_use]
+pub fn manual_setup_url(request: &PublishRequest) -> String {
+	if request.registry == RegistryKind::CratesIo {
+		format!("https://crates.io/crates/{}", encode(&request.package_name))
+	} else if request.registry == RegistryKind::PubDev {
+		format!("https://pub.dev/packages/{}/admin", request.package_name)
+	} else if request.registry == RegistryKind::Jsr {
+		format!("https://jsr.io/{}", request.package_name)
+	} else if request.registry == RegistryKind::Pypi {
+		format!(
+			"https://pypi.org/manage/project/{}/settings/publishing/",
+			request.package_name
+		)
+	} else if request.registry == RegistryKind::GoProxy {
+		format!("https://pkg.go.dev/{}", go_module_path(request))
+	} else {
+		format!(
+			"https://www.npmjs.com/package/{}/access",
+			request.package_name
+		)
+	}
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PublishRequest {
 	pub package_id: String,
@@ -108,6 +311,534 @@ pub struct CommandSpec {
 	pub program: String,
 	pub args: Vec<String>,
 	pub cwd: PathBuf,
+}
+
+pub type PlaceholderManifestWriter =
+	dyn Fn(&Path, &PublishRequest, &Path, Option<&SourceConfiguration>) -> MonochangeResult<()>;
+
+pub type PublishReadinessChecker =
+	dyn Fn(&Path, &PublishRequest) -> MonochangeResult<Option<String>>;
+
+#[derive(Default)]
+pub struct PublishReadinessRegistry {
+	checkers: Vec<(RegistryKind, Box<PublishReadinessChecker>)>,
+}
+
+impl PublishReadinessRegistry {
+	#[must_use]
+	pub fn new() -> Self {
+		Self::default()
+	}
+
+	#[must_use]
+	pub fn with_checker(
+		mut self,
+		registry: RegistryKind,
+		checker: Box<PublishReadinessChecker>,
+	) -> Self {
+		self.checkers.push((registry, checker));
+		self
+	}
+
+	pub fn push_checker(&mut self, registry: RegistryKind, checker: Box<PublishReadinessChecker>) {
+		self.checkers.push((registry, checker));
+	}
+
+	pub fn blocked_message(
+		&self,
+		root: &Path,
+		request: &PublishRequest,
+	) -> MonochangeResult<Option<String>> {
+		let Some((_, checker)) = self
+			.checkers
+			.iter()
+			.find(|(registry, _)| *registry == request.registry)
+		else {
+			return Ok(None);
+		};
+		checker(root, request)
+	}
+}
+
+#[derive(Default)]
+pub struct PlaceholderManifestWriterRegistry {
+	writers: Vec<(RegistryKind, Box<PlaceholderManifestWriter>)>,
+}
+
+impl PlaceholderManifestWriterRegistry {
+	#[must_use]
+	pub fn new() -> Self {
+		Self::default()
+	}
+
+	#[must_use]
+	pub fn with_writer(
+		mut self,
+		registry: RegistryKind,
+		writer: Box<PlaceholderManifestWriter>,
+	) -> Self {
+		self.writers.push((registry, writer));
+		self
+	}
+
+	pub fn push_writer(&mut self, registry: RegistryKind, writer: Box<PlaceholderManifestWriter>) {
+		self.writers.push((registry, writer));
+	}
+
+	pub fn write_manifest(
+		&self,
+		placeholder_dir: &Path,
+		request: &PublishRequest,
+		root: &Path,
+		source: Option<&SourceConfiguration>,
+	) -> MonochangeResult<()> {
+		let (_, writer) = self
+			.writers
+			.iter()
+			.find(|(registry, _)| *registry == request.registry)
+			.expect("unsupported built-in publish registry");
+		writer(placeholder_dir, request, root, source)
+	}
+}
+
+pub fn build_placeholder_directory(
+	root: &Path,
+	request: &PublishRequest,
+	source: Option<&SourceConfiguration>,
+	manifest_writers: &PlaceholderManifestWriterRegistry,
+) -> MonochangeResult<TempDir> {
+	let tempdir = tempfile::tempdir().map_err(|error| placeholder_tempdir_error(&error))?;
+	fs::write(
+		tempdir.path().join("README.md"),
+		&request.placeholder_readme,
+	)
+	.map_err(|error| MonochangeError::Io(format!("failed to write placeholder README: {error}")))?;
+
+	manifest_writers.write_manifest(tempdir.path(), request, root, source)?;
+
+	Ok(tempdir)
+}
+
+fn placeholder_tempdir_error(error: &std::io::Error) -> MonochangeError {
+	MonochangeError::Io(format!("failed to create placeholder tempdir: {error}"))
+}
+
+#[must_use]
+pub fn current_env_map() -> BTreeMap<String, String> {
+	env::vars().collect()
+}
+
+pub trait PublishTrustHandler {
+	fn trust_outcome_for_skip(
+		&self,
+		request: &PublishRequest,
+		source: Option<&SourceConfiguration>,
+		root: &Path,
+		env_map: &BTreeMap<String, String>,
+	) -> TrustedPublishingOutcome;
+
+	fn planned_trust_outcome(
+		&self,
+		request: &PublishRequest,
+		source: Option<&SourceConfiguration>,
+		root: &Path,
+		env_map: &BTreeMap<String, String>,
+	) -> TrustedPublishingOutcome;
+
+	fn enforce_release_trust_prerequisites(
+		&self,
+		request: &PublishRequest,
+		source: Option<&SourceConfiguration>,
+		root: &Path,
+		env_map: &BTreeMap<String, String>,
+	) -> MonochangeResult<()>;
+
+	fn configure_successful_publish_trust(
+		&self,
+		request: &PublishRequest,
+		source: Option<&SourceConfiguration>,
+		root: &Path,
+		env_map: &BTreeMap<String, String>,
+		executor: &mut dyn CommandExecutor,
+	) -> MonochangeResult<TrustedPublishingOutcome>;
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn execute_publish_requests_with_process(
+	root: &Path,
+	source: Option<&SourceConfiguration>,
+	mode: PackagePublishRunMode,
+	dry_run: bool,
+	requests: &[PublishRequest],
+	command_builder: &PublishCommandBuilder,
+	manifest_writers: &PlaceholderManifestWriterRegistry,
+	readiness: &PublishReadinessRegistry,
+	trust_handler: &dyn PublishTrustHandler,
+) -> MonochangeResult<PackagePublishReport> {
+	let env_map = current_env_map();
+	let endpoints = RegistryEndpoints::from_env();
+	let client = registry_client()?;
+	let mut executor = ProcessCommandExecutor;
+	execute_publish_requests(
+		root,
+		source,
+		mode,
+		dry_run,
+		requests,
+		&client,
+		&endpoints,
+		&env_map,
+		&mut executor,
+		command_builder,
+		manifest_writers,
+		readiness,
+		trust_handler,
+	)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn execute_publish_requests(
+	root: &Path,
+	source: Option<&SourceConfiguration>,
+	mode: PackagePublishRunMode,
+	dry_run: bool,
+	requests: &[PublishRequest],
+	client: &Client,
+	endpoints: &RegistryEndpoints,
+	env_map: &BTreeMap<String, String>,
+	executor: &mut dyn CommandExecutor,
+	command_builder: &PublishCommandBuilder,
+	manifest_writers: &PlaceholderManifestWriterRegistry,
+	readiness: &PublishReadinessRegistry,
+	trust_handler: &dyn PublishTrustHandler,
+) -> MonochangeResult<PackagePublishReport> {
+	let mut outcomes = Vec::new();
+
+	for request in requests {
+		if request.mode == PublishMode::External {
+			outcomes.push(PackagePublishOutcome {
+				package: request.package_id.clone(),
+				ecosystem: request.ecosystem,
+				registry: request.registry.to_string(),
+				version: request.version.clone(),
+				status: PackagePublishStatus::SkippedExternal,
+				message: "package opted out of built-in publishing".to_string(),
+				placeholder: mode == PackagePublishRunMode::Placeholder,
+				trusted_publishing: disabled_trust_outcome(),
+				command: None,
+				stdout: None,
+				stderr: None,
+			});
+			continue;
+		}
+
+		let version_exists = registry_version_exists(client, endpoints, request)?;
+		if version_exists {
+			outcomes.push(PackagePublishOutcome {
+				package: request.package_id.clone(),
+				ecosystem: request.ecosystem,
+				registry: request.registry.to_string(),
+				version: request.version.clone(),
+				status: PackagePublishStatus::SkippedExisting,
+				message: format!(
+					"{} {} already exists on {}",
+					request.package_name, request.version, request.registry
+				),
+				placeholder: mode == PackagePublishRunMode::Placeholder,
+				trusted_publishing: trust_handler
+					.trust_outcome_for_skip(request, source, root, env_map),
+				command: None,
+				stdout: None,
+				stderr: None,
+			});
+			continue;
+		}
+
+		let blocked_message = if mode == PackagePublishRunMode::Release {
+			readiness.blocked_message(root, request)?
+		} else {
+			None
+		};
+		if let Some(message) = blocked_message {
+			if dry_run {
+				outcomes.push(PackagePublishOutcome {
+					package: request.package_id.clone(),
+					ecosystem: request.ecosystem,
+					registry: request.registry.to_string(),
+					version: request.version.clone(),
+					status: PackagePublishStatus::Blocked,
+					message,
+					placeholder: mode == PackagePublishRunMode::Placeholder,
+					trusted_publishing: trust_handler
+						.planned_trust_outcome(request, source, root, env_map),
+					command: None,
+					stdout: None,
+					stderr: None,
+				});
+				continue;
+			}
+
+			return Err(MonochangeError::Config(message));
+		}
+
+		let placeholder_dir = if mode == PackagePublishRunMode::Placeholder {
+			Some(build_placeholder_directory(
+				root,
+				request,
+				source,
+				manifest_writers,
+			)?)
+		} else {
+			None
+		};
+		let publish_command = command_builder.build_publish_command(
+			request,
+			mode,
+			placeholder_dir.as_ref().map(TempDir::path),
+			dry_run,
+		);
+
+		if dry_run {
+			outcomes.push(PackagePublishOutcome {
+				package: request.package_id.clone(),
+				ecosystem: request.ecosystem,
+				registry: request.registry.to_string(),
+				version: request.version.clone(),
+				status: PackagePublishStatus::Planned,
+				message: planned_publish_message(mode, request),
+				placeholder: mode == PackagePublishRunMode::Placeholder,
+				trusted_publishing: trust_handler
+					.planned_trust_outcome(request, source, root, env_map),
+				command: None,
+				stdout: None,
+				stderr: None,
+			});
+			continue;
+		}
+
+		if mode == PackagePublishRunMode::Release {
+			trust_handler.enforce_release_trust_prerequisites(request, source, root, env_map)?;
+			enforce_release_attestation_prerequisites(request, env_map, command_builder)?;
+		}
+
+		let output = match executor.run(&publish_command) {
+			Ok(output) => output,
+			Err(error) => {
+				outcomes.push(failed_publish_outcome(mode, request, error.to_string()));
+				break;
+			}
+		};
+		if !output.success {
+			let mut outcome = failed_publish_outcome(
+				mode,
+				request,
+				format!(
+					"`{}` failed: {}",
+					render_command(&publish_command),
+					render_command_error(&output)
+				),
+			);
+			outcome.command = Some(render_command(&publish_command));
+			outcome.stdout = non_empty_output(output.stdout);
+			outcome.stderr = non_empty_output(output.stderr);
+			outcomes.push(outcome);
+			break;
+		}
+
+		let trusted_publishing = if request.trusted_publishing.enabled {
+			trust_handler
+				.configure_successful_publish_trust(request, source, root, env_map, executor)?
+		} else {
+			disabled_trust_outcome()
+		};
+
+		outcomes.push(PackagePublishOutcome {
+			package: request.package_id.clone(),
+			ecosystem: request.ecosystem,
+			registry: request.registry.to_string(),
+			version: request.version.clone(),
+			status: PackagePublishStatus::Published,
+			message: format!(
+				"published {} {} to {}",
+				request.package_name, request.version, request.registry
+			),
+			placeholder: mode == PackagePublishRunMode::Placeholder,
+			trusted_publishing,
+			command: Some(render_command(&publish_command)),
+			stdout: non_empty_output(output.stdout),
+			stderr: non_empty_output(output.stderr),
+		});
+	}
+
+	Ok(PackagePublishReport {
+		mode,
+		dry_run,
+		packages: outcomes,
+	})
+}
+
+pub fn build_placeholder_requests(
+	root: &Path,
+	configuration: &WorkspaceConfiguration,
+	packages: &[PackageRecord],
+	selected_packages: &BTreeSet<String>,
+) -> MonochangeResult<Vec<PublishRequest>> {
+	let packages_by_config_id = packages_by_config_id(packages);
+	let mut requests = Vec::new();
+
+	for package_definition in &configuration.packages {
+		let package = packages_by_config_id
+			.get(package_definition.id.as_str())
+			.copied();
+		let should_publish =
+			package.is_some_and(|package| package_can_be_published(package_definition, package));
+		if let Some(package) = package.filter(|_| {
+			should_publish
+				&& (selected_packages.is_empty()
+					|| selected_packages.contains(&package_definition.id))
+		}) {
+			requests.push(PublishRequest {
+				package_id: package_definition.id.clone(),
+				package_name: package.name.clone(),
+				ecosystem: package.ecosystem,
+				manifest_path: package.manifest_path.clone(),
+				package_root: package
+					.manifest_path
+					.parent()
+					.unwrap_or(&package.workspace_root)
+					.to_path_buf(),
+				registry: resolve_registry_kind(
+					package_definition.publish.registry.as_ref(),
+					package.ecosystem,
+				)?,
+				package_manager: package.metadata.get("manager").cloned(),
+				package_metadata: package.metadata.clone(),
+				mode: package_definition.publish.mode,
+				version: PLACEHOLDER_VERSION.to_string(),
+				placeholder: true,
+				trusted_publishing: package_definition.publish.trusted_publishing.clone(),
+				attestations: package_definition.publish.attestations.clone(),
+				placeholder_readme: resolve_placeholder_readme(
+					root,
+					package_definition.publish.placeholder.readme.as_deref(),
+					package_definition
+						.publish
+						.placeholder
+						.readme_file
+						.as_deref(),
+					&package.name,
+				)?,
+			});
+		}
+	}
+
+	requests.sort_by(|left, right| left.package_id.cmp(&right.package_id));
+	Ok(requests)
+}
+
+pub fn build_release_requests(
+	configuration: &WorkspaceConfiguration,
+	packages: &[PackageRecord],
+	publications: &[PackagePublicationTarget],
+	selected_packages: &BTreeSet<String>,
+) -> MonochangeResult<Vec<PublishRequest>> {
+	let packages_by_config_id = packages_by_config_id(packages);
+	let mut requests = Vec::new();
+
+	for publication in publications {
+		if !selected_packages.is_empty() && !selected_packages.contains(&publication.package) {
+			continue;
+		}
+
+		let Some(package_definition) = configuration.package_by_id(&publication.package) else {
+			continue;
+		};
+		let Some(package) = packages_by_config_id
+			.get(publication.package.as_str())
+			.copied()
+		else {
+			continue;
+		};
+
+		if !package_can_be_published(package_definition, package) {
+			continue;
+		}
+
+		requests.push(PublishRequest {
+			package_id: publication.package.clone(),
+			package_name: package.name.clone(),
+			ecosystem: package.ecosystem,
+			manifest_path: package.manifest_path.clone(),
+			package_root: package
+				.manifest_path
+				.parent()
+				.unwrap_or(&package.workspace_root)
+				.to_path_buf(),
+			registry: resolve_registry_kind(publication.registry.as_ref(), package.ecosystem)?,
+			package_manager: package.metadata.get("manager").cloned(),
+			package_metadata: package.metadata.clone(),
+			mode: publication.mode,
+			version: publication.version.clone(),
+			placeholder: false,
+			trusted_publishing: publication.trusted_publishing.clone(),
+			attestations: publication.attestations.clone(),
+			placeholder_readme: default_placeholder_readme(&package.name),
+		});
+	}
+
+	order_release_requests_by_publish_dependencies(packages, requests)
+}
+
+pub fn resolve_registry_kind(
+	registry: Option<&PublishRegistry>,
+	ecosystem: Ecosystem,
+) -> MonochangeResult<RegistryKind> {
+	match registry {
+		Some(PublishRegistry::Builtin(registry)) => Ok(*registry),
+		Some(PublishRegistry::Custom(name)) => {
+			Err(MonochangeError::Config(format!(
+				"built-in package publishing does not support custom registry `{name}`"
+			)))
+		}
+		None => default_registry_kind_for_ecosystem(ecosystem.as_str()),
+	}
+}
+
+pub fn default_registry_kind_for_ecosystem(ecosystem: &str) -> MonochangeResult<RegistryKind> {
+	let parsed = ecosystem.parse::<Ecosystem>().map_err(|()| {
+		MonochangeError::Config(format!(
+			"built-in package publishing does not support ecosystem `{ecosystem}`"
+		))
+	})?;
+	Ok(monochange_core::default_registry_kind_for_ecosystem(parsed)
+		.expect("all built-in ecosystems have default registries"))
+}
+
+pub fn resolve_placeholder_readme(
+	root: &Path,
+	inline: Option<&str>,
+	file: Option<&Path>,
+	package_name: &str,
+) -> MonochangeResult<String> {
+	if let Some(inline) = inline {
+		return Ok(inline.to_string());
+	}
+	if let Some(file) = file {
+		let path = root.join(file);
+		return fs::read_to_string(&path).map_err(|error| {
+			MonochangeError::Io(format!(
+				"failed to read placeholder README {}: {error}",
+				path.display()
+			))
+		});
+	}
+	Ok(default_placeholder_readme(package_name))
+}
+
+pub fn default_placeholder_readme(package_name: &str) -> String {
+	format!(
+		"# {package_name}\n\nThis is a placeholder release published by monochange to bootstrap trusted publishing.\n"
+	)
 }
 
 /// Adapter for building ecosystem-specific publish commands.
@@ -1081,9 +1812,6 @@ fn circle_project_slug(env_map: &BTreeMap<String, String>) -> Option<String> {
 		.map(|(owner, repo)| format!("gh/{owner}/{repo}"))
 		.or_else(|| env_map.get("CIRCLE_PROJECT_REPONAME").cloned())
 }
-
-use std::collections::BTreeSet;
-use std::fs;
 
 use monochange_core::DependencyKind;
 use monochange_core::materialize_dependency_edges;

--- a/monochange.toml
+++ b/monochange.toml
@@ -248,6 +248,9 @@ path = "crates/monochange_npm"
 [package.monochange_config]
 path = "crates/monochange_config"
 
+[package.monochange_changelog]
+path = "crates/monochange_changelog"
+
 [package.monochange_deno]
 path = "crates/monochange_deno"
 
@@ -407,6 +410,7 @@ packages = [
 	"monochange",
 	"monochange_analysis",
 	"monochange_cargo",
+	"monochange_changelog",
 	"monochange_config",
 	"monochange_core",
 	"monochange_dart",


### PR DESCRIPTION
## Summary

Draft PR for early feedback on the crate-boundaries audit refactor.

- extract changelog rendering/building into the new `monochange_changelog` crate
- move publish planning, placeholder setup, execution helpers, readiness hooks, and publish adapter abstractions into `monochange_publish`
- reduce `monochange_config` coupling to concrete ecosystem/provider crates
- make the top-level `monochange` crate thinner by keeping concrete CLI wiring there while moving domain behavior into focused crates
- replace hardcoded workspace discovery dispatch with the ecosystem registry

## Validation

- `cargo check -q -p monochange_publish`
- `cargo check -q -p monochange`
- `cargo test -q -p monochange_publish --lib`
- `cargo test -q -p monochange --lib publish`

## Notes

This is intentionally opened as a draft so you can start leaving review comments while the larger crate-boundaries refactor continues.
