### PR TITLE
fix(schema): allow lints table in monochange config schema

### DIFF
--- a/.changeset/schema-lints-table.md
+++ b/.changeset/schema-lints-table.md
@@ -1,0 +1,8 @@
+---
+monochange_config: patch
+monochange_schema: patch
+---
+
+# Add lints to the monochange config schema
+
+Allow the top-level `[lints]` table in generated `monochange.toml` JSON Schema assets. The lint configuration schema is intentionally permissive so all current and future lint rule shapes are accepted by editors and TOML language servers.

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -201,7 +201,7 @@ pub(crate) struct RawWorkspaceConfiguration {
 	#[serde(default)]
 	source: Option<RawSourceConfiguration>,
 	#[serde(default)]
-	#[cfg_attr(feature = "schema", schemars(skip))]
+	#[cfg_attr(feature = "schema", schemars(with = "serde_json::Value"))]
 	lints: WorkspaceLintSettings,
 	#[serde(default)]
 	ecosystems: RawEcosystems,

--- a/crates/monochange_integration_tests/tests/schema_assets.rs
+++ b/crates/monochange_integration_tests/tests/schema_assets.rs
@@ -143,13 +143,17 @@ fn config_schema_covers_current_root_toml_top_level_keys() -> Result<(), Box<dyn
 	assert!(!json_bool(&schema, "/additionalProperties")?);
 
 	for key in config_table.keys() {
-		// Schema generation skips lints because the lint type tree is complex
-		if key == "lints" {
-			continue;
-		}
 		assert!(
 			schema_properties.contains_key(key),
 			"config schema is missing root monochange.toml key `{key}`"
+		);
+	}
+
+	let lints_schema = json_object(&schema, "/properties/lints")?;
+	for keyword in ["additionalProperties", "properties", "type"] {
+		assert!(
+			!lints_schema.contains_key(keyword),
+			"lints schema should not restrict lint rule shapes with `{keyword}`"
 		);
 	}
 

--- a/crates/monochange_schema/schemas/monochange.schema.json
+++ b/crates/monochange_schema/schemas/monochange.schema.json
@@ -2015,6 +2015,16 @@
 			},
 			"type": "object"
 		},
+		"lints": {
+			"default": {
+				"disable_gitignore": false,
+				"exclude": [],
+				"include": [],
+				"rules": {},
+				"scopes": [],
+				"use": []
+			}
+		},
 		"package": {
 			"additionalProperties": {
 				"$ref": "#/$defs/packageDefinition"

--- a/docs/src/schemas/monochange.schema.json
+++ b/docs/src/schemas/monochange.schema.json
@@ -2015,6 +2015,16 @@
 			},
 			"type": "object"
 		},
+		"lints": {
+			"default": {
+				"disable_gitignore": false,
+				"exclude": [],
+				"include": [],
+				"rules": {},
+				"scopes": [],
+				"use": []
+			}
+		},
 		"package": {
 			"additionalProperties": {
 				"$ref": "#/$defs/packageDefinition"

--- a/docs/src/schemas/monochange.v0.1.schema.json
+++ b/docs/src/schemas/monochange.v0.1.schema.json
@@ -2015,6 +2015,16 @@
 			},
 			"type": "object"
 		},
+		"lints": {
+			"default": {
+				"disable_gitignore": false,
+				"exclude": [],
+				"include": [],
+				"rules": {},
+				"scopes": [],
+				"use": []
+			}
+		},
 		"package": {
 			"additionalProperties": {
 				"$ref": "#/$defs/packageDefinition"


### PR DESCRIPTION
## Summary

- Adds the top-level `lints` property to generated `monochange.toml` JSON Schema assets
- Keeps the lint configuration schema intentionally permissive so all lint rule shapes are accepted
- Updates schema asset integration tests to require `lints` coverage and verify it remains unrestricted
- Adds a changeset for `monochange_config` and `monochange_schema`

## Validation

- `cargo test -p monochange_integration_tests --test schema_assets`
- `cargo run -p xtask -- schema check`
- `cargo test -p monochange_config --features schema --lib`
- `cargo check --workspace --all-features --all-targets`
- `devenv shell mc validate`