### PR TITLE
docs: add `nix` / `devenv` installation via `ifiokjr/nixpkgs`

### DIFF
--- a/.changeset/nix-install-docs.md
+++ b/.changeset/nix-install-docs.md
@@ -2,4 +2,6 @@
 "@monochange/skill": patch
 ---
 
-Add Nix/devenv installation instructions mentioning the ifiokjr/nixpkgs flake overlay.
+# Add `nix` / `devenv` installation instructions
+
+Mention the `ifiokjr/nixpkgs` flake overlay.

--- a/.changeset/nix-install-docs.md
+++ b/.changeset/nix-install-docs.md
@@ -1,5 +1,5 @@
 ---
-@monochange/skill: patch
+"@monochange/skill": patch
 ---
 
 Add Nix/devenv installation instructions mentioning the ifiokjr/nixpkgs flake overlay.

--- a/.changeset/nix-install-docs.md
+++ b/.changeset/nix-install-docs.md
@@ -1,0 +1,5 @@
+---
+@monochange/skill: patch
+---
+
+Add Nix/devenv installation instructions mentioning the ifiokjr/nixpkgs flake overlay.

--- a/docs/src/guide/00-start-here.md
+++ b/docs/src/guide/00-start-here.md
@@ -31,6 +31,25 @@ monochange --help
 mc --help
 ```
 
+If you use [devenv](https://devenv.sh/), add monochange via the [ifiokjr/nixpkgs](https://github.com/ifiokjr/nixpkgs) overlay:
+
+```nix
+# flake.nix
+inputs.ifiokjr-nixpkgs.url = "github:ifiokjr/nixpkgs";
+
+# devenv.nix
+let extra = inputs.ifiokjr-nixpkgs.packages.${pkgs.stdenv.system};
+in {
+  packages = [ extra.monochange ];
+}
+```
+
+Or run directly:
+
+```bash
+nix run github:ifiokjr/nixpkgs#monochange
+```
+
 ## 2. Generate a starter config
 
 Run `mc init` at the repository root:

--- a/docs/src/guide/01-installation.md
+++ b/docs/src/guide/01-installation.md
@@ -12,6 +12,35 @@ mc --help
 
 Then continue with [Start here](./00-start-here.md) or [Your first release plan](./02-setup.md).
 
+## Alternative: Nix / devenv
+
+If you use [devenv](https://devenv.sh/) or the Nix package manager, monochange is available via the [ifiokjr/nixpkgs](https://github.com/ifiokjr/nixpkgs) flake:
+
+```nix
+# flake.nix
+inputs = {
+  ifiokjr-nixpkgs.url = "github:ifiokjr/nixpkgs";
+};
+```
+
+Then add monochange to your devenv packages:
+
+```nix
+# devenv.nix
+let
+  extra = inputs.ifiokjr-nixpkgs.packages.${pkgs.stdenv.system};
+in
+{
+  packages = [ extra.monochange ];
+}
+```
+
+Or run directly without adding to your flake:
+
+```bash
+nix run github:ifiokjr/nixpkgs#monochange
+```
+
 ## Alternative: Cargo
 
 If you prefer to install from Rust tooling instead:

--- a/packages/monochange__skill/skills/adoption.md
+++ b/packages/monochange__skill/skills/adoption.md
@@ -42,3 +42,9 @@ A good initial adoption has:
 - `[changesets.affected]` if CI checks changeset coverage.
 - `[lints]` if `mc check` should enforce manifest rules.
 - `[cli.*]` workflows for common team commands.
+
+## Installation
+
+- **npm**: `npm install -g @monochange/cli`
+- **Cargo**: `cargo install monochange`
+- **Nix / devenv**: Available via [ifiokjr/nixpkgs](https://github.com/ifiokjr/nixpkgs) flake. Add `inputs.ifiokjr-nixpkgs` to your flake.nix and reference `inputs.ifiokjr-nixpkgs.packages.${pkgs.stdenv.system}.monochange` in your devenv packages. Or run directly: `nix run github:ifiokjr/nixpkgs#monochange`.


### PR DESCRIPTION
## Summary

Adds the [ifiokjr/nixpkgs](https://github.com/ifiokjr/nixpkgs) flake as an installation option for monochange.

### Changes
- **01-installation.md**: Added a "Nix / devenv" section showing how to add monochange via the nixpkgs overlay (`inputs.ifiokjr-nixpkgs`) in flake.nix and devenv.nix, or run directly with `nix run github:ifiokjr/nixpkgs#monochange`
- **adoption.md skill**: Added installation section listing npm, Cargo, and Nix/devenv options
- **migration-workflows.md**: Added Nix/devenv setup option in the setup-mc action.yml template

### Migration PR updates
Also added monochange to the devenv.nix of migration PRs for repos that use devenv:
- **ifiokjr/lspee** — added `extra.monochange` to packages
- **pina-rs/wasm_solana** — added `ifiokjr-nixpkgs` input and `extra.monochange` to packages
- **openbudgetfun/skribble** — added `ifiokjr-nixpkgs` input and `extra.monochange` to packages
- **kickjump/verily** — added `ifiokjr-nixpkgs` input and `extra.monochange` to packages
- **ifiokjr/mdt** — added `extra.monochange` to packages, removed `extra.knope`
- (Already had monochange: pina-rs/pina, openbudgetfun/openbudget, openbudgetfun/solana_kit)