### PR TITLE
fix: group CLI help options by source

### DIFF
--- a/.changeset/cli-help-option-headings.md
+++ b/.changeset/cli-help-option-headings.md
@@ -1,0 +1,7 @@
+---
+monochange: patch
+---
+
+# Group CLI help options by source
+
+Command help now separates generated release flags, configured command inputs, and global flags into distinct headings so users can see where each option originates.

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -603,6 +603,30 @@ fn cli_help_returns_success_output() {
 }
 
 #[test]
+fn cli_configured_command_help_groups_generated_configured_and_global_options() {
+	let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+	let output = run_with_args_in_dir(
+		"mc",
+		[
+			OsString::from("mc"),
+			OsString::from("release"),
+			OsString::from("--help"),
+		],
+		&root,
+	)
+	.unwrap_or_else(|error| panic!("release help: {error}"));
+
+	assert!(output.contains("Release Options:"));
+	assert!(output.contains("Global Options:"));
+	assert!(output.contains("Release Options:\n      --dry-run"));
+	assert!(output.contains("      --prepared-release <PATH>"));
+	assert!(output.contains("Options:\n      --format <FORMAT>"));
+	assert!(output.contains("Global Options:\n  -q, --quiet"));
+	assert!(output.contains("      --progress-format <FORMAT>"));
+	assert!(output.contains("      --jq <EXPRESSION>"));
+}
+
+#[test]
 fn publish_release_help_documents_draft_release_options() {
 	let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
 	let output = run_with_args_in_dir(

--- a/crates/monochange/src/__tests__/snapshots/monochange__tests__subagents_help_describes_supported_targets.snap
+++ b/crates/monochange/src/__tests__/snapshots/monochange__tests__subagents_help_describes_supported_targets.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/monochange/src/__tests__/lib_tests.rs
+assertion_line: 892
 expression: output
 ---
 Generate repo-local monochange subagents and agent guidance files
@@ -10,16 +11,18 @@ Arguments:
   [TARGET]...  Subagent target(s) to generate [possible values: claude, vscode, copilot, pi, codex, cursor]
 
 Options:
-      --all                       Generate files for all supported targets
-      --force                     Overwrite generated files that already exist with different contents
+      --all              Generate files for all supported targets
+      --force            Overwrite generated files that already exist with different contents
+      --dry-run          Preview the generated files without writing them
+      --format <format>  Output format for the generated subagent plan [default: markdown] [possible values: text, json, markdown, md]
+      --sha              Output only the commit SHA of the discovered release record
+      --no-mcp           Skip repo-local MCP config files for supported targets
+  -h, --help             Print help
+
+Global Options:
   -q, --quiet                     Suppress stdout/stderr output and run in dry-run mode when supported
-      --dry-run                   Preview the generated files without writing them
       --progress-format <FORMAT>  Control progress output on stderr [possible values: auto, unicode, ascii, json]
-      --format <format>           Output format for the generated subagent plan [default: markdown] [possible values: text, json, markdown, md]
       --jq <EXPRESSION>           Filter JSON output with a jq-style expression, such as `.assets[].name`
-      --sha                       Output only the commit SHA of the discovered release record
-      --no-mcp                    Skip repo-local MCP config files for supported targets
-  -h, --help                      Print help
 
 Examples:
   mc help subagents

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -135,6 +135,9 @@ fn monochange_styles() -> clap::builder::Styles {
 		.invalid(crate::cli_theme::error())
 }
 
+const GLOBAL_OPTIONS_HELP_HEADING: &str = "Global Options";
+const RELEASE_OPTIONS_HELP_HEADING: &str = "Release Options";
+
 #[allow(clippy::redundant_closure_for_method_calls)]
 pub(crate) fn build_command_with_cli(
 	bin_name: &'static str,
@@ -149,10 +152,12 @@ pub(crate) fn build_command_with_cli(
 			.subcommand_required(true)
 			.arg_required_else_help(true)
 			.subcommand_help_heading("Built-in Commands")
+			.next_help_heading(GLOBAL_OPTIONS_HELP_HEADING)
 			.arg(
 				Arg::new("log-level")
 					.long("log-level")
 					.global(true)
+					.help_heading(GLOBAL_OPTIONS_HELP_HEADING)
 					.help("Set tracing filter (e.g. debug, monochange=trace)")
 					.value_name("FILTER")
 					.hide(true),
@@ -162,6 +167,7 @@ pub(crate) fn build_command_with_cli(
 					.long("quiet")
 					.short('q')
 					.global(true)
+					.help_heading(GLOBAL_OPTIONS_HELP_HEADING)
 					.help("Suppress stdout/stderr output and run in dry-run mode when supported")
 					.action(ArgAction::SetTrue),
 			)
@@ -169,6 +175,7 @@ pub(crate) fn build_command_with_cli(
 				Arg::new("progress-format")
 					.long("progress-format")
 					.global(true)
+					.help_heading(GLOBAL_OPTIONS_HELP_HEADING)
 					.help("Control progress output on stderr")
 					.value_name("FORMAT")
 					.value_parser(["auto", "unicode", "ascii", "json"]),
@@ -177,6 +184,7 @@ pub(crate) fn build_command_with_cli(
 				Arg::new("jq")
 					.long("jq")
 					.global(true)
+					.help_heading(GLOBAL_OPTIONS_HELP_HEADING)
 					.help("Filter JSON output with a jq-style expression, such as `.assets[].name`")
 					.value_name("EXPRESSION"),
 			)
@@ -827,9 +835,11 @@ pub(crate) fn build_cli_command_subcommand(cli_command: &CliCommandDefinition) -
 	let mut command = Command::new(leak_string(cli_command.name.clone()))
 		.about(help_text)
 		.override_usage(usage)
+		.next_help_heading(RELEASE_OPTIONS_HELP_HEADING)
 		.arg(
 			Arg::new("dry-run")
 				.long("dry-run")
+				.help_heading(RELEASE_OPTIONS_HELP_HEADING)
 				.help("Run the command in dry-run mode when supported")
 				.action(ArgAction::SetTrue),
 		);
@@ -839,12 +849,14 @@ pub(crate) fn build_cli_command_subcommand(cli_command: &CliCommandDefinition) -
 			.arg(
 				Arg::new("diff")
 					.long("diff")
+					.help_heading(RELEASE_OPTIONS_HELP_HEADING)
 					.help("Show unified file diffs for prepared release changes")
 					.action(ArgAction::SetTrue),
 			)
 			.arg(
 				Arg::new("prepared-release")
 					.long("prepared-release")
+					.help_heading(RELEASE_OPTIONS_HELP_HEADING)
 					.help("Read or write the prepared release artifact at a specific path")
 					.value_name("PATH"),
 			);
@@ -854,6 +866,7 @@ pub(crate) fn build_cli_command_subcommand(cli_command: &CliCommandDefinition) -
 		command = command.after_help(after_help);
 	}
 
+	command = command.next_help_heading("Options");
 	for input in &cli_command.inputs {
 		command = command.arg(build_cli_command_input_arg(input));
 	}

--- a/crates/monochange/tests/snapshots/cli_output__change_cli_help_documents_package_and_group_targeting_rules@change_cli_help_documents_package_and_group_targeting_rules.snap
+++ b/crates/monochange/tests/snapshots/cli_output__change_cli_help_documents_package_and_group_targeting_rules@change_cli_help_documents_package_and_group_targeting_rules.snap
@@ -18,20 +18,26 @@ Create a change file for one or more packages
 Usage: mc change [--dry-run] [--interactive] [--package <PACKAGE>] [--bump <BUMP>] [--version <VERSION>] [--reason <REASON>] [--type <TYPE>] [--caused-by <CAUSED_BY>] [--details <DETAILS>] [--output <PATH>]
 
 Options:
-      --dry-run                   Run the command in dry-run mode when supported
-  -i, --interactive               Select packages, bumps, and options interactively
+  -h, --help  Print help
+
+Release Options:
+      --dry-run  Run the command in dry-run mode when supported
+
+Options:
+  -i, --interactive            Select packages, bumps, and options interactively
+      --package <PACKAGE>      Package or group to include in the change
+      --bump <BUMP>            Requested semantic version bump [default: patch] [possible values: none, patch, minor, major]
+      --version <VERSION>      Pin an explicit version for this release
+      --reason <REASON>        Short release-note summary for this change
+      --type <TYPE>            Optional release-note type such as `security` or `note` [possible values: security, test]
+      --caused-by <CAUSED_BY>  Package or group ids that caused this dependent change
+      --details <DETAILS>      Optional multi-line release-note details
+      --output <PATH>          Write the generated change file to a specific path
+
+Global Options:
   -q, --quiet                     Suppress stdout/stderr output and run in dry-run mode when supported
-      --package <PACKAGE>         Package or group to include in the change
       --progress-format <FORMAT>  Control progress output on stderr [possible values: auto, unicode, ascii, json]
-      --bump <BUMP>               Requested semantic version bump [default: patch] [possible values: none, patch, minor, major]
       --jq <EXPRESSION>           Filter JSON output with a jq-style expression, such as `.assets[].name`
-      --version <VERSION>         Pin an explicit version for this release
-      --reason <REASON>           Short release-note summary for this change
-      --type <TYPE>               Optional release-note type such as `security` or `note` [possible values: security, test]
-      --caused-by <CAUSED_BY>     Package or group ids that caused this dependent change
-      --details <DETAILS>         Optional multi-line release-note details
-      --output <PATH>             Write the generated change file to a specific path
-  -h, --help                      Print help
 
 Examples:
   mc change --package sdk-core --bump patch --reason "fix panic"


### PR DESCRIPTION
## Summary
- group global CLI flags under `Global Options`
- group generated release flags under `Release Options`
- keep configured command inputs under the default `Options` heading

Closes #475

## Validation
- `devenv shell cargo test -p monochange --lib cli_configured_command_help_groups_generated_configured_and_global_options`
- `devenv shell mc validate`