### PR TITLE
fix: include schema in main release group

### DIFF
--- a/.changeset/group-monochange-schema.md
+++ b/.changeset/group-monochange-schema.md
@@ -1,0 +1,7 @@
+---
+main: patch
+---
+
+# Include schema in main releases
+
+Include `monochange_schema` in the main release group so published crates receive the schema crate update before dependent crates publish.

--- a/monochange.toml
+++ b/monochange.toml
@@ -429,6 +429,7 @@ packages = [
 	"monochange_npm",
 	"monochange_publish",
 	"monochange_python",
+	"monochange_schema",
 	"monochange_semver",
 	"monochange_telemetry",
 	"monochange_test_helpers",


### PR DESCRIPTION
## Summary
- Add `monochange_schema` to the `main` release group.
- Add a changeset documenting the release-group fix.

## Why
The v0.4.2 publish run reached `monochange_core` before `monochange_schema 0.1.1` was available on crates.io. Grouping `monochange_schema` with `main` makes future main releases include the schema crate in the same publication set so dependency ordering can publish it before dependent crates.

## Validation
- `devenv shell mc validate`
