### PR TITLE
ci: run checks for merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- add the GitHub Actions `merge_group` trigger to CI so merge queue entries run the required checks
- add a changeset noting merge queue support

## Tests
- `devenv shell mc validate`
- `devenv shell lint:format`
- `git diff --check`