### PR TITLE
docs: require signed agent commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@
 
 ## Git rules
 
+- Always GPG sign commits with `git commit -S` so commits show as verified on GitHub.
 - Never use `--no-verify` with `git commit` or `git push`.
 - Never change `commit.gpgsign` in local, global, or workspace git config.
 - The only allowed exception is during `git rebase` workflows when a rebase continuation or amend step would otherwise block on hooks/editor behavior.


### PR DESCRIPTION
## Summary
- Require agent commits to use `git commit -S` so GitHub marks them verified.

## Tests
- Not run; documentation-only change.