### PR TITLE
fix: eliminate flaky prepared-release staleness check in CLI runtime tests

### DIFF
--- a/.changeset/fix-flaky-prepared-release-stale-test.md
+++ b/.changeset/fix-flaky-prepared-release-stale-test.md
@@ -1,0 +1,9 @@
+---
+monochange: test
+---
+
+# Fix flaky `reuses_prepared_release_artifact_for_versions` test
+
+The `execute_cli_command_with_options_reuses_prepared_release_artifact_for_versions` test (and the related `plans_publish_rate_limits_from_prepared_release_artifact` and `reports_invalid_versions_output_formats` tests) operated on the real repository workspace root without holding the `TEST_ENV_LOCK`. When other test threads modified workspace files concurrently, the `git status` snapshot captured at artifact save time could differ from the snapshot taken at validation time, causing an intermittent "workspace status no longer matches the saved prepared release" error.
+
+All three tests now acquire `TEST_ENV_LOCK` before reading the workspace, serialising them against other tests that modify git state.

--- a/crates/monochange/src/__tests__/cli_runtime_tests.rs
+++ b/crates/monochange/src/__tests__/cli_runtime_tests.rs
@@ -1798,6 +1798,9 @@ fn execute_cli_command_with_options_covers_final_artifact_save_call() {
 
 #[test]
 fn execute_cli_command_with_options_plans_publish_rate_limits_from_prepared_release_artifact() {
+	let _guard = TEST_ENV_LOCK
+		.lock()
+		.unwrap_or_else(|error| panic!("test env lock: {error}"));
 	let root = fs::canonicalize(Path::new(env!("CARGO_MANIFEST_DIR")).join("../.."))
 		.unwrap_or_else(|error| panic!("workspace root: {error}"));
 	let configuration = sample_configuration(&root);
@@ -1894,6 +1897,9 @@ fn execute_cli_command_with_options_rejects_readiness_for_placeholder_publish_pl
 
 #[test]
 fn execute_cli_command_with_options_reuses_prepared_release_artifact_for_versions() {
+	let _guard = TEST_ENV_LOCK
+		.lock()
+		.unwrap_or_else(|error| panic!("test env lock: {error}"));
 	let root = fs::canonicalize(Path::new(env!("CARGO_MANIFEST_DIR")).join("../.."))
 		.unwrap_or_else(|error| panic!("workspace root: {error}"));
 	let configuration = sample_configuration(&root);
@@ -1964,6 +1970,9 @@ fn execute_cli_command_with_options_reports_invalid_versions_artifacts() {
 
 #[test]
 fn execute_cli_command_with_options_reports_invalid_versions_output_formats() {
+	let _guard = TEST_ENV_LOCK
+		.lock()
+		.unwrap_or_else(|error| panic!("test env lock: {error}"));
 	let root = fs::canonicalize(Path::new(env!("CARGO_MANIFEST_DIR")).join("../.."))
 		.unwrap_or_else(|error| panic!("workspace root: {error}"));
 	let configuration = sample_configuration(&root);


### PR DESCRIPTION
## Problem

The test `execute_cli_command_with_options_reuses_prepared_release_artifact_for_versions` was flaky, failing intermittently in CI with:

```
prepared release artifact `/tmp/.tmphBzCUZ/prepared-release.json` is stale: workspace status no longer matches the saved prepared release
```

## Root Cause

Three CLI runtime tests that call `save_prepared_release_execution` on the **real repository workspace root** all operated without holding `TEST_ENV_LOCK`:

1. `execute_cli_command_with_options_reuses_prepared_release_artifact_for_versions`
2. `execute_cli_command_with_options_plans_publish_rate_limits_from_prepared_release_artifact`
3. `execute_cli_command_with_options_reports_invalid_versions_output_formats`

The `save_prepared_release_execution` function captures a `git status` snapshot as part of the artifact's `worktree_status` field. Later, `validate_prepared_release_artifact` re-runs `git status` and compares the result. When other test threads modify workspace files concurrently (which happens in parallel test execution), the git status output changes between save and load, causing the staleness check to fail.

## Fix

Add `TEST_ENV_LOCK` acquisition at the start of all three affected tests, serialising them against other tests that modify git state. This follows the existing pattern used by other tests in the same file (e.g., `execute_cli_command_captures_telemetry_when_step_input_resolution_fails`).

## Changeset

- `.changeset/fix-flaky-prepared-release-stale-test.md` — patch for monochange
- `crates/monochange/src/__tests__/cli_runtime_tests.rs` — added `TEST_ENV_LOCK` guard to three tests

Closes the CI failure seen in https://github.com/monochange/monochange/actions/runs/25663684298/job/75330543475?pr=456