### PR TITLE
fix: include member changelogs in group release notes

### DIFF
--- a/.changeset/fix-group-release-notes.md
+++ b/.changeset/fix-group-release-notes.md
@@ -1,0 +1,8 @@
+---
+"monochange_github": patch
+"monochange_hosting": patch
+---
+
+# Include member changelogs in grouped provider release notes
+
+Provider release notes now supplement filtered or empty group changelog bodies with member package changelog entries, so grouped releases do not publish the "No group-facing notes" fallback when member packages have release notes.

--- a/crates/monochange/tests/github_releases.rs
+++ b/crates/monochange/tests/github_releases.rs
@@ -11,6 +11,7 @@ use test_support::snapshot_settings;
 
 #[rstest]
 #[case::group("group")]
+#[case::group_filtered("group-filtered")]
 #[case::ungrouped("ungrouped")]
 #[case::custom_sections("custom-sections")]
 #[case::default_custom_sections("default-custom-sections")]

--- a/crates/monochange/tests/snapshots/github_releases__multiline_manifest_changelogs_0__rendered@group_filtered.snap
+++ b/crates/monochange/tests/snapshots/github_releases__multiline_manifest_changelogs_0__rendered@group_filtered.snap
@@ -1,0 +1,11 @@
+---
+source: crates/monochange/tests/github_releases.rs
+assertion_line: 26
+expression: contents
+---
+## [1.1.0](https://github.com/ifiokjr/monochange/releases/tag/v1.1.0) ([DATE])
+
+Grouped release for `sdk`.
+### Changed
+
+- No group-facing notes were recorded for this release. Member packages were updated as part of the synchronized group `sdk` version, but their changes are not configured for inclusion in this changelog.

--- a/crates/monochange/tests/snapshots/github_releases__multiline_manifest_changelogs_1__rendered@group_filtered.snap
+++ b/crates/monochange/tests/snapshots/github_releases__multiline_manifest_changelogs_1__rendered@group_filtered.snap
@@ -1,0 +1,10 @@
+---
+source: crates/monochange/tests/github_releases.rs
+assertion_line: 26
+expression: contents
+---
+## [1.1.0](https://github.com/ifiokjr/monochange/releases/tag/v1.1.0) ([DATE])
+
+### 🚀 Feature
+
+#### add feature

--- a/crates/monochange/tests/snapshots/github_releases__multiline_releases_0__body@group_filtered.snap
+++ b/crates/monochange/tests/snapshots/github_releases__multiline_releases_0__body@group_filtered.snap
@@ -1,0 +1,16 @@
+---
+source: crates/monochange/tests/github_releases.rs
+assertion_line: 26
+expression: contents
+---
+## [1.1.0](https://github.com/ifiokjr/monochange/releases/tag/v1.1.0) ([DATE])
+
+Grouped release for `sdk`.
+
+## Member package changelogs
+
+### `core`
+
+#### 🚀 Feature
+
+#### add feature

--- a/crates/monochange/tests/snapshots/github_releases__publish_github_release_dry_run_matches_snapshot@group_filtered.snap
+++ b/crates/monochange/tests/snapshots/github_releases__publish_github_release_dry_run_matches_snapshot@group_filtered.snap
@@ -1,0 +1,212 @@
+---
+source: crates/monochange/tests/github_releases.rs
+assertion_line: 26
+expression: redacted
+---
+{
+  "issueComments": [],
+  "manifest": {
+    "changedFiles": [
+      "Cargo.toml",
+      "changelog.md",
+      "crates/app/Cargo.toml",
+      "crates/core/CHANGELOG.md",
+      "crates/core/Cargo.toml",
+      "group.toml"
+    ],
+    "changelogs": [
+      {
+        "format": "monochange",
+        "notes": {
+          "sections": [
+            {
+              "collapsed": false,
+              "entries": [
+                "- No group-facing notes were recorded for this release. Member packages were updated as part of the synchronized group `sdk` version, but their changes are not configured for inclusion in this changelog."
+              ],
+              "title": "Changed"
+            }
+          ],
+          "summary": [
+            "Grouped release for `sdk`."
+          ],
+          "title": "[1.1.0](https://github.com/ifiokjr/monochange/releases/tag/v1.1.0) ([DATE])"
+        },
+        "ownerId": "sdk",
+        "ownerKind": "group",
+        "path": "changelog.md",
+        "rendered": "[multiline text]"
+      },
+      {
+        "format": "monochange",
+        "notes": {
+          "sections": [
+            {
+              "collapsed": false,
+              "entries": [
+                "#### add feature"
+              ],
+              "title": "🚀 Feature"
+            }
+          ],
+          "summary": [],
+          "title": "[1.1.0](https://github.com/ifiokjr/monochange/releases/tag/v1.1.0) ([DATE])"
+        },
+        "ownerId": "core",
+        "ownerKind": "package",
+        "path": "crates/core/CHANGELOG.md",
+        "rendered": "[multiline text]"
+      }
+    ],
+    "changesets": [
+      {
+        "context": {
+          "capabilities": {
+            "actorProfiles": true,
+            "commitWebUrls": true,
+            "issueComments": true,
+            "relatedIssues": true,
+            "reviewRequestLookup": true
+          },
+          "host": "github.com",
+          "introduced": null,
+          "lastUpdated": null,
+          "provider": "github",
+          "relatedIssues": []
+        },
+        "details": null,
+        "path": ".changeset/feature.md",
+        "summary": "add feature",
+        "targets": [
+          {
+            "bump": "minor",
+            "changeType": "minor",
+            "evidenceRefs": [],
+            "id": "core",
+            "kind": "package",
+            "origin": "direct-change"
+          }
+        ]
+      }
+    ],
+    "command": "publish-release",
+    "deletedChangesets": [],
+    "dryRun": true,
+    "groupVersion": "1.1.0",
+    "packagePublications": [
+      {
+        "ecosystem": "cargo",
+        "mode": "builtin",
+        "package": "app",
+        "registry": "crates_io",
+        "trustedPublishing": {
+          "enabled": true,
+          "environment": null,
+          "repository": null,
+          "workflow": null
+        },
+        "version": "1.1.0"
+      },
+      {
+        "ecosystem": "cargo",
+        "mode": "builtin",
+        "package": "core",
+        "registry": "crates_io",
+        "trustedPublishing": {
+          "enabled": true,
+          "environment": null,
+          "repository": null,
+          "workflow": null
+        },
+        "version": "1.1.0"
+      }
+    ],
+    "plan": {
+      "compatibilityEvidence": [],
+      "decisions": [
+        {
+          "bump": "minor",
+          "package": "cargo:crates/app/Cargo.toml",
+          "plannedVersion": "1.1.0",
+          "reasons": [
+            "depends on `cargo:crates/core/Cargo.toml`",
+            "shares version group `sdk`"
+          ],
+          "trigger": "version-group-synchronization",
+          "upstreamSources": [
+            "cargo:crates/core/Cargo.toml"
+          ]
+        },
+        {
+          "bump": "minor",
+          "package": "cargo:crates/core/Cargo.toml",
+          "plannedVersion": "1.1.0",
+          "reasons": [
+            "add feature",
+            "shares version group `sdk`"
+          ],
+          "trigger": "direct-change",
+          "upstreamSources": [
+            "cargo:crates/core/Cargo.toml"
+          ]
+        }
+      ],
+      "groups": [
+        {
+          "bump": "minor",
+          "id": "sdk",
+          "members": [
+            "cargo:crates/core/Cargo.toml",
+            "cargo:crates/app/Cargo.toml"
+          ],
+          "plannedVersion": "1.1.0"
+        }
+      ],
+      "unresolvedItems": [],
+      "warnings": [],
+      "workspaceRoot": "."
+    },
+    "releaseTargets": [
+      {
+        "id": "sdk",
+        "kind": "group",
+        "members": [
+          "core",
+          "app"
+        ],
+        "release": true,
+        "renderedChangelogTitle": "[1.1.0](https://github.com/ifiokjr/monochange/releases/tag/v1.1.0) ([DATE])",
+        "renderedTitle": "1.1.0 ([DATE])",
+        "tag": true,
+        "tagName": "v1.1.0",
+        "version": "1.1.0",
+        "versionFormat": "primary"
+      }
+    ],
+    "releasedPackages": [
+      "workflow-app",
+      "workflow-core"
+    ],
+    "version": "1.1.0"
+  },
+  "packagePublish": null,
+  "publishRateLimits": null,
+  "releaseCommit": null,
+  "releaseRequest": null,
+  "releases": [
+    {
+      "body": "[multiline text]",
+      "draft": false,
+      "generateReleaseNotes": false,
+      "name": "1.1.0 ([DATE])",
+      "owner": "ifiokjr",
+      "prerelease": false,
+      "provider": "github",
+      "repo": "monochange",
+      "repository": "ifiokjr/monochange",
+      "tagName": "v1.1.0",
+      "targetId": "sdk",
+      "targetKind": "group"
+    }
+  ]
+}

--- a/crates/monochange_github/src/__tests__/lib_tests.rs
+++ b/crates/monochange_github/src/__tests__/lib_tests.rs
@@ -2817,6 +2817,214 @@ fn build_test_client(server: &MockServer) -> Octocrab {
 		.unwrap_or_else(|error| panic!("octocrab client: {error}"))
 }
 
+fn github_release_section(title: &str, entries: Vec<&str>) -> ReleaseNotesSection {
+	ReleaseNotesSection {
+		title: title.to_string(),
+		collapsed: false,
+		entries: entries.into_iter().map(str::to_string).collect(),
+	}
+}
+
+fn github_release_changelog(
+	owner_id: &str,
+	owner_kind: ReleaseOwnerKind,
+	summary: Vec<String>,
+	sections: Vec<ReleaseNotesSection>,
+	rendered: &str,
+) -> ReleaseManifestChangelog {
+	ReleaseManifestChangelog {
+		owner_id: owner_id.to_string(),
+		owner_kind,
+		path: PathBuf::from(format!("{owner_id}.md")),
+		format: monochange_core::ChangelogFormat::Monochange,
+		notes: ReleaseNotesDocument {
+			title: "1.2.0".to_string(),
+			summary,
+			sections,
+		},
+		rendered: rendered.to_string(),
+	}
+}
+
+fn github_group_release_target(
+	rendered_title: &str,
+	rendered_changelog_title: &str,
+) -> ReleaseManifestTarget {
+	ReleaseManifestTarget {
+		id: "sdk".to_string(),
+		kind: ReleaseOwnerKind::Group,
+		version: "1.2.0".to_string(),
+		tag: true,
+		release: true,
+		version_format: VersionFormat::Primary,
+		tag_name: "sdk-v1.2.0".to_string(),
+		rendered_title: rendered_title.to_string(),
+		rendered_changelog_title: rendered_changelog_title.to_string(),
+		members: vec!["core".to_string(), "cli".to_string()],
+	}
+}
+
+fn github_release_source() -> SourceConfiguration {
+	SourceConfiguration {
+		releases: ProviderReleaseSettings {
+			source: ProviderReleaseNotesSource::Monochange,
+			..ProviderReleaseSettings::default()
+		},
+		..sample_source(None)
+	}
+}
+
+#[test]
+fn release_body_appends_uncovered_member_notes_for_github_releases() {
+	let source = github_release_source();
+	let target = github_group_release_target("sdk 1.2.0", "sdk changelog 1.2.0");
+	let mut manifest = sample_manifest();
+	manifest.changelogs = vec![
+		github_release_changelog(
+			"sdk",
+			ReleaseOwnerKind::Group,
+			vec!["Group summary".to_string()],
+			vec![github_release_section("Features", vec!["- group feature"])],
+			"## sdk changelog 1.2.0\n\nGroup summary\n\n### Features\n\n- group feature\n",
+		),
+		github_release_changelog(
+			"core",
+			ReleaseOwnerKind::Package,
+			vec!["Core summary".to_string()],
+			vec![
+				github_release_section("Features", vec!["- core feature\n_Packages: core_"]),
+				github_release_section("Empty", vec![]),
+			],
+			"## core 1.2.0",
+		),
+	];
+
+	let body = release_body(&source, &manifest, &target).expect("release body");
+
+	assert!(body.contains("## sdk changelog 1.2.0"), "body:\n{body}");
+	assert!(
+		body.contains("## Member package changelogs"),
+		"body:\n{body}"
+	);
+	assert!(body.contains("Core summary"), "body:\n{body}");
+	assert!(body.contains("- core feature"), "body:\n{body}");
+	assert!(!body.contains("#### Empty"), "body:\n{body}");
+}
+
+#[test]
+fn release_body_uses_grouped_member_body_when_github_group_notes_are_empty() {
+	let source = github_release_source();
+	let target = github_group_release_target("sdk release title", "");
+	let mut manifest = sample_manifest();
+	manifest.changelogs = vec![
+		github_release_changelog(
+			"sdk",
+			ReleaseOwnerKind::Group,
+			vec![],
+			vec![github_release_section(
+				"Other",
+				vec!["No group-facing notes were recorded for this release."],
+			)],
+			"## sdk\n\nNo group-facing notes were recorded for this release.",
+		),
+		github_release_changelog(
+			"core",
+			ReleaseOwnerKind::Package,
+			vec![],
+			vec![github_release_section("Fixes", vec!["- fix core bug"])],
+			"## core 1.2.0",
+		),
+	];
+
+	let body = release_body(&source, &manifest, &target).expect("release body");
+
+	assert!(body.starts_with("## sdk release title"), "body:\n{body}");
+	assert!(body.contains("Grouped release for `sdk`."), "body:\n{body}");
+	assert!(body.contains("### `core`"), "body:\n{body}");
+	assert!(!body.contains("No group-facing notes"), "body:\n{body}");
+}
+
+#[test]
+fn release_body_uses_tag_title_for_github_group_when_titles_are_empty() {
+	let source = github_release_source();
+	let target = github_group_release_target("", "");
+	let mut manifest = sample_manifest();
+	manifest.changelogs = vec![github_release_changelog(
+		"core",
+		ReleaseOwnerKind::Package,
+		vec![],
+		vec![github_release_section("Fixes", vec!["- fix core bug"])],
+		"## core 1.2.0",
+	)];
+
+	let body = release_body(&source, &manifest, &target).expect("release body");
+
+	assert!(body.starts_with("## sdk-v1.2.0"), "body:\n{body}");
+	assert!(body.contains("### `core`"), "body:\n{body}");
+}
+
+#[test]
+fn release_body_does_not_duplicate_github_member_notes_already_in_group() {
+	let source = github_release_source();
+	let target = github_group_release_target("sdk 1.2.0", "sdk changelog 1.2.0");
+	let mut manifest = sample_manifest();
+	manifest.changelogs = vec![
+		github_release_changelog(
+			"sdk",
+			ReleaseOwnerKind::Group,
+			vec![],
+			vec![github_release_section("Features", vec!["- shared feature"])],
+			"## sdk changelog 1.2.0\n\n### Features\n\n- shared feature",
+		),
+		github_release_changelog(
+			"core",
+			ReleaseOwnerKind::Package,
+			vec![],
+			vec![github_release_section(
+				"Features",
+				vec!["- shared feature\n_Packages: core_"],
+			)],
+			"## core 1.2.0",
+		),
+	];
+
+	let body = release_body(&source, &manifest, &target).expect("release body");
+
+	assert_eq!(
+		body,
+		"## sdk changelog 1.2.0\n\n### Features\n\n- shared feature"
+	);
+}
+
+#[test]
+fn release_body_ignores_github_member_changelogs_for_package_targets() {
+	let source = github_release_source();
+	let target = ReleaseManifestTarget {
+		id: "core".to_string(),
+		kind: ReleaseOwnerKind::Package,
+		version: "1.2.0".to_string(),
+		tag: true,
+		release: true,
+		version_format: VersionFormat::Namespaced,
+		tag_name: "core-v1.2.0".to_string(),
+		rendered_title: String::new(),
+		rendered_changelog_title: String::new(),
+		members: vec![],
+	};
+	let mut manifest = sample_manifest();
+	manifest.changelogs = vec![github_release_changelog(
+		"core",
+		ReleaseOwnerKind::Package,
+		vec![],
+		vec![github_release_section("Fixes", vec!["- fix package bug"])],
+		"## core 1.2.0\n\n### Fixes\n\n- fix package bug",
+	)];
+
+	let body = release_body(&source, &manifest, &target).expect("release body");
+
+	assert_eq!(body, "## core 1.2.0\n\n### Fixes\n\n- fix package bug");
+}
+
 fn sample_source(api_url: Option<String>) -> SourceConfiguration {
 	SourceConfiguration {
 		provider: SourceProvider::GitHub,

--- a/crates/monochange_github/src/lib.rs
+++ b/crates/monochange_github/src/lib.rs
@@ -115,6 +115,7 @@ use monochange_core::MonochangeResult;
 use monochange_core::PreparedChangeset;
 use monochange_core::ProviderReleaseNotesSource;
 use monochange_core::ReleaseManifest;
+use monochange_core::ReleaseManifestChangelog;
 use monochange_core::ReleaseManifestTarget;
 use monochange_core::ReleaseOwnerKind;
 use monochange_core::RetargetOperation;
@@ -2001,17 +2002,149 @@ fn release_body(
 ) -> Option<String> {
 	match github.releases.source {
 		ProviderReleaseNotesSource::GitHubGenerated => None,
-		ProviderReleaseNotesSource::Monochange => {
-			manifest
-				.changelogs
-				.iter()
-				.find(|changelog| {
-					changelog.owner_id == target.id && changelog.owner_kind == target.kind
-				})
-				.map(|changelog| changelog.rendered.clone())
-				.or_else(|| Some(minimal_release_body(manifest, target)))
-		}
+		ProviderReleaseNotesSource::Monochange => Some(monochange_release_body(manifest, target)),
 	}
+}
+
+fn monochange_release_body(manifest: &ReleaseManifest, target: &ReleaseManifestTarget) -> String {
+	let target_changelog = manifest
+		.changelogs
+		.iter()
+		.find(|changelog| changelog.owner_id == target.id && changelog.owner_kind == target.kind);
+	let member_changelogs = uncovered_member_changelogs(manifest, target, target_changelog);
+
+	match (target_changelog, member_changelogs.is_empty()) {
+		(Some(changelog), true) => changelog.rendered.clone(),
+		(Some(changelog), false) if changelog_has_release_notes(changelog) => {
+			append_member_changelogs(&changelog.rendered, &member_changelogs)
+		}
+		(_, false) => grouped_member_release_body(target, &member_changelogs),
+		(None, true) => minimal_release_body(manifest, target),
+	}
+}
+
+fn uncovered_member_changelogs<'a>(
+	manifest: &'a ReleaseManifest,
+	target: &ReleaseManifestTarget,
+	target_changelog: Option<&ReleaseManifestChangelog>,
+) -> Vec<&'a ReleaseManifestChangelog> {
+	if target.kind != ReleaseOwnerKind::Group {
+		return Vec::new();
+	}
+
+	manifest
+		.changelogs
+		.iter()
+		.filter(|changelog| {
+			changelog.owner_kind == ReleaseOwnerKind::Package
+				&& target.members.contains(&changelog.owner_id)
+				&& changelog_has_release_notes(changelog)
+				&& changelog_has_uncovered_notes(changelog, target_changelog)
+		})
+		.collect()
+}
+
+fn append_member_changelogs(
+	rendered: &str,
+	member_changelogs: &[&ReleaseManifestChangelog],
+) -> String {
+	let mut lines = vec![rendered.trim_end().to_string(), String::new()];
+	push_member_changelogs(&mut lines, member_changelogs);
+	lines.join("\n")
+}
+
+fn grouped_member_release_body(
+	target: &ReleaseManifestTarget,
+	member_changelogs: &[&ReleaseManifestChangelog],
+) -> String {
+	let title = if target.rendered_changelog_title.is_empty() {
+		target.rendered_title.as_str()
+	} else {
+		target.rendered_changelog_title.as_str()
+	};
+	let title = if title.is_empty() {
+		target.tag_name.as_str()
+	} else {
+		title
+	};
+	let mut lines = vec![format!("## {title}"), String::new()];
+	lines.push(format!("Grouped release for `{}`.", target.id));
+	lines.push(String::new());
+	push_member_changelogs(&mut lines, member_changelogs);
+	lines.join("\n")
+}
+
+fn push_member_changelogs(lines: &mut Vec<String>, changelogs: &[&ReleaseManifestChangelog]) {
+	lines.push("## Member package changelogs".to_string());
+
+	for changelog in changelogs {
+		lines.push(String::new());
+		lines.push(format!("### `{}`", changelog.owner_id));
+		push_changelog_notes(lines, changelog);
+	}
+}
+
+fn push_changelog_notes(lines: &mut Vec<String>, changelog: &ReleaseManifestChangelog) {
+	for paragraph in &changelog.notes.summary {
+		lines.push(String::new());
+		lines.push(paragraph.clone());
+	}
+
+	for section in &changelog.notes.sections {
+		if section.entries.is_empty() {
+			continue;
+		}
+		lines.push(String::new());
+		lines.push(format!("#### {}", section.title));
+		lines.push(String::new());
+		push_body_entries(lines, &section.entries);
+	}
+}
+
+fn changelog_has_release_notes(changelog: &ReleaseManifestChangelog) -> bool {
+	changelog.notes.sections.iter().any(|section| {
+		section
+			.entries
+			.iter()
+			.any(|entry| !is_empty_group_release_note(entry))
+	})
+}
+
+fn is_empty_group_release_note(entry: &str) -> bool {
+	entry.contains("No group-facing notes were recorded for this release")
+}
+
+fn changelog_has_uncovered_notes(
+	changelog: &ReleaseManifestChangelog,
+	target_changelog: Option<&ReleaseManifestChangelog>,
+) -> bool {
+	let Some(target_changelog) = target_changelog else {
+		return true;
+	};
+	let covered_entries = target_changelog
+		.notes
+		.sections
+		.iter()
+		.flat_map(|section| &section.entries)
+		.map(|entry| normalized_release_entry(entry))
+		.collect::<Vec<_>>();
+
+	changelog
+		.notes
+		.sections
+		.iter()
+		.flat_map(|section| &section.entries)
+		.any(|entry| !covered_entries.contains(&normalized_release_entry(entry)))
+}
+
+fn normalized_release_entry(entry: &str) -> String {
+	entry
+		.lines()
+		.filter(|line| !line.trim_start().starts_with("_Packages:"))
+		.collect::<Vec<_>>()
+		.join("\n")
+		.trim()
+		.to_string()
 }
 
 fn release_pull_request_branch(branch_prefix: &str, command: &str) -> String {

--- a/crates/monochange_hosting/src/__tests__/lib_tests.rs
+++ b/crates/monochange_hosting/src/__tests__/lib_tests.rs
@@ -582,6 +582,229 @@ fn release_body_falls_back_to_minimal_when_only_non_matching_changelog_exists() 
 	);
 }
 
+fn monochange_release_source() -> SourceConfiguration {
+	SourceConfiguration {
+		provider: monochange_core::SourceProvider::GitLab,
+		owner: "org".to_string(),
+		repo: "repo".to_string(),
+		host: None,
+		api_url: None,
+		releases: monochange_core::ProviderReleaseSettings {
+			enabled: true,
+			draft: false,
+			prerelease: false,
+			generate_notes: false,
+			source: ProviderReleaseNotesSource::Monochange,
+			..monochange_core::ProviderReleaseSettings::default()
+		},
+		pull_requests: monochange_core::ProviderMergeRequestSettings::default(),
+	}
+}
+
+fn release_changelog(
+	owner_id: &str,
+	owner_kind: ReleaseOwnerKind,
+	summary: Vec<String>,
+	sections: Vec<ReleaseNotesSection>,
+	rendered: &str,
+) -> ReleaseManifestChangelog {
+	ReleaseManifestChangelog {
+		owner_id: owner_id.to_string(),
+		owner_kind,
+		path: PathBuf::from(format!("{owner_id}.md")),
+		format: monochange_core::ChangelogFormat::Monochange,
+		notes: ReleaseNotesDocument {
+			title: "1.2.0".to_string(),
+			summary,
+			sections,
+		},
+		rendered: rendered.to_string(),
+	}
+}
+
+fn release_section(title: &str, entries: Vec<&str>) -> ReleaseNotesSection {
+	ReleaseNotesSection {
+		title: title.to_string(),
+		collapsed: false,
+		entries: entries.into_iter().map(str::to_string).collect(),
+	}
+}
+
+fn group_release_target(
+	rendered_title: &str,
+	rendered_changelog_title: &str,
+) -> ReleaseManifestTarget {
+	let mut target = minimal_target("sdk");
+	target.kind = ReleaseOwnerKind::Group;
+	target.tag_name = "sdk-v1.2.0".to_string();
+	target.members = vec!["core".to_string(), "cli".to_string()];
+	target.rendered_title = rendered_title.to_string();
+	target.rendered_changelog_title = rendered_changelog_title.to_string();
+	target
+}
+
+#[test]
+fn release_body_appends_member_changelogs_not_already_in_group_changelog() {
+	let mut manifest = sample_manifest();
+	let source = monochange_release_source();
+	let target = group_release_target("sdk 1.2.0", "sdk changelog 1.2.0");
+	manifest.changelogs = vec![
+		release_changelog(
+			"sdk",
+			ReleaseOwnerKind::Group,
+			vec!["Group summary".to_string()],
+			vec![release_section("Features", vec!["- group feature"])],
+			"## sdk changelog 1.2.0\n\nGroup summary\n\n### Features\n\n- group feature\n",
+		),
+		release_changelog(
+			"core",
+			ReleaseOwnerKind::Package,
+			vec!["Core package summary".to_string()],
+			vec![
+				release_section("Features", vec!["- core feature\n_Packages: core_"]),
+				release_section("Empty", vec![]),
+			],
+			"## core 1.2.0",
+		),
+	];
+
+	let body = release_body(&source, &manifest, &target).expect("release body");
+
+	assert!(body.contains("## sdk changelog 1.2.0"), "body:\n{body}");
+	assert!(
+		body.contains("## Member package changelogs"),
+		"body:\n{body}"
+	);
+	assert!(body.contains("### `core`"), "body:\n{body}");
+	assert!(body.contains("Core package summary"), "body:\n{body}");
+	assert!(body.contains("#### Features"), "body:\n{body}");
+	assert!(body.contains("- core feature"), "body:\n{body}");
+	assert!(!body.contains("#### Empty"), "body:\n{body}");
+}
+
+#[test]
+fn release_body_uses_member_changelogs_when_group_only_has_empty_fallback() {
+	let mut manifest = sample_manifest();
+	let source = monochange_release_source();
+	let target = group_release_target("sdk release title", "");
+	manifest.changelogs = vec![
+		release_changelog(
+			"sdk",
+			ReleaseOwnerKind::Group,
+			vec![],
+			vec![release_section(
+				"Other",
+				vec!["No group-facing notes were recorded for this release."],
+			)],
+			"## sdk\n\nNo group-facing notes were recorded for this release.",
+		),
+		release_changelog(
+			"core",
+			ReleaseOwnerKind::Package,
+			vec![],
+			vec![release_section("Fixes", vec!["- fix core bug"])],
+			"## core 1.2.0",
+		),
+	];
+
+	let body = release_body(&source, &manifest, &target).expect("release body");
+
+	assert!(body.starts_with("## sdk release title"), "body:\n{body}");
+	assert!(body.contains("Grouped release for `sdk`."), "body:\n{body}");
+	assert!(body.contains("### `core`"), "body:\n{body}");
+	assert!(body.contains("- fix core bug"), "body:\n{body}");
+	assert!(!body.contains("No group-facing notes"), "body:\n{body}");
+}
+
+#[test]
+fn release_body_prefers_group_changelog_title_for_member_only_group_notes() {
+	let mut manifest = sample_manifest();
+	let source = monochange_release_source();
+	let target = group_release_target("sdk release title", "sdk changelog title");
+	manifest.changelogs = vec![release_changelog(
+		"core",
+		ReleaseOwnerKind::Package,
+		vec![],
+		vec![release_section("Fixes", vec!["- fix core bug"])],
+		"## core 1.2.0",
+	)];
+
+	let body = release_body(&source, &manifest, &target).expect("release body");
+
+	assert!(body.starts_with("## sdk changelog title"), "body:\n{body}");
+	assert!(body.contains("### `core`"), "body:\n{body}");
+}
+
+#[test]
+fn release_body_uses_tag_title_when_group_titles_are_empty() {
+	let mut manifest = sample_manifest();
+	let source = monochange_release_source();
+	let target = group_release_target("", "");
+	manifest.changelogs = vec![release_changelog(
+		"core",
+		ReleaseOwnerKind::Package,
+		vec![],
+		vec![release_section("Fixes", vec!["- fix core bug"])],
+		"## core 1.2.0",
+	)];
+
+	let body = release_body(&source, &manifest, &target).expect("release body");
+
+	assert!(body.starts_with("## sdk-v1.2.0"), "body:\n{body}");
+	assert!(body.contains("### `core`"), "body:\n{body}");
+}
+
+#[test]
+fn release_body_does_not_duplicate_member_notes_already_covered_by_group() {
+	let mut manifest = sample_manifest();
+	let source = monochange_release_source();
+	let target = group_release_target("sdk 1.2.0", "sdk changelog 1.2.0");
+	manifest.changelogs = vec![
+		release_changelog(
+			"sdk",
+			ReleaseOwnerKind::Group,
+			vec![],
+			vec![release_section("Features", vec!["- shared feature"])],
+			"## sdk changelog 1.2.0\n\n### Features\n\n- shared feature",
+		),
+		release_changelog(
+			"core",
+			ReleaseOwnerKind::Package,
+			vec![],
+			vec![release_section(
+				"Features",
+				vec!["- shared feature\n_Packages: core_"],
+			)],
+			"## core 1.2.0",
+		),
+	];
+
+	let body = release_body(&source, &manifest, &target).expect("release body");
+
+	assert_eq!(
+		body,
+		"## sdk changelog 1.2.0\n\n### Features\n\n- shared feature"
+	);
+}
+
+#[test]
+fn release_body_ignores_package_changelogs_for_package_targets() {
+	let mut manifest = sample_manifest();
+	let source = monochange_release_source();
+	let target = minimal_target("core");
+	manifest.changelogs = vec![release_changelog(
+		"core",
+		ReleaseOwnerKind::Package,
+		vec![],
+		vec![release_section("Fixes", vec!["- fix package bug"])],
+		"## core 1.2.0\n\n### Fixes\n\n- fix package bug",
+	)];
+
+	let body = release_body(&source, &manifest, &target).expect("release body");
+
+	assert_eq!(body, "## core 1.2.0\n\n### Fixes\n\n- fix package bug");
+}
+
 #[test]
 fn get_optional_json_returns_none_for_404_and_some_for_success() {
 	let server = MockServer::start();

--- a/crates/monochange_hosting/src/lib.rs
+++ b/crates/monochange_hosting/src/lib.rs
@@ -37,6 +37,7 @@ use monochange_core::MonochangeError;
 use monochange_core::MonochangeResult;
 use monochange_core::ProviderReleaseNotesSource;
 use monochange_core::ReleaseManifest;
+use monochange_core::ReleaseManifestChangelog;
 use monochange_core::ReleaseManifestTarget;
 use monochange_core::ReleaseOwnerKind;
 use monochange_core::SourceConfiguration;
@@ -217,17 +218,149 @@ pub fn release_body(
 ) -> Option<String> {
 	match source.releases.source {
 		ProviderReleaseNotesSource::GitHubGenerated => None,
-		ProviderReleaseNotesSource::Monochange => {
-			manifest
-				.changelogs
-				.iter()
-				.find(|changelog| {
-					changelog.owner_id == target.id && changelog.owner_kind == target.kind
-				})
-				.map(|changelog| changelog.rendered.clone())
-				.or_else(|| Some(minimal_release_body(manifest, target)))
-		}
+		ProviderReleaseNotesSource::Monochange => Some(monochange_release_body(manifest, target)),
 	}
+}
+
+fn monochange_release_body(manifest: &ReleaseManifest, target: &ReleaseManifestTarget) -> String {
+	let target_changelog = manifest
+		.changelogs
+		.iter()
+		.find(|changelog| changelog.owner_id == target.id && changelog.owner_kind == target.kind);
+	let member_changelogs = uncovered_member_changelogs(manifest, target, target_changelog);
+
+	match (target_changelog, member_changelogs.is_empty()) {
+		(Some(changelog), true) => changelog.rendered.clone(),
+		(Some(changelog), false) if changelog_has_release_notes(changelog) => {
+			append_member_changelogs(&changelog.rendered, &member_changelogs)
+		}
+		(_, false) => grouped_member_release_body(target, &member_changelogs),
+		(None, true) => minimal_release_body(manifest, target),
+	}
+}
+
+fn uncovered_member_changelogs<'a>(
+	manifest: &'a ReleaseManifest,
+	target: &ReleaseManifestTarget,
+	target_changelog: Option<&ReleaseManifestChangelog>,
+) -> Vec<&'a ReleaseManifestChangelog> {
+	if target.kind != ReleaseOwnerKind::Group {
+		return Vec::new();
+	}
+
+	manifest
+		.changelogs
+		.iter()
+		.filter(|changelog| {
+			changelog.owner_kind == ReleaseOwnerKind::Package
+				&& target.members.contains(&changelog.owner_id)
+				&& changelog_has_release_notes(changelog)
+				&& changelog_has_uncovered_notes(changelog, target_changelog)
+		})
+		.collect()
+}
+
+fn append_member_changelogs(
+	rendered: &str,
+	member_changelogs: &[&ReleaseManifestChangelog],
+) -> String {
+	let mut lines = vec![rendered.trim_end().to_string(), String::new()];
+	push_member_changelogs(&mut lines, member_changelogs);
+	lines.join("\n")
+}
+
+fn grouped_member_release_body(
+	target: &ReleaseManifestTarget,
+	member_changelogs: &[&ReleaseManifestChangelog],
+) -> String {
+	let title = if target.rendered_changelog_title.is_empty() {
+		target.rendered_title.as_str()
+	} else {
+		target.rendered_changelog_title.as_str()
+	};
+	let title = if title.is_empty() {
+		target.tag_name.as_str()
+	} else {
+		title
+	};
+	let mut lines = vec![format!("## {title}"), String::new()];
+	lines.push(format!("Grouped release for `{}`.", target.id));
+	lines.push(String::new());
+	push_member_changelogs(&mut lines, member_changelogs);
+	lines.join("\n")
+}
+
+fn push_member_changelogs(lines: &mut Vec<String>, changelogs: &[&ReleaseManifestChangelog]) {
+	lines.push("## Member package changelogs".to_string());
+
+	for changelog in changelogs {
+		lines.push(String::new());
+		lines.push(format!("### `{}`", changelog.owner_id));
+		push_changelog_notes(lines, changelog);
+	}
+}
+
+fn push_changelog_notes(lines: &mut Vec<String>, changelog: &ReleaseManifestChangelog) {
+	for paragraph in &changelog.notes.summary {
+		lines.push(String::new());
+		lines.push(paragraph.clone());
+	}
+
+	for section in &changelog.notes.sections {
+		if section.entries.is_empty() {
+			continue;
+		}
+		lines.push(String::new());
+		lines.push(format!("#### {}", section.title));
+		lines.push(String::new());
+		push_body_entries(lines, &section.entries);
+	}
+}
+
+fn changelog_has_release_notes(changelog: &ReleaseManifestChangelog) -> bool {
+	changelog.notes.sections.iter().any(|section| {
+		section
+			.entries
+			.iter()
+			.any(|entry| !is_empty_group_release_note(entry))
+	})
+}
+
+fn is_empty_group_release_note(entry: &str) -> bool {
+	entry.contains("No group-facing notes were recorded for this release")
+}
+
+fn changelog_has_uncovered_notes(
+	changelog: &ReleaseManifestChangelog,
+	target_changelog: Option<&ReleaseManifestChangelog>,
+) -> bool {
+	let Some(target_changelog) = target_changelog else {
+		return true;
+	};
+	let covered_entries = target_changelog
+		.notes
+		.sections
+		.iter()
+		.flat_map(|section| &section.entries)
+		.map(|entry| normalized_release_entry(entry))
+		.collect::<Vec<_>>();
+
+	changelog
+		.notes
+		.sections
+		.iter()
+		.flat_map(|section| &section.entries)
+		.any(|entry| !covered_entries.contains(&normalized_release_entry(entry)))
+}
+
+fn normalized_release_entry(entry: &str) -> String {
+	entry
+		.lines()
+		.filter(|line| !line.trim_start().starts_with("_Packages:"))
+		.collect::<Vec<_>>()
+		.join("\n")
+		.trim()
+		.to_string()
 }
 
 /// Build a blocking HTTP client for provider API calls.

--- a/fixtures/tests/github-releases/group-filtered/.changeset/feature.md
+++ b/fixtures/tests/github-releases/group-filtered/.changeset/feature.md
@@ -1,0 +1,5 @@
+---
+core: minor
+---
+
+#### add feature

--- a/fixtures/tests/github-releases/group-filtered/Cargo.toml
+++ b/fixtures/tests/github-releases/group-filtered/Cargo.toml
@@ -1,0 +1,10 @@
+[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[workspace.package]
+version = "1.0.0"
+
+[workspace.dependencies]
+workflow-core = { path = "./crates/core", version = "1.0.0" }
+workflow-app = { path = "./crates/app", version = "1.0.0" }

--- a/fixtures/tests/github-releases/group-filtered/changelog.md
+++ b/fixtures/tests/github-releases/group-filtered/changelog.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/fixtures/tests/github-releases/group-filtered/crates/app/Cargo.toml
+++ b/fixtures/tests/github-releases/group-filtered/crates/app/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "workflow-app"
+version = { workspace = true }
+edition = "2021"
+
+[dependencies]
+workflow-core = { workspace = true }

--- a/fixtures/tests/github-releases/group-filtered/crates/core/Cargo.toml
+++ b/fixtures/tests/github-releases/group-filtered/crates/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "workflow-core"
+version = { workspace = true }
+edition = "2021"

--- a/fixtures/tests/github-releases/group-filtered/group.toml
+++ b/fixtures/tests/github-releases/group-filtered/group.toml
@@ -1,0 +1,6 @@
+[workspace.package]
+version = "1.0.0"
+
+[workspace.dependencies]
+workflow-core = { version = "1.0.0" }
+workflow-app = { version = "1.0.0" }

--- a/fixtures/tests/github-releases/group-filtered/monochange.toml
+++ b/fixtures/tests/github-releases/group-filtered/monochange.toml
@@ -1,0 +1,57 @@
+[defaults]
+parent_bump = "patch"
+package_type = "cargo"
+changelog = false
+
+[package.core]
+path = "crates/core"
+changelog = true
+
+[package.app]
+path = "crates/app"
+changelog = false
+
+[group.sdk]
+packages = ["core", "app"]
+changelog = { path = "changelog.md", include = ["app"] }
+versioned_files = [{ path = "group.toml", type = "cargo" }]
+tag = true
+release = true
+version_format = "primary"
+
+[source]
+provider = "github"
+owner = "ifiokjr"
+repo = "monochange"
+
+[source.releases]
+source = "monochange"
+
+[ecosystems.cargo]
+enabled = true
+
+[cli.publish-release]
+
+[[cli.publish-release.inputs]]
+name = "format"
+type = "choice"
+choices = ["text", "json"]
+default = "text"
+
+[[cli.publish-release.inputs]]
+name = "from-ref"
+type = "string"
+default = "HEAD"
+
+[[cli.publish-release.inputs]]
+name = "draft"
+type = "boolean"
+default = false
+
+[[cli.publish-release.steps]]
+type = "PrepareRelease"
+inputs = ["format"]
+
+[[cli.publish-release.steps]]
+type = "PublishRelease"
+inputs = ["format", "from-ref", "draft"]

--- a/monochange.toml
+++ b/monochange.toml
@@ -552,6 +552,11 @@ name = "published cargo packages"
 match = { ecosystems = ["cargo"], managed = true, publishable = true }
 rules = { "cargo/required-package-fields" = "error" }
 
+[[lints.scopes]]
+name = "published npm CLI package"
+match = { paths = ["packages/monochange__cli/package.json"] }
+rules = { "npm/workspace-protocol" = "off" }
+
 # =============================================================================
 # [ecosystems.*] — per-ecosystem discovery and publishing settings
 # =============================================================================
@@ -748,7 +753,6 @@ steps = [
 	{ type = "Command", name = "update json schemas", when = "{{ number_of_changesets > 0 }}", command = "cargo xtask schema release update --versioned" },
 	{ type = "Command", name = "format changed files", when = "{{ number_of_changesets > 0 }}", command = "dprint fmt --allow-no-files" },
 	{ type = "Command", name = "stage schema assets", when = "{{ number_of_changesets > 0 }}", command = "git add crates/monochange_schema/SCHEMA_VERSION crates/monochange_schema/schemas docs/src/schemas" },
-	{ type = "Command", name = "refresh shared markdown", when = "{{ number_of_changesets > 0 }}", command = "mdt update" },
 	{ type = "CommitRelease", name = "create release commit", when = "{{ number_of_changesets > 0 && inputs.commit }}", inputs = { no_verify = "{{ inputs.no_verify }}", stage_all = true } },
 	{ type = "OpenReleaseRequest", name = "create the pr", when = "{{ number_of_changesets > 0 && inputs.commit && inputs.create_pr }}", inputs = { no_verify = "{{ inputs.no_verify }}", stage_all = true } },
 ]


### PR DESCRIPTION
## Summary

- Fix grouped provider release notes so filtered group changelogs do not publish the empty "No group-facing notes" fallback when member packages have real notes.
- Include uncovered member package changelog entries in grouped release bodies while avoiding duplicates already covered by the group changelog.
- Add a filtered-group GitHub release fixture and snapshots to prevent regressions.

## Validation

- `devenv shell cargo fmt --all`
- `devenv shell cargo clippy -p monochange_hosting -p monochange_github -p monochange --tests -- -D warnings`
- `devenv shell cargo test -p monochange --test github_releases`
- `devenv shell mc step:validate`
