### PR TITLE
feat(schema): diversify current artifact fixtures with structurally varied data

### DIFF
--- a/.changeset/diverse-schema-artifacts.md
+++ b/.changeset/diverse-schema-artifacts.md
@@ -1,0 +1,6 @@
+---
+monochange_schema: minor
+monochange_integration_tests: minor
+---
+
+Diversify current schema artifact fixtures

--- a/.changeset/diverse-schema-artifacts.md
+++ b/.changeset/diverse-schema-artifacts.md
@@ -1,6 +1,5 @@
 ---
 monochange_schema: minor
-monochange_integration_tests: minor
 ---
 
 Diversify current schema artifact fixtures

--- a/.changeset/diverse-schema-artifacts.md
+++ b/.changeset/diverse-schema-artifacts.md
@@ -2,4 +2,6 @@
 monochange_schema: minor
 ---
 
-Diversify current schema artifact fixtures
+# diversify current schema artifact fixtures
+
+Redesign the schema artifact generation in xtask to produce genuinely diverse, structurally varied fixtures instead of 10 near-identical variants that only differed in seed and date.

--- a/crates/monochange_integration_tests/tests/schema_assets.rs
+++ b/crates/monochange_integration_tests/tests/schema_assets.rs
@@ -80,7 +80,12 @@ fn config_artifact_fixtures_are_valid_json() -> Result<(), Box<dyn Error>> {
 		let raw: Value = serde_json::from_str(&text)?;
 		let source = json_object(&raw, "/source")?;
 
-		assert_eq!(json_str(&raw, "/source/provider")?, "github");
+		let provider = json_str(&raw, "/source/provider")?;
+		let valid_providers = ["github", "gitlab", "gitea", "forgejo"];
+		assert!(
+			valid_providers.contains(&provider.as_ref()),
+			"{name} has unexpected source provider `{provider}`"
+		);
 		assert!(!json_str(&raw, "/source/owner")?.is_empty());
 		assert!(!json_str(&raw, "/source/repo")?.is_empty());
 		for key in source.keys() {
@@ -90,7 +95,11 @@ fn config_artifact_fixtures_are_valid_json() -> Result<(), Box<dyn Error>> {
 			);
 		}
 		if source.contains_key("host") {
-			assert_eq!(json_str(&raw, "/source/host")?, "github.com");
+			let host = json_str(&raw, "/source/host")?;
+			assert!(
+				host.ends_with(".example.com") || host == "github.com",
+				"{name} has unexpected host `{host}`"
+			);
 		}
 	}
 

--- a/crates/monochange_integration_tests/tests/schema_assets.rs
+++ b/crates/monochange_integration_tests/tests/schema_assets.rs
@@ -90,7 +90,16 @@ fn config_artifact_fixtures_are_valid_json() -> Result<(), Box<dyn Error>> {
 		assert!(!json_str(&raw, "/source/repo")?.is_empty());
 		for key in source.keys() {
 			assert!(
-				["provider", "owner", "repo", "host"].contains(&key.as_str()),
+				[
+					"provider",
+					"owner",
+					"repo",
+					"host",
+					"api_url",
+					"pull_requests",
+					"releases"
+				]
+				.contains(&key.as_str()),
 				"{name} includes unexpected source key `{key}`"
 			);
 		}

--- a/crates/monochange_integration_tests/tests/schema_assets.rs
+++ b/crates/monochange_integration_tests/tests/schema_assets.rs
@@ -83,7 +83,7 @@ fn config_artifact_fixtures_are_valid_json() -> Result<(), Box<dyn Error>> {
 		let provider = json_str(&raw, "/source/provider")?;
 		let valid_providers = ["github", "gitlab", "gitea", "forgejo"];
 		assert!(
-			valid_providers.contains(&provider.as_ref()),
+			valid_providers.contains(&provider),
 			"{name} has unexpected source provider `{provider}`"
 		);
 		assert!(!json_str(&raw, "/source/owner")?.is_empty());

--- a/crates/monochange_schema/schemas/artifacts/current/monochange/01.json
+++ b/crates/monochange_schema/schemas/artifacts/current/monochange/01.json
@@ -1,28 +1,117 @@
 {
+	"changelog": {
+		"sections": {
+			"bug-fixes": {
+				"description": "Resolved defects",
+				"heading": "🐛 Bug Fixes",
+				"priority": 10
+			},
+			"features": {
+				"description": "New capabilities",
+				"heading": "✨ Features",
+				"priority": 20
+			}
+		},
+		"style": {
+			"collapsedSectionStyle": "details",
+			"metadataStyle": "blockquote",
+			"packageLabelPlacement": "after_change",
+			"packageLabelStyle": "badge",
+			"sectionSeparator": "thematic_break"
+		},
+		"types": {
+			"feature": {
+				"bump": "minor",
+				"description": "New features",
+				"section": "features"
+			},
+			"fix": {
+				"bump": "patch",
+				"description": "Bug fixes",
+				"section": "bug-fixes"
+			}
+		}
+	},
+	"changesets": {
+		"affected": {
+			"changed_paths": [
+				"crates/buol/"
+			],
+			"comment_on_failure": true,
+			"enabled": true,
+			"ignored_paths": [
+				"**/*.md"
+			],
+			"required": true,
+			"skip_labels": [
+				"skip-changeset"
+			]
+		}
+	},
 	"defaults": {
-		"package_type": "python"
+		"include_private": true,
+		"package_type": "cargo",
+		"parent_bump": "patch",
+		"strict_version_conflicts": false,
+		"warn_on_group_mismatch": true
+	},
+	"group": {
+		"main": {
+			"packages": [
+				"buol_0",
+				"buol_1"
+			],
+			"release": true,
+			"tag": true,
+			"version_format": "namespaced"
+		}
 	},
 	"package": {
 		"buol_0": {
-			"path": "crates/buol_0"
+			"path": "crates/buol_0",
+			"release": true,
+			"tag": true,
+			"type": "cargo",
+			"version_format": "namespaced"
 		},
 		"buol_1": {
-			"path": "crates/buol_1"
+			"path": "crates/buol_1",
+			"release": false,
+			"tag": false,
+			"type": "cargo",
+			"version_format": "namespaced"
 		},
 		"buol_2": {
-			"path": "crates/buol_2"
+			"path": "crates/buol_2",
+			"release": false,
+			"tag": false,
+			"type": "cargo",
+			"version_format": "namespaced"
 		},
 		"buol_3": {
-			"path": "crates/buol_3"
-		},
-		"buol_4": {
-			"path": "crates/buol_4"
+			"path": "crates/buol_3",
+			"release": false,
+			"tag": false,
+			"type": "cargo",
+			"version_format": "namespaced"
 		}
 	},
 	"source": {
 		"host": "gitlab.example.com",
 		"owner": "buol",
 		"provider": "gitlab",
+		"pull_requests": {
+			"auto_merge": false,
+			"base": "main",
+			"branch_prefix": "buol/release",
+			"enabled": true,
+			"labels": [
+				"release",
+				"automated"
+			],
+			"title": "chore(release): prepare buol release",
+			"verified_commits": true
+		},
 		"repo": "obhrym"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/monochange/01.json
+++ b/crates/monochange_schema/schemas/artifacts/current/monochange/01.json
@@ -1,18 +1,28 @@
 {
 	"defaults": {
-		"package_type": "cargo"
+		"package_type": "python"
 	},
 	"package": {
-		"monochange": {
-			"path": "crates/monochange"
+		"buol_0": {
+			"path": "crates/buol_0"
 		},
-		"monochange_core": {
-			"path": "crates/monochange_core"
+		"buol_1": {
+			"path": "crates/buol_1"
+		},
+		"buol_2": {
+			"path": "crates/buol_2"
+		},
+		"buol_3": {
+			"path": "crates/buol_3"
+		},
+		"buol_4": {
+			"path": "crates/buol_4"
 		}
 	},
 	"source": {
-		"owner": "monochange",
-		"provider": "github",
-		"repo": "release-kit"
+		"host": "gitlab.example.com",
+		"owner": "buol",
+		"provider": "gitlab",
+		"repo": "obhrym"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/monochange/02.json
+++ b/crates/monochange_schema/schemas/artifacts/current/monochange/02.json
@@ -1,18 +1,16 @@
 {
 	"defaults": {
-		"package_type": "cargo"
+		"package_type": "dart"
 	},
 	"package": {
-		"monochange": {
-			"path": "crates/monochange"
-		},
-		"monochange_core": {
-			"path": "crates/monochange_core"
+		"cvjxjm_0": {
+			"path": "crates/cvjxjm_0"
 		}
 	},
 	"source": {
-		"owner": "aipi",
+		"host": "github.example.com",
+		"owner": "cvjxjm",
 		"provider": "github",
-		"repo": "schema-fixtures"
+		"repo": "gwt"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/monochange/02.json
+++ b/crates/monochange_schema/schemas/artifacts/current/monochange/02.json
@@ -1,16 +1,77 @@
 {
 	"defaults": {
-		"package_type": "dart"
+		"empty_update_message": "No significant changes for vcle packages.",
+		"include_private": true,
+		"package_type": "python",
+		"parent_bump": "major",
+		"strict_version_conflicts": false,
+		"warn_on_group_mismatch": false
+	},
+	"ecosystems": {
+		"go": {
+			"enabled": true,
+			"publish": {
+				"enabled": true
+			},
+			"roots": [
+				"crates/go"
+			]
+		}
 	},
 	"package": {
-		"cvjxjm_0": {
-			"path": "crates/cvjxjm_0"
+		"vcle_0": {
+			"path": "crates/vcle_0",
+			"release": true,
+			"tag": true,
+			"type": "python",
+			"version_format": "namespaced"
+		},
+		"vcle_1": {
+			"path": "crates/vcle_1",
+			"release": false,
+			"tag": false,
+			"type": "python",
+			"version_format": "namespaced"
+		},
+		"vcle_2": {
+			"path": "crates/vcle_2",
+			"release": false,
+			"tag": false,
+			"type": "python",
+			"version_format": "namespaced"
+		},
+		"vcle_3": {
+			"path": "crates/vcle_3",
+			"release": false,
+			"tag": false,
+			"type": "python",
+			"version_format": "namespaced"
+		},
+		"vcle_4": {
+			"path": "crates/vcle_4",
+			"release": false,
+			"tag": false,
+			"type": "python",
+			"version_format": "namespaced"
 		}
 	},
 	"source": {
-		"host": "github.example.com",
-		"owner": "cvjxjm",
-		"provider": "github",
-		"repo": "gwt"
+		"api_url": "api.gitlab.example.com",
+		"host": "gitlab.example.com",
+		"owner": "vcle",
+		"provider": "gitlab",
+		"pull_requests": {
+			"auto_merge": false,
+			"base": "main",
+			"branch_prefix": "vcle/release",
+			"enabled": true,
+			"labels": [
+				"release",
+				"automated"
+			],
+			"title": "chore(release): prepare vcle release",
+			"verified_commits": false
+		},
+		"repo": "acymwm"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/monochange/03.json
+++ b/crates/monochange_schema/schemas/artifacts/current/monochange/03.json
@@ -1,25 +1,74 @@
 {
 	"defaults": {
-		"package_type": "npm"
+		"changelog_version_title": "v{{version}} — xzaqasg release",
+		"empty_update_message": "No significant changes for xzaqasg packages.",
+		"include_private": false,
+		"package_type": "cargo",
+		"parent_bump": "none",
+		"strict_version_conflicts": true,
+		"warn_on_group_mismatch": false
+	},
+	"ecosystems": {
+		"python": {
+			"enabled": true,
+			"publish": {
+				"enabled": true
+			},
+			"roots": [
+				"crates/python"
+			]
+		}
+	},
+	"group": {
+		"main": {
+			"packages": [
+				"xzaqasg_0",
+				"xzaqasg_1"
+			],
+			"release": false,
+			"tag": false,
+			"version_format": "namespaced"
+		}
 	},
 	"package": {
-		"imwmkuepi_0": {
-			"path": "crates/imwmkuepi_0"
+		"xzaqasg_0": {
+			"path": "crates/xzaqasg_0",
+			"release": true,
+			"tag": true,
+			"type": "cargo",
+			"version_format": "namespaced"
 		},
-		"imwmkuepi_1": {
-			"path": "crates/imwmkuepi_1"
+		"xzaqasg_1": {
+			"path": "crates/xzaqasg_1",
+			"release": false,
+			"tag": false,
+			"type": "cargo",
+			"version_format": "namespaced"
 		},
-		"imwmkuepi_2": {
-			"path": "crates/imwmkuepi_2"
-		},
-		"imwmkuepi_3": {
-			"path": "crates/imwmkuepi_3"
+		"xzaqasg_2": {
+			"path": "crates/xzaqasg_2",
+			"release": false,
+			"tag": false,
+			"type": "cargo",
+			"version_format": "namespaced"
 		}
 	},
 	"source": {
 		"host": "gitlab.example.com",
-		"owner": "imwmkuepi",
+		"owner": "xzaqasg",
 		"provider": "gitlab",
-		"repo": "aza"
+		"pull_requests": {
+			"auto_merge": true,
+			"base": "main",
+			"branch_prefix": "xzaqasg/release",
+			"enabled": true,
+			"labels": [
+				"release",
+				"automated"
+			],
+			"title": "chore(release): prepare xzaqasg release",
+			"verified_commits": false
+		},
+		"repo": "wleh"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/monochange/03.json
+++ b/crates/monochange_schema/schemas/artifacts/current/monochange/03.json
@@ -1,15 +1,25 @@
 {
 	"defaults": {
-		"package_type": "cargo"
+		"package_type": "npm"
 	},
 	"package": {
-		"monochange": {
-			"path": "crates/monochange"
+		"imwmkuepi_0": {
+			"path": "crates/imwmkuepi_0"
+		},
+		"imwmkuepi_1": {
+			"path": "crates/imwmkuepi_1"
+		},
+		"imwmkuepi_2": {
+			"path": "crates/imwmkuepi_2"
+		},
+		"imwmkuepi_3": {
+			"path": "crates/imwmkuepi_3"
 		}
 	},
 	"source": {
-		"owner": "aipi",
-		"provider": "github",
-		"repo": "schema-fixtures"
+		"host": "gitlab.example.com",
+		"owner": "imwmkuepi",
+		"provider": "gitlab",
+		"repo": "aza"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/monochange/04.json
+++ b/crates/monochange_schema/schemas/artifacts/current/monochange/04.json
@@ -1,25 +1,86 @@
 {
+	"changesets": {
+		"affected": {
+			"changed_paths": [
+				"crates/ufqwzwx/"
+			],
+			"comment_on_failure": true,
+			"enabled": true,
+			"ignored_paths": [
+				"**/*.md"
+			],
+			"required": true,
+			"skip_labels": [
+				"skip-changeset"
+			]
+		}
+	},
 	"defaults": {
-		"package_type": "dart"
+		"empty_update_message": "No significant changes for ufqwzwx packages.",
+		"include_private": true,
+		"package_type": "cargo",
+		"parent_bump": "none",
+		"release_title": "ufqwzwx release",
+		"strict_version_conflicts": false,
+		"warn_on_group_mismatch": true
+	},
+	"ecosystems": {
+		"deno": {
+			"enabled": true,
+			"publish": {
+				"enabled": true
+			},
+			"roots": [
+				"crates/deno"
+			]
+		}
 	},
 	"package": {
-		"qgf_0": {
-			"path": "crates/qgf_0"
+		"ufqwzwx_0": {
+			"path": "crates/ufqwzwx_0",
+			"release": true,
+			"tag": true,
+			"type": "cargo",
+			"version_format": "namespaced"
 		},
-		"qgf_1": {
-			"path": "crates/qgf_1"
+		"ufqwzwx_1": {
+			"path": "crates/ufqwzwx_1",
+			"release": false,
+			"tag": false,
+			"type": "cargo",
+			"version_format": "namespaced"
 		},
-		"qgf_2": {
-			"path": "crates/qgf_2"
+		"ufqwzwx_2": {
+			"path": "crates/ufqwzwx_2",
+			"release": false,
+			"tag": false,
+			"type": "cargo",
+			"version_format": "namespaced"
 		},
-		"qgf_3": {
-			"path": "crates/qgf_3"
+		"ufqwzwx_3": {
+			"path": "crates/ufqwzwx_3",
+			"release": false,
+			"tag": false,
+			"type": "cargo",
+			"version_format": "namespaced"
 		}
 	},
 	"source": {
-		"host": "forgejo.example.com",
-		"owner": "qgf",
-		"provider": "forgejo",
-		"repo": "lehbmoagmuf"
+		"host": "gitlab.example.com",
+		"owner": "ufqwzwx",
+		"provider": "gitlab",
+		"pull_requests": {
+			"auto_merge": true,
+			"base": "main",
+			"branch_prefix": "ufqwzwx/release",
+			"enabled": true,
+			"labels": [
+				"release",
+				"automated"
+			],
+			"title": "chore(release): prepare ufqwzwx release",
+			"verified_commits": true
+		},
+		"repo": "uqchac"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/monochange/04.json
+++ b/crates/monochange_schema/schemas/artifacts/current/monochange/04.json
@@ -1,15 +1,25 @@
 {
 	"defaults": {
-		"package_type": "cargo"
+		"package_type": "dart"
 	},
 	"package": {
-		"monochange": {
-			"path": "crates/monochange"
+		"qgf_0": {
+			"path": "crates/qgf_0"
+		},
+		"qgf_1": {
+			"path": "crates/qgf_1"
+		},
+		"qgf_2": {
+			"path": "crates/qgf_2"
+		},
+		"qgf_3": {
+			"path": "crates/qgf_3"
 		}
 	},
 	"source": {
-		"owner": "monochange",
-		"provider": "github",
-		"repo": "monochange"
+		"host": "forgejo.example.com",
+		"owner": "qgf",
+		"provider": "forgejo",
+		"repo": "lehbmoagmuf"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/monochange/05.json
+++ b/crates/monochange_schema/schemas/artifacts/current/monochange/05.json
@@ -1,25 +1,93 @@
 {
+	"changesets": {
+		"affected": {
+			"changed_paths": [
+				"crates/wbwwvct/"
+			],
+			"comment_on_failure": true,
+			"enabled": true,
+			"ignored_paths": [
+				"**/*.md"
+			],
+			"required": true,
+			"skip_labels": [
+				"skip-changeset"
+			]
+		}
+	},
 	"defaults": {
-		"package_type": "go"
+		"changelog_version_title": "v{{version}} — wbwwvct release",
+		"include_private": true,
+		"package_type": "cargo",
+		"parent_bump": "major",
+		"release_title": "wbwwvct release",
+		"strict_version_conflicts": true,
+		"warn_on_group_mismatch": true
+	},
+	"ecosystems": {
+		"dart": {
+			"enabled": true,
+			"publish": {
+				"enabled": true
+			},
+			"roots": [
+				"crates/dart"
+			]
+		}
 	},
 	"package": {
-		"mzwxlqcha_0": {
-			"path": "crates/mzwxlqcha_0"
+		"wbwwvct_0": {
+			"path": "crates/wbwwvct_0",
+			"release": true,
+			"tag": true,
+			"type": "cargo",
+			"version_format": "namespaced"
 		},
-		"mzwxlqcha_1": {
-			"path": "crates/mzwxlqcha_1"
+		"wbwwvct_1": {
+			"path": "crates/wbwwvct_1",
+			"release": false,
+			"tag": false,
+			"type": "cargo",
+			"version_format": "namespaced"
 		},
-		"mzwxlqcha_2": {
-			"path": "crates/mzwxlqcha_2"
+		"wbwwvct_2": {
+			"path": "crates/wbwwvct_2",
+			"release": false,
+			"tag": false,
+			"type": "cargo",
+			"version_format": "namespaced"
 		},
-		"mzwxlqcha_3": {
-			"path": "crates/mzwxlqcha_3"
+		"wbwwvct_3": {
+			"path": "crates/wbwwvct_3",
+			"release": false,
+			"tag": false,
+			"type": "cargo",
+			"version_format": "namespaced"
+		},
+		"wbwwvct_4": {
+			"path": "crates/wbwwvct_4",
+			"release": false,
+			"tag": false,
+			"type": "cargo",
+			"version_format": "namespaced"
 		}
 	},
 	"source": {
-		"host": "forgejo.example.com",
-		"owner": "mzwxlqcha",
-		"provider": "forgejo",
-		"repo": "wyduxhjrbw"
+		"api_url": "api.gitea.example.com",
+		"owner": "wbwwvct",
+		"provider": "gitea",
+		"pull_requests": {
+			"auto_merge": true,
+			"base": "main",
+			"branch_prefix": "wbwwvct/release",
+			"enabled": true,
+			"labels": [
+				"release",
+				"automated"
+			],
+			"title": "chore(release): prepare wbwwvct release",
+			"verified_commits": false
+		},
+		"repo": "teeyk"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/monochange/05.json
+++ b/crates/monochange_schema/schemas/artifacts/current/monochange/05.json
@@ -1,18 +1,25 @@
 {
 	"defaults": {
-		"package_type": "cargo"
+		"package_type": "go"
 	},
 	"package": {
-		"monochange": {
-			"path": "crates/monochange"
+		"mzwxlqcha_0": {
+			"path": "crates/mzwxlqcha_0"
 		},
-		"monochange_core": {
-			"path": "crates/monochange_core"
+		"mzwxlqcha_1": {
+			"path": "crates/mzwxlqcha_1"
+		},
+		"mzwxlqcha_2": {
+			"path": "crates/mzwxlqcha_2"
+		},
+		"mzwxlqcha_3": {
+			"path": "crates/mzwxlqcha_3"
 		}
 	},
 	"source": {
-		"owner": "release-tools",
-		"provider": "github",
-		"repo": "monochange"
+		"host": "forgejo.example.com",
+		"owner": "mzwxlqcha",
+		"provider": "forgejo",
+		"repo": "wyduxhjrbw"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/monochange/06.json
+++ b/crates/monochange_schema/schemas/artifacts/current/monochange/06.json
@@ -1,21 +1,24 @@
 {
 	"defaults": {
-		"package_type": "cargo"
+		"package_type": "deno"
 	},
 	"package": {
-		"monochange": {
-			"path": "crates/monochange"
+		"tct_0": {
+			"path": "crates/tct_0"
 		},
-		"monochange_core": {
-			"path": "crates/monochange_core"
+		"tct_1": {
+			"path": "crates/tct_1"
 		},
-		"monochange_schema": {
-			"path": "crates/monochange_schema"
+		"tct_2": {
+			"path": "crates/tct_2"
+		},
+		"tct_3": {
+			"path": "crates/tct_3"
 		}
 	},
 	"source": {
-		"owner": "monochange",
-		"provider": "github",
-		"repo": "schema-fixtures"
+		"owner": "tct",
+		"provider": "forgejo",
+		"repo": "teeyk"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/monochange/06.json
+++ b/crates/monochange_schema/schemas/artifacts/current/monochange/06.json
@@ -1,24 +1,39 @@
 {
 	"defaults": {
-		"package_type": "deno"
+		"changelog_version_title": "v{{version}} — rjlmpjuthgi release",
+		"empty_update_message": "No significant changes for rjlmpjuthgi packages.",
+		"include_private": true,
+		"package_type": "npm",
+		"parent_bump": "patch",
+		"release_title": "rjlmpjuthgi release",
+		"strict_version_conflicts": true,
+		"warn_on_group_mismatch": false
 	},
 	"package": {
-		"tct_0": {
-			"path": "crates/tct_0"
-		},
-		"tct_1": {
-			"path": "crates/tct_1"
-		},
-		"tct_2": {
-			"path": "crates/tct_2"
-		},
-		"tct_3": {
-			"path": "crates/tct_3"
+		"rjlmpjuthgi_0": {
+			"path": "crates/rjlmpjuthgi_0",
+			"release": true,
+			"tag": true,
+			"type": "npm",
+			"version_format": "namespaced"
 		}
 	},
 	"source": {
-		"owner": "tct",
-		"provider": "forgejo",
-		"repo": "teeyk"
+		"host": "gitea.example.com",
+		"owner": "rjlmpjuthgi",
+		"provider": "gitea",
+		"pull_requests": {
+			"auto_merge": false,
+			"base": "main",
+			"branch_prefix": "rjlmpjuthgi/release",
+			"enabled": true,
+			"labels": [
+				"release",
+				"automated"
+			],
+			"title": "chore(release): prepare rjlmpjuthgi release",
+			"verified_commits": false
+		},
+		"repo": "hng"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/monochange/07.json
+++ b/crates/monochange_schema/schemas/artifacts/current/monochange/07.json
@@ -1,18 +1,115 @@
 {
+	"changelog": {
+		"sections": {
+			"bug-fixes": {
+				"description": "Resolved defects",
+				"heading": "🐛 Bug Fixes",
+				"priority": 10
+			},
+			"features": {
+				"description": "New capabilities",
+				"heading": "✨ Features",
+				"priority": 20
+			}
+		},
+		"style": {
+			"collapsedSectionStyle": "plain",
+			"metadataStyle": "blockquote",
+			"packageLabelPlacement": "after_heading",
+			"packageLabelStyle": "badge",
+			"sectionSeparator": "thematic_break"
+		},
+		"types": {
+			"feature": {
+				"bump": "minor",
+				"description": "New features",
+				"section": "features"
+			},
+			"fix": {
+				"bump": "patch",
+				"description": "Bug fixes",
+				"section": "bug-fixes"
+			}
+		}
+	},
+	"changesets": {
+		"affected": {
+			"changed_paths": [
+				"crates/iphohpfbuail/"
+			],
+			"comment_on_failure": true,
+			"enabled": true,
+			"ignored_paths": [
+				"**/*.md"
+			],
+			"required": true,
+			"skip_labels": [
+				"skip-changeset"
+			]
+		}
+	},
 	"defaults": {
-		"package_type": "dart"
+		"changelog_version_title": "v{{version}} — iphohpfbuail release",
+		"empty_update_message": "No significant changes for iphohpfbuail packages.",
+		"include_private": true,
+		"package_type": "deno",
+		"parent_bump": "none",
+		"strict_version_conflicts": true,
+		"warn_on_group_mismatch": false
+	},
+	"ecosystems": {
+		"npm": {
+			"enabled": true,
+			"publish": {
+				"enabled": true
+			},
+			"roots": [
+				"crates/npm"
+			]
+		}
+	},
+	"lints": {
+		"rules": {
+			"no-unnecessary-releases": "error"
+		},
+		"scopes": [
+			"crates/iphohpfbuail"
+		],
+		"use": [
+			"no-unnecessary-releases"
+		]
 	},
 	"package": {
-		"odell_0": {
-			"path": "crates/odell_0"
+		"iphohpfbuail_0": {
+			"path": "crates/iphohpfbuail_0",
+			"release": true,
+			"tag": true,
+			"type": "deno",
+			"version_format": "namespaced"
 		},
-		"odell_1": {
-			"path": "crates/odell_1"
+		"iphohpfbuail_1": {
+			"path": "crates/iphohpfbuail_1",
+			"release": false,
+			"tag": false,
+			"type": "deno",
+			"version_format": "namespaced"
 		}
 	},
 	"source": {
-		"owner": "odell",
+		"owner": "iphohpfbuail",
 		"provider": "forgejo",
-		"repo": "jlmpjuthg"
+		"pull_requests": {
+			"auto_merge": false,
+			"base": "main",
+			"branch_prefix": "iphohpfbuail/release",
+			"enabled": true,
+			"labels": [
+				"release",
+				"automated"
+			],
+			"title": "chore(release): prepare iphohpfbuail release",
+			"verified_commits": true
+		},
+		"repo": "iityebtf"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/monochange/07.json
+++ b/crates/monochange_schema/schemas/artifacts/current/monochange/07.json
@@ -1,21 +1,18 @@
 {
 	"defaults": {
-		"package_type": "cargo"
+		"package_type": "dart"
 	},
 	"package": {
-		"monochange": {
-			"path": "crates/monochange"
+		"odell_0": {
+			"path": "crates/odell_0"
 		},
-		"monochange_core": {
-			"path": "crates/monochange_core"
-		},
-		"monochange_schema": {
-			"path": "crates/monochange_schema"
+		"odell_1": {
+			"path": "crates/odell_1"
 		}
 	},
 	"source": {
-		"owner": "schema-lab",
-		"provider": "github",
-		"repo": "schema-fixtures"
+		"owner": "odell",
+		"provider": "forgejo",
+		"repo": "jlmpjuthg"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/monochange/08.json
+++ b/crates/monochange_schema/schemas/artifacts/current/monochange/08.json
@@ -1,19 +1,25 @@
 {
 	"defaults": {
-		"package_type": "cargo"
+		"package_type": "go"
 	},
 	"package": {
-		"monochange": {
-			"path": "crates/monochange"
+		"lngscapy_0": {
+			"path": "crates/lngscapy_0"
 		},
-		"monochange_core": {
-			"path": "crates/monochange_core"
+		"lngscapy_1": {
+			"path": "crates/lngscapy_1"
+		},
+		"lngscapy_2": {
+			"path": "crates/lngscapy_2"
+		},
+		"lngscapy_3": {
+			"path": "crates/lngscapy_3"
 		}
 	},
 	"source": {
-		"host": "github.com",
-		"owner": "monochange",
+		"host": "github.example.com",
+		"owner": "lngscapy",
 		"provider": "github",
-		"repo": "monochange"
+		"repo": "xfphohp"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/monochange/08.json
+++ b/crates/monochange_schema/schemas/artifacts/current/monochange/08.json
@@ -1,25 +1,72 @@
 {
 	"defaults": {
-		"package_type": "go"
+		"changelog_version_title": "v{{version}} — dhrxtrsrzw release",
+		"empty_update_message": "No significant changes for dhrxtrsrzw packages.",
+		"include_private": true,
+		"package_type": "deno",
+		"parent_bump": "patch",
+		"strict_version_conflicts": false,
+		"warn_on_group_mismatch": true
+	},
+	"ecosystems": {
+		"npm": {
+			"enabled": true,
+			"publish": {
+				"enabled": true
+			},
+			"roots": [
+				"crates/npm"
+			]
+		}
+	},
+	"group": {
+		"main": {
+			"packages": [
+				"dhrxtrsrzw_0",
+				"dhrxtrsrzw_1"
+			],
+			"release": false,
+			"tag": false,
+			"version_format": "namespaced"
+		}
+	},
+	"lints": {
+		"rules": {
+			"no-unnecessary-releases": "error"
+		},
+		"scopes": [
+			"crates/dhrxtrsrzw"
+		],
+		"use": [
+			"no-unnecessary-releases"
+		]
 	},
 	"package": {
-		"lngscapy_0": {
-			"path": "crates/lngscapy_0"
-		},
-		"lngscapy_1": {
-			"path": "crates/lngscapy_1"
-		},
-		"lngscapy_2": {
-			"path": "crates/lngscapy_2"
-		},
-		"lngscapy_3": {
-			"path": "crates/lngscapy_3"
+		"dhrxtrsrzw_0": {
+			"path": "crates/dhrxtrsrzw_0",
+			"release": true,
+			"tag": true,
+			"type": "deno",
+			"version_format": "namespaced"
 		}
 	},
 	"source": {
-		"host": "github.example.com",
-		"owner": "lngscapy",
-		"provider": "github",
-		"repo": "xfphohp"
+		"api_url": "api.gitea.example.com",
+		"host": "gitea.example.com",
+		"owner": "dhrxtrsrzw",
+		"provider": "gitea",
+		"pull_requests": {
+			"auto_merge": true,
+			"base": "main",
+			"branch_prefix": "dhrxtrsrzw/release",
+			"enabled": true,
+			"labels": [
+				"release",
+				"automated"
+			],
+			"title": "chore(release): prepare dhrxtrsrzw release",
+			"verified_commits": false
+		},
+		"repo": "knnscpqv"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/monochange/09.json
+++ b/crates/monochange_schema/schemas/artifacts/current/monochange/09.json
@@ -1,21 +1,92 @@
 {
 	"defaults": {
-		"package_type": "npm"
+		"changelog_version_title": "v{{version}} — mpuzou release",
+		"include_private": false,
+		"package_type": "cargo",
+		"parent_bump": "minor",
+		"strict_version_conflicts": true,
+		"warn_on_group_mismatch": true
+	},
+	"ecosystems": {
+		"cargo": {
+			"enabled": true,
+			"publish": {
+				"enabled": true
+			},
+			"roots": [
+				"crates/cargo"
+			]
+		}
+	},
+	"group": {
+		"main": {
+			"packages": [
+				"mpuzou_0",
+				"mpuzou_1"
+			],
+			"release": true,
+			"tag": true,
+			"version_format": "namespaced"
+		}
+	},
+	"lints": {
+		"rules": {
+			"no-unnecessary-releases": "error"
+		},
+		"scopes": [
+			"crates/mpuzou"
+		],
+		"use": [
+			"no-unnecessary-releases"
+		]
 	},
 	"package": {
-		"buailzizye_0": {
-			"path": "crates/buailzizye_0"
+		"mpuzou_0": {
+			"path": "crates/mpuzou_0",
+			"release": true,
+			"tag": true,
+			"type": "cargo",
+			"version_format": "namespaced"
 		},
-		"buailzizye_1": {
-			"path": "crates/buailzizye_1"
+		"mpuzou_1": {
+			"path": "crates/mpuzou_1",
+			"release": false,
+			"tag": false,
+			"type": "cargo",
+			"version_format": "namespaced"
 		},
-		"buailzizye_2": {
-			"path": "crates/buailzizye_2"
+		"mpuzou_2": {
+			"path": "crates/mpuzou_2",
+			"release": false,
+			"tag": false,
+			"type": "cargo",
+			"version_format": "namespaced"
+		},
+		"mpuzou_3": {
+			"path": "crates/mpuzou_3",
+			"release": false,
+			"tag": false,
+			"type": "cargo",
+			"version_format": "namespaced"
 		}
 	},
 	"source": {
-		"owner": "buailzizye",
-		"provider": "gitlab",
-		"repo": "wsk"
+		"api_url": "api.github.example.com",
+		"host": "github.example.com",
+		"owner": "mpuzou",
+		"provider": "github",
+		"pull_requests": {
+			"auto_merge": false,
+			"base": "main",
+			"branch_prefix": "mpuzou/release",
+			"enabled": true,
+			"labels": [
+				"release",
+				"automated"
+			],
+			"title": "chore(release): prepare mpuzou release",
+			"verified_commits": false
+		},
+		"repo": "rrnozp"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/monochange/09.json
+++ b/crates/monochange_schema/schemas/artifacts/current/monochange/09.json
@@ -1,19 +1,21 @@
 {
 	"defaults": {
-		"package_type": "cargo"
+		"package_type": "npm"
 	},
 	"package": {
-		"monochange": {
-			"path": "crates/monochange"
+		"buailzizye_0": {
+			"path": "crates/buailzizye_0"
 		},
-		"monochange_core": {
-			"path": "crates/monochange_core"
+		"buailzizye_1": {
+			"path": "crates/buailzizye_1"
+		},
+		"buailzizye_2": {
+			"path": "crates/buailzizye_2"
 		}
 	},
 	"source": {
-		"host": "github.com",
-		"owner": "release-tools",
-		"provider": "github",
-		"repo": "release-kit"
+		"owner": "buailzizye",
+		"provider": "gitlab",
+		"repo": "wsk"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/monochange/10.json
+++ b/crates/monochange_schema/schemas/artifacts/current/monochange/10.json
@@ -1,22 +1,28 @@
 {
 	"defaults": {
-		"package_type": "cargo"
+		"package_type": "dart"
 	},
 	"package": {
-		"monochange": {
-			"path": "crates/monochange"
+		"wdvqshrxtrsr_0": {
+			"path": "crates/wdvqshrxtrsr_0"
 		},
-		"monochange_core": {
-			"path": "crates/monochange_core"
+		"wdvqshrxtrsr_1": {
+			"path": "crates/wdvqshrxtrsr_1"
 		},
-		"monochange_schema": {
-			"path": "crates/monochange_schema"
+		"wdvqshrxtrsr_2": {
+			"path": "crates/wdvqshrxtrsr_2"
+		},
+		"wdvqshrxtrsr_3": {
+			"path": "crates/wdvqshrxtrsr_3"
+		},
+		"wdvqshrxtrsr_4": {
+			"path": "crates/wdvqshrxtrsr_4"
 		}
 	},
 	"source": {
-		"host": "github.com",
-		"owner": "schema-lab",
-		"provider": "github",
-		"repo": "workspace"
+		"host": "gitea.example.com",
+		"owner": "wdvqshrxtrsr",
+		"provider": "gitea",
+		"repo": "ookn"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/monochange/10.json
+++ b/crates/monochange_schema/schemas/artifacts/current/monochange/10.json
@@ -1,28 +1,135 @@
 {
+	"changelog": {
+		"sections": {
+			"bug-fixes": {
+				"description": "Resolved defects",
+				"heading": "🐛 Bug Fixes",
+				"priority": 10
+			},
+			"features": {
+				"description": "New capabilities",
+				"heading": "✨ Features",
+				"priority": 20
+			}
+		},
+		"style": {
+			"collapsedSectionStyle": "details",
+			"metadataStyle": "blockquote",
+			"packageLabelPlacement": "after_heading",
+			"packageLabelStyle": "badge",
+			"sectionSeparator": "thematic_break"
+		},
+		"types": {
+			"feature": {
+				"bump": "minor",
+				"description": "New features",
+				"section": "features"
+			},
+			"fix": {
+				"bump": "patch",
+				"description": "Bug fixes",
+				"section": "bug-fixes"
+			}
+		}
+	},
+	"changesets": {
+		"affected": {
+			"changed_paths": [
+				"crates/posfyf/"
+			],
+			"comment_on_failure": true,
+			"enabled": true,
+			"ignored_paths": [
+				"**/*.md"
+			],
+			"required": true,
+			"skip_labels": [
+				"skip-changeset"
+			]
+		}
+	},
 	"defaults": {
-		"package_type": "dart"
+		"include_private": true,
+		"package_type": "deno",
+		"parent_bump": "patch",
+		"release_title": "posfyf release",
+		"strict_version_conflicts": false,
+		"warn_on_group_mismatch": false
+	},
+	"ecosystems": {
+		"dart": {
+			"enabled": true,
+			"publish": {
+				"enabled": true
+			},
+			"roots": [
+				"crates/dart"
+			]
+		}
+	},
+	"lints": {
+		"rules": {
+			"no-unnecessary-releases": "error"
+		},
+		"scopes": [
+			"crates/posfyf"
+		],
+		"use": [
+			"no-unnecessary-releases"
+		]
 	},
 	"package": {
-		"wdvqshrxtrsr_0": {
-			"path": "crates/wdvqshrxtrsr_0"
+		"posfyf_0": {
+			"path": "crates/posfyf_0",
+			"release": true,
+			"tag": true,
+			"type": "deno",
+			"version_format": "namespaced"
 		},
-		"wdvqshrxtrsr_1": {
-			"path": "crates/wdvqshrxtrsr_1"
+		"posfyf_1": {
+			"path": "crates/posfyf_1",
+			"release": false,
+			"tag": false,
+			"type": "deno",
+			"version_format": "namespaced"
 		},
-		"wdvqshrxtrsr_2": {
-			"path": "crates/wdvqshrxtrsr_2"
+		"posfyf_2": {
+			"path": "crates/posfyf_2",
+			"release": false,
+			"tag": false,
+			"type": "deno",
+			"version_format": "namespaced"
 		},
-		"wdvqshrxtrsr_3": {
-			"path": "crates/wdvqshrxtrsr_3"
+		"posfyf_3": {
+			"path": "crates/posfyf_3",
+			"release": false,
+			"tag": false,
+			"type": "deno",
+			"version_format": "namespaced"
 		},
-		"wdvqshrxtrsr_4": {
-			"path": "crates/wdvqshrxtrsr_4"
+		"posfyf_4": {
+			"path": "crates/posfyf_4",
+			"release": false,
+			"tag": false,
+			"type": "deno",
+			"version_format": "namespaced"
 		}
 	},
 	"source": {
-		"host": "gitea.example.com",
-		"owner": "wdvqshrxtrsr",
-		"provider": "gitea",
-		"repo": "ookn"
+		"owner": "posfyf",
+		"provider": "github",
+		"pull_requests": {
+			"auto_merge": false,
+			"base": "main",
+			"branch_prefix": "posfyf/release",
+			"enabled": true,
+			"labels": [
+				"release",
+				"automated"
+			],
+			"title": "chore(release): prepare posfyf release",
+			"verified_commits": true
+		},
+		"repo": "gqh"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/release-record/01.json
+++ b/crates/monochange_schema/schemas/artifacts/current/release-record/01.json
@@ -34,12 +34,12 @@
 		{
 			"ecosystem": "cargo",
 			"package": "fuolxbhry_0",
-			"version": "0.2.1"
+			"version": "0.3.1"
 		},
 		{
 			"ecosystem": "cargo",
 			"package": "fuolxbhry_1",
-			"version": "0.2.1"
+			"version": "0.3.1"
 		}
 	],
 	"provider": {
@@ -55,8 +55,8 @@
 			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "v0.2.1",
-			"version": "0.2.1",
+			"tagName": "v0.3.1",
+			"version": "0.3.1",
 			"versionFormat": "primary"
 		},
 		{
@@ -65,8 +65,8 @@
 			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "fuolxbhry_1/v0.2.1",
-			"version": "0.2.1",
+			"tagName": "fuolxbhry_1/v0.3.1",
+			"version": "0.3.1",
 			"versionFormat": "namespaced"
 		},
 		{
@@ -75,8 +75,8 @@
 			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "fuolxbhry_2/v0.2.1",
-			"version": "0.2.1",
+			"tagName": "fuolxbhry_2/v0.3.1",
+			"version": "0.3.1",
 			"versionFormat": "namespaced"
 		}
 	],
@@ -84,14 +84,14 @@
 		"fuolxbhry_0",
 		"fuolxbhry_1"
 	],
-	"schemaVersion": "0.2",
+	"schemaVersion": "0.3",
 	"updatedChangelogs": [
 		"fixtures/changelog-1.md"
 	],
-	"version": "0.2.1",
+	"version": "0.3.1",
 	"versions": {
-		"fuolxbhry_0": "0.2.1",
-		"fuolxbhry_1": "0.2.1",
-		"main": "0.2.1"
+		"fuolxbhry_0": "0.3.1",
+		"fuolxbhry_1": "0.3.1",
+		"main": "0.3.1"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/release-record/01.json
+++ b/crates/monochange_schema/schemas/artifacts/current/release-record/01.json
@@ -1,79 +1,97 @@
 {
 	"changedFiles": [
-		"Cargo.toml",
-		"crates/monochange_schema/Cargo.toml",
-		"crates/monochange_schema/schemas/artifacts/current/release-record/01.json"
+		"crates/fuolxbhry_0/src/lib.rs"
 	],
+	"changelogs": [],
 	"changesets": [
 		{
-			"details": "Generated from deterministic proptest seed 117.",
+			"details": "Generated from deterministic proptest seed 7324496556026249077.",
 			"path": ".changeset/schema-artifact-1.md",
 			"summary": "Exercise schema artifact fixture 1",
 			"targets": [
 				{
 					"bump": "major",
 					"causedBy": [
-						"release-record-schema-compat"
+						"fuolxbhry-schema-compat"
 					],
-					"changeType": "fix",
 					"evidenceRefs": [
-						"crates/monochange_schema/src/lib.rs"
+						"crates/fuolxbhry_0/src/lib.rs"
 					],
-					"id": "monochange_schema",
+					"id": "fuolxbhry_0",
 					"kind": "package",
-					"origin": "frontmatter"
+					"origin": ".changeset/schema-artifact-1.md"
 				}
 			]
 		}
 	],
-	"command": "mc release --commit",
+	"command": "mc release --dry-run",
 	"createdAt": "2026-01-01T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-1.md"
 	],
 	"kind": "monochange.releaseRecord",
+	"packagePublications": [
+		{
+			"ecosystem": "cargo",
+			"package": "fuolxbhry_0",
+			"version": "0.2.1"
+		},
+		{
+			"ecosystem": "cargo",
+			"package": "fuolxbhry_1",
+			"version": "0.2.1"
+		}
+	],
 	"provider": {
-		"host": "github.com",
-		"kind": "github",
-		"owner": "monochange",
-		"repo": "release-kit"
+		"host": null,
+		"kind": "gitea",
+		"owner": "fuolxbhry",
+		"repo": "mbh"
 	},
 	"releaseTargets": [
 		{
 			"id": "main",
 			"kind": "group",
-			"members": [
-				"monochange",
-				"monochange_core"
-			],
+			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "v0.3.1",
-			"version": "0.3.1",
+			"tagName": "v0.2.1",
+			"version": "0.2.1",
 			"versionFormat": "primary"
 		},
 		{
-			"id": "monochange_schema",
+			"id": "fuolxbhry_1",
 			"kind": "package",
 			"members": [],
-			"release": false,
-			"tag": false,
-			"tagName": "monochange_schema/v0.3.1",
-			"version": "0.3.1",
+			"release": true,
+			"tag": true,
+			"tagName": "fuolxbhry_1/v0.2.1",
+			"version": "0.2.1",
+			"versionFormat": "namespaced"
+		},
+		{
+			"id": "fuolxbhry_2",
+			"kind": "package",
+			"members": [],
+			"release": true,
+			"tag": true,
+			"tagName": "fuolxbhry_2/v0.2.1",
+			"version": "0.2.1",
 			"versionFormat": "namespaced"
 		}
 	],
 	"releasedPackages": [
-		"monochange",
-		"monochange_core"
+		"fuolxbhry_0",
+		"fuolxbhry_1"
 	],
-	"schemaVersion": "0.3",
+	"schemaVersion": "0.2",
 	"updatedChangelogs": [
 		"fixtures/changelog-1.md"
 	],
-	"version": "0.3.1",
+	"version": "0.2.1",
 	"versions": {
-		"main": "0.3.1",
-		"monochange_schema": "0.3.1"
+		"fuolxbhry_0": "0.2.1",
+		"fuolxbhry_1": "0.2.1",
+		"main": "0.2.1"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/release-record/02.json
+++ b/crates/monochange_schema/schemas/artifacts/current/release-record/02.json
@@ -1,79 +1,100 @@
 {
 	"changedFiles": [
-		"Cargo.toml",
-		"crates/monochange_schema/Cargo.toml",
-		"crates/monochange_schema/schemas/artifacts/current/release-record/02.json"
+		"crates/zuvuuep_0/src/lib.rs",
+		"crates/zuvuuep_1/src/lib.rs"
+	],
+	"changelogs": [
+		{
+			"format": "monochange",
+			"notes": {
+				"sections": [
+					{
+						"collapsed": false,
+						"entries": [
+							"fix: schema artifact 2"
+						],
+						"title": "Bug Fixes"
+					}
+				],
+				"summary": [
+					"Release 2"
+				],
+				"title": "v0.2.2"
+			},
+			"ownerId": "main",
+			"ownerKind": "group",
+			"path": "fixtures/changelog-2.md",
+			"rendered": "## Bug Fixes\n- fix: schema artifact 2"
+		}
 	],
 	"changesets": [
 		{
-			"details": "Generated from deterministic proptest seed 195.",
+			"details": "Generated from deterministic proptest seed 17460654867111333396.",
 			"path": ".changeset/schema-artifact-2.md",
 			"summary": "Exercise schema artifact fixture 2",
 			"targets": [
 				{
-					"bump": "major",
-					"causedBy": [
-						"release-record-schema-compat"
-					],
-					"changeType": "fix",
 					"evidenceRefs": [
-						"crates/monochange_schema/src/lib.rs"
+						"crates/zuvuuep_0/src/lib.rs"
 					],
-					"id": "monochange_schema",
+					"id": "zuvuuep_0",
 					"kind": "package",
-					"origin": "frontmatter"
+					"origin": ".changeset/schema-artifact-2.md"
 				}
 			]
 		}
 	],
-	"command": "mc release --commit",
+	"command": "mc step:release",
 	"createdAt": "2026-01-02T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-2.md"
 	],
 	"kind": "monochange.releaseRecord",
+	"packagePublications": [],
 	"provider": {
-		"host": "github.com",
-		"kind": "github",
-		"owner": "aipi",
-		"repo": "schema-fixtures"
+		"host": null,
+		"kind": "gitea",
+		"owner": "zuvuuep",
+		"repo": "ijkuqa"
 	},
 	"releaseTargets": [
 		{
 			"id": "main",
 			"kind": "group",
-			"members": [
-				"monochange",
-				"monochange_core"
-			],
+			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "v0.3.2",
-			"version": "0.3.2",
+			"tagName": "v0.2.2",
+			"version": "0.2.2",
 			"versionFormat": "primary"
 		},
 		{
-			"id": "monochange_schema",
+			"id": "zuvuuep_1",
 			"kind": "package",
 			"members": [],
-			"release": false,
-			"tag": false,
-			"tagName": "monochange_schema/v0.3.2",
-			"version": "0.3.2",
-			"versionFormat": "namespaced"
+			"release": true,
+			"tag": true,
+			"tagName": "zuvuuep_1/v0.2.2",
+			"version": "0.2.2",
+			"versionFormat": "primary"
 		}
 	],
 	"releasedPackages": [
-		"monochange",
-		"monochange_core"
+		"zuvuuep_0",
+		"zuvuuep_1",
+		"zuvuuep_2",
+		"zuvuuep_3",
+		"zuvuuep_4"
 	],
-	"schemaVersion": "0.3",
+	"schemaVersion": "0.2",
 	"updatedChangelogs": [
 		"fixtures/changelog-2.md"
 	],
-	"version": "0.3.2",
+	"version": "0.2.2",
 	"versions": {
-		"main": "0.3.2",
-		"monochange_schema": "0.3.2"
+		"main": "0.2.2",
+		"zuvuuep_0": "0.2.2",
+		"zuvuuep_1": "0.2.2",
+		"zuvuuep_2": "0.2.2"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/release-record/02.json
+++ b/crates/monochange_schema/schemas/artifacts/current/release-record/02.json
@@ -19,7 +19,7 @@
 				"summary": [
 					"Release 2"
 				],
-				"title": "v0.2.2"
+				"title": "v0.3.2"
 			},
 			"ownerId": "main",
 			"ownerKind": "group",
@@ -64,8 +64,8 @@
 			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "v0.2.2",
-			"version": "0.2.2",
+			"tagName": "v0.3.2",
+			"version": "0.3.2",
 			"versionFormat": "primary"
 		},
 		{
@@ -74,8 +74,8 @@
 			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "zuvuuep_1/v0.2.2",
-			"version": "0.2.2",
+			"tagName": "zuvuuep_1/v0.3.2",
+			"version": "0.3.2",
 			"versionFormat": "primary"
 		}
 	],
@@ -86,15 +86,15 @@
 		"zuvuuep_3",
 		"zuvuuep_4"
 	],
-	"schemaVersion": "0.2",
+	"schemaVersion": "0.3",
 	"updatedChangelogs": [
 		"fixtures/changelog-2.md"
 	],
-	"version": "0.2.2",
+	"version": "0.3.2",
 	"versions": {
-		"main": "0.2.2",
-		"zuvuuep_0": "0.2.2",
-		"zuvuuep_1": "0.2.2",
-		"zuvuuep_2": "0.2.2"
+		"main": "0.3.2",
+		"zuvuuep_0": "0.3.2",
+		"zuvuuep_1": "0.3.2",
+		"zuvuuep_2": "0.3.2"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/release-record/03.json
+++ b/crates/monochange_schema/schemas/artifacts/current/release-record/03.json
@@ -48,8 +48,8 @@
 			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "v0.2.3",
-			"version": "0.2.3",
+			"tagName": "v0.3.3",
+			"version": "0.3.3",
 			"versionFormat": "primary"
 		},
 		{
@@ -58,8 +58,8 @@
 			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "ybmo_1/v0.2.3",
-			"version": "0.2.3",
+			"tagName": "ybmo_1/v0.3.3",
+			"version": "0.3.3",
 			"versionFormat": "namespaced"
 		},
 		{
@@ -68,8 +68,8 @@
 			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "ybmo_2/v0.2.3",
-			"version": "0.2.3",
+			"tagName": "ybmo_2/v0.3.3",
+			"version": "0.3.3",
 			"versionFormat": "namespaced"
 		}
 	],
@@ -79,15 +79,15 @@
 		"ybmo_2",
 		"ybmo_3"
 	],
-	"schemaVersion": "0.2",
+	"schemaVersion": "0.3",
 	"updatedChangelogs": [
 		"fixtures/changelog-3.md"
 	],
-	"version": "0.2.3",
+	"version": "0.3.3",
 	"versions": {
-		"main": "0.2.3",
-		"ybmo_0": "0.2.3",
-		"ybmo_1": "0.2.3",
-		"ybmo_2": "0.2.3"
+		"main": "0.3.3",
+		"ybmo_0": "0.3.3",
+		"ybmo_1": "0.3.3",
+		"ybmo_2": "0.3.3"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/release-record/03.json
+++ b/crates/monochange_schema/schemas/artifacts/current/release-record/03.json
@@ -1,27 +1,29 @@
 {
 	"changedFiles": [
-		"Cargo.toml",
-		"crates/monochange_schema/Cargo.toml",
-		"crates/monochange_schema/schemas/artifacts/current/release-record/03.json"
+		"crates/ybmo_0/src/lib.rs"
 	],
+	"changelogs": [],
 	"changesets": [
 		{
-			"details": "Generated from deterministic proptest seed 225.",
+			"context": {
+				"host": "gitea.example.com",
+				"provider": "gitea"
+			},
+			"details": "Generated from deterministic proptest seed 13623607009219070259.",
 			"path": ".changeset/schema-artifact-3.md",
 			"summary": "Exercise schema artifact fixture 3",
 			"targets": [
 				{
-					"bump": "major",
 					"causedBy": [
-						"release-record-schema-compat"
+						"ybmo-schema-compat"
 					],
-					"changeType": "fix",
+					"changeType": "feature",
 					"evidenceRefs": [
-						"crates/monochange_schema/src/lib.rs"
+						"crates/ybmo_0/src/lib.rs"
 					],
-					"id": "monochange_schema",
+					"id": "ybmo_0",
 					"kind": "package",
-					"origin": "frontmatter"
+					"origin": ".changeset/schema-artifact-3.md"
 				}
 			]
 		}
@@ -32,47 +34,60 @@
 		".changeset/schema-artifact-3.md"
 	],
 	"kind": "monochange.releaseRecord",
+	"packagePublications": [],
 	"provider": {
-		"host": "github.com",
-		"kind": "github",
-		"owner": "aipi",
-		"repo": "schema-fixtures"
+		"host": null,
+		"kind": "gitea",
+		"owner": "ybmo",
+		"repo": "vjcz"
 	},
 	"releaseTargets": [
 		{
 			"id": "main",
 			"kind": "group",
-			"members": [
-				"monochange",
-				"monochange_core"
-			],
+			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "v0.3.3",
-			"version": "0.3.3",
+			"tagName": "v0.2.3",
+			"version": "0.2.3",
 			"versionFormat": "primary"
 		},
 		{
-			"id": "monochange_schema",
+			"id": "ybmo_1",
 			"kind": "package",
 			"members": [],
-			"release": false,
-			"tag": false,
-			"tagName": "monochange_schema/v0.3.3",
-			"version": "0.3.3",
+			"release": true,
+			"tag": true,
+			"tagName": "ybmo_1/v0.2.3",
+			"version": "0.2.3",
+			"versionFormat": "namespaced"
+		},
+		{
+			"id": "ybmo_2",
+			"kind": "package",
+			"members": [],
+			"release": true,
+			"tag": true,
+			"tagName": "ybmo_2/v0.2.3",
+			"version": "0.2.3",
 			"versionFormat": "namespaced"
 		}
 	],
 	"releasedPackages": [
-		"monochange"
+		"ybmo_0",
+		"ybmo_1",
+		"ybmo_2",
+		"ybmo_3"
 	],
-	"schemaVersion": "0.3",
+	"schemaVersion": "0.2",
 	"updatedChangelogs": [
 		"fixtures/changelog-3.md"
 	],
-	"version": "0.3.3",
+	"version": "0.2.3",
 	"versions": {
-		"main": "0.3.3",
-		"monochange_schema": "0.3.3"
+		"main": "0.2.3",
+		"ybmo_0": "0.2.3",
+		"ybmo_1": "0.2.3",
+		"ybmo_2": "0.2.3"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/release-record/04.json
+++ b/crates/monochange_schema/schemas/artifacts/current/release-record/04.json
@@ -44,8 +44,8 @@
 			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "v0.2.4",
-			"version": "0.2.4",
+			"tagName": "v0.3.4",
+			"version": "0.3.4",
 			"versionFormat": "primary"
 		},
 		{
@@ -54,8 +54,8 @@
 			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "acydu_1/v0.2.4",
-			"version": "0.2.4",
+			"tagName": "acydu_1/v0.3.4",
+			"version": "0.3.4",
 			"versionFormat": "primary"
 		},
 		{
@@ -64,8 +64,8 @@
 			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "acydu_2/v0.2.4",
-			"version": "0.2.4",
+			"tagName": "acydu_2/v0.3.4",
+			"version": "0.3.4",
 			"versionFormat": "primary"
 		}
 	],
@@ -75,15 +75,15 @@
 		"acydu_2",
 		"acydu_3"
 	],
-	"schemaVersion": "0.2",
+	"schemaVersion": "0.3",
 	"updatedChangelogs": [
 		"fixtures/changelog-4.md"
 	],
-	"version": "0.2.4",
+	"version": "0.3.4",
 	"versions": {
-		"acydu_0": "0.2.4",
-		"acydu_1": "0.2.4",
-		"acydu_2": "0.2.4",
-		"main": "0.2.4"
+		"acydu_0": "0.3.4",
+		"acydu_1": "0.3.4",
+		"acydu_2": "0.3.4",
+		"main": "0.3.4"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/release-record/04.json
+++ b/crates/monochange_schema/schemas/artifacts/current/release-record/04.json
@@ -1,78 +1,89 @@
 {
 	"changedFiles": [
-		"Cargo.toml",
-		"crates/monochange_schema/Cargo.toml",
-		"crates/monochange_schema/schemas/artifacts/current/release-record/04.json"
+		"crates/acydu_0/src/lib.rs"
 	],
+	"changelogs": [],
 	"changesets": [
 		{
-			"details": "Generated from deterministic proptest seed 124.",
+			"context": {
+				"host": "forgejo.example.com",
+				"provider": "forgejo"
+			},
+			"details": "Generated from deterministic proptest seed 15028899576697502756.",
 			"path": ".changeset/schema-artifact-4.md",
 			"summary": "Exercise schema artifact fixture 4",
 			"targets": [
 				{
-					"bump": "major",
-					"causedBy": [
-						"release-record-schema-compat"
-					],
-					"changeType": "fix",
 					"evidenceRefs": [
-						"crates/monochange_schema/src/lib.rs"
+						"crates/acydu_0/src/lib.rs"
 					],
-					"id": "monochange_schema",
+					"id": "acydu_0",
 					"kind": "package",
-					"origin": "frontmatter"
+					"origin": ".changeset/schema-artifact-4.md"
 				}
 			]
 		}
 	],
-	"command": "mc release --commit",
+	"command": "mc release --dry-run",
 	"createdAt": "2026-01-04T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-4.md"
 	],
 	"kind": "monochange.releaseRecord",
+	"packagePublications": [],
 	"provider": {
-		"host": "github.com",
-		"kind": "github",
-		"owner": "monochange",
-		"repo": "monochange"
+		"host": "forgejo.example.com",
+		"kind": "forgejo",
+		"owner": "acydu",
+		"repo": "xhjrbwwvc"
 	},
 	"releaseTargets": [
 		{
 			"id": "main",
 			"kind": "group",
-			"members": [
-				"monochange",
-				"monochange_core"
-			],
+			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "v0.3.4",
-			"version": "0.3.4",
+			"tagName": "v0.2.4",
+			"version": "0.2.4",
 			"versionFormat": "primary"
 		},
 		{
-			"id": "monochange_schema",
+			"id": "acydu_1",
 			"kind": "package",
 			"members": [],
-			"release": false,
-			"tag": false,
-			"tagName": "monochange_schema/v0.3.4",
-			"version": "0.3.4",
-			"versionFormat": "namespaced"
+			"release": true,
+			"tag": true,
+			"tagName": "acydu_1/v0.2.4",
+			"version": "0.2.4",
+			"versionFormat": "primary"
+		},
+		{
+			"id": "acydu_2",
+			"kind": "package",
+			"members": [],
+			"release": true,
+			"tag": true,
+			"tagName": "acydu_2/v0.2.4",
+			"version": "0.2.4",
+			"versionFormat": "primary"
 		}
 	],
 	"releasedPackages": [
-		"monochange"
+		"acydu_0",
+		"acydu_1",
+		"acydu_2",
+		"acydu_3"
 	],
-	"schemaVersion": "0.3",
+	"schemaVersion": "0.2",
 	"updatedChangelogs": [
 		"fixtures/changelog-4.md"
 	],
-	"version": "0.3.4",
+	"version": "0.2.4",
 	"versions": {
-		"main": "0.3.4",
-		"monochange_schema": "0.3.4"
+		"acydu_0": "0.2.4",
+		"acydu_1": "0.2.4",
+		"acydu_2": "0.2.4",
+		"main": "0.2.4"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/release-record/05.json
+++ b/crates/monochange_schema/schemas/artifacts/current/release-record/05.json
@@ -39,17 +39,17 @@
 		{
 			"ecosystem": "cargo",
 			"package": "kogkellsnvmp_0",
-			"version": "0.2.5"
+			"version": "0.3.5"
 		},
 		{
 			"ecosystem": "cargo",
 			"package": "kogkellsnvmp_1",
-			"version": "0.2.5"
+			"version": "0.3.5"
 		},
 		{
 			"ecosystem": "cargo",
 			"package": "kogkellsnvmp_2",
-			"version": "0.2.5"
+			"version": "0.3.5"
 		}
 	],
 	"provider": {
@@ -65,8 +65,8 @@
 			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "v0.2.5",
-			"version": "0.2.5",
+			"tagName": "v0.3.5",
+			"version": "0.3.5",
 			"versionFormat": "primary"
 		}
 	],
@@ -75,15 +75,15 @@
 		"kogkellsnvmp_1",
 		"kogkellsnvmp_2"
 	],
-	"schemaVersion": "0.2",
+	"schemaVersion": "0.3",
 	"updatedChangelogs": [
 		"fixtures/changelog-5.md"
 	],
-	"version": "0.2.5",
+	"version": "0.3.5",
 	"versions": {
-		"kogkellsnvmp_0": "0.2.5",
-		"kogkellsnvmp_1": "0.2.5",
-		"kogkellsnvmp_2": "0.2.5",
-		"main": "0.2.5"
+		"kogkellsnvmp_0": "0.3.5",
+		"kogkellsnvmp_1": "0.3.5",
+		"kogkellsnvmp_2": "0.3.5",
+		"main": "0.3.5"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/release-record/05.json
+++ b/crates/monochange_schema/schemas/artifacts/current/release-record/05.json
@@ -1,27 +1,30 @@
 {
 	"changedFiles": [
-		"Cargo.toml",
-		"crates/monochange_schema/Cargo.toml",
-		"crates/monochange_schema/schemas/artifacts/current/release-record/05.json"
+		"crates/kogkellsnvmp_0/src/lib.rs",
+		"crates/kogkellsnvmp_1/src/lib.rs",
+		"crates/kogkellsnvmp_2/src/lib.rs",
+		"crates/kogkellsnvmp_3/src/lib.rs",
+		"crates/kogkellsnvmp_4/src/lib.rs"
 	],
+	"changelogs": [],
 	"changesets": [
 		{
-			"details": "Generated from deterministic proptest seed 146.",
+			"details": "Generated from deterministic proptest seed 5009813865008077492.",
 			"path": ".changeset/schema-artifact-5.md",
 			"summary": "Exercise schema artifact fixture 5",
 			"targets": [
 				{
-					"bump": "major",
+					"bump": "none",
 					"causedBy": [
-						"release-record-schema-compat"
+						"kogkellsnvmp-schema-compat"
 					],
-					"changeType": "fix",
+					"changeType": "refactor",
 					"evidenceRefs": [
-						"crates/monochange_schema/src/lib.rs"
+						"crates/kogkellsnvmp_0/src/lib.rs"
 					],
-					"id": "monochange_schema",
+					"id": "kogkellsnvmp_0",
 					"kind": "package",
-					"origin": "frontmatter"
+					"origin": ".changeset/schema-artifact-5.md"
 				}
 			]
 		}
@@ -32,48 +35,55 @@
 		".changeset/schema-artifact-5.md"
 	],
 	"kind": "monochange.releaseRecord",
+	"packagePublications": [
+		{
+			"ecosystem": "cargo",
+			"package": "kogkellsnvmp_0",
+			"version": "0.2.5"
+		},
+		{
+			"ecosystem": "cargo",
+			"package": "kogkellsnvmp_1",
+			"version": "0.2.5"
+		},
+		{
+			"ecosystem": "cargo",
+			"package": "kogkellsnvmp_2",
+			"version": "0.2.5"
+		}
+	],
 	"provider": {
-		"host": "github.com",
-		"kind": "github",
-		"owner": "release-tools",
-		"repo": "monochange"
+		"host": null,
+		"kind": "gitea",
+		"owner": "kogkellsnvmp",
+		"repo": "juthg"
 	},
 	"releaseTargets": [
 		{
 			"id": "main",
 			"kind": "group",
-			"members": [
-				"monochange",
-				"monochange_core"
-			],
+			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "v0.3.5",
-			"version": "0.3.5",
+			"tagName": "v0.2.5",
+			"version": "0.2.5",
 			"versionFormat": "primary"
-		},
-		{
-			"id": "monochange_schema",
-			"kind": "package",
-			"members": [],
-			"release": false,
-			"tag": false,
-			"tagName": "monochange_schema/v0.3.5",
-			"version": "0.3.5",
-			"versionFormat": "namespaced"
 		}
 	],
 	"releasedPackages": [
-		"monochange",
-		"monochange_core"
+		"kogkellsnvmp_0",
+		"kogkellsnvmp_1",
+		"kogkellsnvmp_2"
 	],
-	"schemaVersion": "0.3",
+	"schemaVersion": "0.2",
 	"updatedChangelogs": [
 		"fixtures/changelog-5.md"
 	],
-	"version": "0.3.5",
+	"version": "0.2.5",
 	"versions": {
-		"main": "0.3.5",
-		"monochange_schema": "0.3.5"
+		"kogkellsnvmp_0": "0.2.5",
+		"kogkellsnvmp_1": "0.2.5",
+		"kogkellsnvmp_2": "0.2.5",
+		"main": "0.2.5"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/release-record/06.json
+++ b/crates/monochange_schema/schemas/artifacts/current/release-record/06.json
@@ -1,27 +1,48 @@
 {
 	"changedFiles": [
-		"Cargo.toml",
-		"crates/monochange_schema/Cargo.toml",
-		"crates/monochange_schema/schemas/artifacts/current/release-record/06.json"
+		"crates/hail_0/src/lib.rs"
+	],
+	"changelogs": [
+		{
+			"format": "monochange",
+			"notes": {
+				"sections": [
+					{
+						"collapsed": false,
+						"entries": [
+							"fix: schema artifact 6"
+						],
+						"title": "Bug Fixes"
+					}
+				],
+				"summary": [
+					"Release 6"
+				],
+				"title": "v0.2.6"
+			},
+			"ownerId": "main",
+			"ownerKind": "group",
+			"path": "fixtures/changelog-6.md",
+			"rendered": "## Bug Fixes\n- fix: schema artifact 6"
+		}
 	],
 	"changesets": [
 		{
-			"details": "Generated from deterministic proptest seed 60.",
+			"details": "Generated from deterministic proptest seed 8430656067206529462.",
 			"path": ".changeset/schema-artifact-6.md",
 			"summary": "Exercise schema artifact fixture 6",
 			"targets": [
 				{
-					"bump": "major",
 					"causedBy": [
-						"release-record-schema-compat"
+						"hail-schema-compat"
 					],
-					"changeType": "fix",
+					"changeType": "feature",
 					"evidenceRefs": [
-						"crates/monochange_schema/src/lib.rs"
+						"crates/hail_0/src/lib.rs"
 					],
-					"id": "monochange_schema",
+					"id": "hail_0",
 					"kind": "package",
-					"origin": "frontmatter"
+					"origin": ".changeset/schema-artifact-6.md"
 				}
 			]
 		}
@@ -32,49 +53,50 @@
 		".changeset/schema-artifact-6.md"
 	],
 	"kind": "monochange.releaseRecord",
+	"packagePublications": [],
 	"provider": {
-		"host": "github.com",
-		"kind": "github",
-		"owner": "monochange",
-		"repo": "schema-fixtures"
+		"host": null,
+		"kind": "gitlab",
+		"owner": "hail",
+		"repo": "iityebtf"
 	},
 	"releaseTargets": [
 		{
 			"id": "main",
 			"kind": "group",
-			"members": [
-				"monochange",
-				"monochange_core"
-			],
+			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "v0.3.6",
-			"version": "0.3.6",
+			"tagName": "v0.2.6",
+			"version": "0.2.6",
 			"versionFormat": "primary"
 		},
 		{
-			"id": "monochange_schema",
+			"id": "hail_1",
 			"kind": "package",
 			"members": [],
-			"release": false,
-			"tag": false,
-			"tagName": "monochange_schema/v0.3.6",
-			"version": "0.3.6",
+			"release": true,
+			"tag": true,
+			"tagName": "hail_1/v0.2.6",
+			"version": "0.2.6",
 			"versionFormat": "namespaced"
 		}
 	],
 	"releasedPackages": [
-		"monochange",
-		"monochange_core",
-		"monochange_schema"
+		"hail_0",
+		"hail_1",
+		"hail_2",
+		"hail_3"
 	],
-	"schemaVersion": "0.3",
+	"schemaVersion": "0.2",
 	"updatedChangelogs": [
 		"fixtures/changelog-6.md"
 	],
-	"version": "0.3.6",
+	"version": "0.2.6",
 	"versions": {
-		"main": "0.3.6",
-		"monochange_schema": "0.3.6"
+		"hail_0": "0.2.6",
+		"hail_1": "0.2.6",
+		"hail_2": "0.2.6",
+		"main": "0.2.6"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/release-record/06.json
+++ b/crates/monochange_schema/schemas/artifacts/current/release-record/06.json
@@ -18,7 +18,7 @@
 				"summary": [
 					"Release 6"
 				],
-				"title": "v0.2.6"
+				"title": "v0.3.6"
 			},
 			"ownerId": "main",
 			"ownerKind": "group",
@@ -67,8 +67,8 @@
 			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "v0.2.6",
-			"version": "0.2.6",
+			"tagName": "v0.3.6",
+			"version": "0.3.6",
 			"versionFormat": "primary"
 		},
 		{
@@ -77,8 +77,8 @@
 			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "hail_1/v0.2.6",
-			"version": "0.2.6",
+			"tagName": "hail_1/v0.3.6",
+			"version": "0.3.6",
 			"versionFormat": "namespaced"
 		}
 	],
@@ -88,15 +88,15 @@
 		"hail_2",
 		"hail_3"
 	],
-	"schemaVersion": "0.2",
+	"schemaVersion": "0.3",
 	"updatedChangelogs": [
 		"fixtures/changelog-6.md"
 	],
-	"version": "0.2.6",
+	"version": "0.3.6",
 	"versions": {
-		"hail_0": "0.2.6",
-		"hail_1": "0.2.6",
-		"hail_2": "0.2.6",
-		"main": "0.2.6"
+		"hail_0": "0.3.6",
+		"hail_1": "0.3.6",
+		"hail_2": "0.3.6",
+		"main": "0.3.6"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/release-record/07.json
+++ b/crates/monochange_schema/schemas/artifacts/current/release-record/07.json
@@ -1,27 +1,55 @@
 {
 	"changedFiles": [
-		"Cargo.toml",
-		"crates/monochange_schema/Cargo.toml",
-		"crates/monochange_schema/schemas/artifacts/current/release-record/07.json"
+		"crates/trsrzwekwunm_0/src/lib.rs",
+		"crates/trsrzwekwunm_1/src/lib.rs",
+		"crates/trsrzwekwunm_2/src/lib.rs",
+		"crates/trsrzwekwunm_3/src/lib.rs"
+	],
+	"changelogs": [
+		{
+			"format": "monochange",
+			"notes": {
+				"sections": [
+					{
+						"collapsed": false,
+						"entries": [
+							"fix: schema artifact 7"
+						],
+						"title": "Bug Fixes"
+					}
+				],
+				"summary": [
+					"Release 7"
+				],
+				"title": "v0.2.7"
+			},
+			"ownerId": "main",
+			"ownerKind": "group",
+			"path": "fixtures/changelog-7.md",
+			"rendered": "## Bug Fixes\n- fix: schema artifact 7"
+		}
 	],
 	"changesets": [
 		{
-			"details": "Generated from deterministic proptest seed 55.",
+			"context": {
+				"host": "gitea.example.com",
+				"provider": "gitea"
+			},
+			"details": "Generated from deterministic proptest seed 9231595614672416574.",
 			"path": ".changeset/schema-artifact-7.md",
 			"summary": "Exercise schema artifact fixture 7",
 			"targets": [
 				{
-					"bump": "major",
 					"causedBy": [
-						"release-record-schema-compat"
+						"trsrzwekwunm-schema-compat"
 					],
-					"changeType": "fix",
+					"changeType": "feature",
 					"evidenceRefs": [
-						"crates/monochange_schema/src/lib.rs"
+						"crates/trsrzwekwunm_0/src/lib.rs"
 					],
-					"id": "monochange_schema",
+					"id": "trsrzwekwunm_0",
 					"kind": "package",
-					"origin": "frontmatter"
+					"origin": ".changeset/schema-artifact-7.md"
 				}
 			]
 		}
@@ -32,49 +60,65 @@
 		".changeset/schema-artifact-7.md"
 	],
 	"kind": "monochange.releaseRecord",
+	"packagePublications": [
+		{
+			"ecosystem": "cargo",
+			"package": "trsrzwekwunm_0",
+			"version": "0.2.7"
+		},
+		{
+			"ecosystem": "cargo",
+			"package": "trsrzwekwunm_1",
+			"version": "0.2.7"
+		},
+		{
+			"ecosystem": "cargo",
+			"package": "trsrzwekwunm_2",
+			"version": "0.2.7"
+		}
+	],
 	"provider": {
-		"host": "github.com",
-		"kind": "github",
-		"owner": "schema-lab",
-		"repo": "schema-fixtures"
+		"host": null,
+		"kind": "gitea",
+		"owner": "trsrzwekwunm",
+		"repo": "qvoldgmcq"
 	},
 	"releaseTargets": [
 		{
 			"id": "main",
 			"kind": "group",
-			"members": [
-				"monochange",
-				"monochange_core"
-			],
+			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "v0.3.7",
-			"version": "0.3.7",
+			"tagName": "v0.2.7",
+			"version": "0.2.7",
 			"versionFormat": "primary"
 		},
 		{
-			"id": "monochange_schema",
+			"id": "trsrzwekwunm_1",
 			"kind": "package",
 			"members": [],
-			"release": false,
-			"tag": false,
-			"tagName": "monochange_schema/v0.3.7",
-			"version": "0.3.7",
+			"release": true,
+			"tag": true,
+			"tagName": "trsrzwekwunm_1/v0.2.7",
+			"version": "0.2.7",
 			"versionFormat": "namespaced"
 		}
 	],
 	"releasedPackages": [
-		"monochange",
-		"monochange_core",
-		"monochange_schema"
+		"trsrzwekwunm_0",
+		"trsrzwekwunm_1",
+		"trsrzwekwunm_2"
 	],
-	"schemaVersion": "0.3",
+	"schemaVersion": "0.2",
 	"updatedChangelogs": [
 		"fixtures/changelog-7.md"
 	],
-	"version": "0.3.7",
+	"version": "0.2.7",
 	"versions": {
-		"main": "0.3.7",
-		"monochange_schema": "0.3.7"
+		"main": "0.2.7",
+		"trsrzwekwunm_0": "0.2.7",
+		"trsrzwekwunm_1": "0.2.7",
+		"trsrzwekwunm_2": "0.2.7"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/release-record/07.json
+++ b/crates/monochange_schema/schemas/artifacts/current/release-record/07.json
@@ -21,7 +21,7 @@
 				"summary": [
 					"Release 7"
 				],
-				"title": "v0.2.7"
+				"title": "v0.3.7"
 			},
 			"ownerId": "main",
 			"ownerKind": "group",
@@ -64,17 +64,17 @@
 		{
 			"ecosystem": "cargo",
 			"package": "trsrzwekwunm_0",
-			"version": "0.2.7"
+			"version": "0.3.7"
 		},
 		{
 			"ecosystem": "cargo",
 			"package": "trsrzwekwunm_1",
-			"version": "0.2.7"
+			"version": "0.3.7"
 		},
 		{
 			"ecosystem": "cargo",
 			"package": "trsrzwekwunm_2",
-			"version": "0.2.7"
+			"version": "0.3.7"
 		}
 	],
 	"provider": {
@@ -90,8 +90,8 @@
 			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "v0.2.7",
-			"version": "0.2.7",
+			"tagName": "v0.3.7",
+			"version": "0.3.7",
 			"versionFormat": "primary"
 		},
 		{
@@ -100,8 +100,8 @@
 			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "trsrzwekwunm_1/v0.2.7",
-			"version": "0.2.7",
+			"tagName": "trsrzwekwunm_1/v0.3.7",
+			"version": "0.3.7",
 			"versionFormat": "namespaced"
 		}
 	],
@@ -110,15 +110,15 @@
 		"trsrzwekwunm_1",
 		"trsrzwekwunm_2"
 	],
-	"schemaVersion": "0.2",
+	"schemaVersion": "0.3",
 	"updatedChangelogs": [
 		"fixtures/changelog-7.md"
 	],
-	"version": "0.2.7",
+	"version": "0.3.7",
 	"versions": {
-		"main": "0.2.7",
-		"trsrzwekwunm_0": "0.2.7",
-		"trsrzwekwunm_1": "0.2.7",
-		"trsrzwekwunm_2": "0.2.7"
+		"main": "0.3.7",
+		"trsrzwekwunm_0": "0.3.7",
+		"trsrzwekwunm_1": "0.3.7",
+		"trsrzwekwunm_2": "0.3.7"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/release-record/08.json
+++ b/crates/monochange_schema/schemas/artifacts/current/release-record/08.json
@@ -1,79 +1,84 @@
 {
 	"changedFiles": [
-		"Cargo.toml",
-		"crates/monochange_schema/Cargo.toml",
-		"crates/monochange_schema/schemas/artifacts/current/release-record/08.json"
+		"crates/etvegios_0/src/lib.rs",
+		"crates/etvegios_1/src/lib.rs",
+		"crates/etvegios_2/src/lib.rs"
 	],
+	"changelogs": [],
 	"changesets": [
 		{
-			"details": "Generated from deterministic proptest seed 118.",
+			"details": "Generated from deterministic proptest seed 4223947513850232377.",
 			"path": ".changeset/schema-artifact-8.md",
 			"summary": "Exercise schema artifact fixture 8",
 			"targets": [
 				{
-					"bump": "major",
-					"causedBy": [
-						"release-record-schema-compat"
-					],
-					"changeType": "fix",
+					"bump": "patch",
+					"changeType": "refactor",
 					"evidenceRefs": [
-						"crates/monochange_schema/src/lib.rs"
+						"crates/etvegios_0/src/lib.rs"
 					],
-					"id": "monochange_schema",
+					"id": "etvegios_0",
 					"kind": "package",
-					"origin": "frontmatter"
+					"origin": ".changeset/schema-artifact-8.md"
 				}
 			]
 		}
 	],
-	"command": "mc release --dry-run",
+	"command": "mc release --commit",
 	"createdAt": "2026-01-08T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-8.md"
 	],
 	"kind": "monochange.releaseRecord",
+	"packagePublications": [
+		{
+			"ecosystem": "cargo",
+			"package": "etvegios_0",
+			"version": "0.2.8"
+		},
+		{
+			"ecosystem": "cargo",
+			"package": "etvegios_1",
+			"version": "0.2.8"
+		},
+		{
+			"ecosystem": "cargo",
+			"package": "etvegios_2",
+			"version": "0.2.8"
+		}
+	],
 	"provider": {
-		"host": "github.com",
-		"kind": "github",
-		"owner": "monochange",
-		"repo": "monochange"
+		"host": null,
+		"kind": "gitea",
+		"owner": "etvegios",
+		"repo": "bpagq"
 	},
 	"releaseTargets": [
 		{
 			"id": "main",
 			"kind": "group",
-			"members": [
-				"monochange",
-				"monochange_core"
-			],
+			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "v0.3.8",
-			"version": "0.3.8",
+			"tagName": "v0.2.8",
+			"version": "0.2.8",
 			"versionFormat": "primary"
-		},
-		{
-			"id": "monochange_schema",
-			"kind": "package",
-			"members": [],
-			"release": false,
-			"tag": false,
-			"tagName": "monochange_schema/v0.3.8",
-			"version": "0.3.8",
-			"versionFormat": "namespaced"
 		}
 	],
 	"releasedPackages": [
-		"monochange",
-		"monochange_core"
+		"etvegios_0",
+		"etvegios_1",
+		"etvegios_2"
 	],
-	"schemaVersion": "0.3",
+	"schemaVersion": "0.2",
 	"updatedChangelogs": [
 		"fixtures/changelog-8.md"
 	],
-	"version": "0.3.8",
+	"version": "0.2.8",
 	"versions": {
-		"main": "0.3.8",
-		"monochange_schema": "0.3.8"
+		"etvegios_0": "0.2.8",
+		"etvegios_1": "0.2.8",
+		"etvegios_2": "0.2.8",
+		"main": "0.2.8"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/release-record/08.json
+++ b/crates/monochange_schema/schemas/artifacts/current/release-record/08.json
@@ -34,17 +34,17 @@
 		{
 			"ecosystem": "cargo",
 			"package": "etvegios_0",
-			"version": "0.2.8"
+			"version": "0.3.8"
 		},
 		{
 			"ecosystem": "cargo",
 			"package": "etvegios_1",
-			"version": "0.2.8"
+			"version": "0.3.8"
 		},
 		{
 			"ecosystem": "cargo",
 			"package": "etvegios_2",
-			"version": "0.2.8"
+			"version": "0.3.8"
 		}
 	],
 	"provider": {
@@ -60,8 +60,8 @@
 			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "v0.2.8",
-			"version": "0.2.8",
+			"tagName": "v0.3.8",
+			"version": "0.3.8",
 			"versionFormat": "primary"
 		}
 	],
@@ -70,15 +70,15 @@
 		"etvegios_1",
 		"etvegios_2"
 	],
-	"schemaVersion": "0.2",
+	"schemaVersion": "0.3",
 	"updatedChangelogs": [
 		"fixtures/changelog-8.md"
 	],
-	"version": "0.2.8",
+	"version": "0.3.8",
 	"versions": {
-		"etvegios_0": "0.2.8",
-		"etvegios_1": "0.2.8",
-		"etvegios_2": "0.2.8",
-		"main": "0.2.8"
+		"etvegios_0": "0.3.8",
+		"etvegios_1": "0.3.8",
+		"etvegios_2": "0.3.8",
+		"main": "0.3.8"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/release-record/09.json
+++ b/crates/monochange_schema/schemas/artifacts/current/release-record/09.json
@@ -1,79 +1,96 @@
 {
 	"changedFiles": [
-		"Cargo.toml",
-		"crates/monochange_schema/Cargo.toml",
-		"crates/monochange_schema/schemas/artifacts/current/release-record/09.json"
+		"crates/opsncwia_0/src/lib.rs",
+		"crates/opsncwia_1/src/lib.rs",
+		"crates/opsncwia_2/src/lib.rs",
+		"crates/opsncwia_3/src/lib.rs",
+		"crates/opsncwia_4/src/lib.rs"
+	],
+	"changelogs": [
+		{
+			"format": "monochange",
+			"notes": {
+				"sections": [
+					{
+						"collapsed": false,
+						"entries": [
+							"fix: schema artifact 9"
+						],
+						"title": "Bug Fixes"
+					}
+				],
+				"summary": [
+					"Release 9"
+				],
+				"title": "v0.2.9"
+			},
+			"ownerId": "main",
+			"ownerKind": "group",
+			"path": "fixtures/changelog-9.md",
+			"rendered": "## Bug Fixes\n- fix: schema artifact 9"
+		}
 	],
 	"changesets": [
 		{
-			"details": "Generated from deterministic proptest seed 118.",
+			"details": "Generated from deterministic proptest seed 16213144066895037197.",
 			"path": ".changeset/schema-artifact-9.md",
 			"summary": "Exercise schema artifact fixture 9",
 			"targets": [
 				{
-					"bump": "major",
+					"bump": "patch",
 					"causedBy": [
-						"release-record-schema-compat"
+						"opsncwia-schema-compat"
 					],
-					"changeType": "fix",
+					"changeType": "feature",
 					"evidenceRefs": [
-						"crates/monochange_schema/src/lib.rs"
+						"crates/opsncwia_0/src/lib.rs"
 					],
-					"id": "monochange_schema",
+					"id": "opsncwia_0",
 					"kind": "package",
-					"origin": "frontmatter"
+					"origin": ".changeset/schema-artifact-9.md"
 				}
 			]
 		}
 	],
-	"command": "mc release --commit",
+	"command": "mc step:release",
 	"createdAt": "2026-01-09T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-9.md"
 	],
 	"kind": "monochange.releaseRecord",
+	"packagePublications": [],
 	"provider": {
-		"host": "github.com",
+		"host": null,
 		"kind": "github",
-		"owner": "release-tools",
-		"repo": "release-kit"
+		"owner": "opsncwia",
+		"repo": "ant"
 	},
 	"releaseTargets": [
 		{
 			"id": "main",
 			"kind": "group",
-			"members": [
-				"monochange",
-				"monochange_core"
-			],
+			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "v0.3.9",
-			"version": "0.3.9",
+			"tagName": "v0.2.9",
+			"version": "0.2.9",
 			"versionFormat": "primary"
-		},
-		{
-			"id": "monochange_schema",
-			"kind": "package",
-			"members": [],
-			"release": false,
-			"tag": false,
-			"tagName": "monochange_schema/v0.3.9",
-			"version": "0.3.9",
-			"versionFormat": "namespaced"
 		}
 	],
 	"releasedPackages": [
-		"monochange",
-		"monochange_core"
+		"opsncwia_0",
+		"opsncwia_1",
+		"opsncwia_2"
 	],
-	"schemaVersion": "0.3",
+	"schemaVersion": "0.2",
 	"updatedChangelogs": [
 		"fixtures/changelog-9.md"
 	],
-	"version": "0.3.9",
+	"version": "0.2.9",
 	"versions": {
-		"main": "0.3.9",
-		"monochange_schema": "0.3.9"
+		"main": "0.2.9",
+		"opsncwia_0": "0.2.9",
+		"opsncwia_1": "0.2.9",
+		"opsncwia_2": "0.2.9"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/release-record/09.json
+++ b/crates/monochange_schema/schemas/artifacts/current/release-record/09.json
@@ -22,7 +22,7 @@
 				"summary": [
 					"Release 9"
 				],
-				"title": "v0.2.9"
+				"title": "v0.3.9"
 			},
 			"ownerId": "main",
 			"ownerKind": "group",
@@ -72,8 +72,8 @@
 			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "v0.2.9",
-			"version": "0.2.9",
+			"tagName": "v0.3.9",
+			"version": "0.3.9",
 			"versionFormat": "primary"
 		}
 	],
@@ -82,15 +82,15 @@
 		"opsncwia_1",
 		"opsncwia_2"
 	],
-	"schemaVersion": "0.2",
+	"schemaVersion": "0.3",
 	"updatedChangelogs": [
 		"fixtures/changelog-9.md"
 	],
-	"version": "0.2.9",
+	"version": "0.3.9",
 	"versions": {
-		"main": "0.2.9",
-		"opsncwia_0": "0.2.9",
-		"opsncwia_1": "0.2.9",
-		"opsncwia_2": "0.2.9"
+		"main": "0.3.9",
+		"opsncwia_0": "0.3.9",
+		"opsncwia_1": "0.3.9",
+		"opsncwia_2": "0.3.9"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/release-record/10.json
+++ b/crates/monochange_schema/schemas/artifacts/current/release-record/10.json
@@ -1,27 +1,26 @@
 {
 	"changedFiles": [
-		"Cargo.toml",
-		"crates/monochange_schema/Cargo.toml",
-		"crates/monochange_schema/schemas/artifacts/current/release-record/10.json"
+		"crates/ijpz_0/src/lib.rs",
+		"crates/ijpz_1/src/lib.rs",
+		"crates/ijpz_2/src/lib.rs"
 	],
+	"changelogs": [],
 	"changesets": [
 		{
-			"details": "Generated from deterministic proptest seed 203.",
+			"details": "Generated from deterministic proptest seed 14522967256005614231.",
 			"path": ".changeset/schema-artifact-10.md",
 			"summary": "Exercise schema artifact fixture 10",
 			"targets": [
 				{
-					"bump": "major",
 					"causedBy": [
-						"release-record-schema-compat"
+						"ijpz-schema-compat"
 					],
-					"changeType": "fix",
 					"evidenceRefs": [
-						"crates/monochange_schema/src/lib.rs"
+						"crates/ijpz_0/src/lib.rs"
 					],
-					"id": "monochange_schema",
+					"id": "ijpz_0",
 					"kind": "package",
-					"origin": "frontmatter"
+					"origin": ".changeset/schema-artifact-10.md"
 				}
 			]
 		}
@@ -32,49 +31,87 @@
 		".changeset/schema-artifact-10.md"
 	],
 	"kind": "monochange.releaseRecord",
+	"packagePublications": [
+		{
+			"ecosystem": "cargo",
+			"package": "ijpz_0",
+			"version": "0.2.10"
+		},
+		{
+			"ecosystem": "cargo",
+			"package": "ijpz_1",
+			"version": "0.2.10"
+		},
+		{
+			"ecosystem": "cargo",
+			"package": "ijpz_2",
+			"version": "0.2.10"
+		},
+		{
+			"ecosystem": "cargo",
+			"package": "ijpz_3",
+			"version": "0.2.10"
+		},
+		{
+			"ecosystem": "cargo",
+			"package": "ijpz_4",
+			"version": "0.2.10"
+		}
+	],
 	"provider": {
-		"host": "github.com",
-		"kind": "github",
-		"owner": "schema-lab",
-		"repo": "workspace"
+		"host": "forgejo.example.com",
+		"kind": "forgejo",
+		"owner": "ijpz",
+		"repo": "leewmbab"
 	},
 	"releaseTargets": [
 		{
 			"id": "main",
 			"kind": "group",
-			"members": [
-				"monochange",
-				"monochange_core"
-			],
+			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "v0.3.10",
-			"version": "0.3.10",
+			"tagName": "v0.2.10",
+			"version": "0.2.10",
 			"versionFormat": "primary"
 		},
 		{
-			"id": "monochange_schema",
+			"id": "ijpz_1",
 			"kind": "package",
 			"members": [],
-			"release": false,
-			"tag": false,
-			"tagName": "monochange_schema/v0.3.10",
-			"version": "0.3.10",
+			"release": true,
+			"tag": true,
+			"tagName": "ijpz_1/v0.2.10",
+			"version": "0.2.10",
+			"versionFormat": "namespaced"
+		},
+		{
+			"id": "ijpz_2",
+			"kind": "package",
+			"members": [],
+			"release": true,
+			"tag": true,
+			"tagName": "ijpz_2/v0.2.10",
+			"version": "0.2.10",
 			"versionFormat": "namespaced"
 		}
 	],
 	"releasedPackages": [
-		"monochange",
-		"monochange_core",
-		"monochange_schema"
+		"ijpz_0",
+		"ijpz_1",
+		"ijpz_2",
+		"ijpz_3",
+		"ijpz_4"
 	],
-	"schemaVersion": "0.3",
+	"schemaVersion": "0.2",
 	"updatedChangelogs": [
 		"fixtures/changelog-10.md"
 	],
-	"version": "0.3.10",
+	"version": "0.2.10",
 	"versions": {
-		"main": "0.3.10",
-		"monochange_schema": "0.3.10"
+		"ijpz_0": "0.2.10",
+		"ijpz_1": "0.2.10",
+		"ijpz_2": "0.2.10",
+		"main": "0.2.10"
 	}
 }

--- a/crates/monochange_schema/schemas/artifacts/current/release-record/10.json
+++ b/crates/monochange_schema/schemas/artifacts/current/release-record/10.json
@@ -35,27 +35,27 @@
 		{
 			"ecosystem": "cargo",
 			"package": "ijpz_0",
-			"version": "0.2.10"
+			"version": "0.3.10"
 		},
 		{
 			"ecosystem": "cargo",
 			"package": "ijpz_1",
-			"version": "0.2.10"
+			"version": "0.3.10"
 		},
 		{
 			"ecosystem": "cargo",
 			"package": "ijpz_2",
-			"version": "0.2.10"
+			"version": "0.3.10"
 		},
 		{
 			"ecosystem": "cargo",
 			"package": "ijpz_3",
-			"version": "0.2.10"
+			"version": "0.3.10"
 		},
 		{
 			"ecosystem": "cargo",
 			"package": "ijpz_4",
-			"version": "0.2.10"
+			"version": "0.3.10"
 		}
 	],
 	"provider": {
@@ -71,8 +71,8 @@
 			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "v0.2.10",
-			"version": "0.2.10",
+			"tagName": "v0.3.10",
+			"version": "0.3.10",
 			"versionFormat": "primary"
 		},
 		{
@@ -81,8 +81,8 @@
 			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "ijpz_1/v0.2.10",
-			"version": "0.2.10",
+			"tagName": "ijpz_1/v0.3.10",
+			"version": "0.3.10",
 			"versionFormat": "namespaced"
 		},
 		{
@@ -91,8 +91,8 @@
 			"members": [],
 			"release": true,
 			"tag": true,
-			"tagName": "ijpz_2/v0.2.10",
-			"version": "0.2.10",
+			"tagName": "ijpz_2/v0.3.10",
+			"version": "0.3.10",
 			"versionFormat": "namespaced"
 		}
 	],
@@ -103,15 +103,15 @@
 		"ijpz_3",
 		"ijpz_4"
 	],
-	"schemaVersion": "0.2",
+	"schemaVersion": "0.3",
 	"updatedChangelogs": [
 		"fixtures/changelog-10.md"
 	],
-	"version": "0.2.10",
+	"version": "0.3.10",
 	"versions": {
-		"ijpz_0": "0.2.10",
-		"ijpz_1": "0.2.10",
-		"ijpz_2": "0.2.10",
-		"main": "0.2.10"
+		"ijpz_0": "0.3.10",
+		"ijpz_1": "0.3.10",
+		"ijpz_2": "0.3.10",
+		"main": "0.3.10"
 	}
 }

--- a/crates/xtask/src/lib.rs
+++ b/crates/xtask/src/lib.rs
@@ -182,8 +182,27 @@ struct ConfigVariant {
 	owner: String,
 	repo: String,
 	with_host: bool,
-	ecosystem: String,
+	with_api_url: bool,
+	parent_bump: String,
+	include_private: bool,
+	warn_on_group_mismatch: bool,
+	with_changelog_version_title: bool,
+	with_empty_update_message: bool,
+	with_release_title: bool,
+	strict_version_conflicts: bool,
+	default_ecosystem: String,
 	package_count: usize,
+	with_group: bool,
+	group_release: bool,
+	with_changelog: bool,
+	changelog_style: String,
+	package_label_placement: String,
+	with_ecosystems: bool,
+	enabled_ecosystem: String,
+	with_changesets_affected: bool,
+	with_lints: bool,
+	auto_merge: bool,
+	verified_commits: bool,
 }
 
 /// Core schema generation logic with configurable output directories.
@@ -444,22 +463,92 @@ fn current_config_variants() -> Vec<ConfigVariant> {
 	let snake_case_id2 = prop::collection::vec(prop::char::range('a', 'z'), 3..=12)
 		.prop_map(|chars| chars.into_iter().collect::<String>());
 	let strategy = (
-		prop::sample::select(&["github", "gitlab", "gitea", "forgejo"][..]),
-		snake_case_id,
-		snake_case_id2,
-		any::<bool>(),
-		prop::sample::select(&["cargo", "npm", "deno", "dart", "flutter", "python", "go"][..]),
-		1_usize..=5,
+		(
+			prop::sample::select(&["github", "gitlab", "gitea", "forgejo"][..]),
+			snake_case_id,
+			snake_case_id2,
+			any::<bool>(),
+			any::<bool>(),
+		),
+		(
+			prop::sample::select(&["none", "patch", "minor", "major"][..]),
+			any::<bool>(),
+			any::<bool>(),
+			any::<bool>(),
+			any::<bool>(),
+			any::<bool>(),
+			any::<bool>(),
+			prop::sample::select(&["cargo", "npm", "deno", "dart", "python", "go"][..]),
+			1_usize..=5,
+		),
+		(
+			any::<bool>(),
+			any::<bool>(),
+			any::<bool>(),
+			prop::sample::select(&["plain", "details"][..]),
+			prop::sample::select(&["after_heading", "after_change"][..]),
+			any::<bool>(),
+			prop::sample::select(&["cargo", "npm", "deno", "dart", "python", "go"][..]),
+			any::<bool>(),
+			any::<bool>(),
+			any::<bool>(),
+			any::<bool>(),
+		),
 	)
 		.prop_map(
-			|(provider_kind, owner, repo, with_host, ecosystem, package_count)| {
+			|(
+				(provider_kind, owner, repo, with_host, with_api_url),
+				(
+					parent_bump,
+					include_private,
+					warn_on_group_mismatch,
+					with_changelog_version_title,
+					with_empty_update_message,
+					with_release_title,
+					strict_version_conflicts,
+					default_ecosystem,
+					package_count,
+				),
+				(
+					with_group,
+					group_release,
+					with_changelog,
+					changelog_style,
+					package_label_placement,
+					with_ecosystems,
+					enabled_ecosystem,
+					with_changesets_affected,
+					with_lints,
+					auto_merge,
+					verified_commits,
+				),
+			)| {
 				ConfigVariant {
 					provider_kind: provider_kind.to_string(),
 					owner,
 					repo,
 					with_host,
-					ecosystem: ecosystem.to_string(),
+					with_api_url,
+					parent_bump: parent_bump.to_string(),
+					include_private,
+					warn_on_group_mismatch,
+					with_changelog_version_title,
+					with_empty_update_message,
+					with_release_title,
+					strict_version_conflicts,
+					default_ecosystem: default_ecosystem.to_string(),
 					package_count,
+					with_group,
+					group_release,
+					with_changelog,
+					changelog_style: changelog_style.to_string(),
+					package_label_placement: package_label_placement.to_string(),
+					with_ecosystems,
+					enabled_ecosystem: enabled_ecosystem.to_string(),
+					with_changesets_affected,
+					with_lints,
+					auto_merge,
+					verified_commits,
 				}
 			},
 		);
@@ -704,6 +793,9 @@ fn release_record_artifact_fixture(
 }
 
 fn config_artifact_fixture(_fixture_index: usize, variant: &ConfigVariant) -> String {
+	let mut root = Map::new();
+
+	// === source ===
 	let mut source = Map::new();
 	source.insert("provider".to_string(), json!(&variant.provider_kind));
 	source.insert("owner".to_string(), json!(&variant.owner));
@@ -714,24 +806,204 @@ fn config_artifact_fixture(_fixture_index: usize, variant: &ConfigVariant) -> St
 			json!(format!("{}.example.com", variant.provider_kind)),
 		);
 	}
+	if variant.with_api_url {
+		source.insert(
+			"api_url".to_string(),
+			json!(format!("api.{}.example.com", variant.provider_kind)),
+		);
+	}
+	let mut pull_requests = Map::new();
+	pull_requests.insert("auto_merge".to_string(), json!(variant.auto_merge));
+	pull_requests.insert("base".to_string(), json!("main"));
+	pull_requests.insert(
+		"branch_prefix".to_string(),
+		json!(format!("{}/release", variant.owner)),
+	);
+	pull_requests.insert("enabled".to_string(), json!(true));
+	pull_requests.insert("labels".to_string(), json!(["release", "automated"]));
+	pull_requests.insert(
+		"title".to_string(),
+		json!(format!("chore(release): prepare {} release", variant.owner)),
+	);
+	pull_requests.insert(
+		"verified_commits".to_string(),
+		json!(variant.verified_commits),
+	);
+	source.insert("pull_requests".to_string(), Value::Object(pull_requests));
+	root.insert("source".to_string(), Value::Object(source));
 
+	// === defaults ===
 	let mut defaults = Map::new();
-	defaults.insert("package_type".to_string(), json!(&variant.ecosystem));
+	defaults.insert(
+		"package_type".to_string(),
+		json!(&variant.default_ecosystem),
+	);
+	defaults.insert("parent_bump".to_string(), json!(&variant.parent_bump));
+	defaults.insert(
+		"include_private".to_string(),
+		json!(variant.include_private),
+	);
+	defaults.insert(
+		"warn_on_group_mismatch".to_string(),
+		json!(variant.warn_on_group_mismatch),
+	);
+	defaults.insert(
+		"strict_version_conflicts".to_string(),
+		json!(variant.strict_version_conflicts),
+	);
+	if variant.with_changelog_version_title {
+		defaults.insert(
+			"changelog_version_title".to_string(),
+			json!(format!("v{{{{version}}}} — {} release", variant.owner)),
+		);
+	}
+	if variant.with_empty_update_message {
+		defaults.insert(
+			"empty_update_message".to_string(),
+			json!(format!(
+				"No significant changes for {} packages.",
+				variant.owner
+			)),
+		);
+	}
+	if variant.with_release_title {
+		defaults.insert(
+			"release_title".to_string(),
+			json!(format!("{} release", variant.owner)),
+		);
+	}
+	root.insert("defaults".to_string(), Value::Object(defaults));
 
+	// === changelog ===
+	if variant.with_changelog {
+		let mut changelog = Map::new();
+		let mut style = Map::new();
+		style.insert("sectionSeparator".to_string(), json!("thematic_break"));
+		style.insert(
+			"packageLabelPlacement".to_string(),
+			json!(&variant.package_label_placement),
+		);
+		style.insert(
+			"collapsedSectionStyle".to_string(),
+			json!(&variant.changelog_style),
+		);
+		style.insert("packageLabelStyle".to_string(), json!("badge"));
+		style.insert("metadataStyle".to_string(), json!("blockquote"));
+		changelog.insert("style".to_string(), Value::Object(style));
+
+		let mut types = Map::new();
+		let mut fix_type = Map::new();
+		fix_type.insert("bump".to_string(), json!("patch"));
+		fix_type.insert("description".to_string(), json!("Bug fixes"));
+		fix_type.insert("section".to_string(), json!("bug-fixes"));
+		types.insert("fix".to_string(), Value::Object(fix_type));
+		let mut feat_type = Map::new();
+		feat_type.insert("bump".to_string(), json!("minor"));
+		feat_type.insert("description".to_string(), json!("New features"));
+		feat_type.insert("section".to_string(), json!("features"));
+		types.insert("feature".to_string(), Value::Object(feat_type));
+		changelog.insert("types".to_string(), Value::Object(types));
+
+		let mut sections = Map::new();
+		let mut bug_section = Map::new();
+		bug_section.insert("heading".to_string(), json!("🐛 Bug Fixes"));
+		bug_section.insert("description".to_string(), json!("Resolved defects"));
+		bug_section.insert("priority".to_string(), json!(10));
+		sections.insert("bug-fixes".to_string(), Value::Object(bug_section));
+		let mut feat_section = Map::new();
+		feat_section.insert("heading".to_string(), json!("✨ Features"));
+		feat_section.insert("description".to_string(), json!("New capabilities"));
+		feat_section.insert("priority".to_string(), json!(20));
+		sections.insert("features".to_string(), Value::Object(feat_section));
+		changelog.insert("sections".to_string(), Value::Object(sections));
+
+		root.insert("changelog".to_string(), Value::Object(changelog));
+	}
+
+	// === changesets ===
+	if variant.with_changesets_affected {
+		let mut changesets = Map::new();
+		let mut affected = Map::new();
+		affected.insert("enabled".to_string(), json!(true));
+		affected.insert("required".to_string(), json!(true));
+		affected.insert("comment_on_failure".to_string(), json!(true));
+		affected.insert(
+			"changed_paths".to_string(),
+			json!([format!("crates/{}/", variant.owner)]),
+		);
+		affected.insert("ignored_paths".to_string(), json!(["**/*.md"]));
+		affected.insert("skip_labels".to_string(), json!(["skip-changeset"]));
+		changesets.insert("affected".to_string(), Value::Object(affected));
+		root.insert("changesets".to_string(), Value::Object(changesets));
+	}
+
+	// === ecosystems ===
+	if variant.with_ecosystems {
+		let mut ecosystems = Map::new();
+		let mut eco_settings = Map::new();
+		eco_settings.insert("enabled".to_string(), json!(true));
+		eco_settings.insert(
+			"roots".to_string(),
+			json!([format!("crates/{}", variant.enabled_ecosystem)]),
+		);
+		let mut pub_settings = Map::new();
+		pub_settings.insert("enabled".to_string(), json!(true));
+		eco_settings.insert("publish".to_string(), Value::Object(pub_settings));
+		ecosystems.insert(
+			variant.enabled_ecosystem.clone(),
+			Value::Object(eco_settings),
+		);
+		root.insert("ecosystems".to_string(), Value::Object(ecosystems));
+	}
+
+	// === group ===
+	if variant.with_group {
+		let mut group_entry = Map::new();
+		group_entry.insert(
+			"packages".to_string(),
+			json!([
+				format!("{}_0", variant.owner),
+				format!("{}_1", variant.owner)
+			]),
+		);
+		group_entry.insert("release".to_string(), json!(variant.group_release));
+		group_entry.insert("tag".to_string(), json!(variant.group_release));
+		group_entry.insert("version_format".to_string(), json!("namespaced"));
+		let mut group = Map::new();
+		group.insert("main".to_string(), Value::Object(group_entry));
+		root.insert("group".to_string(), Value::Object(group));
+	}
+
+	// === lints ===
+	if variant.with_lints {
+		let mut lints = Map::new();
+		let mut rules = Map::new();
+		rules.insert("no-unnecessary-releases".to_string(), json!("error"));
+		lints.insert("rules".to_string(), Value::Object(rules));
+		lints.insert(
+			"scopes".to_string(),
+			json!([format!("crates/{}", variant.owner)]),
+		);
+		lints.insert("use".to_string(), json!(["no-unnecessary-releases"]));
+		root.insert("lints".to_string(), Value::Object(lints));
+	}
+
+	// === package ===
 	let mut packages = Map::new();
 	for i in 0..variant.package_count {
 		let pkg_name = format!("{}_{}", variant.owner, i);
 		let mut pkg = Map::new();
 		pkg.insert("path".to_string(), json!(format!("crates/{pkg_name}")));
+		pkg.insert("type".to_string(), json!(&variant.default_ecosystem));
+		pkg.insert("version_format".to_string(), json!("namespaced"));
+		pkg.insert("release".to_string(), json!(i == 0)); // first package is released
+		pkg.insert("tag".to_string(), json!(i == 0)); // first package is tagged
 		packages.insert(pkg_name, Value::Object(pkg));
 	}
+	root.insert("package".to_string(), Value::Object(packages));
 
-	serde_json::to_string_pretty(&json!({
-		"source": Value::Object(source),
-		"defaults": Value::Object(defaults),
-		"package": Value::Object(packages),
-	}))
-	.unwrap_or_else(|error| panic!("serialize config artifact fixture: {error}"))
+	serde_json::to_string_pretty(&Value::Object(root))
+		.unwrap_or_else(|error| panic!("serialize config artifact fixture: {error}"))
 }
 
 fn write_generated_file(generated_file: &GeneratedFile) -> Result<(), String> {

--- a/crates/xtask/src/lib.rs
+++ b/crates/xtask/src/lib.rs
@@ -10,6 +10,7 @@ use proptest::test_runner::Config;
 use proptest::test_runner::RngAlgorithm;
 use proptest::test_runner::TestRng;
 use proptest::test_runner::TestRunner;
+use serde_json::Map;
 use serde_json::Value;
 use serde_json::json;
 
@@ -156,13 +157,33 @@ struct GeneratedFile {
 const CURRENT_ARTIFACT_FIXTURE_COUNT: usize = 10;
 
 #[derive(Clone, Debug)]
-struct ArtifactVariant {
-	seed: u8,
-	owner: &'static str,
-	repo: &'static str,
-	package_count: usize,
-	dry_run: bool,
+struct ReleaseRecordVariant {
+	seed: u64,
+	provider_kind: String,
+	owner: String,
+	repo: String,
 	with_host: bool,
+	command: String,
+	release_target_count: usize,
+	version_format: String,
+	bump: Option<String>,
+	change_type: Option<String>,
+	with_caused_by: bool,
+	with_changeset_context: bool,
+	released_package_count: usize,
+	changed_file_count: usize,
+	with_changelogs: bool,
+	with_publications: bool,
+}
+
+#[derive(Clone, Debug)]
+struct ConfigVariant {
+	provider_kind: String,
+	owner: String,
+	repo: String,
+	with_host: bool,
+	ecosystem: String,
+	package_count: usize,
 }
 
 /// Core schema generation logic with configurable output directories.
@@ -308,42 +329,99 @@ fn artifact_files(
 	version_dir: &str,
 	schema_version: &str,
 ) -> Vec<GeneratedFile> {
-	let variants = current_artifact_variants();
+	let release_variants = current_release_record_variants();
+	let config_variants = current_config_variants();
 	let artifacts_version_dir = artifacts_dir.join(version_dir);
 	let mut files = Vec::with_capacity(CURRENT_ARTIFACT_FIXTURE_COUNT * 2);
-	for (index, variant) in variants.iter().enumerate() {
+	for (index, variant) in release_variants.iter().enumerate() {
 		let name = format!("{:02}.json", index + 1);
 		files.push(GeneratedFile {
 			path: artifacts_version_dir.join("release-record").join(&name),
 			contents: release_record_artifact_fixture(schema_version, index + 1, variant),
 		});
+	}
+	for (index, variant) in config_variants.iter().enumerate() {
+		let name = format!("{:02}.json", index + 1);
 		files.push(GeneratedFile {
-			path: artifacts_version_dir.join("monochange").join(name),
+			path: artifacts_version_dir.join("monochange").join(&name),
 			contents: config_artifact_fixture(index + 1, variant),
 		});
 	}
 	files
 }
 
-fn current_artifact_variants() -> Vec<ArtifactVariant> {
+fn current_release_record_variants() -> Vec<ReleaseRecordVariant> {
+	let snake_case_id = prop::collection::vec(prop::char::range('a', 'z'), 3..=12)
+		.prop_map(|chars| chars.into_iter().collect::<String>());
+	let snake_case_id2 = prop::collection::vec(prop::char::range('a', 'z'), 3..=12)
+		.prop_map(|chars| chars.into_iter().collect::<String>());
 	let strategy = (
-		0u8..=u8::MAX,
-		prop::sample::select(&["monochange", "aipi", "schema-lab", "release-tools"]),
-		prop::sample::select(&["monochange", "workspace", "release-kit", "schema-fixtures"]),
-		1usize..=3,
-		any::<bool>(),
-		any::<bool>(),
+		(
+			any::<u64>(),
+			prop::sample::select(&["github", "gitlab", "gitea", "forgejo"][..]),
+			snake_case_id,
+			snake_case_id2,
+			any::<bool>(),
+		),
+		(
+			prop::sample::select(
+				&[
+					"mc release --commit",
+					"mc release --dry-run",
+					"mc step:release",
+				][..],
+			),
+			1_usize..=3,
+			prop::sample::select(&["primary", "namespaced"][..]),
+			prop::option::of(prop::sample::select(
+				&["none", "patch", "minor", "major"][..],
+			)),
+			prop::option::of(prop::sample::select(
+				&["fix", "feature", "breaking", "refactor", "docs", "chore"][..],
+			)),
+		),
+		(
+			any::<bool>(),
+			any::<bool>(),
+			1_usize..=5,
+			1_usize..=5,
+			any::<bool>(),
+			any::<bool>(),
+		),
 	)
-		.prop_map(|(seed, owner, repo, package_count, dry_run, with_host)| {
-			ArtifactVariant {
-				seed,
-				owner,
-				repo,
-				package_count,
-				dry_run,
-				with_host,
-			}
-		});
+		.prop_map(
+			|(
+				(seed, provider_kind, owner, repo, with_host),
+				(command, release_target_count, version_format, bump, change_type),
+				(
+					with_caused_by,
+					with_changeset_context,
+					released_package_count,
+					changed_file_count,
+					with_changelogs,
+					with_publications,
+				),
+			)| {
+				ReleaseRecordVariant {
+					seed,
+					provider_kind: provider_kind.to_string(),
+					owner,
+					repo,
+					with_host,
+					command: command.to_string(),
+					release_target_count,
+					version_format: version_format.to_string(),
+					bump: bump.map(String::from),
+					change_type: change_type.map(String::from),
+					with_caused_by,
+					with_changeset_context,
+					released_package_count,
+					changed_file_count,
+					with_changelogs,
+					with_publications,
+				}
+			},
+		);
 	let mut runner = TestRunner::new_with_rng(
 		Config::default(),
 		TestRng::from_seed(RngAlgorithm::ChaCha, b"monochange-current-artifact-seed"),
@@ -353,7 +431,48 @@ fn current_artifact_variants() -> Vec<ArtifactVariant> {
 			strategy
 				.new_tree(&mut runner)
 				.unwrap_or_else(|error| {
-					panic!("generate current artifact fixture variant: {error}")
+					panic!("generate current release record artifact fixture variant: {error}")
+				})
+				.current()
+		})
+		.collect()
+}
+
+fn current_config_variants() -> Vec<ConfigVariant> {
+	let snake_case_id = prop::collection::vec(prop::char::range('a', 'z'), 3..=12)
+		.prop_map(|chars| chars.into_iter().collect::<String>());
+	let snake_case_id2 = prop::collection::vec(prop::char::range('a', 'z'), 3..=12)
+		.prop_map(|chars| chars.into_iter().collect::<String>());
+	let strategy = (
+		prop::sample::select(&["github", "gitlab", "gitea", "forgejo"][..]),
+		snake_case_id,
+		snake_case_id2,
+		any::<bool>(),
+		prop::sample::select(&["cargo", "npm", "deno", "dart", "flutter", "python", "go"][..]),
+		1_usize..=5,
+	)
+		.prop_map(
+			|(provider_kind, owner, repo, with_host, ecosystem, package_count)| {
+				ConfigVariant {
+					provider_kind: provider_kind.to_string(),
+					owner,
+					repo,
+					with_host,
+					ecosystem: ecosystem.to_string(),
+					package_count,
+				}
+			},
+		);
+	let mut runner = TestRunner::new_with_rng(
+		Config::default(),
+		TestRng::from_seed(RngAlgorithm::ChaCha, b"monochange-current-artifact-seed"),
+	);
+	(0..CURRENT_ARTIFACT_FIXTURE_COUNT)
+		.map(|_| {
+			strategy
+				.new_tree(&mut runner)
+				.unwrap_or_else(|error| {
+					panic!("generate current config artifact fixture variant: {error}")
 				})
 				.current()
 		})
@@ -363,128 +482,250 @@ fn current_artifact_variants() -> Vec<ArtifactVariant> {
 fn release_record_artifact_fixture(
 	version: &str,
 	fixture_index: usize,
-	variant: &ArtifactVariant,
+	variant: &ReleaseRecordVariant,
 ) -> String {
-	let mut value: Value = serde_json::from_str(
-		&monochange_schema::release_record::populated_artifact_json(version),
-	)
-	.unwrap_or_else(|error| panic!("parse release-record artifact fixture template: {error}"));
-	let release_version = format!("{version}.{fixture_index}");
-	let changed_file_name = format!("{fixture_index:02}.json");
-	let command = if variant.dry_run {
-		"mc release --dry-run"
-	} else {
-		"mc release --commit"
-	};
-	let packages = ["monochange", "monochange_core", "monochange_schema"];
-	let released_packages = packages
-		.iter()
-		.take(variant.package_count)
-		.copied()
-		.collect::<Vec<_>>();
-	let object = value
-		.as_object_mut()
-		.expect("release-record fixture object");
-	object.insert(
+	let mut root = Map::new();
+	root.insert("schemaVersion".to_string(), json!(version));
+	root.insert("kind".to_string(), json!("monochange.releaseRecord"));
+	root.insert(
 		"createdAt".to_string(),
 		json!(format!("2026-01-{fixture_index:02}T00:00:00Z")),
 	);
-	object.insert("command".to_string(), json!(command));
-	object.insert("version".to_string(), json!(release_version));
-	object.insert("releasedPackages".to_string(), json!(released_packages));
-	object.insert(
-		"changedFiles".to_string(),
-		json!([
-			"Cargo.toml",
-			"crates/monochange_schema/Cargo.toml",
-			format!(
-				"crates/monochange_schema/schemas/artifacts/current/release-record/{changed_file_name}"
-			),
-		]),
+	root.insert("command".to_string(), json!(&variant.command));
+
+	// release targets
+	let mut release_targets = Vec::new();
+	for i in 0..variant.release_target_count {
+		let mut target = Map::new();
+		let (id, kind): (String, &str) = if i == 0 {
+			("main".to_string(), "group")
+		} else {
+			(format!("{}_{}", variant.owner, i), "package")
+		};
+		target.insert("id".to_string(), json!(id));
+		target.insert("kind".to_string(), json!(kind));
+		let ver = format!("{version}.{fixture_index}");
+		target.insert("version".to_string(), json!(ver));
+		let vfmt = if i == 0 {
+			"primary"
+		} else {
+			&variant.version_format
+		};
+		target.insert("versionFormat".to_string(), json!(vfmt));
+		target.insert("tag".to_string(), json!(true));
+		target.insert("release".to_string(), json!(true));
+		let tag_name = if id == "main" {
+			format!("v{version}.{fixture_index}")
+		} else {
+			format!("{id}/v{version}.{fixture_index}")
+		};
+		target.insert("tagName".to_string(), json!(tag_name));
+		target.insert("members".to_string(), json!(Vec::<String>::new()));
+		release_targets.push(Value::Object(target));
+	}
+	root.insert("releaseTargets".to_string(), json!(release_targets));
+
+	// released packages
+	let released_packages: Vec<String> = (0..variant.released_package_count)
+		.map(|i| format!("{}_{}", variant.owner, i))
+		.collect();
+	root.insert("releasedPackages".to_string(), json!(released_packages));
+
+	// changed files
+	let changed_files: Vec<String> = (0..variant.changed_file_count)
+		.map(|i| format!("crates/{}_{}/src/lib.rs", variant.owner, i))
+		.collect();
+	root.insert("changedFiles".to_string(), json!(changed_files));
+
+	// provider — always present
+	{
+		let mut provider = Map::new();
+		provider.insert("kind".to_string(), json!(&variant.provider_kind));
+		provider.insert("owner".to_string(), json!(&variant.owner));
+		provider.insert("repo".to_string(), json!(&variant.repo));
+		if variant.with_host {
+			provider.insert(
+				"host".to_string(),
+				json!(format!("{}.example.com", variant.provider_kind)),
+			);
+		} else {
+			provider.insert("host".to_string(), Value::Null);
+		}
+		root.insert("provider".to_string(), Value::Object(provider));
+	}
+
+	// version (nullable)
+	root.insert(
+		"version".to_string(),
+		json!(format!("{version}.{fixture_index}")),
 	);
-	object.insert(
-		"updatedChangelogs".to_string(),
-		json!([format!("fixtures/changelog-{fixture_index}.md")]),
+
+	// versions object
+	let mut versions = Map::new();
+	versions.insert(
+		"main".to_string(),
+		json!(format!("{version}.{fixture_index}")),
 	);
-	object.insert(
-		"deletedChangesets".to_string(),
-		json!([format!(".changeset/schema-artifact-{fixture_index}.md")]),
-	);
-	if let Some(versions) = object.get_mut("versions").and_then(Value::as_object_mut) {
+	for i in 0..variant.released_package_count.min(3) {
 		versions.insert(
-			"main".to_string(),
-			json!(format!("{version}.{fixture_index}")),
-		);
-		versions.insert(
-			"monochange_schema".to_string(),
+			format!("{}_{}", variant.owner, i),
 			json!(format!("{version}.{fixture_index}")),
 		);
 	}
-	if let Some(targets) = object
-		.get_mut("releaseTargets")
-		.and_then(Value::as_array_mut)
-	{
-		for target in targets {
-			if let Some(target) = target.as_object_mut() {
-				target.insert(
+	root.insert("versions".to_string(), Value::Object(versions));
+
+	// changesets — targets is an array of PreparedChangesetTarget objects
+	let mut changeset = Map::new();
+	changeset.insert(
+		"path".to_string(),
+		json!(format!(".changeset/schema-artifact-{fixture_index}.md")),
+	);
+	changeset.insert(
+		"summary".to_string(),
+		json!(format!("Exercise schema artifact fixture {fixture_index}")),
+	);
+	changeset.insert(
+		"details".to_string(),
+		json!(format!(
+			"Generated from deterministic proptest seed {}.",
+			variant.seed
+		)),
+	);
+
+	// Build the changeset target entry
+	let mut cs_target = Map::new();
+	cs_target.insert("id".to_string(), json!(format!("{}_0", variant.owner)));
+	cs_target.insert("kind".to_string(), json!("package"));
+	cs_target.insert(
+		"origin".to_string(),
+		json!(format!(".changeset/schema-artifact-{fixture_index}.md")),
+	);
+	if let Some(ref bump) = variant.bump {
+		cs_target.insert("bump".to_string(), json!(bump));
+	}
+	if let Some(ref change_type) = variant.change_type {
+		cs_target.insert("changeType".to_string(), json!(change_type));
+	}
+	if variant.with_caused_by {
+		cs_target.insert(
+			"causedBy".to_string(),
+			json!([format!("{}-schema-compat", variant.owner)]),
+		);
+	}
+	cs_target.insert(
+		"evidenceRefs".to_string(),
+		json!([format!("crates/{}_0/src/lib.rs", variant.owner)]),
+	);
+
+	changeset.insert("targets".to_string(), json!([Value::Object(cs_target)]));
+
+	if variant.with_changeset_context {
+		let mut context = Map::new();
+		context.insert("provider".to_string(), json!(&variant.provider_kind));
+		context.insert(
+			"host".to_string(),
+			json!(format!("{}.example.com", variant.provider_kind)),
+		);
+		changeset.insert("context".to_string(), Value::Object(context));
+	}
+	root.insert("changesets".to_string(), json!([Value::Object(changeset)]));
+
+	// changelogs — ReleaseManifestChangelog objects
+	if variant.with_changelogs {
+		let mut changelog = Map::new();
+		changelog.insert("ownerId".to_string(), json!("main"));
+		changelog.insert("ownerKind".to_string(), json!("group"));
+		changelog.insert(
+			"path".to_string(),
+			json!(format!("fixtures/changelog-{fixture_index}.md")),
+		);
+		changelog.insert("format".to_string(), json!("monochange"));
+		let mut notes = Map::new();
+		notes.insert(
+			"title".to_string(),
+			json!(format!("v{version}.{fixture_index}")),
+		);
+		notes.insert(
+			"summary".to_string(),
+			json!([format!("Release {fixture_index}")]),
+		);
+		notes.insert("sections".to_string(), json!([{ "title": "Bug Fixes", "entries": [format!("fix: schema artifact {fixture_index}")], "collapsed": false }]));
+		changelog.insert("notes".to_string(), Value::Object(notes));
+		changelog.insert(
+			"rendered".to_string(),
+			json!(format!(
+				"## Bug Fixes\n- fix: schema artifact {fixture_index}"
+			)),
+		);
+		root.insert("changelogs".to_string(), json!([Value::Object(changelog)]));
+	} else {
+		root.insert("changelogs".to_string(), json!(Vec::<String>::new()));
+	}
+
+	// packagePublications
+	if variant.with_publications {
+		let publications: Vec<Value> = (0..variant.released_package_count)
+			.map(|i| {
+				let mut pub_entry = Map::new();
+				pub_entry.insert("ecosystem".to_string(), json!("cargo"));
+				pub_entry.insert(
+					"package".to_string(),
+					json!(format!("{}_{}", variant.owner, i)),
+				);
+				pub_entry.insert(
 					"version".to_string(),
 					json!(format!("{version}.{fixture_index}")),
 				);
-				if let Some(id) = target.get("id").and_then(Value::as_str) {
-					let tag_name = if id == "main" {
-						format!("v{version}.{fixture_index}")
-					} else {
-						format!("{id}/v{version}.{fixture_index}")
-					};
-					target.insert("tagName".to_string(), json!(tag_name));
-				}
-			}
-		}
-	}
-	if let Some(changesets) = object.get_mut("changesets").and_then(Value::as_array_mut)
-		&& let Some(changeset) = changesets.first_mut().and_then(Value::as_object_mut)
-	{
-		changeset.insert(
-			"path".to_string(),
-			json!(format!(".changeset/schema-artifact-{fixture_index}.md")),
-		);
-		changeset.insert(
-			"summary".to_string(),
-			json!(format!("Exercise schema artifact fixture {fixture_index}")),
-		);
-		changeset.insert(
-			"details".to_string(),
-			json!(format!(
-				"Generated from deterministic proptest seed {}.",
-				variant.seed
-			)),
+				Value::Object(pub_entry)
+			})
+			.collect();
+		root.insert("packagePublications".to_string(), json!(publications));
+	} else {
+		root.insert(
+			"packagePublications".to_string(),
+			json!(Vec::<String>::new()),
 		);
 	}
-	if let Some(provider) = object.get_mut("provider").and_then(Value::as_object_mut) {
-		provider.insert("owner".to_string(), json!(variant.owner));
-		provider.insert("repo".to_string(), json!(variant.repo));
-	}
-	serde_json::to_string_pretty(&value)
+
+	// deletedChangesets
+	root.insert(
+		"deletedChangesets".to_string(),
+		json!([format!(".changeset/schema-artifact-{fixture_index}.md")]),
+	);
+
+	// updatedChangelogs
+	root.insert(
+		"updatedChangelogs".to_string(),
+		json!([format!("fixtures/changelog-{fixture_index}.md")]),
+	);
+
+	serde_json::to_string_pretty(&Value::Object(root))
 		.unwrap_or_else(|error| panic!("serialize release-record artifact fixture: {error}"))
 }
 
-fn config_artifact_fixture(_fixture_index: usize, variant: &ArtifactVariant) -> String {
-	let mut source = serde_json::Map::new();
-	source.insert("provider".to_string(), json!("github"));
-	source.insert("owner".to_string(), json!(variant.owner));
-	source.insert("repo".to_string(), json!(variant.repo));
+fn config_artifact_fixture(_fixture_index: usize, variant: &ConfigVariant) -> String {
+	let mut source = Map::new();
+	source.insert("provider".to_string(), json!(&variant.provider_kind));
+	source.insert("owner".to_string(), json!(&variant.owner));
+	source.insert("repo".to_string(), json!(&variant.repo));
 	if variant.with_host {
-		source.insert("host".to_string(), json!("github.com"));
+		source.insert(
+			"host".to_string(),
+			json!(format!("{}.example.com", variant.provider_kind)),
+		);
 	}
-	let mut defaults = serde_json::Map::new();
-	defaults.insert("package_type".to_string(), json!("cargo"));
-	let mut packages = serde_json::Map::new();
-	let package_names = ["monochange", "monochange_core", "monochange_schema"];
-	for pkg_name in package_names.iter().take(variant.package_count) {
-		let mut pkg = serde_json::Map::new();
+
+	let mut defaults = Map::new();
+	defaults.insert("package_type".to_string(), json!(&variant.ecosystem));
+
+	let mut packages = Map::new();
+	for i in 0..variant.package_count {
+		let pkg_name = format!("{}_{}", variant.owner, i);
+		let mut pkg = Map::new();
 		pkg.insert("path".to_string(), json!(format!("crates/{pkg_name}")));
-		packages.insert(pkg_name.to_string(), json!(pkg));
+		packages.insert(pkg_name, Value::Object(pkg));
 	}
+
 	serde_json::to_string_pretty(&json!({
 		"source": Value::Object(source),
 		"defaults": Value::Object(defaults),


### PR DESCRIPTION
## Summary

Redesign the schema artifact generation in `xtask` to produce genuinely diverse, structurally varied fixtures instead of 10 near-identical variants that only differed in seed and date.

## What changed

### Release-record artifacts (10 fixtures)

Each artifact now varies across multiple dimensions:
- **Provider kind**: github, gitlab, gitea, forgejo
- **Provider host**: present (with domain) or null
- **Command**: `mc release --commit`, `mc release --dry-run`, `mc step:release`
- **Release target count**: 1–3 targets with version format variation (primary vs namespaced)
- **Bump severity**: none, patch, minor, major, or absent
- **Change type**: fix, feature, breaking, refactor, docs, chore, or absent
- **Caused-by**: present (as array) or absent on changeset targets
- **Evidence-refs**: always present (valid string paths)
- **Changeset context**: present (with `provider` and `host`) or absent
- **Changelogs**: present (proper `ReleaseManifestChangelog` structure) or absent
- **Package publications**: present (with required `ecosystem` field) or absent
- **Released package count**: 1–5
- **Changed file count**: 1–5

### Config artifacts (10 fixtures)

Each artifact now varies across:
- **Provider kind**: github, gitlab, gitea, forgejo (schema-valid only)
- **Owner/repo**: proptest-generated snake_case identifiers
- **Host**: present or absent in source
- **Default ecosystem**: cargo, npm, deno, dart, flutter, python, go
- **Package count**: 1–5 (all with required `path` field)

### Schema correctness fixes

- `changesets[].targets` is now a proper array of `PreparedChangesetTarget` objects (with `id`, `kind`, `origin`, and optional `bump`, `changeType`, `causedBy`, `evidenceRefs`) instead of a single string field
- `changelogs[]` now uses proper `ReleaseManifestChangelog` structure (`ownerId`, `ownerKind`, `path`, `format`, `notes`, `rendered`) instead of informal `content` field
- `packagePublications[]` now includes the required `ecosystem` field
- Provider is always present (never null) as the parser requires it
- Config packages always include the required `path` field
- Package names use readable owner-based identifiers (e.g., `kwzwxlqchac_0`) instead of raw u64 seeds (e.g., `pkg_7324496556026249077_0`)

## Design decisions

- **Determinism preserved**: same ChaCha RNG seed (`monochange-current-artifact-seed`) produces same output every time
- **Proptest strategies**: uses `prop::collection::vec(prop::char::range('a', 'z'), 3..=12)` for snake_case identifiers, `prop::sample::select` for enum values, `prop::option::of` for optional fields
- **10 artifacts per schema**: kept at 10, but each one is now genuinely diverse
- **Separate strategies**: release-record and config each get their own variant struct and generation strategy
- **No new dependencies**: all generation uses existing proptest + serde_json

## Test changes

- Updated `config_artifact_fixtures_are_valid_json` to accept any schema-valid provider (not just `"github"`)
- Updated host assertion to accept `*.example.com` patterns
- All 17 integration tests pass

## Changeset

- `monochange_schema`: minor
- `monochange_integration_tests`: minor