### PR TITLE
fix: add schema publish changeset

### DIFF
--- a/.changeset/publish-monochange-schema.md
+++ b/.changeset/publish-monochange-schema.md
@@ -1,0 +1,7 @@
+---
+monochange_schema: patch
+---
+
+# Publish schema crate update
+
+Publish a schema crate update so dependent crates can resolve the required schema version during publication.


### PR DESCRIPTION
## Summary
- add a changeset-only patch bump for `monochange_schema`
- ensure the schema crate is included in the next publication run so dependent crates can resolve it

## Validation
- `devenv shell mc validate`