### PR TITLE
fix: replace release record group version

### DIFF
--- a/.changeset/release-record-version-map.md
+++ b/.changeset/release-record-version-map.md
@@ -1,0 +1,9 @@
+---
+monochange: patch
+monochange_core: patch
+monochange_schema: patch
+---
+
+# Replace release record `groupVersion` with `versions`
+
+Release records now include a `versions` map keyed by released package or group id, and no longer write the redundant `groupVersion` field.

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -4621,7 +4621,10 @@ fn build_release_record_captures_provider_and_release_targets() {
 	let record = crate::build_release_record(Some(&source), &manifest);
 	assert_eq!(record.command, "release-pr");
 	assert_eq!(record.version.as_deref(), Some("1.2.3"));
-	assert_eq!(record.group_version.as_deref(), Some("1.2.3"));
+	assert_eq!(
+		record.versions.get("sdk").map(String::as_str),
+		Some("1.2.3")
+	);
 	assert_eq!(record.release_targets.len(), 1);
 	assert_eq!(record.release_targets[0].tag_name, "v1.2.3");
 	assert_eq!(record.updated_changelogs.len(), 1);
@@ -4722,7 +4725,8 @@ fn text_release_record_discovery_renders_targets_packages_and_provider() {
 	assert!(rendered.contains("record commit: abc1234"));
 	assert!(rendered.contains("distance: 0"));
 	assert!(rendered.contains("version: 1.2.3"));
-	assert!(rendered.contains("group version: 1.2.3"));
+	assert!(rendered.contains("versions:"));
+	assert!(rendered.contains("sdk: 1.2.3"));
 	assert!(rendered.contains("- group sdk -> 1.2.3 (tag: v1.2.3)"));
 	assert!(rendered.contains("- monochange"));
 	assert!(rendered.contains("- monochange_core"));
@@ -4736,7 +4740,7 @@ fn sample_release_record_for_discovery_text() -> monochange_core::ReleaseRecord 
 		created_at: "2026-04-07T08:00:00Z".to_string(),
 		command: "release-pr".to_string(),
 		version: Some("1.2.3".to_string()),
-		group_version: Some("1.2.3".to_string()),
+		versions: BTreeMap::from([("sdk".to_string(), "1.2.3".to_string())]),
 		release_targets: vec![monochange_core::ReleaseRecordTarget {
 			id: "sdk".to_string(),
 			kind: monochange_core::ReleaseOwnerKind::Group,
@@ -4776,7 +4780,7 @@ fn text_release_record_discovery_omits_empty_sections() {
 			created_at: "2026-04-07T08:00:00Z".to_string(),
 			command: "release-pr".to_string(),
 			version: None,
-			group_version: None,
+			versions: BTreeMap::new(),
 			release_targets: Vec::new(),
 			released_packages: Vec::new(),
 			changed_files: Vec::new(),
@@ -10323,7 +10327,7 @@ fn sample_release_record_for_retarget() -> monochange_core::ReleaseRecord {
 		created_at: "2026-04-07T08:00:00Z".to_string(),
 		command: "release-pr".to_string(),
 		version: Some("1.2.3".to_string()),
-		group_version: Some("1.2.3".to_string()),
+		versions: BTreeMap::from([("sdk".to_string(), "1.2.3".to_string())]),
 		release_targets: vec![monochange_core::ReleaseRecordTarget {
 			id: "sdk".to_string(),
 			kind: monochange_core::ReleaseOwnerKind::Group,
@@ -13381,7 +13385,7 @@ fn build_release_manifest_from_record_populates_manifest_from_release_record() {
 		created_at: "2024-01-01T00:00:00Z".to_string(),
 		command: "release-pr".to_string(),
 		version: Some("1.0.0".to_string()),
-		group_version: None,
+		versions: BTreeMap::new(),
 		release_targets: vec![ReleaseRecordTarget {
 			id: "core".to_string(),
 			kind: ReleaseOwnerKind::Package,
@@ -13463,7 +13467,7 @@ fn build_release_manifest_from_record_preserves_changelog_metadata() {
 		created_at: "2024-01-01T00:00:00Z".to_string(),
 		command: "publish-release".to_string(),
 		version: Some("1.0.0".to_string()),
-		group_version: None,
+		versions: BTreeMap::new(),
 		release_targets: Vec::new(),
 		released_packages: Vec::new(),
 		changed_files: Vec::new(),
@@ -13560,7 +13564,7 @@ branches = ["release/*"]
 		created_at: "2024-01-01T00:00:00Z".to_string(),
 		command: "release-pr".to_string(),
 		version: Some("1.0.0".to_string()),
-		group_version: None,
+		versions: BTreeMap::new(),
 		release_targets: vec![monochange_core::ReleaseRecordTarget {
 			id: "test".to_string(),
 			kind: monochange_core::ReleaseOwnerKind::Group,
@@ -13706,7 +13710,7 @@ repo = "monochange"
 		created_at: "2024-01-01T00:00:00Z".to_string(),
 		command: "release-pr".to_string(),
 		version: Some("1.0.0".to_string()),
-		group_version: None,
+		versions: BTreeMap::new(),
 		release_targets: vec![monochange_core::ReleaseRecordTarget {
 			id: "test".to_string(),
 			kind: monochange_core::ReleaseOwnerKind::Group,

--- a/crates/monochange/src/__tests__/package_publish_tests.rs
+++ b/crates/monochange/src/__tests__/package_publish_tests.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::VecDeque;
 use std::path::PathBuf;
@@ -306,7 +307,7 @@ fn commit_release_record(root: &Path, publications: Vec<PackagePublicationTarget
 		created_at: "2026-04-14T08:00:00Z".to_string(),
 		command: "release-pr".to_string(),
 		version: Some("1.2.3".to_string()),
-		group_version: None,
+		versions: BTreeMap::from([("pkg".to_string(), "1.2.3".to_string())]),
 		release_targets: vec![monochange_core::ReleaseRecordTarget {
 			id: "pkg".to_string(),
 			kind: monochange_core::ReleaseOwnerKind::Package,

--- a/crates/monochange/src/__tests__/snapshots/monochange__tests__release_record_file_snapshot.snap
+++ b/crates/monochange/src/__tests__/snapshots/monochange__tests__release_record_file_snapshot.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/monochange/src/__tests__/lib_tests.rs
+assertion_line: 13858
 expression: value
 ---
 {
@@ -11,7 +12,6 @@ expression: value
   "command": "release-pr",
   "createdAt": "[timestamp]",
   "deletedChangesets": [],
-  "groupVersion": "1.2.3",
   "kind": "monochange.releaseRecord",
   "packagePublications": [],
   "provider": null,
@@ -36,5 +36,8 @@ expression: value
   ],
   "schemaVersion": "0.1",
   "updatedChangelogs": [],
-  "version": "1.2.3"
+  "version": "1.2.3",
+  "versions": {
+    "sdk": "1.2.3"
+  }
 }

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -1096,7 +1096,7 @@ pub(crate) fn build_release_manifest_from_record(record: &ReleaseRecord) -> Rele
 		command: record.command.clone(),
 		dry_run: false,
 		version: record.version.clone(),
-		group_version: record.group_version.clone(),
+		group_version: None,
 		release_targets: record
 			.release_targets
 			.iter()
@@ -1153,6 +1153,13 @@ pub(crate) fn build_release_manifest_from_record(record: &ReleaseRecord) -> Rele
 	}
 }
 
+fn release_record_versions(release_targets: &[ReleaseManifestTarget]) -> BTreeMap<String, String> {
+	release_targets
+		.iter()
+		.map(|target| (target.id.clone(), target.version.clone()))
+		.collect()
+}
+
 pub(crate) fn build_release_record(
 	source: Option<&SourceConfiguration>,
 	manifest: &ReleaseManifest,
@@ -1165,7 +1172,7 @@ pub(crate) fn build_release_record(
 			.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
 		command: manifest.command.clone(),
 		version: manifest.version.clone(),
-		group_version: manifest.group_version.clone(),
+		versions: release_record_versions(&manifest.release_targets),
 		release_targets: manifest
 			.release_targets
 			.iter()

--- a/crates/monochange/src/release_record.rs
+++ b/crates/monochange/src/release_record.rs
@@ -535,8 +535,11 @@ pub(crate) fn text_release_record_discovery(discovery: &ReleaseRecordDiscovery) 
 	if let Some(version) = &discovery.record.version {
 		lines.push(format!("  version: {version}"));
 	}
-	if let Some(group_version) = &discovery.record.group_version {
-		lines.push(format!("  group version: {group_version}"));
+	if !discovery.record.versions.is_empty() {
+		lines.push("  versions:".to_string());
+		for (id, version) in &discovery.record.versions {
+			lines.push(format!("    - {id}: {version}"));
+		}
 	}
 	if !discovery.record.release_targets.is_empty() {
 		lines.push("  targets:".to_string());

--- a/crates/monochange/tests/release_record.rs
+++ b/crates/monochange/tests/release_record.rs
@@ -800,7 +800,7 @@ fn sample_release_record() -> ReleaseRecord {
 		created_at: "2026-04-07T08:00:00Z".to_string(),
 		command: "release-pr".to_string(),
 		version: Some("1.2.3".to_string()),
-		group_version: Some("1.2.3".to_string()),
+		versions: std::collections::BTreeMap::from([("sdk".to_string(), "1.2.3".to_string())]),
 		release_targets: vec![ReleaseRecordTarget {
 			id: "sdk".to_string(),
 			kind: ReleaseOwnerKind::Group,

--- a/crates/monochange/tests/snapshots/release_record__release_record_command_reports_record_from_tag_as_json@release_record_command_reports_record_from_tag_as_json.snap
+++ b/crates/monochange/tests/snapshots/release_record__release_record_command_reports_record_from_tag_as_json@release_record_command_reports_record_from_tag_as_json.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/monochange/tests/release_record.rs
+assertion_line: 51
 expression: redacted
 ---
 {
@@ -16,7 +17,6 @@ expression: redacted
     "deletedChangesets": [
       ".changeset/feature.md"
     ],
-    "groupVersion": "1.2.3",
     "kind": "monochange.releaseRecord",
     "packagePublications": [],
     "provider": {
@@ -48,7 +48,10 @@ expression: redacted
     "updatedChangelogs": [
       "crates/monochange/CHANGELOG.md"
     ],
-    "version": "1.2.3"
+    "version": "1.2.3",
+    "versions": {
+      "sdk": "1.2.3"
+    }
   },
   "recordCommit": "[SHA]",
   "resolvedCommit": "[SHA]"

--- a/crates/monochange/tests/snapshots/release_record__release_record_command_walks_first_parent_ancestry_from_head@release_record_command_walks_first_parent_ancestry_from_head.snap
+++ b/crates/monochange/tests/snapshots/release_record__release_record_command_walks_first_parent_ancestry_from_head@release_record_command_walks_first_parent_ancestry_from_head.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/monochange/tests/release_record.rs
+assertion_line: 82
 expression: "String::from_utf8(output.stdout).unwrap_or_else(|error|\npanic!(\"stdout utf8: {error}\"))"
 ---
 release record:
@@ -8,7 +9,8 @@ release record:
   record commit: [SHA]
   distance: 2
   version: 1.2.3
-  group version: 1.2.3
+  versions:
+    - sdk: 1.2.3
   targets:
     - group sdk -> 1.2.3 (tag: v1.2.3)
   packages:

--- a/crates/monochange_core/src/__tests__/lib_tests.rs
+++ b/crates/monochange_core/src/__tests__/lib_tests.rs
@@ -2422,7 +2422,7 @@ fn sample_release_record() -> ReleaseRecord {
 		created_at: "2026-04-06T12:00:00Z".to_string(),
 		command: "release-pr".to_string(),
 		version: Some("1.2.3".to_string()),
-		group_version: Some("1.2.3".to_string()),
+		versions: BTreeMap::from([("main".to_string(), "1.2.3".to_string())]),
 		release_targets: vec![ReleaseRecordTarget {
 			id: "main".to_string(),
 			kind: ReleaseOwnerKind::Group,

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -3277,7 +3277,7 @@ pub struct ReleaseRecord {
 	#[serde(default)]
 	pub version: Option<String>,
 	#[serde(default)]
-	pub group_version: Option<String>,
+	pub versions: BTreeMap<String, String>,
 	pub release_targets: Vec<ReleaseRecordTarget>,
 	pub released_packages: Vec<String>,
 	pub changed_files: Vec<PathBuf>,

--- a/crates/monochange_schema/schemas/release-record.schema.json
+++ b/crates/monochange_schema/schemas/release-record.schema.json
@@ -808,13 +808,6 @@
 			},
 			"type": "array"
 		},
-		"groupVersion": {
-			"default": null,
-			"type": [
-				"string",
-				"null"
-			]
-		},
 		"kind": {
 			"const": "monochange.releaseRecord",
 			"type": "string"
@@ -866,6 +859,13 @@
 				"string",
 				"null"
 			]
+		},
+		"versions": {
+			"additionalProperties": {
+				"type": "string"
+			},
+			"default": {},
+			"type": "object"
 		}
 	},
 	"required": [

--- a/docs/src/schemas/release-record.schema.json
+++ b/docs/src/schemas/release-record.schema.json
@@ -808,13 +808,6 @@
 			},
 			"type": "array"
 		},
-		"groupVersion": {
-			"default": null,
-			"type": [
-				"string",
-				"null"
-			]
-		},
 		"kind": {
 			"const": "monochange.releaseRecord",
 			"type": "string"
@@ -866,6 +859,13 @@
 				"string",
 				"null"
 			]
+		},
+		"versions": {
+			"additionalProperties": {
+				"type": "string"
+			},
+			"default": {},
+			"type": "object"
 		}
 	},
 	"required": [

--- a/docs/src/schemas/release-record.v0.1.schema.json
+++ b/docs/src/schemas/release-record.v0.1.schema.json
@@ -808,13 +808,6 @@
 			},
 			"type": "array"
 		},
-		"groupVersion": {
-			"default": null,
-			"type": [
-				"string",
-				"null"
-			]
-		},
 		"kind": {
 			"const": "monochange.releaseRecord",
 			"type": "string"
@@ -866,6 +859,13 @@
 				"string",
 				"null"
 			]
+		},
+		"versions": {
+			"additionalProperties": {
+				"type": "string"
+			},
+			"default": {},
+			"type": "object"
 		}
 	},
 	"required": [


### PR DESCRIPTION
## Summary
- remove `groupVersion` from generated `monochange.releaseRecord` data
- add a `versions` map keyed by released package/group id
- update release-record schema and snapshots

## Validation
- `cargo test -q -p monochange_core -p monochange -p monochange_schema release_record -- --skip release_record_snapshot`
- `cargo xtask schema check`
- `mc validate`
- `cargo clippy --workspace --all-features --all-targets -q -- -D warnings`
