### PR TITLE
fix: allow publish-check without changesets

### DIFF
--- a/.changeset/publish-check-empty-changesets.md
+++ b/.changeset/publish-check-empty-changesets.md
@@ -1,0 +1,7 @@
+---
+"monochange": patch
+---
+
+# Allow publish-check with no pending changesets
+
+The repository `publish-check` workflow now treats an empty changeset directory as a valid dry-run input while still running the package publish validation step.

--- a/monochange.toml
+++ b/monochange.toml
@@ -758,6 +758,6 @@ steps = [
 help_text = "Validate the release and preview package publishing in dry-run mode"
 dry_run = true
 steps = [
-	{ type = "PrepareRelease", name = "plan release" },
+	{ type = "PrepareRelease", name = "plan release", allow_empty_changesets = true },
 	{ type = "PublishPackages", name = "publish packages dry run" },
 ]


### PR DESCRIPTION
## Summary
- allow the repository publish-check workflow to plan an empty release without failing
- skip the publish package dry-run step when there are no changesets
- add a changeset for monochange

## Testing
- cargo test -p monochange_config load_workspace_configuration_parses_dry_run_on_cli_command
- cargo run -p monochange --bin mc -- step:validate
- manual empty .changeset smoke test: cargo run -p monochange --bin mc -- publish-check