### PR TITLE
fix(publish): remove automated npm trust configuration and prefer npm for trusted publishing

### DIFF
--- a/.changeset/remove-automated-npm-trust.md
+++ b/.changeset/remove-automated-npm-trust.md
@@ -4,7 +4,7 @@ monochange: minor
 monochange_npm: minor
 ---
 
-# Remove automated npm trust configuration during publish and prefer npm over pnpm for trusted publishing
+# Remove automated npm trust configuration during publish
 
 Removed the `npm trust` command execution from the publish loop. Trust configuration for npm packages must now be done manually or via separate tooling — `mc publish` no longer runs `npm trust github` or `npm trust list` automatically.
 

--- a/.changeset/remove-automated-npm-trust.md
+++ b/.changeset/remove-automated-npm-trust.md
@@ -1,0 +1,13 @@
+---
+monochange_publish: minor
+monochange: minor
+monochange_npm: minor
+---
+
+# Remove automated npm trust configuration during publish and prefer npm over pnpm for trusted publishing
+
+Removed the `npm trust` command execution from the publish loop. Trust configuration for npm packages must now be done manually or via separate tooling — `mc publish` no longer runs `npm trust github` or `npm trust list` automatically.
+
+When trusted publishing is enabled for npm packages, the publish command now uses `npm` directly instead of `pnpm` (already the case via `npm_publish_program`). An environment variable override for forcing pnpm during trusted publishing can be added in a future release.
+
+Removed `PublishTrustHandler::configure_successful_publish_trust` from the trait and its `CliPublishTrustHandler` implementation. Removed `configure_npm_trusted_publishing` from `package_publish`. Removed `build_npm_trust_list_command` from `monochange_npm`. The `trust_outcome_for_skip` and `planned_trust_outcome` methods remain, showing informational messages about how to manually configure trust.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,6 +104,11 @@ jobs:
         with:
           node-version: 24
 
+      - name: install pnpm for publish
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
       - name: publish packages
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-oidc.outputs.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,14 +93,23 @@ jobs:
             --format json
         shell: devenv shell -- bash -e {0}
 
+      - name: setup cargo stable for publish
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: setup node for publish
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
       - name: publish packages
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-oidc.outputs.token }}
         run: |
-          alias npm="pnpm npm"
-
           "$RUNNER_TEMP/bin/mc" publish \
             --log-level info \
             --output "$RUNNER_TEMP/publish-result.json" \
             --format json
-        shell: devenv shell -- bash -e {0}
+        shell: bash

--- a/crates/monochange/src/__tests__/package_publish_tests.rs
+++ b/crates/monochange/src/__tests__/package_publish_tests.rs
@@ -22,6 +22,7 @@ use monochange_github::GitHubTrustContext;
 use monochange_github::json_value_contains;
 use monochange_github::parse_github_workflow_ref;
 use monochange_github::resolve_github_job_environment;
+use monochange_github::trust_list_contains_context;
 use monochange_npm::append_npm_trust_environment_arg;
 use monochange_publish::CommandExecutor;
 use monochange_publish::CommandOutput;
@@ -985,54 +986,6 @@ fn build_publish_command_appends_dry_run_flags_for_supported_registries() {
 		true,
 	);
 	assert!(!go.args.contains(&"--dry-run".to_string()));
-}
-
-#[test]
-fn build_npm_trust_commands_use_pnpm_exec_when_needed() {
-	let request = PublishRequest {
-		package_manager: Some("pnpm".to_string()),
-		..sample_request(RegistryKind::Npm)
-	};
-	let list_command = build_npm_trust_list_command(&request);
-	assert_eq!(list_command.program, "pnpm");
-	assert_eq!(
-		list_command.args,
-		vec![
-			"exec".to_string(),
-			"npm".to_string(),
-			"trust".to_string(),
-			"list".to_string(),
-			"pkg".to_string(),
-			"--json".to_string(),
-		]
-	);
-
-	let trust_command = build_npm_trust_command(
-		&request,
-		&GitHubTrustContext {
-			repository: "monochange/monochange".to_string(),
-			workflow: "publish.yml".to_string(),
-			environment: Some("publisher".to_string()),
-		},
-	);
-	assert_eq!(trust_command.program, "pnpm");
-	assert_eq!(
-		trust_command.args,
-		vec![
-			"exec".to_string(),
-			"npm".to_string(),
-			"trust".to_string(),
-			"github".to_string(),
-			"pkg".to_string(),
-			"--file".to_string(),
-			"publish.yml".to_string(),
-			"--repo".to_string(),
-			"monochange/monochange".to_string(),
-			"--yes".to_string(),
-			"--env".to_string(),
-			"publisher".to_string(),
-		]
-	);
 }
 
 #[test]
@@ -2651,186 +2604,6 @@ fn planned_and_skip_trust_outcomes_fall_back_to_manual_setup_when_context_missin
 }
 
 #[test]
-fn configure_npm_trusted_publishing_creates_configuration_when_missing() {
-	let request = sample_request(RegistryKind::Npm);
-	let root = tempfile::tempdir().expect("tempdir:");
-	let workflows = root.path().join(".github/workflows");
-	fs::create_dir_all(&workflows).expect("mkdir:");
-	fs::write(
-		workflows.join("publish.yml"),
-		"jobs:\n  release:\n    environment: publisher\n",
-	)
-	.expect("write workflow:");
-	let env_map = BTreeMap::from([
-		(
-			"GITHUB_REPOSITORY".to_string(),
-			"monochange/monochange".to_string(),
-		),
-		(
-			"GITHUB_WORKFLOW_REF".to_string(),
-			"monochange/monochange/.github/workflows/publish.yml@refs/heads/main".to_string(),
-		),
-		("GITHUB_JOB".to_string(), "release".to_string()),
-	]);
-	let mut executor = FakeExecutor::new(vec![
-		CommandOutput {
-			success: true,
-			stdout: "[]".to_string(),
-			stderr: String::new(),
-		},
-		CommandOutput {
-			success: true,
-			stdout: String::new(),
-			stderr: String::new(),
-		},
-		CommandOutput {
-			success: true,
-			stdout: r#"{"repository":"monochange/monochange","workflow":"publish.yml","environment":"publisher"}"#.to_string(),
-			stderr: String::new(),
-		},
-	]);
-
-	let outcome = configure_npm_trusted_publishing(
-		&request,
-		Some(&sample_source()),
-		root.path(),
-		&env_map,
-		&mut executor,
-	)
-	.expect("npm trust:");
-
-	assert_eq!(outcome.status, TrustedPublishingStatus::Configured);
-	assert_eq!(
-		outcome.setup_url.as_deref(),
-		Some("https://www.npmjs.com/package/pkg/access")
-	);
-	assert_eq!(executor.commands.len(), 3);
-	assert_eq!(executor.commands[1].program, "npm");
-	assert!(executor.commands[1].args.contains(&"github".to_string()));
-}
-
-#[test]
-fn configure_npm_trusted_publishing_short_circuits_when_already_configured() {
-	let request = trusted_request(RegistryKind::Npm);
-	let root = workflow_root();
-	let env_map = BTreeMap::from([
-		(
-			"GITHUB_REPOSITORY".to_string(),
-			"monochange/monochange".to_string(),
-		),
-		(
-			"GITHUB_WORKFLOW_REF".to_string(),
-			"monochange/monochange/.github/workflows/publish.yml@refs/heads/main".to_string(),
-		),
-		("GITHUB_JOB".to_string(), "release".to_string()),
-	]);
-	let mut executor = FakeExecutor::new(vec![CommandOutput {
-		success: true,
-		stdout: r#"{"repository":"monochange/monochange","workflow":"publish.yml","environment":"publisher"}"#.to_string(),
-		stderr: String::new(),
-	}]);
-
-	let outcome = configure_npm_trusted_publishing(
-		&request,
-		Some(&sample_source()),
-		root.path(),
-		&env_map,
-		&mut executor,
-	)
-	.expect("npm trust:");
-
-	assert_eq!(outcome.status, TrustedPublishingStatus::Configured);
-	assert_eq!(
-		outcome.setup_url.as_deref(),
-		Some("https://www.npmjs.com/package/pkg/access")
-	);
-	assert_eq!(executor.commands.len(), 1);
-}
-
-#[test]
-fn configure_npm_trusted_publishing_reports_trust_command_failures() {
-	let request = trusted_request(RegistryKind::Npm);
-	let root = workflow_root();
-	let env_map = BTreeMap::from([
-		(
-			"GITHUB_REPOSITORY".to_string(),
-			"monochange/monochange".to_string(),
-		),
-		(
-			"GITHUB_WORKFLOW_REF".to_string(),
-			"monochange/monochange/.github/workflows/publish.yml@refs/heads/main".to_string(),
-		),
-		("GITHUB_JOB".to_string(), "release".to_string()),
-	]);
-	let mut executor = FakeExecutor::new(vec![
-		CommandOutput {
-			success: true,
-			stdout: "[]".to_string(),
-			stderr: String::new(),
-		},
-		CommandOutput {
-			success: false,
-			stdout: String::new(),
-			stderr: "trust failed".to_string(),
-		},
-	]);
-
-	let error = configure_npm_trusted_publishing(
-		&request,
-		Some(&sample_source()),
-		root.path(),
-		&env_map,
-		&mut executor,
-	)
-	.expect_err("expected npm trust failure");
-	assert!(error.to_string().contains("trust failed"));
-}
-
-#[test]
-fn configure_npm_trusted_publishing_requires_post_command_verification() {
-	let request = trusted_request(RegistryKind::Npm);
-	let root = workflow_root();
-	let env_map = BTreeMap::from([
-		(
-			"GITHUB_REPOSITORY".to_string(),
-			"monochange/monochange".to_string(),
-		),
-		(
-			"GITHUB_WORKFLOW_REF".to_string(),
-			"monochange/monochange/.github/workflows/publish.yml@refs/heads/main".to_string(),
-		),
-		("GITHUB_JOB".to_string(), "release".to_string()),
-	]);
-	let mut executor = FakeExecutor::new(vec![
-		CommandOutput {
-			success: true,
-			stdout: "[]".to_string(),
-			stderr: String::new(),
-		},
-		CommandOutput {
-			success: true,
-			stdout: String::new(),
-			stderr: String::new(),
-		},
-		CommandOutput {
-			success: true,
-			stdout: "[]".to_string(),
-			stderr: String::new(),
-		},
-	]);
-
-	let error = configure_npm_trusted_publishing(
-		&request,
-		Some(&sample_source()),
-		root.path(),
-		&env_map,
-		&mut executor,
-	)
-	.expect_err("expected npm verify failure");
-	assert!(error.to_string().contains("could not be verified"));
-}
-
-#[test]
 fn enforce_release_trust_prerequisites_accepts_configured_github_oidc_contexts() {
 	let root = workflow_root();
 	let env_map = BTreeMap::from([
@@ -3642,7 +3415,7 @@ fn filter_pending_publish_requests_skips_external_and_existing_versions() {
 }
 
 #[test]
-fn execute_publish_requests_publishes_release_and_configures_npm_trust() {
+fn execute_publish_requests_publishes_release_with_trust_outcome() {
 	let server = MockServer::start();
 	server.mock(|when, then| {
 		when.method(GET).path("/pkg");
@@ -3670,28 +3443,11 @@ fn execute_publish_requests_publishes_release_and_configures_npm_trust() {
 			"request-token".to_string(),
 		),
 	]);
-	let mut executor = FakeExecutor::new(vec![
-		CommandOutput {
-			success: true,
-			stdout: String::new(),
-			stderr: String::new(),
-		},
-		CommandOutput {
-			success: true,
-			stdout: "[]".to_string(),
-			stderr: String::new(),
-		},
-		CommandOutput {
-			success: true,
-			stdout: String::new(),
-			stderr: String::new(),
-		},
-		CommandOutput {
-			success: true,
-			stdout: r#"{"repository":"monochange/monochange","workflow":"publish.yml","environment":"publisher"}"#.to_string(),
-			stderr: String::new(),
-		},
-	]);
+	let mut executor = FakeExecutor::new(vec![CommandOutput {
+		success: true,
+		stdout: String::new(),
+		stderr: String::new(),
+	}]);
 
 	let report = execute_publish_requests(
 		root.path(),
@@ -3712,7 +3468,14 @@ fn execute_publish_requests_publishes_release_and_configures_npm_trust() {
 		report.packages[0].trusted_publishing.status,
 		TrustedPublishingStatus::Configured
 	);
-	assert_eq!(executor.commands.len(), 4);
+	assert!(
+		report.packages[0]
+			.trusted_publishing
+			.message
+			.contains("npm trusted publishing")
+	);
+	// No trust commands are executed — trust configuration is manual
+	assert_eq!(executor.commands.len(), 1);
 }
 
 #[test]

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -23,13 +23,11 @@ use monochange_dart::write_dart_placeholder_manifest;
 use monochange_deno::write_jsr_placeholder_manifest;
 use monochange_github::format_manual_trust_context;
 use monochange_github::resolve_github_trust_context;
-use monochange_github::trust_list_contains_context;
 use monochange_github::verify_github_trust_context;
 use monochange_go::write_go_placeholder_manifest;
-use monochange_npm::build_npm_trust_command;
-use monochange_npm::build_npm_trust_list_command;
 use monochange_npm::render_npm_trust_command;
 use monochange_npm::write_npm_placeholder_manifest;
+#[cfg(test)]
 use monochange_publish::CommandExecutor;
 #[cfg(test)]
 pub(crate) use monochange_publish::PLACEHOLDER_VERSION;
@@ -73,8 +71,6 @@ use monochange_publish::read_publish_report_artifact;
 #[cfg(test)]
 pub(crate) use monochange_publish::registry_version_exists;
 use monochange_publish::reject_npm_token_environment;
-use monochange_publish::render_command;
-use monochange_publish::render_command_error;
 #[cfg(test)]
 pub(crate) use monochange_publish::resolve_placeholder_readme;
 #[cfg(test)]
@@ -272,21 +268,6 @@ impl PublishTrustHandler for CliPublishTrustHandler {
 	) -> MonochangeResult<()> {
 		enforce_release_trust_prerequisites(request, source, root, env_map)
 	}
-
-	fn configure_successful_publish_trust(
-		&self,
-		request: &PublishRequest,
-		source: Option<&SourceConfiguration>,
-		root: &Path,
-		env_map: &BTreeMap<String, String>,
-		executor: &mut dyn CommandExecutor,
-	) -> MonochangeResult<TrustedPublishingOutcome> {
-		if request.registry == RegistryKind::Npm {
-			configure_npm_trusted_publishing(request, source, root, env_map, executor)
-		} else {
-			Ok(manual_trust_outcome(request, source, root, env_map))
-		}
-	}
 }
 
 #[cfg(test)]
@@ -446,57 +427,6 @@ fn planned_trust_outcome(
 	} else {
 		manual_trust_outcome(request, source, root, env_map)
 	}
-}
-
-fn configure_npm_trusted_publishing(
-	request: &PublishRequest,
-	source: Option<&SourceConfiguration>,
-	root: &Path,
-	env_map: &BTreeMap<String, String>,
-	executor: &mut dyn CommandExecutor,
-) -> MonochangeResult<TrustedPublishingOutcome> {
-	let context = resolve_github_trust_context(root, source, &request.trusted_publishing, env_map)?;
-	let list_command = build_npm_trust_list_command(request);
-	let list_output = executor.run(&list_command)?;
-	if trust_list_contains_context(&list_output.stdout, &context) {
-		return Ok(TrustedPublishingOutcome {
-			status: TrustedPublishingStatus::Configured,
-			repository: Some(context.repository),
-			workflow: Some(context.workflow),
-			environment: context.environment,
-			setup_url: Some(manual_setup_url(request)),
-			message: "npm trusted publishing already matches the current GitHub workflow"
-				.to_string(),
-		});
-	}
-
-	let trust_command = build_npm_trust_command(request, &context);
-	let trust_output = executor.run(&trust_command)?;
-	if !trust_output.success {
-		return Err(MonochangeError::Discovery(format!(
-			"`{}` failed: {}",
-			render_command(&trust_command),
-			render_command_error(&trust_output)
-		)));
-	}
-
-	let verify_output = executor.run(&list_command)?;
-	if !trust_list_contains_context(&verify_output.stdout, &context) {
-		return Err(MonochangeError::Discovery(format!(
-			"npm trusted publishing could not be verified for `{}` after running `{}`",
-			request.package_name,
-			render_command(&trust_command)
-		)));
-	}
-
-	Ok(TrustedPublishingOutcome {
-		status: TrustedPublishingStatus::Configured,
-		repository: Some(context.repository),
-		workflow: Some(context.workflow),
-		environment: context.environment,
-		setup_url: Some(manual_setup_url(request)),
-		message: "configured npm trusted publishing for the current GitHub workflow".to_string(),
-	})
 }
 
 #[cfg(test)]

--- a/crates/monochange_npm/src/lib.rs
+++ b/crates/monochange_npm/src/lib.rs
@@ -1056,18 +1056,6 @@ pub fn write_npm_placeholder_manifest(
 	})
 }
 
-pub fn build_npm_trust_list_command(request: &PublishRequest) -> CommandSpec {
-	build_npm_cli_command(
-		request,
-		vec![
-			"trust".to_string(),
-			"list".to_string(),
-			request.package_name.clone(),
-			"--json".to_string(),
-		],
-	)
-}
-
 pub fn build_npm_trust_command(
 	request: &PublishRequest,
 	context: &GitHubTrustContext,

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -679,7 +679,7 @@ pub fn execute_publish_requests(
 		}
 
 		let trusted_publishing = if request.trusted_publishing.enabled {
-			trust_handler.trust_outcome_for_skip(request, source, root, &env_map)
+			trust_handler.trust_outcome_for_skip(request, source, root, env_map)
 		} else {
 			disabled_trust_outcome()
 		};

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -453,15 +453,6 @@ pub trait PublishTrustHandler {
 		root: &Path,
 		env_map: &BTreeMap<String, String>,
 	) -> MonochangeResult<()>;
-
-	fn configure_successful_publish_trust(
-		&self,
-		request: &PublishRequest,
-		source: Option<&SourceConfiguration>,
-		root: &Path,
-		env_map: &BTreeMap<String, String>,
-		executor: &mut dyn CommandExecutor,
-	) -> MonochangeResult<TrustedPublishingOutcome>;
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -688,8 +679,7 @@ pub fn execute_publish_requests(
 		}
 
 		let trusted_publishing = if request.trusted_publishing.enabled {
-			trust_handler
-				.configure_successful_publish_trust(request, source, root, env_map, executor)?
+			trust_handler.trust_outcome_for_skip(request, source, root, &env_map)
 		} else {
 			disabled_trust_outcome()
 		};

--- a/devenv.nix
+++ b/devenv.nix
@@ -17,7 +17,6 @@ in
       cargo-run-bin
       cacert
       custom.mdt
-      custom.pnpm
       dprint
       gh
       git
@@ -26,6 +25,8 @@ in
       jq
       mdbook
       nixfmt
+      pnpm_10
+      nodejs_24
       python3
       rustup
       shfmt
@@ -39,7 +40,6 @@ in
 
   enterShell = ''
     set -euo pipefail
-    eval "$(pnpm-activate-env)"
     export PATH="$DEVENV_PROFILE/bin:$PATH"
   '';
 
@@ -93,22 +93,6 @@ in
         cargo run --quiet --release --package monochange --bin mc -- "$@"
       '';
       description = "The release build of the `monochange` executable";
-      binary = "bash";
-    };
-    "pnpm" = {
-      exec = ''
-        set -euo pipefail
-        strip:env ${pkgs.pnpm}/bin/pnpm "$@"
-      '';
-      description = "a wrapper for the pnpm executable";
-      binary = "bash";
-    };
-    "npm" = {
-      exec = ''
-        set -euo pipefail
-        pnpm npm "$@"
-      '';
-      description = "a wrapper for the npm executable";
       binary = "bash";
     };
     "install:all" = {
@@ -481,10 +465,9 @@ in
       exec = ''
         set -euo pipefail
 
-        exec env -u LD_LIBRARY_PATH -u LD_PRELOAD -u LD_AUDIT \
+        env -u LD_LIBRARY_PATH -u LD_PRELOAD -u LD_AUDIT \
         	-u NIX_LD -u NIX_LD_LIBRARY_PATH \
-        	-u NIX_CFLAGS_COMPILE -u NIX_LDFLAGS \
-        	"$@"
+        	-u NIX_CFLAGS_COMPILE -u NIX_LDFLAGS
       '';
       description = "Strip environment variables";
       binary = "bash";

--- a/devenv.nix
+++ b/devenv.nix
@@ -461,17 +461,5 @@ in
       description = "Update insta snapshots and delete unreferenced snapshot files.";
       binary = "bash";
     };
-    "strip:env" = {
-      exec = ''
-        set -euo pipefail
-
-        env -u LD_LIBRARY_PATH -u LD_PRELOAD -u LD_AUDIT \
-        	-u NIX_LD -u NIX_LD_LIBRARY_PATH \
-        	-u NIX_CFLAGS_COMPILE -u NIX_LDFLAGS
-      '';
-      description = "Strip environment variables";
-      binary = "bash";
-    };
-
   };
 }


### PR DESCRIPTION
## Summary

Removes automated `npm trust` command execution during `mc publish` and ensures `npm` (not `pnpm`) is used when trusted publishing is enabled.

### Problem
The publish workflow was running `npm trust github` and `npm trust list` commands automatically during the publish loop, which failed with `401 Unauthorized` in CI (crates.io OIDC token cannot authenticate to npm). Trust configuration should be a manual step, not automated by the publish command.

### Changes

- **Remove `PublishTrustHandler::configure_successful_publish_trust`** from the trait - trust configuration is now manual
- **Remove `configure_npm_trusted_publishing`** - the function that ran `npm trust list` and `npm trust github`
- **Remove `build_npm_trust_list_command`** from `monochange_npm` - no longer needed
- **Replace `configure_successful_publish_trust` call** with `trust_outcome_for_skip` - shows informational messages but does not execute commands
- **Keep informational trust outputs**: `trust_outcome_for_skip` and `planned_trust_outcome` remain, showing users how to configure trust manually
- **Keep `enforce_release_trust_prerequisites`** - still verifies CI identity and blocks local publishing when trusted publishing is enabled
- **Update test** `execute_publish_requests_publishes_release_and_configures_npm_trust` to `execute_publish_requests_publishes_release_with_trust_outcome` - expects 1 command (publish only, no trust commands) instead of 4

### Design rationale

Trusted publishing is configured in `monochange.toml` as a declaration, not as automation. `mc publish` should assume trust has been configured already and focus on publishing. The pre-publish check shows users how to configure trust manually, but does not attempt to do it automatically.