### PR TITLE
feat!: require explicit CLI step inputs

### DIFF
--- a/.changeset/explicit-cli-step-inputs.md
+++ b/.changeset/explicit-cli-step-inputs.md
@@ -1,0 +1,40 @@
+---
+"monochange": major
+"monochange_core": major
+"monochange_config": major
+"monochange_schema": major
+"@monochange/skill": major
+---
+
+# require CLI steps to opt in to inherited command inputs
+
+> **Breaking change** — CLI step inputs are now explicit. Command-level inputs no longer automatically appear in every configured CLI step.
+
+A configured step now receives only the inputs listed in that step's `inputs` field. This removes ambiguous behavior where a command-level flag could unexpectedly shadow a step-specific input with the same name.
+
+**Before:** every step implicitly saw all command inputs, even with no step-level `inputs` entry:
+
+```toml
+[cli.release]
+inputs = [{ name = "format", type = "choice", choices = ["text", "json"], default = "text" }]
+steps = [{ type = "PrepareRelease" }]
+```
+
+**After:** inherit command inputs explicitly with the array shorthand:
+
+```toml
+[cli.release]
+inputs = [{ name = "format", type = "choice", choices = ["text", "json"], default = "text" }]
+steps = [{ type = "PrepareRelease", inputs = ["format"] }]
+```
+
+Map overrides still work for fixed or templated step values:
+
+```toml
+steps = [
+	{ type = "PrepareRelease", inputs = ["format"] },
+	{ type = "PublishRelease", inputs = { format = "json", draft = "{{ inputs.draft }}" } },
+]
+```
+
+Migration path: review custom `[cli.<command>]` definitions and add `inputs = ["name"]` to every step that needs a command-level input. Built-in default CLI commands and generated templates have been updated to declare their inherited inputs explicitly.

--- a/.templates/cli-steps.t.md
+++ b/.templates/cli-steps.t.md
@@ -25,6 +25,49 @@ The reference pages in this section document each built-in step with:
 
 <!-- {/cliStepReferenceOverview} -->
 
+<!-- {@cliStepExplicitInputInheritance} -->
+
+## Explicit step input inheritance
+
+Config-defined workflow commands have two input layers:
+
+1. `[[cli.<command>.inputs]]` declares the flags and arguments accepted by `mc <command>`.
+2. `inputs` on each step decides which of those parsed command inputs are visible while that step runs.
+
+Command inputs are **not inherited automatically**. A step receives a command input only when the step explicitly lists it. This makes wrappers predictable when a command-level flag and a step-specific input share the same name.
+
+Use the array shorthand when a step should inherit command inputs unchanged:
+
+```toml
+[cli.discover]
+inputs = [
+	{ name = "format", type = "choice", choices = ["text", "json"], default = "text" },
+]
+steps = [
+	{ type = "Discover", inputs = ["format"] },
+]
+```
+
+Use the map form when a step needs fixed values, renamed values, templates, or a mixture of inherited and overridden values:
+
+```toml
+[cli.release-pr]
+inputs = [
+	{ name = "format", type = "choice", choices = ["text", "json", "markdown"], default = "markdown" },
+	{ name = "open_as_draft", type = "boolean", default = false },
+]
+steps = [
+	{ type = "PrepareRelease", inputs = ["format"] },
+	{ type = "OpenReleaseRequest", inputs = { format = "markdown", draft = "{{ inputs.open_as_draft }}" } },
+]
+```
+
+Step-local `when` expressions and command templates evaluate against the same explicit step input context. If a `when` condition references `inputs.publish`, the step must include `publish` in its `inputs` array or map. Use `inputs = ["publish"]` for unchanged inheritance, or `inputs = { publish = "{{ inputs.publish }}" }` when you need the map form for other overrides.
+
+Built-in `mc step:*` commands are different: they are generated directly from the step schema, so their CLI flags map to that single step without a `[cli.*]` wrapper.
+
+<!-- {/cliStepExplicitInputInheritance} -->
+
 <!-- {@cliStepReferenceChoosingGuide} -->
 
 | Step                    | Use it when you want to…                                                  | Requires previous step?          | Typical follow-up                                                                           |
@@ -82,6 +125,7 @@ default = "text"
 
 [[cli.discover.steps]]
 type = "Discover"
+inputs = ["format"]
 ```
 
 <!-- {/cliStepDiscoverExample} -->
@@ -133,6 +177,17 @@ type = "string"
 
 [[cli.change.steps]]
 type = "CreateChangeFile"
+inputs = [
+	"interactive",
+	"package",
+	"bump",
+	"version",
+	"type",
+	"caused_by",
+	"reason",
+	"details",
+	"output",
+]
 ```
 
 <!-- {/cliStepCreateChangeFileExample} -->
@@ -151,6 +206,7 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 ```
 
 <!-- {/cliStepPrepareReleaseExample} -->
@@ -169,6 +225,7 @@ default = "text"
 
 [[cli.commit-release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.commit-release.steps]]
 type = "CommitRelease"
@@ -190,9 +247,11 @@ default = "text"
 
 [[cli.publish-release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.publish-release.steps]]
 type = "PublishRelease"
+inputs = ["format"]
 ```
 
 <!-- {/cliStepPublishReleaseExample} -->
@@ -211,9 +270,11 @@ default = "text"
 
 [[cli.release-pr.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-pr.steps]]
 type = "OpenReleaseRequest"
+inputs = ["format"]
 ```
 
 <!-- {/cliStepOpenReleaseRequestExample} -->
@@ -250,9 +311,11 @@ default = "text"
 
 [[cli.publish-and-comment.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.publish-and-comment.steps]]
 type = "PublishRelease"
+inputs = ["format"]
 
 [[cli.publish-and-comment.steps]]
 type = "CommentReleasedIssues"
@@ -287,6 +350,7 @@ type = "boolean"
 
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label", "verify"]
 ```
 
 <!-- {/cliStepAffectedPackagesExample} -->
@@ -309,6 +373,7 @@ type = "string_list"
 
 [[cli.diagnostics.steps]]
 type = "DiagnoseChangesets"
+inputs = ["format", "changeset"]
 ```
 
 <!-- {/cliStepDiagnoseChangesetsExample} -->
@@ -347,6 +412,7 @@ default = "text"
 
 [[cli.repair-release.steps]]
 type = "RetargetRelease"
+inputs = ["from", "target", "force", "sync_provider"]
 ```
 
 <!-- {/cliStepRetargetReleaseExample} -->
@@ -380,6 +446,7 @@ default = "text"
 
 [[cli.release-with-notes.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-with-notes.steps]]
 type = "Command"
@@ -436,6 +503,7 @@ help_text = "Show already-published and skipped placeholder packages instead of 
 [[cli.placeholder-publish.steps]]
 name = "publish placeholder packages"
 type = "PlaceholderPublish"
+inputs = ["format", "package", "show-all"]
 ```
 
 <!-- {/cliStepPlaceholderPublishExample} -->
@@ -479,6 +547,7 @@ help_text = "Write the package publish result JSON artifact for retry/resume"
 [[cli.publish.steps]]
 name = "publish packages"
 type = "PublishPackages"
+inputs = ["format", "package", "group", "ecosystem", "resume", "output"]
 ```
 
 <!-- {/cliStepPublishPackagesExample} -->
@@ -501,6 +570,7 @@ default = "HEAD"
 
 [[cli.repair-and-notify.steps]]
 type = "RetargetRelease"
+inputs = ["from", "target"]
 
 [[cli.repair-and-notify.steps]]
 type = "Command"

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -265,6 +265,7 @@ default = "text"
 [[cli.discover.steps]]
 name = "discover packages"
 type = "Discover"
+inputs = ["format"]
 
 [cli.release]
 help_text = "Prepare a release from discovered change files"
@@ -278,6 +279,7 @@ default = "text"
 [[cli.release.steps]]
 name = "prepare release"
 type = "PrepareRelease"
+inputs = ["format"]
 
 [cli.publish-release]
 help_text = "Prepare a release and publish provider releases"
@@ -291,10 +293,12 @@ default = "text"
 [[cli.publish-release.steps]]
 name = "prepare release"
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.publish-release.steps]]
 name = "publish release"
 type = "PublishRelease"
+inputs = ["format"]
 
 [[cli.publish-release.steps]]
 name = "comment released issues"
@@ -312,10 +316,12 @@ default = "text"
 [[cli.release-pr.steps]]
 name = "prepare release"
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-pr.steps]]
 name = "open release request"
 type = "OpenReleaseRequest"
+inputs = ["format"]
 
 name = "format"
 type = "choice"
@@ -350,6 +356,7 @@ type = "string_list"
 [[cli.affected.steps]]
 name = "evaluate affected packages"
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]
 ```
 
 <!-- {/configurationWorkflowsSnippet} -->
@@ -774,6 +781,7 @@ default = "text"
 
 [[cli.publish-release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.publish-release.steps]]
 type = "PublishRelease"
@@ -792,9 +800,11 @@ default = "text"
 
 [[cli.release-pr.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-pr.steps]]
 type = "OpenReleaseRequest"
+inputs = ["format"]
 ```
 
 <!-- {/githubAutomationReleaseConfigExample} -->

--- a/.templates/project.t.md
+++ b/.templates/project.t.md
@@ -352,6 +352,7 @@ default = "text"
 [[cli.discover.steps]]
 name = "discover packages"
 type = "Discover"
+inputs = ["format"]
 
 [cli.change]
 help_text = "Create a change file for one or more packages"
@@ -394,6 +395,7 @@ type = "path"
 [[cli.change.steps]]
 name = "create change file"
 type = "CreateChangeFile"
+inputs = ["interactive", "package", "bump", "version", "type", "reason", "details", "output"]
 
 [cli.release]
 help_text = "Prepare a release from discovered change files"
@@ -407,6 +409,7 @@ default = "text"
 [[cli.release.steps]]
 name = "prepare release"
 type = "PrepareRelease"
+inputs = ["format"]
 
 [cli.publish-release]
 help_text = "Prepare a release and publish provider releases"
@@ -420,10 +423,12 @@ default = "text"
 [[cli.publish-release.steps]]
 name = "prepare release"
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.publish-release.steps]]
 name = "publish release"
 type = "PublishRelease"
+inputs = ["format"]
 
 [cli.release-pr]
 help_text = "Prepare a release and open or update a provider release request"
@@ -437,17 +442,12 @@ default = "text"
 [[cli.release-pr.steps]]
 name = "prepare release"
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-pr.steps]]
 name = "open release request"
 type = "OpenReleaseRequest"
-
-name = "format"
-type = "choice"
-choices = ["text", "json"]
-default = "text"
-
-type = "PrepareRelease"
+inputs = ["format"]
 
 [cli.affected]
 help_text = "Evaluate pull-request changeset policy"
@@ -470,6 +470,7 @@ type = "string_list"
 [[cli.affected.steps]]
 name = "evaluate affected packages"
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]
 ```
 
 <!-- {/projectSetupConfig} -->

--- a/crates/monochange/src/__tests__/cli_runtime_tests.rs
+++ b/crates/monochange/src/__tests__/cli_runtime_tests.rs
@@ -14,6 +14,7 @@ use monochange_core::ChangesetPolicyEvaluation;
 use monochange_core::ChangesetPolicyStatus;
 use monochange_core::CliCommandDefinition;
 use monochange_core::CliStepDefinition;
+use monochange_core::CliStepInputValue;
 use monochange_core::ReleaseOwnerKind;
 use monochange_core::ReleasePlan;
 use monochange_core::ShellConfig;
@@ -51,6 +52,14 @@ fn cli_context() -> CliContext {
 		step_outputs: BTreeMap::new(),
 		command_logs: Vec::new(),
 	}
+}
+
+#[test]
+fn resolve_step_input_override_treats_inherited_as_empty() {
+	let template_context = serde_json::Map::new();
+	let values = resolve_step_input_override(&CliStepInputValue::Inherited, &template_context)
+		.unwrap_or_else(|error| panic!("resolve inherited step input: {error}"));
+	assert!(values.is_empty());
 }
 
 fn sample_source_configuration() -> SourceConfiguration {
@@ -1867,7 +1876,10 @@ fn execute_cli_command_with_options_rejects_readiness_for_placeholder_publish_pl
 			name: None,
 			when: None,
 			always_run: false,
-			inputs: BTreeMap::new(),
+			inputs: BTreeMap::from([
+				("mode".to_string(), CliStepInputValue::Inherited),
+				("readiness".to_string(), CliStepInputValue::Inherited),
+			]),
 		}],
 		dry_run: false,
 	};

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -6655,13 +6655,16 @@ fn execute_cli_command_change_step_requires_reason_input() {
 		name: "change".to_string(),
 		help_text: None,
 		inputs: Vec::new(),
-		steps: vec![monochange_core::CliStepDefinition::CreateChangeFile {
-			show_progress: None,
-			name: None,
-			when: None,
-			always_run: false,
-			inputs: BTreeMap::new(),
-		}],
+		steps: vec![
+			monochange_core::CliStepDefinition::CreateChangeFile {
+				show_progress: None,
+				name: None,
+				when: None,
+				always_run: false,
+				inputs: BTreeMap::new(),
+			}
+			.with_inherited_step_inputs(),
+		],
 		dry_run: false,
 	};
 	let error = crate::execute_cli_command(
@@ -6709,7 +6712,7 @@ fn execute_cli_command_prepare_release_writes_default_manifest_cache_and_follow_
 			name: None,
 			when: None,
 			always_run: false,
-			inputs: BTreeMap::new(),
+			inputs: text_format_step_inputs(),
 			allow_empty_changesets: false,
 		}],
 		dry_run: false,
@@ -6736,14 +6739,14 @@ fn execute_cli_command_prepare_release_writes_default_manifest_cache_and_follow_
 				name: None,
 				when: None,
 				always_run: false,
-				inputs: BTreeMap::new(),
+				inputs: text_format_step_inputs(),
 				allow_empty_changesets: false,
 			},
 			monochange_core::CliStepDefinition::PublishRelease {
 				name: None,
 				when: None,
 				always_run: false,
-				inputs: BTreeMap::new(),
+				inputs: text_format_step_inputs(),
 			},
 		],
 		dry_run: false,
@@ -6768,7 +6771,7 @@ fn execute_cli_command_prepare_release_writes_default_manifest_cache_and_follow_
 				name: None,
 				when: None,
 				always_run: false,
-				inputs: BTreeMap::new(),
+				inputs: text_format_step_inputs(),
 				allow_empty_changesets: false,
 			},
 			monochange_core::CliStepDefinition::OpenReleaseRequest {
@@ -6776,7 +6779,7 @@ fn execute_cli_command_prepare_release_writes_default_manifest_cache_and_follow_
 				when: None,
 				always_run: false,
 				no_verify: false,
-				inputs: BTreeMap::new(),
+				inputs: text_format_step_inputs(),
 			},
 		],
 		dry_run: false,
@@ -6801,14 +6804,14 @@ fn execute_cli_command_prepare_release_writes_default_manifest_cache_and_follow_
 				name: None,
 				when: None,
 				always_run: false,
-				inputs: BTreeMap::new(),
+				inputs: text_format_step_inputs(),
 				allow_empty_changesets: false,
 			},
 			monochange_core::CliStepDefinition::CommentReleasedIssues {
 				name: None,
 				when: None,
 				always_run: false,
-				inputs: BTreeMap::new(),
+				inputs: text_format_step_inputs(),
 			},
 		],
 		dry_run: false,
@@ -6894,7 +6897,7 @@ fn execute_cli_command_supports_placeholder_and_package_publish_steps() {
 					name: None,
 					when: None,
 					always_run: false,
-					inputs: BTreeMap::new(),
+					inputs: inherited_format_package_step_inputs(),
 				}],
 				dry_run: false,
 			};
@@ -6919,14 +6922,14 @@ fn execute_cli_command_supports_placeholder_and_package_publish_steps() {
 						name: None,
 						when: None,
 						always_run: false,
-						inputs: BTreeMap::new(),
+						inputs: text_format_step_inputs(),
 						allow_empty_changesets: false,
 					},
 					monochange_core::CliStepDefinition::PublishPackages {
 						name: None,
 						when: None,
 						always_run: false,
-						inputs: BTreeMap::new(),
+						inputs: inherited_format_package_step_inputs(),
 					},
 				],
 				dry_run: false,
@@ -6976,7 +6979,7 @@ fn execute_cli_command_allows_package_publish_steps_without_readiness_or_matchin
 					name: None,
 					when: None,
 					always_run: false,
-					inputs: BTreeMap::new(),
+					inputs: inherited_format_package_step_inputs(),
 				}],
 				dry_run: false,
 			};
@@ -7004,14 +7007,14 @@ fn execute_cli_command_allows_package_publish_steps_without_readiness_or_matchin
 						name: None,
 						when: None,
 						always_run: false,
-						inputs: BTreeMap::new(),
+						inputs: text_format_step_inputs(),
 						allow_empty_changesets: false,
 					},
 					monochange_core::CliStepDefinition::PublishPackages {
 						name: None,
 						when: None,
 						always_run: false,
-						inputs: BTreeMap::new(),
+						inputs: inherited_format_package_step_inputs(),
 					},
 				],
 				dry_run: false,
@@ -7047,7 +7050,7 @@ fn execute_cli_command_allows_package_publish_steps_without_readiness_or_matchin
 					name: None,
 					when: None,
 					always_run: false,
-					inputs: BTreeMap::new(),
+					inputs: inherited_format_package_output_step_inputs(),
 				}],
 				dry_run: false,
 			};
@@ -7080,7 +7083,7 @@ fn execute_cli_command_allows_package_publish_steps_without_readiness_or_matchin
 					name: None,
 					when: None,
 					always_run: false,
-					inputs: BTreeMap::new(),
+					inputs: inherited_publish_plan_step_inputs(),
 				}],
 				dry_run: false,
 			};
@@ -10421,6 +10424,65 @@ fn versioned_test_context<'a>(
 fn write_blank_monochange_config(root: &Path) {
 	fs::write(root.join("monochange.toml"), "")
 		.unwrap_or_else(|error| panic!("write monochange.toml: {error}"));
+}
+
+fn text_format_step_inputs() -> BTreeMap<String, monochange_core::CliStepInputValue> {
+	BTreeMap::from([(
+		"format".to_string(),
+		monochange_core::CliStepInputValue::String("text".to_string()),
+	)])
+}
+
+fn inherited_format_package_step_inputs() -> BTreeMap<String, monochange_core::CliStepInputValue> {
+	BTreeMap::from([
+		(
+			"format".to_string(),
+			monochange_core::CliStepInputValue::Inherited,
+		),
+		(
+			"package".to_string(),
+			monochange_core::CliStepInputValue::Inherited,
+		),
+	])
+}
+
+fn inherited_format_package_output_step_inputs()
+-> BTreeMap<String, monochange_core::CliStepInputValue> {
+	BTreeMap::from([
+		(
+			"format".to_string(),
+			monochange_core::CliStepInputValue::Inherited,
+		),
+		(
+			"package".to_string(),
+			monochange_core::CliStepInputValue::Inherited,
+		),
+		(
+			"output".to_string(),
+			monochange_core::CliStepInputValue::Inherited,
+		),
+	])
+}
+
+fn inherited_publish_plan_step_inputs() -> BTreeMap<String, monochange_core::CliStepInputValue> {
+	BTreeMap::from([
+		(
+			"format".to_string(),
+			monochange_core::CliStepInputValue::Inherited,
+		),
+		(
+			"mode".to_string(),
+			monochange_core::CliStepInputValue::Inherited,
+		),
+		(
+			"package".to_string(),
+			monochange_core::CliStepInputValue::Inherited,
+		),
+		(
+			"readiness".to_string(),
+			monochange_core::CliStepInputValue::Inherited,
+		),
+	])
 }
 
 fn create_release_record_history(root: &Path) {

--- a/crates/monochange/src/__tests__/workspace_ops_tests.rs
+++ b/crates/monochange/src/__tests__/workspace_ops_tests.rs
@@ -90,6 +90,28 @@ use monochange_test_helpers::workspace_ops::strip_workspace_prefix;
 
 use super::*;
 
+#[test]
+fn render_step_inputs_toml_uses_array_for_inherited_and_map_for_mixed_inputs() {
+	let mut inherited_inputs = BTreeMap::new();
+	inherited_inputs.insert(
+		"format".to_string(),
+		monochange_core::CliStepInputValue::Inherited,
+	);
+	let mut rendered = String::new();
+	render_step_inputs_toml(&mut rendered, &inherited_inputs);
+	assert_eq!(rendered, "inputs = [\"format\"]\n");
+
+	inherited_inputs.insert(
+		"draft".to_string(),
+		monochange_core::CliStepInputValue::Boolean(true),
+	);
+	let rendered = render_step_inputs_inline_table(&inherited_inputs);
+	assert_eq!(
+		rendered,
+		"{ draft = true, format = \"{{ inputs.format }}\" }"
+	);
+}
+
 fn setup_workspace_ops_fixture() -> tempfile::TempDir {
 	monochange_test_helpers::fs::setup_fixture_from(
 		env!("CARGO_MANIFEST_DIR"),

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -229,6 +229,7 @@ When provided, the generated config includes:\n\
 
 	command = command.next_help_heading("Step Commands");
 	for step in monochange_core::all_step_variants() {
+		let step = step.with_inherited_step_inputs();
 		let kebab = step.step_kebab_name();
 		let synthetic = CliCommandDefinition {
 			name: format!("step:{kebab}"),

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -189,17 +189,16 @@ fn resolve_step_inputs(
 	context: &CliContext,
 	step: &CliStepDefinition,
 ) -> MonochangeResult<BTreeMap<String, Vec<String>>> {
-	let mut resolved = context.inputs.clone();
-	if step.inputs().is_empty() {
-		return Ok(resolved);
-	}
-
+	let mut resolved = BTreeMap::new();
 	let template_context = build_cli_template_context(context, &context.inputs, None);
 	for (input_name, input_value) in step.inputs() {
-		resolved.insert(
-			input_name.clone(),
-			resolve_step_input_override(input_value, &template_context)?,
-		);
+		let values = match input_value {
+			CliStepInputValue::Inherited => {
+				context.inputs.get(input_name).cloned().unwrap_or_default()
+			}
+			_ => resolve_step_input_override(input_value, &template_context)?,
+		};
+		resolved.insert(input_name.clone(), values);
 	}
 
 	Ok(resolved)
@@ -210,6 +209,7 @@ fn resolve_step_input_override(
 	template_context: &serde_json::Map<String, serde_json::Value>,
 ) -> MonochangeResult<Vec<String>> {
 	match input_value {
+		CliStepInputValue::Inherited => Ok(Vec::new()),
 		CliStepInputValue::Boolean(value) => Ok(vec![value.to_string()]),
 		CliStepInputValue::List(values) => {
 			let mut resolved = Vec::new();
@@ -1284,10 +1284,10 @@ fn step_references_release_file_diffs(step: &CliStepDefinition) -> bool {
 	let inputs_mention_file_diffs = step.inputs().values().any(|value| {
 		match value {
 			CliStepInputValue::String(value) => mentions_file_diffs(value),
-			CliStepInputValue::Boolean(_) => false,
 			CliStepInputValue::List(values) => {
 				values.iter().any(|value| mentions_file_diffs(value))
 			}
+			CliStepInputValue::Inherited | CliStepInputValue::Boolean(_) => false,
 		}
 	});
 	if step.when().is_some_and(mentions_file_diffs) || inputs_mention_file_diffs {

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -224,7 +224,7 @@ pub(crate) fn synthetic_step_command_definition(
 		name: cli_command_name.to_string(),
 		help_text: step.name().map(ToString::to_string),
 		inputs: step.step_inputs_schema(),
-		steps: vec![step],
+		steps: vec![step.with_inherited_step_inputs()],
 		dry_run: false,
 	})
 }

--- a/crates/monochange/src/monochange.toml.template
+++ b/crates/monochange/src/monochange.toml.template
@@ -838,11 +838,12 @@ help_text = "Discover packages across supported ecosystems"
 inputs = [
 	{ name = "format", type = "choice", choices = ["text", "json"], default = "text" },
 ]
-steps = [{ name = "discover packages", type = "Discover" }]
+steps = [{ name = "discover packages", type = "Discover", inputs = ["format"] }]
 
 [cli.change]
 help_text = "Create a change file for one or more packages"
 inputs = [
+	{ name = "interactive", type = "boolean", default = false },
 	{ name = "package", type = "string_list", required = true },
 	{ name = "bump", type = "choice", choices = ["none", "patch", "minor", "major"], default = "patch" },
 	{ name = "reason", type = "string", required = true },
@@ -852,21 +853,21 @@ inputs = [
 	{ name = "details", type = "string" },
 	{ name = "output", type = "path" },
 ]
-steps = [{ name = "create change file", type = "CreateChangeFile" }]
+steps = [{ name = "create change file", type = "CreateChangeFile", inputs = ["interactive", "package", "bump", "version", "reason", "type", "details", "output"] }]
 
 [cli.release]
 help_text = "Prepare a release from discovered change files"
 inputs = [
 	{ name = "format", type = "choice", choices = ["markdown", "text", "json"], default = "markdown" },
 ]
-steps = [{ name = "prepare release", type = "PrepareRelease" }]
+steps = [{ name = "prepare release", type = "PrepareRelease", inputs = ["format"] }]
 
 [cli.versions]
 help_text = "Display planned package and group versions from discovered change files"
 inputs = [
 	{ name = "format", type = "choice", choices = ["text", "markdown", "json"], default = "text" },
 ]
-steps = [{ name = "display versions", type = "DisplayVersions" }]
+steps = [{ name = "display versions", type = "DisplayVersions", inputs = ["format"] }]
 
 [cli.placeholder-publish]
 help_text = "Publish placeholder package versions for missing registry packages"
@@ -875,17 +876,19 @@ inputs = [
 	{ name = "package", type = "string_list" },
 	{ name = "show-all", type = "boolean", help_text = "Show already-published and skipped placeholder packages instead of only packages that need action" },
 ]
-steps = [{ name = "publish placeholder packages", type = "PlaceholderPublish" }]
+steps = [{ name = "publish placeholder packages", type = "PlaceholderPublish", inputs = ["format", "package", "show-all"] }]
 
 [cli.publish]
 help_text = "Publish package versions from monochange release state using built-in workflows"
 inputs = [
 	{ name = "format", type = "choice", choices = ["text", "markdown", "json"], default = "text" },
 	{ name = "package", type = "string_list" },
+	{ name = "group", type = "string_list" },
+	{ name = "ecosystem", type = "string_list" },
 	{ name = "resume", type = "path", help_text = "JSON result artifact from an earlier mc publish run; completed package versions are skipped" },
 	{ name = "output", type = "path", help_text = "Write the package publish result JSON artifact for retry/resume" },
 ]
-steps = [{ name = "publish packages", type = "PublishPackages" }]
+steps = [{ name = "publish packages", type = "PublishPackages", inputs = ["format", "package", "group", "ecosystem", "resume", "output"] }]
 
 [cli.publish-plan]
 help_text = "Plan package-registry publish work against known ecosystem rate limits"
@@ -896,7 +899,7 @@ inputs = [
 	{ name = "readiness", type = "path", help_text = "JSON artifact from mc publish-readiness; limits publish plans to ready package work" },
 	{ name = "ci", type = "choice", choices = ["github-actions", "gitlab-ci"] },
 ]
-steps = [{ name = "plan publish rate limits", type = "PlanPublishRateLimits" }]
+steps = [{ name = "plan publish rate limits", type = "PlanPublishRateLimits", inputs = ["format", "mode", "package", "readiness", "ci"] }]
 
 [cli.affected]
 help_text = "Evaluate pull-request changeset policy"
@@ -908,7 +911,7 @@ inputs = [
 {% raw -%}
 # Step inputs example: { changed_paths = "{{ inputs.changed_paths }}", label = "{{ inputs.label }}", verify = true }
 {% endraw -%}
-steps = [{ name = "evaluate affected packages", type = "AffectedPackages" }]
+steps = [{ name = "evaluate affected packages", type = "AffectedPackages", inputs = ["changed_paths", "label"] }]
 
 [cli.diagnostics]
 help_text = "Show changeset diagnostics and context"
@@ -916,7 +919,7 @@ inputs = [
 	{ name = "format", type = "choice", choices = ["text", "json"], default = "text" },
 	{ name = "changeset", type = "string_list", help_text = "changeset path(s), e.g. .changeset/feature.md (omit for all changesets)" },
 ]
-steps = [{ name = "diagnose changesets", type = "DiagnoseChangesets" }]
+steps = [{ name = "diagnose changesets", type = "DiagnoseChangesets", inputs = ["format", "changeset"] }]
 
 [cli.repair-release]
 help_text = "Repair a recent release by moving its release tags to a later commit"
@@ -927,7 +930,7 @@ inputs = [
 	{ name = "sync_provider", type = "boolean", help_text = "sync hosted release state after tag movement (disable with --sync-provider=false)", default = "true" },
 	{ name = "format", type = "choice", choices = ["text", "json"], default = "text" },
 ]
-steps = [{ name = "retarget release", type = "RetargetRelease" }]
+steps = [{ name = "retarget release", type = "RetargetRelease", inputs = ["from", "target", "force", "sync_provider"] }]
 {% if provider %}
 
 [cli.commit-release]
@@ -936,7 +939,7 @@ inputs = [
 	{ name = "format", type = "choice", choices = ["text", "json"], default = "text" },
 ]
 steps = [
-	{ type = "PrepareRelease" },
+	{ type = "PrepareRelease", inputs = ["format"] },
 	{ type = "CommitRelease" },
 ]
 
@@ -946,8 +949,8 @@ inputs = [
 	{ name = "format", type = "choice", choices = ["text", "json", "markdown"], default = "markdown" },
 ]
 steps = [
-	{ type = "PrepareRelease", name = "plan release" },
-	{ type = "OpenReleaseRequest", name = "open release PR" },
+	{ type = "PrepareRelease", name = "plan release", inputs = ["format"] },
+	{ type = "OpenReleaseRequest", name = "open release PR", inputs = ["format"] },
 ]
 
 [cli.publish-release]
@@ -957,14 +960,15 @@ inputs = [
 	{ name = "draft", type = "boolean", default = false },
 	{ name = "format", type = "choice", choices = ["text", "json", "markdown"], default = "text" },
 ]
-steps = [{ name = "publish release", type = "PublishRelease" }]
+steps = [{ name = "publish release", type = "PublishRelease", inputs = ["format", "from-ref", "draft"] }]
 
 [cli.comment-released-issues]
 help_text = "Comment on and optionally close issues referenced in released changesets"
 inputs = [
 	{ name = "from-ref", type = "string", default = "HEAD" },
+	{ name = "format", type = "choice", choices = ["text", "json", "markdown"], default = "text" },
 	{ name = "auto-close-issues", type = "boolean", default = false },
 ]
-steps = [{ name = "comment on released issues", type = "CommentReleasedIssues" }]
+steps = [{ name = "comment on released issues", type = "CommentReleasedIssues", inputs = ["format", "auto-close-issues"] }]
 
 {% endif %}

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -404,12 +404,16 @@ fn render_step_inputs_toml(
 	if inputs.is_empty() {
 		return;
 	}
-	writeln!(
-		rendered,
-		"inputs = {}",
+	let rendered_inputs = if inputs
+		.values()
+		.all(|value| matches!(value, monochange_core::CliStepInputValue::Inherited))
+	{
+		render_toml_array(&inputs.keys().cloned().collect::<Vec<_>>())
+	} else {
 		render_step_inputs_inline_table(inputs)
-	)
-	.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+	};
+	writeln!(rendered, "inputs = {rendered_inputs}")
+		.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
 }
 
 fn render_step_inputs_inline_table(
@@ -419,14 +423,17 @@ fn render_step_inputs_inline_table(
 		"{{ {} }}",
 		inputs
 			.iter()
-			.map(|(name, value)| format!("{name} = {}", render_step_input_value(value)))
+			.map(|(name, value)| format!("{name} = {}", render_step_input_value(name, value)))
 			.collect::<Vec<_>>()
 			.join(", ")
 	)
 }
 
-fn render_step_input_value(value: &monochange_core::CliStepInputValue) -> String {
+fn render_step_input_value(name: &str, value: &monochange_core::CliStepInputValue) -> String {
 	match value {
+		monochange_core::CliStepInputValue::Inherited => {
+			render_toml_string(&format!("{{{{ inputs.{name} }}}}"))
+		}
 		monochange_core::CliStepInputValue::String(value) => render_toml_string(value),
 		monochange_core::CliStepInputValue::Boolean(value) => value.to_string(),
 		monochange_core::CliStepInputValue::List(values) => render_toml_array(values),

--- a/crates/monochange/tests/cli_step_input_overrides.rs
+++ b/crates/monochange/tests/cli_step_input_overrides.rs
@@ -65,6 +65,102 @@ fn create_change_file_step_can_hardcode_inputs_without_cli_inputs() {
 }
 
 #[test]
+fn command_inputs_do_not_implicitly_flow_into_steps() {
+	let tempdir = setup_scenario_workspace("cli-step-input-overrides/workspace");
+	append_config(
+		tempdir.path(),
+		r#"
+[cli.implicit-command-input]
+inputs = [{ name = "message", type = "string" }]
+
+[[cli.implicit-command-input.steps]]
+type = "Command"
+command = "printf '%s' '{{ inputs.message is defined }}' > command-output.txt"
+shell = true
+"#,
+	);
+
+	let output = run_command_args_without_dry_run(
+		tempdir.path(),
+		&["implicit-command-input", "--message", "hello"],
+	);
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	let contents = fs::read_to_string(tempdir.path().join("command-output.txt"))
+		.unwrap_or_else(|error| panic!("command output file: {error}"));
+	assert_eq!(contents, "false");
+}
+
+#[test]
+fn step_inputs_array_inherits_selected_command_inputs() {
+	let tempdir = setup_scenario_workspace("cli-step-input-overrides/workspace");
+	append_config(
+		tempdir.path(),
+		r#"
+[cli.selected-command-input]
+inputs = [{ name = "message", type = "string" }]
+
+[[cli.selected-command-input.steps]]
+type = "Command"
+command = "printf '%s' '{{ inputs.message }}' > command-output.txt"
+shell = true
+inputs = ["message"]
+"#,
+	);
+
+	let output = run_command_args_without_dry_run(
+		tempdir.path(),
+		&["selected-command-input", "--message", "hello"],
+	);
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	let contents = fs::read_to_string(tempdir.path().join("command-output.txt"))
+		.unwrap_or_else(|error| panic!("command output file: {error}"));
+	assert_eq!(contents, "hello");
+}
+
+#[test]
+fn when_conditions_use_explicit_step_input_context() {
+	let tempdir = setup_scenario_workspace("cli-step-input-overrides/workspace");
+	append_config(
+		tempdir.path(),
+		r#"
+[cli.when-explicit-inputs]
+inputs = [{ name = "enabled", type = "boolean" }]
+
+[[cli.when-explicit-inputs.steps]]
+type = "Command"
+when = "{{ inputs.enabled is defined }}"
+command = "touch implicit-output.txt"
+shell = true
+
+[[cli.when-explicit-inputs.steps]]
+type = "Command"
+when = "{{ inputs.enabled }}"
+command = "touch selected-output.txt"
+shell = true
+inputs = ["enabled"]
+"#,
+	);
+
+	let output =
+		run_command_args_without_dry_run(tempdir.path(), &["when-explicit-inputs", "--enabled"]);
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	assert!(!tempdir.path().join("implicit-output.txt").exists());
+	assert!(tempdir.path().join("selected-output.txt").exists());
+}
+
+#[test]
 fn command_step_can_hardcode_inputs_without_cli_inputs() {
 	let mut settings = snapshot_settings();
 	settings.set_snapshot_suffix(current_test_name());
@@ -93,11 +189,24 @@ fn run_command(root: &Path, command: &str) -> std::process::Output {
 }
 
 fn run_command_without_dry_run(root: &Path, command: &str) -> std::process::Output {
+	run_command_args_without_dry_run(root, &[command])
+}
+
+fn run_command_args_without_dry_run(root: &Path, args: &[&str]) -> std::process::Output {
 	monochange_command(None)
 		.current_dir(root)
-		.arg(command)
+		.args(args)
 		.output()
 		.unwrap_or_else(|error| panic!("command output: {error}"))
+}
+
+fn append_config(root: &Path, config: &str) {
+	let config_path = root.join("monochange.toml");
+	let mut contents = fs::read_to_string(&config_path)
+		.unwrap_or_else(|error| panic!("read monochange config: {error}"));
+	contents.push_str(config);
+	fs::write(&config_path, contents)
+		.unwrap_or_else(|error| panic!("write monochange config: {error}"));
 }
 
 fn run_json_command(root: &Path, command: &str) -> Value {

--- a/crates/monochange/tests/test_support.rs
+++ b/crates/monochange/tests/test_support.rs
@@ -207,7 +207,7 @@ help_text = "Discover packages across supported ecosystems"
 inputs = [
 	{ name = "format", type = "choice", choices = ["text", "json"], default = "text" },
 ]
-steps = [{ name = "discover packages", type = "Discover" }]
+steps = [{ name = "discover packages", type = "Discover", inputs = ["format"] }]
 "#,
 	),
 	(
@@ -225,7 +225,7 @@ inputs = [
 	{ name = "details", type = "string", help_text = "Optional multi-line release-note details" },
 	{ name = "output", type = "path", help_text = "Write the generated change file to a specific path" },
 ]
-steps = [{ name = "create change file", type = "CreateChangeFile" }]
+steps = [{ name = "create change file", type = "CreateChangeFile", inputs = ["interactive", "package", "bump", "version", "reason", "type", "details", "output"] }]
 "#,
 	),
 	(
@@ -235,7 +235,7 @@ help_text = "Prepare a release from discovered change files"
 inputs = [
 	{ name = "format", type = "choice", choices = ["markdown", "text", "json"], default = "markdown" },
 ]
-steps = [{ name = "prepare release", type = "PrepareRelease" }]
+steps = [{ name = "prepare release", type = "PrepareRelease", inputs = ["format"] }]
 "#,
 	),
 	(
@@ -245,7 +245,7 @@ help_text = "Display planned package and group versions from discovered change f
 inputs = [
 	{ name = "format", type = "choice", choices = ["text", "markdown", "json"], default = "text" },
 ]
-steps = [{ name = "display versions", type = "DisplayVersions" }]
+steps = [{ name = "display versions", type = "DisplayVersions", inputs = ["format"] }]
 "#,
 	),
 	(
@@ -256,7 +256,7 @@ inputs = [
 	{ name = "format", type = "choice", choices = ["text", "markdown", "json"], default = "text" },
 	{ name = "package", type = "string_list", help_text = "Restrict placeholder publishing to explicit package ids" },
 ]
-steps = [{ name = "publish placeholder packages", type = "PlaceholderPublish" }]
+steps = [{ name = "publish placeholder packages", type = "PlaceholderPublish", inputs = ["format", "package"] }]
 "#,
 	),
 	(
@@ -267,7 +267,7 @@ inputs = [
 	{ name = "format", type = "choice", choices = ["text", "json"], default = "text" },
 	{ name = "changeset", type = "string_list", help_text = "Changeset path(s) to inspect, relative to .changeset (omit for all changesets)" },
 ]
-steps = [{ name = "diagnose changesets", type = "DiagnoseChangesets" }]
+steps = [{ name = "diagnose changesets", type = "DiagnoseChangesets", inputs = ["format", "changeset"] }]
 "#,
 	),
 ];

--- a/crates/monochange_config/src/__tests__/lib_tests.rs
+++ b/crates/monochange_config/src/__tests__/lib_tests.rs
@@ -79,6 +79,7 @@ fn infer_group_bump_from_explicit_version(
 }
 
 use crate::apply_version_groups;
+use crate::cli_input_kind_matches_step_input;
 use crate::frontmatter_span_for_line_column;
 use crate::line_and_column_for_offset;
 use crate::line_index_for_offset;
@@ -92,7 +93,123 @@ use crate::render_source_snippet;
 use crate::render_source_snippets;
 use crate::resolve_package_reference;
 use crate::sort_labels_by_location;
+use crate::validate_step_input_overrides;
+use crate::validate_step_override_kind;
 use crate::validate_workspace;
+
+fn validate_step() -> CliStepDefinition {
+	CliStepDefinition::Validate {
+		name: None,
+		when: None,
+		always_run: false,
+		inputs: BTreeMap::new(),
+	}
+}
+
+#[test]
+fn cli_step_override_validation_covers_type_helpers_and_missing_inherited_inputs() {
+	let command = CliCommandDefinition {
+		name: "release".to_string(),
+		help_text: None,
+		inputs: vec![
+			cli_input("fix", CliInputKind::Boolean),
+			cli_input("format", CliInputKind::Choice),
+		],
+		steps: Vec::new(),
+		dry_run: false,
+	};
+	let validate = validate_step();
+	validate_step_override_kind(
+		&command,
+		&validate,
+		"fix",
+		Some(&CliStepInputValue::Boolean(true)),
+		true,
+	)
+	.unwrap_or_else(|error| panic!("boolean override should validate: {error}"));
+	validate_step_override_kind(
+		&command,
+		&validate,
+		"fix",
+		Some(&CliStepInputValue::String("{{ inputs.fix }}".to_string())),
+		true,
+	)
+	.unwrap_or_else(|error| panic!("boolean template override should validate: {error}"));
+	validate_step_override_kind(
+		&command,
+		&validate,
+		"format",
+		Some(&CliStepInputValue::String("json".to_string())),
+		false,
+	)
+	.unwrap_or_else(|error| panic!("string override should validate: {error}"));
+	validate_step_override_kind(
+		&command,
+		&validate,
+		"format",
+		Some(&CliStepInputValue::List(vec!["json".to_string()])),
+		false,
+	)
+	.unwrap_or_else(|error| panic!("list override should validate: {error}"));
+	assert!(
+		validate_step_override_kind(
+			&command,
+			&validate,
+			"fix",
+			Some(&CliStepInputValue::List(vec!["true".to_string()])),
+			true,
+		)
+		.is_err()
+	);
+	assert!(
+		validate_step_override_kind(
+			&command,
+			&validate,
+			"format",
+			Some(&CliStepInputValue::Boolean(true)),
+			false,
+		)
+		.is_err()
+	);
+
+	assert!(cli_input_kind_matches_step_input(
+		CliInputKind::String,
+		CliInputKind::Choice,
+	));
+	assert!(cli_input_kind_matches_step_input(
+		CliInputKind::Path,
+		CliInputKind::String,
+	));
+	assert!(cli_input_kind_matches_step_input(
+		CliInputKind::Choice,
+		CliInputKind::Path,
+	));
+
+	let mut inherited_inputs = BTreeMap::new();
+	inherited_inputs.insert("format".to_string(), CliStepInputValue::Inherited);
+	let step = CliStepDefinition::PrepareRelease {
+		name: None,
+		when: None,
+		always_run: false,
+		allow_empty_changesets: false,
+		inputs: inherited_inputs,
+	};
+	let command_without_format = CliCommandDefinition {
+		name: "release".to_string(),
+		help_text: None,
+		inputs: Vec::new(),
+		steps: Vec::new(),
+		dry_run: false,
+	};
+	let error = validate_step_input_overrides(&command_without_format, &step)
+		.err()
+		.unwrap_or_else(|| panic!("expected missing inherited input error"));
+	assert!(
+		error
+			.to_string()
+			.contains("inherits input `format` but the command does not declare it")
+	);
+}
 
 fn fixture_path(relative: &str) -> PathBuf {
 	monochange_test_helpers::fs::fixture_path_from(env!("CARGO_MANIFEST_DIR"), relative)
@@ -5353,7 +5470,10 @@ fn validate_cli_runtime_requirements_enforce_affected_package_inputs() {
 			name: None,
 			when: None,
 			always_run: false,
-			inputs: BTreeMap::new(),
+			inputs: BTreeMap::from([
+				("changed_paths".to_string(), CliStepInputValue::Inherited),
+				("label".to_string(), CliStepInputValue::Inherited),
+			]),
 		}],
 	);
 	command.inputs = vec![
@@ -5370,7 +5490,7 @@ fn validate_cli_runtime_requirements_enforce_affected_package_inputs() {
 	assert!(
 		invalid_label
 			.to_string()
-			.contains("input `label` must use type `string_list`")
+			.contains("inherits input `label` with incompatible type")
 	);
 }
 

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -4190,22 +4190,11 @@ fn validate_cli_runtime_requirements(
 			if let CliStepDefinition::AffectedPackages { inputs, .. } = step {
 				validate_affected_packages_step_enabled(cli_command, changesets.affected.enabled)?;
 
-				let has_changed_paths = inputs.contains_key("changed_paths")
-					|| cli_command_input(cli_command, "changed_paths")
-						.is_some_and(|input| matches!(input.kind, CliInputKind::StringList));
-				let has_from =
-					inputs.contains_key("from") || cli_command_input(cli_command, "from").is_some();
+				let has_changed_paths = inputs.contains_key("changed_paths");
+				let has_from = inputs.contains_key("from");
 				if !has_changed_paths && !has_from {
 					return Err(MonochangeError::Config(format!(
 						"CLI command `{}` uses `AffectedPackages` but declares neither a `changed_paths` nor a `from` input and does not override either on the step",
-						cli_command.name
-					)));
-				}
-				if let Some(label_input) = cli_command_input(cli_command, "label")
-					&& !matches!(label_input.kind, CliInputKind::StringList)
-				{
-					return Err(MonochangeError::Config(format!(
-						"CLI command `{}` input `label` must use type `string_list` when used with `AffectedPackages`",
 						cli_command.name
 					)));
 				}
@@ -4255,17 +4244,18 @@ fn validate_step_override_kind(
 	let Some(value) = value else {
 		return Ok(());
 	};
-	let valid = if expect_boolean {
-		matches!(
-			value,
-			CliStepInputValue::Boolean(_) | CliStepInputValue::String(_)
-		)
-	} else {
-		matches!(
-			value,
-			CliStepInputValue::String(_) | CliStepInputValue::List(_)
-		)
-	};
+	let valid = matches!(value, CliStepInputValue::Inherited)
+		|| if expect_boolean {
+			matches!(
+				value,
+				CliStepInputValue::Boolean(_) | CliStepInputValue::String(_)
+			)
+		} else {
+			matches!(
+				value,
+				CliStepInputValue::String(_) | CliStepInputValue::List(_)
+			)
+		};
 	if valid {
 		return Ok(());
 	}
@@ -4280,6 +4270,18 @@ fn validate_step_override_kind(
 			"string or string_list value"
 		}
 	)))
+}
+
+fn cli_input_kind_matches_step_input(actual: CliInputKind, expected: CliInputKind) -> bool {
+	match expected {
+		CliInputKind::Boolean => matches!(actual, CliInputKind::Boolean),
+		CliInputKind::StringList => matches!(actual, CliInputKind::StringList),
+		CliInputKind::String | CliInputKind::Path | CliInputKind::Choice => {
+			actual == CliInputKind::String
+				|| actual == CliInputKind::Path
+				|| actual == CliInputKind::Choice
+		}
+	}
 }
 
 /// Validate that every input override key on a step is recognised and that
@@ -4314,7 +4316,31 @@ fn validate_step_input_overrides(
 			)));
 		}
 
-		// Validate value type against expected kind.
+		// Validate inherited command inputs and literal override types against the step schema.
+		if matches!(value, CliStepInputValue::Inherited) {
+			let Some(command_input) = cli_command_input(cli_command, name) else {
+				return Err(MonochangeError::Config(format!(
+					"CLI command `{}` step `{}` inherits input `{}` but the command does not declare it",
+					cli_command.name,
+					step.kind_name(),
+					name,
+				)));
+			};
+			if let Some(expected_kind) = step.expected_input_kind(name)
+				&& !cli_input_kind_matches_step_input(command_input.kind, expected_kind)
+			{
+				return Err(MonochangeError::Config(format!(
+					"CLI command `{}` step `{}` inherits input `{}` with incompatible type `{:?}`; expected `{:?}`",
+					cli_command.name,
+					step.kind_name(),
+					name,
+					command_input.kind,
+					expected_kind,
+				)));
+			}
+			continue;
+		}
+
 		if let Some(expected_kind) = step.expected_input_kind(name) {
 			let type_ok = match expected_kind {
 				CliInputKind::Boolean => {

--- a/crates/monochange_core/src/__tests__/lib_tests.rs
+++ b/crates/monochange_core/src/__tests__/lib_tests.rs
@@ -2081,6 +2081,27 @@ fn shell_config_serializes_roundtrip() {
 }
 
 #[test]
+fn cli_step_inputs_serialize_inherited_entries_inside_mixed_maps() {
+	let mut inputs = BTreeMap::new();
+	inputs.insert("format".to_string(), crate::CliStepInputValue::Inherited);
+	inputs.insert(
+		"message".to_string(),
+		crate::CliStepInputValue::String("fixed".to_string()),
+	);
+	let step = CliStepDefinition::PrepareRelease {
+		name: None,
+		when: None,
+		always_run: false,
+		allow_empty_changesets: false,
+		inputs,
+	};
+	let value = serde_json::to_value(&step)
+		.unwrap_or_else(|error| panic!("serialize step inputs: {error}"));
+	assert_eq!(value["inputs"]["format"], "{{ inputs.format }}");
+	assert_eq!(value["inputs"]["message"], "fixed");
+}
+
+#[test]
 fn cli_step_command_with_id_deserializes() {
 	let json_str = r#"{"type":"Command","command":"echo hello","id":"greet","shell":"bash"}"#;
 	let step: CliStepDefinition =

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -1807,9 +1807,97 @@ where
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum CliStepInputValue {
+	#[serde(skip)]
+	Inherited,
 	String(String),
 	Boolean(bool),
 	List(Vec<String>),
+}
+
+#[cfg(feature = "schema")]
+#[allow(dead_code)]
+#[derive(schemars::JsonSchema, Serialize, Deserialize)]
+#[serde(untagged)]
+enum CliStepInputOverrideValueSchema {
+	String(String),
+	Boolean(bool),
+	List(Vec<String>),
+}
+
+#[cfg(feature = "schema")]
+#[allow(dead_code)]
+#[derive(schemars::JsonSchema, Serialize, Deserialize)]
+#[serde(untagged)]
+enum CliStepInputsSchema {
+	Overrides(BTreeMap<String, CliStepInputOverrideValueSchema>),
+	Inherited(Vec<String>),
+}
+
+fn serialize_cli_step_inputs<S>(
+	inputs: &BTreeMap<String, CliStepInputValue>,
+	serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+	S: serde::Serializer,
+{
+	if inputs
+		.values()
+		.all(|value| matches!(value, CliStepInputValue::Inherited))
+	{
+		return inputs.keys().collect::<Vec<_>>().serialize(serializer);
+	}
+
+	#[derive(Serialize)]
+	#[serde(untagged)]
+	enum SerializableCliStepInputValue {
+		String(String),
+		Boolean(bool),
+		List(Vec<String>),
+	}
+
+	let serialized_inputs = inputs
+		.iter()
+		.map(|(name, value)| {
+			let value = match value {
+				CliStepInputValue::Inherited => {
+					SerializableCliStepInputValue::String(format!("{{{{ inputs.{name} }}}}"))
+				}
+				CliStepInputValue::String(value) => {
+					SerializableCliStepInputValue::String(value.clone())
+				}
+				CliStepInputValue::Boolean(value) => SerializableCliStepInputValue::Boolean(*value),
+				CliStepInputValue::List(value) => {
+					SerializableCliStepInputValue::List(value.clone())
+				}
+			};
+			(name, value)
+		})
+		.collect::<BTreeMap<_, _>>();
+	serialized_inputs.serialize(serializer)
+}
+
+fn deserialize_cli_step_inputs<'de, D>(
+	deserializer: D,
+) -> Result<BTreeMap<String, CliStepInputValue>, D::Error>
+where
+	D: serde::Deserializer<'de>,
+{
+	#[derive(Deserialize)]
+	#[serde(untagged)]
+	enum RawInputs {
+		Overrides(BTreeMap<String, CliStepInputValue>),
+		Inherited(Vec<String>),
+	}
+
+	match RawInputs::deserialize(deserializer)? {
+		RawInputs::Overrides(overrides) => Ok(overrides),
+		RawInputs::Inherited(names) => {
+			Ok(names
+				.into_iter()
+				.map(|name| (name, CliStepInputValue::Inherited))
+				.collect())
+		}
+	}
 }
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
@@ -1916,7 +2004,12 @@ pub enum CliStepDefinition {
 		when: Option<String>,
 		#[serde(default)]
 		always_run: bool,
-		#[serde(default)]
+		#[serde(
+			default,
+			deserialize_with = "deserialize_cli_step_inputs",
+			serialize_with = "serialize_cli_step_inputs"
+		)]
+		#[cfg_attr(feature = "schema", schemars(with = "CliStepInputsSchema"))]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Validate `monochange` configuration and changesets, and run lint rules
@@ -1928,7 +2021,12 @@ pub enum CliStepDefinition {
 		when: Option<String>,
 		#[serde(default)]
 		always_run: bool,
-		#[serde(default)]
+		#[serde(
+			default,
+			deserialize_with = "deserialize_cli_step_inputs",
+			serialize_with = "serialize_cli_step_inputs"
+		)]
+		#[cfg_attr(feature = "schema", schemars(with = "CliStepInputsSchema"))]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Discover packages across supported ecosystems and render the result.
@@ -1939,7 +2037,12 @@ pub enum CliStepDefinition {
 		when: Option<String>,
 		#[serde(default)]
 		always_run: bool,
-		#[serde(default)]
+		#[serde(
+			default,
+			deserialize_with = "deserialize_cli_step_inputs",
+			serialize_with = "serialize_cli_step_inputs"
+		)]
+		#[cfg_attr(feature = "schema", schemars(with = "CliStepInputsSchema"))]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Display planned package and group versions without mutating release files.
@@ -1950,7 +2053,12 @@ pub enum CliStepDefinition {
 		when: Option<String>,
 		#[serde(default)]
 		always_run: bool,
-		#[serde(default)]
+		#[serde(
+			default,
+			deserialize_with = "deserialize_cli_step_inputs",
+			serialize_with = "serialize_cli_step_inputs"
+		)]
+		#[cfg_attr(feature = "schema", schemars(with = "CliStepInputsSchema"))]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Create a `.changeset/*.md` file from typed CLI inputs or interactive
@@ -1964,7 +2072,12 @@ pub enum CliStepDefinition {
 		always_run: bool,
 		#[serde(default)]
 		show_progress: Option<bool>,
-		#[serde(default)]
+		#[serde(
+			default,
+			deserialize_with = "deserialize_cli_step_inputs",
+			serialize_with = "serialize_cli_step_inputs"
+		)]
+		#[cfg_attr(feature = "schema", schemars(with = "CliStepInputsSchema"))]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Prepare a release and expose structured `release.*` context to later
@@ -1976,7 +2089,12 @@ pub enum CliStepDefinition {
 		when: Option<String>,
 		#[serde(default)]
 		always_run: bool,
-		#[serde(default)]
+		#[serde(
+			default,
+			deserialize_with = "deserialize_cli_step_inputs",
+			serialize_with = "serialize_cli_step_inputs"
+		)]
+		#[cfg_attr(feature = "schema", schemars(with = "CliStepInputsSchema"))]
 		inputs: BTreeMap<String, CliStepInputValue>,
 		/// When true, do not error when there are no pending changesets.
 		/// Instead, succeed with zero changesets, allowing downstream steps
@@ -1998,7 +2116,12 @@ pub enum CliStepDefinition {
 		no_verify: bool,
 		#[serde(default)]
 		update_release_json: bool,
-		#[serde(default)]
+		#[serde(
+			default,
+			deserialize_with = "deserialize_cli_step_inputs",
+			serialize_with = "serialize_cli_step_inputs"
+		)]
+		#[cfg_attr(feature = "schema", schemars(with = "CliStepInputsSchema"))]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Verify a commit is reachable from one of the configured release branches.
@@ -2009,7 +2132,12 @@ pub enum CliStepDefinition {
 		when: Option<String>,
 		#[serde(default)]
 		always_run: bool,
-		#[serde(default)]
+		#[serde(
+			default,
+			deserialize_with = "deserialize_cli_step_inputs",
+			serialize_with = "serialize_cli_step_inputs"
+		)]
+		#[cfg_attr(feature = "schema", schemars(with = "CliStepInputsSchema"))]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Publish hosted releases from a prepared `monochange` release.
@@ -2023,7 +2151,12 @@ pub enum CliStepDefinition {
 		when: Option<String>,
 		#[serde(default)]
 		always_run: bool,
-		#[serde(default)]
+		#[serde(
+			default,
+			deserialize_with = "deserialize_cli_step_inputs",
+			serialize_with = "serialize_cli_step_inputs"
+		)]
+		#[cfg_attr(feature = "schema", schemars(with = "CliStepInputsSchema"))]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Publish placeholder package versions for missing registry packages.
@@ -2034,7 +2167,12 @@ pub enum CliStepDefinition {
 		when: Option<String>,
 		#[serde(default)]
 		always_run: bool,
-		#[serde(default)]
+		#[serde(
+			default,
+			deserialize_with = "deserialize_cli_step_inputs",
+			serialize_with = "serialize_cli_step_inputs"
+		)]
+		#[cfg_attr(feature = "schema", schemars(with = "CliStepInputsSchema"))]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Publish package versions from durable monochange release state.
@@ -2045,7 +2183,12 @@ pub enum CliStepDefinition {
 		when: Option<String>,
 		#[serde(default)]
 		always_run: bool,
-		#[serde(default)]
+		#[serde(
+			default,
+			deserialize_with = "deserialize_cli_step_inputs",
+			serialize_with = "serialize_cli_step_inputs"
+		)]
+		#[cfg_attr(feature = "schema", schemars(with = "CliStepInputsSchema"))]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Plan package-registry rate-limit windows for publish operations.
@@ -2056,7 +2199,12 @@ pub enum CliStepDefinition {
 		when: Option<String>,
 		#[serde(default)]
 		always_run: bool,
-		#[serde(default)]
+		#[serde(
+			default,
+			deserialize_with = "deserialize_cli_step_inputs",
+			serialize_with = "serialize_cli_step_inputs"
+		)]
+		#[cfg_attr(feature = "schema", schemars(with = "CliStepInputsSchema"))]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Open or update a hosted release request from prepared release state.
@@ -2072,7 +2220,12 @@ pub enum CliStepDefinition {
 		always_run: bool,
 		#[serde(default)]
 		no_verify: bool,
-		#[serde(default)]
+		#[serde(
+			default,
+			deserialize_with = "deserialize_cli_step_inputs",
+			serialize_with = "serialize_cli_step_inputs"
+		)]
+		#[cfg_attr(feature = "schema", schemars(with = "CliStepInputsSchema"))]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Comment on linked released issues after a prepared release.
@@ -2086,7 +2239,12 @@ pub enum CliStepDefinition {
 		when: Option<String>,
 		#[serde(default)]
 		always_run: bool,
-		#[serde(default)]
+		#[serde(
+			default,
+			deserialize_with = "deserialize_cli_step_inputs",
+			serialize_with = "serialize_cli_step_inputs"
+		)]
+		#[cfg_attr(feature = "schema", schemars(with = "CliStepInputsSchema"))]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Evaluate affected packages and changeset coverage for changed files.
@@ -2099,7 +2257,12 @@ pub enum CliStepDefinition {
 		when: Option<String>,
 		#[serde(default)]
 		always_run: bool,
-		#[serde(default)]
+		#[serde(
+			default,
+			deserialize_with = "deserialize_cli_step_inputs",
+			serialize_with = "serialize_cli_step_inputs"
+		)]
+		#[cfg_attr(feature = "schema", schemars(with = "CliStepInputsSchema"))]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Inspect parsed changeset data, provenance, and linked metadata.
@@ -2110,7 +2273,12 @@ pub enum CliStepDefinition {
 		when: Option<String>,
 		#[serde(default)]
 		always_run: bool,
-		#[serde(default)]
+		#[serde(
+			default,
+			deserialize_with = "deserialize_cli_step_inputs",
+			serialize_with = "serialize_cli_step_inputs"
+		)]
+		#[cfg_attr(feature = "schema", schemars(with = "CliStepInputsSchema"))]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Repair a recent release by retargeting its stored release tag set.
@@ -2124,7 +2292,12 @@ pub enum CliStepDefinition {
 		when: Option<String>,
 		#[serde(default)]
 		always_run: bool,
-		#[serde(default)]
+		#[serde(
+			default,
+			deserialize_with = "deserialize_cli_step_inputs",
+			serialize_with = "serialize_cli_step_inputs"
+		)]
+		#[cfg_attr(feature = "schema", schemars(with = "CliStepInputsSchema"))]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 	/// Run an arbitrary command with `monochange` template context.
@@ -2148,7 +2321,12 @@ pub enum CliStepDefinition {
 		id: Option<String>,
 		#[serde(default)]
 		variables: Option<BTreeMap<String, CommandVariable>>,
-		#[serde(default)]
+		#[serde(
+			default,
+			deserialize_with = "deserialize_cli_step_inputs",
+			serialize_with = "serialize_cli_step_inputs"
+		)]
+		#[cfg_attr(feature = "schema", schemars(with = "CliStepInputsSchema"))]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
 }
@@ -2177,6 +2355,38 @@ impl CliStepDefinition {
 			| Self::RetargetRelease { inputs, .. }
 			| Self::Command { inputs, .. } => inputs,
 		}
+	}
+
+	/// Return a copy of this step that explicitly inherits every supported
+	/// command input for the step kind.
+	#[must_use]
+	pub fn with_inherited_step_inputs(mut self) -> Self {
+		let inherited = self
+			.step_inputs_schema()
+			.into_iter()
+			.map(|input| (input.name, CliStepInputValue::Inherited))
+			.collect();
+		match &mut self {
+			Self::Config { inputs, .. }
+			| Self::Validate { inputs, .. }
+			| Self::Discover { inputs, .. }
+			| Self::DisplayVersions { inputs, .. }
+			| Self::CreateChangeFile { inputs, .. }
+			| Self::PrepareRelease { inputs, .. }
+			| Self::CommitRelease { inputs, .. }
+			| Self::VerifyReleaseBranch { inputs, .. }
+			| Self::PublishRelease { inputs, .. }
+			| Self::PlaceholderPublish { inputs, .. }
+			| Self::PublishPackages { inputs, .. }
+			| Self::PlanPublishRateLimits { inputs, .. }
+			| Self::OpenReleaseRequest { inputs, .. }
+			| Self::CommentReleasedIssues { inputs, .. }
+			| Self::AffectedPackages { inputs, .. }
+			| Self::DiagnoseChangesets { inputs, .. }
+			| Self::RetargetRelease { inputs, .. }
+			| Self::Command { inputs, .. } => *inputs = inherited,
+		}
+		self
 	}
 
 	/// Return the optional configured display name for this step.

--- a/crates/monochange_schema/schemas/monochange.schema.json
+++ b/crates/monochange_schema/schemas/monochange.schema.json
@@ -243,11 +243,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -282,11 +279,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -321,11 +315,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -360,11 +351,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -399,11 +387,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -450,11 +435,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -489,11 +471,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -536,11 +515,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -575,11 +551,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -614,11 +587,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -653,11 +623,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -692,11 +659,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -731,11 +695,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -774,11 +735,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -813,11 +771,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -852,11 +807,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -891,11 +843,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -947,11 +896,8 @@
 							]
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -1001,13 +947,29 @@
 				}
 			]
 		},
-		"CliStepInputValue": {
+		"CliStepInputOverrideValueSchema": {
 			"anyOf": [
 				{
 					"type": "string"
 				},
 				{
 					"type": "boolean"
+				},
+				{
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				}
+			]
+		},
+		"CliStepInputsSchema": {
+			"anyOf": [
+				{
+					"additionalProperties": {
+						"$ref": "#/$defs/CliStepInputOverrideValueSchema"
+					},
+					"type": "object"
 				},
 				{
 					"items": {

--- a/docs/src/guide/02-setup.md
+++ b/docs/src/guide/02-setup.md
@@ -290,6 +290,7 @@ default = "text"
 [[cli.discover.steps]]
 name = "discover packages"
 type = "Discover"
+inputs = ["format"]
 
 [cli.change]
 help_text = "Create a change file for one or more packages"
@@ -332,6 +333,7 @@ type = "path"
 [[cli.change.steps]]
 name = "create change file"
 type = "CreateChangeFile"
+inputs = ["interactive", "package", "bump", "version", "type", "reason", "details", "output"]
 
 [cli.release]
 help_text = "Prepare a release from discovered change files"
@@ -345,6 +347,7 @@ default = "text"
 [[cli.release.steps]]
 name = "prepare release"
 type = "PrepareRelease"
+inputs = ["format"]
 
 [cli.publish-release]
 help_text = "Prepare a release and publish provider releases"
@@ -358,10 +361,12 @@ default = "text"
 [[cli.publish-release.steps]]
 name = "prepare release"
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.publish-release.steps]]
 name = "publish release"
 type = "PublishRelease"
+inputs = ["format"]
 
 [cli.release-pr]
 help_text = "Prepare a release and open or update a provider release request"
@@ -375,17 +380,12 @@ default = "text"
 [[cli.release-pr.steps]]
 name = "prepare release"
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-pr.steps]]
 name = "open release request"
 type = "OpenReleaseRequest"
-
-name = "format"
-type = "choice"
-choices = ["text", "json"]
-default = "text"
-
-type = "PrepareRelease"
+inputs = ["format"]
 
 [cli.affected]
 help_text = "Evaluate pull-request changeset policy"
@@ -408,6 +408,7 @@ type = "string_list"
 [[cli.affected.steps]]
 name = "evaluate affected packages"
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]
 ```
 
 <!-- {/projectSetupConfig} -->

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -455,6 +455,49 @@ Built-in steps are also available directly as immutable `mc step:*` commands. Th
 
 Some top-level names are reserved for hardcoded binary commands, including `init`, `mcp`, `help`, `version`, `analyze`, `check`, and `validate`. The `step:` prefix is also reserved. Do not define `[cli.validate]` or `[cli.step:*]` tables.
 
+<!-- {=cliStepExplicitInputInheritance} -->
+
+## Explicit step input inheritance
+
+Config-defined workflow commands have two input layers:
+
+1. `[[cli.<command>.inputs]]` declares the flags and arguments accepted by `mc <command>`.
+2. `inputs` on each step decides which of those parsed command inputs are visible while that step runs.
+
+Command inputs are **not inherited automatically**. A step receives a command input only when the step explicitly lists it. This makes wrappers predictable when a command-level flag and a step-specific input share the same name.
+
+Use the array shorthand when a step should inherit command inputs unchanged:
+
+```toml
+[cli.discover]
+inputs = [
+	{ name = "format", type = "choice", choices = ["text", "json"], default = "text" },
+]
+steps = [
+	{ type = "Discover", inputs = ["format"] },
+]
+```
+
+Use the map form when a step needs fixed values, renamed values, templates, or a mixture of inherited and overridden values:
+
+```toml
+[cli.release-pr]
+inputs = [
+	{ name = "format", type = "choice", choices = ["text", "json", "markdown"], default = "markdown" },
+	{ name = "open_as_draft", type = "boolean", default = false },
+]
+steps = [
+	{ type = "PrepareRelease", inputs = ["format"] },
+	{ type = "OpenReleaseRequest", inputs = { format = "markdown", draft = "{{ inputs.open_as_draft }}" } },
+]
+```
+
+Step-local `when` expressions and command templates evaluate against the same explicit step input context. If a `when` condition references `inputs.publish`, the step must include `publish` in its `inputs` array or map. Use `inputs = ["publish"]` for unchanged inheritance, or `inputs = { publish = "{{ inputs.publish }}" }` when you need the map form for other overrides.
+
+Built-in `mc step:*` commands are different: they are generated directly from the step schema, so their CLI flags map to that single step without a `[cli.*]` wrapper.
+
+<!-- {/cliStepExplicitInputInheritance} -->
+
 <!-- {=configurationWorkflowsSnippet} -->
 
 ```toml
@@ -484,6 +527,7 @@ default = "text"
 [[cli.discover.steps]]
 name = "discover packages"
 type = "Discover"
+inputs = ["format"]
 
 [cli.release]
 help_text = "Prepare a release from discovered change files"
@@ -497,6 +541,7 @@ default = "text"
 [[cli.release.steps]]
 name = "prepare release"
 type = "PrepareRelease"
+inputs = ["format"]
 
 [cli.publish-release]
 help_text = "Prepare a release and publish provider releases"
@@ -510,10 +555,12 @@ default = "text"
 [[cli.publish-release.steps]]
 name = "prepare release"
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.publish-release.steps]]
 name = "publish release"
 type = "PublishRelease"
+inputs = ["format"]
 
 [[cli.publish-release.steps]]
 name = "comment released issues"
@@ -531,10 +578,12 @@ default = "text"
 [[cli.release-pr.steps]]
 name = "prepare release"
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-pr.steps]]
 name = "open release request"
 type = "OpenReleaseRequest"
+inputs = ["format"]
 
 name = "format"
 type = "choice"
@@ -569,6 +618,7 @@ type = "string_list"
 [[cli.affected.steps]]
 name = "evaluate affected packages"
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]
 ```
 
 <!-- {/configurationWorkflowsSnippet} -->

--- a/docs/src/guide/08-github-automation.md
+++ b/docs/src/guide/08-github-automation.md
@@ -189,6 +189,7 @@ default = "text"
 
 [[cli.publish-release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.publish-release.steps]]
 type = "PublishRelease"
@@ -207,9 +208,11 @@ default = "text"
 
 [[cli.release-pr.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-pr.steps]]
 type = "OpenReleaseRequest"
+inputs = ["format"]
 ```
 
 <!-- {/githubAutomationReleaseConfigExample} -->

--- a/docs/src/reference/cli-steps/00-index.md
+++ b/docs/src/reference/cli-steps/00-index.md
@@ -27,6 +27,49 @@ The reference pages in this section document each built-in step with:
 
 <!-- {/cliStepReferenceOverview} -->
 
+<!-- {=cliStepExplicitInputInheritance} -->
+
+## Explicit step input inheritance
+
+Config-defined workflow commands have two input layers:
+
+1. `[[cli.<command>.inputs]]` declares the flags and arguments accepted by `mc <command>`.
+2. `inputs` on each step decides which of those parsed command inputs are visible while that step runs.
+
+Command inputs are **not inherited automatically**. A step receives a command input only when the step explicitly lists it. This makes wrappers predictable when a command-level flag and a step-specific input share the same name.
+
+Use the array shorthand when a step should inherit command inputs unchanged:
+
+```toml
+[cli.discover]
+inputs = [
+	{ name = "format", type = "choice", choices = ["text", "json"], default = "text" },
+]
+steps = [
+	{ type = "Discover", inputs = ["format"] },
+]
+```
+
+Use the map form when a step needs fixed values, renamed values, templates, or a mixture of inherited and overridden values:
+
+```toml
+[cli.release-pr]
+inputs = [
+	{ name = "format", type = "choice", choices = ["text", "json", "markdown"], default = "markdown" },
+	{ name = "open_as_draft", type = "boolean", default = false },
+]
+steps = [
+	{ type = "PrepareRelease", inputs = ["format"] },
+	{ type = "OpenReleaseRequest", inputs = { format = "markdown", draft = "{{ inputs.open_as_draft }}" } },
+]
+```
+
+Step-local `when` expressions and command templates evaluate against the same explicit step input context. If a `when` condition references `inputs.publish`, the step must include `publish` in its `inputs` array or map. Use `inputs = ["publish"]` for unchanged inheritance, or `inputs = { publish = "{{ inputs.publish }}" }` when you need the map form for other overrides.
+
+Built-in `mc step:*` commands are different: they are generated directly from the step schema, so their CLI flags map to that single step without a `[cli.*]` wrapper.
+
+<!-- {/cliStepExplicitInputInheritance} -->
+
 ## Choosing the right step
 
 <!-- {=cliStepReferenceChoosingGuide} -->

--- a/docs/src/reference/cli-steps/02-discover.md
+++ b/docs/src/reference/cli-steps/02-discover.md
@@ -67,6 +67,7 @@ default = "text"
 
 [[cli.discover.steps]]
 type = "Discover"
+inputs = ["format"]
 ```
 
 <!-- {/cliStepDiscoverExample} -->

--- a/docs/src/reference/cli-steps/03-create-change-file.md
+++ b/docs/src/reference/cli-steps/03-create-change-file.md
@@ -113,6 +113,17 @@ type = "string"
 
 [[cli.change.steps]]
 type = "CreateChangeFile"
+inputs = [
+	"interactive",
+	"package",
+	"bump",
+	"version",
+	"type",
+	"caused_by",
+	"reason",
+	"details",
+	"output",
+]
 ```
 
 <!-- {/cliStepCreateChangeFileExample} -->

--- a/docs/src/reference/cli-steps/04-affected-packages.md
+++ b/docs/src/reference/cli-steps/04-affected-packages.md
@@ -88,6 +88,7 @@ type = "boolean"
 
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label", "verify"]
 ```
 
 <!-- {/cliStepAffectedPackagesExample} -->

--- a/docs/src/reference/cli-steps/05-diagnose-changesets.md
+++ b/docs/src/reference/cli-steps/05-diagnose-changesets.md
@@ -87,6 +87,7 @@ type = "string_list"
 
 [[cli.diagnostics.steps]]
 type = "DiagnoseChangesets"
+inputs = ["format", "changeset"]
 ```
 
 <!-- {/cliStepDiagnoseChangesetsExample} -->

--- a/docs/src/reference/cli-steps/06-retarget-release.md
+++ b/docs/src/reference/cli-steps/06-retarget-release.md
@@ -128,6 +128,7 @@ default = "text"
 
 [[cli.repair-release.steps]]
 type = "RetargetRelease"
+inputs = ["from", "target", "force", "sync_provider"]
 ```
 
 <!-- {/cliStepRetargetReleaseExample} -->
@@ -154,6 +155,7 @@ default = "HEAD"
 
 [[cli.repair-and-notify.steps]]
 type = "RetargetRelease"
+inputs = ["from", "target"]
 
 [[cli.repair-and-notify.steps]]
 type = "Command"

--- a/docs/src/reference/cli-steps/07-prepare-release.md
+++ b/docs/src/reference/cli-steps/07-prepare-release.md
@@ -94,6 +94,7 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 ```
 
 <!-- {/cliStepPrepareReleaseExample} -->
@@ -116,6 +117,7 @@ default = "text"
 
 [[cli.release-with-notes.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-with-notes.steps]]
 type = "Command"

--- a/docs/src/reference/cli-steps/08-commit-release.md
+++ b/docs/src/reference/cli-steps/08-commit-release.md
@@ -103,6 +103,7 @@ default = "text"
 
 [[cli.commit-release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.commit-release.steps]]
 type = "CommitRelease"

--- a/docs/src/reference/cli-steps/10-publish-release.md
+++ b/docs/src/reference/cli-steps/10-publish-release.md
@@ -72,9 +72,11 @@ default = "text"
 
 [[cli.publish-release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.publish-release.steps]]
 type = "PublishRelease"
+inputs = ["format"]
 ```
 
 <!-- {/cliStepPublishReleaseExample} -->
@@ -97,9 +99,11 @@ default = "text"
 
 [[cli.publish-and-comment.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.publish-and-comment.steps]]
 type = "PublishRelease"
+inputs = ["format"]
 
 [[cli.publish-and-comment.steps]]
 type = "CommentReleasedIssues"

--- a/docs/src/reference/cli-steps/11-open-release-request.md
+++ b/docs/src/reference/cli-steps/11-open-release-request.md
@@ -87,9 +87,11 @@ default = "text"
 
 [[cli.release-pr.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-pr.steps]]
 type = "OpenReleaseRequest"
+inputs = ["format"]
 ```
 
 <!-- {/cliStepOpenReleaseRequestExample} -->

--- a/docs/src/reference/cli-steps/12-comment-released-issues.md
+++ b/docs/src/reference/cli-steps/12-comment-released-issues.md
@@ -67,9 +67,11 @@ default = "text"
 
 [[cli.publish-and-comment.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.publish-and-comment.steps]]
 type = "PublishRelease"
+inputs = ["format"]
 
 [[cli.publish-and-comment.steps]]
 type = "CommentReleasedIssues"

--- a/docs/src/reference/cli-steps/13-command.md
+++ b/docs/src/reference/cli-steps/13-command.md
@@ -87,6 +87,7 @@ default = "text"
 
 [[cli.release-with-notes.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-with-notes.steps]]
 type = "Command"
@@ -141,6 +142,7 @@ default = "HEAD"
 
 [[cli.repair-and-notify.steps]]
 type = "RetargetRelease"
+inputs = ["from", "target"]
 
 [[cli.repair-and-notify.steps]]
 type = "Command"

--- a/docs/src/reference/cli-steps/15-placeholder-publish.md
+++ b/docs/src/reference/cli-steps/15-placeholder-publish.md
@@ -88,6 +88,7 @@ help_text = "Show already-published and skipped placeholder packages instead of 
 [[cli.placeholder-publish.steps]]
 name = "publish placeholder packages"
 type = "PlaceholderPublish"
+inputs = ["format", "package", "show-all"]
 ```
 
 <!-- {/cliStepPlaceholderPublishExample} -->

--- a/docs/src/reference/cli-steps/16-publish-packages.md
+++ b/docs/src/reference/cli-steps/16-publish-packages.md
@@ -151,6 +151,7 @@ help_text = "Write the package publish result JSON artifact for retry/resume"
 [[cli.publish.steps]]
 name = "publish packages"
 type = "PublishPackages"
+inputs = ["format", "package", "group", "ecosystem", "resume", "output"]
 ```
 
 <!-- {/cliStepPublishPackagesExample} -->

--- a/docs/src/schemas/monochange.schema.json
+++ b/docs/src/schemas/monochange.schema.json
@@ -243,11 +243,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -282,11 +279,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -321,11 +315,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -360,11 +351,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -399,11 +387,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -450,11 +435,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -489,11 +471,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -536,11 +515,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -575,11 +551,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -614,11 +587,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -653,11 +623,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -692,11 +659,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -731,11 +695,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -774,11 +735,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -813,11 +771,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -852,11 +807,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -891,11 +843,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -947,11 +896,8 @@
 							]
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -1001,13 +947,29 @@
 				}
 			]
 		},
-		"CliStepInputValue": {
+		"CliStepInputOverrideValueSchema": {
 			"anyOf": [
 				{
 					"type": "string"
 				},
 				{
 					"type": "boolean"
+				},
+				{
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				}
+			]
+		},
+		"CliStepInputsSchema": {
+			"anyOf": [
+				{
+					"additionalProperties": {
+						"$ref": "#/$defs/CliStepInputOverrideValueSchema"
+					},
+					"type": "object"
 				},
 				{
 					"items": {

--- a/docs/src/schemas/monochange.v0.1.schema.json
+++ b/docs/src/schemas/monochange.v0.1.schema.json
@@ -243,11 +243,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -282,11 +279,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -321,11 +315,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -360,11 +351,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -399,11 +387,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -450,11 +435,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -489,11 +471,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -536,11 +515,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -575,11 +551,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -614,11 +587,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -653,11 +623,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -692,11 +659,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -731,11 +695,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -774,11 +735,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -813,11 +771,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -852,11 +807,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -891,11 +843,8 @@
 							"type": "boolean"
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -947,11 +896,8 @@
 							]
 						},
 						"inputs": {
-							"additionalProperties": {
-								"$ref": "#/$defs/CliStepInputValue"
-							},
-							"default": {},
-							"type": "object"
+							"$ref": "#/$defs/CliStepInputsSchema",
+							"default": []
 						},
 						"name": {
 							"default": null,
@@ -1001,13 +947,29 @@
 				}
 			]
 		},
-		"CliStepInputValue": {
+		"CliStepInputOverrideValueSchema": {
 			"anyOf": [
 				{
 					"type": "string"
 				},
 				{
 					"type": "boolean"
+				},
+				{
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				}
+			]
+		},
+		"CliStepInputsSchema": {
+			"anyOf": [
+				{
+					"additionalProperties": {
+						"$ref": "#/$defs/CliStepInputOverrideValueSchema"
+					},
+					"type": "object"
 				},
 				{
 					"items": {

--- a/fixtures/affected/additional-paths/monochange.toml
+++ b/fixtures/affected/additional-paths/monochange.toml
@@ -32,3 +32,4 @@ name = "label"
 type = "string_list"
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/affected/group-coverage-missing/monochange.toml
+++ b/fixtures/affected/group-coverage-missing/monochange.toml
@@ -37,3 +37,4 @@ name = "label"
 type = "string_list"
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/affected/group-coverage/monochange.toml
+++ b/fixtures/affected/group-coverage/monochange.toml
@@ -34,3 +34,4 @@ name = "label"
 type = "string_list"
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/affected/ignored-paths/monochange.toml
+++ b/fixtures/affected/ignored-paths/monochange.toml
@@ -32,3 +32,4 @@ name = "label"
 type = "string_list"
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/affected/multi-package/monochange.toml
+++ b/fixtures/affected/multi-package/monochange.toml
@@ -32,3 +32,4 @@ name = "label"
 type = "string_list"
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/affected/single-package-with-changeset/monochange.toml
+++ b/fixtures/affected/single-package-with-changeset/monochange.toml
@@ -32,3 +32,4 @@ name = "label"
 type = "string_list"
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/affected/single-package-wrong-target/monochange.toml
+++ b/fixtures/affected/single-package-wrong-target/monochange.toml
@@ -32,3 +32,4 @@ name = "label"
 type = "string_list"
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/affected/single-package/monochange.toml
+++ b/fixtures/affected/single-package/monochange.toml
@@ -32,3 +32,4 @@ name = "label"
 type = "string_list"
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/affected/skip-label/monochange.toml
+++ b/fixtures/affected/skip-label/monochange.toml
@@ -32,3 +32,4 @@ name = "label"
 type = "string_list"
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/source/gitea/monochange.toml
+++ b/fixtures/source/gitea/monochange.toml
@@ -34,6 +34,8 @@ default = "text"
 
 [[cli.release-pr.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-pr.steps]]
 type = "OpenReleaseRequest"
+inputs = ["format"]

--- a/fixtures/source/github/monochange.toml
+++ b/fixtures/source/github/monochange.toml
@@ -33,11 +33,23 @@ type = "choice"
 choices = ["text", "json"]
 default = "text"
 
+[[cli.publish-release.inputs]]
+name = "from-ref"
+type = "string"
+default = "HEAD"
+
+[[cli.publish-release.inputs]]
+name = "draft"
+type = "boolean"
+default = false
+
 [[cli.publish-release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.publish-release.steps]]
 type = "PublishRelease"
+inputs = ["format", "from-ref", "draft"]
 
 [cli.release-pr]
 
@@ -49,9 +61,11 @@ default = "text"
 
 [[cli.release-pr.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-pr.steps]]
 type = "OpenReleaseRequest"
+inputs = ["format"]
 
 [cli.release-comments]
 
@@ -61,8 +75,15 @@ type = "choice"
 choices = ["text", "json"]
 default = "text"
 
+[[cli.release-comments.inputs]]
+name = "auto-close-issues"
+type = "boolean"
+default = false
+
 [[cli.release-comments.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-comments.steps]]
 type = "CommentReleasedIssues"
+inputs = ["format", "auto-close-issues"]

--- a/fixtures/source/gitlab/monochange.toml
+++ b/fixtures/source/gitlab/monochange.toml
@@ -32,8 +32,20 @@ type = "choice"
 choices = ["text", "json"]
 default = "text"
 
+[[cli.publish-release.inputs]]
+name = "from-ref"
+type = "string"
+default = "HEAD"
+
+[[cli.publish-release.inputs]]
+name = "draft"
+type = "boolean"
+default = false
+
 [[cli.publish-release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.publish-release.steps]]
 type = "PublishRelease"
+inputs = ["format", "from-ref", "draft"]

--- a/fixtures/tests/affected/additional-paths/monochange.toml
+++ b/fixtures/tests/affected/additional-paths/monochange.toml
@@ -32,3 +32,4 @@ name = "label"
 type = "string_list"
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/tests/affected/changelog-paths/monochange.toml
+++ b/fixtures/tests/affected/changelog-paths/monochange.toml
@@ -33,3 +33,4 @@ name = "label"
 type = "string_list"
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/tests/affected/group-coverage-missing/monochange.toml
+++ b/fixtures/tests/affected/group-coverage-missing/monochange.toml
@@ -37,3 +37,4 @@ name = "label"
 type = "string_list"
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/tests/affected/group-coverage/monochange.toml
+++ b/fixtures/tests/affected/group-coverage/monochange.toml
@@ -34,3 +34,4 @@ name = "label"
 type = "string_list"
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/tests/affected/ignored-paths/monochange.toml
+++ b/fixtures/tests/affected/ignored-paths/monochange.toml
@@ -32,3 +32,4 @@ name = "label"
 type = "string_list"
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/tests/affected/multi-package/monochange.toml
+++ b/fixtures/tests/affected/multi-package/monochange.toml
@@ -32,3 +32,4 @@ name = "label"
 type = "string_list"
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/tests/affected/since-base/monochange.toml
+++ b/fixtures/tests/affected/since-base/monochange.toml
@@ -28,3 +28,4 @@ name = "label"
 type = "string_list"
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/tests/affected/since-changed-source/monochange.toml
+++ b/fixtures/tests/affected/since-changed-source/monochange.toml
@@ -28,3 +28,4 @@ name = "label"
 type = "string_list"
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/tests/affected/since-changed-with-changeset/monochange.toml
+++ b/fixtures/tests/affected/since-changed-with-changeset/monochange.toml
@@ -28,3 +28,4 @@ name = "label"
 type = "string_list"
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/tests/affected/single-package-with-changeset/monochange.toml
+++ b/fixtures/tests/affected/single-package-with-changeset/monochange.toml
@@ -32,3 +32,4 @@ name = "label"
 type = "string_list"
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/tests/affected/single-package-wrong-target/monochange.toml
+++ b/fixtures/tests/affected/single-package-wrong-target/monochange.toml
@@ -32,3 +32,4 @@ name = "label"
 type = "string_list"
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/tests/affected/single-package/monochange.toml
+++ b/fixtures/tests/affected/single-package/monochange.toml
@@ -32,3 +32,4 @@ name = "label"
 type = "string_list"
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/tests/affected/skip-label/monochange.toml
+++ b/fixtures/tests/affected/skip-label/monochange.toml
@@ -32,3 +32,4 @@ name = "label"
 type = "string_list"
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/tests/changelog-formats/alert-multi-packages/monochange.toml
+++ b/fixtures/tests/changelog-formats/alert-multi-packages/monochange.toml
@@ -26,6 +26,13 @@ format = "monochange"
 enabled = true
 
 [cli.release]
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/changelog-formats/alert-multiline/monochange.toml
+++ b/fixtures/tests/changelog-formats/alert-multiline/monochange.toml
@@ -26,6 +26,13 @@ format = "monochange"
 enabled = true
 
 [cli.release]
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/changelog-formats/custom-changelog-sections/monochange.toml
+++ b/fixtures/tests/changelog-formats/custom-changelog-sections/monochange.toml
@@ -51,6 +51,13 @@ path = "docs/sdk-CHANGELOG.md"
 enabled = true
 
 [cli.release]
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/changelog-formats/default-sections-mixed-types/monochange.toml
+++ b/fixtures/tests/changelog-formats/default-sections-mixed-types/monochange.toml
@@ -24,6 +24,13 @@ path = "docs/sdk-CHANGELOG.md"
 enabled = true
 
 [cli.release]
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/changelog-formats/defaults-keep-a/monochange.toml
+++ b/fixtures/tests/changelog-formats/defaults-keep-a/monochange.toml
@@ -25,6 +25,13 @@ path = "docs/sdk-CHANGELOG.md"
 enabled = true
 
 [cli.release]
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/changelog-formats/defaults-then-package-override/monochange.toml
+++ b/fixtures/tests/changelog-formats/defaults-then-package-override/monochange.toml
@@ -31,6 +31,13 @@ format = "monochange"
 enabled = true
 
 [cli.release]
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/changelog-formats/excluded-changelog-types/monochange.toml
+++ b/fixtures/tests/changelog-formats/excluded-changelog-types/monochange.toml
@@ -48,6 +48,13 @@ path = "docs/sdk-CHANGELOG.md"
 enabled = true
 
 [cli.release]
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/changelog-formats/group-include-group-note/monochange.toml
+++ b/fixtures/tests/changelog-formats/group-include-group-note/monochange.toml
@@ -26,6 +26,13 @@ include = "group-only"
 enabled = true
 
 [cli.release]
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/changelog-formats/group-include-group-only/monochange.toml
+++ b/fixtures/tests/changelog-formats/group-include-group-only/monochange.toml
@@ -26,6 +26,13 @@ include = "group-only"
 enabled = true
 
 [cli.release]
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/changelog-formats/group-include-multi-target-blocked/monochange.toml
+++ b/fixtures/tests/changelog-formats/group-include-multi-target-blocked/monochange.toml
@@ -26,6 +26,13 @@ include = ["core"]
 enabled = true
 
 [cli.release]
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/changelog-formats/group-include-selected/monochange.toml
+++ b/fixtures/tests/changelog-formats/group-include-selected/monochange.toml
@@ -26,6 +26,13 @@ include = ["core"]
 enabled = true
 
 [cli.release]
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/changelog-formats/keep-a-changelog-with-sections/monochange.toml
+++ b/fixtures/tests/changelog-formats/keep-a-changelog-with-sections/monochange.toml
@@ -45,6 +45,13 @@ format = "keep_a_changelog"
 enabled = true
 
 [cli.release]
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/changelog-formats/linked-title/monochange.toml
+++ b/fixtures/tests/changelog-formats/linked-title/monochange.toml
@@ -21,6 +21,13 @@ repo = "monochange"
 enabled = true
 
 [cli.release]
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/changelog-formats/section-priority-ordering/monochange.toml
+++ b/fixtures/tests/changelog-formats/section-priority-ordering/monochange.toml
@@ -43,6 +43,13 @@ path = "docs/sdk-CHANGELOG.md"
 enabled = true
 
 [cli.release]
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/changeset-context/base/monochange.toml
+++ b/fixtures/tests/changeset-context/base/monochange.toml
@@ -34,8 +34,15 @@ path = "crates/core"
 [cli.release]
 help_text = "Prepare a release and refresh the cached release manifest"
 
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [cli.diagnostics]
 help_text = "Show changeset diagnostics and context"
@@ -52,3 +59,4 @@ type = "string_list"
 
 [[cli.diagnostics.steps]]
 type = "DiagnoseChangesets"
+inputs = ["format", "changeset"]

--- a/fixtures/tests/changeset-context/with-updated-changeset/monochange.toml
+++ b/fixtures/tests/changeset-context/with-updated-changeset/monochange.toml
@@ -18,8 +18,15 @@ path = "crates/core"
 [cli.release]
 help_text = "Prepare a release and refresh the cached release manifest"
 
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [cli.diagnostics]
 help_text = "Show changeset diagnostics and context"
@@ -36,3 +43,4 @@ type = "string_list"
 
 [[cli.diagnostics.steps]]
 type = "DiagnoseChangesets"
+inputs = ["format", "changeset"]

--- a/fixtures/tests/changeset-policy/no-changeset/monochange.toml
+++ b/fixtures/tests/changeset-policy/no-changeset/monochange.toml
@@ -33,3 +33,4 @@ type = "string_list"
 
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/tests/changeset-policy/with-changeset-core/monochange.toml
+++ b/fixtures/tests/changeset-policy/with-changeset-core/monochange.toml
@@ -33,3 +33,4 @@ type = "string_list"
 
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/tests/changeset-policy/with-changeset-invalid-core/monochange.toml
+++ b/fixtures/tests/changeset-policy/with-changeset-invalid-core/monochange.toml
@@ -33,3 +33,4 @@ type = "string_list"
 
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/tests/changeset-policy/with-changeset-other/monochange.toml
+++ b/fixtures/tests/changeset-policy/with-changeset-other/monochange.toml
@@ -33,3 +33,4 @@ type = "string_list"
 
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/tests/changeset-target-metadata/release-workspace/monochange.toml
+++ b/fixtures/tests/changeset-target-metadata/release-workspace/monochange.toml
@@ -46,3 +46,4 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/cli-output/changeset-policy-no-changeset/monochange.toml
+++ b/fixtures/tests/cli-output/changeset-policy-no-changeset/monochange.toml
@@ -30,3 +30,4 @@ type = "string_list"
 
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/tests/cli-output/group-basic/monochange.toml
+++ b/fixtures/tests/cli-output/group-basic/monochange.toml
@@ -33,3 +33,4 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/cli-output/group-explicit-version/monochange.toml
+++ b/fixtures/tests/cli-output/group-explicit-version/monochange.toml
@@ -32,3 +32,4 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/cli-output/group-json/monochange.toml
+++ b/fixtures/tests/cli-output/group-json/monochange.toml
@@ -33,3 +33,4 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/cli-output/group-no-changelog/monochange.toml
+++ b/fixtures/tests/cli-output/group-no-changelog/monochange.toml
@@ -25,6 +25,13 @@ version_format = "primary"
 enabled = true
 
 [cli.release]
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/cli-output/publish-plan-dependency-order/monochange.toml
+++ b/fixtures/tests/cli-output/publish-plan-dependency-order/monochange.toml
@@ -8,8 +8,8 @@ inputs = [
 	{ name = "all", type = "boolean", default = false },
 ]
 steps = [
-	{ name = "prepare release", type = "PrepareRelease" },
-	{ name = "plan publish rate limits", type = "PlanPublishRateLimits" },
+	{ name = "prepare release", type = "PrepareRelease", inputs = ["format"] },
+	{ name = "plan publish rate limits", type = "PlanPublishRateLimits", inputs = ["format", "all"] },
 ]
 
 [cli.publish]
@@ -18,7 +18,7 @@ inputs = [
 	{ name = "all", type = "boolean", default = false },
 ]
 steps = [
-	{ name = "publish packages", type = "PublishPackages" },
+	{ name = "publish packages", type = "PublishPackages", inputs = ["format", "all"] },
 ]
 
 [package.zeta_transport]

--- a/fixtures/tests/cli-output/release-manifest-workflow/monochange.toml
+++ b/fixtures/tests/cli-output/release-manifest-workflow/monochange.toml
@@ -25,5 +25,12 @@ enabled = true
 [cli.release]
 help_text = "Prepare a release and refresh the cached release manifest"
 
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/cli-output/release-pr-workflow/monochange.toml
+++ b/fixtures/tests/cli-output/release-pr-workflow/monochange.toml
@@ -33,9 +33,17 @@ labels = ["release", "automated"]
 enabled = true
 
 [cli.release-pr]
+[[cli.release-pr.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.release-pr.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-pr.steps]]
 type = "OpenReleaseRequest"
+inputs = ["format"]

--- a/fixtures/tests/cli-output/ungrouped-basic/monochange.toml
+++ b/fixtures/tests/cli-output/ungrouped-basic/monochange.toml
@@ -50,6 +50,7 @@ type = "path"
 
 [[cli.change.steps]]
 type = "CreateChangeFile"
+inputs = ["interactive", "package", "bump", "version", "reason", "type", "details", "output"]
 
 [cli.release]
 
@@ -61,3 +62,4 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/cli-output/ungrouped-no-changeset/monochange.toml
+++ b/fixtures/tests/cli-output/ungrouped-no-changeset/monochange.toml
@@ -21,3 +21,4 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/cli-step-input-overrides/source-github/monochange.toml
+++ b/fixtures/tests/cli-step-input-overrides/source-github/monochange.toml
@@ -28,8 +28,15 @@ enabled = true
 [cli.publish-release]
 help_text = "Publish releases"
 
+[[cli.publish-release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 [[cli.publish-release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.publish-release.steps]]
 type = "PublishRelease"
@@ -38,8 +45,15 @@ inputs = { format = "json" }
 [cli.release-pr]
 help_text = "Open a release pull request"
 
+[[cli.release-pr.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 [[cli.release-pr.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-pr.steps]]
 type = "OpenReleaseRequest"
@@ -48,8 +62,15 @@ inputs = { format = "json" }
 [cli.release-comments]
 help_text = "Comment on released issues"
 
+[[cli.release-comments.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 [[cli.release-comments.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-comments.steps]]
 type = "CommentReleasedIssues"

--- a/fixtures/tests/cli-step-when/monochange.toml
+++ b/fixtures/tests/cli-step-when/monochange.toml
@@ -13,6 +13,7 @@ default = "false"
 
 [[cli.when-command.steps]]
 type = "Command"
+inputs = ["run", "extra"]
 when = "{{ inputs.run && inputs.extra }}"
 command = "printf '%s' hello > when-command-output.txt"
 shell = true
@@ -27,6 +28,7 @@ default = "true"
 
 [[cli.not-condition.steps]]
 type = "Command"
+inputs = ["skip"]
 when = "{{ ! inputs.skip }}"
 command = "printf '%s' okay > not-output.txt"
 shell = true
@@ -35,10 +37,11 @@ shell = true
 help_text = "Conditionally run Validate"
 
 [[cli.when-validate.inputs]]
-name = "skip"
+name = "fix"
 type = "boolean"
 default = "true"
 
 [[cli.when-validate.steps]]
 type = "Validate"
-when = "{{ ! inputs.skip }}"
+inputs = ["fix"]
+when = "{{ ! inputs.fix }}"

--- a/fixtures/tests/config/diagnostics-cli/monochange.toml
+++ b/fixtures/tests/config/diagnostics-cli/monochange.toml
@@ -19,3 +19,4 @@ type = "string_list"
 
 [[cli.diagnostics.steps]]
 type = "DiagnoseChangesets"
+inputs = ["format"]

--- a/fixtures/tests/github-releases/custom-sections/monochange.toml
+++ b/fixtures/tests/github-releases/custom-sections/monochange.toml
@@ -38,8 +38,20 @@ type = "choice"
 choices = ["text", "json"]
 default = "text"
 
+[[cli.publish-release.inputs]]
+name = "from-ref"
+type = "string"
+default = "HEAD"
+
+[[cli.publish-release.inputs]]
+name = "draft"
+type = "boolean"
+default = false
+
 [[cli.publish-release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.publish-release.steps]]
 type = "PublishRelease"
+inputs = ["format", "from-ref", "draft"]

--- a/fixtures/tests/github-releases/default-custom-sections/monochange.toml
+++ b/fixtures/tests/github-releases/default-custom-sections/monochange.toml
@@ -38,8 +38,20 @@ type = "choice"
 choices = ["text", "json"]
 default = "text"
 
+[[cli.publish-release.inputs]]
+name = "from-ref"
+type = "string"
+default = "HEAD"
+
+[[cli.publish-release.inputs]]
+name = "draft"
+type = "boolean"
+default = false
+
 [[cli.publish-release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.publish-release.steps]]
 type = "PublishRelease"
+inputs = ["format", "from-ref", "draft"]

--- a/fixtures/tests/github-releases/group/monochange.toml
+++ b/fixtures/tests/github-releases/group/monochange.toml
@@ -38,8 +38,20 @@ type = "choice"
 choices = ["text", "json"]
 default = "text"
 
+[[cli.publish-release.inputs]]
+name = "from-ref"
+type = "string"
+default = "HEAD"
+
+[[cli.publish-release.inputs]]
+name = "draft"
+type = "boolean"
+default = false
+
 [[cli.publish-release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.publish-release.steps]]
 type = "PublishRelease"
+inputs = ["format", "from-ref", "draft"]

--- a/fixtures/tests/github-releases/ungrouped/monochange.toml
+++ b/fixtures/tests/github-releases/ungrouped/monochange.toml
@@ -33,8 +33,20 @@ type = "choice"
 choices = ["text", "json"]
 default = "text"
 
+[[cli.publish-release.inputs]]
+name = "from-ref"
+type = "string"
+default = "HEAD"
+
+[[cli.publish-release.inputs]]
+name = "draft"
+type = "boolean"
+default = false
+
 [[cli.publish-release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.publish-release.steps]]
 type = "PublishRelease"
+inputs = ["format", "from-ref", "draft"]

--- a/fixtures/tests/manifest-formatting/preserve-cargo/monochange.toml
+++ b/fixtures/tests/manifest-formatting/preserve-cargo/monochange.toml
@@ -26,6 +26,13 @@ version_format = "primary"
 enabled = true
 
 [cli.release]
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/manifest-formatting/preserve-ecosystem-manifests/monochange.toml
+++ b/fixtures/tests/manifest-formatting/preserve-ecosystem-manifests/monochange.toml
@@ -29,6 +29,13 @@ enabled = true
 enabled = true
 
 [cli.release]
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/monochange/bun-lock-release/monochange.toml
+++ b/fixtures/tests/monochange/bun-lock-release/monochange.toml
@@ -7,5 +7,12 @@ path = "packages/app"
 
 [cli.release]
 
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/monochange/cargo-lock-release/monochange.toml
+++ b/fixtures/tests/monochange/cargo-lock-release/monochange.toml
@@ -7,5 +7,12 @@ path = "crates/core"
 
 [cli.release]
 
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/monochange/changeset-policy-base/monochange.toml
+++ b/fixtures/tests/monochange/changeset-policy-base/monochange.toml
@@ -32,3 +32,4 @@ type = "string_list"
 
 [[cli.affected.steps]]
 type = "AffectedPackages"
+inputs = ["format", "changed_paths", "label"]

--- a/fixtures/tests/monochange/commit-release/monochange.toml
+++ b/fixtures/tests/monochange/commit-release/monochange.toml
@@ -31,6 +31,7 @@ default = "text"
 
 [[cli.commit-release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.commit-release.steps]]
 type = "CommitRelease"

--- a/fixtures/tests/monochange/custom-lockfile-command/monochange.toml
+++ b/fixtures/tests/monochange/custom-lockfile-command/monochange.toml
@@ -10,5 +10,12 @@ lockfile_commands = [{ command = "custom-lock", cwd = "packages/app", shell = tr
 
 [cli.release]
 
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/monochange/deno-lock-release/monochange.toml
+++ b/fixtures/tests/monochange/deno-lock-release/monochange.toml
@@ -7,5 +7,12 @@ path = "packages/app"
 
 [cli.release]
 
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/monochange/diagnostics-base/monochange.toml
+++ b/fixtures/tests/monochange/diagnostics-base/monochange.toml
@@ -19,3 +19,4 @@ type = "string_list"
 
 [[cli.diagnostics.steps]]
 type = "DiagnoseChangesets"
+inputs = ["format", "changeset"]

--- a/fixtures/tests/monochange/diagnostics-two-changesets/monochange.toml
+++ b/fixtures/tests/monochange/diagnostics-two-changesets/monochange.toml
@@ -19,3 +19,4 @@ type = "string_list"
 
 [[cli.diagnostics.steps]]
 type = "DiagnoseChangesets"
+inputs = ["format", "changeset"]

--- a/fixtures/tests/monochange/explicit-lockfile-override/monochange.toml
+++ b/fixtures/tests/monochange/explicit-lockfile-override/monochange.toml
@@ -8,5 +8,12 @@ versioned_files = [{ path = "lockfiles/shared/package-lock.json", type = "npm" }
 
 [cli.release]
 
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/monochange/group-empty-update-message/monochange.toml
+++ b/fixtures/tests/monochange/group-empty-update-message/monochange.toml
@@ -23,5 +23,12 @@ enabled = true
 
 [cli.release]
 
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/monochange/npm-lock-release/monochange.toml
+++ b/fixtures/tests/monochange/npm-lock-release/monochange.toml
@@ -7,5 +7,12 @@ path = "packages/app"
 
 [cli.release]
 
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/monochange/populate-partial-cli/monochange.toml
+++ b/fixtures/tests/monochange/populate-partial-cli/monochange.toml
@@ -4,5 +4,12 @@ parent_bump = "patch"
 [cli.release]
 help_text = "Custom release pipeline"
 
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/monochange/regex-versioned-file/monochange.toml
+++ b/fixtures/tests/monochange/regex-versioned-file/monochange.toml
@@ -34,3 +34,4 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/monochange/release-apply-github/workspace/monochange.toml
+++ b/fixtures/tests/monochange/release-apply-github/workspace/monochange.toml
@@ -36,3 +36,4 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/monochange/release-base/monochange.toml
+++ b/fixtures/tests/monochange/release-base/monochange.toml
@@ -31,3 +31,4 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/monochange/release-failing-changelog/monochange.toml
+++ b/fixtures/tests/monochange/release-failing-changelog/monochange.toml
@@ -32,3 +32,4 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/monochange/release-heading-normalization/monochange.toml
+++ b/fixtures/tests/monochange/release-heading-normalization/monochange.toml
@@ -31,3 +31,4 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/monochange/release-progress-failure/monochange.toml
+++ b/fixtures/tests/monochange/release-progress-failure/monochange.toml
@@ -31,6 +31,7 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [cli.progress-failure]
 help_text = "Exercise progress output"

--- a/fixtures/tests/monochange/release-progress/monochange.toml
+++ b/fixtures/tests/monochange/release-progress/monochange.toml
@@ -31,6 +31,7 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [cli.progress-release]
 help_text = "Exercise progress output"

--- a/fixtures/tests/monochange/release-with-command-step/monochange.toml
+++ b/fixtures/tests/monochange/release-with-command-step/monochange.toml
@@ -31,6 +31,7 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release.steps]]
 type = "Command"

--- a/fixtures/tests/monochange/release-with-file-diff-command/monochange.toml
+++ b/fixtures/tests/monochange/release-with-file-diff-command/monochange.toml
@@ -31,6 +31,7 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release.steps]]
 type = "Command"

--- a/fixtures/tests/pre-stable-versioning/pre-stable-grouped-major/monochange.toml
+++ b/fixtures/tests/pre-stable-versioning/pre-stable-grouped-major/monochange.toml
@@ -27,3 +27,4 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/pre-stable-versioning/pre-stable-major/monochange.toml
+++ b/fixtures/tests/pre-stable-versioning/pre-stable-major/monochange.toml
@@ -21,3 +21,4 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/pre-stable-versioning/pre-stable-minor/monochange.toml
+++ b/fixtures/tests/pre-stable-versioning/pre-stable-minor/monochange.toml
@@ -21,3 +21,4 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/pre-stable-versioning/stable-major/monochange.toml
+++ b/fixtures/tests/pre-stable-versioning/stable-major/monochange.toml
@@ -21,3 +21,4 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/prepared-release/commit-release-flexible/workspace/monochange.toml
+++ b/fixtures/tests/prepared-release/commit-release-flexible/workspace/monochange.toml
@@ -35,6 +35,7 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [cli.commit-from-cache]
 
@@ -58,6 +59,7 @@ default = "text"
 
 [[cli.release-with-manifest.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-with-manifest.steps]]
 type = "CommitRelease"

--- a/fixtures/tests/prepared-release/source-github-follow-up/workspace/monochange.toml
+++ b/fixtures/tests/prepared-release/source-github-follow-up/workspace/monochange.toml
@@ -35,6 +35,7 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [cli.commit-release]
 
@@ -46,6 +47,7 @@ default = "text"
 
 [[cli.commit-release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.commit-release.steps]]
 type = "CommitRelease"
@@ -61,6 +63,8 @@ default = "text"
 
 [[cli.release-pr.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-pr.steps]]
 type = "OpenReleaseRequest"
+inputs = ["format"]

--- a/fixtures/tests/release-notes-and-propagation/grouped-change-template/monochange.toml
+++ b/fixtures/tests/release-notes-and-propagation/grouped-change-template/monochange.toml
@@ -25,6 +25,13 @@ version_format = "primary"
 enabled = true
 
 [cli.release]
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/release-notes-and-propagation/grouped-default/monochange.toml
+++ b/fixtures/tests/release-notes-and-propagation/grouped-default/monochange.toml
@@ -31,3 +31,4 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/release-notes-and-propagation/grouped-empty-message/monochange.toml
+++ b/fixtures/tests/release-notes-and-propagation/grouped-empty-message/monochange.toml
@@ -32,3 +32,4 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/release-notes-and-propagation/ungrouped-caused-by/monochange.toml
+++ b/fixtures/tests/release-notes-and-propagation/ungrouped-caused-by/monochange.toml
@@ -24,3 +24,4 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/release-notes-and-propagation/ungrouped-custom-default-message/monochange.toml
+++ b/fixtures/tests/release-notes-and-propagation/ungrouped-custom-default-message/monochange.toml
@@ -16,6 +16,13 @@ path = "crates/app"
 enabled = true
 
 [cli.release]
+[[cli.release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/release-notes-and-propagation/ungrouped-custom-package-message/monochange.toml
+++ b/fixtures/tests/release-notes-and-propagation/ungrouped-custom-package-message/monochange.toml
@@ -37,3 +37,4 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/release-notes-and-propagation/ungrouped-minor/monochange.toml
+++ b/fixtures/tests/release-notes-and-propagation/ungrouped-minor/monochange.toml
@@ -24,3 +24,4 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/release-notes-and-propagation/ungrouped-patch/monochange.toml
+++ b/fixtures/tests/release-notes-and-propagation/ungrouped-patch/monochange.toml
@@ -24,3 +24,4 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]

--- a/fixtures/tests/release-pr/group/monochange.toml
+++ b/fixtures/tests/release-pr/group/monochange.toml
@@ -39,6 +39,8 @@ default = "text"
 
 [[cli.release-pr.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-pr.steps]]
 type = "OpenReleaseRequest"
+inputs = ["format"]

--- a/fixtures/tests/release-pr/ungrouped/monochange.toml
+++ b/fixtures/tests/release-pr/ungrouped/monochange.toml
@@ -36,6 +36,8 @@ default = "text"
 
 [[cli.release-pr.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-pr.steps]]
 type = "OpenReleaseRequest"
+inputs = ["format"]

--- a/fixtures/tests/source/forgejo/monochange.toml
+++ b/fixtures/tests/source/forgejo/monochange.toml
@@ -34,6 +34,8 @@ default = "text"
 
 [[cli.release-pr.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-pr.steps]]
 type = "OpenReleaseRequest"
+inputs = ["format"]

--- a/fixtures/tests/source/gitea/monochange.toml
+++ b/fixtures/tests/source/gitea/monochange.toml
@@ -34,6 +34,8 @@ default = "text"
 
 [[cli.release-pr.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-pr.steps]]
 type = "OpenReleaseRequest"
+inputs = ["format"]

--- a/fixtures/tests/source/github/monochange.toml
+++ b/fixtures/tests/source/github/monochange.toml
@@ -33,11 +33,23 @@ type = "choice"
 choices = ["text", "json"]
 default = "text"
 
+[[cli.publish-release.inputs]]
+name = "from-ref"
+type = "string"
+default = "HEAD"
+
+[[cli.publish-release.inputs]]
+name = "draft"
+type = "boolean"
+default = false
+
 [[cli.publish-release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.publish-release.steps]]
 type = "PublishRelease"
+inputs = ["format", "from-ref", "draft"]
 
 [cli.release-pr]
 
@@ -49,9 +61,11 @@ default = "text"
 
 [[cli.release-pr.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-pr.steps]]
 type = "OpenReleaseRequest"
+inputs = ["format"]
 
 [cli.release-comments]
 
@@ -61,8 +75,15 @@ type = "choice"
 choices = ["text", "json"]
 default = "text"
 
+[[cli.release-comments.inputs]]
+name = "auto-close-issues"
+type = "boolean"
+default = false
+
 [[cli.release-comments.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release-comments.steps]]
 type = "CommentReleasedIssues"
+inputs = ["format", "auto-close-issues"]

--- a/fixtures/tests/source/gitlab/monochange.toml
+++ b/fixtures/tests/source/gitlab/monochange.toml
@@ -32,8 +32,20 @@ type = "choice"
 choices = ["text", "json"]
 default = "text"
 
+[[cli.publish-release.inputs]]
+name = "from-ref"
+type = "string"
+default = "HEAD"
+
+[[cli.publish-release.inputs]]
+name = "draft"
+type = "boolean"
+default = false
+
 [[cli.publish-release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.publish-release.steps]]
 type = "PublishRelease"
+inputs = ["format", "from-ref", "draft"]

--- a/fixtures/tests/step-outputs/base/monochange.toml
+++ b/fixtures/tests/step-outputs/base/monochange.toml
@@ -16,6 +16,7 @@ default = "text"
 
 [[cli.release.steps]]
 type = "PrepareRelease"
+inputs = ["format"]
 
 [[cli.release.steps]]
 type = "Command"

--- a/fixtures/tests/validate-step-inputs/unknown-input-on-diagnose/monochange.toml
+++ b/fixtures/tests/validate-step-inputs/unknown-input-on-diagnose/monochange.toml
@@ -5,6 +5,12 @@ package_type = "cargo"
 path = "crates/core"
 
 [cli.diag]
+[[cli.diag.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.diag.steps]]
 type = "DiagnoseChangesets"

--- a/fixtures/tests/validate-step-inputs/unknown-input-on-discover/monochange.toml
+++ b/fixtures/tests/validate-step-inputs/unknown-input-on-discover/monochange.toml
@@ -5,6 +5,12 @@ package_type = "cargo"
 path = "crates/core"
 
 [cli.discover]
+[[cli.discover.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.discover.steps]]
 type = "Discover"

--- a/fixtures/tests/validate-step-inputs/unknown-input-on-validate/monochange.toml
+++ b/fixtures/tests/validate-step-inputs/unknown-input-on-validate/monochange.toml
@@ -5,6 +5,12 @@ package_type = "cargo"
 path = "crates/core"
 
 [cli.inspect]
+[[cli.inspect.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.inspect.steps]]
 type = "Validate"

--- a/fixtures/tests/validate-step-inputs/valid-diagnose-inputs/monochange.toml
+++ b/fixtures/tests/validate-step-inputs/valid-diagnose-inputs/monochange.toml
@@ -5,6 +5,12 @@ package_type = "cargo"
 path = "crates/core"
 
 [cli.diag]
+[[cli.diag.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.diag.steps]]
 type = "DiagnoseChangesets"

--- a/fixtures/tests/validate-step-inputs/wrong-type-format-on-discover/monochange.toml
+++ b/fixtures/tests/validate-step-inputs/wrong-type-format-on-discover/monochange.toml
@@ -5,6 +5,12 @@ package_type = "cargo"
 path = "crates/core"
 
 [cli.discover]
+[[cli.discover.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
 
 [[cli.discover.steps]]
 type = "Discover"

--- a/monochange.toml
+++ b/monochange.toml
@@ -720,11 +720,12 @@ verified_commits = true
 [cli.discover]
 help_text = "Discover packages across supported ecosystems"
 inputs = [{ name = "format", type = "choice", choices = ["text", "json"], default = "text" }]
-steps = [{ name = "discover packages", type = "Discover" }]
+steps = [{ name = "discover packages", type = "Discover", inputs = ["format"] }]
 
 [cli.change]
 help_text = "Create a change file for one or more packages"
 inputs = [
+	{ name = "interactive", type = "boolean", default = false },
 	{ name = "package", type = "string_list", required = true },
 	{ name = "bump", type = "choice", choices = ["none", "patch", "minor", "major"], default = "patch" },
 	{ name = "reason", type = "string", required = true },
@@ -734,14 +735,16 @@ inputs = [
 	{ name = "details", type = "string" },
 	{ name = "output", type = "path" },
 ]
-steps = [{ name = "create change file", type = "CreateChangeFile" }]
+steps = [
+	{ name = "create change file", type = "CreateChangeFile", inputs = ["interactive", "package", "bump", "version", "reason", "type", "details", "output"] },
+]
 
 [cli.versions]
 help_text = "Display planned package and group versions from discovered change files"
 inputs = [
 	{ name = "format", type = "choice", choices = ["text", "markdown", "json"], default = "text" },
 ]
-steps = [{ name = "display versions", type = "DisplayVersions" }]
+steps = [{ name = "display versions", type = "DisplayVersions", inputs = ["format"] }]
 
 [cli.placeholder-publish]
 help_text = "Publish placeholder package versions for missing registry packages"
@@ -750,7 +753,9 @@ inputs = [
 	{ name = "package", type = "string_list" },
 	{ name = "show-all", type = "boolean", help_text = "Show already-published and skipped placeholder packages instead of only packages that need action" },
 ]
-steps = [{ name = "publish placeholder packages", type = "PlaceholderPublish" }]
+steps = [
+	{ name = "publish placeholder packages", type = "PlaceholderPublish", inputs = ["format", "package", "show-all"] },
+]
 
 [cli.publish-plan]
 help_text = "Plan package-registry publish work against known ecosystem rate limits"
@@ -761,7 +766,9 @@ inputs = [
 	{ name = "readiness", type = "path", help_text = "JSON artifact from mc publish-readiness; limits publish plans to ready package work" },
 	{ name = "ci", type = "choice", choices = ["github-actions", "gitlab-ci"] },
 ]
-steps = [{ name = "plan publish rate limits", type = "PlanPublishRateLimits" }]
+steps = [
+	{ name = "plan publish rate limits", type = "PlanPublishRateLimits", inputs = ["format", "mode", "package", "readiness", "ci"] },
+]
 
 [cli.diagnostics]
 help_text = "Show changeset diagnostics and context"
@@ -769,7 +776,9 @@ inputs = [
 	{ name = "format", type = "choice", choices = ["text", "json"], default = "text" },
 	{ name = "changeset", type = "string_list", help_text = "changeset path(s), e.g. .changeset/feature.md (omit for all changesets)" },
 ]
-steps = [{ name = "diagnose changesets", type = "DiagnoseChangesets" }]
+steps = [
+	{ name = "diagnose changesets", type = "DiagnoseChangesets", inputs = ["format", "changeset"] },
+]
 
 [cli.release]
 help_text = "Prepare a release from discovered change files"
@@ -821,26 +830,35 @@ inputs = [
 	{ name = "draft", type = "boolean", default = false },
 	{ name = "format", type = "choice", choices = ["text", "json", "markdown"], default = "text" },
 ]
-steps = [{ name = "publish release", type = "PublishRelease" }]
+steps = [
+	{ name = "publish release", type = "PublishRelease", inputs = ["format", "from-ref", "draft"] },
+]
 
 [cli.comment-released-issues]
 help_text = "Comment on and optionally close issues referenced in released changesets"
 inputs = [
 	{ name = "from-ref", type = "string", default = "HEAD" },
+	{ name = "format", type = "choice", choices = ["text", "json", "markdown"], default = "text" },
 	{ name = "auto-close-issues", type = "boolean", default = false },
 ]
-steps = [{ name = "comment on released issues", type = "CommentReleasedIssues" }]
+steps = [
+	{ name = "comment on released issues", type = "CommentReleasedIssues", inputs = ["format", "auto-close-issues"] },
+]
 
 [cli.publish]
 help_text = "Publish packages from this release using built-in publishing workflows"
 inputs = [
 	{ name = "package", type = "string_list" },
 	{ name = "all", type = "boolean", help_text = "Publish every configured package instead of only packages from the release record" },
+	{ name = "group", type = "string_list" },
+	{ name = "ecosystem", type = "string_list" },
 	{ name = "resume", type = "path", help_text = "JSON result artifact from an earlier mc publish run; completed package versions are skipped" },
 	{ name = "output", type = "path", help_text = "Write the package publish result JSON artifact for retry/resume" },
 	{ name = "format", type = "choice", choices = ["text", "markdown", "json"], default = "text" },
 ]
-steps = [{ name = "publish packages", type = "PublishPackages" }]
+steps = [
+	{ name = "publish packages", type = "PublishPackages", inputs = ["format", "package", "all", "group", "ecosystem", "resume", "output"] },
+]
 
 [cli.publish-check]
 help_text = "Validate the release and preview package publishing in dry-run mode"

--- a/packages/monochange__skill/SKILL.md
+++ b/packages/monochange__skill/SKILL.md
@@ -16,6 +16,7 @@ Agents should optimize for safety and traceability: inspect config first, prefer
 - Read `monochange.toml` before recommending commands. Top-level `mc <name>` workflow commands can be user-defined by `[cli.<name>]` and vary per repository.
 - Do not assume `mc discover`, `mc change`, `mc release`, `mc publish`, or similar workflow names exist in every repo. They are user-defined unless they appear in `mc help` for that workspace.
 - Built-in commands are hardcoded by the CLI. Step commands are always exposed as `mc step:<step-name>` for built-in step variants, except the generic `Command` step.
+- When authoring `[cli.*]` workflows, command inputs are explicit per step. Add `inputs = ["name"]` on a step to inherit a command input unchanged, or use the map form for overrides and renamed values.
 - Prefer package or group ids from `monochange.toml` over manifest names.
 - Use dry-run or preview commands before mutating versions, committing, tagging, releasing, or publishing.
 - Never publish with local credentials on behalf of a user unless they explicitly own that operation and the project rules allow it.

--- a/packages/monochange__skill/examples/publishing.md
+++ b/packages/monochange__skill/examples/publishing.md
@@ -16,7 +16,9 @@ inputs = [
 	{ name = "format", type = "choice", choices = ["markdown", "json"], default = "markdown" },
 	{ name = "readiness", type = "path" },
 ]
-steps = [{ name = "plan publish rate limits", type = "PlanPublishRateLimits" }]
+steps = [
+	{ name = "plan publish rate limits", type = "PlanPublishRateLimits", inputs = ["format", "mode", "package", "readiness", "ci"] },
+]
 
 [cli.publish]
 help_text = "Publish package artifacts"
@@ -24,7 +26,9 @@ inputs = [
 	{ name = "output", type = "path" },
 	{ name = "resume", type = "path" },
 ]
-steps = [{ name = "publish packages", type = "PublishPackages" }]
+steps = [
+	{ name = "publish packages", type = "PublishPackages", inputs = ["format", "package", "group", "ecosystem", "resume", "output"] },
+]
 ```
 
 Use dry-run checks and keep JSON artifacts for resume/retry.

--- a/packages/monochange__skill/examples/release-pr.md
+++ b/packages/monochange__skill/examples/release-pr.md
@@ -10,10 +10,10 @@ inputs = [
 	{ name = "no_verify", type = "boolean", default = false },
 ]
 steps = [
-	{ name = "plan release", type = "PrepareRelease", allow_empty_changesets = true },
+	{ name = "plan release", type = "PrepareRelease", allow_empty_changesets = true, inputs = ["format"] },
 	{ name = "refresh lockfile", type = "Command", command = "pnpm install --lockfile-only", when = "{{ number_of_changesets > 0 }}" },
 	{ name = "create release commit", type = "CommitRelease", when = "{{ number_of_changesets > 0 }}" },
-	{ name = "open release request", type = "OpenReleaseRequest", when = "{{ number_of_changesets > 0 }}" },
+	{ name = "open release request", type = "OpenReleaseRequest", when = "{{ number_of_changesets > 0 }}", inputs = ["format"] },
 ]
 ```
 

--- a/packages/monochange__skill/skills/commands.md
+++ b/packages/monochange__skill/skills/commands.md
@@ -184,6 +184,49 @@ Inputs may also use `help_text`, `required`, `default`, `choices`, and `short`.
 
 Use `choice` for values that should be self-documenting in `mc help`, such as output formats or bump severities. Use `string_list` for repeatable selectors such as packages, groups, labels, or `caused_by` references. Use `path` when the workflow reads or writes artifacts so shell completion and help text communicate that a filesystem path is expected.
 
+<!-- {=cliStepExplicitInputInheritance} -->
+
+## Explicit step input inheritance
+
+Config-defined workflow commands have two input layers:
+
+1. `[[cli.<command>.inputs]]` declares the flags and arguments accepted by `mc <command>`.
+2. `inputs` on each step decides which of those parsed command inputs are visible while that step runs.
+
+Command inputs are **not inherited automatically**. A step receives a command input only when the step explicitly lists it. This makes wrappers predictable when a command-level flag and a step-specific input share the same name.
+
+Use the array shorthand when a step should inherit command inputs unchanged:
+
+```toml
+[cli.discover]
+inputs = [
+	{ name = "format", type = "choice", choices = ["text", "json"], default = "text" },
+]
+steps = [
+	{ type = "Discover", inputs = ["format"] },
+]
+```
+
+Use the map form when a step needs fixed values, renamed values, templates, or a mixture of inherited and overridden values:
+
+```toml
+[cli.release-pr]
+inputs = [
+	{ name = "format", type = "choice", choices = ["text", "json", "markdown"], default = "markdown" },
+	{ name = "open_as_draft", type = "boolean", default = false },
+]
+steps = [
+	{ type = "PrepareRelease", inputs = ["format"] },
+	{ type = "OpenReleaseRequest", inputs = { format = "markdown", draft = "{{ inputs.open_as_draft }}" } },
+]
+```
+
+Step-local `when` expressions and command templates evaluate against the same explicit step input context. If a `when` condition references `inputs.publish`, the step must include `publish` in its `inputs` array or map. Use `inputs = ["publish"]` for unchanged inheritance, or `inputs = { publish = "{{ inputs.publish }}" }` when you need the map form for other overrides.
+
+Built-in `mc step:*` commands are different: they are generated directly from the step schema, so their CLI flags map to that single step without a `[cli.*]` wrapper.
+
+<!-- {/cliStepExplicitInputInheritance} -->
+
 ## User-defined workflow example
 
 ```toml
@@ -193,7 +236,7 @@ inputs = [
 	{ name = "format", type = "choice", choices = ["text", "json"], default = "json" },
 ]
 steps = [
-	{ name = "discover packages", type = "Discover" },
+	{ name = "discover packages", type = "Discover", inputs = ["format"] },
 ]
 
 [cli.release-preview]
@@ -203,7 +246,7 @@ inputs = [
 	{ name = "format", type = "choice", choices = ["markdown", "json"], default = "markdown" },
 ]
 steps = [
-	{ name = "plan release", type = "PrepareRelease" },
+	{ name = "plan release", type = "PrepareRelease", inputs = ["format"] },
 ]
 ```
 

--- a/packages/monochange__skill/skills/configuration.md
+++ b/packages/monochange__skill/skills/configuration.md
@@ -161,7 +161,9 @@ inputs = [
 	{ name = "type", type = "string" },
 	{ name = "caused_by", type = "string_list" },
 ]
-steps = [{ name = "create change file", type = "CreateChangeFile" }]
+steps = [
+	{ name = "create change file", type = "CreateChangeFile", inputs = ["interactive", "package", "bump", "version", "type", "caused_by", "reason", "details", "output"] },
+]
 
 [cli.release]
 help_text = "Prepare versioned package files"
@@ -169,7 +171,7 @@ inputs = [
 	{ name = "format", type = "choice", choices = ["text", "markdown", "json"], default = "markdown" },
 ]
 steps = [
-	{ name = "plan release", type = "PrepareRelease" },
+	{ name = "plan release", type = "PrepareRelease", inputs = ["format"] },
 	{ name = "refresh lockfiles", type = "Command", command = "pnpm install --lockfile-only" },
 ]
 ```


### PR DESCRIPTION
## Summary
- Require configured CLI steps to opt in to inherited command inputs instead of receiving every command-level input automatically.
- Add `inputs = ["name"]` array shorthand for inherited command inputs while keeping map overrides for fixed or templated step values.
- Update built-in/default CLI commands, schema assets, validation, tests, and fixtures to declare inherited inputs explicitly.

## Why
This is a breaking CLI/config behavior change that removes ambiguous flag/name clashes between command-level inputs and step-specific inputs. A step now receives only the inputs listed on that step, and `when` conditions/template interpolation evaluate against that explicit per-step input context.

## Change type and areas
- Breaking feature: CLI command step input resolution.
- Affected areas: CLI runtime, config/schema serialization, default command templates, fixture configs, tests.
- Changeset: added `.changeset/explicit-cli-step-inputs.md` for `monochange`, `monochange_core`, and `monochange_config` as major bumps.

## Validation
- `devenv shell env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false coverage:patch`
  - `PATCH_COVERAGE 0/0 (100.00%)`
- `git diff --check`
- `devenv shell env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false lint:all`
  - Rust checks, schema check, and architecture boundary checks passed.
  - Local run then stopped because `oxlint` is not installed in this machine's pnpm toolchain (`Command "oxlint" not found`).
- `devenv shell env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false fix:all`
  - Rust checks, schema update, `mc validate`, lint suite, and dprint formatting passed.
  - Local run then stopped because `oxfmt` is not installed in this machine's pnpm toolchain (`Command "oxfmt" not found`).

## Risk and rollout
- Breaking change for custom `[cli.<command>]` definitions: any step that needs a command input must list it explicitly with `inputs = ["name"]` or provide a map override.
- Built-in defaults and generated templates have been migrated to the explicit form.
