### PR TITLE
ci: use workspace binary for release record detection

### DIFF
--- a/.changeset/config-schema-artifact-variants.md
+++ b/.changeset/config-schema-artifact-variants.md
@@ -1,0 +1,7 @@
+---
+monochange_schema: patch
+---
+
+# Add configuration schema artifact variants
+
+Generate populated `monochange` configuration artifact fixtures alongside the release-record fixtures so schema consumers have stable `current` and versioned examples for the configuration schema.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
           set -euo pipefail
 
           release_record_error="$(mktemp)"
-          if is_release_commit="$(mc step:release-record --from HEAD --format json --jq '.resolvedCommit == .recordCommit' 2>"$release_record_error")"; then
+          if is_release_commit="$(cargo run --quiet --package monochange --bin monochange -- step:release-record --from HEAD --format json --jq '.resolvedCommit == .recordCommit' 2>"$release_record_error")"; then
             echo "is_release_commit=${is_release_commit}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -581,7 +581,7 @@ jobs:
           set -euo pipefail
 
           release_record_error="$(mktemp)"
-          if is_release_commit="$(mc step:release-record --from HEAD --format json --jq '.resolvedCommit == .recordCommit' 2>"$release_record_error")"; then
+          if is_release_commit="$(cargo run --quiet --package monochange --bin monochange -- step:release-record --from HEAD --format json --jq '.resolvedCommit == .recordCommit' 2>"$release_record_error")"; then
             echo "is_release_commit=${is_release_commit}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -638,7 +638,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if is_release_commit="$(mc step:release-record --from HEAD --format json --jq '.resolvedCommit == .recordCommit')"; then
+          if is_release_commit="$(cargo run --quiet --package monochange --bin monochange -- step:release-record --from HEAD --format json --jq '.resolvedCommit == .recordCommit')"; then
             echo "is_release_commit=${is_release_commit}" >> "$GITHUB_OUTPUT"
             if [ "${is_release_commit}" = "true" ]; then
               mc step:tag-release --from HEAD --push=true --format json | tee /tmp/tag-report.json
@@ -647,7 +647,7 @@ jobs:
             subject="$(git log -1 --pretty=%s)"
             if [[ "$subject" == chore\(release\):\ prepare\ release* ]]; then
               echo "Release-looking commit could not be read as a release record; failing instead of silently skipping release automation."
-              mc step:release-record --from HEAD --format json
+              cargo run --quiet --package monochange --bin monochange -- step:release-record --from HEAD --format json
               exit 1
             fi
             echo "is_release_commit=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,8 @@ jobs:
 
       - name: install rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
 
       - name: setup cross toolchain
         uses: taiki-e/setup-cross-toolchain-action@129361238c06ff2cc1c4ca5c5d2217af441ffdf6 # v1.40.1


### PR DESCRIPTION
## Summary

- Use the workspace-built `monochange` binary for CI release-record detection.
- Replace ambiguous `mc step:release-record` calls in CI release detection with `cargo run --quiet --package monochange --bin monochange -- step:release-record`.

## Why

The `main` CI run for `chore(release): prepare release (#492)` failed even though the commit contains `.monochange/releases/a67cec35dd2c8ec5/release.json`. Local verification with the workspace binary successfully detects the release record, so CI should avoid resolving a stale/ambient `mc` from PATH during release detection.

## Validation

- `devenv shell cargo run --quiet --package monochange --bin monochange -- step:release-record --from 7163d2649d40b1eb430dbeba82571803f08d9307 --format json --jq '.resolvedCommit == .recordCommit'`
- `devenv shell dprint check .github/workflows/ci.yml`
- `git diff --check`
- `devenv shell mc step:affected-packages --verify --changed-paths .github/workflows/ci.yml`
