### PR TITLE
ci: check publish readiness before publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,28 @@ jobs:
         run: echo "HEAD is a release commit; skipping package:check."
         shell: devenv shell -- bash -e {0}
 
+  publish-readiness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: setup
+        uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          free-runner-space: "true"
+
+      - name: check publish readiness
+        run: publish:check
+        shell: devenv shell -- bash -e {0}
+
   coverage:
     timeout-minutes: 60
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,8 +201,87 @@ jobs:
             echo "::endgroup::"
           done
 
-  publish_draft:
+  publish_readiness:
+    if: >-
+      github.repository_owner == 'monochange' &&
+      startsWith(inputs.tag || github.ref_name, 'v')
     needs: attest_assets
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      actions: read
+      contents: read
+    env:
+      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+    steps:
+      - name: checkout release tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+
+      - name: verify checkout matches release tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected_tag="${RELEASE_TAG}"
+          actual_commit=$(git rev-parse HEAD)
+          tag_commit=$(git rev-list -n1 "$expected_tag")
+          if [ "$actual_commit" != "$tag_commit" ]; then
+            echo "::error::Checked-out commit $actual_commit does not match tag $expected_tag ($tag_commit)" >&2
+            exit 1
+          fi
+
+          if ! git merge-base --is-ancestor "$actual_commit" refs/remotes/origin/main 2>/dev/null; then
+            echo "::error::Tag $expected_tag ($actual_commit) is not on the main branch" >&2
+            exit 1
+          fi
+
+          echo "Verified: checked-out commit matches tag $expected_tag and is on main"
+
+      - name: setup current monochange cli
+        uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: build current monochange cli
+        run: |
+          cargo build --release --package monochange --bin mc
+          mkdir -p "$RUNNER_TEMP/bin"
+          cp target/release/mc "$RUNNER_TEMP/bin/mc"
+        shell: devenv shell -- bash -e {0}
+
+      - name: download release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/release-assets"
+          gh release download "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "monochange-*-${RELEASE_TAG}.tar.gz" \
+            --pattern "monochange-*-${RELEASE_TAG}.zip" \
+            --dir "$RUNNER_TEMP/release-assets"
+        shell: devenv shell -- bash -e {0}
+
+      - name: populate cli npm packages with release binaries
+        run: |
+          pnpm node scripts/npm/build-packages.mjs \
+            --release-tag "$RELEASE_TAG" \
+            --assets-dir "$RUNNER_TEMP/release-assets"
+          pnpm node scripts/npm/populate-packages.mjs \
+            --packages-dir packages
+        shell: devenv shell -- bash -e {0}
+
+      - name: check publish readiness
+        run: |
+          "$RUNNER_TEMP/bin/mc" step:publish-readiness \
+            --from HEAD \
+            --output "$RUNNER_TEMP/publish-readiness.json" \
+            --format json
+        shell: devenv shell -- bash -e {0}
+
+  publish_draft:
+    needs: publish_readiness
     environment: publisher
     env:
       RELEASE_TAG: ${{ inputs.tag || github.ref_name }}

--- a/devenv.nix
+++ b/devenv.nix
@@ -163,9 +163,11 @@ in
     "publish:check" = {
       exec = ''
         set -euo pipefail
-        mc publish-check || true
+        output="''${MONOCHANGE_PUBLISH_READINESS_OUTPUT:-target/publish-readiness.json}"
+        mkdir -p "$(dirname "$output")"
+        mc step:publish-readiness --from HEAD --output "$output" --format json
       '';
-      description = "Check that publication is valid for this project";
+      description = "Run publish readiness for the current commit and fail on publication blockers";
       binary = "bash";
     };
     "package:check" = {

--- a/docs/plans/active/publish-readiness-ci.md
+++ b/docs/plans/active/publish-readiness-ci.md
@@ -1,0 +1,30 @@
+# Publish readiness CI
+
+## Why
+
+The release workflow should not be the first place publish-readiness errors are discovered. The release job added for PR #524 protects the final publication path, but it only runs for release tags or manual release dispatches. A normal pull request can therefore stay green while the publish-readiness command would fail.
+
+## Goals
+
+- Run publish readiness as a normal CI check on every pull request update, merge queue run, and push covered by the CI workflow.
+- Keep the release workflow publish-readiness gate before draft publication and before dispatching package publication.
+- Make the `publish:check` devenv script fail on real publish-readiness blockers instead of swallowing failures.
+- Keep the check non-publishing: it may perform dry-run/readiness work, but must not publish packages.
+
+## Decisions
+
+- Reuse `publish:check` as the CI entry point so local and CI validation execute the same command.
+- Store the JSON report at `target/publish-readiness.json` by default, with `MONOCHANGE_PUBLISH_READINESS_OUTPUT` as an override.
+- Add a separate `publish-readiness` CI job rather than hiding the readiness gate inside an existing build or packaging job.
+
+## Progress
+
+- [x] Added a dedicated `publish-readiness` job to `.github/workflows/ci.yml`.
+- [x] Changed `publish:check` to run `mc step:publish-readiness --from HEAD --output "$output" --format json` without `|| true`.
+- [x] Validated formatting and whitespace locally with `dprint check` and `git diff --check`.
+- [x] Confirmed `publish:check` now fails locally on the known cyclic publish dependency blocker instead of swallowing the error.
+- [ ] Push the PR #524 update and monitor the new check.
+
+## Follow-up
+
+The current mainline publish-readiness graph still depends on PR #525 to remove the `monochange_core` → `monochange_test_helpers` dev-dependency cycle. Until that lands or the branch includes that fix, the new CI job should fail for the same blocker that already breaks publication.


### PR DESCRIPTION
## Summary

- add a `publish_readiness` release workflow job before the draft release is published and before `publish.yml` is dispatched
- add a `publish-readiness` CI job so publish-readiness runs on normal PR updates / CI pushes, not only during release-tag workflows
- make `publish:check` run `mc step:publish-readiness` and fail on real publication blockers instead of swallowing errors
- document the CI plan and the dependency on PR #525 for the currently known cycle blocker

## Validation

- `dprint check .github/workflows/ci.yml .github/workflows/release.yml devenv.nix docs/plans/active/publish-readiness-ci.md`
- `git diff --check`
- `cargo run -q -p monochange --bin mc -- step:validate`
- `devenv shell publish:check` now fails locally on the known cyclic publish dependency blocker (`monochange_core` ↔ `monochange_test_helpers`), confirming the check is no longer a no-op
- `~/.cargo/bin/zizmor .github/workflows/ci.yml .github/workflows/release.yml .github/actions/` still reports existing unrelated findings in existing workflow/action files
