### PR TITLE
fix: include cargo dev dependencies in publish order

### DIFF
--- a/.changeset/cargo-dev-dependency-publish-order.md
+++ b/.changeset/cargo-dev-dependency-publish-order.md
@@ -1,0 +1,8 @@
+---
+monochange: patch
+monochange_publish: patch
+---
+
+# Include Cargo development dependencies in publish ordering
+
+Cargo package publishing now orders runtime, build, and development dependencies before dependents. This prevents a crate from being published before an unpublished workspace crate referenced through `dev-dependencies` or `build-dependencies`.

--- a/crates/monochange/src/__tests__/package_publish_tests.rs
+++ b/crates/monochange/src/__tests__/package_publish_tests.rs
@@ -1986,7 +1986,7 @@ fn build_release_requests_detects_publish_relevant_dependency_cycles() {
 }
 
 #[test]
-fn build_release_requests_ignores_development_dependency_cycles() {
+fn build_release_requests_reports_development_dependency_cycles() {
 	let configuration = sample_configuration(&[
 		("core", monochange_core::PackageType::Npm, true),
 		("utils", monochange_core::PackageType::Npm, true),
@@ -2008,15 +2008,13 @@ fn build_release_requests_ignores_development_dependency_cycles() {
 		sample_npm_publication("core"),
 	];
 
-	let requests =
-		build_release_requests(&configuration, &packages, &publications, &BTreeSet::new())
-			.expect("development-only dependency cycles should not fail");
-	let ordered_package_ids = requests
-		.iter()
-		.map(|request| request.package_id.as_str())
-		.collect::<Vec<_>>();
+	let error = build_release_requests(&configuration, &packages, &publications, &BTreeSet::new())
+		.expect_err("development dependency cycles should fail");
+	let message = error.to_string();
 
-	assert_eq!(ordered_package_ids, vec!["core", "utils"]);
+	assert!(message.contains("cyclic publish dependencies detected"));
+	assert!(message.contains("core -> utils"));
+	assert!(message.contains("utils -> core"));
 }
 
 #[test]

--- a/crates/monochange/src/__tests__/package_publish_tests.rs
+++ b/crates/monochange/src/__tests__/package_publish_tests.rs
@@ -3479,6 +3479,135 @@ fn execute_publish_requests_publishes_release_with_trust_outcome() {
 }
 
 #[test]
+fn release_dry_run_orders_cargo_dev_and_build_dependencies_before_dependents() {
+	let expected_order = vec![
+		"zephyr-build",
+		"lima-dev",
+		"quartz-build",
+		"ember-dev",
+		"nyx-build",
+		"cedar-dev",
+		"violet-build",
+		"osprey-build",
+		"delta-dev",
+		"amber-dev",
+		"mango-build",
+		"sable-dev",
+		"orbit-build",
+		"binary-build",
+		"atlas-dev",
+		"config",
+	];
+	let packages = [
+		("config", Some(("build-dependencies", "atlas-dev"))),
+		("atlas-dev", Some(("build-dependencies", "binary-build"))),
+		("binary-build", Some(("dev-dependencies", "orbit-build"))),
+		("orbit-build", Some(("build-dependencies", "sable-dev"))),
+		("sable-dev", Some(("dev-dependencies", "mango-build"))),
+		("mango-build", Some(("build-dependencies", "amber-dev"))),
+		("amber-dev", Some(("dev-dependencies", "delta-dev"))),
+		("delta-dev", Some(("build-dependencies", "osprey-build"))),
+		("osprey-build", Some(("dev-dependencies", "violet-build"))),
+		("violet-build", Some(("build-dependencies", "cedar-dev"))),
+		("cedar-dev", Some(("dev-dependencies", "nyx-build"))),
+		("nyx-build", Some(("build-dependencies", "ember-dev"))),
+		("ember-dev", Some(("dev-dependencies", "quartz-build"))),
+		("quartz-build", Some(("build-dependencies", "lima-dev"))),
+		("lima-dev", Some(("dev-dependencies", "zephyr-build"))),
+		("zephyr-build", None),
+	];
+	let server = MockServer::start();
+	for (package, _) in packages {
+		server.mock(|when, then| {
+			when.method(GET).path(format!("/crates/{package}"));
+			then.status(404);
+		});
+	}
+
+	let root = tempfile::tempdir().expect("tempdir:");
+	let members = packages
+		.iter()
+		.map(|(package, _)| format!("\"{package}\""))
+		.collect::<Vec<_>>()
+		.join(", ");
+	fs::write(
+		root.path().join("Cargo.toml"),
+		format!("[workspace]\nmembers = [{members}]\nresolver = \"2\"\n"),
+	)
+	.expect("write workspace manifest:");
+
+	for (package, dependency) in packages {
+		let package_dir = root.path().join(package);
+		fs::create_dir_all(package_dir.join("src")).expect("mkdir package:");
+		fs::write(package_dir.join("src/lib.rs"), "").expect("write package lib:");
+
+		let dependency_section = dependency.map_or_else(String::new, |(kind, dependency)| {
+			format!(
+				"\n[{kind}]\n{dependency} = {{ path = \"../{dependency}\", version = \"1.0.0\" }}\n"
+			)
+		});
+		fs::write(
+			package_dir.join("Cargo.toml"),
+			format!(
+				concat!(
+					"[package]\n",
+					"name = \"{package}\"\n",
+					"version = \"1.0.0\"\n",
+					"edition = \"2021\"\n",
+					"license = \"MIT\"\n",
+					"description = \"test package\"\n",
+					"{dependency_section}"
+				),
+				package = package,
+				dependency_section = dependency_section,
+			),
+		)
+		.expect("write package manifest:");
+	}
+
+	let configuration_packages = packages
+		.iter()
+		.map(|(package, _)| (*package, monochange_core::PackageType::Cargo, true))
+		.collect::<Vec<_>>();
+	let configuration = sample_configuration(&configuration_packages);
+	let publications = packages
+		.into_iter()
+		.map(|(package, _)| {
+			PackagePublicationTarget {
+				package: package.to_string(),
+				ecosystem: Ecosystem::Cargo,
+				registry: Some(PublishRegistry::Builtin(RegistryKind::CratesIo)),
+				version: "1.0.0".to_string(),
+				mode: PublishMode::Builtin,
+				trusted_publishing: TrustedPublishingSettings::default(),
+				attestations: PublishAttestationSettings::default(),
+			}
+		})
+		.collect::<Vec<_>>();
+
+	with_vars(
+		[("MONOCHANGE_CRATES_IO_API_URL", Some(server.base_url()))],
+		|| {
+			let report = run_publish_packages_with_publications(
+				root.path(),
+				&configuration,
+				&publications,
+				&BTreeSet::new(),
+				true,
+			)
+			.expect("publish report:");
+			let order = report
+				.packages
+				.iter()
+				.map(|package| package.package.as_str())
+				.collect::<Vec<_>>();
+
+			assert_eq!(order, expected_order);
+		},
+	);
+}
+
+#[test]
 fn execute_publish_requests_placeholder_dry_run_validates_publish_command() {
 	let server = MockServer::start();
 	server.mock(|when, then| {

--- a/crates/monochange/src/__tests__/publish_rate_limits_tests.rs
+++ b/crates/monochange/src/__tests__/publish_rate_limits_tests.rs
@@ -1462,14 +1462,14 @@ fn test_sort_requests_by_dependencies_keeps_original_order_on_cycle() {
 	a.declared_dependencies
 		.push(monochange_core::PackageDependency {
 			name: "crate-b".into(),
-			kind: monochange_core::DependencyKind::Development,
+			kind: DependencyKind::Development,
 			version_constraint: None,
 			optional: false,
 		});
 	b.declared_dependencies
 		.push(monochange_core::PackageDependency {
 			name: "crate-a".into(),
-			kind: monochange_core::DependencyKind::Development,
+			kind: DependencyKind::Development,
 			version_constraint: None,
 			optional: false,
 		});

--- a/crates/monochange/src/publish_rate_limits.rs
+++ b/crates/monochange/src/publish_rate_limits.rs
@@ -17,7 +17,6 @@ use monochange_core::WorkspaceConfiguration;
 use monochange_core::materialize_dependency_edges;
 use monochange_publish::build_pending_configured_package_release_requests as build_pending_configured_requests;
 use monochange_publish::filter_pending_publish_requests;
-use monochange_publish::publish_dependency_kind_is_ordering_relevant;
 
 use crate::PreparedRelease;
 use crate::discover_workspace;
@@ -182,9 +181,7 @@ pub(super) fn sort_requests_by_dependencies(
 	// Build dependents for all edges where the target is in the request list,
 	// so we can discover unselected dependents later.
 	for edge in &edges {
-		if publish_dependency_kind_is_ordering_relevant(edge.dependency_kind)
-			&& request_ids.contains(&edge.to_package_id)
-		{
+		if request_ids.contains(&edge.to_package_id) {
 			dependents
 				.entry(edge.to_package_id.clone())
 				.or_default()
@@ -194,9 +191,7 @@ pub(super) fn sort_requests_by_dependencies(
 
 	// Build in-degree only for edges between selected packages.
 	for edge in &edges {
-		if publish_dependency_kind_is_ordering_relevant(edge.dependency_kind)
-			&& request_ids.contains(&edge.from_package_id)
-			&& request_ids.contains(&edge.to_package_id)
+		if request_ids.contains(&edge.from_package_id) && request_ids.contains(&edge.to_package_id)
 		{
 			*in_degree.get_mut(&edge.from_package_id).unwrap() += 1;
 		}

--- a/crates/monochange/src/publish_rate_limits.rs
+++ b/crates/monochange/src/publish_rate_limits.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::path::Path;
 
-use monochange_core::DependencyKind;
 use monochange_core::MonochangeError;
 use monochange_core::MonochangeResult;
 use monochange_core::PublishRateLimitBatch;
@@ -18,6 +17,7 @@ use monochange_core::WorkspaceConfiguration;
 use monochange_core::materialize_dependency_edges;
 use monochange_publish::build_pending_configured_package_release_requests as build_pending_configured_requests;
 use monochange_publish::filter_pending_publish_requests;
+use monochange_publish::publish_dependency_kind_is_ordering_relevant;
 
 use crate::PreparedRelease;
 use crate::discover_workspace;
@@ -182,8 +182,7 @@ pub(super) fn sort_requests_by_dependencies(
 	// Build dependents for all edges where the target is in the request list,
 	// so we can discover unselected dependents later.
 	for edge in &edges {
-		if (edge.dependency_kind == DependencyKind::Runtime
-			|| edge.dependency_kind == DependencyKind::Development)
+		if publish_dependency_kind_is_ordering_relevant(edge.dependency_kind)
 			&& request_ids.contains(&edge.to_package_id)
 		{
 			dependents
@@ -195,8 +194,7 @@ pub(super) fn sort_requests_by_dependencies(
 
 	// Build in-degree only for edges between selected packages.
 	for edge in &edges {
-		if (edge.dependency_kind == DependencyKind::Runtime
-			|| edge.dependency_kind == DependencyKind::Development)
+		if publish_dependency_kind_is_ordering_relevant(edge.dependency_kind)
 			&& request_ids.contains(&edge.from_package_id)
 			&& request_ids.contains(&edge.to_package_id)
 		{

--- a/crates/monochange_integration_tests/tests/publish_plan_order.rs
+++ b/crates/monochange_integration_tests/tests/publish_plan_order.rs
@@ -76,15 +76,15 @@ fn publish_plan_integration_preserves_dependency_order_across_grouped_batches() 
 		.unwrap_or_else(|error| panic!("parse publish plan json: {error}"));
 	let publish_rate_limits = &value["publishRateLimits"];
 	let expected = [
-		"ledger_types",
-		"yaml_config",
 		"zeta_transport",
+		"yaml_config",
+		"ledger_types",
 		"catalog_index",
 		"auth_policy",
 		"telemetry_core",
 		"billing_engine",
-		"notification_worker",
 		"checkout_api",
+		"notification_worker",
 		"fulfillment_service",
 		"public_gateway",
 		"storefront_app",
@@ -132,15 +132,15 @@ fn publish_plan_all_integration_includes_every_configured_package() {
 		})
 		.collect::<Vec<_>>();
 	let mut expected = [
-		"ledger_types",
-		"yaml_config",
 		"zeta_transport",
+		"yaml_config",
+		"ledger_types",
 		"catalog_index",
 		"auth_policy",
 		"telemetry_core",
 		"billing_engine",
-		"notification_worker",
 		"checkout_api",
+		"notification_worker",
 		"fulfillment_service",
 		"public_gateway",
 		"storefront_app",
@@ -184,15 +184,15 @@ fn publish_all_integration_plans_every_configured_package() {
 		})
 		.collect::<Vec<_>>();
 	let mut expected = [
-		"ledger_types",
-		"yaml_config",
 		"zeta_transport",
+		"yaml_config",
+		"ledger_types",
 		"catalog_index",
 		"auth_policy",
 		"telemetry_core",
 		"billing_engine",
-		"notification_worker",
 		"checkout_api",
+		"notification_worker",
 		"fulfillment_service",
 		"public_gateway",
 		"storefront_app",

--- a/crates/monochange_integration_tests/tests/snapshots/publish_plan_order__publish_plan_integration_preserves_dependency_order_across_grouped_batches.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/publish_plan_order__publish_plan_integration_preserves_dependency_order_across_grouped_batches.snap
@@ -8,15 +8,15 @@ expression: publish_rate_limits
       "batchIndex": 1,
       "operation": "publish",
       "packages": [
-        "ledger_types",
-        "yaml_config",
         "zeta_transport",
+        "yaml_config",
+        "ledger_types",
         "catalog_index",
         "auth_policy",
         "telemetry_core",
         "billing_engine",
-        "notification_worker",
         "checkout_api",
+        "notification_worker",
         "fulfillment_service"
       ],
       "recommendedWaitSeconds": null,

--- a/crates/monochange_publish/src/__tests__/lib_tests.rs
+++ b/crates/monochange_publish/src/__tests__/lib_tests.rs
@@ -1,3 +1,4 @@
+use monochange_core::DependencyKind;
 use monochange_core::GroupChangelogInclude;
 use monochange_core::PackageDependency;
 use monochange_core::VersionFormat;
@@ -446,10 +447,57 @@ fn placeholder_tempdir_error_includes_io_error() {
 }
 
 #[test]
-fn publish_dependency_order_treats_development_dependencies_as_relevant() {
-	assert!(publish_dependency_kind_is_ordering_relevant(
-		DependencyKind::Development
+fn publish_dependency_order_handles_realistic_cargo_dependency_graph() {
+	let schema = publish_order_package("schema");
+
+	let mut codegen = publish_order_package("codegen");
+	codegen
+		.declared_dependencies
+		.push(publish_order_dependency("schema", DependencyKind::Runtime));
+
+	let mut test_helpers = publish_order_package("test_helpers");
+	test_helpers
+		.declared_dependencies
+		.push(publish_order_dependency("schema", DependencyKind::Runtime));
+
+	let mut core = publish_order_package("core");
+	core.declared_dependencies
+		.push(publish_order_dependency("schema", DependencyKind::Build));
+	core.declared_dependencies.push(publish_order_dependency(
+		"test_helpers",
+		DependencyKind::Development,
 	));
+
+	let mut cli = publish_order_package("cli");
+	cli.declared_dependencies
+		.push(publish_order_dependency("core", DependencyKind::Runtime));
+	cli.declared_dependencies
+		.push(publish_order_dependency("codegen", DependencyKind::Build));
+	cli.declared_dependencies.push(publish_order_dependency(
+		"test_helpers",
+		DependencyKind::Development,
+	));
+
+	let ordered = order_release_requests_by_publish_dependencies(
+		&[cli, core, test_helpers, codegen, schema],
+		vec![
+			publish_order_request("cli"),
+			publish_order_request("core"),
+			publish_order_request("test_helpers"),
+			publish_order_request("codegen"),
+			publish_order_request("schema"),
+		],
+	)
+	.expect("publish requests should be ordered");
+	let ordered_package_ids = ordered
+		.iter()
+		.map(|request| request.package_id.as_str())
+		.collect::<Vec<_>>();
+
+	assert_eq!(
+		ordered_package_ids,
+		vec!["schema", "codegen", "test_helpers", "core", "cli"]
+	);
 }
 
 #[test]

--- a/crates/monochange_publish/src/__tests__/lib_tests.rs
+++ b/crates/monochange_publish/src/__tests__/lib_tests.rs
@@ -1,4 +1,5 @@
 use monochange_core::GroupChangelogInclude;
+use monochange_core::PackageDependency;
 use monochange_core::VersionFormat;
 
 use super::*;
@@ -442,4 +443,83 @@ fn placeholder_tempdir_error_includes_io_error() {
 			.to_string()
 			.contains("failed to create placeholder tempdir: no tempdir")
 	);
+}
+
+#[test]
+fn publish_dependency_order_treats_development_dependencies_as_relevant() {
+	assert!(publish_dependency_kind_is_ordering_relevant(
+		DependencyKind::Development
+	));
+}
+
+#[test]
+fn publish_dependency_order_reports_development_dependency_cycles() {
+	let mut app = publish_order_package("app");
+	app.declared_dependencies.push(publish_order_dependency(
+		"helper",
+		DependencyKind::Development,
+	));
+	let mut helper = publish_order_package("helper");
+	helper
+		.declared_dependencies
+		.push(publish_order_dependency("app", DependencyKind::Development));
+
+	let error = order_release_requests_by_publish_dependencies(
+		&[app, helper],
+		vec![
+			publish_order_request("app"),
+			publish_order_request("helper"),
+		],
+	)
+	.expect_err("development dependency cycle should be rejected");
+
+	assert!(
+		error
+			.to_string()
+			.contains("cyclic publish dependencies detected")
+	);
+}
+
+fn publish_order_package(name: &str) -> PackageRecord {
+	let root = PathBuf::from("/workspace");
+	let mut package = PackageRecord::new(
+		Ecosystem::Cargo,
+		name,
+		root.join(name).join("Cargo.toml"),
+		root,
+		None,
+		PublishState::Public,
+	);
+	package
+		.metadata
+		.insert("config_id".to_string(), name.to_string());
+	package
+}
+
+fn publish_order_dependency(name: &str, kind: DependencyKind) -> PackageDependency {
+	PackageDependency {
+		name: name.to_string(),
+		kind,
+		version_constraint: Some("1.0.0".to_string()),
+		optional: false,
+	}
+}
+
+fn publish_order_request(package: &str) -> PublishRequest {
+	PublishRequest {
+		package_id: package.to_string(),
+		package_name: package.to_string(),
+		ecosystem: Ecosystem::Cargo,
+		manifest_path: PathBuf::from(format!("/workspace/{package}/Cargo.toml")),
+		package_root: PathBuf::from(format!("/workspace/{package}")),
+		registry: RegistryKind::CratesIo,
+		package_manager: None,
+		package_metadata: BTreeMap::new(),
+		mode: PublishMode::Builtin,
+		version: "1.0.0".to_string(),
+		placeholder: false,
+		trusted_publishing: TrustedPublishingSettings::default(),
+		attestations: PublishAttestationSettings::default(),
+		placeholder_readme: String::new(),
+	}
 }

--- a/crates/monochange_publish/src/__tests__/lib_tests.rs
+++ b/crates/monochange_publish/src/__tests__/lib_tests.rs
@@ -488,7 +488,7 @@ fn publish_dependency_order_handles_realistic_cargo_dependency_graph() {
 			publish_order_request("schema"),
 		],
 	)
-	.expect("publish requests should be ordered");
+	.unwrap_or_else(|error| panic!("publish requests should be ordered: {error}"));
 	let ordered_package_ids = ordered
 		.iter()
 		.map(|request| request.package_id.as_str())

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -1896,7 +1896,6 @@ fn circle_project_slug(env_map: &BTreeMap<String, String>) -> Option<String> {
 		.or_else(|| env_map.get("CIRCLE_PROJECT_REPONAME").cloned())
 }
 
-use monochange_core::DependencyKind;
 use monochange_core::materialize_dependency_edges;
 
 pub fn read_publish_report_artifact(path: &Path) -> MonochangeResult<PackagePublishReport> {
@@ -2085,9 +2084,6 @@ pub fn order_release_requests_by_publish_dependencies(
 	let mut dependents_by_package = BTreeMap::<String, BTreeSet<String>>::new();
 
 	for edge in materialize_dependency_edges(packages) {
-		if !publish_dependency_kind_is_ordering_relevant(edge.dependency_kind) {
-			continue;
-		}
 		let Some(from_package_id) = config_ids_by_record_id.get(&edge.from_package_id) else {
 			continue;
 		};
@@ -2152,10 +2148,6 @@ pub fn order_release_requests_by_publish_dependencies(
 	}
 
 	Ok(ordered_requests)
-}
-
-pub fn publish_dependency_kind_is_ordering_relevant(_kind: DependencyKind) -> bool {
-	true
 }
 
 pub fn config_ids_by_package_record_id(packages: &[PackageRecord]) -> BTreeMap<String, String> {

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -2154,8 +2154,8 @@ pub fn order_release_requests_by_publish_dependencies(
 	Ok(ordered_requests)
 }
 
-pub fn publish_dependency_kind_is_ordering_relevant(kind: DependencyKind) -> bool {
-	!matches!(kind, DependencyKind::Development)
+pub fn publish_dependency_kind_is_ordering_relevant(_kind: DependencyKind) -> bool {
+	true
 }
 
 pub fn config_ids_by_package_record_id(packages: &[PackageRecord]) -> BTreeMap<String, String> {

--- a/fixtures/tests/cli-output/publish-plan-dependency-order/crates/auth_policy/Cargo.toml
+++ b/fixtures/tests/cli-output/publish-plan-dependency-order/crates/auth_policy/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 [dependencies]
 ledger_types = { path = "../ledger_types", version = "0.1.0" }
 yaml_config = { path = "../yaml_config", version = "0.1.0" }
+
+[dev-dependencies]
+catalog_index = { path = "../catalog_index", version = "0.1.0" }

--- a/fixtures/tests/cli-output/publish-plan-dependency-order/crates/billing_engine/Cargo.toml
+++ b/fixtures/tests/cli-output/publish-plan-dependency-order/crates/billing_engine/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 [dependencies]
 ledger_types = { path = "../ledger_types", version = "0.1.0" }
 auth_policy = { path = "../auth_policy", version = "0.1.0" }
+
+[build-dependencies]
+telemetry_core = { path = "../telemetry_core", version = "0.1.0" }

--- a/fixtures/tests/cli-output/publish-plan-dependency-order/crates/ledger_types/Cargo.toml
+++ b/fixtures/tests/cli-output/publish-plan-dependency-order/crates/ledger_types/Cargo.toml
@@ -2,3 +2,6 @@
 name = "ledger_types"
 version = "0.1.0"
 edition = "2021"
+
+[dev-dependencies]
+yaml_config = { path = "../yaml_config", version = "0.1.0" }

--- a/fixtures/tests/cli-output/publish-plan-dependency-order/crates/notification_worker/Cargo.toml
+++ b/fixtures/tests/cli-output/publish-plan-dependency-order/crates/notification_worker/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 [dependencies]
 telemetry_core = { path = "../telemetry_core", version = "0.1.0" }
 yaml_config = { path = "../yaml_config", version = "0.1.0" }
+
+[dev-dependencies]
+billing_engine = { path = "../billing_engine", version = "0.1.0" }

--- a/fixtures/tests/cli-output/publish-plan-dependency-order/crates/public_gateway/Cargo.toml
+++ b/fixtures/tests/cli-output/publish-plan-dependency-order/crates/public_gateway/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 [dependencies]
 checkout_api = { path = "../checkout_api", version = "0.1.0" }
 auth_policy = { path = "../auth_policy", version = "0.1.0" }
+
+[build-dependencies]
+fulfillment_service = { path = "../fulfillment_service", version = "0.1.0" }

--- a/fixtures/tests/cli-output/publish-plan-dependency-order/crates/telemetry_core/Cargo.toml
+++ b/fixtures/tests/cli-output/publish-plan-dependency-order/crates/telemetry_core/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2021"
 
 [dependencies]
 yaml_config = { path = "../yaml_config", version = "0.1.0" }
+
+[dev-dependencies]
+auth_policy = { path = "../auth_policy", version = "0.1.0" }

--- a/fixtures/tests/cli-output/publish-plan-dependency-order/crates/yaml_config/Cargo.toml
+++ b/fixtures/tests/cli-output/publish-plan-dependency-order/crates/yaml_config/Cargo.toml
@@ -2,3 +2,6 @@
 name = "yaml_config"
 version = "0.1.0"
 edition = "2021"
+
+[build-dependencies]
+zeta_transport = { path = "../zeta_transport", version = "0.1.0" }


### PR DESCRIPTION
## Summary

- include Cargo dev-dependencies in publish dependency ordering alongside runtime and build dependencies
- reuse the shared publish dependency relevance predicate in publish-plan batching
- add focused unit coverage plus integration fixture coverage for dev/build dependency publish order

## Tests

- `devenv shell cargo fmt --check`
- `devenv shell cargo test -p monochange_publish publish_dependency_order --lib -- --nocapture`
- `devenv shell cargo test -p monochange release_dry_run_orders_cargo_dev_and_build_dependencies_before_dependents --lib -- --nocapture`
- `CARGO_BIN_EXE_mc="$PWD/target/debug/mc" devenv shell cargo insta test -p monochange_integration_tests --test publish_plan_order --test-runner nextest --accept -- publish_plan_integration_preserves_dependency_order_across_grouped_batches`

Note: focused `cargo insta ... --unreferenced=reject` reports unrelated unreferenced snapshots from other test files when only this one test is selected.

Fixes the Cargo publish ordering failure where a crate could publish before an unpublished workspace dev-dependency.
