### PR TITLE
fix: set release rust toolchain

### DIFF
--- a/.changeset/config-schema-artifact-variants.md
+++ b/.changeset/config-schema-artifact-variants.md
@@ -1,0 +1,7 @@
+---
+monochange_schema: patch
+---
+
+# Add configuration schema artifact variants
+
+Generate populated `monochange` configuration artifact fixtures alongside the release-record fixtures so schema consumers have stable `current` and versioned examples for the configuration schema.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,8 @@ jobs:
 
       - name: install rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
 
       - name: setup cross toolchain
         uses: taiki-e/setup-cross-toolchain-action@129361238c06ff2cc1c4ca5c5d2217af441ffdf6 # v1.40.1


### PR DESCRIPTION
## Summary
- revert release commit 7163d2649d40b1eb430dbeba82571803f08d9307
- set the release workflow rust toolchain to stable

## Testing
- push hooks passed via `devenv shell env GIT_SSH=/etc/profiles/per-user/ifiokjr/bin/ssh git push -u origin fix/release-rust-toolchain`