### PR TITLE
ci: harden publish workflow tag lookup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,8 +31,11 @@ jobs:
         run: |
           TAG='${{ inputs.tag }}'
 
-          # Validate the tag exists on the remote before proceeding
-          if ! git ls-remote --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+          repo_url="https://github.com/${GITHUB_REPOSITORY}.git"
+
+          # Validate the tag exists on the remote before proceeding. This step
+          # runs before checkout, so use the repository URL instead of `origin`.
+          if ! git ls-remote --exit-code --tags "$repo_url" "refs/tags/$TAG" >/dev/null 2>&1; then
             echo "::error::Tag '$TAG' does not exist on the remote" >&2
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,6 +236,24 @@ jobs:
     steps:
       - name: trigger publish workflow
         run: |
+          set -euo pipefail
+
+          repo_url="https://github.com/${GITHUB_REPOSITORY}.git"
+          for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+            if git ls-remote --exit-code --tags "$repo_url" "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+              echo "Release tag ${RELEASE_TAG} is visible on the remote."
+              break
+            fi
+
+            if [ "$attempt" -eq 12 ]; then
+              echo "::error::Tag ${RELEASE_TAG} was not visible on the remote after waiting." >&2
+              exit 1
+            fi
+
+            echo "Tag ${RELEASE_TAG} is not visible on the remote yet; retrying in 5 seconds..."
+            sleep 5
+          done
+
           gh workflow run publish.yml \
             --repo "${{ github.repository }}" \
             --ref "${{ env.RELEASE_TAG }}" \


### PR DESCRIPTION
## Summary

- Fix `publish.yml` tag validation before checkout by querying the repository URL instead of an absent `origin` remote.
- Add `--exit-code` so missing tags fail reliably.
- Harden `release.yml` by polling until the release tag is visible on the remote before dispatching `publish.yml`.

## Why

The v0.5.0 publish workflow failed in its first step because it ran `git ls-remote --tags origin ...` before checkout, so `origin` was not configured. The release trigger can also race GitHub tag visibility, so it now waits briefly for the tag to be resolvable before dispatching publish.

## Validation

- `git ls-remote --exit-code --tags https://github.com/monochange/monochange.git refs/tags/v0.5.0`
- `devenv shell dprint check .github/workflows/publish.yml .github/workflows/release.yml`
- `git diff --check`
- `bash -n` over embedded workflow shell snippets
- `devenv shell mc step:affected-packages --verify --changed-paths .github/workflows/publish.yml --changed-paths .github/workflows/release.yml`
