### PR TITLE
fix(schema): allow boolean and numeric defaults for CLI input definitions

### DIFF
--- a/.changeset/boolean-number-default-schema.md
+++ b/.changeset/boolean-number-default-schema.md
@@ -1,0 +1,23 @@
+---
+monochange_core: patch
+monochange_schema: patch
+---
+
+#### allow boolean and numeric literals in `CliInputDefinition.default`
+
+The JSON schema for `monochange.toml` `[cli.*.inputs]` previously rejected boolean and numeric defaults, even though the Rust deserializer already accepted them correctly.
+
+**Before:**
+
+```toml
+[[cli.release-pr.inputs]]
+name = "no_verify"
+type = "boolean"
+default = true # jsonschema error: "true is not of types \"null\", \"string\""
+```
+
+**After:**
+
+The `default` field in `CliInputDefinition` now accepts `string | boolean | integer | number | null` in the generated schema. TOML like the snippet above validates cleanly, and numeric defaults such as `default = 42` are also accepted.
+
+The internal `CliInputDefault` enum gained `Integer(i64)` and `Number(f64)` variants, and the `schemars` derive now generates a multi-type `anyOf` schema for the `default` property.

--- a/.changeset/boolean-number-default-schema.md
+++ b/.changeset/boolean-number-default-schema.md
@@ -1,9 +1,10 @@
 ---
 monochange_core: patch
 monochange_schema: patch
+monochange_config: patch
 ---
 
-#### allow boolean and numeric literals in `CliInputDefinition.default`
+# allow boolean and numeric literals in `CliInputDefinition.default`
 
 The JSON schema for `monochange.toml` `[cli.*.inputs]` previously rejected boolean and numeric defaults, even though the Rust deserializer already accepted them correctly.
 

--- a/crates/monochange_config/src/__tests__/lib_tests.rs
+++ b/crates/monochange_config/src/__tests__/lib_tests.rs
@@ -276,6 +276,50 @@ fn load_workspace_configuration_supports_boolean_input_default_values() {
 }
 
 #[test]
+fn load_workspace_configuration_supports_numeric_input_default_values() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	std::fs::write(
+		tempdir.path().join("monochange.toml"),
+		r#"
+[cli.deploy]
+
+[[cli.deploy.inputs]]
+name = "port"
+type = "string"
+default = 8080
+
+[[cli.deploy.inputs]]
+name = "timeout"
+type = "string"
+default = 3.5
+
+[[cli.deploy.steps]]
+type = "Validate"
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write config: {error}"));
+	let configuration = load_workspace_configuration(tempdir.path())
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+	let command = configuration
+		.cli
+		.iter()
+		.find(|command| command.name == "deploy")
+		.unwrap_or_else(|| panic!("expected deploy command"));
+	let port = command
+		.inputs
+		.iter()
+		.find(|input| input.name == "port")
+		.unwrap_or_else(|| panic!("missing port input"));
+	let timeout = command
+		.inputs
+		.iter()
+		.find(|input| input.name == "timeout")
+		.unwrap_or_else(|| panic!("missing timeout input"));
+	assert_eq!(port.default.as_deref(), Some("8080"));
+	assert_eq!(timeout.default.as_deref(), Some("3.5"));
+}
+
+#[test]
 fn load_workspace_configuration_parses_package_group_and_cli_command_declarations() {
 	let root = fixture_path("config/package-group-and-cli");
 	let configuration = load_workspace_configuration(&root)

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -1770,6 +1770,7 @@ pub struct CliInputDefinition {
 	#[serde(default)]
 	pub required: bool,
 	#[serde(default, deserialize_with = "deserialize_cli_input_default")]
+	#[cfg_attr(feature = "schema", schemars(with = "Option<CliInputDefault>"))]
 	pub default: Option<String>,
 	#[serde(default)]
 	pub choices: Vec<String>,
@@ -1777,11 +1778,14 @@ pub struct CliInputDefinition {
 	pub short: Option<char>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
-enum CliInputDefault {
+pub enum CliInputDefault {
 	String(String),
 	Boolean(bool),
+	Integer(i64),
+	Number(f64),
 }
 
 fn deserialize_cli_input_default<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
@@ -1793,6 +1797,8 @@ where
 		match value {
 			CliInputDefault::String(value) => value,
 			CliInputDefault::Boolean(value) => value.to_string(),
+			CliInputDefault::Integer(value) => value.to_string(),
+			CliInputDefault::Number(value) => value.to_string(),
 		}
 	}))
 }

--- a/crates/monochange_schema/schemas/monochange.schema.json
+++ b/crates/monochange_schema/schemas/monochange.schema.json
@@ -149,6 +149,24 @@
 			},
 			"type": "object"
 		},
+		"CliInputDefault": {
+			"anyOf": [
+				{
+					"type": "string"
+				},
+				{
+					"type": "boolean"
+				},
+				{
+					"format": "int64",
+					"type": "integer"
+				},
+				{
+					"format": "double",
+					"type": "number"
+				}
+			]
+		},
 		"CliInputDefinition": {
 			"additionalProperties": false,
 			"properties": {
@@ -160,11 +178,15 @@
 					"type": "array"
 				},
 				"default": {
-					"default": null,
-					"type": [
-						"string",
-						"null"
-					]
+					"anyOf": [
+						{
+							"$ref": "#/$defs/CliInputDefault"
+						},
+						{
+							"type": "null"
+						}
+					],
+					"default": null
 				},
 				"help_text": {
 					"default": null,

--- a/docs/src/schemas/monochange.schema.json
+++ b/docs/src/schemas/monochange.schema.json
@@ -149,6 +149,24 @@
 			},
 			"type": "object"
 		},
+		"CliInputDefault": {
+			"anyOf": [
+				{
+					"type": "string"
+				},
+				{
+					"type": "boolean"
+				},
+				{
+					"format": "int64",
+					"type": "integer"
+				},
+				{
+					"format": "double",
+					"type": "number"
+				}
+			]
+		},
 		"CliInputDefinition": {
 			"additionalProperties": false,
 			"properties": {
@@ -160,11 +178,15 @@
 					"type": "array"
 				},
 				"default": {
-					"default": null,
-					"type": [
-						"string",
-						"null"
-					]
+					"anyOf": [
+						{
+							"$ref": "#/$defs/CliInputDefault"
+						},
+						{
+							"type": "null"
+						}
+					],
+					"default": null
 				},
 				"help_text": {
 					"default": null,

--- a/docs/src/schemas/monochange.v0.1.schema.json
+++ b/docs/src/schemas/monochange.v0.1.schema.json
@@ -149,6 +149,24 @@
 			},
 			"type": "object"
 		},
+		"CliInputDefault": {
+			"anyOf": [
+				{
+					"type": "string"
+				},
+				{
+					"type": "boolean"
+				},
+				{
+					"format": "int64",
+					"type": "integer"
+				},
+				{
+					"format": "double",
+					"type": "number"
+				}
+			]
+		},
 		"CliInputDefinition": {
 			"additionalProperties": false,
 			"properties": {
@@ -160,11 +178,15 @@
 					"type": "array"
 				},
 				"default": {
-					"default": null,
-					"type": [
-						"string",
-						"null"
-					]
+					"anyOf": [
+						{
+							"$ref": "#/$defs/CliInputDefault"
+						},
+						{
+							"type": "null"
+						}
+					],
+					"default": null
 				},
 				"help_text": {
 					"default": null,


### PR DESCRIPTION
## Summary

The JSON schema for `monochange.toml` `[cli.*.inputs]` previously rejected boolean and numeric defaults, even though the Rust deserializer already accepted them correctly.

## Changes

- **`CliInputDefault` enum** (`monochange_core`): expanded from `String | Boolean` to `String | Boolean | Integer | Number`, making it public and deriving `schemars::JsonSchema`.
- **`CliInputDefinition.default`** (`monochange_core`): added `#[schemars(with = "Option<CliInputDefault>")]` so the generated schema accepts `string | boolean | integer | number | null`.
- **Schema assets**: regenerated `monochange.schema.json` (and versioned alias) so the `default` property uses `anyOf` referencing the new `CliInputDefault` definition.

This means TOML like the following now validates cleanly against the JSON schema:

```toml
[[cli.release-pr.inputs]]
name = "no_verify"
type = "boolean"
default = true
```

## Checklist

- [x] Change follows the coding style
- [x] Tests pass (`cargo test` for affected crates)
- [x] Schema assets regenerated and formatted
- [x] Changeset added
