### PR TITLE
fix(ci): support release records in shallow checkouts

### DIFF
--- a/.changeset/release-record-shallow-discovery.md
+++ b/.changeset/release-record-shallow-discovery.md
@@ -1,0 +1,7 @@
+---
+monochange: patch
+---
+
+# Support release records in shallow checkouts
+
+Fix release record discovery for shallow checkouts when the parent commit is unavailable.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,8 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: setup devenv
         if: runner.os != 'Windows'
@@ -188,7 +190,11 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: run coverage
-        run: CARGO_BUILD_JOBS=1 coverage:all
+        run: |
+          CARGO_BUILD_JOBS=1 coverage:all || {
+            rm -rf target/llvm-cov-target
+            CARGO_BUILD_JOBS=1 coverage:all
+          }
         shell: devenv shell -- bash -e {0}
 
       - name: verify 100% patch coverage

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -5766,6 +5766,59 @@ fn find_release_record_files_at_commit_reports_git_errors() {
 }
 
 #[test]
+fn find_release_record_files_at_commit_falls_back_to_tree_when_parent_is_missing() {
+	let source = tempdir().unwrap_or_else(|error| panic!("source tempdir: {error}"));
+	let source_root = source.path();
+	git_in_temp_repo(source_root, &["init"]);
+	git_in_temp_repo(source_root, &["config", "user.name", "monochange Tests"]);
+	git_in_temp_repo(
+		source_root,
+		&["config", "user.email", "monochange-tests@example.com"],
+	);
+	fs::write(source_root.join("readme.md"), "initial\n")
+		.unwrap_or_else(|error| panic!("write readme: {error}"));
+	git_in_temp_repo(source_root, &["add", "readme.md"]);
+	git_in_temp_repo(source_root, &["commit", "-m", "initial"]);
+
+	let release_dir = source_root.join(".monochange/releases/0000000000000000");
+	fs::create_dir_all(&release_dir).unwrap_or_else(|error| panic!("create release dir: {error}"));
+	fs::write(release_dir.join("release.json"), "{}\n")
+		.unwrap_or_else(|error| panic!("write release record: {error}"));
+	git_in_temp_repo(
+		source_root,
+		&["add", ".monochange/releases/0000000000000000/release.json"],
+	);
+	git_in_temp_repo(source_root, &["commit", "-m", "release"]);
+
+	let clone = tempdir().unwrap_or_else(|error| panic!("clone tempdir: {error}"));
+	let clone_root = clone.path();
+	let source_url = format!("file://{}", source_root.display());
+	let clone_path = clone_root
+		.to_str()
+		.unwrap_or_else(|| panic!("clone path is not utf-8: {}", clone_root.display()));
+	let status = sanitized_git_command()
+		.args([
+			"clone",
+			"--depth",
+			"1",
+			"--no-local",
+			&source_url,
+			clone_path,
+		])
+		.current_dir(source_root)
+		.status()
+		.unwrap_or_else(|error| panic!("git clone shallow: {error}"));
+	assert!(status.success(), "git clone shallow failed");
+
+	let files = crate::git_support::find_release_record_files_at_commit(clone_root, "HEAD")
+		.unwrap_or_else(|error| panic!("find release record files: {error}"));
+	assert_eq!(
+		files,
+		vec![".monochange/releases/0000000000000000/release.json"]
+	);
+}
+
+#[test]
 #[cfg(unix)]
 fn write_release_record_file_reports_error_when_releases_dir_unreadable() {
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));

--- a/crates/monochange/src/git_support.rs
+++ b/crates/monochange/src/git_support.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command as ProcessCommand;
@@ -146,15 +147,32 @@ pub(crate) fn find_release_record_files_at_commit(
 	let suffix = "/release.json";
 	let filter = |line: &&str| line.starts_with(prefix) && line.ends_with(suffix);
 
-	let has_parent = run_git_capture(
+	let first_parent = run_git_capture(
 		root,
 		&["cat-file", "-p", commit],
 		"failed to inspect commit",
 	)?
 	.lines()
-	.any(|line| line.starts_with("parent "));
+	.find_map(|line| line.strip_prefix("parent ").map(str::to_string));
 
-	if has_parent {
+	let resolved_commit =
+		run_git_capture(root, &["rev-parse", commit], "failed to resolve commit")?;
+	let shallow_file = run_git_capture(
+		root,
+		&["rev-parse", "--git-path", "shallow"],
+		"failed to resolve shallow boundary path",
+	)
+	.unwrap_or_else(|_| String::from(".git/shallow"));
+	let shallow_file = root.join(PathBuf::from(shallow_file.trim()));
+	let is_shallow_boundary = fs::read_to_string(shallow_file)
+		.is_ok_and(|contents| contents.lines().any(|line| line == resolved_commit.trim()));
+	let has_available_parent = if let Some(parent) = first_parent.as_deref() {
+		git_command_output(root, &["cat-file", "-e", &format!("{parent}^{{commit}}")]).is_ok()
+	} else {
+		false
+	};
+
+	if has_available_parent && !is_shallow_boundary {
 		let args = [
 			"diff-tree",
 			"-m",


### PR DESCRIPTION
## Summary
- fetch full history for the build job before release-record detection
- make release record discovery fall back to tree scanning when the commit is a shallow boundary or parent is unavailable
- add regression coverage for depth-1 release-record discovery

## Validation
- `devenv shell cargo test --package monochange find_release_record_files_at_commit_falls_back_to_tree_when_parent_is_missing -- --nocapture`
- `devenv shell cargo fmt --check`
- `devenv shell dprint check .github/workflows/ci.yml .changeset/release-record-shallow-discovery.md`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`\n- `devenv shell coverage:patch` (PATCH_COVERAGE 0/0, 100.00%)