### PR TITLE
feat: add semantic semver release guardrails

### DIFF
--- a/.changeset/semantic-semver-release-guardrails.md
+++ b/.changeset/semantic-semver-release-guardrails.md
@@ -1,0 +1,9 @@
+---
+monochange: minor
+monochange_semver: minor
+"@monochange/skill": patch
+---
+
+# add semantic semver guardrails to release planning
+
+Release planning now folds semantic analyzer evidence into compatibility assessments so public API and export diffs can raise the planned bump during previews. The guardrail is advisory: analyzer failures and uncovered semantic changes are reported as warnings instead of blocking release planning.

--- a/crates/monochange/src/__tests__/changesets_tests.rs
+++ b/crates/monochange/src/__tests__/changesets_tests.rs
@@ -1,12 +1,16 @@
 #![allow(clippy::disallowed_methods)]
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 
 use monochange_core::BumpSeverity;
+use monochange_core::ChangeSignal;
 use monochange_core::ChangesetContext;
 use monochange_core::ChangesetRevision;
 use monochange_core::ChangesetTargetKind;
+use monochange_core::DiscoveryReport;
+use monochange_core::Ecosystem;
 use monochange_core::HostedCommitRef;
 use monochange_core::HostedIssueRef;
 use monochange_core::HostedIssueRelationshipKind;
@@ -14,21 +18,56 @@ use monochange_core::HostedReviewRequestKind;
 use monochange_core::HostedReviewRequestRef;
 use monochange_core::HostingCapabilities;
 use monochange_core::HostingProviderKind;
+use monochange_core::PackageRecord;
+use monochange_core::PublishState;
+use semver::Version;
 
 use super::batch_git_log;
 use super::build_prepared_changesets;
+use super::build_release_plan_from_signals;
 use super::diagnose_changesets;
 use super::discover_changeset_paths;
+use super::has_semantic_guardrail_candidate;
 use super::parse_batch_git_log_bytes;
 use super::parse_batch_git_log_output;
 use super::render_changeset_diagnostics;
 use super::render_changeset_markdown;
+use super::semantic_compatibility_evidence;
+use super::semantic_package_targets;
 use crate::ChangesetDiagnosticsReport;
 use crate::PreparedChangeset;
 use crate::PreparedChangesetTarget;
 
 fn setup_fixture(relative: &str) -> tempfile::TempDir {
 	monochange_test_helpers::fs::setup_fixture_from(env!("CARGO_MANIFEST_DIR"), relative)
+}
+
+fn make_test_package_record(id: &str) -> PackageRecord {
+	let mut package = PackageRecord::new(
+		Ecosystem::Cargo,
+		id.to_string(),
+		PathBuf::from("crates/core/Cargo.toml"),
+		PathBuf::from("crates/core"),
+		Some(Version::new(1, 0, 0)),
+		PublishState::Public,
+	);
+	package.id = id.to_string();
+	package
+}
+
+fn make_test_change_signal(package_id: &str, bump: BumpSeverity) -> ChangeSignal {
+	ChangeSignal {
+		package_id: package_id.to_string(),
+		requested_bump: Some(bump),
+		explicit_version: None,
+		change_origin: "test".to_string(),
+		evidence_refs: Vec::new(),
+		notes: None,
+		details: None,
+		change_type: None,
+		caused_by: Vec::new(),
+		source_path: PathBuf::from(".changeset/test.md"),
+	}
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -451,4 +490,210 @@ fn parse_batch_git_log_output_ignores_malformed_name_status_lines() {
 	);
 	assert!(introduced.is_empty());
 	assert!(last_updated.is_empty());
+}
+
+#[test]
+fn semantic_guardrail_skips_non_git_roots_without_warning() {
+	let tempdir = tempfile::TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let signal = make_test_change_signal("core", BumpSeverity::Patch);
+
+	let (evidence, warnings) = semantic_compatibility_evidence(tempdir.path(), &[], &[signal]);
+
+	assert!(evidence.is_empty());
+	assert!(warnings.is_empty());
+}
+
+#[test]
+fn semantic_guardrail_skips_changeset_only_updates_without_warning() {
+	let tempdir = tempfile::TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	run_git_test_command(tempdir.path(), &["init", "-b", "main"]);
+	run_git_test_command(tempdir.path(), &["config", "user.name", "monochange test"]);
+	run_git_test_command(
+		tempdir.path(),
+		&["config", "user.email", "test@example.com"],
+	);
+	fs::create_dir_all(tempdir.path().join(".changeset"))
+		.unwrap_or_else(|error| panic!("create changeset directory: {error}"));
+	fs::write(tempdir.path().join(".changeset/core.md"), "initial")
+		.unwrap_or_else(|error| panic!("write initial changeset: {error}"));
+	run_git_test_command(tempdir.path(), &["add", "."]);
+	run_git_test_command(tempdir.path(), &["commit", "-m", "initial fixture"]);
+	fs::write(tempdir.path().join(".changeset/core.md"), "updated")
+		.unwrap_or_else(|error| panic!("write updated changeset: {error}"));
+	let signal = make_test_change_signal("core", BumpSeverity::Patch);
+
+	let (evidence, warnings) = semantic_compatibility_evidence(tempdir.path(), &[], &[signal]);
+
+	assert!(evidence.is_empty());
+	assert!(warnings.is_empty());
+}
+
+#[test]
+fn semantic_guardrail_candidate_detection_uses_supported_source_extensions() {
+	assert!(has_semantic_guardrail_candidate(&[PathBuf::from(
+		"crates/core/src/lib.rs"
+	)]));
+	assert!(has_semantic_guardrail_candidate(&[PathBuf::from(
+		"packages/core/package.json"
+	)]));
+	assert!(!has_semantic_guardrail_candidate(&[PathBuf::from(
+		".changeset/core.md"
+	)]));
+	assert!(!has_semantic_guardrail_candidate(&[PathBuf::from(
+		"README"
+	)]));
+}
+
+#[test]
+fn semantic_package_targets_skips_packages_without_changesets() {
+	let packages = vec![
+		make_test_package_record("core"),
+		make_test_package_record("other"),
+	];
+	let changeset_packages = BTreeSet::from(["core"]);
+
+	let targets = semantic_package_targets(&packages, &changeset_packages);
+
+	assert_eq!(targets.get("core").map(String::as_str), Some("core"));
+	assert!(!targets.contains_key("other"));
+}
+
+#[test]
+fn release_plan_propagates_graph_errors_after_semantic_guardrail_collection() {
+	let tempdir = tempfile::TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let mut configuration = monochange_config::load_workspace_configuration(tempdir.path())
+		.unwrap_or_else(|error| panic!("load configuration: {error}"));
+	configuration.root_path = tempdir.path().to_path_buf();
+	let discovery = DiscoveryReport {
+		workspace_root: tempdir.path().to_path_buf(),
+		packages: vec![make_test_package_record("core")],
+		dependencies: Vec::new(),
+		version_groups: Vec::new(),
+		warnings: Vec::new(),
+	};
+	let mut signal = make_test_change_signal("core", BumpSeverity::Patch);
+	signal.explicit_version = Some(Version::new(1, 0, 0));
+
+	let error = build_release_plan_from_signals(&configuration, &discovery, &[signal])
+		.expect_err("unknown signal target should fail release planning");
+
+	assert!(error.to_string().contains("greater than current version"));
+}
+
+fn run_git_test_command(root: &Path, args: &[&str]) {
+	let mut command = std::process::Command::new("git");
+	command.arg("-C").arg(root);
+	if args.first() == Some(&"commit") {
+		command.arg("-c").arg("commit.gpgsign=false");
+	}
+	let status = command
+		.args(args)
+		.status()
+		.unwrap_or_else(|error| panic!("run git {args:?}: {error}"));
+	assert!(status.success(), "git {args:?} failed");
+}
+
+fn replace_workspace_contents(destination: &Path, source: &Path) {
+	for entry in
+		fs::read_dir(destination).unwrap_or_else(|error| panic!("read temp workspace: {error}"))
+	{
+		let entry = entry.unwrap_or_else(|error| panic!("read temp entry: {error}"));
+		if entry.file_name() == ".git" {
+			continue;
+		}
+		let path = entry.path();
+		if path.is_dir() {
+			fs::remove_dir_all(&path)
+				.unwrap_or_else(|error| panic!("remove dir {}: {error}", path.display()));
+		} else {
+			fs::remove_file(&path)
+				.unwrap_or_else(|error| panic!("remove file {}: {error}", path.display()));
+		}
+	}
+	monochange_test_helpers::fs::copy_directory(source, destination);
+}
+
+fn setup_semantic_guardrail_git_fixture(relative: &str) -> tempfile::TempDir {
+	let before = monochange_test_helpers::fs::fixture_path_from(
+		env!("CARGO_MANIFEST_DIR"),
+		&format!("semantic-release-guardrails/{relative}/before"),
+	);
+	let after = monochange_test_helpers::fs::fixture_path_from(
+		env!("CARGO_MANIFEST_DIR"),
+		&format!("semantic-release-guardrails/{relative}/after"),
+	);
+	let tempdir = tempfile::TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	monochange_test_helpers::fs::copy_directory(&before, tempdir.path());
+	run_git_test_command(tempdir.path(), &["init", "-b", "main"]);
+	run_git_test_command(tempdir.path(), &["config", "user.name", "monochange test"]);
+	run_git_test_command(
+		tempdir.path(),
+		&["config", "user.email", "test@example.com"],
+	);
+	run_git_test_command(tempdir.path(), &["add", "."]);
+	run_git_test_command(tempdir.path(), &["commit", "-m", "initial fixture"]);
+	replace_workspace_contents(tempdir.path(), &after);
+	tempdir
+}
+
+#[test]
+fn semantic_guardrail_warns_when_change_frame_detection_fails_in_git_root() {
+	let tempdir = tempfile::TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	fs::write(tempdir.path().join(".git"), "not a git directory")
+		.unwrap_or_else(|error| panic!("write git marker: {error}"));
+	let signal = make_test_change_signal("core", BumpSeverity::Patch);
+
+	let (evidence, warnings) = semantic_compatibility_evidence(tempdir.path(), &[], &[signal]);
+
+	assert!(evidence.is_empty());
+	assert!(
+		warnings
+			.iter()
+			.any(|warning| warning.contains("change frame could not be detected"))
+	);
+}
+
+#[test]
+fn semantic_guardrail_warns_when_semantic_analysis_fails() {
+	let tempdir = tempfile::TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	run_git_test_command(tempdir.path(), &["init", "-b", "main"]);
+	run_git_test_command(tempdir.path(), &["config", "user.name", "monochange test"]);
+	run_git_test_command(
+		tempdir.path(),
+		&["config", "user.email", "test@example.com"],
+	);
+	fs::write(tempdir.path().join("monochange.toml"), "packages = [")
+		.unwrap_or_else(|error| panic!("write invalid config: {error}"));
+	run_git_test_command(tempdir.path(), &["add", "."]);
+	run_git_test_command(tempdir.path(), &["commit", "-m", "initial fixture"]);
+	fs::write(
+		tempdir.path().join("monochange.toml"),
+		"packages = [invalid",
+	)
+	.unwrap_or_else(|error| panic!("write invalid changed config: {error}"));
+	let signal = make_test_change_signal("core", BumpSeverity::Patch);
+
+	let (evidence, warnings) = semantic_compatibility_evidence(tempdir.path(), &[], &[signal]);
+
+	assert!(evidence.is_empty());
+	assert!(
+		warnings
+			.iter()
+			.any(|warning| warning.contains("semantic analysis failed"))
+	);
+}
+
+#[test]
+fn semantic_guardrail_warns_for_semantic_changes_without_matching_changeset_target() {
+	let fixture = setup_semantic_guardrail_git_fixture("changeset-covered-breaking-public-api");
+	let signal = make_test_change_signal("other", BumpSeverity::Patch);
+
+	let (evidence, warnings) = semantic_compatibility_evidence(fixture.path(), &[], &[signal]);
+
+	assert!(evidence.is_empty());
+	assert!(
+		warnings
+			.iter()
+			.any(|warning| warning.contains("no pending changeset targets"))
+	);
 }

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -2175,6 +2175,43 @@ fn workspace_discover_json_output_contains_contract_fields() {
 }
 
 #[test]
+fn plan_release_uses_semantic_guardrail_evidence_for_changeset_covered_breaking_public_api() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let fixture_root = "semantic-release-guardrails/changeset-covered-breaking-public-api";
+	copy_fixture(&format!("{fixture_root}/before"), tempdir.path());
+	init_git_repo(tempdir.path());
+	git_in_temp_repo(tempdir.path(), &["add", "."]);
+	git_in_temp_repo(tempdir.path(), &["commit", "-m", "initial fixture"]);
+	copy_fixture(&format!("{fixture_root}/after"), tempdir.path());
+
+	let plan = plan_release(
+		tempdir.path(),
+		&tempdir.path().join(".changeset/core-breaking-api.md"),
+	)
+	.unwrap_or_else(|error| panic!("release plan: {error}"));
+	let core_decision = plan
+		.decisions
+		.iter()
+		.find(|decision| decision.package_id.contains("core"))
+		.unwrap_or_else(|| panic!("expected core release decision"));
+	let semantic_evidence = plan
+		.compatibility_evidence
+		.iter()
+		.find(|assessment| assessment.provider_id.starts_with("semantic-analysis:"))
+		.unwrap_or_else(|| panic!("expected semantic compatibility evidence"));
+
+	assert_eq!(core_decision.recommended_bump, BumpSeverity::Major);
+	assert_eq!(semantic_evidence.package_id, core_decision.package_id);
+	assert_eq!(semantic_evidence.severity, BumpSeverity::Major);
+	assert_eq!(semantic_evidence.confidence, "high");
+	assert!(
+		plan.warnings.is_empty(),
+		"unexpected warnings: {:?}",
+		plan.warnings
+	);
+}
+
+#[test]
 fn plan_release_aggregates_transitive_dependents_and_version_groups() {
 	let fixture_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/mixed");
 	let plan = plan_release(&fixture_root, &fixture_root.join("changes-minor.md"))

--- a/crates/monochange/src/changesets.rs
+++ b/crates/monochange/src/changesets.rs
@@ -1,5 +1,11 @@
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::fmt::Write as _;
+
+use monochange_analysis::AnalysisConfig;
+use monochange_analysis::ChangeFrame;
+use monochange_core::CompatibilityAssessment;
+use monochange_core::PackageRecord;
 
 use super::*;
 use crate::changeset_policy::configuration_package_records;
@@ -588,7 +594,15 @@ pub(crate) fn build_release_plan_from_signals(
 	#[cfg(not(feature = "cargo"))]
 	let compatibility_evidence = Vec::new();
 
-	build_release_plan(
+	let (semantic_evidence, semantic_warnings) = semantic_compatibility_evidence(
+		&discovery.workspace_root,
+		&discovery.packages,
+		change_signals,
+	);
+	let mut compatibility_evidence = compatibility_evidence;
+	compatibility_evidence.extend(semantic_evidence);
+
+	let mut plan = build_release_plan(
 		&discovery.workspace_root,
 		&discovery.packages,
 		&discovery.dependencies,
@@ -597,7 +611,117 @@ pub(crate) fn build_release_plan_from_signals(
 		&compatibility_evidence,
 		configuration.defaults.parent_bump,
 		configuration.defaults.strict_version_conflicts,
-	)
+	)?;
+	plan.warnings.extend(semantic_warnings);
+
+	Ok(plan)
+}
+
+fn semantic_compatibility_evidence(
+	root: &Path,
+	packages: &[PackageRecord],
+	change_signals: &[ChangeSignal],
+) -> (Vec<CompatibilityAssessment>, Vec<String>) {
+	let frame = match ChangeFrame::detect(root) {
+		Ok(frame) => frame,
+		Err(error) => {
+			if !root.join(".git").exists() {
+				return (Vec::new(), Vec::new());
+			}
+			return (
+				Vec::new(),
+				vec![format!(
+					"semantic SemVer analysis was skipped because the change frame could not be detected: {error}"
+				)],
+			);
+		}
+	};
+	let changed_files = frame.changed_files(root).unwrap_or_default();
+	if !has_semantic_guardrail_candidate(&changed_files) {
+		return (Vec::new(), Vec::new());
+	}
+
+	let analysis =
+		match monochange_analysis::analyze_changes(root, &frame, &AnalysisConfig::default()) {
+			Ok(analysis) => analysis,
+			Err(error) => {
+				return (
+					Vec::new(),
+					vec![format!(
+						"semantic SemVer analysis was skipped because semantic analysis failed: {error}"
+					)],
+				);
+			}
+		};
+	let changeset_packages = change_signals
+		.iter()
+		.map(|signal| signal.package_id.as_str())
+		.collect::<BTreeSet<_>>();
+	let semantic_package_targets = semantic_package_targets(packages, &changeset_packages);
+	let mut warnings = Vec::new();
+	let evidence = analysis
+		.package_analyses
+		.values()
+		.filter_map(|package_analysis| {
+			let Some(target_package_id) = semantic_package_targets
+				.get(package_analysis.package_id.as_str())
+				.map(String::as_str)
+			else {
+				if !package_analysis.semantic_changes.is_empty() {
+					warnings.push(format!(
+						"semantic SemVer analysis found changes for `{}` but no pending changeset targets that package",
+						package_analysis.package_id
+					));
+				}
+				return None;
+			};
+			let analyzer_id = package_analysis
+				.analyzer_id
+				.as_deref()
+				.unwrap_or("semantic-analysis");
+			let provider_id = format!("semantic-analysis:{analyzer_id}");
+			monochange_semver::semantic_changes_assessment(
+				target_package_id,
+				&provider_id,
+				&package_analysis.semantic_changes,
+			)
+		})
+		.collect();
+
+	(evidence, warnings)
+}
+
+pub(crate) fn has_semantic_guardrail_candidate(changed_files: &[PathBuf]) -> bool {
+	changed_files.iter().any(|path| {
+		let Some(extension) = path.extension().and_then(|extension| extension.to_str()) else {
+			return false;
+		};
+		matches!(
+			extension,
+			"cjs"
+				| "dart" | "js"
+				| "jsx" | "json"
+				| "mjs" | "rs"
+				| "toml" | "ts"
+				| "tsx" | "yaml"
+				| "yml"
+		)
+	})
+}
+
+fn semantic_package_targets(
+	packages: &[PackageRecord],
+	changeset_packages: &BTreeSet<&str>,
+) -> BTreeMap<String, String> {
+	let mut targets = BTreeMap::new();
+	for package in packages {
+		if !changeset_packages.contains(package.id.as_str()) {
+			continue;
+		}
+		targets.insert(package.id.clone(), package.id.clone());
+		targets.insert(package.name.clone(), package.id.clone());
+	}
+	targets
 }
 
 pub(crate) fn canonical_change_packages(

--- a/crates/monochange_semver/src/__tests__/lib_tests.rs
+++ b/crates/monochange_semver/src/__tests__/lib_tests.rs
@@ -6,6 +6,9 @@ use monochange_core::CompatibilityAssessment;
 use monochange_core::Ecosystem;
 use monochange_core::PackageRecord;
 use monochange_core::PublishState;
+use monochange_core::SemanticChange;
+use monochange_core::SemanticChangeCategory;
+use monochange_core::SemanticChangeKind;
 use semver::Version;
 
 use crate::CompatibilityProvider;
@@ -13,6 +16,8 @@ use crate::collect_assessments;
 use crate::direct_release_severity;
 use crate::merge_severities;
 use crate::propagated_release_severity;
+use crate::semantic_change_severity;
+use crate::semantic_changes_assessment;
 use crate::strongest_assessment;
 use crate::strongest_assessment_for_package;
 
@@ -456,6 +461,83 @@ fn collect_assessments_returns_empty_for_unmatched_signals() {
 	assert!(assessments.is_empty());
 }
 
+fn semantic_change(
+	category: SemanticChangeCategory,
+	kind: SemanticChangeKind,
+	summary: &str,
+) -> SemanticChange {
+	SemanticChange {
+		category,
+		kind,
+		item_kind: "function".to_string(),
+		item_path: "pkg::api".to_string(),
+		summary: summary.to_string(),
+		file_path: PathBuf::from("src/lib.rs"),
+		before_signature: None,
+		after_signature: None,
+	}
+}
+
+#[test]
+fn semantic_change_severity_maps_public_api_breaks_to_major() {
+	let removed = semantic_change(
+		SemanticChangeCategory::PublicApi,
+		SemanticChangeKind::Removed,
+		"removed public function",
+	);
+	let modified = semantic_change(
+		SemanticChangeCategory::Export,
+		SemanticChangeKind::Modified,
+		"modified export signature",
+	);
+
+	assert_eq!(semantic_change_severity(&removed), BumpSeverity::Major);
+	assert_eq!(semantic_change_severity(&modified), BumpSeverity::Major);
+}
+
+#[test]
+fn semantic_change_severity_maps_additions_to_minor_and_metadata_to_patch() {
+	let added = semantic_change(
+		SemanticChangeCategory::PublicApi,
+		SemanticChangeKind::Added,
+		"added public function",
+	);
+	let metadata = semantic_change(
+		SemanticChangeCategory::Metadata,
+		SemanticChangeKind::Modified,
+		"changed package metadata",
+	);
+
+	assert_eq!(semantic_change_severity(&added), BumpSeverity::Minor);
+	assert_eq!(semantic_change_severity(&metadata), BumpSeverity::Patch);
+}
+
+#[test]
+fn semantic_changes_assessment_uses_strongest_semver_impact() {
+	let changes = vec![
+		semantic_change(
+			SemanticChangeCategory::Dependency,
+			SemanticChangeKind::Modified,
+			"updated dependency range",
+		),
+		semantic_change(
+			SemanticChangeCategory::Export,
+			SemanticChangeKind::Removed,
+			"removed exported function",
+		),
+	];
+
+	let assessment = semantic_changes_assessment("pkg", "semantic-analysis:test", &changes)
+		.unwrap_or_else(|| panic!("expected semantic assessment"));
+
+	assert_eq!(assessment.package_id, "pkg");
+	assert_eq!(assessment.provider_id, "semantic-analysis:test");
+	assert_eq!(assessment.severity, BumpSeverity::Major);
+	assert_eq!(assessment.confidence, "high");
+	assert_eq!(assessment.evidence_location.as_deref(), Some("src/lib.rs"));
+	assert!(assessment.summary.contains("2 semantic change"));
+}
+
 #[test]
 fn collect_assessments_returns_empty_without_providers() {
 	let root = PathBuf::from("/workspace");
@@ -482,4 +564,29 @@ fn collect_assessments_returns_empty_without_providers() {
 	let providers: Vec<&dyn CompatibilityProvider> = vec![];
 	let assessments = collect_assessments(&providers, &packages, &signals);
 	assert!(assessments.is_empty());
+}
+
+#[test]
+fn semantic_assessment_confidence_describes_each_supported_severity() {
+	assert_eq!(
+		crate::semantic_assessment_confidence(BumpSeverity::Major),
+		"high"
+	);
+	assert_eq!(
+		crate::semantic_assessment_confidence(BumpSeverity::Minor),
+		"high"
+	);
+	assert_eq!(
+		crate::semantic_assessment_confidence(BumpSeverity::Patch),
+		"medium"
+	);
+	assert_eq!(
+		crate::semantic_assessment_confidence(BumpSeverity::None),
+		"low"
+	);
+}
+
+#[test]
+fn semantic_changes_assessment_returns_none_without_release_impact() {
+	assert!(semantic_changes_assessment("core", "semantic", &[]).is_none());
 }

--- a/crates/monochange_semver/src/lib.rs
+++ b/crates/monochange_semver/src/lib.rs
@@ -45,6 +45,9 @@ use monochange_core::BumpSeverity;
 use monochange_core::ChangeSignal;
 use monochange_core::CompatibilityAssessment;
 use monochange_core::PackageRecord;
+use monochange_core::SemanticChange;
+use monochange_core::SemanticChangeCategory;
+use monochange_core::SemanticChangeKind;
 
 /// Provider interface for ecosystem-specific compatibility evidence.
 pub trait CompatibilityProvider {
@@ -134,6 +137,80 @@ pub fn propagated_release_severity(
 		default_parent_bump,
 		assessment.map_or(BumpSeverity::None, |value| value.severity),
 	)
+}
+
+/// Infer the minimum `SemVer` bump for one semantic diff record.
+#[must_use]
+#[rustfmt::skip]
+pub fn semantic_change_severity(change: &SemanticChange) -> BumpSeverity {
+	if matches!(
+		(change.category, change.kind),
+		(
+			SemanticChangeCategory::PublicApi | SemanticChangeCategory::Export,
+			SemanticChangeKind::Removed | SemanticChangeKind::Modified
+		)
+	) {
+		return BumpSeverity::Major;
+	}
+
+	if matches!(
+		(change.category, change.kind),
+		(
+			SemanticChangeCategory::PublicApi | SemanticChangeCategory::Export,
+			SemanticChangeKind::Added
+		)
+	) {
+		return BumpSeverity::Minor;
+	}
+
+	let is_dependency_or_metadata = matches!(
+		change.category,
+		SemanticChangeCategory::Dependency | SemanticChangeCategory::Metadata
+	);
+	if is_dependency_or_metadata { BumpSeverity::Patch } else { BumpSeverity::None }
+}
+/// Build release-planning compatibility evidence from semantic analyzer output.
+#[must_use]
+pub fn semantic_changes_assessment(
+	package_id: &str,
+	provider_id: &str,
+	semantic_changes: &[SemanticChange],
+) -> Option<CompatibilityAssessment> {
+	let severity = semantic_changes
+		.iter()
+		.map(semantic_change_severity)
+		.max()
+		.unwrap_or(BumpSeverity::None);
+
+	if !severity.is_release() {
+		return None;
+	}
+
+	let first_change = semantic_changes
+		.first()
+		.expect("release-impact semantic assessments include at least one semantic change");
+	let evidence_location = Some(first_change.file_path.display().to_string());
+	let example = first_change.summary.clone();
+
+	Some(CompatibilityAssessment {
+		package_id: package_id.to_string(),
+		provider_id: provider_id.to_string(),
+		severity,
+		confidence: semantic_assessment_confidence(severity).to_string(),
+		summary: format!(
+			"{severity} SemVer impact inferred from {} semantic change(s); {example}",
+			semantic_changes.len()
+		),
+		evidence_location,
+	})
+}
+
+fn semantic_assessment_confidence(severity: BumpSeverity) -> &'static str {
+	match severity {
+		BumpSeverity::Major | BumpSeverity::Minor => "high",
+		BumpSeverity::Patch => "medium",
+		_ => "low",
+	}
 }
 
 #[cfg(test)]

--- a/docs/plans/active/semver-release-flow.md
+++ b/docs/plans/active/semver-release-flow.md
@@ -1,0 +1,35 @@
+# Semantic SemVer release-flow guardrails
+
+## Goal
+
+Use existing ecosystem semantic analyzers as release guardrails without replacing human-authored changesets. The first rollout is advisory: release planning keeps working, but release previews include compatibility evidence and warnings when semantic analysis suggests a stronger bump or finds uncovered package changes.
+
+## Phases
+
+1. **Normalize semantic impact**
+   - Map `SemanticChange` records to a minimum `BumpSeverity`.
+   - Aggregate per-package semantic changes into `CompatibilityAssessment` evidence.
+
+2. **Wire evidence into release planning**
+   - During release-plan construction, run semantic analysis for the detected git change frame.
+   - Merge inferred compatibility evidence with existing changeset evidence before graph planning.
+   - Keep analyzer failures advisory by adding release-plan warnings instead of failing the command.
+
+3. **Surface release-preview guardrails**
+   - Preserve `ReleasePlan.compatibility_evidence` in dry-run previews and release manifests.
+   - Warn when semantic analysis sees package changes that do not have a matching pending changeset.
+
+4. **Document and teach agents**
+   - Document the advisory behavior in release-planning docs.
+   - Update the monochange skill so agents inspect semantic evidence in release previews.
+
+## Initial SemVer policy
+
+- Removed or modified public API/export: `major`.
+- Added public API/export: `minor`.
+- Dependency or metadata changes: `patch` advisory evidence.
+- Pre-1.0 version shifting remains handled by `BumpSeverity::apply_to_version` in the graph planner.
+
+## Rollout notes
+
+The guardrail is intentionally non-blocking. Future phases can add `[analysis.semver]` configuration for `warn`/`error` modes once analyzer confidence and repository adoption improve.

--- a/docs/src/guide/06-release-planning.md
+++ b/docs/src/guide/06-release-planning.md
@@ -133,6 +133,17 @@ Validate before planning:
 mc step:validate
 ```
 
+## Semantic SemVer guardrails
+
+Release planning also runs semantic analysis for the detected git change frame when it can. The analyzer output is advisory release evidence, not a replacement for changesets:
+
+- removed or modified public API/export evidence can raise the minimum bump to `major`;
+- added public API/export evidence can raise the minimum bump to `minor`;
+- dependency and metadata evidence is treated as `patch` advisory context;
+- analyzer failures become release-plan warnings instead of blocking the command.
+
+Dry-run JSON and release manifest payloads include this data under `compatibilityEvidence`. Human reviewers should compare that evidence with the authored changesets before preparing a release.
+
 ## Release manifests vs release records
 
 Release planning and release repair use two different artifacts on purpose.

--- a/fixtures/tests/semantic-release-guardrails/changeset-covered-breaking-public-api/after/.changeset/core-breaking-api.md
+++ b/fixtures/tests/semantic-release-guardrails/changeset-covered-breaking-public-api/after/.changeset/core-breaking-api.md
@@ -1,0 +1,7 @@
+---
+core: patch
+---
+
+# change greeting API
+
+Update the greeting API while the semantic guardrail verifies the required version bump.

--- a/fixtures/tests/semantic-release-guardrails/changeset-covered-breaking-public-api/after/crates/core/Cargo.toml
+++ b/fixtures/tests/semantic-release-guardrails/changeset-covered-breaking-public-api/after/crates/core/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "core"
+version = "1.0.0"
+edition = "2024"
+
+[dependencies]
+serde = "1"
+tracing = "0.1"
+
+[features]
+default = ["cli"]
+cli = []

--- a/fixtures/tests/semantic-release-guardrails/changeset-covered-breaking-public-api/after/crates/core/src/lib.rs
+++ b/fixtures/tests/semantic-release-guardrails/changeset-covered-breaking-public-api/after/crates/core/src/lib.rs
@@ -1,0 +1,5 @@
+pub struct Greeter;
+
+pub fn greet(name: &str) -> String {
+	format!("hello {name}")
+}

--- a/fixtures/tests/semantic-release-guardrails/changeset-covered-breaking-public-api/after/monochange.toml
+++ b/fixtures/tests/semantic-release-guardrails/changeset-covered-breaking-public-api/after/monochange.toml
@@ -1,0 +1,3 @@
+[package.core]
+path = "crates/core"
+type = "cargo"

--- a/fixtures/tests/semantic-release-guardrails/changeset-covered-breaking-public-api/before/crates/core/Cargo.toml
+++ b/fixtures/tests/semantic-release-guardrails/changeset-covered-breaking-public-api/before/crates/core/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "core"
+version = "1.0.0"
+edition = "2021"
+
+[dependencies]
+serde = "1"
+
+[features]
+default = []

--- a/fixtures/tests/semantic-release-guardrails/changeset-covered-breaking-public-api/before/crates/core/src/lib.rs
+++ b/fixtures/tests/semantic-release-guardrails/changeset-covered-breaking-public-api/before/crates/core/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn greet() -> &'static str {
+	"hello"
+}

--- a/fixtures/tests/semantic-release-guardrails/changeset-covered-breaking-public-api/before/monochange.toml
+++ b/fixtures/tests/semantic-release-guardrails/changeset-covered-breaking-public-api/before/monochange.toml
@@ -1,0 +1,3 @@
+[package.core]
+path = "crates/core"
+type = "cargo"

--- a/packages/monochange__skill/SKILL.md
+++ b/packages/monochange__skill/SKILL.md
@@ -26,7 +26,7 @@ Agents should optimize for safety and traceability: inspect config first, prefer
 1. Inspect configuration: `mc step:validate`, `mc step:config --format json`, or `mc help`. Use this to learn package ids, enabled ecosystems, groups, and which top-level workflow commands actually exist.
 2. Inspect packages: use the configured workflow command (often `mc discover --format json`) or `mc step:discover --format json`. Prefer JSON when another tool or agent will consume the package graph.
 3. Create release intent: use a configured workflow command (often `mc change ...`) or write `.changeset/*.md` manually. Read existing changesets first so you can update or merge related intent instead of creating duplicates.
-4. Preview versioned files: use the configured workflow command (often `mc release --dry-run --format json` or `--diff`) or `mc step:prepare-release --dry-run`. The preview is where you verify versions, changelog entries, generated manifests, and lockfile work before mutating the tree.
+4. Preview versioned files: use the configured workflow command (often `mc release --dry-run --format json` or `--diff`) or `mc step:prepare-release --dry-run`. The preview is where you verify versions, changelog entries, generated manifests, lockfile work, and semantic SemVer `compatibilityEvidence` before mutating the tree.
 5. Run validation and linting: `mc check` and `mc step:validate`. `validate` catches monochange configuration and target issues; `check` also runs manifest lint rules.
 6. Only after review, run configured commit/release/publish workflows. Keep release-record, readiness, bootstrap, plan, and publish artifacts when the workflow emits them.
 
@@ -101,3 +101,26 @@ The `mc mcp` server exposes these tools:
 - `monochange_validate_changeset` — check one changeset against the current semantic diff.
 
 Prefer MCP tools when the caller needs structured data and the shell when you need to run the exact repository workflow that maintainers use locally or in CI.
+
+## Semantic SemVer guardrails
+
+Release planning treats semantic analysis as advisory guardrails. When a git change frame can be analyzed, `mc release --dry-run --format json`, `monochange_release_preview`, and release manifests may include `compatibilityEvidence` inferred from public API/export, dependency, and metadata changes. Compare this with human-authored changesets:
+
+- removed or modified public API/export evidence implies at least `major`;
+- added public API/export evidence implies at least `minor`;
+- dependency or metadata evidence is usually `patch` context;
+- warnings about semantic changes without matching changesets should be resolved before release.
+
+Do not let semantic analysis author releases automatically. Use it to catch mismatched or missing changesets, then update `.changeset/*.md` deliberately.
+
+For comparing two refs today, use `mc analyze`:
+
+```nu
+mc analyze --package core --main-ref <base-ref> --head-ref <head-ref>
+```
+
+For release-aware trajectory:
+
+```nu
+mc analyze --package core --release-ref <last-release-tag> --main-ref main --head-ref HEAD --format json
+```


### PR DESCRIPTION
## Summary

- Adds semantic analyzer output as advisory SemVer compatibility evidence during release planning.
- Maps semantic public API/export changes to SemVer bump evidence and folds it into existing release-plan compatibility assessments.
- Adds a fixture-based release-planning regression test for a changeset-covered breaking public API change.
- Updates release planning docs, the implementation plan, the packaged monochange skill, and adds a changeset.

## Related issue

- Related to #249. This PR uses the existing multi-frame semantic analysis foundation as release-planning guardrail evidence, but does not close #249 because full synthesized multi-frame compatibility guidance is still future work.

## Change type and affected areas

- Change type: feature
- Affected areas: release planning, semantic/SemVer analysis, Cargo fixture tests, docs, agent skill package docs

## Validation

- `cargo test -p monochange_semver --lib`
- `cargo test -p monochange plan_release_uses_semantic_guardrail_evidence_for_changeset_covered_breaking_public_api --lib --features cargo`
- `cargo test -p monochange semantic_guardrail --lib --all-features`
- `cargo check -p monochange`
- `cargo fmt`
- `git diff --check`
- `devenv shell coverage:patch` — 100% patch coverage
- `devenv shell mc step:validate`
- PR CI passed, including `coverage`, `codecov/patch`, `benchmark-binary`, `release-lint`, `build`, `test`, `lint`, `security`, and `zizmor`.

## Changeset status

- Added `.changeset/semantic-semver-release-guardrails.md` for `monochange`, `monochange_semver`, and `@monochange/skill`.

## Risk and rollout

- Semantic evidence is advisory: analyzer failures and uncovered semantic changes produce release-plan warnings instead of blocking release planning.
- Existing ecosystem analyzers remain ecosystem-specific; this change only normalizes their semantic output into compatibility evidence.
