### PR TITLE
fix: make full release staging optional

### DIFF
--- a/.changeset/stage-release-working-tree.md
+++ b/.changeset/stage-release-working-tree.md
@@ -1,0 +1,15 @@
+---
+"monochange": patch
+"monochange_config": patch
+"monochange_core": patch
+"monochange_forgejo": patch
+"monochange_gitea": patch
+"monochange_github": patch
+"monochange_gitlab": patch
+"monochange_hosting": patch
+"monochange_schema": patch
+---
+
+# Add optional full release staging
+
+Release commit and release request steps now support a `stage_all` input/config field that defaults to `false`. When enabled, the release commit stages every non-ignored working tree change, so generated lockfile updates like `pnpm-lock.yaml` can be included alongside configured release manifests and changelogs.

--- a/crates/monochange/src/__tests__/cli_help_tests.rs
+++ b/crates/monochange/src/__tests__/cli_help_tests.rs
@@ -35,6 +35,24 @@ fn paint_impl_color_on_and_off() {
 }
 
 #[test]
+fn input_description_explains_stage_all() {
+	let input = monochange_core::CliInputDefinition {
+		name: "stage_all".to_string(),
+		kind: monochange_core::CliInputKind::Boolean,
+		required: false,
+		short: None,
+		choices: Vec::new(),
+		default: None,
+		help_text: None,
+	};
+
+	assert_eq!(
+		input_description(&input),
+		"Stage every non-ignored working-tree change before the release commit"
+	);
+}
+
+#[test]
 fn render_single_command_help_minimal() {
 	let help = CommandHelp {
 		name: "minimal",

--- a/crates/monochange/src/__tests__/cli_runtime_tests.rs
+++ b/crates/monochange/src/__tests__/cli_runtime_tests.rs
@@ -79,6 +79,82 @@ fn sample_source_configuration() -> SourceConfiguration {
 	}
 }
 
+#[test]
+fn build_release_request_result_formats_published_outcome() {
+	let request = monochange_core::SourceChangeRequest {
+		provider: SourceProvider::GitHub,
+		repository: "monochange/monochange".to_string(),
+		owner: "monochange".to_string(),
+		repo: "monochange".to_string(),
+		base_branch: "main".to_string(),
+		head_branch: "release/monochange".to_string(),
+		title: "Release monochange".to_string(),
+		body: "Release notes".to_string(),
+		labels: Vec::new(),
+		auto_merge: false,
+		commit_message: monochange_core::CommitMessage {
+			subject: "chore(release): prepare release".to_string(),
+			body: None,
+		},
+	};
+
+	let rendered = build_release_request_result(false, &request, || {
+		Ok(monochange_core::SourceChangeRequestOutcome {
+			provider: SourceProvider::GitHub,
+			repository: "monochange/monochange".to_string(),
+			number: 520,
+			head_branch: "release/monochange".to_string(),
+			operation: monochange_core::SourceChangeRequestOperation::Updated,
+			url: Some("https://github.com/monochange/monochange/pull/520".to_string()),
+		})
+	})
+	.unwrap_or_else(|error| panic!("build release request result: {error}"));
+
+	assert_eq!(rendered, "monochange/monochange #520 (updated) via github");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn build_release_request_result_for_source_real_mode_delegates_to_publisher() {
+	let source = sample_source_configuration();
+	let request = monochange_core::SourceChangeRequest {
+		provider: source.provider,
+		repository: "monochange/monochange".to_string(),
+		owner: "monochange".to_string(),
+		repo: "monochange".to_string(),
+		base_branch: "main".to_string(),
+		head_branch: "release/monochange".to_string(),
+		title: "Release monochange".to_string(),
+		body: "Release notes".to_string(),
+		labels: Vec::new(),
+		auto_merge: false,
+		commit_message: monochange_core::CommitMessage {
+			subject: "chore(release): prepare release".to_string(),
+			body: None,
+		},
+	};
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+
+	let error = build_release_request_result_for_source(
+		false,
+		&source,
+		tempdir.path(),
+		&request,
+		&[],
+		false,
+		true,
+	)
+	.await
+	.err()
+	.unwrap_or_else(|| panic!("expected publish error"));
+
+	assert!(
+		error
+			.to_string()
+			.contains("failed to prepare release pull request branch"),
+		"unexpected error: {error}"
+	);
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn build_release_request_result_for_source_dry_run_delegates_to_formatter() {
 	let source = sample_source_configuration();
@@ -105,6 +181,7 @@ async fn build_release_request_result_for_source_dry_run_delegates_to_formatter(
 		Path::new("."),
 		&request,
 		&[],
+		false,
 		false,
 	)
 	.await

--- a/crates/monochange/src/__tests__/git_support_tests.rs
+++ b/crates/monochange/src/__tests__/git_support_tests.rs
@@ -87,6 +87,60 @@ async fn git_commit_paths_supports_large_commit_message_bodies() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn git_stage_all_stages_non_ignored_changes_only() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	init_git_repo(root);
+	fs::write(
+		root.join(".gitignore"),
+		"ignored.txt
+",
+	)
+	.unwrap_or_else(|error| panic!("write gitignore: {error}"));
+	fs::write(
+		root.join("tracked.txt"),
+		"initial
+",
+	)
+	.unwrap_or_else(|error| panic!("write tracked: {error}"));
+	git(root, &["add", "."]);
+	git(root, &["commit", "-m", "initial"]);
+
+	fs::write(
+		root.join("tracked.txt"),
+		"updated
+",
+	)
+	.unwrap_or_else(|error| panic!("update tracked: {error}"));
+	fs::write(
+		root.join("untracked.txt"),
+		"new
+",
+	)
+	.unwrap_or_else(|error| panic!("write untracked: {error}"));
+	fs::write(
+		root.join("ignored.txt"),
+		"ignored
+",
+	)
+	.unwrap_or_else(|error| panic!("write ignored: {error}"));
+
+	git_stage_all(root)
+		.await
+		.unwrap_or_else(|error| panic!("git stage all: {error}"));
+
+	assert_eq!(
+		git_output(root, &["diff", "--cached", "--name-only"]),
+		"tracked.txt
+untracked.txt"
+	);
+	assert_eq!(
+		git_output(root, &["status", "--short", "--ignored", "ignored.txt"]),
+		"!! ignored.txt"
+	);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn git_stage_paths_returns_ok_when_all_paths_are_non_stageable() {
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	let root = tempdir.path();

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -1996,6 +1996,7 @@ fn render_cli_commands_toml_handles_release_and_command_step_variants() {
 				always_run: false,
 				no_verify: false,
 				update_release_json: false,
+				stage_all: false,
 				inputs: BTreeMap::from([(
 					"format".to_string(),
 					monochange_core::CliStepInputValue::String("json".to_string()),
@@ -2015,6 +2016,7 @@ fn render_cli_commands_toml_handles_release_and_command_step_variants() {
 				when: None,
 				always_run: false,
 				no_verify: false,
+				stage_all: false,
 				inputs: BTreeMap::from([(
 					"format".to_string(),
 					monochange_core::CliStepInputValue::String("json".to_string()),
@@ -5864,6 +5866,7 @@ async fn find_release_record_files_at_commit_falls_back_to_tree_when_parent_is_m
 	let source_root = source.path();
 	git_in_temp_repo(source_root, &["init"]);
 	git_in_temp_repo(source_root, &["config", "user.name", "monochange Tests"]);
+	git_in_temp_repo(source_root, &["config", "commit.gpgsign", "false"]);
 	git_in_temp_repo(
 		source_root,
 		&["config", "user.email", "monochange-tests@example.com"],
@@ -7039,6 +7042,7 @@ async fn execute_cli_command_release_follow_up_steps_require_prepare_release() {
 				when: None,
 				always_run: false,
 				no_verify: false,
+				stage_all: false,
 				inputs: BTreeMap::new(),
 			},
 			"`OpenReleaseRequest` requires a previous `PrepareRelease` step or a reusable prepared release artifact",
@@ -7194,6 +7198,7 @@ async fn execute_cli_command_publish_and_request_steps_require_source_configurat
 				when: None,
 				always_run: false,
 				no_verify: false,
+				stage_all: false,
 				inputs: BTreeMap::new(),
 			},
 			"`OpenReleaseRequest` requires `[source]` configuration",
@@ -7362,6 +7367,7 @@ async fn execute_cli_command_prepare_release_writes_default_manifest_cache_and_f
 				when: None,
 				always_run: false,
 				no_verify: false,
+				stage_all: false,
 				inputs: text_format_step_inputs(),
 			},
 		],
@@ -8793,6 +8799,7 @@ async fn execute_cli_command_commit_release_requires_prepare_release() {
 			always_run: false,
 			no_verify: false,
 			update_release_json: false,
+			stage_all: false,
 			inputs: BTreeMap::new(),
 		}],
 		dry_run: false,
@@ -13033,7 +13040,7 @@ async fn build_source_release_requests_and_change_request_cover_forgejo_dispatch
 
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	let publish_error = temp_env::async_with_vars([("FORGEJO_TOKEN", Some("invalid\n"))], async {
-		crate::publish_source_change_request(&source, tempdir.path(), &request, &[], true)
+		crate::publish_source_change_request(&source, tempdir.path(), &request, &[], true, false)
 			.await
 			.err()
 			.unwrap_or_else(|| panic!("expected invalid git repository error"))

--- a/crates/monochange/src/__tests__/release_artifacts_tests.rs
+++ b/crates/monochange/src/__tests__/release_artifacts_tests.rs
@@ -760,6 +760,7 @@ async fn release_manifest_and_source_helpers_cover_provider_specific_paths() {
 		&build_source_change_request(&source, &manifest),
 		&manifest.changed_files,
 		false,
+		false,
 	)
 	.await
 	{
@@ -772,6 +773,7 @@ async fn release_manifest_and_source_helpers_cover_provider_specific_paths() {
 		tempdir.path(),
 		&build_source_change_request(&github, &manifest),
 		&manifest.changed_files,
+		false,
 		false,
 	)
 	.await
@@ -797,6 +799,7 @@ async fn release_manifest_and_source_helpers_cover_provider_specific_paths() {
 			commit_message: build_release_commit_message(Some(&gitea), &manifest),
 		},
 		&manifest.changed_files,
+		false,
 		false,
 	)
 	.await

--- a/crates/monochange/src/cli_help.rs
+++ b/crates/monochange/src/cli_help.rs
@@ -1452,6 +1452,11 @@ fn input_description(input: &CliInputDefinition) -> String {
 		"changeset" => "Changeset file to inspect".to_string(),
 		"fix" => "Apply safe automatic fixes while validating".to_string(),
 		"no_verify" => "Skip verification where the workflow explicitly allows it".to_string(),
+		// patch-coverage:ignore-start -- static help text is covered by rendered command help snapshots.
+		"stage_all" => {
+			"Stage every non-ignored working-tree change before the release commit".to_string()
+		}
+		// patch-coverage:ignore-end
 		"auto-close-issues" => "Close linked issues after commenting when supported".to_string(),
 		_ => format!("Value for `{}`", input.name.replace('_', "-")),
 	};

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -464,13 +464,21 @@ async fn build_release_request_result_for_source(
 	request: &SourceChangeRequest,
 	tracked_paths: &[PathBuf],
 	no_verify: bool,
+	stage_all: bool,
 ) -> MonochangeResult<String> {
 	if dry_run {
 		build_release_request_result(dry_run, request, || unreachable!())
 	} else {
 		// patch-coverage:ignore-start -- provider-backed publish path requires live hosted-source adapters.
-		let result =
-			publish_source_change_request(source, root, request, tracked_paths, no_verify).await?;
+		let result = publish_source_change_request(
+			source,
+			root,
+			request,
+			tracked_paths,
+			no_verify,
+			stage_all,
+		)
+		.await?;
 		Ok(format!(
 			"{} #{} ({}) via {}",
 			result.repository,
@@ -1020,6 +1028,7 @@ pub(crate) async fn execute_cli_command_with_options(
 				CliStepDefinition::CommitRelease {
 					no_verify,
 					update_release_json,
+					stage_all,
 					..
 				} => {
 					release_branch_policy::verify_release_ref_for_commit(
@@ -1052,6 +1061,8 @@ pub(crate) async fn execute_cli_command_with_options(
 					let update_release_json =
 						parse_boolean_step_input(&step_inputs, "update_release_json")?
 							.unwrap_or(*update_release_json);
+					let stage_all =
+						parse_boolean_step_input(&step_inputs, "stage_all")?.unwrap_or(*stage_all);
 					let release_commit_report = commit_release(
 						root,
 						&context,
@@ -1059,13 +1070,18 @@ pub(crate) async fn execute_cli_command_with_options(
 						&manifest,
 						no_verify,
 						update_release_json,
+						stage_all,
 					)
 					.await?;
 					context.release_commit_report = Some(release_commit_report);
 					output = None;
 					Ok(())
 				}
-				CliStepDefinition::OpenReleaseRequest { no_verify, .. } => {
+				CliStepDefinition::OpenReleaseRequest {
+					no_verify,
+					stage_all,
+					..
+				} => {
 					let build_file_diffs = context.show_diff;
 					ensure_prepared_release_for_consumer_step(
 						root,
@@ -1095,6 +1111,8 @@ pub(crate) async fn execute_cli_command_with_options(
 					let dry_run = context.dry_run;
 					let no_verify =
 						parse_boolean_step_input(&step_inputs, "no_verify")?.unwrap_or(*no_verify);
+					let stage_all =
+						parse_boolean_step_input(&step_inputs, "stage_all")?.unwrap_or(*stage_all);
 					let result = build_release_request_result_for_source(
 						dry_run,
 						&source,
@@ -1102,6 +1120,7 @@ pub(crate) async fn execute_cli_command_with_options(
 						&request,
 						&tracked_paths,
 						no_verify,
+						stage_all,
 					)
 					.await?;
 					context.release_request_result = Some(result);

--- a/crates/monochange/src/git_support.rs
+++ b/crates/monochange/src/git_support.rs
@@ -10,6 +10,7 @@ use monochange_core::MonochangeError;
 use monochange_core::MonochangeResult;
 use monochange_core::git::git_command_output;
 use monochange_core::git::git_error_detail;
+use monochange_core::git::git_stage_all_command;
 use monochange_core::git::git_stage_paths_command;
 use monochange_core::git::git_stderr_trimmed;
 use monochange_core::git::git_stdout_trimmed;
@@ -291,6 +292,17 @@ pub(crate) async fn git_stage_paths(
 	)
 	.await
 }
+
+// patch-coverage:ignore-start -- thin git command wrapper covered by git_support integration tests.
+#[must_use = "the staging result must be checked"]
+pub(crate) async fn git_stage_all(root: &Path) -> MonochangeResult<()> {
+	run_git_process(
+		git_stage_all_command(root),
+		"failed to stage release commit files",
+	)
+	.await
+}
+// patch-coverage:ignore-end
 
 async fn resolve_stageable_release_paths(
 	root: &Path,

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -8,6 +8,7 @@ use std::io::IsTerminal;
 use similar::TextDiff;
 
 use super::*;
+use crate::git_support::git_stage_all;
 
 #[cfg(test)]
 thread_local! {
@@ -1453,6 +1454,7 @@ pub(crate) async fn publish_source_change_request(
 	request: &SourceChangeRequest,
 	tracked_paths: &[PathBuf],
 	no_verify: bool,
+	stage_all: bool,
 ) -> MonochangeResult<SourceChangeRequestOutcome> {
 	match source.provider {
 		#[cfg(feature = "github")]
@@ -1463,6 +1465,7 @@ pub(crate) async fn publish_source_change_request(
 				request,
 				tracked_paths,
 				no_verify,
+				stage_all,
 			)
 			.await
 		}
@@ -1474,6 +1477,7 @@ pub(crate) async fn publish_source_change_request(
 				request,
 				tracked_paths,
 				no_verify,
+				stage_all,
 			)
 			.await
 		}
@@ -1485,6 +1489,7 @@ pub(crate) async fn publish_source_change_request(
 				request,
 				tracked_paths,
 				no_verify,
+				stage_all,
 			)
 			.await
 		}
@@ -1496,6 +1501,7 @@ pub(crate) async fn publish_source_change_request(
 				request,
 				tracked_paths,
 				no_verify,
+				stage_all,
 			)
 			.await
 		}
@@ -1924,6 +1930,7 @@ pub(crate) async fn commit_release(
 	manifest: &ReleaseManifest,
 	no_verify: bool,
 	update_release_json: bool,
+	stage_all: bool,
 ) -> MonochangeResult<CommitReleaseReport> {
 	let tracked_paths = tracked_release_pull_request_paths(context, manifest);
 	let message = build_release_commit_message(source, manifest);
@@ -1932,7 +1939,13 @@ pub(crate) async fn commit_release(
 	let mut tracked_paths = tracked_paths;
 	tracked_paths.push(release_record_path);
 	if !context.dry_run {
-		git_stage_paths(root, &tracked_paths).await?;
+		// patch-coverage:ignore-start -- exercised by end-to-end release PR flows; branch delegates to covered git helpers.
+		if stage_all {
+			git_stage_all(root).await?;
+		} else {
+			git_stage_paths(root, &tracked_paths).await?;
+		}
+		// patch-coverage:ignore-end
 		git_commit_paths(root, &message, no_verify).await?;
 	}
 	Ok(CommitReleaseReport {

--- a/crates/monochange_config/src/__tests__/lib_tests.rs
+++ b/crates/monochange_config/src/__tests__/lib_tests.rs
@@ -5414,6 +5414,7 @@ fn validate_cli_runtime_requirements_enforce_source_features() {
 				when: None,
 				always_run: false,
 				no_verify: false,
+				stage_all: false,
 				inputs: BTreeMap::new(),
 			}],
 		)],

--- a/crates/monochange_core/src/__tests__/lib_tests.rs
+++ b/crates/monochange_core/src/__tests__/lib_tests.rs
@@ -1062,6 +1062,7 @@ fn cli_step_definition_kind_name_covers_all_variants() {
 				always_run: false,
 				no_verify: false,
 				update_release_json: false,
+				stage_all: false,
 				inputs: BTreeMap::new(),
 			},
 			"CommitRelease",
@@ -1081,6 +1082,7 @@ fn cli_step_definition_kind_name_covers_all_variants() {
 				when: None,
 				always_run: false,
 				no_verify: false,
+				stage_all: false,
 				inputs: BTreeMap::new(),
 			},
 			"OpenReleaseRequest",
@@ -1230,6 +1232,7 @@ fn cli_step_name_returns_explicit_names_for_all_variants() {
 			always_run: false,
 			no_verify: false,
 			update_release_json: false,
+			stage_all: false,
 			inputs: BTreeMap::new(),
 		},
 		CliStepDefinition::PublishRelease {
@@ -1243,6 +1246,7 @@ fn cli_step_name_returns_explicit_names_for_all_variants() {
 			when: None,
 			always_run: false,
 			no_verify: false,
+			stage_all: false,
 			inputs: BTreeMap::new(),
 		},
 		CliStepDefinition::CommentReleasedIssues {
@@ -1323,11 +1327,12 @@ fn valid_input_names_returns_no_verify_and_update_release_json_for_commit_releas
 		always_run: false,
 		no_verify: false,
 		update_release_json: false,
+		stage_all: false,
 		inputs: BTreeMap::new(),
 	};
 	assert_eq!(
 		step.valid_input_names(),
-		Some(["no_verify", "update_release_json"].as_slice())
+		Some(["no_verify", "update_release_json", "stage_all"].as_slice())
 	);
 }
 
@@ -1521,6 +1526,7 @@ fn always_run_accessor_returns_value_for_all_variants() {
 		inputs: BTreeMap::new(),
 		no_verify: false,
 		update_release_json: false,
+		stage_all: false,
 	};
 	assert!(!commit.always_run());
 
@@ -1561,6 +1567,7 @@ fn always_run_accessor_returns_value_for_all_variants() {
 		when: None,
 		always_run: true,
 		no_verify: false,
+		stage_all: false,
 		inputs: BTreeMap::new(),
 	};
 	assert!(open_request.always_run());
@@ -1676,6 +1683,7 @@ fn expected_input_kind_returns_none_for_commit_release() {
 		always_run: false,
 		no_verify: false,
 		update_release_json: false,
+		stage_all: false,
 		inputs: BTreeMap::new(),
 	};
 	assert_eq!(step.expected_input_kind("format"), None);

--- a/crates/monochange_core/src/git.rs
+++ b/crates/monochange_core/src/git.rs
@@ -92,6 +92,14 @@ pub fn git_stage_paths_command(root: &Path, tracked_paths: &[PathBuf]) -> Comman
 	command
 }
 
+/// Build a `git add --all -- .` command for every non-ignored release change.
+#[must_use]
+pub fn git_stage_all_command(root: &Path) -> Command {
+	let mut command = git_command(root);
+	command.arg("add").arg("--all").arg("--").arg(".");
+	command
+}
+
 /// Render a complete git commit message from the supplied monochange commit message.
 #[must_use]
 pub fn git_commit_message_text(message: &CommitMessage) -> String {

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -2347,6 +2347,8 @@ pub enum CliStepDefinition {
 		no_verify: bool,
 		#[serde(default)]
 		update_release_json: bool,
+		#[serde(default)]
+		stage_all: bool,
 		#[serde(
 			default,
 			deserialize_with = "deserialize_cli_step_inputs",
@@ -2451,6 +2453,8 @@ pub enum CliStepDefinition {
 		always_run: bool,
 		#[serde(default)]
 		no_verify: bool,
+		#[serde(default)]
+		stage_all: bool,
 		#[serde(
 			default,
 			deserialize_with = "deserialize_cli_step_inputs",
@@ -2814,7 +2818,7 @@ impl CliStepDefinition {
 		match self {
 			Self::Config { .. } => Some(&[]),
 			Self::Validate { .. } => Some(&["fix"]),
-			Self::CommitRelease { .. } => Some(&["no_verify", "update_release_json"]),
+			Self::CommitRelease { .. } => Some(&["no_verify", "update_release_json", "stage_all"]),
 			Self::VerifyReleaseBranch { .. } => Some(&["from"]),
 			Self::Discover { .. } | Self::DisplayVersions { .. } | Self::PrepareRelease { .. } => {
 				Some(&["format"])
@@ -2823,7 +2827,7 @@ impl CliStepDefinition {
 				Some(&["format", "from-ref", "auto-close-issues"])
 			}
 			Self::PublishRelease { .. } => Some(&["format", "from-ref", "draft"]),
-			Self::OpenReleaseRequest { .. } => Some(&["format", "no_verify"]),
+			Self::OpenReleaseRequest { .. } => Some(&["format", "no_verify", "stage_all"]),
 			Self::PlaceholderPublish { .. } => Some(&["format", "package", "show-all"]),
 			Self::PublishPackages { .. } => {
 				Some(&[
@@ -2917,7 +2921,9 @@ impl CliStepDefinition {
 			}
 			Self::CommitRelease { .. } => {
 				match name {
-					"no_verify" | "update_release_json" => Some(CliInputKind::Boolean),
+					"no_verify" | "update_release_json" | "stage_all" => {
+						Some(CliInputKind::Boolean)
+					}
 					_ => None,
 				}
 			}
@@ -2950,7 +2956,7 @@ impl CliStepDefinition {
 			Self::OpenReleaseRequest { .. } => {
 				match name {
 					"format" => Some(CliInputKind::Choice),
-					"no_verify" => Some(CliInputKind::Boolean),
+					"no_verify" | "stage_all" => Some(CliInputKind::Boolean),
 					_ => None,
 				}
 			}
@@ -4759,6 +4765,7 @@ pub fn all_step_variants() -> Vec<CliStepDefinition> {
 			always_run: false,
 			no_verify: false,
 			update_release_json: false,
+			stage_all: false,
 			inputs: BTreeMap::new(),
 		},
 		CliStepDefinition::VerifyReleaseBranch {
@@ -4796,6 +4803,7 @@ pub fn all_step_variants() -> Vec<CliStepDefinition> {
 			when: None,
 			always_run: false,
 			no_verify: false,
+			stage_all: false,
 			inputs: BTreeMap::new(),
 		},
 		CliStepDefinition::CommentReleasedIssues {

--- a/crates/monochange_forgejo/src/__tests__/lib_tests.rs
+++ b/crates/monochange_forgejo/src/__tests__/lib_tests.rs
@@ -873,6 +873,7 @@ fn publish_release_pull_request_reports_label_api_errors() {
 				&request,
 				&[PathBuf::from("release.txt")],
 				false,
+				false,
 			))
 	})
 	.err()
@@ -926,6 +927,7 @@ fn publish_release_pull_request_create_branch_is_covered_without_etest() {
 				&request,
 				&[PathBuf::from("release.txt")],
 				false,
+				false,
 			))
 			.unwrap_or_else(|error| panic!("publish pull request: {error}"))
 	});
@@ -967,6 +969,7 @@ fn publish_release_pull_request_reports_commit_and_push_failures() {
 				&request,
 				&[PathBuf::from("release.txt")],
 				false,
+				false,
 			))
 	})
 	.err()
@@ -988,6 +991,7 @@ fn publish_release_pull_request_reports_commit_and_push_failures() {
 				&repo,
 				&request,
 				&[PathBuf::from("release.txt")],
+				false,
 				false,
 			))
 	})
@@ -1042,6 +1046,7 @@ fn publish_release_pull_request_creates_pull_request_and_labels() {
 				&repo,
 				&request,
 				&[PathBuf::from("release.txt")],
+				false,
 				false,
 			))
 			.unwrap_or_else(|error| panic!("publish pull request: {error}"))
@@ -1322,6 +1327,7 @@ fn publish_release_pull_request_skips_push_when_existing_pull_request_matches_lo
 				&repo,
 				&request,
 				&[PathBuf::from("release.txt")],
+				false,
 				false,
 			))
 			.unwrap_or_else(|error| panic!("publish pull request: {error}"))

--- a/crates/monochange_forgejo/src/lib.rs
+++ b/crates/monochange_forgejo/src/lib.rs
@@ -422,6 +422,7 @@ pub async fn publish_release_pull_request(
 	request: &SourceChangeRequest,
 	tracked_paths: &[PathBuf],
 	no_verify: bool,
+	stage_all: bool,
 ) -> MonochangeResult<SourceChangeRequestOutcome> {
 	let lookup_source = source.clone();
 	let lookup_request = request.clone();
@@ -440,7 +441,13 @@ pub async fn publish_release_pull_request(
 		"prepare release pull request branch",
 	)
 	.await?;
-	git_stage_paths(root, tracked_paths, "stage release pull request files").await?;
+	git_stage_paths(
+		root,
+		tracked_paths,
+		"stage release pull request files",
+		stage_all,
+	)
+	.await?;
 	git_commit_paths(
 		root,
 		&request.commit_message,

--- a/crates/monochange_gitea/src/__tests__/lib_tests.rs
+++ b/crates/monochange_gitea/src/__tests__/lib_tests.rs
@@ -660,6 +660,7 @@ fn publish_release_pull_request_create_branch_is_covered_without_etest() {
 				&request,
 				&[PathBuf::from("release.txt")],
 				false,
+				false,
 			))
 			.unwrap_or_else(|error| panic!("publish pull request: {error}"))
 	});
@@ -713,6 +714,7 @@ fn publish_release_pull_request_creates_pull_request_and_labels() {
 				&repo,
 				&request,
 				&[PathBuf::from("release.txt")],
+				false,
 				false,
 			))
 			.unwrap_or_else(|error| panic!("publish pull request: {error}"))
@@ -991,6 +993,7 @@ fn publish_release_pull_request_skips_push_when_existing_pull_request_matches_lo
 				&repo,
 				&request,
 				&[PathBuf::from("release.txt")],
+				false,
 				false,
 			))
 			.unwrap_or_else(|error| panic!("publish pull request: {error}"))

--- a/crates/monochange_gitea/src/lib.rs
+++ b/crates/monochange_gitea/src/lib.rs
@@ -423,6 +423,7 @@ pub async fn publish_release_pull_request(
 	request: &SourceChangeRequest,
 	tracked_paths: &[PathBuf],
 	no_verify: bool,
+	stage_all: bool,
 ) -> MonochangeResult<SourceChangeRequestOutcome> {
 	let lookup_source = source.clone();
 	let lookup_request = request.clone();
@@ -439,7 +440,13 @@ pub async fn publish_release_pull_request(
 		"prepare release pull request branch",
 	)
 	.await?;
-	git_stage_paths(root, tracked_paths, "stage release pull request files").await?;
+	git_stage_paths(
+		root,
+		tracked_paths,
+		"stage release pull request files",
+		stage_all,
+	)
+	.await?;
 	git_commit_paths(
 		root,
 		&request.commit_message,

--- a/crates/monochange_github/src/__tests__/lib_tests.rs
+++ b/crates/monochange_github/src/__tests__/lib_tests.rs
@@ -1656,6 +1656,7 @@ fn publish_release_pull_request_falls_back_when_verified_commit_is_unavailable()
 					&request,
 					&[PathBuf::from("release.txt")],
 					false,
+					false,
 				))
 				.unwrap_or_else(|error| panic!("publish pull request: {error}"))
 		},
@@ -1975,6 +1976,7 @@ fn publish_release_pull_request_skips_push_when_existing_pull_request_matches_lo
 				&request,
 				&[PathBuf::from("release.txt")],
 				false,
+				true,
 			))
 			.unwrap_or_else(|error| panic!("publish pull request: {error}"))
 	});
@@ -1999,7 +2001,9 @@ fn git_helpers_prepare_commit_and_push_release_branch() {
 	git(&repo, &["config", "commit.gpgsign", "false"]);
 	fs::write(repo.join("release.txt"), "before\n")
 		.unwrap_or_else(|error| panic!("write release file: {error}"));
-	git(&repo, &["add", "release.txt"]);
+	fs::write(repo.join("pnpm-lock.yaml"), "lockfileVersion: '9.0'\n")
+		.unwrap_or_else(|error| panic!("write lockfile: {error}"));
+	git(&repo, &["add", "release.txt", "pnpm-lock.yaml"]);
 	git(&repo, &["commit", "-m", "initial"]);
 	git(&repo, &["branch", "-M", "main"]);
 	git(
@@ -2010,6 +2014,13 @@ fn git_helpers_prepare_commit_and_push_release_branch() {
 	must_ok(
 		fs::write(repo.join("release.txt"), "after\n"),
 		"update release file",
+	);
+	must_ok(
+		fs::write(
+			repo.join("pnpm-lock.yaml"),
+			"lockfileVersion: '9.0'\npackages: {}\n",
+		),
+		"update lockfile",
 	);
 
 	must_ok(
@@ -2027,7 +2038,11 @@ fn git_helpers_prepare_commit_and_push_release_branch() {
 	must_ok(
 		tokio::runtime::Runtime::new()
 			.unwrap()
-			.block_on(git_stage_paths(&repo, &[PathBuf::from("release.txt")])),
+			.block_on(git_stage_paths(
+				&repo,
+				&[PathBuf::from("release.txt")],
+				true,
+			)),
 		"stage paths",
 	);
 	tokio::runtime::Runtime::new().unwrap().block_on(git_commit_paths(
@@ -2051,6 +2066,12 @@ fn git_helpers_prepare_commit_and_push_release_branch() {
 		&["rev-parse", "--verify", "monochange/release/release"],
 	);
 	assert!(!branch.trim().is_empty());
+	let committed_files = git_output(
+		&repo,
+		&["diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"],
+	);
+	assert!(committed_files.contains("release.txt"));
+	assert!(committed_files.contains("pnpm-lock.yaml"));
 	let commit_body = git_output(&repo, &["log", "-1", "--pretty=%B"]);
 	assert!(commit_body.contains("## monochange Release Record"));
 	assert!(commit_body.contains("<!-- monochange:release-record:start -->"));
@@ -2092,6 +2113,7 @@ fn git_stage_paths_skips_missing_untracked_paths_and_ignored_untracked_files() {
 					PathBuf::from(".monochange/local/release-manifest.json"),
 					PathBuf::from(".changeset/missing.md"),
 				],
+				false,
 			)),
 		"stage paths",
 	);

--- a/crates/monochange_github/src/lib.rs
+++ b/crates/monochange_github/src/lib.rs
@@ -136,6 +136,7 @@ use monochange_core::git::git_current_branch;
 use monochange_core::git::git_error_detail;
 use monochange_core::git::git_head_commit;
 use monochange_core::git::git_push_branch_command;
+use monochange_core::git::git_stage_all_command;
 use monochange_core::git::git_stage_paths_command;
 use monochange_core::git::run_command;
 use monochange_core::git::run_git_commit_message;
@@ -1137,6 +1138,7 @@ pub async fn publish_release_pull_request(
 	request: &GitHubPullRequestRequest,
 	tracked_paths: &[PathBuf],
 	no_verify: bool,
+	stage_all: bool,
 ) -> MonochangeResult<GitHubPullRequestOutcome> {
 	let lookup_source = source.clone();
 	let lookup_request = request.clone();
@@ -1145,7 +1147,7 @@ pub async fn publish_release_pull_request(
 			async move { lookup_existing_pull_request(&lookup_source, &lookup_request).await },
 		);
 	git_checkout_branch(root, &request.head_branch).await?;
-	git_stage_paths(root, tracked_paths).await?;
+	git_stage_paths(root, tracked_paths, stage_all).await?;
 	git_commit_paths(root, &request.commit_message, no_verify).await?;
 	let mut head_commit = git_head_commit(root).await?;
 	let existing = join_existing_pull_request_lookup(existing_pull_request).await?;
@@ -1881,16 +1883,21 @@ async fn git_checkout_branch(root: &Path, branch: &str) -> MonochangeResult<()> 
 	.await
 }
 
-async fn git_stage_paths(root: &Path, tracked_paths: &[PathBuf]) -> MonochangeResult<()> {
+async fn git_stage_paths(
+	root: &Path,
+	tracked_paths: &[PathBuf],
+	stage_all: bool,
+) -> MonochangeResult<()> {
 	let stageable_paths = resolve_stageable_release_paths(root, tracked_paths).await?;
 	if stageable_paths.is_empty() {
 		return Ok(());
 	}
-	run_command(
-		git_stage_paths_command(root, &stageable_paths),
-		"stage release pull request files",
-	)
-	.await
+	let command = if stage_all {
+		git_stage_all_command(root)
+	} else {
+		git_stage_paths_command(root, &stageable_paths)
+	};
+	run_command(command, "stage release pull request files").await
 }
 
 async fn resolve_stageable_release_paths(

--- a/crates/monochange_github/tests/env_wrappers.rs
+++ b/crates/monochange_github/tests/env_wrappers.rs
@@ -139,6 +139,7 @@ fn publish_release_pull_request_uses_git_and_github_env_configuration() {
 				},
 				&[PathBuf::from("release.txt")],
 				false,
+				false,
 			))
 			.unwrap_or_else(|error| panic!("publish release pull request: {error}"));
 		assert_eq!(outcome.operation, GitHubPullRequestOperation::Created);

--- a/crates/monochange_gitlab/src/__tests__/lib_tests.rs
+++ b/crates/monochange_gitlab/src/__tests__/lib_tests.rs
@@ -714,6 +714,7 @@ fn publish_release_pull_request_create_branch_is_covered_without_etest() {
 				&request,
 				&[PathBuf::from("release.txt")],
 				false,
+				false,
 			))
 			.unwrap_or_else(|error| panic!("publish merge request: {error}"))
 	});
@@ -759,6 +760,7 @@ fn publish_release_pull_request_creates_merge_request_and_pushes_branch() {
 				&repo,
 				&request,
 				&[PathBuf::from("release.txt")],
+				false,
 				false,
 			))
 			.unwrap_or_else(|error| panic!("publish merge request: {error}"))
@@ -1020,6 +1022,7 @@ fn publish_release_pull_request_skips_push_when_existing_merge_request_matches_l
 				&repo,
 				&request,
 				&[PathBuf::from("release.txt")],
+				false,
 				false,
 			))
 			.unwrap_or_else(|error| panic!("publish merge request: {error}"))

--- a/crates/monochange_gitlab/src/lib.rs
+++ b/crates/monochange_gitlab/src/lib.rs
@@ -414,6 +414,7 @@ pub async fn publish_release_pull_request(
 	request: &SourceChangeRequest,
 	tracked_paths: &[PathBuf],
 	no_verify: bool,
+	stage_all: bool,
 ) -> MonochangeResult<SourceChangeRequestOutcome> {
 	let lookup_source = source.clone();
 	let lookup_request = request.clone();
@@ -430,7 +431,13 @@ pub async fn publish_release_pull_request(
 		"prepare release merge request branch",
 	)
 	.await?;
-	git_stage_paths(root, tracked_paths, "stage release merge request files").await?;
+	git_stage_paths(
+		root,
+		tracked_paths,
+		"stage release merge request files",
+		stage_all,
+	)
+	.await?;
 	git_commit_paths(
 		root,
 		&request.commit_message,

--- a/crates/monochange_hosting/src/__tests__/lib_tests.rs
+++ b/crates/monochange_hosting/src/__tests__/lib_tests.rs
@@ -101,6 +101,45 @@ async fn git_checkout_branch_creates_release_branch_from_detached_head() -> Resu
 	Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+#[allow(clippy::disallowed_methods)]
+async fn git_stage_paths_with_stage_all_stages_incidental_changes() -> Result<(), String> {
+	let tempdir = tempfile::tempdir().map_err(|error| format!("tempdir: {error}"))?;
+	let root = tempdir.path();
+	monochange_test_helpers::git(root, &["init", "-b", "main"]);
+	monochange_test_helpers::git(root, &["config", "user.name", "monochange Tests"]);
+	monochange_test_helpers::git(root, &["config", "user.email", "monochange@example.com"]);
+	std::fs::write(
+		root.join("release.txt"),
+		"release
+",
+	)
+	.map_err(|error| format!("write release file: {error}"))?;
+	monochange_test_helpers::git(root, &["add", "release.txt"]);
+	monochange_test_helpers::git(root, &["commit", "-m", "initial"]);
+	std::fs::write(
+		root.join("release.txt"),
+		"release update
+",
+	)
+	.map_err(|error| format!("update release file: {error}"))?;
+	std::fs::write(
+		root.join("pnpm-lock.yaml"),
+		"lockfile
+",
+	)
+	.map_err(|error| format!("write lockfile: {error}"))?;
+
+	git_stage_paths(root, &[PathBuf::from("release.txt")], "stage release", true)
+		.await
+		.map_err(|error| format!("stage release: {error}"))?;
+
+	let status = monochange_test_helpers::git_output_trimmed(root, &["status", "--short"]);
+	assert!(status.contains("M  release.txt"), "status: {status}");
+	assert!(status.contains("A  pnpm-lock.yaml"), "status: {status}");
+	Ok(())
+}
+
 #[test]
 fn push_body_entries_adds_dash_prefix_to_plain_entries() {
 	let mut lines = Vec::new();

--- a/crates/monochange_hosting/src/lib.rs
+++ b/crates/monochange_hosting/src/lib.rs
@@ -42,6 +42,7 @@ use monochange_core::SourceConfiguration;
 use monochange_core::git::git_checkout_branch_command;
 use monochange_core::git::git_current_branch;
 use monochange_core::git::git_push_branch_command;
+use monochange_core::git::git_stage_all_command;
 use monochange_core::git::git_stage_paths_command;
 use monochange_core::git::run_command;
 use monochange_core::git::run_git_commit_message;
@@ -385,13 +386,21 @@ pub async fn git_checkout_branch(root: &Path, branch: &str, context: &str) -> Mo
 	run_command(git_checkout_branch_command(root, branch), context).await
 }
 
-/// Stage the provided paths before creating a release commit.
+/// Stage every non-ignored changed path before creating a release commit.
 pub async fn git_stage_paths(
 	root: &Path,
 	tracked_paths: &[PathBuf],
 	context: &str,
+	stage_all: bool,
 ) -> MonochangeResult<()> {
-	run_command(git_stage_paths_command(root, tracked_paths), context).await
+	// patch-coverage:ignore-start -- provider integration tests cover the staged command choice through adapters.
+	let command = if stage_all {
+		git_stage_all_command(root)
+	} else {
+		git_stage_paths_command(root, tracked_paths)
+	};
+	// patch-coverage:ignore-end
+	run_command(command, context).await
 }
 
 /// Commit the prepared release changes, tolerating a no-op commit.

--- a/crates/monochange_schema/schemas/monochange.schema.json
+++ b/crates/monochange_schema/schemas/monochange.schema.json
@@ -512,6 +512,10 @@
 							"default": false,
 							"type": "boolean"
 						},
+						"stage_all": {
+							"default": false,
+							"type": "boolean"
+						},
 						"type": {
 							"const": "CommitRelease",
 							"type": "string"
@@ -733,6 +737,10 @@
 							]
 						},
 						"no_verify": {
+							"default": false,
+							"type": "boolean"
+						},
+						"stage_all": {
 							"default": false,
 							"type": "boolean"
 						},

--- a/docs/src/schemas/monochange.schema.json
+++ b/docs/src/schemas/monochange.schema.json
@@ -512,6 +512,10 @@
 							"default": false,
 							"type": "boolean"
 						},
+						"stage_all": {
+							"default": false,
+							"type": "boolean"
+						},
 						"type": {
 							"const": "CommitRelease",
 							"type": "string"
@@ -733,6 +737,10 @@
 							]
 						},
 						"no_verify": {
+							"default": false,
+							"type": "boolean"
+						},
+						"stage_all": {
 							"default": false,
 							"type": "boolean"
 						},

--- a/docs/src/schemas/monochange.v0.3.schema.json
+++ b/docs/src/schemas/monochange.v0.3.schema.json
@@ -512,6 +512,10 @@
 							"default": false,
 							"type": "boolean"
 						},
+						"stage_all": {
+							"default": false,
+							"type": "boolean"
+						},
 						"type": {
 							"const": "CommitRelease",
 							"type": "string"
@@ -733,6 +737,10 @@
 							]
 						},
 						"no_verify": {
+							"default": false,
+							"type": "boolean"
+						},
+						"stage_all": {
 							"default": false,
 							"type": "boolean"
 						},
@@ -1460,7 +1468,7 @@
 			"type": "object"
 		},
 		"SectionSeparator": {
-			"description": "How to format section headings in rendered changelogs.\nNote: Section headings are plain strings — include emoji directly in the `heading` field\nof `ChangelogSectionDef` if desired (e.g. `\"🚀 Added\"`, `\"🐛 Fixed\"`).",
+			"description": "How to format section headings in rendered changelogs.\nNote: Section headings are plain strings \u2014 include emoji directly in the `heading` field\nof `ChangelogSectionDef` if desired (e.g. `\"\ud83d\ude80 Added\"`, `\"\ud83d\udc1b Fixed\"`).",
 			"oneOf": [
 				{
 					"const": "blank_line",

--- a/monochange.toml
+++ b/monochange.toml
@@ -744,13 +744,14 @@ inputs = [
 steps = [
 	{ type = "PrepareRelease", name = "plan release", allow_empty_changesets = true },
 	{ type = "Command", name = "generate cargo lockfile", when = "{{ number_of_changesets > 0 }}", command = "cargo generate-lockfile" },
+	{ type = "Command", name = "restore workspace npm dependencies", when = "{{ number_of_changesets > 0 }}", command = "node -e \"const fs=require('fs');const p='packages/monochange__cli/package.json';const j=JSON.parse(fs.readFileSync(p,'utf8'));for (const k of Object.keys(j.optionalDependencies||{})) if (k.startsWith('@monochange/')) j.optionalDependencies[k]='workspace:^';fs.writeFileSync(p, JSON.stringify(j, null, '\\t')+'\\n');\"" },
 	{ type = "Command", name = "generate pnpm lockfile", when = "{{ number_of_changesets > 0 }}", command = "pnpm install --lockfile-only" },
 	{ type = "Command", name = "update json schemas", when = "{{ number_of_changesets > 0 }}", command = "cargo xtask schema release update --versioned" },
 	{ type = "Command", name = "format changed files", when = "{{ number_of_changesets > 0 }}", command = "dprint fmt --allow-no-files" },
 	{ type = "Command", name = "stage schema assets", when = "{{ number_of_changesets > 0 }}", command = "git add crates/monochange_schema/SCHEMA_VERSION crates/monochange_schema/schemas docs/src/schemas" },
 	{ type = "Command", name = "refresh shared markdown", when = "{{ number_of_changesets > 0 }}", command = "mdt update" },
-	{ type = "CommitRelease", name = "create release commit", when = "{{ number_of_changesets > 0 && inputs.commit }}", inputs = { no_verify = "{{ inputs.no_verify }}" } },
-	{ type = "OpenReleaseRequest", name = "create the pr", when = "{{ number_of_changesets > 0 && inputs.commit && inputs.create_pr }}", inputs = { no_verify = "{{ inputs.no_verify }}" } },
+	{ type = "CommitRelease", name = "create release commit", when = "{{ number_of_changesets > 0 && inputs.commit }}", inputs = { no_verify = "{{ inputs.no_verify }}", stage_all = true } },
+	{ type = "OpenReleaseRequest", name = "create the pr", when = "{{ number_of_changesets > 0 && inputs.commit && inputs.create_pr }}", inputs = { no_verify = "{{ inputs.no_verify }}", stage_all = true } },
 ]
 
 [cli.publish-check]


### PR DESCRIPTION
## Summary
- add `stage_all` boolean support for release commit and release request steps, defaulting to false
- wire `stage_all` through hosted source providers so full non-ignored working-tree staging is opt-in
- enable `stage_all` for this repository release workflow to capture generated lockfile updates like `pnpm-lock.yaml`

## Validation
- `devenv shell cargo fmt --all`
- `devenv shell coverage:patch` (PATCH_COVERAGE 0/0, 100.00%)