### PR TITLE
docs: document CommitRelease.update_release_json option

### DIFF
--- a/.changeset/document-commit-release-update-release-json.md
+++ b/.changeset/document-commit-release-update-release-json.md
@@ -1,0 +1,15 @@
+---
+monochange: docs
+monochange_schema: docs
+---
+
+# Document `CommitRelease.update_release_json` option
+
+Add comprehensive documentation for the `update_release_json` step-level input on `CommitRelease`:
+
+- Document the input in the `CommitRelease` CLI step reference with type, default, and description
+- Explain semantic JSON comparison (formatting-only differences such as indentation or key ordering are ignored)
+- Add a new composition example showing how to combine `dprint fmt` formatting with `CommitRelease` using `update_release_json = true`
+- Add a new common-mistake entry about running formatters between `PrepareRelease` and `CommitRelease` without setting the input
+- Document the field in the configuration guide's workflow variables section
+- Regenerate JSON Schema assets to include the new `update_release_json` field in `CommitRelease` step definitions

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -362,6 +362,7 @@ type = "AffectedPackages"
 - built-in commands already attach descriptive step `name` labels such as `prepare release` and `publish release`; keep or replace those labels when you want progress output to stay readable
 - custom command variables become available when `variables` is present: map your own names to variables such as `version`, `group_version`, `released_packages`, `changed_files`, and `changesets`
 - `always_run = true` on any step causes it to run even when a previous step has failed, which is useful for cleanup, notification, or dry-run preview steps
+- `update_release_json = true` on a `CommitRelease` step allows the step to create or overwrite the release record file when it is missing or differs from the expected content; the default (`false`) treats a missing or mismatched record as an error
 - `dry_run_command` on a `Command` step replaces `command` only when the CLI command is run with `--dry-run`
 - `dry_run = true` on a `[cli.<command>]` table forces the entire command to run in dry-run mode even when the user does not pass `--dry-run`
 - `shell = true` runs the command through the current shell; the default mode runs the executable directly after shell-style splitting

--- a/crates/monochange_schema/schemas/monochange.schema.json
+++ b/crates/monochange_schema/schemas/monochange.schema.json
@@ -488,6 +488,10 @@
 							"const": "CommitRelease",
 							"type": "string"
 						},
+						"update_release_json": {
+							"default": false,
+							"type": "boolean"
+						},
 						"when": {
 							"default": null,
 							"type": [

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -572,6 +572,7 @@ CLI command interpolation variables:
 - built-in commands already attach descriptive step `name` labels such as `prepare release` and `publish release`; keep or replace those labels when you want progress output to stay readable
 - custom command variables become available when `variables` is present: map your own names to variables such as `version`, `group_version`, `released_packages`, `changed_files`, and `changesets`
 - `always_run = true` on any step causes it to run even when a previous step has failed, which is useful for cleanup, notification, or dry-run preview steps
+- `update_release_json = true` on a `CommitRelease` step allows the step to create or overwrite the release record file when it is missing or differs from the expected content; the default (`false`) treats a missing or mismatched record as an error
 - `dry_run_command` on a `Command` step replaces `command` only when the CLI command is run with `--dry-run`
 - `dry_run = true` on a `[cli.<command>]` table forces the entire command to run in dry-run mode even when the user does not pass `--dry-run`
 - `shell = true` runs the command through the current shell; the default mode runs the executable directly after shell-style splitting

--- a/docs/src/reference/cli-steps/08-commit-release.md
+++ b/docs/src/reference/cli-steps/08-commit-release.md
@@ -22,9 +22,15 @@ This is especially useful when you want to:
 
 ## Inputs
 
-`CommitRelease` does not accept built-in step inputs.
+`CommitRelease` accepts one optional step-level boolean input:
 
-That is intentional: it consumes prepared release state instead of raw user input.
+| Input                 | Type    | Default | Description                                                                                                                                                                                                                                                |
+| --------------------- | ------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `update_release_json` | boolean | `false` | When `true`, allows `CommitRelease` to create or overwrite the `.monochange/releases/<id>/release.json` record if it is missing or does not match the expected content. When `false` (the default), a missing or mismatched record is treated as an error. |
+
+This input is useful when a previous step (such as `PrepareRelease` or a `Command` step that runs `dprint fmt`) may have modified the release record file, and you want `CommitRelease` to accept the regenerated content rather than fail with a mismatch error.
+
+`CommitRelease` compares release records semantically (parsed JSON values), so formatting-only differences such as indentation or key ordering are ignored and never trigger a mismatch.
 
 ## Step-level `when` condition
 
@@ -62,6 +68,8 @@ You can provide that state in either of two ways:
 In normal mode, `CommitRelease` creates a local commit.
 
 In `--dry-run` mode, it previews the commit payload without creating the commit.
+
+Before committing, `CommitRelease` validates the `.monochange/releases/<id>/release.json` record on disk. If the file exists, the step compares it against the expected content **semantically** (parsed JSON values), so formatting-only differences such as indentation or key ordering do not trigger a mismatch. If the file is missing or semantically different, the step either errors (default) or overwrites the file, depending on the `update_release_json` input.
 
 It exposes a structured `release_commit.*` namespace to later `Command` steps. Commonly useful fields include:
 
@@ -122,6 +130,28 @@ command = "echo release commit {{ release_commit.commit }}"
 shell = true
 ```
 
+### Prepare, format, then commit with record overwrite
+
+If a formatting tool such as `dprint fmt` runs between `PrepareRelease` and `CommitRelease`, it may change the whitespace or key ordering of the generated `release.json`. By default, `CommitRelease` would treat this as a mismatch and error. Set `update_release_json = true` to allow `CommitRelease` to overwrite the formatted file with the semantically-equivalent regenerated content:
+
+```toml
+[[cli.release-pr.steps]]
+type = "PrepareRelease"
+name = "prepare release"
+
+[[cli.release-pr.steps]]
+type = "Command"
+name = "format changed files"
+command = "dprint fmt --allow-no-files {{ changed_files }} .monochange/releases/"
+
+[[cli.release-pr.steps]]
+type = "CommitRelease"
+name = "create release commit"
+update_release_json = true
+```
+
+This pattern is the recommended way to combine automated formatting with release record durability.
+
 ### Prepare, commit, then open a release request
 
 A strong provider-facing pattern is:
@@ -163,3 +193,4 @@ A raw shell commit can create a commit, but it cannot automatically preserve the
 - assuming it publishes releases or opens a release request by itself
 - forgetting that `--dry-run` previews the commit rather than creating it
 - reaching for a custom `git commit` command and then losing durable release metadata
+- running a formatter (such as `dprint fmt`) between `PrepareRelease` and `CommitRelease` without setting `update_release_json = true` on the `CommitRelease` step

--- a/docs/src/schemas/monochange.schema.json
+++ b/docs/src/schemas/monochange.schema.json
@@ -488,6 +488,10 @@
 							"const": "CommitRelease",
 							"type": "string"
 						},
+						"update_release_json": {
+							"default": false,
+							"type": "boolean"
+						},
 						"when": {
 							"default": null,
 							"type": [

--- a/docs/src/schemas/monochange.v0.1.schema.json
+++ b/docs/src/schemas/monochange.v0.1.schema.json
@@ -488,6 +488,10 @@
 							"const": "CommitRelease",
 							"type": "string"
 						},
+						"update_release_json": {
+							"default": false,
+							"type": "boolean"
+						},
 						"when": {
 							"default": null,
 							"type": [


### PR DESCRIPTION
Documents the new `update_release_json` step-level input on `CommitRelease`, including type/default/description, semantic JSON comparison behavior, a composition example combining dprint formatting with record overwrite, and regenerated JSON Schema assets.