### PR TITLE
feat: configure publish order dependency fields

### DIFF
--- a/.changeset/npm-publish-order-fields.md
+++ b/.changeset/npm-publish-order-fields.md
@@ -1,0 +1,19 @@
+---
+"monochange": minor
+"@monochange/skill": minor
+"monochange_cargo": minor
+"monochange_config": minor
+"monochange_core": minor
+"monochange_dart": minor
+"monochange_deno": minor
+"monochange_go": minor
+"monochange_graph": minor
+"monochange_npm": minor
+"monochange_publish": minor
+"monochange_python": minor
+"monochange_schema": minor
+---
+
+# Configurable publish-order dependency fields
+
+Add configurable ecosystem-specific dependency fields for package publish ordering across npm, Cargo, Deno, Dart/Flutter, Python, and Go.

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -9215,6 +9215,7 @@ fn build_cargo_manifest_updates_updates_dependents_of_released_packages() {
 			kind: monochange_core::DependencyKind::Runtime,
 			version_constraint: Some("1.0.0".to_string()),
 			optional: false,
+			source_field: None,
 		});
 
 	let plan = monochange_core::ReleasePlan {
@@ -12504,6 +12505,7 @@ fn discovery_report_helpers_include_version_groups_and_warnings() {
 			source_kind: monochange_core::DependencySourceKind::Manifest,
 			version_constraint: Some("^1.2.3".to_string()),
 			is_optional: false,
+			source_field: None,
 			is_direct: true,
 		}],
 		version_groups: vec![monochange_core::VersionGroup {

--- a/crates/monochange/src/__tests__/package_publish_tests.rs
+++ b/crates/monochange/src/__tests__/package_publish_tests.rs
@@ -1970,6 +1970,14 @@ fn sample_npm_dependency(name: &str, kind: DependencyKind) -> monochange_core::P
 		kind,
 		version_constraint: Some("workspace:*".to_string()),
 		optional: false,
+		source_field: Some(
+			match kind {
+				DependencyKind::Development => "devDependencies",
+				DependencyKind::Peer => "peerDependencies",
+				_ => "dependencies",
+			}
+			.to_string(),
+		),
 	}
 }
 

--- a/crates/monochange/src/__tests__/publish_rate_limits_tests.rs
+++ b/crates/monochange/src/__tests__/publish_rate_limits_tests.rs
@@ -257,6 +257,7 @@ fn dependency_packages(
 						kind: DependencyKind::Runtime,
 						version_constraint: None,
 						optional: false,
+						source_field: None,
 					}
 				})
 				.collect();
@@ -1455,6 +1456,7 @@ fn test_sort_requests_by_dependencies_orders_dependencies_first() {
 			kind: DependencyKind::Development,
 			version_constraint: None,
 			optional: false,
+			source_field: None,
 		});
 	let mut extra = monochange_core::PackageRecord::new(
 		monochange_core::Ecosystem::Cargo,
@@ -1471,6 +1473,7 @@ fn test_sort_requests_by_dependencies_orders_dependencies_first() {
 			kind: DependencyKind::Development,
 			version_constraint: None,
 			optional: false,
+			source_field: None,
 		});
 	let packages = vec![helper.clone(), dependent.clone(), extra.clone()];
 	let mut requests = vec![
@@ -1537,6 +1540,7 @@ fn test_sort_requests_by_dependencies_keeps_original_order_on_cycle() {
 			kind: DependencyKind::Development,
 			version_constraint: None,
 			optional: false,
+			source_field: None,
 		});
 	b.declared_dependencies
 		.push(monochange_core::PackageDependency {
@@ -1544,6 +1548,7 @@ fn test_sort_requests_by_dependencies_keeps_original_order_on_cycle() {
 			kind: DependencyKind::Development,
 			version_constraint: None,
 			optional: false,
+			source_field: None,
 		});
 	let packages = vec![a.clone(), b.clone()];
 	let original_ids = [a.id.clone(), b.id.clone()];

--- a/crates/monochange/src/__tests__/snapshots/monochange__mcp__tests__discover_reports_workspace_packages@discover_reports_workspace_packages.snap
+++ b/crates/monochange/src/__tests__/snapshots/monochange__mcp__tests__discover_reports_workspace_packages@discover_reports_workspace_packages.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/monochange/src/__tests__/mcp_tests.rs
+assertion_line: 378
 expression: content_text(&result)
 ---
 {
@@ -12,6 +13,7 @@ expression: content_text(&result)
         "from_package_id": "cargo:crates/app/Cargo.toml",
         "is_direct": true,
         "is_optional": false,
+        "source_field": "dependencies",
         "source_kind": "manifest",
         "to_package_id": "cargo:crates/core/Cargo.toml",
         "version_constraint": null
@@ -25,6 +27,7 @@ expression: content_text(&result)
             "kind": "runtime",
             "name": "workflow-core",
             "optional": false,
+            "source_field": "dependencies",
             "version_constraint": null
           }
         ],

--- a/crates/monochange_cargo/src/__tests__/lib_tests.rs
+++ b/crates/monochange_cargo/src/__tests__/lib_tests.rs
@@ -397,6 +397,7 @@ fn lockfile_requires_command_refresh_for_incomplete_lockfiles() {
 			kind: monochange_core::DependencyKind::Runtime,
 			version_constraint: Some("1.0".to_string()),
 			optional: false,
+			source_field: None,
 		});
 	let app = PackageRecord::new(
 		Ecosystem::Cargo,

--- a/crates/monochange_cargo/src/lib.rs
+++ b/crates/monochange_cargo/src/lib.rs
@@ -1045,6 +1045,7 @@ fn parse_dependency_table(
 							.and_then(|table| table.get("optional"))
 							.and_then(Value::as_bool)
 							.unwrap_or(false),
+						source_field: Some(section.to_string()),
 					}
 				})
 				.collect::<Vec<_>>()

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -115,6 +115,7 @@ use monochange_core::ProviderReleaseNotesSource;
 use monochange_core::ProviderReleaseSettings;
 use monochange_core::PublishAttestationSettings;
 use monochange_core::PublishMode;
+use monochange_core::PublishOrderSettings;
 use monochange_core::PublishRegistry;
 use monochange_core::PublishSettings;
 use monochange_core::RegistryKind;
@@ -400,6 +401,8 @@ pub(crate) struct RawEcosystemSettings {
 	lockfile_commands: Vec<LockfileCommandDefinition>,
 	#[serde(default)]
 	publish: RawPublishSettings,
+	#[serde(default)]
+	publish_order: PublishOrderSettings,
 }
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -881,6 +884,7 @@ fn normalize_ecosystem_settings(
 		versioned_files,
 		lockfile_commands: raw.lockfile_commands,
 		publish,
+		publish_order: raw.publish_order,
 	})
 }
 

--- a/crates/monochange_core/src/__tests__/lib_tests.rs
+++ b/crates/monochange_core/src/__tests__/lib_tests.rs
@@ -69,6 +69,7 @@ use crate::VersionedFileDefinition;
 use crate::WorkspaceConfiguration;
 use crate::WorkspaceDefaults;
 use crate::default_cli_commands;
+use crate::default_publish_order_dependency_fields;
 use crate::git::git_checkout_branch_command;
 use crate::git::git_command;
 use crate::git::git_current_branch;
@@ -76,6 +77,38 @@ use crate::git::git_head_commit;
 use crate::git::git_push_branch_command;
 use crate::materialize_dependency_edges;
 use crate::render_release_notes;
+
+#[test]
+fn default_publish_order_dependency_fields_cover_all_ecosystems() {
+	assert_eq!(
+		default_publish_order_dependency_fields(Ecosystem::Cargo),
+		["dependencies", "dev-dependencies", "build-dependencies"]
+	);
+	assert_eq!(
+		default_publish_order_dependency_fields(Ecosystem::Npm),
+		["dependencies", "devDependencies"]
+	);
+	assert_eq!(
+		default_publish_order_dependency_fields(Ecosystem::Deno),
+		["dependencies", "imports"]
+	);
+	assert_eq!(
+		default_publish_order_dependency_fields(Ecosystem::Dart),
+		["dependencies", "dev_dependencies"]
+	);
+	assert_eq!(
+		default_publish_order_dependency_fields(Ecosystem::Flutter),
+		["dependencies", "dev_dependencies"]
+	);
+	assert_eq!(
+		default_publish_order_dependency_fields(Ecosystem::Python),
+		["dependencies"]
+	);
+	assert_eq!(
+		default_publish_order_dependency_fields(Ecosystem::Go),
+		["require"]
+	);
+}
 
 fn must_ok<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> T {
 	match result {
@@ -757,6 +790,7 @@ fn package_dependencies_preserve_kind_and_constraint() {
 		kind: DependencyKind::Runtime,
 		version_constraint: Some("^1.0.0".to_string()),
 		optional: false,
+		source_field: None,
 	};
 
 	assert_eq!(dependency.kind, DependencyKind::Runtime);
@@ -786,6 +820,7 @@ fn materialize_dependency_edges_matches_dependency_names_to_packages() {
 		kind: DependencyKind::Runtime,
 		version_constraint: Some("^1.0.0".to_string()),
 		optional: false,
+		source_field: None,
 	});
 
 	let edges = materialize_dependency_edges(&[source.clone(), target.clone()]);

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -368,6 +368,8 @@ pub struct PackageDependency {
 	pub kind: DependencyKind,
 	pub version_constraint: Option<String>,
 	pub optional: bool,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub source_field: Option<String>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -545,6 +547,8 @@ pub struct DependencyEdge {
 	pub version_constraint: Option<String>,
 	pub is_optional: bool,
 	pub is_direct: bool,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub source_field: Option<String>,
 }
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -1729,6 +1733,15 @@ pub struct EcosystemSettings {
 	pub lockfile_commands: Vec<LockfileCommandDefinition>,
 	#[serde(default)]
 	pub publish: PublishSettings,
+	#[serde(default)]
+	pub publish_order: PublishOrderSettings,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct PublishOrderSettings {
+	#[serde(default)]
+	pub dependency_fields: Option<Vec<String>>,
 }
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -4616,6 +4629,18 @@ impl EcosystemRegistry {
 	}
 }
 
+#[must_use]
+pub fn default_publish_order_dependency_fields(ecosystem: Ecosystem) -> &'static [&'static str] {
+	match ecosystem {
+		Ecosystem::Cargo => &["dependencies", "dev-dependencies", "build-dependencies"],
+		Ecosystem::Npm => &["dependencies", "devDependencies"],
+		Ecosystem::Deno => &["dependencies", "imports"],
+		Ecosystem::Dart | Ecosystem::Flutter => &["dependencies", "dev_dependencies"],
+		Ecosystem::Python => &["dependencies"],
+		Ecosystem::Go => &["require"],
+	}
+}
+
 pub fn materialize_dependency_edges(packages: &[PackageRecord]) -> Vec<DependencyEdge> {
 	let mut package_ids_by_name = BTreeMap::<String, Vec<String>>::new();
 	for package in packages {
@@ -4638,6 +4663,7 @@ pub fn materialize_dependency_edges(packages: &[PackageRecord]) -> Vec<Dependenc
 						version_constraint: dependency.version_constraint.clone(),
 						is_optional: dependency.optional,
 						is_direct: true,
+						source_field: dependency.source_field.clone(),
 					});
 				}
 			}

--- a/crates/monochange_dart/src/__tests__/lib_tests.rs
+++ b/crates/monochange_dart/src/__tests__/lib_tests.rs
@@ -339,7 +339,9 @@ fn workspace_and_manifest_helpers_cover_yaml_and_error_paths() {
 		Some("1.2.3")
 	);
 	assert!(app.declared_dependencies.iter().any(|dependency| {
-		dependency.name == "shared" && dependency.version_constraint.as_deref() == Some("^1.0.0")
+		dependency.name == "shared"
+			&& dependency.version_constraint.as_deref() == Some("^1.0.0")
+			&& dependency.source_field.as_deref() == Some("dependencies")
 	}));
 
 	let private_manifest = fixture_root.join("packages/private/pubspec.yaml");

--- a/crates/monochange_dart/src/lib.rs
+++ b/crates/monochange_dart/src/lib.rs
@@ -611,9 +611,11 @@ fn manifest_publish_state(parsed: &Mapping) -> PublishState {
 fn parse_dependencies(parsed: &Mapping) -> Vec<PackageDependency> {
 	["dependencies", "dev_dependencies"]
 		.into_iter()
-		.filter_map(|section| yaml_mapping(parsed, section))
-		.flat_map(|dependencies| {
-			dependencies.iter().map(|(name, value)| {
+		.filter_map(|section| {
+			yaml_mapping(parsed, section).map(|dependencies| (section, dependencies))
+		})
+		.flat_map(|(section, dependencies)| {
+			dependencies.iter().map(move |(name, value)| {
 				PackageDependency {
 					name: name.as_str().unwrap_or_default().to_string(),
 					kind: DependencyKind::Runtime,
@@ -628,6 +630,7 @@ fn parse_dependencies(parsed: &Mapping) -> Vec<PackageDependency> {
 						_ => None,
 					},
 					optional: false,
+					source_field: Some(section.to_string()),
 				}
 			})
 		})

--- a/crates/monochange_deno/src/__tests__/lib_tests.rs
+++ b/crates/monochange_deno/src/__tests__/lib_tests.rs
@@ -41,6 +41,10 @@ fn discovers_deno_workspace_packages() {
 	);
 	let dependency_edges = materialize_dependency_edges(&discovery.packages);
 	assert_eq!(dependency_edges.len(), 1);
+	assert_eq!(
+		dependency_edges.first().unwrap().source_field.as_deref(),
+		Some("dependencies")
+	);
 }
 
 #[test]

--- a/crates/monochange_deno/src/lib.rs
+++ b/crates/monochange_deno/src/lib.rs
@@ -417,6 +417,7 @@ fn parse_dependency_map(parsed: &Value, section: &str) -> Vec<PackageDependency>
 							kind: DependencyKind::Runtime,
 							version_constraint: Some(constraint.to_string()),
 							optional: false,
+							source_field: Some(section.to_string()),
 						}
 					})
 				})

--- a/crates/monochange_go/src/__tests__/lib_tests.rs
+++ b/crates/monochange_go/src/__tests__/lib_tests.rs
@@ -196,6 +196,7 @@ require github.com/nats-io/nats.go v1.31.0
 	let gin = deps.iter().find(|d| d.name == "gin").unwrap();
 	assert_eq!(gin.kind, DependencyKind::Runtime);
 	assert_eq!(gin.version_constraint.as_deref(), Some("1.9.1"));
+	assert_eq!(gin.source_field.as_deref(), Some("require"));
 
 	let sys = deps.iter().find(|d| d.name == "sys").unwrap();
 	assert_eq!(sys.kind, DependencyKind::Development);

--- a/crates/monochange_go/src/lib.rs
+++ b/crates/monochange_go/src/lib.rs
@@ -447,6 +447,7 @@ fn parse_require_entry(entry: &str) -> Option<PackageDependency> {
 		kind,
 		version_constraint: constraint,
 		optional: false,
+		source_field: Some("require".to_string()),
 	})
 }
 

--- a/crates/monochange_graph/src/__tests__/lib_tests.rs
+++ b/crates/monochange_graph/src/__tests__/lib_tests.rs
@@ -41,6 +41,7 @@ fn edge(from: &str, to: &str) -> DependencyEdge {
 		version_constraint: None,
 		is_optional: false,
 		is_direct: true,
+		source_field: None,
 	}
 }
 

--- a/crates/monochange_graph/src/__tests__/mutant_killers_tests.rs
+++ b/crates/monochange_graph/src/__tests__/mutant_killers_tests.rs
@@ -37,6 +37,7 @@ fn edge(from: &str, to: &str) -> DependencyEdge {
 		version_constraint: None,
 		is_optional: false,
 		is_direct: true,
+		source_field: None,
 	}
 }
 

--- a/crates/monochange_graph/src/__tests__/prop_tests.rs
+++ b/crates/monochange_graph/src/__tests__/prop_tests.rs
@@ -86,6 +86,7 @@ proptest! {
 						version_constraint: None,
 						is_optional: false,
 						is_direct: true,
+		source_field: None,
 					}
 				})
 				.collect()

--- a/crates/monochange_npm/src/lib.rs
+++ b/crates/monochange_npm/src/lib.rs
@@ -915,6 +915,7 @@ fn parse_dependency_map(
 							kind,
 							version_constraint: Some(constraint.to_string()),
 							optional: false,
+							source_field: Some(section.to_string()),
 						}
 					})
 				})

--- a/crates/monochange_publish/src/__tests__/lib_tests.rs
+++ b/crates/monochange_publish/src/__tests__/lib_tests.rs
@@ -1,7 +1,12 @@
+use monochange_core::ChangelogSettings;
+use monochange_core::ChangesetSettings;
 use monochange_core::DependencyKind;
 use monochange_core::GroupChangelogInclude;
 use monochange_core::PackageDependency;
+use monochange_core::PublishOrderSettings;
 use monochange_core::VersionFormat;
+use monochange_core::WorkspaceDefaults;
+use monochange_core::lint::WorkspaceLintSettings;
 
 use super::*;
 
@@ -479,6 +484,7 @@ fn publish_dependency_order_handles_realistic_cargo_dependency_graph() {
 	));
 
 	let ordered = order_release_requests_by_publish_dependencies(
+		&publish_order_configuration(None),
 		&[cli, core, test_helpers, codegen, schema],
 		vec![
 			publish_order_request("cli"),
@@ -513,6 +519,7 @@ fn publish_dependency_order_reports_development_dependency_cycles() {
 		.push(publish_order_dependency("app", DependencyKind::Development));
 
 	let error = order_release_requests_by_publish_dependencies(
+		&publish_order_configuration(None),
 		&[app, helper],
 		vec![
 			publish_order_request("app"),
@@ -525,6 +532,316 @@ fn publish_dependency_order_reports_development_dependency_cycles() {
 		error
 			.to_string()
 			.contains("cyclic publish dependencies detected")
+	);
+}
+
+#[test]
+fn npm_publish_order_ignores_peer_dependencies_by_default() {
+	let peer = npm_publish_order_package("peer", Vec::new());
+	let app = npm_publish_order_package(
+		"app",
+		vec![npm_publish_order_dependency("peer", "peerDependencies")],
+	);
+	let packages = vec![app.clone(), peer.clone()];
+	let requests = vec![
+		publish_order_request_for_package(&app),
+		publish_order_request_for_package(&peer),
+	];
+
+	let ordered = order_release_requests_by_publish_dependencies(
+		&publish_order_configuration(None),
+		&packages,
+		requests,
+	)
+	.unwrap();
+
+	let package_names = ordered
+		.into_iter()
+		.map(|request| request.package_name)
+		.collect::<Vec<_>>();
+	assert_eq!(package_names, ["app", "peer"]);
+}
+
+#[test]
+fn npm_publish_order_can_include_peer_dependencies() {
+	let peer = npm_publish_order_package("peer", Vec::new());
+	let app = npm_publish_order_package(
+		"app",
+		vec![npm_publish_order_dependency("peer", "peerDependencies")],
+	);
+	let packages = vec![app.clone(), peer.clone()];
+	let requests = vec![
+		publish_order_request_for_package(&app),
+		publish_order_request_for_package(&peer),
+	];
+
+	let ordered = order_release_requests_by_publish_dependencies(
+		&publish_order_configuration(Some(vec![
+			"dependencies",
+			"devDependencies",
+			"peerDependencies",
+		])),
+		&packages,
+		requests,
+	)
+	.unwrap();
+
+	let package_names = ordered
+		.into_iter()
+		.map(|request| request.package_name)
+		.collect::<Vec<_>>();
+	assert_eq!(package_names, ["peer", "app"]);
+}
+
+#[test]
+fn npm_publish_order_can_include_custom_manifest_fields() {
+	let tempdir = TempDir::new().unwrap();
+	let workspace = tempdir.path();
+	fs::create_dir_all(workspace.join("packages/app")).unwrap();
+	fs::write(
+		workspace.join("packages/app/package.json"),
+		r#"{"name":"app","version":"1.0.0","catalogDependencies":{"external":"1.0.0","tool":"1.0.0"}}"#,
+	)
+	.unwrap();
+
+	let tool = npm_publish_order_package("tool", Vec::new());
+	let mut app = npm_publish_order_package("app", Vec::new());
+	app.manifest_path = workspace.join("packages/app/package.json");
+	let packages = vec![app.clone(), tool.clone()];
+	let requests = vec![
+		publish_order_request_for_package(&app),
+		publish_order_request_for_package(&tool),
+	];
+
+	let ordered = order_release_requests_by_publish_dependencies(
+		&publish_order_configuration(Some(vec!["dependencies", "catalogDependencies"])),
+		&packages,
+		requests,
+	)
+	.unwrap();
+
+	let package_names = ordered
+		.into_iter()
+		.map(|request| request.package_name)
+		.collect::<Vec<_>>();
+	assert_eq!(package_names, ["tool", "app"]);
+}
+
+#[test]
+fn npm_publish_order_can_remove_dev_dependencies() {
+	let tool = npm_publish_order_package("tool", Vec::new());
+	let app = npm_publish_order_package(
+		"app",
+		vec![npm_publish_order_dependency("tool", "devDependencies")],
+	);
+	let packages = vec![app.clone(), tool.clone()];
+	let requests = vec![
+		publish_order_request_for_package(&app),
+		publish_order_request_for_package(&tool),
+	];
+
+	let ordered = order_release_requests_by_publish_dependencies(
+		&publish_order_configuration(Some(vec!["dependencies"])),
+		&packages,
+		requests,
+	)
+	.unwrap();
+
+	let package_names = ordered
+		.into_iter()
+		.map(|request| request.package_name)
+		.collect::<Vec<_>>();
+	assert_eq!(package_names, ["app", "tool"]);
+}
+
+#[test]
+fn non_npm_publish_order_uses_matching_ecosystem_defaults() {
+	let tool = python_publish_order_package("tool", Vec::new());
+	let app = python_publish_order_package(
+		"app",
+		vec![publish_order_dependency_from_field("tool", "dependencies")],
+	);
+	let packages = vec![app.clone(), tool.clone()];
+	let requests = vec![
+		publish_order_request_for_package(&app),
+		publish_order_request_for_package(&tool),
+	];
+
+	let ordered = order_release_requests_by_publish_dependencies(
+		&publish_order_configuration(None),
+		&packages,
+		requests,
+	)
+	.unwrap();
+
+	let package_names = ordered
+		.into_iter()
+		.map(|request| request.package_name)
+		.collect::<Vec<_>>();
+	assert_eq!(package_names, ["tool", "app"]);
+}
+
+#[test]
+fn python_publish_order_can_include_optional_dependencies() {
+	let extra = python_publish_order_package("extra", Vec::new());
+	let app = python_publish_order_package(
+		"app",
+		vec![publish_order_dependency_from_field(
+			"extra",
+			"optional-dependencies",
+		)],
+	);
+	let packages = vec![app.clone(), extra.clone()];
+
+	let default_order = order_release_requests_by_publish_dependencies(
+		&publish_order_configuration(None),
+		&packages,
+		vec![
+			publish_order_request_for_package(&app),
+			publish_order_request_for_package(&extra),
+		],
+	)
+	.unwrap();
+	assert_eq!(publish_order_package_names(default_order), ["app", "extra"]);
+
+	let configured_order = order_release_requests_by_publish_dependencies(
+		&publish_order_configuration_for(
+			Ecosystem::Python,
+			vec!["dependencies", "optional-dependencies"],
+		),
+		&packages,
+		vec![
+			publish_order_request_for_package(&app),
+			publish_order_request_for_package(&extra),
+		],
+	)
+	.unwrap();
+	assert_eq!(
+		publish_order_package_names(configured_order),
+		["extra", "app"]
+	);
+}
+
+#[test]
+fn go_publish_order_can_disable_require_dependencies() {
+	let library = ecosystem_publish_order_package(Ecosystem::Go, "library", Vec::new());
+	let app = ecosystem_publish_order_package(
+		Ecosystem::Go,
+		"app",
+		vec![publish_order_dependency_from_field("library", "require")],
+	);
+	let packages = vec![app.clone(), library.clone()];
+
+	let default_order = order_release_requests_by_publish_dependencies(
+		&publish_order_configuration(None),
+		&packages,
+		vec![
+			publish_order_request_for_package(&app),
+			publish_order_request_for_package(&library),
+		],
+	)
+	.unwrap();
+	assert_eq!(
+		publish_order_package_names(default_order),
+		["library", "app"]
+	);
+
+	let configured_order = order_release_requests_by_publish_dependencies(
+		&publish_order_configuration_for(Ecosystem::Go, Vec::new()),
+		&packages,
+		vec![
+			publish_order_request_for_package(&app),
+			publish_order_request_for_package(&library),
+		],
+	)
+	.unwrap();
+	assert_eq!(
+		publish_order_package_names(configured_order),
+		["app", "library"]
+	);
+}
+
+#[test]
+fn dart_publish_order_can_remove_dev_dependencies() {
+	let test_tool = ecosystem_publish_order_package(Ecosystem::Dart, "test_tool", Vec::new());
+	let app = ecosystem_publish_order_package(
+		Ecosystem::Dart,
+		"app",
+		vec![publish_order_dependency_from_field(
+			"test_tool",
+			"dev_dependencies",
+		)],
+	);
+	let packages = vec![app.clone(), test_tool.clone()];
+
+	let default_order = order_release_requests_by_publish_dependencies(
+		&publish_order_configuration(None),
+		&packages,
+		vec![
+			publish_order_request_for_package(&app),
+			publish_order_request_for_package(&test_tool),
+		],
+	)
+	.unwrap();
+	assert_eq!(
+		publish_order_package_names(default_order),
+		["test_tool", "app"]
+	);
+
+	let configured_order = order_release_requests_by_publish_dependencies(
+		&publish_order_configuration_for(Ecosystem::Dart, vec!["dependencies"]),
+		&packages,
+		vec![
+			publish_order_request_for_package(&app),
+			publish_order_request_for_package(&test_tool),
+		],
+	)
+	.unwrap();
+	assert_eq!(
+		publish_order_package_names(configured_order),
+		["app", "test_tool"]
+	);
+}
+
+#[test]
+fn deno_publish_order_can_remove_dependencies() {
+	let shared = ecosystem_publish_order_package(Ecosystem::Deno, "shared", Vec::new());
+	let app = ecosystem_publish_order_package(
+		Ecosystem::Deno,
+		"app",
+		vec![publish_order_dependency_from_field(
+			"shared",
+			"dependencies",
+		)],
+	);
+	let packages = vec![app.clone(), shared.clone()];
+
+	let default_order = order_release_requests_by_publish_dependencies(
+		&publish_order_configuration(None),
+		&packages,
+		vec![
+			publish_order_request_for_package(&app),
+			publish_order_request_for_package(&shared),
+		],
+	)
+	.unwrap();
+	assert_eq!(
+		publish_order_package_names(default_order),
+		["shared", "app"]
+	);
+
+	let configured_order = order_release_requests_by_publish_dependencies(
+		&publish_order_configuration_for(Ecosystem::Deno, vec!["imports"]),
+		&packages,
+		vec![
+			publish_order_request_for_package(&app),
+			publish_order_request_for_package(&shared),
+		],
+	)
+	.unwrap();
+	assert_eq!(
+		publish_order_package_names(configured_order),
+		["app", "shared"]
 	);
 }
 
@@ -550,6 +867,147 @@ fn publish_order_dependency(name: &str, kind: DependencyKind) -> PackageDependen
 		kind,
 		version_constraint: Some("1.0.0".to_string()),
 		optional: false,
+		source_field: Some(
+			match kind {
+				DependencyKind::Development => "dev-dependencies",
+				DependencyKind::Build => "build-dependencies",
+				_ => "dependencies",
+			}
+			.to_string(),
+		),
+	}
+}
+
+fn npm_publish_order_package(name: &str, dependencies: Vec<PackageDependency>) -> PackageRecord {
+	let root = PathBuf::from("/workspace");
+	let mut package = PackageRecord::new(
+		Ecosystem::Npm,
+		name,
+		root.join("packages").join(name).join("package.json"),
+		root,
+		None,
+		PublishState::Public,
+	);
+	package.declared_dependencies = dependencies;
+	package
+}
+
+fn python_publish_order_package(name: &str, dependencies: Vec<PackageDependency>) -> PackageRecord {
+	ecosystem_publish_order_package(Ecosystem::Python, name, dependencies)
+}
+
+fn ecosystem_publish_order_package(
+	ecosystem: Ecosystem,
+	name: &str,
+	dependencies: Vec<PackageDependency>,
+) -> PackageRecord {
+	let root = PathBuf::from("/workspace");
+	let manifest_name = match ecosystem {
+		Ecosystem::Cargo => "Cargo.toml",
+		Ecosystem::Dart | Ecosystem::Flutter => "pubspec.yaml",
+		Ecosystem::Python => "pyproject.toml",
+		Ecosystem::Go => "go.mod",
+		_ => "package.json",
+	};
+	let mut package = PackageRecord::new(
+		ecosystem,
+		name,
+		root.join("packages").join(name).join(manifest_name),
+		root,
+		None,
+		PublishState::Public,
+	);
+	package.declared_dependencies = dependencies;
+	package
+}
+
+fn npm_publish_order_dependency(name: &str, source_field: &str) -> PackageDependency {
+	publish_order_dependency_from_field(name, source_field)
+}
+
+fn publish_order_dependency_from_field(name: &str, source_field: &str) -> PackageDependency {
+	PackageDependency {
+		name: name.to_string(),
+		kind: DependencyKind::Runtime,
+		version_constraint: Some("1.0.0".to_string()),
+		optional: false,
+		source_field: Some(source_field.to_string()),
+	}
+}
+
+fn publish_order_configuration(npm_dependency_fields: Option<Vec<&str>>) -> WorkspaceConfiguration {
+	let npm = EcosystemSettings {
+		publish_order: PublishOrderSettings {
+			dependency_fields: npm_dependency_fields
+				.map(|fields| fields.into_iter().map(str::to_string).collect()),
+		},
+		..EcosystemSettings::default()
+	};
+
+	WorkspaceConfiguration {
+		root_path: PathBuf::from("/workspace"),
+		defaults: WorkspaceDefaults::default(),
+		changelog: ChangelogSettings::default(),
+		packages: Vec::new(),
+		groups: Vec::new(),
+		cli: Vec::new(),
+		changesets: ChangesetSettings::default(),
+		source: None,
+		lints: WorkspaceLintSettings::default(),
+		cargo: EcosystemSettings::default(),
+		npm,
+		deno: EcosystemSettings::default(),
+		dart: EcosystemSettings::default(),
+		python: EcosystemSettings::default(),
+		go: EcosystemSettings::default(),
+	}
+}
+
+fn publish_order_configuration_for(
+	ecosystem: Ecosystem,
+	dependency_fields: Vec<&str>,
+) -> WorkspaceConfiguration {
+	let mut configuration = publish_order_configuration(None);
+	let settings = match ecosystem {
+		Ecosystem::Cargo => &mut configuration.cargo,
+		Ecosystem::Deno => &mut configuration.deno,
+		Ecosystem::Dart | Ecosystem::Flutter => &mut configuration.dart,
+		Ecosystem::Python => &mut configuration.python,
+		Ecosystem::Go => &mut configuration.go,
+		_ => &mut configuration.npm,
+	};
+	settings.publish_order.dependency_fields =
+		Some(dependency_fields.into_iter().map(str::to_string).collect());
+	configuration
+}
+
+fn publish_order_package_names(requests: Vec<PublishRequest>) -> Vec<String> {
+	requests
+		.into_iter()
+		.map(|request| request.package_name)
+		.collect()
+}
+
+fn publish_order_request_for_package(package: &PackageRecord) -> PublishRequest {
+	PublishRequest {
+		package_id: package.name.clone(),
+		package_name: package.name.clone(),
+		ecosystem: package.ecosystem,
+		manifest_path: package.manifest_path.clone(),
+		package_root: package.manifest_path.parent().unwrap().to_path_buf(),
+		registry: if package.ecosystem == Ecosystem::Cargo {
+			RegistryKind::CratesIo
+		} else {
+			RegistryKind::Npm
+		},
+		package_manager: None,
+		package_metadata: BTreeMap::new(),
+		mode: PublishMode::Builtin,
+		version: "1.0.0".to_string(),
+		placeholder: false,
+		trusted_publishing: TrustedPublishingSettings::default(),
+		attestations: PublishAttestationSettings::default(),
+		placeholder_readme: String::new(),
 	}
 }
 

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -5,7 +5,11 @@ use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 
+use monochange_core::DependencyEdge;
+use monochange_core::DependencyKind;
+use monochange_core::DependencySourceKind;
 use monochange_core::Ecosystem;
+use monochange_core::EcosystemSettings;
 use monochange_core::GroupDefinition;
 use monochange_core::MonochangeError;
 use monochange_core::MonochangeResult;
@@ -19,6 +23,7 @@ use monochange_core::RegistryKind;
 use monochange_core::SourceConfiguration;
 use monochange_core::TrustedPublishingSettings;
 use monochange_core::WorkspaceConfiguration;
+use monochange_core::default_publish_order_dependency_fields;
 use reqwest::StatusCode;
 use reqwest::blocking::Client;
 use serde::Deserialize;
@@ -904,7 +909,7 @@ pub fn build_release_requests(
 		});
 	}
 
-	order_release_requests_by_publish_dependencies(packages, requests)
+	order_release_requests_by_publish_dependencies(configuration, packages, requests)
 }
 
 pub fn resolve_registry_kind(
@@ -1933,6 +1938,93 @@ fn circle_project_slug(env_map: &BTreeMap<String, String>) -> Option<String> {
 
 use monochange_core::materialize_dependency_edges;
 
+fn publish_order_dependency_edges(
+	configuration: &WorkspaceConfiguration,
+	packages: &[PackageRecord],
+) -> Vec<DependencyEdge> {
+	let mut edges = materialize_dependency_edges(packages);
+	let packages_by_name = packages
+		.iter()
+		.map(|package| (package.name.as_str(), package))
+		.collect::<BTreeMap<_, _>>();
+
+	for package in packages
+		.iter()
+		.filter(|package| package.ecosystem == Ecosystem::Npm)
+	{
+		let parsed = fs::read_to_string(&package.manifest_path)
+			.ok()
+			.and_then(|contents| serde_json::from_str::<JsonValue>(&contents).ok());
+		let Some(JsonValue::Object(root)) = parsed else {
+			continue;
+		};
+
+		let declared_fields = package
+			.declared_dependencies
+			.iter()
+			.filter_map(|dependency| dependency.source_field.as_deref())
+			.collect::<BTreeSet<_>>();
+		for field in publish_order_dependency_fields(configuration, package.ecosystem) {
+			if declared_fields.contains(field.as_str()) {
+				continue;
+			}
+			let Some(JsonValue::Object(dependencies)) = root.get(&field) else {
+				continue;
+			};
+			for (dependency_name, constraint) in dependencies {
+				let Some(target) = packages_by_name.get(dependency_name.as_str()) else {
+					continue;
+				};
+				edges.push(DependencyEdge {
+					from_package_id: package.id.clone(),
+					to_package_id: target.id.clone(),
+					dependency_kind: DependencyKind::Unknown,
+					source_kind: DependencySourceKind::Manifest,
+					version_constraint: constraint.as_str().map(ToString::to_string),
+					is_optional: false,
+					is_direct: true,
+					source_field: Some(field.clone()),
+				});
+			}
+		}
+	}
+
+	edges
+}
+
+fn publish_order_dependency_fields(
+	configuration: &WorkspaceConfiguration,
+	ecosystem: Ecosystem,
+) -> BTreeSet<String> {
+	let settings = ecosystem_settings(configuration, ecosystem);
+	settings
+		.publish_order
+		.dependency_fields
+		.clone()
+		.unwrap_or_else(|| {
+			default_publish_order_dependency_fields(ecosystem)
+				.iter()
+				.map(|field| (*field).to_string())
+				.collect()
+		})
+		.into_iter()
+		.collect()
+}
+
+fn ecosystem_settings(
+	configuration: &WorkspaceConfiguration,
+	ecosystem: Ecosystem,
+) -> &EcosystemSettings {
+	match ecosystem {
+		Ecosystem::Cargo => &configuration.cargo,
+		Ecosystem::Deno => &configuration.deno,
+		Ecosystem::Dart | Ecosystem::Flutter => &configuration.dart,
+		Ecosystem::Python => &configuration.python,
+		Ecosystem::Go => &configuration.go,
+		_ => &configuration.npm,
+	}
+}
+
 pub fn read_publish_report_artifact(path: &Path) -> MonochangeResult<PackagePublishReport> {
 	let body = fs::read_to_string(path).map_err(|error| {
 		MonochangeError::Io(format!(
@@ -2092,6 +2184,7 @@ pub fn merge_publish_resume_report(
 }
 
 pub fn order_release_requests_by_publish_dependencies(
+	configuration: &WorkspaceConfiguration,
 	packages: &[PackageRecord],
 	mut requests: Vec<PublishRequest>,
 ) -> MonochangeResult<Vec<PublishRequest>> {
@@ -2118,7 +2211,16 @@ pub fn order_release_requests_by_publish_dependencies(
 		.collect::<BTreeMap<_, _>>();
 	let mut dependents_by_package = BTreeMap::<String, BTreeSet<String>>::new();
 
-	for edge in materialize_dependency_edges(packages) {
+	for edge in publish_order_dependency_edges(configuration, packages) {
+		let from_package = packages
+			.iter()
+			.find(|package| package.id == edge.from_package_id)
+			.expect("publish-order edges originate from discovered packages");
+		if !publish_order_dependency_fields(configuration, from_package.ecosystem)
+			.contains(edge.source_field.as_deref().unwrap_or_default())
+		{
+			continue;
+		}
 		let Some(from_package_id) = config_ids_by_record_id.get(&edge.from_package_id) else {
 			continue;
 		};
@@ -2224,10 +2326,6 @@ pub fn packages_by_config_id(packages: &[PackageRecord]) -> BTreeMap<&str, &Pack
 		})
 		.collect()
 }
-
-#[cfg(test)]
-#[path = "__tests__/lib_tests.rs"]
-mod tests;
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct RegistryEndpoints {
 	pub npm_registry: String,
@@ -2541,3 +2639,7 @@ pub fn crates_io_index_entry_path(package_name: &str) -> String {
 fn http_error(context: &'static str) -> impl Fn(reqwest::Error) -> MonochangeError {
 	move |error| MonochangeError::Discovery(format!("{context} failed: {error}"))
 }
+
+#[cfg(test)]
+#[path = "__tests__/lib_tests.rs"]
+mod tests;

--- a/crates/monochange_python/src/__tests__/lib_tests.rs
+++ b/crates/monochange_python/src/__tests__/lib_tests.rs
@@ -973,16 +973,16 @@ empty = "not-an-array"
 		.get("project")
 		.unwrap_or_else(|| panic!("expected project table"));
 	let pep621_deps = crate::parse_pep621_dependencies(project_table);
-	assert!(
-		pep621_deps
-			.iter()
-			.any(|dep| dep.name == "requests" && !dep.optional)
-	);
-	assert!(
-		pep621_deps
-			.iter()
-			.any(|dep| dep.name == "pytest" && dep.optional)
-	);
+	assert!(pep621_deps.iter().any(|dep| {
+		dep.name == "requests"
+			&& !dep.optional
+			&& dep.source_field.as_deref() == Some("dependencies")
+	}));
+	assert!(pep621_deps.iter().any(|dep| {
+		dep.name == "pytest"
+			&& dep.optional
+			&& dep.source_field.as_deref() == Some("optional-dependencies")
+	}));
 
 	let poetry = toml::from_str::<toml::Value>(
 		r#"
@@ -1011,10 +1011,11 @@ numbered = 1
 	assert!(crate::parse_poetry_dependencies(&empty_poetry).is_empty());
 
 	let deps = crate::parse_poetry_dependencies(&poetry);
-	assert!(
-		deps.iter()
-			.any(|dep| dep.name == "django" && dep.version_constraint.as_deref() == Some("^4.2"))
-	);
+	assert!(deps.iter().any(|dep| {
+		dep.name == "django"
+			&& dep.version_constraint.as_deref() == Some("^4.2")
+			&& dep.source_field.as_deref() == Some("dependencies")
+	}));
 	assert!(
 		deps.iter()
 			.any(|dep| dep.name == "celery" && dep.version_constraint.as_deref() == Some("^5.3"))
@@ -1023,10 +1024,11 @@ numbered = 1
 		deps.iter()
 			.any(|dep| dep.name == "local" && dep.version_constraint.is_none())
 	);
-	assert!(
-		deps.iter()
-			.any(|dep| dep.name == "ruff" && dep.version_constraint.as_deref() == Some("^0.4"))
-	);
+	assert!(deps.iter().any(|dep| {
+		dep.name == "ruff"
+			&& dep.version_constraint.as_deref() == Some("^0.4")
+			&& dep.source_field.as_deref() == Some("group.dependencies")
+	}));
 	assert!(
 		deps.iter()
 			.any(|dep| dep.name == "tooling" && dep.version_constraint.is_none())

--- a/crates/monochange_python/src/lib.rs
+++ b/crates/monochange_python/src/lib.rs
@@ -564,6 +564,7 @@ fn parse_pep621_dependencies(project: &Value) -> Vec<PackageDependency> {
 					kind: DependencyKind::Runtime,
 					version_constraint: extract_version_constraint(spec, &name),
 					optional: false,
+					source_field: Some("dependencies".to_string()),
 				});
 			}
 		}
@@ -584,6 +585,7 @@ fn parse_pep621_dependencies(project: &Value) -> Vec<PackageDependency> {
 							kind: DependencyKind::Development,
 							version_constraint: extract_version_constraint(spec, &name),
 							optional: true,
+							source_field: Some("optional-dependencies".to_string()),
 						});
 					}
 				}
@@ -617,6 +619,7 @@ fn parse_poetry_dependencies(poetry: &Value) -> Vec<PackageDependency> {
 				kind: DependencyKind::Runtime,
 				version_constraint: constraint,
 				optional: false,
+				source_field: Some("dependencies".to_string()),
 			});
 		}
 	}
@@ -645,6 +648,7 @@ fn parse_poetry_dependencies(poetry: &Value) -> Vec<PackageDependency> {
 						kind: DependencyKind::Development,
 						version_constraint: constraint,
 						optional: false,
+						source_field: Some("group.dependencies".to_string()),
 					});
 				}
 			}

--- a/crates/monochange_schema/schemas/monochange.schema.json
+++ b/crates/monochange_schema/schemas/monochange.schema.json
@@ -1139,6 +1139,22 @@
 			],
 			"type": "string"
 		},
+		"PublishOrderSettings": {
+			"additionalProperties": false,
+			"properties": {
+				"dependency_fields": {
+					"default": null,
+					"items": {
+						"type": "string"
+					},
+					"type": [
+						"array",
+						"null"
+					]
+				}
+			},
+			"type": "object"
+		},
 		"PublishRegistry": {
 			"anyOf": [
 				{
@@ -1494,6 +1510,12 @@
 				},
 				"publish": {
 					"$ref": "#/$defs/publishSettings"
+				},
+				"publish_order": {
+					"$ref": "#/$defs/PublishOrderSettings",
+					"default": {
+						"dependency_fields": null
+					}
 				},
 				"roots": {
 					"default": [],

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -182,6 +182,9 @@ mode = "builtin"
 registry = "npm"
 trusted_publishing = true
 
+[ecosystems.npm.publish_order]
+dependency_fields = ["dependencies", "devDependencies", "peerDependencies", "catalogDependencies"]
+
 [ecosystems.npm.publish.trusted_publishing]
 workflow = "publish.yml"
 environment = "publisher"
@@ -208,6 +211,7 @@ Supported fields:
 - `attestations.require_registry_provenance` - require registry-native package provenance when the selected registry/provider capability supports it
 - `rate_limits.enforce` - block built-in publish runs when the selected package set exceeds a known single registry window
 - `placeholder.readme` - inline placeholder README content
+- `publish_order.dependency_fields` - ecosystem-level dependency fields used to topologically order package publishes
 - `placeholder.readme_file` - workspace-relative file to use as placeholder README content
 
 Inheritance flows from `[ecosystems.<name>.publish]` to matching packages, and package-level values override the inherited ecosystem defaults. Configure shared trusted-publishing, attestation, and context policy on the ecosystem, then use package-level publish settings for opt-outs or package-specific workflows.
@@ -237,6 +241,36 @@ For each managed package with built-in publishing enabled, monochange:
 - renders a default placeholder README unless `placeholder.readme` or `placeholder.readme_file` overrides it
 
 `placeholder.readme` and `placeholder.readme_file` are mutually exclusive. If both are set, config validation fails.
+
+### Publish order dependency fields
+
+`publish_order.dependency_fields` controls which manifest dependency fields create publish-order edges for an ecosystem. npm defaults to `dependencies` and `devDependencies`, so peer packages do not block publishing unless opted in. Cargo defaults stay `dependencies`, `dev-dependencies`, and `build-dependencies`. Deno defaults to `dependencies` and `imports`, Dart/Flutter default to `dependencies` and `dev_dependencies`, Python defaults to `dependencies`, and Go defaults to `require`. Optional Python extras (`optional-dependencies`) and Poetry groups (`group.dependencies`) only affect publish order when you opt in.
+
+```toml
+[ecosystems.npm.publish_order]
+# Add peer and custom package.json fields.
+dependency_fields = ["dependencies", "devDependencies", "peerDependencies", "catalogDependencies"]
+```
+
+```toml
+[ecosystems.npm.publish_order]
+# Or remove devDependencies from publish ordering.
+dependency_fields = ["dependencies"]
+```
+
+```toml
+[ecosystems.python.publish_order]
+# Include optional dependency groups in Python publish ordering.
+dependency_fields = ["dependencies", "optional-dependencies", "group.dependencies"]
+```
+
+```toml
+[ecosystems.go.publish_order]
+# An empty list disables Go require-based publish ordering.
+dependency_fields = []
+```
+
+The same resolved policy is used by `mc plan-release-publish` and `mc publish`.
 
 ### Trusted publishing
 

--- a/docs/src/schemas/monochange.schema.json
+++ b/docs/src/schemas/monochange.schema.json
@@ -1139,6 +1139,22 @@
 			],
 			"type": "string"
 		},
+		"PublishOrderSettings": {
+			"additionalProperties": false,
+			"properties": {
+				"dependency_fields": {
+					"default": null,
+					"items": {
+						"type": "string"
+					},
+					"type": [
+						"array",
+						"null"
+					]
+				}
+			},
+			"type": "object"
+		},
 		"PublishRegistry": {
 			"anyOf": [
 				{
@@ -1494,6 +1510,12 @@
 				},
 				"publish": {
 					"$ref": "#/$defs/publishSettings"
+				},
+				"publish_order": {
+					"$ref": "#/$defs/PublishOrderSettings",
+					"default": {
+						"dependency_fields": null
+					}
 				},
 				"roots": {
 					"default": [],

--- a/docs/src/schemas/monochange.v0.1.schema.json
+++ b/docs/src/schemas/monochange.v0.1.schema.json
@@ -1139,6 +1139,22 @@
 			],
 			"type": "string"
 		},
+		"PublishOrderSettings": {
+			"additionalProperties": false,
+			"properties": {
+				"dependency_fields": {
+					"default": null,
+					"items": {
+						"type": "string"
+					},
+					"type": [
+						"array",
+						"null"
+					]
+				}
+			},
+			"type": "object"
+		},
 		"PublishRegistry": {
 			"anyOf": [
 				{
@@ -1494,6 +1510,12 @@
 				},
 				"publish": {
 					"$ref": "#/$defs/publishSettings"
+				},
+				"publish_order": {
+					"$ref": "#/$defs/PublishOrderSettings",
+					"default": {
+						"dependency_fields": null
+					}
 				},
 				"roots": {
 					"default": [],

--- a/packages/monochange__skill/skills/multi-package-publishing.md
+++ b/packages/monochange__skill/skills/multi-package-publishing.md
@@ -23,6 +23,9 @@ mode = "builtin"
 registry = "npm"
 trusted_publishing = true
 
+[ecosystems.npm.publish_order]
+dependency_fields = ["dependencies", "devDependencies"]
+
 [package."@acme/private-app"]
 path = "apps/private"
 type = "npm"
@@ -37,6 +40,8 @@ publish = { enabled = true, mode = "external" }
 Built-in publishing targets canonical public registries. Use external mode for private registries, custom scheduling, or registry-specific orchestration that monochange should not manage.
 
 Prefer ecosystem-level defaults when every public package publishes the same way, then override individual package tables for private packages, custom registries, or packages that need a different trust model.
+
+Publish ordering uses ecosystem-specific dependency fields. npm defaults to `dependencies` and `devDependencies`; add `peerDependencies` or custom package.json fields through `[ecosystems.npm.publish_order].dependency_fields`, or remove `devDependencies` by setting the list to only `dependencies`. Cargo continues to order by `dependencies`, `dev-dependencies`, and `build-dependencies`. Deno uses `dependencies` and `imports`, Dart/Flutter use `dependencies` and `dev_dependencies`, Python uses `dependencies`, and Go uses `require` by default. Opt Python into `optional-dependencies` or `group.dependencies` only when optional extras or Poetry groups should block publish order.
 
 ## Safety
 


### PR DESCRIPTION
## Summary

- add ecosystem publish-order dependency-field configuration
- default npm publish ordering to `dependencies` and `devDependencies`, with opt-in support for `peerDependencies` and custom package.json fields
- preserve Cargo publish-order defaults and use the same policy for publish plans and publish execution
- document the new config and update the monochange skill guidance

Closes #465.

## Tests

- `devenv shell cargo test -q --workspace`
- `devenv shell cargo clippy -q --workspace --all-targets -- -D warnings`
- `devenv shell dprint check`
- `devenv shell docs:check`
- `devenv shell mc validate`
- `devenv shell cargo xtask skill commands check`
- `git diff --check`
