### PR TITLE
fix(ci): use correct subcommand step:publish-readiness in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,7 +114,7 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-oidc.outputs.token }}
         run: |
-          "$RUNNER_TEMP/bin/mc" publish-readiness \
+          "$RUNNER_TEMP/bin/mc" step:publish-readiness \
             --from HEAD \
             --output "$RUNNER_TEMP/publish-readiness.json" \
             --format json

--- a/monochange.toml
+++ b/monochange.toml
@@ -155,8 +155,8 @@ perf = { heading = "Performance", description = "Performance optimizations and i
 other = { heading = "Other", description = "Miscellaneous changes not categorized elsewhere", priority = 50 }
 
 [changelog.section_thresholds]
-collapse = 127
-ignored = 127
+collapse = 40
+ignored = 45
 
 [changelog.types]
 major = { bump = "major", section = "breaking", description = "Major version bump including breaking API changes requiring migration" }
@@ -171,6 +171,7 @@ fix = { bump = "patch", section = "fix", description = "Bug fixes and error corr
 none = { bump = "none", section = "other", description = "Changes with no version impact such as tooling or formatting" }
 docs = { bump = "none", section = "docs", description = "Documentation updates and clarifications only" }
 security = { bump = "none", section = "security", description = "Security improvements, advisories, and vulnerability fixes" }
+perf = { bump = "none", section = "perf", description = "Performance and benchmarking improvements" }
 
 # =============================================================================
 # [package.*] — declare each release-managed package explicitly


### PR DESCRIPTION
The publish workflow was calling `mc publish-readiness` but the correct CLI subcommand is `mc step:publish-readiness` (with the `step:` prefix). This caused the publish job to fail with:

```
error: unrecognized subcommand 'publish-readiness'

  tip: some similar subcommands exist: 'step:plan-publish-rate-limits', 'publish-check', 'step:publish-readiness'
```

Also lowers changelog section thresholds and adds a `perf` changelog type to `monochange.toml`.