### PR TITLE
fix: improve custom command argument errors

### DIFF
--- a/.changeset/custom-command-argument-errors.md
+++ b/.changeset/custom-command-argument-errors.md
@@ -1,0 +1,7 @@
+---
+"monochange": patch
+---
+
+# Improve custom command argument errors
+
+Unexpected arguments passed to configured CLI commands now show a focused diagnostic with the explicit usage, the `monochange.toml` section to edit, and an example input definition.

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -969,6 +969,91 @@ fn mcp_and_root_command_support_quiet_and_missing_subcommands() {
 }
 
 #[test]
+fn custom_command_unexpected_argument_error_explains_configured_inputs() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	fs::write(
+		root.join("monochange.toml"),
+		r#"
+[cli.publish]
+help_text = "Publish packages"
+inputs = [
+	{ name = "package", type = "string_list" },
+	{ name = "format", type = "choice", choices = ["text", "json"], default = "text" },
+]
+steps = [{ name = "noop", type = "Command", command = "true" }]
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write config: {error}"));
+
+	let error = run_cli(
+		root,
+		[
+			OsString::from("mc"),
+			OsString::from("publish"),
+			OsString::from("--all"),
+		],
+	)
+	.expect_err("unexpected custom command input should fail");
+	let report = error.render();
+
+	assert!(report.contains("✖ Unexpected command input"));
+	assert!(report.contains("Argument --all is not declared for custom command mc publish"));
+	assert!(
+		report
+			.contains("Usage:\n  mc publish [--dry-run] [--package <PACKAGE>] [--format <FORMAT>]")
+	);
+	assert!(report.contains("This command comes from [cli.publish] in monochange.toml"));
+	assert!(report.contains("{ name = \"all\", type = \"boolean\" }"));
+	assert!(!report.contains("config error: error:"));
+	assert!(!report.contains("[OPTIONS]"));
+}
+
+#[test]
+fn cli_command_usage_lists_configured_options() {
+	let cli_command = CliCommandDefinition {
+		name: "publish".to_string(),
+		help_text: Some("Publish packages".to_string()),
+		inputs: vec![
+			CliInputDefinition {
+				name: "package".to_string(),
+				kind: CliInputKind::StringList,
+				help_text: None,
+				required: false,
+				default: None,
+				choices: Vec::new(),
+				short: None,
+			},
+			CliInputDefinition {
+				name: "output".to_string(),
+				kind: CliInputKind::Path,
+				help_text: None,
+				required: false,
+				default: None,
+				choices: Vec::new(),
+				short: None,
+			},
+			CliInputDefinition {
+				name: "all".to_string(),
+				kind: CliInputKind::Boolean,
+				help_text: None,
+				required: false,
+				default: None,
+				choices: Vec::new(),
+				short: None,
+			},
+		],
+		steps: Vec::new(),
+		dry_run: false,
+	};
+
+	assert_eq!(
+		crate::cli::cli_command_usage(&cli_command),
+		"mc publish [--dry-run] [--package <PACKAGE>] [--output <PATH>] [--all]"
+	);
+}
+
+#[test]
 fn release_record_supports_json_output() {
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	let root = tempdir.path();

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -971,8 +971,12 @@ fn mcp_and_root_command_support_quiet_and_missing_subcommands() {
 #[test]
 fn custom_command_diagnostic_colorizes_terminal_output() {
 	assert_eq!(
-		crate::colorize("hello", "1;31", true),
-		"\x1b[1;31mhello\x1b[0m"
+		crate::paint("hello", crate::cli_theme::error(), true),
+		format!(
+			"{}hello{:#}",
+			crate::cli_theme::error(),
+			crate::cli_theme::error()
+		)
 	);
 }
 

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -969,6 +969,14 @@ fn mcp_and_root_command_support_quiet_and_missing_subcommands() {
 }
 
 #[test]
+fn custom_command_diagnostic_colorizes_terminal_output() {
+	assert_eq!(
+		crate::colorize("hello", "1;31", true),
+		"\x1b[1;31mhello\x1b[0m"
+	);
+}
+
+#[test]
 fn custom_command_unexpected_argument_error_explains_configured_inputs() {
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	let root = tempdir.path();

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -821,9 +821,11 @@ pub(crate) fn build_cli_command_subcommand(cli_command: &CliCommandDefinition) -
 		.help_text
 		.clone()
 		.unwrap_or_else(|| format!("Run the `{}` command", cli_command.name));
+	let usage = cli_command_usage(cli_command);
 
 	let mut command = Command::new(leak_string(cli_command.name.clone()))
 		.about(help_text)
+		.override_usage(usage)
 		.arg(
 			Arg::new("dry-run")
 				.long("dry-run")
@@ -1019,6 +1021,42 @@ Tagging notes:
 			)
 		}
 		_ => None,
+	}
+}
+
+pub(crate) fn cli_command_usage(cli_command: &CliCommandDefinition) -> String {
+	let mut parts = vec![
+		"mc".to_string(),
+		cli_command.name.clone(),
+		"[--dry-run]".to_string(),
+	];
+
+	if command_supports_release_diff_preview(cli_command) {
+		parts.push("[--diff]".to_string());
+		parts.push("[--prepared-release <PATH>]".to_string());
+	}
+
+	parts.extend(cli_command.inputs.iter().map(cli_input_usage));
+	parts.join(" ")
+}
+
+pub(crate) fn cli_input_usage(input: &CliInputDefinition) -> String {
+	let long_name = input.name.replace('_', "-");
+	let value_name = match input.kind {
+		CliInputKind::Boolean => None,
+		CliInputKind::Path => Some("PATH".to_string()),
+		CliInputKind::String | CliInputKind::StringList | CliInputKind::Choice => {
+			Some(input.name.to_uppercase())
+		}
+	};
+	let option = value_name.map_or_else(
+		|| format!("--{long_name}"),
+		|name| format!("--{long_name} <{name}>"),
+	);
+	if input.required {
+		option
+	} else {
+		format!("[{option}]")
 	}
 }
 

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -706,6 +706,59 @@ fn format_clap_error(error: &clap::Error, colored: bool) -> String {
 	}
 }
 
+fn colorize(text: &str, code: &str, colored: bool) -> String {
+	if colored {
+		format!("\x1b[{code}m{text}\x1b[0m")
+	} else {
+		text.to_string()
+	}
+}
+
+fn unexpected_argument_from_error(error: &clap::Error) -> Option<String> {
+	let message = error.to_string();
+	let (_, rest) = message.split_once("unexpected argument '")?;
+	let (argument, _) = rest.split_once('\'')?;
+	Some(argument.to_string())
+}
+
+fn custom_command_name_from_args(
+	args: &[OsString],
+	cli: &[CliCommandDefinition],
+) -> Option<String> {
+	args.iter()
+		.skip(1)
+		.filter_map(|arg| arg.to_str())
+		.find_map(|arg| {
+			cli.iter()
+				.any(|command| command.name == arg)
+				.then(|| arg.to_string())
+		})
+}
+
+fn render_custom_command_argument_error(
+	error: &clap::Error,
+	cli_command: &CliCommandDefinition,
+	colored: bool,
+) -> String {
+	let command = format!("mc {}", cli_command.name);
+	let argument =
+		unexpected_argument_from_error(error).unwrap_or_else(|| "the supplied option".to_string());
+	let heading = colorize("✖ Unexpected command input", "1;31", colored);
+	let argument = colorize(&argument, "1;33", colored);
+	let command = colorize(&command, "1", colored);
+	let config_path = colorize(&format!("[cli.{}]", cli_command.name), "36", colored);
+	let usage = colorize("Usage", "1;34", colored);
+	let fix = colorize("How to fix", "1;34", colored);
+
+	format!(
+		"{heading}\n\n  Argument {argument} is not declared for custom command {command}.\n\n{usage}:\n  {}\n\n{fix}:\n  This command comes from {config_path} in monochange.toml.\n  Add a matching input there to make this option valid, for example:\n\n    [cli.{}]\n    inputs = [\n      {{ name = \"{}\", type = \"boolean\" }},\n    ]\n\n  Then run `mc help {}` to confirm the option is listed.",
+		cli::cli_command_usage(cli_command),
+		cli_command.name,
+		argument.trim_start_matches('-').replace('-', "_"),
+		cli_command.name
+	)
+}
+
 /// control both the argv payload and the workspace root used for config loading
 /// and command execution.
 #[doc(hidden)]
@@ -723,7 +776,7 @@ where
 	let cli = cli_commands_from_config(&configuration);
 	let quiet = extract_quiet_from_args(args.iter().cloned());
 	let root_help_requested = is_root_help_request(&args);
-	let matches = match build_command_with_cli(bin_name, &cli).try_get_matches_from(args) {
+	let matches = match build_command_with_cli(bin_name, &cli).try_get_matches_from(args.clone()) {
 		Ok(matches) => matches,
 		Err(error)
 			if matches!(
@@ -740,7 +793,21 @@ where
 				!cfg!(test) && std::io::stdout().is_terminal(),
 			));
 		}
-		Err(error) => return Err(MonochangeError::Config(error.to_string())),
+		Err(error) => {
+			if matches!(error.kind(), ErrorKind::UnknownArgument)
+				&& let Some(command_name) = custom_command_name_from_args(&args, &cli)
+				&& let Some(cli_command) = cli.iter().find(|command| command.name == command_name)
+			{
+				return Err(MonochangeError::Diagnostic(
+					render_custom_command_argument_error(
+						&error,
+						cli_command,
+						!cfg!(test) && std::io::stderr().is_terminal(),
+					),
+				));
+			}
+			return Err(MonochangeError::Config(error.to_string()));
+		}
 	};
 
 	let jq_expression = matches.get_one::<String>("jq").cloned();

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -706,9 +706,9 @@ fn format_clap_error(error: &clap::Error, colored: bool) -> String {
 	}
 }
 
-fn colorize(text: &str, code: &str, colored: bool) -> String {
+fn paint(text: &str, style: anstyle::Style, colored: bool) -> String {
 	if colored {
-		format!("\x1b[{code}m{text}\x1b[0m")
+		format!("{style}{text}{style:#}")
 	} else {
 		text.to_string()
 	}
@@ -743,12 +743,16 @@ fn render_custom_command_argument_error(
 	let command = format!("mc {}", cli_command.name);
 	let argument =
 		unexpected_argument_from_error(error).unwrap_or_else(|| "the supplied option".to_string());
-	let heading = colorize("✖ Unexpected command input", "1;31", colored);
-	let argument = colorize(&argument, "1;33", colored);
-	let command = colorize(&command, "1", colored);
-	let config_path = colorize(&format!("[cli.{}]", cli_command.name), "36", colored);
-	let usage = colorize("Usage", "1;34", colored);
-	let fix = colorize("How to fix", "1;34", colored);
+	let heading = paint("✖ Unexpected command input", cli_theme::error(), colored);
+	let argument = paint(&argument, cli_theme::literal(), colored);
+	let command = paint(&command, cli_theme::usage(), colored);
+	let config_path = paint(
+		&format!("[cli.{}]", cli_command.name),
+		cli_theme::header(),
+		colored,
+	);
+	let usage = paint("Usage", cli_theme::header(), colored);
+	let fix = paint("How to fix", cli_theme::header(), colored);
 
 	format!(
 		"{heading}\n\n  Argument {argument} is not declared for custom command {command}.\n\n{usage}:\n  {}\n\n{fix}:\n  This command comes from {config_path} in monochange.toml.\n  Add a matching input there to make this option valid, for example:\n\n    [cli.{}]\n    inputs = [\n      {{ name = \"{}\", type = \"boolean\" }},\n    ]\n\n  Then run `mc help {}` to confirm the option is listed.",

--- a/crates/monochange/tests/snapshots/cli_output__change_cli_help_documents_package_and_group_targeting_rules@change_cli_help_documents_package_and_group_targeting_rules.snap
+++ b/crates/monochange/tests/snapshots/cli_output__change_cli_help_documents_package_and_group_targeting_rules@change_cli_help_documents_package_and_group_targeting_rules.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/monochange/tests/cli_output.rs
+assertion_line: 184
 info:
   program: mc
   args:
@@ -14,7 +15,7 @@ exit_code: 0
 ----- stdout -----
 Create a change file for one or more packages
 
-Usage: mc change [OPTIONS]
+Usage: mc change [--dry-run] [--interactive] [--package <PACKAGE>] [--bump <BUMP>] [--version <VERSION>] [--reason <REASON>] [--type <TYPE>] [--caused-by <CAUSED_BY>] [--details <DETAILS>] [--output <PATH>]
 
 Options:
       --dry-run                   Run the command in dry-run mode when supported


### PR DESCRIPTION
## Summary
- replace generic custom command usage with explicit configured options
- render unexpected custom command arguments as a focused diagnostic with config guidance
- add unit coverage for the diagnostic and usage formatting

## Testing
- `cargo test -q -p monochange custom_command_unexpected_argument_error_explains_configured_inputs`
- `cargo test -q -p monochange cli_command_usage_lists_configured_options`
- `cargo clippy -q -p monochange --all-targets --all-features -- -D warnings`
- `devenv shell mc validate`
