### PR TITLE
fix: expose command inputs to step conditions

### DIFF
--- a/.changeset/release-when-command-inputs.md
+++ b/.changeset/release-when-command-inputs.md
@@ -1,0 +1,7 @@
+---
+"monochange": patch
+---
+
+# Fix command input references in CLI step conditions
+
+Allow `when` conditions to read command-level inputs while preserving step-level input overrides, so release automation can gate commit and pull request steps on `--commit` and `--create-pr`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,6 +376,8 @@ jobs:
       - name: create release commit
         id: release_commit
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           before="$(git rev-parse HEAD)"
           mc release --commit
           after="$(git rev-parse HEAD)"
@@ -418,6 +420,8 @@ jobs:
       - name: create release commit
         id: release_commit
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           before="$(git rev-parse HEAD)"
           mc release --commit
           after="$(git rev-parse HEAD)"

--- a/crates/monochange/src/__tests__/cli_runtime_tests.rs
+++ b/crates/monochange/src/__tests__/cli_runtime_tests.rs
@@ -1914,13 +1914,21 @@ fn execute_cli_command_with_options_reuses_prepared_release_artifact_for_version
 	let _guard = TEST_ENV_LOCK
 		.lock()
 		.unwrap_or_else(|error| panic!("test env lock: {error}"));
-	let root = fs::canonicalize(Path::new(env!("CARGO_MANIFEST_DIR")).join("../.."))
-		.unwrap_or_else(|error| panic!("workspace root: {error}"));
-	let configuration = sample_configuration(&root);
+	let workspace_dir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = workspace_dir.path();
+	fs::write(root.join("Cargo.toml"), "[workspace]\n")
+		.unwrap_or_else(|error| panic!("write workspace manifest: {error}"));
+	git_in_dir(root, &["init", "-b", "main"]);
+	git_in_dir(root, &["config", "user.name", "monochange Tests"]);
+	git_in_dir(root, &["config", "user.email", "monochange@example.com"]);
+	git_in_dir(root, &["add", "Cargo.toml"]);
+	git_in_dir(root, &["commit", "-m", "initial"]);
+
+	let configuration = sample_configuration(root);
 	let artifact_dir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	let artifact_path = artifact_dir.path().join("prepared-release.json");
 	save_prepared_release_execution(
-		&root,
+		root,
 		&configuration,
 		&sample_prepared_release_with_versions(),
 		&[],
@@ -1929,7 +1937,7 @@ fn execute_cli_command_with_options_reuses_prepared_release_artifact_for_version
 	.unwrap_or_else(|error| panic!("save prepared release artifact: {error}"));
 
 	let output = execute_cli_command_with_options(
-		&root,
+		root,
 		&configuration,
 		&default_cli_command("display-versions"),
 		ExecuteCliCommandOptions {

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -4397,6 +4397,55 @@ fn should_execute_cli_step_runs_when_condition_is_true() {
 }
 
 #[test]
+fn should_execute_cli_step_can_gate_on_command_inputs_not_declared_by_step() {
+	let mut context = cli_context_for_when_evaluation_tests();
+	context.inputs = BTreeMap::from([
+		("commit".to_string(), vec!["true".to_string()]),
+		("create_pr".to_string(), vec!["true".to_string()]),
+	]);
+	let step_inputs = BTreeMap::from([("no_verify".to_string(), vec!["true".to_string()])]);
+	let step = monochange_core::CliStepDefinition::Command {
+		show_progress: None,
+		name: None,
+		when: Some("{{ inputs.commit && inputs.create_pr }}".to_string()),
+		always_run: false,
+		command: "printf hi".to_string(),
+		dry_run_command: None,
+		shell: monochange_core::ShellConfig::default(),
+		id: None,
+		variables: None,
+		inputs: BTreeMap::new(),
+	};
+	assert!(
+		should_execute_cli_step(&step, &context, &step_inputs)
+			.unwrap_or_else(|error| { panic!("when condition: {error}") })
+	);
+}
+
+#[test]
+fn should_execute_cli_step_prefers_step_inputs_over_command_inputs() {
+	let mut context = cli_context_for_when_evaluation_tests();
+	context.inputs = BTreeMap::from([("run".to_string(), vec!["true".to_string()])]);
+	let step_inputs = BTreeMap::from([("run".to_string(), vec!["false".to_string()])]);
+	let step = monochange_core::CliStepDefinition::Command {
+		show_progress: None,
+		name: None,
+		when: Some("{{ inputs.run }}".to_string()),
+		always_run: false,
+		command: "printf hi".to_string(),
+		dry_run_command: None,
+		shell: monochange_core::ShellConfig::default(),
+		id: None,
+		variables: None,
+		inputs: BTreeMap::new(),
+	};
+	assert!(
+		!should_execute_cli_step(&step, &context, &step_inputs)
+			.unwrap_or_else(|error| { panic!("when condition: {error}") })
+	);
+}
+
+#[test]
 fn should_execute_cli_step_skips_when_condition_is_false() {
 	let context = cli_context_for_when_evaluation_tests();
 	let step_inputs = BTreeMap::from([("run".to_string(), vec!["false".to_string()])]);

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -1395,7 +1395,8 @@ fn evaluate_cli_step_condition(
 	if trimmed.is_empty() {
 		return Ok(false);
 	}
-	let template_context = build_cli_template_context(context, step_inputs, None);
+	let condition_inputs = cli_step_condition_inputs(context, step_inputs);
+	let template_context = build_cli_template_context(context, &condition_inputs, None);
 	let template_context_json = serde_json::Value::Object(template_context.clone());
 	if let Some(path) = parse_direct_template_reference(trimmed) {
 		let Some(value) = lookup_template_value(&template_context_json, path) else {
@@ -1410,6 +1411,15 @@ fn evaluate_cli_step_condition(
 		minijinja::Value::from_serialize(serde_json::Value::Object(template_context));
 	let rendered = render_jinja_template(&normalized, &jinja_context)?;
 	parse_string_as_boolean(&rendered, condition)
+}
+
+fn cli_step_condition_inputs(
+	context: &CliContext,
+	step_inputs: &BTreeMap<String, Vec<String>>,
+) -> BTreeMap<String, Vec<String>> {
+	let mut inputs = context.inputs.clone();
+	inputs.extend(step_inputs.clone());
+	inputs
 }
 
 fn parse_template_as_boolean(value: &serde_json::Value, condition: &str) -> MonochangeResult<bool> {

--- a/crates/monochange/tests/cli_step_input_overrides.rs
+++ b/crates/monochange/tests/cli_step_input_overrides.rs
@@ -126,7 +126,7 @@ inputs = ["message"]
 }
 
 #[test]
-fn when_conditions_use_explicit_step_input_context() {
+fn when_conditions_can_use_command_inputs_without_passing_them_to_steps() {
 	let tempdir = setup_scenario_workspace("cli-step-input-overrides/workspace");
 	append_config(
 		tempdir.path(),
@@ -137,7 +137,7 @@ inputs = [{ name = "enabled", type = "boolean" }]
 [[cli.when-explicit-inputs.steps]]
 type = "Command"
 when = "{{ inputs.enabled is defined }}"
-command = "touch implicit-output.txt"
+command = "printf '%s' '{{ inputs.enabled is defined }}' > implicit-output.txt"
 shell = true
 
 [[cli.when-explicit-inputs.steps]]
@@ -156,7 +156,9 @@ inputs = ["enabled"]
 		"{}",
 		String::from_utf8_lossy(&output.stderr)
 	);
-	assert!(!tempdir.path().join("implicit-output.txt").exists());
+	let implicit_contents = fs::read_to_string(tempdir.path().join("implicit-output.txt"))
+		.unwrap_or_else(|error| panic!("implicit command output file: {error}"));
+	assert_eq!(implicit_contents, "false");
 	assert!(tempdir.path().join("selected-output.txt").exists());
 }
 


### PR DESCRIPTION
## Summary
- diagnose release PR skips caused by  conditions seeing step inputs but not command-level flags
- merge command inputs into the condition context while letting step inputs override conflicts
- add regression tests for command-level  conditions
