### PR TITLE
feat(publish): show progress output

### DIFF
--- a/.changeset/publish-progress-output.md
+++ b/.changeset/publish-progress-output.md
@@ -1,0 +1,8 @@
+---
+"monochange": patch
+"monochange_publish": patch
+---
+
+# Publish progress output
+
+Add emoji-based publish progress reporting on stderr with deterministic CI-friendly output and terminal-aware loading markers.

--- a/crates/monochange/src/__tests__/publish_progress_tests.rs
+++ b/crates/monochange/src/__tests__/publish_progress_tests.rs
@@ -1,0 +1,85 @@
+use monochange_core::Ecosystem;
+use monochange_publish::PackagePublishRunMode;
+use monochange_publish::PublishProgressEvent;
+use monochange_publish::PublishProgressPackage;
+use monochange_publish::PublishProgressReporter;
+
+use super::*;
+
+fn package() -> PublishProgressPackage {
+	PublishProgressPackage {
+		package_id: "cli".to_string(),
+		package_name: "monochange".to_string(),
+		version: "1.2.3".to_string(),
+		ecosystem: Ecosystem::Cargo,
+		registry: "crates.io".to_string(),
+	}
+}
+
+#[test]
+fn render_event_uses_clean_ci_start_marker_without_spinner_noise() {
+	let line = StderrPublishProgressReporter::render_event(
+		&PublishProgressEvent::PackageStarted(package()),
+		false,
+	);
+
+	assert_eq!(line, "→ 🦀 cargo monochange publishing 1.2.3 to crates.io");
+}
+
+#[test]
+fn render_event_uses_terminal_spinner_marker_when_interactive() {
+	let line = StderrPublishProgressReporter::render_event(
+		&PublishProgressEvent::RegistryCheckStarted(package()),
+		true,
+	);
+
+	assert_eq!(line, "⠋ 🦀 cargo monochange checking 1.2.3 on crates.io");
+}
+
+#[test]
+fn render_event_summarizes_publish_run_with_emojis() {
+	let line = StderrPublishProgressReporter::render_event(
+		&PublishProgressEvent::RunFinished {
+			mode: PackagePublishRunMode::Release,
+			total: 3,
+			published: 2,
+			skipped: 1,
+			failed: 0,
+		},
+		false,
+	);
+
+	assert_eq!(
+		line,
+		"◆ Publish complete: 3 packages, ✅ 2 published, ⏭️ 1 skipped, ❌ 0 failed"
+	);
+}
+
+#[test]
+fn render_event_reports_published_and_failed_packages() {
+	let package = package();
+
+	assert_eq!(
+		StderrPublishProgressReporter::render_event(
+			&PublishProgressEvent::PackagePublished(package.clone()),
+			false,
+		),
+		"✅ 🦀 cargo monochange published 1.2.3 to crates.io"
+	);
+	assert_eq!(
+		StderrPublishProgressReporter::render_event(
+			&PublishProgressEvent::PackageFailed {
+				package,
+				message: "registry rejected package".to_string(),
+			},
+			false,
+		),
+		"❌ 🦀 cargo monochange failed: registry rejected package"
+	);
+}
+
+#[test]
+fn disabled_reporter_ignores_events() {
+	StderrPublishProgressReporter::new(true)
+		.report(PublishProgressEvent::PackageStarted(package()));
+}

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -248,6 +248,7 @@ mod migration_audit;
 mod package_publish;
 mod prepared_release_cache;
 mod publish_bootstrap;
+mod publish_progress;
 mod publish_rate_limits;
 mod publish_readiness;
 mod release_artifacts;

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -39,7 +39,7 @@ pub(crate) use monochange_publish::build_release_requests;
 use monochange_publish::configured_package_publication_targets;
 use monochange_publish::detect_trusted_publishing_identity;
 use monochange_publish::disabled_trust_outcome;
-use monochange_publish::execute_publish_requests_with_process;
+use monochange_publish::execute_publish_requests_with_process_and_progress;
 use monochange_publish::manual_setup_url;
 use monochange_publish::merge_publish_resume_report;
 use monochange_publish::provider_registry_trust_capability;
@@ -54,6 +54,7 @@ use monochange_python::write_python_placeholder_manifest;
 use crate::PreparedRelease;
 use crate::discover_release_record;
 use crate::discover_workspace;
+use crate::publish_progress::StderrPublishProgressReporter;
 
 pub(crate) fn run_placeholder_publish(
 	root: &Path,
@@ -64,7 +65,8 @@ pub(crate) fn run_placeholder_publish(
 	let discovery = discover_workspace(root)?;
 	let requests =
 		build_placeholder_requests(root, configuration, &discovery.packages, selected_packages)?;
-	execute_publish_requests_with_process(
+	let progress = StderrPublishProgressReporter::new(false);
+	execute_publish_requests_with_process_and_progress(
 		root,
 		configuration.source.as_ref(),
 		PackagePublishRunMode::Placeholder,
@@ -74,6 +76,7 @@ pub(crate) fn run_placeholder_publish(
 		&placeholder_manifest_writer_registry(),
 		&publish_readiness_registry(),
 		&CliPublishTrustHandler,
+		&progress,
 	)
 }
 
@@ -209,7 +212,8 @@ fn execute_release_publish_requests(
 	dry_run: bool,
 	requests: &[PublishRequest],
 ) -> MonochangeResult<PackagePublishReport> {
-	execute_publish_requests_with_process(
+	let progress = StderrPublishProgressReporter::new(false);
+	execute_publish_requests_with_process_and_progress(
 		root,
 		configuration.source.as_ref(),
 		PackagePublishRunMode::Release,
@@ -219,6 +223,7 @@ fn execute_release_publish_requests(
 		&placeholder_manifest_writer_registry(),
 		&publish_readiness_registry(),
 		&CliPublishTrustHandler,
+		&progress,
 	)
 }
 

--- a/crates/monochange/src/publish_progress.rs
+++ b/crates/monochange/src/publish_progress.rs
@@ -1,0 +1,125 @@
+use std::io;
+use std::io::IsTerminal;
+
+use monochange_publish::EcosystemProgressPresentation;
+use monochange_publish::PublishProgressEvent;
+use monochange_publish::PublishProgressPackage;
+use monochange_publish::PublishProgressReporter;
+
+pub(crate) struct StderrPublishProgressReporter {
+	enabled: bool,
+	interactive: bool,
+}
+
+impl StderrPublishProgressReporter {
+	pub(crate) fn new(quiet: bool) -> Self {
+		let no_progress = std::env::var_os("MONOCHANGE_NO_PROGRESS").is_some();
+		let interactive = io::stderr().is_terminal() && std::env::var_os("CI").is_none();
+		Self {
+			enabled: !quiet && !no_progress,
+			interactive,
+		}
+	}
+
+	pub(crate) fn render_event(event: &PublishProgressEvent, interactive: bool) -> String {
+		match event {
+			PublishProgressEvent::RunStarted {
+				mode,
+				dry_run,
+				total,
+				ecosystems,
+			} => {
+				let ecosystems = ecosystems
+					.iter()
+					.map(|ecosystem| {
+						format!(
+							"{} {}",
+							ecosystem.progress_emoji(),
+							ecosystem.progress_label()
+						)
+					})
+					.collect::<Vec<_>>()
+					.join(", ");
+				let dry_run = if *dry_run { " dry-run" } else { "" };
+				format!("◆ Publishing {total} packages ({mode:?}{dry_run}) across {ecosystems}")
+			}
+			PublishProgressEvent::RegistryCheckStarted(package) => {
+				format!(
+					"{} {} checking {} on {}",
+					start_symbol(interactive),
+					package_prefix(package),
+					package.version,
+					package.registry
+				)
+			}
+			PublishProgressEvent::PackageStarted(package) => {
+				format!(
+					"{} {} publishing {} to {}",
+					start_symbol(interactive),
+					package_prefix(package),
+					package.version,
+					package.registry
+				)
+			}
+			PublishProgressEvent::PackageSkipped { package, message } => {
+				format!("⏭️ {} {message}", package_prefix(package))
+			}
+			PublishProgressEvent::PackagePlanned(package) => {
+				format!(
+					"📝 {} would publish {} to {}",
+					package_prefix(package),
+					package.version,
+					package.registry
+				)
+			}
+			PublishProgressEvent::PackagePublished(package) => {
+				format!(
+					"✅ {} published {} to {}",
+					package_prefix(package),
+					package.version,
+					package.registry
+				)
+			}
+			PublishProgressEvent::PackageFailed { package, message } => {
+				format!("❌ {} failed: {message}", package_prefix(package))
+			}
+			PublishProgressEvent::RunFinished {
+				total,
+				published,
+				skipped,
+				failed,
+				..
+			} => {
+				format!(
+					"◆ Publish complete: {total} packages, ✅ {published} published, ⏭️ {skipped} skipped, ❌ {failed} failed"
+				)
+			}
+		}
+	}
+}
+
+impl PublishProgressReporter for StderrPublishProgressReporter {
+	fn report(&self, event: PublishProgressEvent) {
+		if !self.enabled {
+			return;
+		}
+		eprintln!("{}", Self::render_event(&event, self.interactive));
+	}
+}
+
+fn start_symbol(interactive: bool) -> &'static str {
+	if interactive { "⠋" } else { "→" }
+}
+
+fn package_prefix(package: &PublishProgressPackage) -> String {
+	format!(
+		"{} {} {}",
+		package.ecosystem.progress_emoji(),
+		package.ecosystem.progress_label(),
+		package.package_name
+	)
+}
+
+#[cfg(test)]
+#[path = "__tests__/publish_progress_tests.rs"]
+mod tests;

--- a/crates/monochange/tests/snapshots/cli_output__placeholder_publish_dry_run_reports_manual_registry_trust_contexts@placeholder_publish_dry_run_reports_manual_registry_trust_contexts.snap
+++ b/crates/monochange/tests/snapshots/cli_output__placeholder_publish_dry_run_reports_manual_registry_trust_contexts@placeholder_publish_dry_run_reports_manual_registry_trust_contexts.snap
@@ -10,10 +10,10 @@ info:
   env:
     GITHUB_JOB: release
     GITHUB_WORKFLOW_REF: ifiokjr/monochange/.github/workflows/publish.yml@refs/heads/main
-    MONOCHANGE_CRATES_IO_API_URL: "http://127.0.0.1:61223"
-    MONOCHANGE_JSR_BASE_URL: "http://127.0.0.1:61223"
-    MONOCHANGE_NPM_REGISTRY_URL: "http://127.0.0.1:61223"
-    MONOCHANGE_PUB_DEV_API_URL: "http://127.0.0.1:61223"
+    MONOCHANGE_CRATES_IO_API_URL: "http://127.0.0.1:58769"
+    MONOCHANGE_JSR_BASE_URL: "http://127.0.0.1:58769"
+    MONOCHANGE_NPM_REGISTRY_URL: "http://127.0.0.1:58769"
+    MONOCHANGE_PUB_DEV_API_URL: "http://127.0.0.1:58769"
     NO_COLOR: "1"
     RUST_LOG: ""
 ---
@@ -56,3 +56,9 @@ planned batches:
 - npm batch 1/1 packages: npm_pkg
 
 ----- stderr -----
+◆ Publishing 2 packages (Placeholder dry-run) across 🦀 cargo, 📦 npm
+→ 🦀 cargo core checking 0.0.0 on crates_io
+📝 🦀 cargo core would publish 0.0.0 to crates_io
+→ 📦 npm npm-pkg checking 0.0.0 on npm
+📝 📦 npm npm-pkg would publish 0.0.0 to npm
+◆ Publish complete: 2 packages, ✅ 0 published, ⏭️ 2 skipped, ❌ 0 failed

--- a/crates/monochange/tests/snapshots/cli_output__placeholder_publish_dry_run_reports_missing_manual_registry_workflow_configuration@placeholder_publish_dry_run_reports_missing_manual_registry_workflow_configuration.snap
+++ b/crates/monochange/tests/snapshots/cli_output__placeholder_publish_dry_run_reports_missing_manual_registry_workflow_configuration@placeholder_publish_dry_run_reports_missing_manual_registry_workflow_configuration.snap
@@ -15,10 +15,10 @@ info:
     GITHUB_RUN_ID: ""
     GITHUB_WORKFLOW: ""
     GITHUB_WORKFLOW_REF: ""
-    MONOCHANGE_CRATES_IO_API_URL: "http://127.0.0.1:61222"
-    MONOCHANGE_JSR_BASE_URL: "http://127.0.0.1:61222"
-    MONOCHANGE_NPM_REGISTRY_URL: "http://127.0.0.1:61222"
-    MONOCHANGE_PUB_DEV_API_URL: "http://127.0.0.1:61222"
+    MONOCHANGE_CRATES_IO_API_URL: "http://127.0.0.1:58768"
+    MONOCHANGE_JSR_BASE_URL: "http://127.0.0.1:58768"
+    MONOCHANGE_NPM_REGISTRY_URL: "http://127.0.0.1:58768"
+    MONOCHANGE_PUB_DEV_API_URL: "http://127.0.0.1:58768"
     MONOCHANGE_TRUSTED_PUBLISHING_ENVIRONMENT: ""
     NO_COLOR: "1"
     RUST_LOG: ""
@@ -136,3 +136,9 @@ exit_code: 0
 }
 
 ----- stderr -----
+◆ Publishing 2 packages (Placeholder dry-run) across 🦀 cargo, 📦 npm
+→ 🦀 cargo core checking 0.0.0 on crates_io
+📝 🦀 cargo core would publish 0.0.0 to crates_io
+→ 📦 npm npm-pkg checking 0.0.0 on npm
+📝 📦 npm npm-pkg would publish 0.0.0 to npm
+◆ Publish complete: 2 packages, ✅ 0 published, ⏭️ 2 skipped, ❌ 0 failed

--- a/crates/monochange_publish/src/__tests__/lib_tests.rs
+++ b/crates/monochange_publish/src/__tests__/lib_tests.rs
@@ -376,6 +376,143 @@ fn sample_publish_request_for_registry(registry: RegistryKind) -> PublishRequest
 	}
 }
 
+#[derive(Default)]
+struct RecordingPublishProgressReporter {
+	events: std::sync::Mutex<Vec<PublishProgressEvent>>,
+}
+
+impl PublishProgressReporter for RecordingPublishProgressReporter {
+	fn report(&self, event: PublishProgressEvent) {
+		self.events.lock().unwrap().push(event);
+	}
+}
+
+struct PanickingCommandExecutor;
+
+impl CommandExecutor for PanickingCommandExecutor {
+	fn run(&mut self, _spec: &CommandSpec) -> MonochangeResult<CommandOutput> {
+		panic!("external packages must not run publish commands");
+	}
+}
+
+struct TestPublishTrustHandler;
+
+impl PublishTrustHandler for TestPublishTrustHandler {
+	fn trust_outcome_for_skip(
+		&self,
+		_request: &PublishRequest,
+		_source: Option<&SourceConfiguration>,
+		_root: &Path,
+		_env_map: &BTreeMap<String, String>,
+	) -> TrustedPublishingOutcome {
+		disabled_trust_outcome()
+	}
+
+	fn planned_trust_outcome(
+		&self,
+		_request: &PublishRequest,
+		_source: Option<&SourceConfiguration>,
+		_root: &Path,
+		_env_map: &BTreeMap<String, String>,
+	) -> TrustedPublishingOutcome {
+		disabled_trust_outcome()
+	}
+
+	fn enforce_release_trust_prerequisites(
+		&self,
+		_request: &PublishRequest,
+		_source: Option<&SourceConfiguration>,
+		_root: &Path,
+		_env_map: &BTreeMap<String, String>,
+	) -> MonochangeResult<()> {
+		Ok(())
+	}
+}
+
+#[test]
+fn ecosystem_progress_presentation_uses_portable_emojis() {
+	assert_eq!(Ecosystem::Cargo.progress_emoji(), "🦀");
+	assert_eq!(Ecosystem::Npm.progress_emoji(), "📦");
+	assert_eq!(Ecosystem::Deno.progress_emoji(), "🦕");
+	assert_eq!(Ecosystem::Dart.progress_emoji(), "🎯");
+	assert_eq!(Ecosystem::Flutter.progress_emoji(), "🦋");
+	assert_eq!(Ecosystem::Python.progress_emoji(), "🐍");
+	assert_eq!(Ecosystem::Go.progress_emoji(), "🐹");
+	assert_eq!(Ecosystem::Cargo.progress_label(), "cargo");
+	assert_eq!(progress_emoji_for_label("future"), "🌐");
+}
+
+#[test]
+fn execute_publish_requests_uses_noop_progress_reporter_by_default() {
+	let report = execute_publish_requests_with_process(
+		Path::new("."),
+		None,
+		PackagePublishRunMode::Release,
+		false,
+		&[],
+		&build_publish_command_builder(),
+		&PlaceholderManifestWriterRegistry::new(),
+		&PublishReadinessRegistry::new(),
+		&TestPublishTrustHandler,
+	)
+	.unwrap();
+
+	assert!(report.packages.is_empty());
+}
+
+#[test]
+fn publish_progress_reports_external_skip_and_summary_events() {
+	let mut request = sample_publish_request_for_registry(RegistryKind::Npm);
+	request.mode = PublishMode::External;
+	let requests = vec![request];
+	let progress = RecordingPublishProgressReporter::default();
+	let mut executor = PanickingCommandExecutor;
+
+	let report = execute_publish_requests_with_progress(
+		Path::new("."),
+		None,
+		PackagePublishRunMode::Release,
+		false,
+		&requests,
+		&registry_client().unwrap(),
+		&RegistryEndpoints::from_env(),
+		&BTreeMap::new(),
+		&mut executor,
+		&build_publish_command_builder(),
+		&PlaceholderManifestWriterRegistry::new(),
+		&PublishReadinessRegistry::new(),
+		&TestPublishTrustHandler,
+		&progress,
+	)
+	.unwrap();
+
+	assert_eq!(
+		report.packages[0].status,
+		PackagePublishStatus::SkippedExternal
+	);
+	let events = progress.events.lock().unwrap();
+	assert!(matches!(
+		events.first(),
+		Some(PublishProgressEvent::RunStarted { total: 1, ecosystems, .. })
+			if ecosystems == &vec![Ecosystem::Npm]
+	));
+	assert!(matches!(
+		&events[1],
+		PublishProgressEvent::PackageSkipped { package, message }
+			if package.package_name == "pkg" && message == "package opted out of built-in publishing"
+	));
+	assert!(matches!(
+		events.last(),
+		Some(PublishProgressEvent::RunFinished {
+			total: 1,
+			published: 0,
+			skipped: 1,
+			failed: 0,
+			..
+		})
+	));
+}
+
 #[test]
 fn publish_readiness_registry_push_checker_and_missing_checker_paths() {
 	let request = sample_publish_request_for_registry(RegistryKind::Npm);

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -30,6 +30,100 @@ use urlencoding::encode;
 
 pub const PLACEHOLDER_VERSION: &str = "0.0.0";
 
+pub trait EcosystemProgressPresentation {
+	fn progress_emoji(self) -> &'static str;
+	fn progress_label(self) -> &'static str;
+}
+
+impl EcosystemProgressPresentation for Ecosystem {
+	fn progress_emoji(self) -> &'static str {
+		progress_emoji_for_label(self.as_str())
+	}
+
+	fn progress_label(self) -> &'static str {
+		self.as_str()
+	}
+}
+
+fn progress_emoji_for_label(label: &str) -> &'static str {
+	match label {
+		"cargo" => "🦀",
+		"npm" => "📦",
+		"deno" => "🦕",
+		"dart" => "🎯",
+		"flutter" => "🦋",
+		"python" => "🐍",
+		"go" => "🐹",
+		_ => "🌐",
+	}
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct PublishProgressPackage {
+	pub package_id: String,
+	pub package_name: String,
+	pub version: String,
+	pub ecosystem: Ecosystem,
+	pub registry: String,
+}
+
+impl PublishProgressPackage {
+	#[must_use]
+	pub fn from_request(request: &PublishRequest) -> Self {
+		Self {
+			package_id: request.package_id.clone(),
+			package_name: request.package_name.clone(),
+			version: request.version.clone(),
+			ecosystem: request.ecosystem,
+			registry: request.registry.to_string(),
+		}
+	}
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum PublishProgressEvent {
+	RunStarted {
+		mode: PackagePublishRunMode,
+		dry_run: bool,
+		total: usize,
+		ecosystems: Vec<Ecosystem>,
+	},
+	RegistryCheckStarted(PublishProgressPackage),
+	PackageStarted(PublishProgressPackage),
+	PackageSkipped {
+		package: PublishProgressPackage,
+		message: String,
+	},
+	PackagePlanned(PublishProgressPackage),
+	PackagePublished(PublishProgressPackage),
+	PackageFailed {
+		package: PublishProgressPackage,
+		message: String,
+	},
+	RunFinished {
+		mode: PackagePublishRunMode,
+		total: usize,
+		published: usize,
+		skipped: usize,
+		failed: usize,
+	},
+}
+
+pub trait PublishProgressReporter: Send + Sync {
+	fn report(&self, event: PublishProgressEvent);
+}
+
+#[derive(Debug, Default)]
+pub struct NoopPublishProgressReporter;
+
+impl PublishProgressReporter for NoopPublishProgressReporter {
+	fn report(&self, _event: PublishProgressEvent) {}
+}
+
+fn publish_progress_package(request: &PublishRequest) -> PublishProgressPackage {
+	PublishProgressPackage::from_request(request)
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct SelectedReleasePublicationTargets {
 	pub publication_targets: Vec<PackagePublicationTarget>,
@@ -471,7 +565,7 @@ pub fn execute_publish_requests_with_process(
 	let endpoints = RegistryEndpoints::from_env();
 	let client = registry_client()?;
 	let mut executor = ProcessCommandExecutor;
-	execute_publish_requests(
+	execute_publish_requests_with_progress(
 		root,
 		source,
 		mode,
@@ -485,6 +579,42 @@ pub fn execute_publish_requests_with_process(
 		manifest_writers,
 		readiness,
 		trust_handler,
+		&NoopPublishProgressReporter,
+	)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn execute_publish_requests_with_process_and_progress(
+	root: &Path,
+	source: Option<&SourceConfiguration>,
+	mode: PackagePublishRunMode,
+	dry_run: bool,
+	requests: &[PublishRequest],
+	command_builder: &PublishCommandBuilder,
+	manifest_writers: &PlaceholderManifestWriterRegistry,
+	readiness: &PublishReadinessRegistry,
+	trust_handler: &dyn PublishTrustHandler,
+	progress: &dyn PublishProgressReporter,
+) -> MonochangeResult<PackagePublishReport> {
+	let env_map = current_env_map();
+	let endpoints = RegistryEndpoints::from_env();
+	let client = registry_client()?;
+	let mut executor = ProcessCommandExecutor;
+	execute_publish_requests_with_progress(
+		root,
+		source,
+		mode,
+		dry_run,
+		requests,
+		&client,
+		&endpoints,
+		&env_map,
+		&mut executor,
+		command_builder,
+		manifest_writers,
+		readiness,
+		trust_handler,
+		progress,
 	)
 }
 
@@ -504,6 +634,53 @@ pub fn execute_publish_requests(
 	readiness: &PublishReadinessRegistry,
 	trust_handler: &dyn PublishTrustHandler,
 ) -> MonochangeResult<PackagePublishReport> {
+	execute_publish_requests_with_progress(
+		root,
+		source,
+		mode,
+		dry_run,
+		requests,
+		client,
+		endpoints,
+		env_map,
+		executor,
+		command_builder,
+		manifest_writers,
+		readiness,
+		trust_handler,
+		&NoopPublishProgressReporter,
+	)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn execute_publish_requests_with_progress(
+	root: &Path,
+	source: Option<&SourceConfiguration>,
+	mode: PackagePublishRunMode,
+	dry_run: bool,
+	requests: &[PublishRequest],
+	client: &Client,
+	endpoints: &RegistryEndpoints,
+	env_map: &BTreeMap<String, String>,
+	executor: &mut dyn CommandExecutor,
+	command_builder: &PublishCommandBuilder,
+	manifest_writers: &PlaceholderManifestWriterRegistry,
+	readiness: &PublishReadinessRegistry,
+	trust_handler: &dyn PublishTrustHandler,
+	progress: &dyn PublishProgressReporter,
+) -> MonochangeResult<PackagePublishReport> {
+	let ecosystems = requests
+		.iter()
+		.map(|request| request.ecosystem)
+		.collect::<BTreeSet<_>>()
+		.into_iter()
+		.collect::<Vec<_>>();
+	progress.report(PublishProgressEvent::RunStarted {
+		mode,
+		dry_run,
+		total: requests.len(),
+		ecosystems,
+	});
 	let mut outcomes = Vec::new();
 
 	for request in requests {
@@ -514,6 +691,10 @@ pub fn execute_publish_requests(
 				registry = %request.registry,
 				"skipping external package"
 			);
+			progress.report(PublishProgressEvent::PackageSkipped {
+				package: publish_progress_package(request),
+				message: "package opted out of built-in publishing".to_string(),
+			});
 			outcomes.push(PackagePublishOutcome {
 				package: request.package_id.clone(),
 				ecosystem: request.ecosystem,
@@ -539,6 +720,9 @@ pub fn execute_publish_requests(
 			"publishing package"
 		);
 
+		progress.report(PublishProgressEvent::RegistryCheckStarted(
+			publish_progress_package(request),
+		));
 		let version_exists = registry_version_exists(client, endpoints, request)?;
 		if version_exists {
 			info!(
@@ -547,6 +731,13 @@ pub fn execute_publish_requests(
 				registry = %request.registry,
 				"skipping already-published version"
 			);
+			progress.report(PublishProgressEvent::PackageSkipped {
+				package: publish_progress_package(request),
+				message: format!(
+					"{} {} already exists on {}",
+					request.package_name, request.version, request.registry
+				),
+			});
 			outcomes.push(PackagePublishOutcome {
 				package: request.package_id.clone(),
 				ecosystem: request.ecosystem,
@@ -573,6 +764,10 @@ pub fn execute_publish_requests(
 			None
 		};
 		if let Some(message) = blocked_message {
+			progress.report(PublishProgressEvent::PackageSkipped {
+				package: publish_progress_package(request),
+				message: message.clone(),
+			});
 			if dry_run {
 				outcomes.push(PackagePublishOutcome {
 					package: request.package_id.clone(),
@@ -612,6 +807,9 @@ pub fn execute_publish_requests(
 		);
 
 		if dry_run {
+			progress.report(PublishProgressEvent::PackagePlanned(
+				publish_progress_package(request),
+			));
 			if mode == PackagePublishRunMode::Placeholder {
 				outcomes.push(PackagePublishOutcome {
 					package: request.package_id.clone(),
@@ -644,9 +842,18 @@ pub fn execute_publish_requests(
 			enforce_release_attestation_prerequisites(request, env_map, command_builder)?;
 		}
 
+		if !dry_run {
+			progress.report(PublishProgressEvent::PackageStarted(
+				publish_progress_package(request),
+			));
+		}
 		let output = match executor.run(&publish_command) {
 			Ok(output) => output,
 			Err(error) => {
+				progress.report(PublishProgressEvent::PackageFailed {
+					package: publish_progress_package(request),
+					message: error.to_string(),
+				});
 				tracing::error!(
 					package_name = request.package_name,
 					version = %request.version,
@@ -659,6 +866,10 @@ pub fn execute_publish_requests(
 			}
 		};
 		if !output.success {
+			progress.report(PublishProgressEvent::PackageFailed {
+				package: publish_progress_package(request),
+				message: render_command_error(&output),
+			});
 			tracing::error!(
 				package_name = request.package_name,
 				version = %request.version,
@@ -713,6 +924,9 @@ pub fn execute_publish_requests(
 				planned_publish_message(mode, request),
 			)
 		} else {
+			progress.report(PublishProgressEvent::PackagePublished(
+				publish_progress_package(request),
+			));
 			(
 				PackagePublishStatus::Published,
 				format!(
@@ -743,6 +957,22 @@ pub fn execute_publish_requests(
 		});
 	}
 
+	let published = outcomes
+		.iter()
+		.filter(|outcome| outcome.status == PackagePublishStatus::Published)
+		.count();
+	let failed = outcomes
+		.iter()
+		.filter(|outcome| outcome.status == PackagePublishStatus::Failed)
+		.count();
+	let skipped = outcomes.len().saturating_sub(published + failed);
+	progress.report(PublishProgressEvent::RunFinished {
+		mode,
+		total: outcomes.len(),
+		published,
+		skipped,
+		failed,
+	});
 	Ok(PackagePublishReport {
 		mode,
 		dry_run,

--- a/docs/plans/active/publish-progress-and-parallel-ecosystems-report.html
+++ b/docs/plans/active/publish-progress-and-parallel-ecosystems-report.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Publish progress and parallel ecosystems — progress report</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #0f172a;
+      --card: #111827;
+      --text: #e5e7eb;
+      --muted: #9ca3af;
+      --border: #374151;
+      --done: #22c55e;
+      --active: #38bdf8;
+      --todo: #f59e0b;
+    }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.5;
+    }
+    main {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 48px 24px;
+    }
+    h1, h2, h3 { line-height: 1.15; }
+    .lede { color: var(--muted); font-size: 1.05rem; }
+    .cards {
+      display: grid;
+      gap: 16px;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      margin: 28px 0;
+    }
+    .card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 18px;
+    }
+    .metric { font-size: 2rem; font-weight: 800; }
+    .done { color: var(--done); }
+    .active { color: var(--active); }
+    .todo { color: var(--todo); }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      overflow: hidden;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: var(--card);
+    }
+    th, td {
+      border-bottom: 1px solid var(--border);
+      padding: 12px 14px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { color: var(--muted); font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.06em; }
+    tr:last-child td { border-bottom: 0; }
+    code { color: #bfdbfe; }
+    .status {
+      display: inline-block;
+      border-radius: 999px;
+      padding: 2px 10px;
+      font-weight: 700;
+      font-size: 0.85rem;
+      white-space: nowrap;
+    }
+    .status.done { background: rgba(34, 197, 94, 0.14); }
+    .status.active { background: rgba(56, 189, 248, 0.14); }
+    .status.todo { background: rgba(245, 158, 11, 0.14); }
+    ul { padding-left: 1.3rem; }
+  </style>
+</head>
+<body>
+<main>
+  <h1>Publish progress and parallel ecosystems</h1>
+  <p class="lede">Progress report for <code>docs/plans/active/publish-progress-and-parallel-ecosystems.md</code>. Generated while preparing the first pull request for publish progress output.</p>
+
+  <section class="cards" aria-label="summary metrics">
+    <article class="card"><div class="metric done">1 / 3</div><div>planned PR slices implemented</div></article>
+    <article class="card"><div class="metric active">PR 1</div><div>publish progress foundation is ready for review</div></article>
+    <article class="card"><div class="metric todo">2</div><div>follow-up PR slices remain</div></article>
+  </section>
+
+  <h2>PR split status</h2>
+  <table>
+    <thead>
+      <tr><th>Slice</th><th>Status</th><th>Progress</th><th>Remaining work</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1. Progress reporter foundation + publish progress</td>
+        <td><span class="status active">Ready for PR</span></td>
+        <td>
+          <ul>
+            <li>Added structured publish progress events in <code>monochange_publish</code>.</li>
+            <li>Added ecosystem-owned emoji/label presentation.</li>
+            <li>Added stderr renderer with terminal-aware loading marker and deterministic CI/plain lines.</li>
+            <li>Wired publish and placeholder publish paths through the reporter.</li>
+            <li>Added focused unit tests for event sequencing, emoji labels, and renderer output.</li>
+            <li>Added changeset for <code>monochange</code> and <code>monochange_publish</code>.</li>
+          </ul>
+        </td>
+        <td>Monitor PR checks and fix any CI/coverage failures.</td>
+      </tr>
+      <tr>
+        <td>2. Progress across CLI steps</td>
+        <td><span class="status todo">Not started</span></td>
+        <td>Existing command/step progress symbols were updated to emoji-friendly output as preparatory work.</td>
+        <td>
+          Emit progress across all CLI step lifecycle events, add concise step summaries, preserve JSON stdout, and add snapshots/tests for plain stderr formatting.
+        </td>
+      </tr>
+      <tr>
+        <td>3. Parallel publish by ecosystem</td>
+        <td><span class="status todo">Not started</span></td>
+        <td>Design decisions are recorded in the active plan: ecosystem-granularity lanes, stable report ordering, and dependency safety.</td>
+        <td>
+          Build the scheduler, run one sequential lane per ecosystem, preserve dependency/report ordering, handle failures safely, and move the plan to completed after the third PR lands.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Validation completed for PR 1</h2>
+  <ul>
+    <li><code>cargo check -q -p monochange_publish -p monochange</code></li>
+    <li>Targeted publish progress tests for <code>monochange_publish</code> and <code>monochange</code></li>
+    <li><code>cargo clippy -q -p monochange_publish -p monochange --all-targets --all-features -- -D warnings</code></li>
+    <li><code>devenv shell mc validate</code></li>
+  </ul>
+
+  <h2>Next steps</h2>
+  <ol>
+    <li>Open and monitor PR 1.</li>
+    <li>Fix any CI or patch coverage failures reported by the PR.</li>
+    <li>After PR 1 lands, create PR 2 for progress across CLI steps.</li>
+    <li>After PR 2 lands, create PR 3 for dependency-safe parallel publish lanes by ecosystem.</li>
+  </ol>
+</main>
+</body>
+</html>

--- a/docs/plans/active/publish-progress-and-parallel-ecosystems.md
+++ b/docs/plans/active/publish-progress-and-parallel-ecosystems.md
@@ -1,0 +1,86 @@
+# Publish progress and parallel ecosystems
+
+## Why
+
+`mc publish` currently depends on telemetry and log-level output for most of its visibility. That makes local terminal runs feel stalled and makes CI failures hard to diagnose without digging through structured traces. Publishing also runs as one sequential list, so an npm-heavy run can finish all npm work before crates.io starts, even when ecosystems are independent.
+
+This work makes release operations easier to trust by giving users readable progress on stderr while preserving machine-readable reports on stdout/files. It also prepares publish execution for safe ecosystem-level parallelism so independent registries can make progress at the same time without breaking dependency order.
+
+## Goals
+
+- Add a reusable progress reporter that writes to stderr.
+- Use emojis for ecosystem identity in both terminals and CI logs.
+- Use loading indicators only for interactive terminals; CI gets deterministic start/finish lines with emojis and no spinner noise.
+- Let each ecosystem define its own progress emoji through a trait-like abstraction instead of hardcoding all presentation at call sites.
+- Add publish progress first, then broaden progress to all CLI steps, then add safe parallel publish lanes by ecosystem.
+- Keep JSON/stdout outputs stable unless a command explicitly renders human output.
+
+## Non-goals
+
+- Do not publish any packages while implementing or validating this work.
+- Do not change release planning semantics.
+- Do not run same-ecosystem packages in parallel in the first parallel-publish pass.
+- Do not replace telemetry; progress output is complementary.
+
+## Affected areas
+
+- `crates/monochange/src/cli_runtime.rs` — CLI step start/finish/skip progress.
+- `crates/monochange/src/cli_theme.rs` / new progress module — shared styling and stderr rendering.
+- `crates/monochange/src/package_publish.rs` — wire publish progress from the app layer.
+- `crates/monochange_publish/src/lib.rs` — publish events, ecosystem emoji trait, and later ecosystem scheduler.
+- `crates/monochange*/src/__tests__/` — focused unit coverage for changed executable lines.
+- CLI snapshots/integration tests where human output intentionally changes.
+
+## PR split
+
+### 1. Progress reporter foundation + publish progress
+
+- [ ] Add a small progress abstraction with two renderers:
+  - interactive terminal renderer with spinner-style status updates,
+  - CI/plain renderer with deterministic emoji start/finish lines.
+- [ ] Add an ecosystem presentation trait or trait-like helper so ecosystems own their emoji and label.
+- [ ] Emit publish events for:
+  - publish run start and completion,
+  - ecosystem lane/package start,
+  - registry check,
+  - skip existing/external,
+  - dry-run planned publish,
+  - published,
+  - blocked/failed.
+- [ ] Keep progress on stderr and existing reports on stdout/artifacts.
+- [ ] Add tests for emoji labels, CI/plain output, and publish event sequencing.
+- [ ] Validate with `cargo fmt`, targeted tests, `cargo clippy -q -p monochange --all-targets --all-features -- -D warnings`, and `devenv shell mc validate`.
+
+### 2. Progress across CLI steps
+
+- [ ] Emit step-level progress in `cli_runtime`:
+  - command workflow start/finish,
+  - step start/finish,
+  - skipped steps with `when` context,
+  - failure context before returning errors.
+- [ ] Add step-specific concise summaries for discover, validate/check/lint, prepare release, commit/tag/open release request, publish readiness, issue comments, affected packages, and retargeting.
+- [ ] Ensure JSON output commands remain parseable by keeping progress on stderr.
+- [ ] Add tests/snapshots for CI/plain stderr formatting where the harness supports it.
+
+### 3. Parallel publish by ecosystem
+
+- [ ] Build a dependency-aware scheduler that only releases a package when its publish dependencies succeeded or were already published/skipped existing.
+- [ ] Partition runnable work by ecosystem and run one sequential lane per ecosystem.
+- [ ] Preserve dependency order inside each ecosystem lane.
+- [ ] Preserve stable `PackagePublishReport.packages` ordering by original plan order, not completion order.
+- [ ] Stop scheduling new work after failure, while allowing in-flight ecosystem lanes to finish and report outcomes.
+- [ ] Add tests for independent npm/cargo concurrency, cross-ecosystem dependencies, failure behavior, and stable report ordering.
+- [ ] Move this plan to `docs/plans/completed/` when the third PR lands.
+
+## Decisions
+
+- Use emojis, not nerdfonts, for portability and readability.
+- Emojis are allowed in CI logs; only spinner/loading animation is terminal-only.
+- stderr is the default channel for progress so stdout remains usable for JSON and command composition.
+- Parallelism starts at ecosystem granularity, not package granularity, to limit registry-rate and dependency-order risk.
+
+## Open questions
+
+- Whether to add an explicit `--no-progress`/`NO_COLOR`-style opt-out for progress lines or rely on stdout/stderr separation.
+- Whether the progress abstraction should live in `monochange` only first, then move to `monochange_core`/`monochange_publish` once the parallel scheduler needs it across crates.
+- Whether parallel publish should be opt-in for one release before becoming default.


### PR DESCRIPTION
## Summary

- add structured publish progress events in `monochange_publish`
- render publish progress to stderr with emoji output, terminal-aware loading markers, and deterministic CI/plain lines
- add focused tests plus an HTML progress report for the active publish-progress/parallel-ecosystems plan

## Validation

- `cargo check -q -p monochange_publish -p monochange`
- `cargo test -q -p monochange_publish publish_progress -- --nocapture`
- `cargo test -q -p monochange publish_progress -- --nocapture`
- `cargo clippy -q -p monochange_publish -p monochange --all-targets --all-features -- -D warnings`
- `devenv shell mc validate`
- `devenv shell mc step:affected-packages --verify ...`

## Plan report

- HTML report: `docs/plans/active/publish-progress-and-parallel-ecosystems-report.html`
