### PR TITLE
feat(publish): add progress logging for each package during mc publish

### DIFF
--- a/.changeset/publish-progress-logging.md
+++ b/.changeset/publish-progress-logging.md
@@ -1,3 +1,7 @@
+---
+monochange_publish: minor
+---
+
 # Add progress logging to `mc publish`
 
 When running `mc publish`, each package being processed is now logged via `tracing::info!` so users can observe progress in real time. Use `--log-level info` or set `RUST_LOG=info` to see these messages. When `--quiet` is set, no tracing subscriber is initialized so the log messages are silently discarded (zero overhead).
@@ -11,7 +15,3 @@ Log events emitted during the publish loop:
 - **`published package`** — on successful publish
 - **`publish command failed to execute`** (`tracing::error`) — when the publish command cannot run
 - **`publish command returned non-zero exit`** (`tracing::error`) — when the publish command fails
-
----
-
-monochange_publish: patch

--- a/.changeset/publish-progress-logging.md
+++ b/.changeset/publish-progress-logging.md
@@ -1,0 +1,17 @@
+# Add progress logging to `mc publish`
+
+When running `mc publish`, each package being processed is now logged via `tracing::info!` so users can observe progress in real time. Use `--log-level info` or set `RUST_LOG=info` to see these messages. When `--quiet` is set, no tracing subscriber is initialized so the log messages are silently discarded (zero overhead).
+
+Log events emitted during the publish loop:
+
+- **`publishing package`** — at the start of processing each package, with `package_name`, `version`, `registry`, `dry_run`, and `mode` fields
+- **`skipping external package`** — when a package opts out of built-in publishing
+- **`skipping already-published version`** — when the version already exists on the registry
+- **`would publish package (dry run)`** — when `--dry-run` would publish the package
+- **`published package`** — on successful publish
+- **`publish command failed to execute`** (`tracing::error`) — when the publish command cannot run
+- **`publish command returned non-zero exit`** (`tracing::error`) — when the publish command fails
+
+---
+
+monochange_publish: patch

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,6 +100,7 @@ jobs:
           alias npm="pnpm npm"
 
           "$RUNNER_TEMP/bin/mc" publish \
+            --log-level info \
             --output "$RUNNER_TEMP/publish-result.json" \
             --format json
         shell: devenv shell -- bash -e {0}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2466,6 +2466,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tracing",
  "urlencoding",
 ]
 

--- a/crates/monochange_publish/Cargo.toml
+++ b/crates/monochange_publish/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = { workspace = true, features = ["blocking", "json"] }
 serde = { workspace = true, default-features = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
+tracing = { workspace = true, default-features = true }
 urlencoding = { workspace = true }
 
 [lints]

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -25,6 +25,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 use tempfile::TempDir;
+use tracing::info;
 use urlencoding::encode;
 
 pub const PLACEHOLDER_VERSION: &str = "0.0.0";
@@ -516,6 +517,12 @@ pub fn execute_publish_requests(
 
 	for request in requests {
 		if request.mode == PublishMode::External {
+			info!(
+				package_name = request.package_name,
+				version = %request.version,
+				registry = %request.registry,
+				"skipping external package"
+			);
 			outcomes.push(PackagePublishOutcome {
 				package: request.package_id.clone(),
 				ecosystem: request.ecosystem,
@@ -532,8 +539,23 @@ pub fn execute_publish_requests(
 			continue;
 		}
 
+		info!(
+			package_name = request.package_name,
+			version = %request.version,
+			registry = %request.registry,
+			dry_run,
+			mode = ?mode,
+			"publishing package"
+		);
+
 		let version_exists = registry_version_exists(client, endpoints, request)?;
 		if version_exists {
+			info!(
+				package_name = request.package_name,
+				version = %request.version,
+				registry = %request.registry,
+				"skipping already-published version"
+			);
 			outcomes.push(PackagePublishOutcome {
 				package: request.package_id.clone(),
 				ecosystem: request.ecosystem,
@@ -599,6 +621,13 @@ pub fn execute_publish_requests(
 		);
 
 		if dry_run {
+			info!(
+				package_name = request.package_name,
+				version = %request.version,
+				registry = %request.registry,
+				mode = ?mode,
+				"would publish package (dry run)"
+			);
 			outcomes.push(PackagePublishOutcome {
 				package: request.package_id.clone(),
 				ecosystem: request.ecosystem,
@@ -624,11 +653,24 @@ pub fn execute_publish_requests(
 		let output = match executor.run(&publish_command) {
 			Ok(output) => output,
 			Err(error) => {
+				tracing::error!(
+					package_name = request.package_name,
+					version = %request.version,
+					registry = %request.registry,
+					error = %error,
+					"publish command failed to execute"
+				);
 				outcomes.push(failed_publish_outcome(mode, request, error.to_string()));
 				break;
 			}
 		};
 		if !output.success {
+			tracing::error!(
+				package_name = request.package_name,
+				version = %request.version,
+				registry = %request.registry,
+				"publish command returned non-zero exit"
+			);
 			let mut outcome = failed_publish_outcome(
 				mode,
 				request,
@@ -652,6 +694,12 @@ pub fn execute_publish_requests(
 			disabled_trust_outcome()
 		};
 
+		info!(
+			package_name = request.package_name,
+			version = %request.version,
+			registry = %request.registry,
+			"published package"
+		);
 		outcomes.push(PackagePublishOutcome {
 			package: request.package_id.clone(),
 			ecosystem: request.ecosystem,

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -25,7 +25,6 @@ use serde::Deserialize;
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 use tempfile::TempDir;
-use tracing::debug;
 use tracing::info;
 use urlencoding::encode;
 
@@ -477,12 +476,6 @@ pub fn execute_publish_requests_with_process(
 	readiness: &PublishReadinessRegistry,
 	trust_handler: &dyn PublishTrustHandler,
 ) -> MonochangeResult<PackagePublishReport> {
-	debug!(
-		request_count = requests.len(),
-		dry_run,
-		mode = ?mode,
-		"executing publish requests with process"
-	);
 	let env_map = current_env_map();
 	let endpoints = RegistryEndpoints::from_env();
 	let client = registry_client()?;
@@ -521,13 +514,6 @@ pub fn execute_publish_requests(
 	trust_handler: &dyn PublishTrustHandler,
 ) -> MonochangeResult<PackagePublishReport> {
 	let mut outcomes = Vec::new();
-
-	debug!(
-		request_count = requests.len(),
-		dry_run,
-		mode = ?mode,
-		"executing publish requests"
-	);
 
 	for request in requests {
 		if request.mode == PublishMode::External {
@@ -745,10 +731,6 @@ pub fn build_placeholder_requests(
 	packages: &[PackageRecord],
 	selected_packages: &BTreeSet<String>,
 ) -> MonochangeResult<Vec<PublishRequest>> {
-	debug!(
-		selected_package_count = selected_packages.len(),
-		"building placeholder publish requests"
-	);
 	let packages_by_config_id = packages_by_config_id(packages);
 	let mut requests = Vec::new();
 
@@ -808,11 +790,6 @@ pub fn build_release_requests(
 	publications: &[PackagePublicationTarget],
 	selected_packages: &BTreeSet<String>,
 ) -> MonochangeResult<Vec<PublishRequest>> {
-	debug!(
-		publication_count = publications.len(),
-		selected_package_count = selected_packages.len(),
-		"building release publish requests"
-	);
 	let packages_by_config_id = packages_by_config_id(packages);
 	let mut requests = Vec::new();
 
@@ -2268,12 +2245,6 @@ pub fn registry_version_exists(
 	endpoints: &RegistryEndpoints,
 	request: &PublishRequest,
 ) -> MonochangeResult<bool> {
-	debug!(
-		package_name = request.package_name,
-		version = %request.version,
-		registry = %request.registry,
-		"checking if version exists on registry"
-	);
 	if request.registry == RegistryKind::Npm {
 		let url = format!(
 			"{}/{}",

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -25,6 +25,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 use tempfile::TempDir;
+use tracing::debug;
 use tracing::info;
 use urlencoding::encode;
 
@@ -476,6 +477,12 @@ pub fn execute_publish_requests_with_process(
 	readiness: &PublishReadinessRegistry,
 	trust_handler: &dyn PublishTrustHandler,
 ) -> MonochangeResult<PackagePublishReport> {
+	debug!(
+		request_count = requests.len(),
+		dry_run,
+		mode = ?mode,
+		"executing publish requests with process"
+	);
 	let env_map = current_env_map();
 	let endpoints = RegistryEndpoints::from_env();
 	let client = registry_client()?;
@@ -514,6 +521,13 @@ pub fn execute_publish_requests(
 	trust_handler: &dyn PublishTrustHandler,
 ) -> MonochangeResult<PackagePublishReport> {
 	let mut outcomes = Vec::new();
+
+	debug!(
+		request_count = requests.len(),
+		dry_run,
+		mode = ?mode,
+		"executing publish requests"
+	);
 
 	for request in requests {
 		if request.mode == PublishMode::External {
@@ -731,6 +745,10 @@ pub fn build_placeholder_requests(
 	packages: &[PackageRecord],
 	selected_packages: &BTreeSet<String>,
 ) -> MonochangeResult<Vec<PublishRequest>> {
+	debug!(
+		selected_package_count = selected_packages.len(),
+		"building placeholder publish requests"
+	);
 	let packages_by_config_id = packages_by_config_id(packages);
 	let mut requests = Vec::new();
 
@@ -790,6 +808,11 @@ pub fn build_release_requests(
 	publications: &[PackagePublicationTarget],
 	selected_packages: &BTreeSet<String>,
 ) -> MonochangeResult<Vec<PublishRequest>> {
+	debug!(
+		publication_count = publications.len(),
+		selected_package_count = selected_packages.len(),
+		"building release publish requests"
+	);
 	let packages_by_config_id = packages_by_config_id(packages);
 	let mut requests = Vec::new();
 
@@ -2245,6 +2268,12 @@ pub fn registry_version_exists(
 	endpoints: &RegistryEndpoints,
 	request: &PublishRequest,
 ) -> MonochangeResult<bool> {
+	debug!(
+		package_name = request.package_name,
+		version = %request.version,
+		registry = %request.registry,
+		"checking if version exists on registry"
+	);
 	if request.registry == RegistryKind::Npm {
 		let url = format!(
 			"{}/{}",


### PR DESCRIPTION
## Problem

When running `mc publish`, there is no output until the entire operation completes. Users cannot tell which package is currently being published, whether packages are being skipped, or if any have failed — until the final report appears.

## Solution

Add `tracing::info!` and `tracing::error!` calls to the publish loop in `monochange_publish::execute_publish_requests` so each package gets logged as it is processed.

### Log events

| Event | Level | Fields |
|---|---|---|
| `publishing package` | `INFO` | `package_name`, `version`, `registry`, `dry_run`, `mode` |
| `skipping external package` | `INFO` | `package_name`, `version`, `registry` |
| `skipping already-published version` | `INFO` | `package_name`, `version`, `registry` |
| `would publish package (dry run)` | `INFO` | `package_name`, `version`, `registry`, `mode` |
| `published package` | `INFO` | `package_name`, `version`, `registry` |
| `publish command failed to execute` | `ERROR` | `package_name`, `version`, `registry`, `error` |
| `publish command returned non-zero exit` | `ERROR` | `package_name`, `version`, `registry` |

### How to enable

Use `--log-level info` or set `RUST_LOG=info`:

```sh
mc publish --log-level info
```

When `--quiet` is set, the tracing subscriber is not initialised so all log calls become no-ops with zero overhead.

## Changes

- Added `tracing` dependency to `monochange_publish/Cargo.toml`
- Added `use tracing::info` import and `tracing::error!` calls in `execute_publish_requests`
- Created changeset `publish-progress-logging.md`

## Testing

- All existing tests pass (`cargo test --workspace --all-features --all-targets`)
- Clippy clean (`cargo clippy -p monochange_publish --all-features --all-targets`)
- The log statements are observability-only; no business logic changed, so existing tests cover all code paths