### PR TITLE
fix: update versioned schema asset

### DIFF
--- a/docs/src/schemas/monochange.v0.2.schema.json
+++ b/docs/src/schemas/monochange.v0.2.schema.json
@@ -1139,6 +1139,22 @@
 			],
 			"type": "string"
 		},
+		"PublishOrderSettings": {
+			"additionalProperties": false,
+			"properties": {
+				"dependency_fields": {
+					"default": null,
+					"items": {
+						"type": "string"
+					},
+					"type": [
+						"array",
+						"null"
+					]
+				}
+			},
+			"type": "object"
+		},
 		"PublishRegistry": {
 			"anyOf": [
 				{
@@ -1494,6 +1510,12 @@
 				},
 				"publish": {
 					"$ref": "#/$defs/publishSettings"
+				},
+				"publish_order": {
+					"$ref": "#/$defs/PublishOrderSettings",
+					"default": {
+						"dependency_fields": null
+					}
 				},
 				"roots": {
 					"default": [],


### PR DESCRIPTION
## Summary
- update the versioned monochange v0.2 config schema to match the current generated schema
- restore the schema asset contract test on main

## Verification
- devenv shell cargo test -p monochange_integration_tests schema_assets -- --nocapture
- devenv shell lint:all
- devenv shell test:all
- MONOCHANGE_PATCH_COVERAGE_BASE=origin/main MONOCHANGE_PATCH_COVERAGE_HEAD=HEAD devenv shell coverage:patch
- git diff --check