### PR TITLE
test: redact schema versions in snapshots

### DIFF
--- a/.changeset/redact-schema-snapshot-versions.md
+++ b/.changeset/redact-schema-snapshot-versions.md
@@ -1,0 +1,7 @@
+---
+monochange_test_helpers: test
+---
+
+# Redact schema versions in snapshot helpers
+
+Shared snapshot settings now redact release-record schema versions in JSON fields and diagnostics so release PR tests do not fail when the schema crate version changes.

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -14087,6 +14087,10 @@ fn write_release_record_file_snapshot_matches_expected_content() {
 		serde_json::from_str(&content).unwrap_or_else(|error| panic!("parse record: {error}"));
 	let mut value = value;
 	value["createdAt"] = serde_json::Value::String("[timestamp]".to_string());
+	// The on-disk schemaVersion follows the release package version. Redacting it
+	// keeps this snapshot focused on record shape instead of failing every schema
+	// crate bump in release PRs.
+	value["schemaVersion"] = serde_json::Value::String("[schema version]".to_string());
 	insta::assert_json_snapshot!("release_record_file_snapshot", value);
 }
 

--- a/crates/monochange/src/__tests__/snapshots/monochange__tests__release_record_file_snapshot.snap
+++ b/crates/monochange/src/__tests__/snapshots/monochange__tests__release_record_file_snapshot.snap
@@ -34,7 +34,7 @@ expression: value
     "monochange",
     "monochange_core"
   ],
-  "schemaVersion": "0.1",
+  "schemaVersion": "[schema version]",
   "updatedChangelogs": [],
   "version": "1.2.3",
   "versions": {

--- a/crates/monochange/tests/release_record.rs
+++ b/crates/monochange/tests/release_record.rs
@@ -188,22 +188,41 @@ fn release_record_command_reports_unsupported_schema_version() {
 
 	let tempdir = setup_release_repo();
 	let repo = tempdir.path();
-	let json_text = r#"{
-  "v": "0.2",
+	let schema_version = unsupported_release_record_schema_version();
+	let json_text = format!(
+		r#"{{
+  "v": "{schema_version}",
   "kind": "monochange.releaseRecord",
   "createdAt": "2026-04-07T08:00:00Z",
   "command": "release-pr",
   "releaseTargets": [],
   "releasedPackages": [],
   "changedFiles": []
-}"#;
-	commit_file_based_record_raw(repo, json_text, "release-record/commit-body");
+}}"#
+	);
+	commit_file_based_record_raw(repo, &json_text, "release-record/commit-body");
 
 	let output = release_record_output(repo, &["--from", "HEAD"]);
 	assert!(!output.status.success());
 	assert_snapshot!(
 		String::from_utf8(output.stderr).unwrap_or_else(|error| panic!("stderr utf8: {error}"))
 	);
+}
+
+// Keep this test ahead of the current durable schema version. Release PRs bump
+// `monochange_schema`, so a hard-coded "future" version eventually becomes
+// current and turns this error-path test into a release-CI failure.
+fn unsupported_release_record_schema_version() -> String {
+	let (major, minor) = monochange_core::RELEASE_RECORD_SCHEMA_VERSION
+		.split_once('.')
+		.unwrap_or_else(|| panic!("schema version should be major.minor"));
+	let major = major
+		.parse::<u64>()
+		.unwrap_or_else(|error| panic!("parse schema major: {error}"));
+	let minor = minor
+		.parse::<u64>()
+		.unwrap_or_else(|error| panic!("parse schema minor: {error}"));
+	format!("{major}.{}", minor + 1)
 }
 
 #[etest::etest]

--- a/crates/monochange/tests/snapshots/release_record__release_record_command_reports_unsupported_schema_version@release_record_command_reports_unsupported_schema_version.snap
+++ b/crates/monochange/tests/snapshots/release_record__release_record_command_reports_unsupported_schema_version@release_record_command_reports_unsupported_schema_version.snap
@@ -2,4 +2,4 @@
 source: crates/monochange/tests/release_record.rs
 expression: "String::from_utf8(output.stderr).unwrap_or_else(|error|\npanic!(\"stderr utf8: {error}\"))"
 ---
-discovery error: release record in commit [SHA] uses unsupported schemaVersion 0.2 (upgrade monochange to read this record)
+discovery error: release record in commit [SHA] uses unsupported schemaVersion [SCHEMA_VERSION] (upgrade monochange to read this record)

--- a/crates/monochange_core/src/__tests__/lib_tests.rs
+++ b/crates/monochange_core/src/__tests__/lib_tests.rs
@@ -2337,13 +2337,14 @@ fn parse_release_record_block_rejects_unsupported_schema_version() {
 	let start = RELEASE_RECORD_START_MARKER;
 	let end = RELEASE_RECORD_END_MARKER;
 	let kind = RELEASE_RECORD_KIND;
+	let schema_version = unsupported_release_record_schema_version();
 	let unsupported_schema = format!(
 		r#"{heading}
 
 {start}
 ```json
 {{
-  "schemaVersion": "0.2",
+  "schemaVersion": "{schema_version}",
   "kind": "{kind}",
   "createdAt": "2026-04-06T12:00:00Z",
   "command": "release-pr",
@@ -2359,7 +2360,7 @@ fn parse_release_record_block_rejects_unsupported_schema_version() {
 		.unwrap_or_else(|| panic!("expected unsupported schema error"));
 	assert!(matches!(
 		error,
-		ReleaseRecordError::UnsupportedSchemaVersionValue(version) if version == "0.2"
+		ReleaseRecordError::UnsupportedSchemaVersionValue(version) if version == schema_version
 	));
 }
 
@@ -2440,6 +2441,15 @@ fn parse_release_record_json_normalizes_legacy_v_field() {
 	assert_eq!(parsed.schema_version, RELEASE_RECORD_SCHEMA_VERSION);
 }
 
+// Keep unsupported-schema tests ahead of the current durable version. Hard-coded
+// schema versions become valid during release bumps, which can mask compatibility
+// regressions and break release-PR CI when `monochange_schema` advances.
+fn unsupported_release_record_schema_version() -> String {
+	let current = monochange_schema::current_schema_version()
+		.unwrap_or_else(|error| panic!("parse current schema version: {error}"));
+	monochange_schema::SchemaVersion::new(current.major(), current.minor() + 1).to_string()
+}
+
 fn sample_release_record() -> ReleaseRecord {
 	ReleaseRecord {
 		schema_version: RELEASE_RECORD_SCHEMA_VERSION.to_string(),
@@ -2502,14 +2512,15 @@ fn render_release_record_block_rejects_unsupported_kind() {
 #[test]
 fn render_release_record_block_rejects_unsupported_schema_version() {
 	let mut record = sample_release_record();
-	record.schema_version = "0.2".to_string();
+	let schema_version = unsupported_release_record_schema_version();
+	record.schema_version.clone_from(&schema_version);
 
 	let error = crate::render_release_record_block(&record)
 		.err()
 		.unwrap_or_else(|| panic!("expected unsupported schema render error"));
 	assert!(matches!(
 		error,
-		ReleaseRecordError::UnsupportedSchemaVersionValue(version) if version == "0.2"
+		ReleaseRecordError::UnsupportedSchemaVersionValue(version) if version == schema_version
 	));
 }
 
@@ -2596,15 +2607,17 @@ fn release_record_schema_errors_map_to_core_errors() {
 		ReleaseRecordError::MissingSchemaVersion
 	));
 
+	let schema_version = unsupported_release_record_schema_version();
 	let unsupported_version = crate::release_record_schema_error_to_error(
 		monochange_schema::SchemaError::UnsupportedVersion {
-			actual: "0.2".to_string(),
-			current: monochange_schema::SchemaVersion::new(0, 1),
+			actual: schema_version.clone(),
+			current: monochange_schema::current_schema_version()
+				.unwrap_or_else(|error| panic!("parse current schema version: {error}")),
 		},
 	);
 	assert!(matches!(
 		unsupported_version,
-		ReleaseRecordError::UnsupportedSchemaVersionValue(version) if version == "0.2"
+		ReleaseRecordError::UnsupportedSchemaVersionValue(version) if version == schema_version
 	));
 
 	let invalid_version = crate::release_record_schema_error_to_error(

--- a/crates/monochange_integration_tests/tests/schema_assets.rs
+++ b/crates/monochange_integration_tests/tests/schema_assets.rs
@@ -305,6 +305,9 @@ fn release_record_migration_outcomes_match_snapshot() {
 		object.insert("schemaVersion".to_string(), json!(1));
 	}
 
+	let current_version = monochange_schema::CURRENT_SCHEMA_VERSION_TEXT;
+	let invalid_version_text = format!("{current_version}.0");
+	let future_version = unsupported_schema_version();
 	let scenarios = vec![
 		("current", sample_release_record()),
 		("not_object", json!(["not", "an", "object"])),
@@ -324,15 +327,18 @@ fn release_record_migration_outcomes_match_snapshot() {
 		),
 		(
 			"invalid_version_text",
-			sample_release_record_with("0.1.0", monochange_schema::release_record::KIND),
+			sample_release_record_with(
+				&invalid_version_text,
+				monochange_schema::release_record::KIND,
+			),
 		),
 		(
 			"old_version_without_migration_edge",
-			sample_release_record_with("0.1", monochange_schema::release_record::KIND),
+			sample_release_record(),
 		),
 		(
 			"future_version",
-			sample_release_record_with("0.2", monochange_schema::release_record::KIND),
+			sample_release_record_with(&future_version, monochange_schema::release_record::KIND),
 		),
 	];
 	let outcomes = scenarios
@@ -357,7 +363,6 @@ fn release_record_migration_outcomes_match_snapshot() {
 		})
 		.collect::<Vec<_>>();
 
-	let current_version = monochange_schema::CURRENT_SCHEMA_VERSION_TEXT;
 	let redacted_outcomes: Vec<Value> = outcomes
 		.into_iter()
 		.map(|mut outcome| {
@@ -375,7 +380,10 @@ fn release_record_migration_outcomes_match_snapshot() {
 				if let Some(v) = map.get_mut("error")
 					&& let Value::String(s) = v
 				{
-					*v = Value::String(s.replace(current_version, "[schema version]"));
+					*v = Value::String(redact_schema_versions(
+						s,
+						&[current_version, &future_version],
+					));
 				}
 			}
 			outcome
@@ -383,6 +391,21 @@ fn release_record_migration_outcomes_match_snapshot() {
 		.collect();
 
 	assert_json_snapshot!(redacted_outcomes);
+}
+
+// Snapshot redaction is intentional: schema versions are derived from release
+// package versions, so release PRs must prove behavior without baking the next
+// version number into expected output.
+fn redact_schema_versions(text: &str, versions: &[&str]) -> String {
+	versions.iter().fold(text.to_string(), |redacted, version| {
+		redacted.replace(version, "[schema version]")
+	})
+}
+
+fn unsupported_schema_version() -> String {
+	let current = monochange_schema::current_schema_version()
+		.unwrap_or_else(|error| panic!("parse current schema version: {error}"));
+	monochange_schema::SchemaVersion::new(current.major(), current.minor() + 1).to_string()
 }
 
 struct SchemaAssetPaths {

--- a/crates/monochange_integration_tests/tests/snapshots/schema_assets__release_record_migration_outcomes_match_snapshot.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/schema_assets__release_record_migration_outcomes_match_snapshot.snap
@@ -49,7 +49,7 @@ expression: redacted_outcomes
     "status": "ok"
   },
   {
-    "error": "artifact uses unsupported schema version `0.2`; current supported version is `[schema version]`",
+    "error": "artifact uses unsupported schema version `[schema version]`; current supported version is `[schema version]`",
     "scenario": "future_version",
     "status": "error"
   }

--- a/crates/monochange_test_helpers/src/insta.rs
+++ b/crates/monochange_test_helpers/src/insta.rs
@@ -20,12 +20,22 @@ pub fn snapshot_settings() -> insta::Settings {
 	settings.add_filter(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}", "[DATETIME]");
 	settings.add_filter(r"\d{4}-\d{2}-\d{2}", "[DATE]");
 
-	// Release-record schema version filter — redact the wire-format `schemaVersion` field so
-	// snapshots survive release bumps that change `monochange_schema` version.
+	// Release-record schema version filters — redact wire-format fields and diagnostic
+	// text so snapshots assert behavior instead of the schema crate version produced by
+	// the current release PR. This keeps schema-version bumps upgrade-compatible.
 	settings.add_filter(
 		r#""schemaVersion": "\d+\.\d+""#,
 		r#""schemaVersion": "[SCHEMA_VERSION]""#,
 	);
+	settings.add_filter(
+		r"schema version `\d+\.\d+(?:\.\d+)?`",
+		"schema version `[SCHEMA_VERSION]`",
+	);
+	settings.add_filter(
+		r"supported version is `\d+\.\d+`",
+		"supported version is `[SCHEMA_VERSION]`",
+	);
+	settings.add_filter(r"schemaVersion \d+\.\d+", "schemaVersion [SCHEMA_VERSION]");
 
 	settings
 }


### PR DESCRIPTION
## Summary
- derive unsupported release-record schema versions from the current schema version
- redact schema versions in snapshots and schema-related diagnostic output on main
- document why schema-version redaction protects future release PR compatibility

## Tests
- devenv shell cargo test -p monochange_core unsupported_schema_version --lib
- devenv shell cargo test -p monochange_integration_tests --test schema_assets release_record_migration_outcomes_match_snapshot
- devenv shell cargo test -p monochange --test release_record release_record_command_reports_unsupported_schema_version
- devenv shell cargo test -p monochange write_release_record_file_snapshot_matches_expected_content --lib