### PR TITLE
feat(ci): add path-filter gate to skip unrelated CI jobs

### DIFF
--- a/.changeset/ci-conditional-jobs.md
+++ b/.changeset/ci-conditional-jobs.md
@@ -3,25 +3,18 @@ monochange: test
 "@monochange/skill": test
 ---
 
-# add path-filter gate to CI jobs
+# add realistic path-filter gates to CI jobs
 
-Introduce a `changes` job using `dorny/paths-filter` so that expensive CI jobs are skipped when a pull request only touches files outside their scope.
+Introduce a `changes` job using `dorny/paths-filter` so CI can skip expensive work for pull requests that do not touch relevant project surfaces.
 
-**Filters**
+The filters now map to monochange's actual repo shape:
 
-- `rust` — `**.rs`, `**/Cargo.toml`, `Cargo.lock`, and other Rust tooling configs.
-- `fixtures` — anything under `fixtures/**`, `crates/**/tests/**`, `crates/**/__tests__/**`, or snapshot directories.
-- `global` — `.github/workflows/ci.yml`, `monochange.toml`, and `.changeset/**`.
-- `js` — JS/TS source files and lockfiles.
-- `docs` — `docs/**`, `**.md`, `book.toml`, and `scripts/**`.
-- `workflows` — `.github/workflows/**` and `.github/actions/**`.
+- `rust` covers Rust source, workspace manifests, lockfile, and Rust tooling config.
+- `fixtures` covers repository fixture and test data folders that feed integration tests.
+- `global` covers repo-wide CI/runtime config such as `.github/workflows/ci.yml`, `monochange.toml`, and devenv files.
+- `release` covers changesets and generated release-record state.
+- `js` covers scripts, npm package sources, TypeScript config, and pnpm files.
+- `docs` covers book/docs, repository docs, agent docs, and shared-doc templates.
+- `workflows` covers GitHub workflow and action definitions.
 
-**Gating rules**
-
-- `merge_group` events always run every job (bypassing the filters).
-- `security` runs when `workflows` or `global` files change.
-- `lint` runs when `rust`, `js`, `docs`, or `global` files change.
-- `test` and `coverage` run when `rust`, `fixtures`, or `global` files change.
-- `build` and `benchmark` run when `rust` or `global` files change.
-- PR-only jobs (`benchmark-binary`, `release-test`, `release-records`, `release-lint`) also check the relevant filters.
-- Main-branch jobs (`release-pr`, `release-post-merge`) are left as-is so release automation is never accidentally skipped.
+The workflow also adds step-level gates inside mixed jobs, plus a lightweight `build-docs` path for documentation-only changes, so docs edits can verify documentation and book builds without launching the cross-platform Rust build matrix. Merge-queue events still bypass the filters and run the full suite.

--- a/.changeset/ci-conditional-jobs.md
+++ b/.changeset/ci-conditional-jobs.md
@@ -1,0 +1,27 @@
+---
+monochange: test
+"@monochange/skill": test
+---
+
+# add path-filter gate to CI jobs
+
+Introduce a `changes` job using `dorny/paths-filter` so that expensive CI jobs are skipped when a pull request only touches files outside their scope.
+
+**Filters**
+
+- `rust` — `**.rs`, `**/Cargo.toml`, `Cargo.lock`, and other Rust tooling configs.
+- `fixtures` — anything under `fixtures/**`, `crates/**/tests/**`, `crates/**/__tests__/**`, or snapshot directories.
+- `global` — `.github/workflows/ci.yml`, `monochange.toml`, and `.changeset/**`.
+- `js` — JS/TS source files and lockfiles.
+- `docs` — `docs/**`, `**.md`, `book.toml`, and `scripts/**`.
+- `workflows` — `.github/workflows/**` and `.github/actions/**`.
+
+**Gating rules**
+
+- `merge_group` events always run every job (bypassing the filters).
+- `security` runs when `workflows` or `global` files change.
+- `lint` runs when `rust`, `js`, `docs`, or `global` files change.
+- `test` and `coverage` run when `rust`, `fixtures`, or `global` files change.
+- `build` and `benchmark` run when `rust` or `global` files change.
+- PR-only jobs (`benchmark-binary`, `release-test`, `release-records`, `release-lint`) also check the relevant filters.
+- Main-branch jobs (`release-pr`, `release-post-merge`) are left as-is so release automation is never accidentally skipped.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,61 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      fixtures: ${{ steps.filter.outputs.fixtures }}
+      global: ${{ steps.filter.outputs.global }}
+      js: ${{ steps.filter.outputs.js }}
+      docs: ${{ steps.filter.outputs.docs }}
+      workflows: ${{ steps.filter.outputs.workflows }}
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            rust:
+              - '**.rs'
+              - '**/Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - '.cargo/config.toml'
+              - 'deny.toml'
+              - 'clippy.toml'
+            fixtures:
+              - 'fixtures/**'
+              - 'crates/**/fixtures/**'
+              - 'crates/**/tests/**'
+              - 'crates/**/__tests__/**'
+              - 'crates/**/snapshots/**'
+            global:
+              - '.github/workflows/ci.yml'
+              - 'monochange.toml'
+              - '.changeset/**'
+            js:
+              - '**.js'
+              - '**.mjs'
+              - '**.ts'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - '.oxlintrc.json'
+            docs:
+              - 'docs/**'
+              - '**.md'
+              - 'book.toml'
+              - 'scripts/**'
+            workflows:
+              - '.github/workflows/**'
+              - '.github/actions/**'
+
   security:
+    needs: changes
+    if: github.event_name == 'merge_group' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.global == 'true'
     timeout-minutes: 5
     runs-on: ubuntu-latest
     permissions:
@@ -34,6 +88,8 @@ jobs:
           advanced-security: true
 
   lint:
+    needs: changes
+    if: github.event_name == 'merge_group' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.global == 'true' || needs.changes.outputs.js == 'true' || needs.changes.outputs.docs == 'true'
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
@@ -78,6 +134,8 @@ jobs:
         shell: devenv shell -- bash -e {0}
 
   test:
+    needs: changes
+    if: github.event_name == 'merge_group' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.fixtures == 'true' || needs.changes.outputs.global == 'true'
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
@@ -98,6 +156,8 @@ jobs:
         shell: devenv shell -- bash -e {0}
 
   build:
+    needs: changes
+    if: github.event_name == 'merge_group' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.global == 'true'
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -169,6 +229,8 @@ jobs:
         shell: devenv shell -- bash -e {0}
 
   coverage:
+    needs: changes
+    if: github.event_name == 'merge_group' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.fixtures == 'true' || needs.changes.outputs.global == 'true'
     timeout-minutes: 60
     runs-on: ubuntu-latest
     outputs:
@@ -267,6 +329,8 @@ jobs:
           verbose: true
 
   benchmark:
+    needs: changes
+    if: github.event_name == 'merge_group' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.global == 'true'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -304,7 +368,8 @@ jobs:
           retention-days: 90
 
   benchmark-binary:
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.global == 'true')
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
@@ -369,7 +434,8 @@ jobs:
         shell: devenv shell -- bash -e {0}
 
   release-test:
-    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'monochange/release')
+    needs: changes
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'monochange/release') && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.fixtures == 'true' || needs.changes.outputs.global == 'true')
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
@@ -413,7 +479,8 @@ jobs:
         run: echo "No pull-request release commit was created; skipping release test preflight."
 
   release-records:
-    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'monochange/release')
+    needs: changes
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'monochange/release') && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.fixtures == 'true' || needs.changes.outputs.global == 'true')
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
@@ -460,7 +527,8 @@ jobs:
         run: echo "No pull-request release commit was created; skipping release record preflight."
 
   release-lint:
-    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'monochange/release')
+    needs: changes
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'monochange/release') && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.global == 'true' || needs.changes.outputs.js == 'true' || needs.changes.outputs.docs == 'true')
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,54 +16,70 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-
   changes:
     runs-on: ubuntu-latest
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       fixtures: ${{ steps.filter.outputs.fixtures }}
       global: ${{ steps.filter.outputs.global }}
+      release: ${{ steps.filter.outputs.release }}
       js: ${{ steps.filter.outputs.js }}
       docs: ${{ steps.filter.outputs.docs }}
       workflows: ${{ steps.filter.outputs.workflows }}
     steps:
       - name: checkout repository
         uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v3
         id: filter
         with:
           filters: |
             rust:
-              - '**.rs'
+              - '**/*.rs'
               - '**/Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
-              - '.cargo/config.toml'
-              - 'deny.toml'
+              - 'rustfmt.toml'
               - 'clippy.toml'
+              - 'deny.toml'
+              - '.cargo/**'
             fixtures:
               - 'fixtures/**'
               - 'crates/**/fixtures/**'
-              - 'crates/**/tests/**'
-              - 'crates/**/__tests__/**'
+              - 'crates/**/test-data/**'
               - 'crates/**/snapshots/**'
             global:
               - '.github/workflows/ci.yml'
               - 'monochange.toml'
+              - 'devenv.nix'
+              - 'devenv.lock'
+              - 'devenv.yaml'
+            release:
               - '.changeset/**'
+              - '.monochange/**'
+              - 'changelog.md'
             js:
-              - '**.js'
-              - '**.mjs'
-              - '**.ts'
+              - '**/*.js'
+              - '**/*.mjs'
+              - '**/*.ts'
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
+              - 'tsconfig.json'
+              - 'tsdown.config.json'
               - '.oxlintrc.json'
+              - '.oxfmtrc.json'
+              - 'scripts/**'
+              - 'packages/**'
             docs:
               - 'docs/**'
-              - '**.md'
-              - 'book.toml'
-              - 'scripts/**'
+              - 'readme.md'
+              - 'CONTRIBUTING.md'
+              - 'ARCHITECTURE.md'
+              - 'AGENTS.md'
+              - 'CLAUDE.md'
+              - 'research.md'
+              - 'mdt.toml'
+              - '.templates/**'
             workflows:
               - '.github/workflows/**'
               - '.github/actions/**'
@@ -89,7 +105,7 @@ jobs:
 
   lint:
     needs: changes
-    if: github.event_name == 'merge_group' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.global == 'true' || needs.changes.outputs.js == 'true' || needs.changes.outputs.docs == 'true'
+    if: github.event_name == 'merge_group' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.global == 'true' || needs.changes.outputs.release == 'true' || needs.changes.outputs.js == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.workflows == 'true'
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
@@ -102,34 +118,42 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: lint clippy
+        if: github.event_name == 'merge_group' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.global == 'true'
         run: lint:clippy
         shell: devenv shell -- bash -e {0}
 
       - name: lint formatting
+        if: github.event_name == 'merge_group' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.global == 'true' || needs.changes.outputs.release == 'true' || needs.changes.outputs.js == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.workflows == 'true'
         run: lint:format
         shell: devenv shell -- bash -e {0}
 
       - name: check architecture boundaries
+        if: github.event_name == 'merge_group' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.js == 'true' || needs.changes.outputs.global == 'true'
         run: lint:architecture
         shell: devenv shell -- bash -e {0}
 
       - name: check documentation sync
+        if: github.event_name == 'merge_group' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.js == 'true' || needs.changes.outputs.global == 'true'
         run: docs:check
         shell: devenv shell -- bash -e {0}
 
       - name: lint js
+        if: github.event_name == 'merge_group' || needs.changes.outputs.js == 'true' || needs.changes.outputs.global == 'true'
         run: pnpm oxlint .
         shell: devenv shell -- bash -e {0}
 
       - name: cargo deny
+        if: github.event_name == 'merge_group' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.global == 'true'
         run: deny:check
         shell: devenv shell -- bash -e {0}
 
       - name: manifest lint
+        if: github.event_name == 'merge_group' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.global == 'true' || needs.changes.outputs.release == 'true'
         run: lint:monochange
         shell: devenv shell -- bash -e {0}
 
       - name: schema check
+        if: github.event_name == 'merge_group' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.fixtures == 'true' || needs.changes.outputs.global == 'true'
         run: schema:check
         shell: devenv shell -- bash -e {0}
 
@@ -182,16 +206,16 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: build
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && (github.event_name == 'merge_group' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.global == 'true')
         run: build:all
         shell: devenv shell -- bash -e {0}
 
       - name: build on windows
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && (github.event_name == 'merge_group' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.global == 'true')
         run: cargo build --workspace --all-features --locked
 
       - name: detect current release commit
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && (github.event_name == 'merge_group' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.global == 'true' || needs.changes.outputs.release == 'true')
         id: release_record
         run: |
           set -euo pipefail
@@ -214,17 +238,35 @@ jobs:
         shell: devenv shell -- bash -e {0}
 
       - name: check publish builds
-        if: runner.os != 'Windows' && steps.release_record.outputs.is_release_commit != 'true'
+        if: runner.os != 'Windows' && (github.event_name == 'merge_group' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.global == 'true' || needs.changes.outputs.release == 'true') && steps.release_record.outputs.is_release_commit != 'true'
         run: publish:check
         shell: devenv shell -- bash -e {0}
 
       - name: skip publish build check on release commit
-        if: runner.os != 'Windows' && steps.release_record.outputs.is_release_commit == 'true'
+        if: runner.os != 'Windows' && (github.event_name == 'merge_group' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.global == 'true' || needs.changes.outputs.release == 'true') && steps.release_record.outputs.is_release_commit == 'true'
         run: echo "HEAD is a release commit; skipping publish:check."
         shell: devenv shell -- bash -e {0}
 
       - name: build book
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && (github.event_name == 'merge_group' || needs.changes.outputs.global == 'true')
+        run: build:book
+        shell: devenv shell -- bash -e {0}
+
+  build-docs:
+    needs: changes
+    if: github.event_name != 'merge_group' && needs.changes.outputs.docs == 'true' && needs.changes.outputs.rust != 'true' && needs.changes.outputs.global != 'true'
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v6
+
+      - name: setup
+        uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: build book
         run: build:book
         shell: devenv shell -- bash -e {0}
 
@@ -435,7 +477,7 @@ jobs:
 
   release-test:
     needs: changes
-    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'monochange/release') && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.fixtures == 'true' || needs.changes.outputs.global == 'true')
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'monochange/release') && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.fixtures == 'true' || needs.changes.outputs.global == 'true' || needs.changes.outputs.release == 'true')
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
@@ -480,7 +522,7 @@ jobs:
 
   release-records:
     needs: changes
-    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'monochange/release') && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.fixtures == 'true' || needs.changes.outputs.global == 'true')
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'monochange/release') && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.fixtures == 'true' || needs.changes.outputs.global == 'true' || needs.changes.outputs.release == 'true')
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
@@ -528,7 +570,7 @@ jobs:
 
   release-lint:
     needs: changes
-    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'monochange/release') && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.global == 'true' || needs.changes.outputs.js == 'true' || needs.changes.outputs.docs == 'true')
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'monochange/release') && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.global == 'true' || needs.changes.outputs.release == 'true' || needs.changes.outputs.js == 'true' || needs.changes.outputs.docs == 'true')
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Add a `changes` job using pinned `dorny/paths-filter` to classify changed files by repo surface.
- Gate expensive CI jobs using realistic monochange-specific filters for Rust, fixtures, release metadata, docs, JS/scripts, workflows, and global config.
- Add step-level gates inside mixed jobs so docs-only or release-only PRs avoid unnecessary Rust/clippy/coverage/build work.
- Add a lightweight `build-docs` job for docs-only changes instead of starting the full cross-platform Rust build matrix.
- Keep merge-queue (`merge_group`) behavior conservative by running the full suite.
- Leave main-branch release automation (`release-pr`, `release-post-merge`) untouched.

## Why this is more realistic

The first pass was too coarse: `.changeset/**` was treated as global, docs matched every markdown file, and docs-only changes could start the cross-platform build matrix. This version separates release metadata from true global config, narrows docs paths, adds actual JS/package/script paths, includes devenv setup files, pins the new action, and gates individual steps inside jobs that mix several types of checks.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `dprint check .github/workflows/ci.yml .changeset/ci-conditional-jobs.md`
