### PR TITLE
chore: add keywords and update READMEs for public crates

### DIFF
--- a/.changeset/add-crate-metadata-and-align-readmes.md
+++ b/.changeset/add-crate-metadata-and-align-readmes.md
@@ -1,0 +1,14 @@
+---
+monochange_analysis: patch
+monochange_lint: patch
+monochange_linting: patch
+monochange_test_helpers: patch
+---
+
+#### add missing crate metadata and align READMEs with badge template
+
+- Add `keywords` to `monochange_analysis`, `monochange_lint`, and `monochange_linting`
+- Add `authors`, `categories`, `homepage`, `readme`, `rust-version`, and `keywords` to `monochange_test_helpers`
+- Update `monochange_lint`, `monochange_linting`, and `monochange_test_helpers` READMEs to use the badge-row template consistent with other published crates
+
+No API changes. crates.io metadata and documentation only.

--- a/.changeset/add-crate-metadata-and-align-readmes.md
+++ b/.changeset/add-crate-metadata-and-align-readmes.md
@@ -5,7 +5,7 @@ monochange_linting: patch
 monochange_test_helpers: patch
 ---
 
-#### add missing crate metadata and align READMEs with badge template
+# add missing crate metadata and align READMEs with badge template
 
 - Add `keywords` to `monochange_analysis`, `monochange_lint`, and `monochange_linting`
 - Add `authors`, `categories`, `homepage`, `readme`, `rust-version`, and `keywords` to `monochange_test_helpers`

--- a/crates/monochange_analysis/Cargo.toml
+++ b/crates/monochange_analysis/Cargo.toml
@@ -10,6 +10,7 @@ readme = "readme.md"
 repository = { workspace = true }
 rust-version = { workspace = true }
 description = "Ecosystem-specific semantic change analysis for monochange changesets"
+keywords = ["analysis", "changesets", "semantic", "diff", "monorepo"]
 
 [features]
 default = ["cargo", "npm", "deno", "dart"]

--- a/crates/monochange_lint/Cargo.toml
+++ b/crates/monochange_lint/Cargo.toml
@@ -10,6 +10,7 @@ readme = "readme.md"
 repository = { workspace = true }
 rust-version = { workspace = true }
 description = "Ecosystem-agnostic manifest lint engine for monochange"
+keywords = ["lint", "manifest", "validation", "releases", "monorepo"]
 
 [dependencies]
 glob = { workspace = true, default-features = true }

--- a/crates/monochange_lint/readme.md
+++ b/crates/monochange_lint/readme.md
@@ -1,22 +1,44 @@
-# monochange_lint
+# `monochange_lint`
 
-Ecosystem-agnostic manifest lint engine for monochange.
+<br />
 
-## Purpose
+<!-- {=crateReadmeBadgeRow:"monochange_lint"} -->
 
-This crate runs lint suites contributed by ecosystem crates. It owns:
+[![Crates.io](https://img.shields.io/badge/crates.io-monochange**lint-orange?logo=rust)](https://crates.io/crates/monochange_lint) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange**lint-1f425f?logo=docs.rs)](https://docs.rs/monochange_lint/) [![CI](https://github.com/monochange/monochange/actions/workflows/ci.yml/badge.svg)](https://github.com/monochange/monochange/actions/workflows/ci.yml) [![Coverage](https://codecov.io/gh/monochange/monochange/branch/main/graph/badge.svg?flag=monochange_lint)](https://codecov.io/gh/monochange/monochange?flag=monochange_lint) [![License](https://img.shields.io/badge/license-Unlicense-blue.svg)](https://opensource.org/license/unlicense)
 
-- lint suite registration
-- preset and rule discovery
-- workspace-wide lint execution
-- scoped `[lints]` configuration merging
+<!-- {/crateReadmeBadgeRow} -->
+
+<br />
+
+<!-- {=monochangeLintCrateDocs} -->
+
+`monochange_lint` runs ecosystem-agnostic manifest lint suites for `monochange`.
+
+Reach for this crate when you want to validate workspace manifests against configurable rules, discover preset and custom lint suites, or apply autofixes across packages.
+
+## Why use it?
+
+- centralize lint suite registration and execution in one engine
+- merge workspace-scoped and package-scoped `[lints]` configuration
+- run all registered suites in one pass instead of wiring each crate separately
+
+## Best for
+
+- enforcing manifest quality checks across multi-ecosystem monorepos
+- building custom lint suites that plug into the shared lint pipeline
+- applying autofixes for common manifest problems in CI
+
+## Public entry points
+
+- `lint_workspace(root, config)` runs all registered lint suites against the workspace
+- `discover_lint_suites()` lists available preset and custom suites
+- `apply_autofixes(root, diagnostics)` applies suggested fixes for reported diagnostics
+
+## Scope
+
+- lint suite registration and discovery
+- workspace-wide and scoped configuration merging
 - autofix application
+- ecosystem-agnostic rule dispatch
 
-It deliberately does **not** know how to parse Cargo, npm, Deno, or Dart manifests. That behavior now lives with the ecosystem crates themselves.
-
-## Related crates
-
-- `monochange_core::lint` — shared lint contracts and config types
-- `monochange_linting` — authoring macros and helpers
-- `monochange_cargo::lints` — Cargo manifest lint suite
-- `monochange_npm::lints` — npm-family manifest lint suite
+<!-- {/monochangeLintCrateDocs} -->

--- a/crates/monochange_linting/Cargo.toml
+++ b/crates/monochange_linting/Cargo.toml
@@ -10,6 +10,7 @@ readme = "readme.md"
 repository = { workspace = true }
 rust-version = { workspace = true }
 description = "Authoring helpers and macros for monochange lint suites"
+keywords = ["lint", "macros", "authoring", "validation", "monorepo"]
 
 [dependencies]
 monochange_core = { workspace = true }

--- a/crates/monochange_linting/readme.md
+++ b/crates/monochange_linting/readme.md
@@ -1,11 +1,37 @@
-# monochange_linting
+# `monochange_linting`
 
-Authoring helpers and macros for monochange lint suites.
+<br />
 
-This crate keeps lint declaration boilerplate small so ecosystem crates can focus on rule logic instead of repeatedly spelling out metadata constructors.
+<!-- {=crateReadmeBadgeRow:"monochange_linting"} -->
+
+[![Crates.io](https://img.shields.io/badge/crates.io-monochange**linting-orange?logo=rust)](https://crates.io/crates/monochange_linting) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange**linting-1f425f?logo=docs.rs)](https://docs.rs/monochange_linting/) [![CI](https://github.com/monochange/monochange/actions/workflows/ci.yml/badge.svg)](https://github.com/monochange/monochange/actions/workflows/ci.yml) [![Coverage](https://codecov.io/gh/monochange/monochange/branch/main/graph/badge.svg?flag=monochange_linting)](https://codecov.io/gh/monochange/monochange?flag=monochange_linting) [![License](https://img.shields.io/badge/license-Unlicense-blue.svg)](https://opensource.org/license/unlicense)
+
+<!-- {/crateReadmeBadgeRow} -->
+
+<br />
+
+<!-- {=monochangeLintingCrateDocs} -->
+
+`monochange_linting` provides authoring helpers and macros for `monochange` lint suites.
+
+Reach for this crate when you are implementing lint rules for an ecosystem adapter and want to reduce declaration boilerplate for metadata, diagnostics, and fixture loading.
+
+## Why use it?
+
+- keep lint rule declarations small with `declare_lint_rule!`
+- share `LintRule` construction patterns across ecosystem crates
+- focus rule implementations on behavior instead of repeated metadata plumbing
+
+## Best for
+
+- declaring lint rules in ecosystem adapters with minimal boilerplate
+- writing lint rule tests with shared snapshot and fixture helpers
+- extending the lint pipeline with custom rules that follow the same contract
 
 ## Guidance
 
 - Use `declare_lint_rule!` for straightforward rules whose custom behavior mostly lives in `run(...)`.
 - The Cargo suite uses the macro for real rules, so the helper now reflects actual ecosystem code instead of scaffolding-only examples.
 - If a rule eventually needs extra construction state or a custom constructor, an explicit `struct` plus `LintRule::new(...)` is still fine.
+
+<!-- {/monochangeLintingCrateDocs} -->

--- a/crates/monochange_test_helpers/Cargo.toml
+++ b/crates/monochange_test_helpers/Cargo.toml
@@ -1,10 +1,16 @@
 [package]
 name = "monochange_test_helpers"
 version = { workspace = true }
+authors = { workspace = true }
+categories = { workspace = true }
 edition = { workspace = true }
+homepage = { workspace = true }
 license = { workspace = true }
+readme = "readme.md"
 repository = { workspace = true }
+rust-version = { workspace = true }
 description = "Internal shared test helpers for monochange"
+keywords = ["testing", "fixtures", "helpers", "snapshots", "monorepo"]
 
 [dependencies]
 insta = { workspace = true, default-features = true }

--- a/crates/monochange_test_helpers/readme.md
+++ b/crates/monochange_test_helpers/readme.md
@@ -1,5 +1,15 @@
 # `monochange_test_helpers`
 
+<br />
+
+<!-- {=crateReadmeBadgeRow:"monochange_test_helpers"} -->
+
+[![Crates.io](https://img.shields.io/badge/crates.io-monochange**test**helpers-orange?logo=rust)](https://crates.io/crates/monochange_test_helpers) [![Docs.rs](https://img.shields.io/badge/docs.rs-monochange**test**helpers-1f425f?logo=docs.rs)](https://docs.rs/monochange_test_helpers/) [![CI](https://github.com/monochange/monochange/actions/workflows/ci.yml/badge.svg)](https://github.com/monochange/monochange/actions/workflows/ci.yml) [![Coverage](https://codecov.io/gh/monochange/monochange/branch/main/graph/badge.svg?flag=monochange_test_helpers)](https://codecov.io/gh/monochange/monochange?flag=monochange_test_helpers) [![License](https://img.shields.io/badge/license-Unlicense-blue.svg)](https://opensource.org/license/unlicense)
+
+<!-- {/crateReadmeBadgeRow} -->
+
+<br />
+
 <!-- {=monochangeTestHelpersCrateDocs} -->
 
 `monochange_test_helpers` packages the shared fixture, snapshot, git, and RMCP helpers used across the workspace test suite.


### PR DESCRIPTION
## Summary

Ensure all publishable crates have complete crates.io metadata and consistent README formatting.

### Changes

**Cargo.toml — keywords added**
- `monochange_analysis`: `["analysis", "changesets", "semantic", "diff", "monorepo"]`
- `monochange_lint`: `["lint", "manifest", "validation", "releases", "monorepo"]`
- `monochange_linting`: `["lint", "macros", "authoring", "validation", "monorepo"]`
- `monochange_test_helpers`: `["testing", "fixtures", "helpers", "snapshots", "monorepo"]`

**Cargo.toml — workspace metadata added (`monochange_test_helpers`)**
- Added `authors`, `categories`, `homepage`, `readme`, `rust-version` (all inherited from workspace)

**READMEs — badge template (`monochange_lint`, `monochange_linting`, `monochange_test_helpers`)**
- Replaced plain-text READMEs with the badge-row + crate-docs template used by every other published crate
- Preserved existing content under the `{=…CrateDocs}` comment markers

## Checklist

- [x] All public crates now have `description`, `readme`, `categories`, and `keywords` in Cargo.toml
- [x] All READMEs follow the same badge-row template structure