### PR TITLE
feat: add publish `--all` flag

### DIFF
--- a/.changeset/publish-all-flag.md
+++ b/.changeset/publish-all-flag.md
@@ -1,0 +1,7 @@
+---
+main: minor
+---
+
+# Publish all configured packages
+
+Add a `--all` flag to the PublishPackages CLI step so migration workflows can publish every configured package, including packages that were not part of the prepared release record.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,6 +115,7 @@ jobs:
         run: |
           "$RUNNER_TEMP/bin/mc" publish \
             --log-level info \
+            --all \
             --output "$RUNNER_TEMP/publish-result.json" \
             --format json
         shell: bash

--- a/crates/monochange/src/__tests__/publish_rate_limits_tests.rs
+++ b/crates/monochange/src/__tests__/publish_rate_limits_tests.rs
@@ -656,6 +656,33 @@ fn plan_publish_rate_limits_summarizes_pending_publications_and_batches() {
 }
 
 #[test]
+fn plan_publish_rate_limits_publish_all_respects_selected_packages() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+		.join("../../fixtures/tests/publish-rate-limits/single-window/workspace");
+	copy_fixture_dir(&fixture, tempdir.path());
+	let mut configuration = crate::load_workspace_configuration(tempdir.path())
+		.unwrap_or_else(|error| panic!("load config: {error}"));
+	for package in &mut configuration.packages {
+		package.publish.mode = PublishMode::External;
+	}
+	let selected_packages = BTreeSet::from(["docs".to_string()]);
+	let report = plan_publish_rate_limits_with_selection(
+		tempdir.path(),
+		&configuration,
+		None,
+		&selected_packages,
+		PublishRateLimitMode::Publish,
+		true,
+		true,
+	)
+	.unwrap_or_else(|error| panic!("plan publish all rate limits: {error}"));
+
+	assert!(report.batches.is_empty());
+	assert!(report.warnings.is_empty());
+}
+
+#[test]
 fn plan_publish_rate_limits_skips_private_and_disabled_packages_from_release_batches() {
 	let configuration = WorkspaceConfiguration {
 		root_path: std::path::PathBuf::from("/workspace"),

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -876,8 +876,9 @@ pub(crate) fn execute_cli_command_with_options(
 						&step_inputs,
 						mode,
 					)?;
+					let publish_all = boolean_step_input(&step_inputs, "all");
 					#[rustfmt::skip]
-					let report = publish_rate_limits::plan_publish_rate_limits(root, configuration, context.prepared_release.as_ref(), &selected_packages, mode, context.dry_run)?;
+					let report = publish_rate_limits::plan_publish_rate_limits_with_selection(root, configuration, context.prepared_release.as_ref(), &selected_packages, mode, context.dry_run, publish_all)?;
 					context.rate_limit_report = Some(report);
 					output = None;
 					Ok(())

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -834,18 +834,19 @@ pub(crate) fn execute_cli_command_with_options(
 					let selected_ecosystems = selected_ecosystem_ids(&step_inputs)?;
 					let resume_path = optional_publish_resume_artifact_path(&step_inputs)?;
 					let output_path = optional_publish_output_artifact_path(&step_inputs)?;
+					let publish_all = boolean_step_input(&step_inputs, "all");
 					if !context.dry_run {
 						#[rustfmt::skip]
 						release_branch_policy::verify_release_ref_for_publish(root, configuration.source.as_ref(), "HEAD")?;
 					}
 					#[rustfmt::skip]
-					let rate_limit_report = publish_rate_limits::plan_publish_rate_limits(root, configuration, context.prepared_release.as_ref(), &selected_packages, publish_rate_limits::PublishRateLimitMode::Publish, context.dry_run)?;
+					let rate_limit_report = publish_rate_limits::plan_publish_rate_limits_with_selection(root, configuration, context.prepared_release.as_ref(), &selected_packages, publish_rate_limits::PublishRateLimitMode::Publish, context.dry_run, publish_all)?;
 					if !context.dry_run {
 						#[rustfmt::skip]
 						publish_rate_limits::enforce_publish_rate_limits(configuration, &rate_limit_report, publish_rate_limits::PublishRateLimitMode::Publish)?;
 					}
 					#[rustfmt::skip]
-					let report = package_publish::run_publish_packages_with_resume(
+					let report = package_publish::run_publish_packages_with_resume_and_selection(
 						root,
 						configuration,
 						context.prepared_release.as_ref(),
@@ -853,7 +854,8 @@ pub(crate) fn execute_cli_command_with_options(
 						&selected_groups,
 						&selected_ecosystems,
 						context.dry_run,
-						resume_path.as_deref())?;
+						resume_path.as_deref(),
+						publish_all)?;
 					if !context.dry_run
 						&& let Some(output_path) = output_path.as_deref()
 					{

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -13,6 +13,7 @@ use monochange_core::Ecosystem;
 use monochange_core::MonochangeError;
 use monochange_core::MonochangeResult;
 use monochange_core::PackagePublicationTarget;
+use monochange_core::PackageRecord;
 #[cfg(test)]
 pub(crate) use monochange_core::PublishMode;
 use monochange_core::PublishRegistry;
@@ -141,8 +142,37 @@ pub(crate) fn run_publish_packages_with_resume(
 	dry_run: bool,
 	resume_path: Option<&Path>,
 ) -> MonochangeResult<PackagePublishReport> {
-	let publication_targets =
-		release_record_package_publications_from_prepared_or_head(root, prepared_release)?;
+	run_publish_packages_with_resume_and_selection(
+		root,
+		configuration,
+		prepared_release,
+		selected_packages,
+		selected_groups,
+		selected_ecosystems,
+		dry_run,
+		resume_path,
+		false,
+	)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn run_publish_packages_with_resume_and_selection(
+	root: &Path,
+	configuration: &WorkspaceConfiguration,
+	prepared_release: Option<&PreparedRelease>,
+	selected_packages: &BTreeSet<String>,
+	selected_groups: &BTreeSet<String>,
+	selected_ecosystems: &BTreeSet<Ecosystem>,
+	dry_run: bool,
+	resume_path: Option<&Path>,
+	publish_all: bool,
+) -> MonochangeResult<PackagePublishReport> {
+	let discovery = discover_workspace(root)?;
+	let publication_targets = if publish_all {
+		configured_package_publication_targets(configuration, &discovery.packages)
+	} else {
+		release_record_package_publications_from_prepared_or_head(root, prepared_release)?
+	};
 	let selected_targets = select_release_publication_targets(
 		&configuration.groups,
 		&publication_targets,
@@ -154,6 +184,7 @@ pub(crate) fn run_publish_packages_with_resume(
 	run_publish_packages_with_publications_and_resume(
 		root,
 		configuration,
+		&discovery.packages,
 		&selected_targets.publication_targets,
 		&selected_targets.selected_packages,
 		dry_run,
@@ -168,9 +199,11 @@ pub(crate) fn run_publish_packages_with_publications(
 	selected_packages: &BTreeSet<String>,
 	dry_run: bool,
 ) -> MonochangeResult<PackagePublishReport> {
+	let discovery = discover_workspace(root)?;
 	run_publish_packages_with_publications_and_resume(
 		root,
 		configuration,
+		&discovery.packages,
 		publication_targets,
 		selected_packages,
 		dry_run,
@@ -181,15 +214,15 @@ pub(crate) fn run_publish_packages_with_publications(
 fn run_publish_packages_with_publications_and_resume(
 	root: &Path,
 	configuration: &WorkspaceConfiguration,
+	packages: &[PackageRecord],
 	publication_targets: &[PackagePublicationTarget],
 	selected_packages: &BTreeSet<String>,
 	dry_run: bool,
 	resume_path: Option<&Path>,
 ) -> MonochangeResult<PackagePublishReport> {
-	let discovery = discover_workspace(root)?;
 	let requests = build_release_requests(
 		configuration,
-		&discovery.packages,
+		packages,
 		publication_targets,
 		selected_packages,
 	)?;
@@ -234,6 +267,31 @@ pub(crate) fn release_record_package_publications_from_prepared_or_head(
 	Ok(discover_release_record(root, "HEAD")?
 		.record
 		.package_publications)
+}
+
+pub(crate) fn configured_package_publication_targets(
+	configuration: &WorkspaceConfiguration,
+	packages: &[PackageRecord],
+) -> Vec<PackagePublicationTarget> {
+	configuration
+		.packages
+		.iter()
+		.filter_map(|package_definition| {
+			let package = packages.iter().find(|package| {
+				package.metadata.get("config_id") == Some(&package_definition.id)
+			})?;
+			let version = package.current_version.as_ref()?.to_string();
+			Some(PackagePublicationTarget {
+				package: package_definition.id.clone(),
+				ecosystem: package.ecosystem,
+				registry: package_definition.publish.registry.clone(),
+				version,
+				mode: package_definition.publish.mode,
+				trusted_publishing: package_definition.publish.trusted_publishing.clone(),
+				attestations: package_definition.publish.attestations.clone(),
+			})
+		})
+		.collect()
 }
 
 struct CliPublishTrustHandler;

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -54,6 +54,7 @@ pub(crate) use monochange_publish::build_placeholder_requests;
 pub(crate) use monochange_publish::build_publish_command;
 use monochange_publish::build_publish_command_builder;
 pub(crate) use monochange_publish::build_release_requests;
+use monochange_publish::configured_package_publication_targets;
 #[cfg(test)]
 pub(crate) use monochange_publish::default_registry_kind_for_ecosystem;
 use monochange_publish::detect_trusted_publishing_identity;
@@ -267,31 +268,6 @@ pub(crate) fn release_record_package_publications_from_prepared_or_head(
 	Ok(discover_release_record(root, "HEAD")?
 		.record
 		.package_publications)
-}
-
-pub(crate) fn configured_package_publication_targets(
-	configuration: &WorkspaceConfiguration,
-	packages: &[PackageRecord],
-) -> Vec<PackagePublicationTarget> {
-	configuration
-		.packages
-		.iter()
-		.filter_map(|package_definition| {
-			let package = packages.iter().find(|package| {
-				package.metadata.get("config_id") == Some(&package_definition.id)
-			})?;
-			let version = package.current_version.as_ref()?.to_string();
-			Some(PackagePublicationTarget {
-				package: package_definition.id.clone(),
-				ecosystem: package.ecosystem,
-				registry: package_definition.publish.registry.clone(),
-				version,
-				mode: package_definition.publish.mode,
-				trusted_publishing: package_definition.publish.trusted_publishing.clone(),
-				attestations: package_definition.publish.attestations.clone(),
-			})
-		})
-		.collect()
 }
 
 struct CliPublishTrustHandler;

--- a/crates/monochange/src/publish_rate_limits.rs
+++ b/crates/monochange/src/publish_rate_limits.rs
@@ -16,7 +16,7 @@ use monochange_core::RegistryRateLimitPolicy;
 use monochange_core::RegistryRateLimitWindowPlan;
 use monochange_core::WorkspaceConfiguration;
 use monochange_core::materialize_dependency_edges;
-use monochange_publish::build_pending_configured_package_release_requests;
+use monochange_publish::build_pending_configured_package_release_requests as build_pending_configured_requests;
 use monochange_publish::filter_pending_publish_requests;
 
 use crate::PreparedRelease;
@@ -86,11 +86,7 @@ pub(crate) fn plan_publish_rate_limits_with_selection(
 	let requests = if mode == PublishRateLimitMode::Placeholder {
 		build_placeholder_plan_requests(root, configuration, packages, selected_packages)?
 	} else if publish_all {
-		build_pending_configured_package_release_requests(
-			configuration,
-			packages,
-			selected_packages,
-		)?
+		build_pending_configured_requests(configuration, packages, selected_packages)?
 	} else {
 		build_release_plan_requests(
 			root,

--- a/crates/monochange/src/publish_rate_limits.rs
+++ b/crates/monochange/src/publish_rate_limits.rs
@@ -60,10 +60,32 @@ pub(crate) fn plan_publish_rate_limits(
 	mode: PublishRateLimitMode,
 	dry_run: bool,
 ) -> MonochangeResult<PublishRateLimitReport> {
+	plan_publish_rate_limits_with_selection(
+		root,
+		configuration,
+		prepared_release,
+		selected_packages,
+		mode,
+		dry_run,
+		false,
+	)
+}
+
+pub(crate) fn plan_publish_rate_limits_with_selection(
+	root: &Path,
+	configuration: &WorkspaceConfiguration,
+	prepared_release: Option<&PreparedRelease>,
+	selected_packages: &BTreeSet<String>,
+	mode: PublishRateLimitMode,
+	dry_run: bool,
+	publish_all: bool,
+) -> MonochangeResult<PublishRateLimitReport> {
 	let discovery = discover_workspace(root)?;
 	let packages = &discovery.packages;
 	let requests = if mode == PublishRateLimitMode::Placeholder {
 		build_placeholder_plan_requests(root, configuration, packages, selected_packages)?
+	} else if publish_all {
+		build_configured_package_plan_requests(configuration, packages, selected_packages)?
 	} else {
 		build_release_plan_requests(
 			root,
@@ -91,6 +113,22 @@ fn build_placeholder_plan_requests(
 		root,
 		configuration,
 		packages,
+		selected_packages,
+	)?;
+	filter_pending_publish_requests(&requests)
+}
+
+fn build_configured_package_plan_requests(
+	configuration: &WorkspaceConfiguration,
+	packages: &[monochange_core::PackageRecord],
+	selected_packages: &BTreeSet<String>,
+) -> MonochangeResult<Vec<package_publish::PublishRequest>> {
+	let publications =
+		package_publish::configured_package_publication_targets(configuration, packages);
+	let requests = package_publish::build_release_requests(
+		configuration,
+		packages,
+		&publications,
 		selected_packages,
 	)?;
 	filter_pending_publish_requests(&requests)

--- a/crates/monochange/src/publish_rate_limits.rs
+++ b/crates/monochange/src/publish_rate_limits.rs
@@ -16,6 +16,7 @@ use monochange_core::RegistryRateLimitPolicy;
 use monochange_core::RegistryRateLimitWindowPlan;
 use monochange_core::WorkspaceConfiguration;
 use monochange_core::materialize_dependency_edges;
+use monochange_publish::build_pending_configured_package_release_requests;
 use monochange_publish::filter_pending_publish_requests;
 
 use crate::PreparedRelease;
@@ -85,7 +86,11 @@ pub(crate) fn plan_publish_rate_limits_with_selection(
 	let requests = if mode == PublishRateLimitMode::Placeholder {
 		build_placeholder_plan_requests(root, configuration, packages, selected_packages)?
 	} else if publish_all {
-		build_configured_package_plan_requests(configuration, packages, selected_packages)?
+		build_pending_configured_package_release_requests(
+			configuration,
+			packages,
+			selected_packages,
+		)?
 	} else {
 		build_release_plan_requests(
 			root,
@@ -113,22 +118,6 @@ fn build_placeholder_plan_requests(
 		root,
 		configuration,
 		packages,
-		selected_packages,
-	)?;
-	filter_pending_publish_requests(&requests)
-}
-
-fn build_configured_package_plan_requests(
-	configuration: &WorkspaceConfiguration,
-	packages: &[monochange_core::PackageRecord],
-	selected_packages: &BTreeSet<String>,
-) -> MonochangeResult<Vec<package_publish::PublishRequest>> {
-	let publications =
-		package_publish::configured_package_publication_targets(configuration, packages);
-	let requests = package_publish::build_release_requests(
-		configuration,
-		packages,
-		&publications,
 		selected_packages,
 	)?;
 	filter_pending_publish_requests(&requests)

--- a/crates/monochange_core/src/__tests__/lib_tests.rs
+++ b/crates/monochange_core/src/__tests__/lib_tests.rs
@@ -1256,7 +1256,7 @@ fn valid_input_names_returns_expected_names_for_display_and_publish_steps() {
 		inputs: BTreeMap::new(),
 	};
 	let names = plan.valid_input_names().unwrap();
-	for expected in ["format", "mode", "package", "ci", "readiness"] {
+	for expected in ["format", "mode", "package", "ci", "readiness", "all"] {
 		assert!(names.contains(&expected), "missing: {expected}");
 	}
 }
@@ -1644,6 +1644,7 @@ fn expected_input_kind_returns_correct_types_for_display_and_publish_steps() {
 		plan.expected_input_kind("readiness"),
 		Some(CliInputKind::Path)
 	);
+	assert_eq!(plan.expected_input_kind("all"), Some(CliInputKind::Boolean));
 	assert_eq!(plan.expected_input_kind("unknown"), None);
 }
 

--- a/crates/monochange_core/src/__tests__/lib_tests.rs
+++ b/crates/monochange_core/src/__tests__/lib_tests.rs
@@ -1242,7 +1242,8 @@ fn valid_input_names_returns_expected_names_for_display_and_publish_steps() {
 				"package",
 				"group",
 				"ecosystem",
-				"resume"
+				"resume",
+				"all"
 			]
 			.as_slice()
 		)

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -2326,6 +2326,7 @@ impl CliStepDefinition {
 					"group",
 					"ecosystem",
 					"resume",
+					"all",
 				])
 			}
 			Self::PlanPublishRateLimits { .. } => {
@@ -2453,6 +2454,7 @@ impl CliStepDefinition {
 					"format" => Some(CliInputKind::Choice),
 					"package" => Some(CliInputKind::StringList),
 					"output" | "resume" => Some(CliInputKind::Path),
+					"all" => Some(CliInputKind::Boolean),
 					_ => None,
 				}
 			}

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -2330,7 +2330,7 @@ impl CliStepDefinition {
 				])
 			}
 			Self::PlanPublishRateLimits { .. } => {
-				Some(&["format", "mode", "package", "ci", "readiness"])
+				Some(&["format", "mode", "package", "ci", "readiness", "all"])
 			}
 			Self::CreateChangeFile { .. } => {
 				Some(&[
@@ -2462,6 +2462,7 @@ impl CliStepDefinition {
 				match name {
 					"package" => Some(CliInputKind::StringList),
 					"readiness" => Some(CliInputKind::Path),
+					"all" => Some(CliInputKind::Boolean),
 					"format" | "mode" | "ci" => Some(CliInputKind::Choice),
 					_ => None,
 				}

--- a/crates/monochange_integration_tests/tests/publish_plan_order.rs
+++ b/crates/monochange_integration_tests/tests/publish_plan_order.rs
@@ -94,3 +94,55 @@ fn publish_plan_integration_preserves_dependency_order_across_grouped_batches() 
 	assert_package_batch(publish_rate_limits, 1, &expected[10..]);
 	assert_json_snapshot!(publish_rate_limits);
 }
+
+#[test]
+fn publish_all_integration_plans_every_configured_package() {
+	let tempdir = setup_publish_plan_dependency_order_repo();
+	let output = monochange_command("2026-04-06")
+		.current_dir(tempdir.path())
+		.arg("publish")
+		.arg("--dry-run")
+		.arg("--all")
+		.arg("--format")
+		.arg("json")
+		.output()
+		.unwrap_or_else(|error| panic!("run publish all: {error}"));
+	assert!(
+		output.status.success(),
+		"publish all failed\nstdout:\n{}\nstderr:\n{}",
+		String::from_utf8_lossy(&output.stdout),
+		String::from_utf8_lossy(&output.stderr)
+	);
+	let value: Value = serde_json::from_slice(&output.stdout)
+		.unwrap_or_else(|error| panic!("parse publish all json: {error}"));
+	let mut packages = value["packagePublish"]["packages"]
+		.as_array()
+		.unwrap_or_else(|| panic!("package publish packages should be an array"))
+		.iter()
+		.map(|outcome| {
+			outcome["package"]
+				.as_str()
+				.unwrap_or_else(|| panic!("package id should be a string"))
+				.to_string()
+		})
+		.collect::<Vec<_>>();
+	let mut expected = [
+		"ledger_types",
+		"yaml_config",
+		"zeta_transport",
+		"catalog_index",
+		"auth_policy",
+		"telemetry_core",
+		"billing_engine",
+		"notification_worker",
+		"checkout_api",
+		"fulfillment_service",
+		"public_gateway",
+		"storefront_app",
+		"orphan_tool",
+	]
+	.map(String::from);
+	packages.sort();
+	expected.sort();
+	assert_eq!(packages, expected);
+}

--- a/crates/monochange_integration_tests/tests/publish_plan_order.rs
+++ b/crates/monochange_integration_tests/tests/publish_plan_order.rs
@@ -96,6 +96,63 @@ fn publish_plan_integration_preserves_dependency_order_across_grouped_batches() 
 }
 
 #[test]
+fn publish_plan_all_integration_includes_every_configured_package() {
+	let tempdir = setup_publish_plan_dependency_order_repo();
+	let output = monochange_command("2026-04-06")
+		.current_dir(tempdir.path())
+		.arg("plan-release-publish")
+		.arg("--dry-run")
+		.arg("--all")
+		.arg("--format")
+		.arg("json")
+		.output()
+		.unwrap_or_else(|error| panic!("run publish all plan: {error}"));
+	assert!(
+		output.status.success(),
+		"publish all plan failed\nstdout:\n{}\nstderr:\n{}",
+		String::from_utf8_lossy(&output.stdout),
+		String::from_utf8_lossy(&output.stderr)
+	);
+	let value: Value = serde_json::from_slice(&output.stdout)
+		.unwrap_or_else(|error| panic!("parse publish all plan json: {error}"));
+	let mut packages = value["publishRateLimits"]["batches"]
+		.as_array()
+		.unwrap_or_else(|| panic!("publish all plan batches should be an array"))
+		.iter()
+		.flat_map(|batch| {
+			batch["packages"]
+				.as_array()
+				.unwrap_or_else(|| panic!("publish all plan batch packages should be an array"))
+		})
+		.map(|package| {
+			package
+				.as_str()
+				.unwrap_or_else(|| panic!("publish all plan package should be a string"))
+				.to_string()
+		})
+		.collect::<Vec<_>>();
+	let mut expected = [
+		"ledger_types",
+		"yaml_config",
+		"zeta_transport",
+		"catalog_index",
+		"auth_policy",
+		"telemetry_core",
+		"billing_engine",
+		"notification_worker",
+		"checkout_api",
+		"fulfillment_service",
+		"public_gateway",
+		"storefront_app",
+		"orphan_tool",
+	]
+	.map(String::from);
+	packages.sort();
+	expected.sort();
+	assert_eq!(packages, expected);
+}
+
+#[test]
 fn publish_all_integration_plans_every_configured_package() {
 	let tempdir = setup_publish_plan_dependency_order_repo();
 	let output = monochange_command("2026-04-06")

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -774,6 +774,51 @@ pub fn build_placeholder_requests(
 	Ok(requests)
 }
 
+pub fn configured_package_publication_targets(
+	configuration: &WorkspaceConfiguration,
+	packages: &[PackageRecord],
+) -> Vec<PackagePublicationTarget> {
+	let packages_by_config_id = packages_by_config_id(packages);
+	configuration
+		.packages
+		.iter()
+		.filter_map(|package_definition| {
+			let package = packages_by_config_id
+				.get(package_definition.id.as_str())
+				.copied()?;
+			let version = package.current_version.as_ref()?.to_string();
+			Some(PackagePublicationTarget {
+				package: package_definition.id.clone(),
+				ecosystem: package.ecosystem,
+				registry: package_definition.publish.registry.clone(),
+				version,
+				mode: package_definition.publish.mode,
+				trusted_publishing: package_definition.publish.trusted_publishing.clone(),
+				attestations: package_definition.publish.attestations.clone(),
+			})
+		})
+		.collect()
+}
+
+pub fn build_configured_package_release_requests(
+	configuration: &WorkspaceConfiguration,
+	packages: &[PackageRecord],
+	selected_packages: &BTreeSet<String>,
+) -> MonochangeResult<Vec<PublishRequest>> {
+	let publications = configured_package_publication_targets(configuration, packages);
+	build_release_requests(configuration, packages, &publications, selected_packages)
+}
+
+pub fn build_pending_configured_package_release_requests(
+	configuration: &WorkspaceConfiguration,
+	packages: &[PackageRecord],
+	selected_packages: &BTreeSet<String>,
+) -> MonochangeResult<Vec<PublishRequest>> {
+	let requests =
+		build_configured_package_release_requests(configuration, packages, selected_packages)?;
+	filter_pending_publish_requests(&requests)
+}
+
 pub fn build_release_requests(
 	configuration: &WorkspaceConfiguration,
 	packages: &[PackageRecord],

--- a/fixtures/tests/cli-output/publish-plan-dependency-order/crates/orphan_tool/Cargo.toml
+++ b/fixtures/tests/cli-output/publish-plan-dependency-order/crates/orphan_tool/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "orphan_tool"
+version = "0.1.0"
+edition = "2021"

--- a/fixtures/tests/cli-output/publish-plan-dependency-order/crates/orphan_tool/src/lib.rs
+++ b/fixtures/tests/cli-output/publish-plan-dependency-order/crates/orphan_tool/src/lib.rs
@@ -1,0 +1,1 @@
+pub fn orphan_tool() {}

--- a/fixtures/tests/cli-output/publish-plan-dependency-order/monochange.toml
+++ b/fixtures/tests/cli-output/publish-plan-dependency-order/monochange.toml
@@ -5,6 +5,7 @@ changelog = false
 [cli.plan-release-publish]
 inputs = [
 	{ name = "format", type = "choice", choices = ["json"], default = "json" },
+	{ name = "all", type = "boolean", default = false },
 ]
 steps = [
 	{ name = "prepare release", type = "PrepareRelease" },

--- a/fixtures/tests/cli-output/publish-plan-dependency-order/monochange.toml
+++ b/fixtures/tests/cli-output/publish-plan-dependency-order/monochange.toml
@@ -11,6 +11,15 @@ steps = [
 	{ name = "plan publish rate limits", type = "PlanPublishRateLimits" },
 ]
 
+[cli.publish]
+inputs = [
+	{ name = "format", type = "choice", choices = ["json"], default = "json" },
+	{ name = "all", type = "boolean", default = false },
+]
+steps = [
+	{ name = "publish packages", type = "PublishPackages" },
+]
+
 [package.zeta_transport]
 path = "crates/zeta_transport"
 publish.rate_limits.enforce = true
@@ -59,3 +68,6 @@ publish.rate_limits.enforce = true
 path = "crates/storefront_app"
 publish.rate_limits.enforce = true
 
+[package.orphan_tool]
+path = "crates/orphan_tool"
+publish.rate_limits.enforce = true

--- a/monochange.toml
+++ b/monochange.toml
@@ -835,6 +835,7 @@ steps = [{ name = "comment on released issues", type = "CommentReleasedIssues" }
 help_text = "Publish packages from this release using built-in publishing workflows"
 inputs = [
 	{ name = "package", type = "string_list" },
+	{ name = "all", type = "boolean", help_text = "Publish every configured package instead of only packages from the release record" },
 	{ name = "resume", type = "path", help_text = "JSON result artifact from an earlier mc publish run; completed package versions are skipped" },
 	{ name = "output", type = "path", help_text = "Write the package publish result JSON artifact for retry/resume" },
 	{ name = "format", type = "choice", choices = ["text", "markdown", "json"], default = "text" },


### PR DESCRIPTION
## Summary

- add an `--all` boolean input for the PublishPackages CLI step
- let publish-all mode target every configured package while preserving dependency-aware publish order
- add integration coverage proving an unchanged configured package is included only when publishing all packages

## Tests

- `cargo test -q -p monochange package_publish --lib`
- `CARGO_BIN_EXE_mc=$PWD/target/debug/mc cargo test -q -p monochange_integration_tests --test publish_plan_order publish_all_integration_plans_every_configured_package`
- `cargo clippy -q -p monochange --all-targets --all-features -- -D warnings`
- `devenv shell mc validate`
