### PR TITLE
fix: validate cargo private publish dependencies

### DIFF
--- a/.changeset/cargo-private-dependency-lint.md
+++ b/.changeset/cargo-private-dependency-lint.md
@@ -1,0 +1,9 @@
+---
+monochange: patch
+monochange_cargo: patch
+monochange_publish: patch
+---
+
+# Validate Cargo private dependency publishing hazards
+
+Cargo linting now reports publishable packages that depend on private workspace packages through `dependencies`, `dev-dependencies`, or `build-dependencies`. Package publish dry runs now execute the registry dry-run command and preserve its stdout and stderr in the publish report instead of only planning the command.

--- a/crates/monochange/src/__tests__/package_publish_tests.rs
+++ b/crates/monochange/src/__tests__/package_publish_tests.rs
@@ -3973,7 +3973,13 @@ fn execute_publish_requests_placeholder_dry_run_validates_publish_command() {
 	.expect("report:");
 
 	assert_eq!(report.packages[0].status, PackagePublishStatus::Planned);
-	assert!(executor.commands.is_empty());
+	assert_eq!(executor.commands.len(), 1);
+	assert!(
+		executor.commands[0]
+			.args
+			.iter()
+			.any(|arg| arg == "--dry-run")
+	);
 }
 
 #[test]

--- a/crates/monochange/src/__tests__/snapshots/monochange__mcp__tests__lint_catalog_lists_rules_and_presets@lint_catalog_lists_rules_and_presets.snap
+++ b/crates/monochange/src/__tests__/snapshots/monochange__mcp__tests__lint_catalog_lists_rules_and_presets@lint_catalog_lists_rules_and_presets.snap
@@ -14,6 +14,7 @@ expression: content_text(&result)
       "rules": {
         "cargo/dependency-field-order": "warning",
         "cargo/internal-dependency-workspace": "error",
+        "cargo/publishable-dependencies": "error",
         "cargo/required-package-fields": "error",
         "cargo/sorted-dependencies": "warning",
         "cargo/unlisted-package-private": "warning"
@@ -27,6 +28,7 @@ expression: content_text(&result)
       "rules": {
         "cargo/dependency-field-order": "error",
         "cargo/internal-dependency-workspace": "error",
+        "cargo/publishable-dependencies": "error",
         "cargo/required-package-fields": "error",
         "cargo/sorted-dependencies": "error",
         "cargo/unlisted-package-private": "warning"
@@ -140,6 +142,15 @@ expression: content_text(&result)
           "name": "fix"
         }
       ]
+    },
+    {
+      "autofixable": false,
+      "category": "correctness",
+      "description": "Requires publishable Cargo packages to avoid dependencies on unpublished workspace packages",
+      "id": "cargo/publishable-dependencies",
+      "maturity": "stable",
+      "name": "Publishable dependencies",
+      "options": []
     },
     {
       "autofixable": false,
@@ -493,5 +504,5 @@ expression: content_text(&result)
       ]
     }
   ],
-  "summary": "Loaded 28 lint rule(s) and 7 preset(s)."
+  "summary": "Loaded 29 lint rule(s) and 7 preset(s)."
 }

--- a/crates/monochange/src/__tests__/snapshots/monochange__mcp__tests__lint_explain_returns_rule_and_preset@lint_explain_returns_rule_and_preset.snap
+++ b/crates/monochange/src/__tests__/snapshots/monochange__mcp__tests__lint_explain_returns_rule_and_preset@lint_explain_returns_rule_and_preset.snap
@@ -13,6 +13,7 @@ expression: redacted
       "rules": {
         "cargo/dependency-field-order": "warning",
         "cargo/internal-dependency-workspace": "error",
+        "cargo/publishable-dependencies": "error",
         "cargo/required-package-fields": "error",
         "cargo/sorted-dependencies": "warning",
         "cargo/unlisted-package-private": "warning"

--- a/crates/monochange_cargo/src/lints/mod.rs
+++ b/crates/monochange_cargo/src/lints/mod.rs
@@ -61,6 +61,7 @@ impl LintSuite for CargoLintSuite {
 		vec![
 			Box::new(DependencyFieldOrderRule::new()),
 			Box::new(InternalDependencyWorkspaceRule::new()),
+			Box::new(PublishableDependencyRule::new()),
 			Box::new(RequiredPackageFieldsRule::new()),
 			Box::new(SortedDependenciesRule::new()),
 			Box::new(UnlistedPackagePrivateRule::new()),
@@ -82,6 +83,10 @@ impl LintSuite for CargoLintSuite {
 				),
 				(
 					"cargo/internal-dependency-workspace".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Error),
+				),
+				(
+					"cargo/publishable-dependencies".to_string(),
 					LintRuleConfig::Severity(LintSeverity::Error),
 				),
 				(
@@ -110,6 +115,10 @@ impl LintSuite for CargoLintSuite {
 				),
 				(
 					"cargo/internal-dependency-workspace".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Error),
+				),
+				(
+					"cargo/publishable-dependencies".to_string(),
 					LintRuleConfig::Severity(LintSeverity::Error),
 				),
 				(

--- a/crates/monochange_publish/src/__tests__/lib_tests.rs
+++ b/crates/monochange_publish/src/__tests__/lib_tests.rs
@@ -571,3 +571,126 @@ fn publish_order_request(package: &str) -> PublishRequest {
 		placeholder_readme: String::new(),
 	}
 }
+
+#[derive(Debug, Default)]
+struct RecordingExecutor {
+	commands: Vec<CommandSpec>,
+}
+
+impl CommandExecutor for RecordingExecutor {
+	fn run(&mut self, spec: &CommandSpec) -> MonochangeResult<CommandOutput> {
+		self.commands.push(spec.clone());
+		Ok(CommandOutput {
+			success: true,
+			stdout: "dry run ok".to_string(),
+			stderr: "validated package".to_string(),
+		})
+	}
+}
+
+#[derive(Debug, Default)]
+struct TestTrustHandler;
+
+impl PublishTrustHandler for TestTrustHandler {
+	fn trust_outcome_for_skip(
+		&self,
+		_request: &PublishRequest,
+		_source: Option<&SourceConfiguration>,
+		_root: &Path,
+		_env_map: &BTreeMap<String, String>,
+	) -> TrustedPublishingOutcome {
+		disabled_trust_outcome()
+	}
+
+	fn planned_trust_outcome(
+		&self,
+		_request: &PublishRequest,
+		_source: Option<&SourceConfiguration>,
+		_root: &Path,
+		_env_map: &BTreeMap<String, String>,
+	) -> TrustedPublishingOutcome {
+		disabled_trust_outcome()
+	}
+
+	fn enforce_release_trust_prerequisites(
+		&self,
+		_request: &PublishRequest,
+		_source: Option<&SourceConfiguration>,
+		_root: &Path,
+		_env_map: &BTreeMap<String, String>,
+	) -> MonochangeResult<()> {
+		Ok(())
+	}
+}
+
+fn cargo_publish_request() -> PublishRequest {
+	PublishRequest {
+		package_id: "pkg".to_string(),
+		package_name: "pkg".to_string(),
+		ecosystem: Ecosystem::Cargo,
+		manifest_path: PathBuf::from("crates/pkg/Cargo.toml"),
+		package_root: PathBuf::from("crates/pkg"),
+		registry: RegistryKind::CratesIo,
+		package_manager: None,
+		package_metadata: BTreeMap::new(),
+		mode: PublishMode::Builtin,
+		version: "1.2.3".to_string(),
+		placeholder: false,
+		trusted_publishing: TrustedPublishingSettings {
+			enabled: false,
+			..TrustedPublishingSettings::default()
+		},
+		attestations: PublishAttestationSettings::default(),
+		placeholder_readme: String::new(),
+	}
+}
+
+#[test]
+fn dry_run_publish_executes_registry_dry_run_and_captures_output() {
+	let request = cargo_publish_request();
+	let client = registry_client().unwrap_or_else(|error| panic!("registry client: {error}"));
+	let endpoints = RegistryEndpoints::from_env();
+	let command_builder = build_publish_command_builder();
+	let manifest_writers = PlaceholderManifestWriterRegistry::default();
+	let readiness = PublishReadinessRegistry::default();
+	let trust_handler = TestTrustHandler;
+	let mut executor = RecordingExecutor::default();
+
+	let report = execute_publish_requests(
+		Path::new("."),
+		None,
+		PackagePublishRunMode::Release,
+		true,
+		&[request],
+		&client,
+		&endpoints,
+		&BTreeMap::new(),
+		&mut executor,
+		&command_builder,
+		&manifest_writers,
+		&readiness,
+		&trust_handler,
+	)
+	.unwrap_or_else(|error| panic!("execute publish dry run: {error}"));
+
+	assert_eq!(executor.commands.len(), 1);
+	assert!(
+		executor.commands[0]
+			.args
+			.iter()
+			.any(|arg| arg == "--dry-run")
+	);
+	let outcome = report
+		.packages
+		.first()
+		.unwrap_or_else(|| panic!("expected publish outcome"));
+	assert_eq!(outcome.status, PackagePublishStatus::Planned);
+	assert_eq!(outcome.stdout.as_deref(), Some("dry run ok"));
+	assert_eq!(outcome.stderr.as_deref(), Some("validated package"));
+	assert!(
+		outcome
+			.command
+			.as_deref()
+			.is_some_and(|command| command.contains("--dry-run"))
+	);
+}

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -612,31 +612,34 @@ pub fn execute_publish_requests(
 		);
 
 		if dry_run {
+			if mode == PackagePublishRunMode::Placeholder {
+				outcomes.push(PackagePublishOutcome {
+					package: request.package_id.clone(),
+					ecosystem: request.ecosystem,
+					registry: request.registry.to_string(),
+					version: request.version.clone(),
+					status: PackagePublishStatus::Planned,
+					message: planned_publish_message(mode, request),
+					placeholder: true,
+					trusted_publishing: trust_handler
+						.planned_trust_outcome(request, source, root, env_map),
+					command: None,
+					stdout: None,
+					stderr: None,
+				});
+				continue;
+			}
+
 			info!(
 				package_name = request.package_name,
 				version = %request.version,
 				registry = %request.registry,
 				mode = ?mode,
-				"would publish package (dry run)"
+				"validating package publish command (dry run)"
 			);
-			outcomes.push(PackagePublishOutcome {
-				package: request.package_id.clone(),
-				ecosystem: request.ecosystem,
-				registry: request.registry.to_string(),
-				version: request.version.clone(),
-				status: PackagePublishStatus::Planned,
-				message: planned_publish_message(mode, request),
-				placeholder: mode == PackagePublishRunMode::Placeholder,
-				trusted_publishing: trust_handler
-					.planned_trust_outcome(request, source, root, env_map),
-				command: None,
-				stdout: None,
-				stderr: None,
-			});
-			continue;
 		}
 
-		if mode == PackagePublishRunMode::Release {
+		if !dry_run && mode == PackagePublishRunMode::Release {
 			trust_handler.enforce_release_trust_prerequisites(request, source, root, env_map)?;
 			enforce_release_attestation_prerequisites(request, env_map, command_builder)?;
 		}
@@ -662,6 +665,24 @@ pub fn execute_publish_requests(
 				registry = %request.registry,
 				"publish command returned non-zero exit"
 			);
+			if dry_run {
+				outcomes.push(PackagePublishOutcome {
+					package: request.package_id.clone(),
+					ecosystem: request.ecosystem,
+					registry: request.registry.to_string(),
+					version: request.version.clone(),
+					status: PackagePublishStatus::Planned,
+					message: planned_publish_message(mode, request),
+					placeholder: mode == PackagePublishRunMode::Placeholder,
+					trusted_publishing: trust_handler
+						.planned_trust_outcome(request, source, root, env_map),
+					command: Some(render_command(&publish_command)),
+					stdout: non_empty_output(output.stdout),
+					stderr: non_empty_output(output.stderr),
+				});
+				continue;
+			}
+
 			let mut outcome = failed_publish_outcome(
 				mode,
 				request,
@@ -678,28 +699,42 @@ pub fn execute_publish_requests(
 			break;
 		}
 
-		let trusted_publishing = if request.trusted_publishing.enabled {
+		let trusted_publishing = if dry_run {
+			trust_handler.planned_trust_outcome(request, source, root, env_map)
+		} else if request.trusted_publishing.enabled {
 			trust_handler.trust_outcome_for_skip(request, source, root, env_map)
 		} else {
 			disabled_trust_outcome()
 		};
 
+		let (status, message) = if dry_run {
+			(
+				PackagePublishStatus::Planned,
+				planned_publish_message(mode, request),
+			)
+		} else {
+			(
+				PackagePublishStatus::Published,
+				format!(
+					"published {} {} to {}",
+					request.package_name, request.version, request.registry
+				),
+			)
+		};
 		info!(
 			package_name = request.package_name,
 			version = %request.version,
 			registry = %request.registry,
-			"published package"
+			dry_run,
+			"package publish command completed"
 		);
 		outcomes.push(PackagePublishOutcome {
 			package: request.package_id.clone(),
 			ecosystem: request.ecosystem,
 			registry: request.registry.to_string(),
 			version: request.version.clone(),
-			status: PackagePublishStatus::Published,
-			message: format!(
-				"published {} {} to {}",
-				request.package_name, request.version, request.registry
-			),
+			status,
+			message,
 			placeholder: mode == PackagePublishRunMode::Placeholder,
 			trusted_publishing,
 			command: Some(render_command(&publish_command)),


### PR DESCRIPTION
## Summary
- enable `cargo/publishable-dependencies` in the Cargo lint suite and recommended/strict presets
- fail publishable Cargo packages that depend on private workspace crates in dependencies, dev-dependencies, or build-dependencies
- make package publish dry runs execute the registry dry-run command and capture stdout/stderr in the report

## Validation
- `devenv shell cargo test -p monochange_cargo --lib -- --nocapture`
- `devenv shell cargo test -p monochange_publish --lib -- --nocapture`
- `devenv shell cargo clippy -p monochange_cargo -p monochange_publish --lib --tests -- -D warnings`
- `devenv shell mc validate`
- `devenv shell mc check`