### PR TITLE
feat(docs): comprehensive documentation refresh

### DIFF
--- a/.templates/crates.t.md
+++ b/.templates/crates.t.md
@@ -734,3 +734,30 @@ sink.capture_command(CommandTelemetry {
 ```
 
 <!-- {/monochangeTelemetryCrateDocs} -->
+
+<!-- {@monochangeForgejoCrateDocs} -->
+
+`monochange_forgejo` turns `monochange` release manifests into Forgejo automation requests.
+
+Reach for this crate when you want to preview or publish Forgejo releases and release pull requests using the same structured release data that powers changelog files and release manifests.
+
+## Why use it?
+
+- derive Forgejo release payloads and release-PR bodies from `monochange`'s structured release manifest
+- keep Forgejo automation aligned with changelog rendering and release targets
+- reuse one publishing path for dry-run previews and real repository updates
+
+## Best for
+
+- building Forgejo release automation on top of `mc release`
+- previewing would-be Forgejo releases and release PRs in CI before publishing
+- self-hosted Forgejo instances that need the same release workflow as GitHub or GitLab
+
+## Public entry points
+
+- `build_release_requests(manifest, source)` builds release payloads from prepared release state
+- `build_change_request(manifest, source)` builds a pull-request payload for the release
+- `validate_source_configuration(source)` validates Forgejo-specific source config
+- `source_capabilities()` returns provider feature flags
+
+<!-- {/monochangeForgejoCrateDocs} -->

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -30,6 +30,18 @@ Use it when your repository has outgrown one-ecosystem release tooling and you w
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__graph-orange?logo=rust)](https://crates.io/crates/monochange_graph) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__graph-1f425f?logo=docs.rs)](https://docs.rs/monochange_graph/)
 - `monochange_github` — converts release manifests into GitHub release payloads and publishing operations.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__github-orange?logo=rust)](https://crates.io/crates/monochange_github) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__github-1f425f?logo=docs.rs)](https://docs.rs/monochange_github/)
+- `monochange_gitlab` — converts release manifests into GitLab release payloads and merge-request operations.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__gitlab-orange?logo=rust)](https://crates.io/crates/monochange_gitlab) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__gitlab-1f425f?logo=docs.rs)](https://docs.rs/monochange_gitlab/)
+- `monochange_gitea` — converts release manifests into Gitea release payloads and pull-request operations.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__gitea-orange?logo=rust)](https://crates.io/crates/monochange_gitea) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__gitea-1f425f?logo=docs.rs)](https://docs.rs/monochange_gitea/)
+- `monochange_forgejo` — converts release manifests into Forgejo automation requests.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__forgejo-orange?logo=rust)](https://crates.io/crates/monochange_forgejo) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__forgejo-1f425f?logo=docs.rs)](https://docs.rs/monochange_forgejo/)
+- `monochange_hosting` — shared release-request abstractions for GitHub, GitLab, Gitea, and Forgejo providers.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__hosting-orange?logo=rust)](https://crates.io/crates/monochange_hosting) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__hosting-1f425f?logo=docs.rs)](https://docs.rs/monochange_hosting/)
+- `monochange_publish` — publishing support and trusted-publishing capability helpers for package registries.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__publish-orange?logo=rust)](https://crates.io/crates/monochange_publish) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__publish-1f425f?logo=docs.rs)](https://docs.rs/monochange_publish/)
+- `monochange_ecmascript` — shared JavaScript/TypeScript ecosystem utilities for npm, Deno, and JSR discovery.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__ecmascript-orange?logo=rust)](https://crates.io/crates/monochange_ecmascript) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__ecmascript-1f425f?logo=docs.rs)](https://docs.rs/monochange_ecmascript/)
 - `monochange_semver` — merges requested bumps with compatibility-provider evidence.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__semver-orange?logo=rust)](https://crates.io/crates/monochange_semver) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__semver-1f425f?logo=docs.rs)](https://docs.rs/monochange_semver/)
 - `monochange_telemetry` — local-only telemetry event sink and privacy-preserving event schema helpers.
@@ -216,8 +228,10 @@ mc release
 ```bash
 monochange --help
 mc --help
-docs:check
-docs:update
+docs:check      # verify mdt shared-doc synchronization
+docs:update     # synchronize shared docs via mdt update
+schema:check    # verify committed JSON schemas are current
+schema:update   # regenerate schema assets from source
 mc validate
 lint:all
 test:all

--- a/crates/monochange_schema/schemas/monochange.schema.json
+++ b/crates/monochange_schema/schemas/monochange.schema.json
@@ -488,6 +488,10 @@
 							"const": "CommitRelease",
 							"type": "string"
 						},
+						"update_release_json": {
+							"default": false,
+							"type": "boolean"
+						},
 						"when": {
 							"default": null,
 							"type": [

--- a/docs/src/guide/01-installation.md
+++ b/docs/src/guide/01-installation.md
@@ -97,8 +97,10 @@ Useful repository-development commands:
 ```bash
 monochange --help
 mc --help
-docs:check
-docs:update
+docs:check      # verify mdt shared-doc synchronization
+docs:update     # synchronize shared docs via mdt update
+schema:check    # verify committed JSON schemas are current
+schema:update   # regenerate schema assets from source
 mc validate
 lint:all
 test:all

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -4,7 +4,7 @@ Repository configuration lives in `monochange.toml`.
 
 ## JSON Schema
 
-A JSON Schema for editor support is published with the book at <https://monochange.github.io/monochange/schemas/monochange.schema.json>. That URL is the moving “current” alias for the latest docs. Stable generated copies use public schema-version suffixes, starting with <https://monochange.github.io/monochange/schemas/monochange.v0.1.schema.json>.
+A JSON Schema for editor support is published with the book at <https://monochange.github.io/monochange/schemas/monochange.schema.json>. That URL is the moving "current" alias for the latest docs. Stable generated copies use public schema-version suffixes, starting with <https://monochange.github.io/monochange/schemas/monochange.v0.1.schema.json>.
 
 Schema-aware TOML editors such as Taplo can opt in with a comment directive at the top of `monochange.toml`:
 
@@ -13,6 +13,17 @@ Schema-aware TOML editors such as Taplo can opt in with a comment directive at t
 ```
 
 The same file is also available from GitHub raw content at <https://raw.githubusercontent.com/monochange/monochange/main/docs/src/schemas/monochange.schema.json>. Regenerate committed schema assets with `schema:update` and verify them with `schema:check`; `lint:all` runs the check in CI.
+
+## Shared documentation
+
+This book is maintained with `mdt` so shared content blocks stay synchronized across pages.
+
+- Shared blocks live in `.templates/*.t.md`
+- Consumer files include them with `<!-- {=templateName} -->` directives
+- Run `mdt update` (or `docs:update` in this repository) after changing any template or consumer block
+- Run `mdt check` (or `docs:check`) before opening a PR to verify synchronization
+
+When you edit a template such as `.templates/cli-steps.t.md`, the changes propagate to every documentation file that references it. This keeps the book, readmes, and inline help consistent without manual copying.
 
 ## Defaults
 
@@ -190,14 +201,14 @@ trusted_publishing = false
 
 Supported fields:
 
-- `enabled` — include this package in managed publishing
-- `mode` — `builtin` or `external`
-- `registry` — public registry override for the package ecosystem
-- `trusted_publishing` — `true`/`false` or a table with `enabled`, `repository`, `workflow`, and `environment`
-- `attestations.require_registry_provenance` — require registry-native package provenance when the selected registry/provider capability supports it
-- `rate_limits.enforce` — block built-in publish runs when the selected package set exceeds a known single registry window
-- `placeholder.readme` — inline placeholder README content
-- `placeholder.readme_file` — workspace-relative file to use as placeholder README content
+- `enabled` - include this package in managed publishing
+- `mode` - `builtin` or `external`
+- `registry` - public registry override for the package ecosystem
+- `trusted_publishing` - `true`/`false` or a table with `enabled`, `repository`, `workflow`, and `environment`
+- `attestations.require_registry_provenance` - require registry-native package provenance when the selected registry/provider capability supports it
+- `rate_limits.enforce` - block built-in publish runs when the selected package set exceeds a known single registry window
+- `placeholder.readme` - inline placeholder README content
+- `placeholder.readme_file` - workspace-relative file to use as placeholder README content
 
 Inheritance flows from `[ecosystems.<name>.publish]` to matching packages, and package-level values override the inherited ecosystem defaults. Configure shared trusted-publishing, attestation, and context policy on the ecosystem, then use package-level publish settings for opt-outs or package-specific workflows.
 
@@ -297,7 +308,7 @@ The built-in package publishing flow is intentionally narrow for now:
 
 If your workflow needs any of those today, keep the package on `mode = "external"` and let your own CI or scripts own publication.
 
-For end-to-end GitHub and GitLab examples — including npm trusted publishing on GitHub and token/external-mode patterns on GitLab — see [Advanced: CI, package publishing, and release PR flows](./13-ci-and-publishing.md).
+For end-to-end GitHub and GitLab examples - including npm trusted publishing on GitHub and token/external-mode patterns on GitLab - see [Advanced: CI, package publishing, and release PR flows](./13-ci-and-publishing.md).
 
 ## Groups
 
@@ -334,9 +345,9 @@ include = ["sdk-cli"]
 
 `include` accepts:
 
-- `"all"` — include direct group-targeted changesets and all member-targeted changesets (default)
-- `"group-only"` — include only direct group-targeted changesets
-- `[]` or `["package-id", ...]` — include direct group-targeted changesets plus member-targeted changesets only when every target in that group is listed
+- `"all"` - include direct group-targeted changesets and all member-targeted changesets (default)
+- `"group-only"` - include only direct group-targeted changesets
+- `[]` or `["package-id", ...]` - include direct group-targeted changesets plus member-targeted changesets only when every target in that group is listed
 
 ## Versioned files
 

--- a/docs/src/guide/12-repairable-releases.md
+++ b/docs/src/guide/12-repairable-releases.md
@@ -46,6 +46,8 @@ The release commit body contains:
 1. a compact human-readable release summary
 2. a reserved monochange release-record block with structured JSON
 
+The `ReleaseRecord` JSON schema is published with the book at <https://monochange.github.io/monochange/schemas/release-record.schema.json>. Stable generated copies use public schema-version suffixes, starting with <https://monochange.github.io/monochange/schemas/release-record.v0.1.schema.json>.
+
 ## How monochange finds a release later
 
 Use `mc release-record` when you want to inspect the durable release declaration for a tag or a newer commit built on top of that release.

--- a/docs/src/readme.md
+++ b/docs/src/readme.md
@@ -86,6 +86,8 @@ When you are ready to prepare the release locally, run `mc release`.
 
 For human-readable local output, `mc release --dry-run` now defaults to terminal-friendly markdown. Use `--format json` for automation, `--format text` when you explicitly want the older plain-text rendering, `mc versions` when you only need planned package and group versions, and `--quiet` when you want dry-run behavior without stdout/stderr output. `mc versions` is a dedicated non-mutating summary command and also supports `--format markdown` and `--format json`.
 
+This book is maintained with `mdt` so shared content blocks stay synchronized across pages. See the [Configuration reference](guide/04-configuration.md#shared-documentation) for how template updates work.
+
 If you want a slower, more guided walkthrough, continue with [Start here](./guide/00-start-here.md) and [Your first release plan](./guide/02-setup.md).
 
 ## What to read next

--- a/docs/src/schemas/monochange.schema.json
+++ b/docs/src/schemas/monochange.schema.json
@@ -488,6 +488,10 @@
 							"const": "CommitRelease",
 							"type": "string"
 						},
+						"update_release_json": {
+							"default": false,
+							"type": "boolean"
+						},
 						"when": {
 							"default": null,
 							"type": [

--- a/docs/src/schemas/monochange.v0.1.schema.json
+++ b/docs/src/schemas/monochange.v0.1.schema.json
@@ -488,6 +488,10 @@
 							"const": "CommitRelease",
 							"type": "string"
 						},
+						"update_release_json": {
+							"default": false,
+							"type": "boolean"
+						},
 						"when": {
 							"default": null,
 							"type": [

--- a/packages/monochange__cli/README.md
+++ b/packages/monochange__cli/README.md
@@ -241,6 +241,18 @@ See [Advanced: Assistant setup and MCP](docs/src/guide/09-assistant-setup.md) fo
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__graph-orange?logo=rust)](https://crates.io/crates/monochange_graph) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__graph-1f425f?logo=docs.rs)](https://docs.rs/monochange_graph/)
 - `monochange_github` — converts release manifests into GitHub release payloads and publishing operations.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__github-orange?logo=rust)](https://crates.io/crates/monochange_github) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__github-1f425f?logo=docs.rs)](https://docs.rs/monochange_github/)
+- `monochange_gitlab` — converts release manifests into GitLab release payloads and merge-request operations.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__gitlab-orange?logo=rust)](https://crates.io/crates/monochange_gitlab) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__gitlab-1f425f?logo=docs.rs)](https://docs.rs/monochange_gitlab/)
+- `monochange_gitea` — converts release manifests into Gitea release payloads and pull-request operations.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__gitea-orange?logo=rust)](https://crates.io/crates/monochange_gitea) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__gitea-1f425f?logo=docs.rs)](https://docs.rs/monochange_gitea/)
+- `monochange_forgejo` — converts release manifests into Forgejo automation requests.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__forgejo-orange?logo=rust)](https://crates.io/crates/monochange_forgejo) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__forgejo-1f425f?logo=docs.rs)](https://docs.rs/monochange_forgejo/)
+- `monochange_hosting` — shared release-request abstractions for GitHub, GitLab, Gitea, and Forgejo providers.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__hosting-orange?logo=rust)](https://crates.io/crates/monochange_hosting) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__hosting-1f425f?logo=docs.rs)](https://docs.rs/monochange_hosting/)
+- `monochange_publish` — publishing support and trusted-publishing capability helpers for package registries.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__publish-orange?logo=rust)](https://crates.io/crates/monochange_publish) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__publish-1f425f?logo=docs.rs)](https://docs.rs/monochange_publish/)
+- `monochange_ecmascript` — shared JavaScript/TypeScript ecosystem utilities for npm, Deno, and JSR discovery.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__ecmascript-orange?logo=rust)](https://crates.io/crates/monochange_ecmascript) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__ecmascript-1f425f?logo=docs.rs)](https://docs.rs/monochange_ecmascript/)
 - `monochange_semver` — merges requested bumps with compatibility-provider evidence.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__semver-orange?logo=rust)](https://crates.io/crates/monochange_semver) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__semver-1f425f?logo=docs.rs)](https://docs.rs/monochange_semver/)
 - `monochange_telemetry` — local-only telemetry event sink and privacy-preserving event schema helpers.
@@ -296,8 +308,10 @@ Useful commands:
 ```bash
 monochange --help
 mc --help
-docs:check
-docs:update
+docs:check      # verify mdt shared-doc synchronization
+docs:update     # synchronize shared docs via mdt update
+schema:check    # verify committed JSON schemas are current
+schema:update   # regenerate schema assets from source
 mc validate
 lint:all
 test:all

--- a/readme.md
+++ b/readme.md
@@ -325,6 +325,18 @@ See [Advanced: Assistant setup and MCP](docs/src/guide/09-assistant-setup.md) fo
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__graph-orange?logo=rust)](https://crates.io/crates/monochange_graph) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__graph-1f425f?logo=docs.rs)](https://docs.rs/monochange_graph/)
 - `monochange_github` — converts release manifests into GitHub release payloads and publishing operations.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__github-orange?logo=rust)](https://crates.io/crates/monochange_github) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__github-1f425f?logo=docs.rs)](https://docs.rs/monochange_github/)
+- `monochange_gitlab` — converts release manifests into GitLab release payloads and merge-request operations.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__gitlab-orange?logo=rust)](https://crates.io/crates/monochange_gitlab) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__gitlab-1f425f?logo=docs.rs)](https://docs.rs/monochange_gitlab/)
+- `monochange_gitea` — converts release manifests into Gitea release payloads and pull-request operations.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__gitea-orange?logo=rust)](https://crates.io/crates/monochange_gitea) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__gitea-1f425f?logo=docs.rs)](https://docs.rs/monochange_gitea/)
+- `monochange_forgejo` — converts release manifests into Forgejo automation requests.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__forgejo-orange?logo=rust)](https://crates.io/crates/monochange_forgejo) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__forgejo-1f425f?logo=docs.rs)](https://docs.rs/monochange_forgejo/)
+- `monochange_hosting` — shared release-request abstractions for GitHub, GitLab, Gitea, and Forgejo providers.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__hosting-orange?logo=rust)](https://crates.io/crates/monochange_hosting) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__hosting-1f425f?logo=docs.rs)](https://docs.rs/monochange_hosting/)
+- `monochange_publish` — publishing support and trusted-publishing capability helpers for package registries.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__publish-orange?logo=rust)](https://crates.io/crates/monochange_publish) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__publish-1f425f?logo=docs.rs)](https://docs.rs/monochange_publish/)
+- `monochange_ecmascript` — shared JavaScript/TypeScript ecosystem utilities for npm, Deno, and JSR discovery.
+  - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__ecmascript-orange?logo=rust)](https://crates.io/crates/monochange_ecmascript) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__ecmascript-1f425f?logo=docs.rs)](https://docs.rs/monochange_ecmascript/)
 - `monochange_semver` — merges requested bumps with compatibility-provider evidence.
   - [![Crates.io](https://img.shields.io/badge/crates.io-monochange__semver-orange?logo=rust)](https://crates.io/crates/monochange_semver) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange__semver-1f425f?logo=docs.rs)](https://docs.rs/monochange_semver/)
 - `monochange_telemetry` — local-only telemetry event sink and privacy-preserving event schema helpers.
@@ -380,8 +392,10 @@ Useful commands:
 ```bash
 monochange --help
 mc --help
-docs:check
-docs:update
+docs:check      # verify mdt shared-doc synchronization
+docs:update     # synchronize shared docs via mdt update
+schema:check    # verify committed JSON schemas are current
+schema:update   # regenerate schema assets from source
 mc validate
 lint:all
 test:all
@@ -393,8 +407,4 @@ build:book
 
 <!-- {/repoCommonDevelopmentCommands} -->
 
-See `docs/` for user-facing guides and `CONTRIBUTING.md` for contribution expectations.
-
-# CI trigger Sat May 9 19:11:35 BST 2026
-
-# CI trigger Sat May 9 19:11:48 BST 2026
+See `docs/` for user-facing guides and `CONTRIBUTING.md` for contribution expectations. This repository uses `mdt` to synchronize shared documentation blocks; run `docs:update` after changing any `.templates/*.t.md` file.


### PR DESCRIPTION
Refresh all book docs and readmes to be more relevant to the project; adopt  for managing shared documentation; ensure CLI step docs fully capture what''s possible; keep the schema up to date and linked from the docs.

### What changed
- Documented  shared-doc workflow in  and referenced it from readmes
- Added missing  template provider to 
- Expanded crate catalog in  to include forgejo, gitlab, gitea, hosting, publish, ecmascript
- Linked release-record JSON schema in 
- Regenerated committed schema assets via 
- Removed stale CI trigger comments from 

### Verification
- Check passed: all consumer blocks are up to date. ✅
- Check passed: all consumer blocks are up to date.
agent-facing documentation checks passed ✅
-  ✅
-  ✅
-  ✅