### PR TITLE
feat: add Inline metadata style and make it default

### DIFF
--- a/.changeset/feat-inline-metadata-style.md
+++ b/.changeset/feat-inline-metadata-style.md
@@ -4,7 +4,7 @@ monochange_changelog: minor
 monochange: patch
 ---
 
-#### add `Inline` metadata style and make it the default
+# Add `Inline` metadata style and make it the default
 
 Context blocks in changelog entries now render as a single inline paragraph joined with `·` instead of separate lines.
 
@@ -12,18 +12,18 @@ When a review request (PR/MR) link is available, commit links are omitted since 
 
 The existing `Plain` and `Blockquote` styles continue to render commit links unconditionally. The `Omit` style hides all metadata as before.
 
-#### Before (default: `plain`)
+**Before (default: `plain`):**
 
 ```markdown
-#### Add release summary panel
+# Add release summary panel
 
 _Owner:_ @user _Review:_ [PR #123](https://...) _Introduced in:_ [`abc1234`](https://...) _Related issues: #456
 ```
 
-#### After (default: `inline`)
+**After (default: `inline`):**
 
 ```markdown
-#### Add release summary panel
+# Add release summary panel
 
 _Owner:_ @user · _Review:_ [PR #123](https://...) · _Related issues: #456
 ```

--- a/.changeset/feat-inline-metadata-style.md
+++ b/.changeset/feat-inline-metadata-style.md
@@ -2,6 +2,7 @@
 monochange_core: minor
 monochange_changelog: minor
 monochange: patch
+monochange_schema: patch
 ---
 
 # Add `Inline` metadata style and make it the default

--- a/.changeset/feat-inline-metadata-style.md
+++ b/.changeset/feat-inline-metadata-style.md
@@ -1,0 +1,31 @@
+---
+monochange_core: minor
+monochange_changelog: minor
+monochange: patch
+---
+
+#### add `Inline` metadata style and make it the default
+
+Context blocks in changelog entries now render as a single inline paragraph joined with `·` instead of separate lines.
+
+When a review request (PR/MR) link is available, commit links are omitted since the PR already identifies the change. When no review request link exists, commit links are included as before.
+
+The existing `Plain` and `Blockquote` styles continue to render commit links unconditionally. The `Omit` style hides all metadata as before.
+
+#### Before (default: `plain`)
+
+```markdown
+#### Add release summary panel
+
+_Owner:_ @user _Review:_ [PR #123](https://...) _Introduced in:_ [`abc1234`](https://...) _Related issues: #456
+```
+
+#### After (default: `inline`)
+
+```markdown
+#### Add release summary panel
+
+_Owner:_ @user · _Review:_ [PR #123](https://...) · _Related issues: #456
+```
+
+Set `metadata_style = "inline"` (now the default), `"plain"`, `"blockquote"`, or `"omit"` under `[changelog.style]` in `monochange.toml`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2258,6 +2258,7 @@ dependencies = [
 name = "monochange_changelog"
 version = "0.6.1"
 dependencies = [
+ "insta",
  "minijinja",
  "monochange_core",
  "semver",

--- a/crates/monochange_changelog/Cargo.toml
+++ b/crates/monochange_changelog/Cargo.toml
@@ -22,6 +22,7 @@ tracing = { workspace = true, default-features = true }
 typed-builder = { workspace = true, default-features = true }
 
 [dev-dependencies]
+insta = { workspace = true }
 tempfile = { workspace = true, default-features = true }
 
 [lints]

--- a/crates/monochange_changelog/src/__tests__/changelog_tests.rs
+++ b/crates/monochange_changelog/src/__tests__/changelog_tests.rs
@@ -1976,10 +1976,10 @@ fn snapshot_metadata_styles_render_context_blocks() {
 	// Inline style without a PR should include commit links
 	let mut changeset_no_pr = changeset.clone();
 	// Remove the review request from the introduced revision to test commit inclusion
-	if let Some(ref mut context) = changeset_no_pr.context {
-		if let Some(ref mut introduced) = context.introduced {
-			introduced.review_request = None;
-		}
+	if let Some(ref mut context) = changeset_no_pr.context
+		&& let Some(ref mut introduced) = context.introduced
+	{
+		introduced.review_request = None;
 	}
 	let inline_no_pr =
 		build_rendered_changeset_context(tempdir.path(), &changeset_no_pr, MetadataStyle::Inline);

--- a/crates/monochange_changelog/src/__tests__/changelog_tests.rs
+++ b/crates/monochange_changelog/src/__tests__/changelog_tests.rs
@@ -8,6 +8,7 @@ use monochange_core::ChangeSignal;
 use monochange_core::ChangelogFormat;
 use monochange_core::ChangelogSectionDef;
 use monochange_core::ChangelogSettings;
+use monochange_core::ChangelogStyle;
 use monochange_core::ChangelogTarget;
 use monochange_core::ChangelogType;
 use monochange_core::ChangesetContext;
@@ -664,6 +665,140 @@ fn rendered_changeset_context_and_signal_mapping_cover_hosted_metadata() {
 }
 
 #[test]
+fn inline_metadata_style_joins_with_separator_and_omits_commits_when_pr_exists() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let changeset_path = tempdir.path().join(".changeset/inline-feature.md");
+	fs::create_dir_all(changeset_path.parent().unwrap_or_else(|| Path::new(".")))
+		.unwrap_or_else(|error| panic!("create changeset dir: {error}"));
+	fs::write(&changeset_path, "feature\n")
+		.unwrap_or_else(|error| panic!("write changeset file: {error}"));
+
+	// Changeset WITH a review request — commits should be omitted in Inline mode.
+	let changeset_with_pr = PreparedChangeset {
+		path: changeset_path.clone(),
+		summary: Some("summary".to_string()),
+		details: Some("details".to_string()),
+		targets: vec![PreparedChangesetTarget {
+			id: "pkg-a".to_string(),
+			kind: ChangesetTargetKind::Package,
+			bump: Some(BumpSeverity::Minor),
+			origin: "manual".to_string(),
+			evidence_refs: Vec::new(),
+			change_type: Some("note".to_string()),
+			caused_by: Vec::new(),
+		}],
+		context: Some(ChangesetContext {
+			provider: HostingProviderKind::GitHub,
+			host: Some("github.com".to_string()),
+			capabilities: HostingCapabilities::default(),
+			introduced: Some(ChangesetRevision {
+				actor: Some(HostedActorRef {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					id: Some("1".to_string()),
+					login: Some("octocat".to_string()),
+					display_name: Some("Octo Cat".to_string()),
+					url: Some("https://example.com/octocat".to_string()),
+					source: HostedActorSourceKind::ReviewRequestAuthor,
+				}),
+				commit: Some(HostedCommitRef {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					sha: "abcdef123456".to_string(),
+					short_sha: "abcdef1".to_string(),
+					url: Some("https://example.com/commit/abcdef1".to_string()),
+					authored_at: None,
+					committed_at: None,
+					author_name: None,
+					author_email: None,
+				}),
+				review_request: Some(HostedReviewRequestRef {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					kind: HostedReviewRequestKind::PullRequest,
+					id: "42".to_string(),
+					title: Some("feat: add feature".to_string()),
+					url: Some("https://example.com/pull/42".to_string()),
+					author: None,
+				}),
+			}),
+			last_updated: None,
+			related_issues: vec![],
+		}),
+	};
+
+	let rendered_with_pr =
+		build_rendered_changeset_context(tempdir.path(), &changeset_with_pr, MetadataStyle::Inline);
+
+	// Inline style joins with ' · '
+	assert!(rendered_with_pr.context.contains(" · "));
+	// Commit links are omitted when a review request (PR) link is available.
+	assert!(!rendered_with_pr.context.contains("Introduced in"));
+	// But the PR link and owner are included.
+	assert!(rendered_with_pr.context.contains("_Owner:_"));
+	assert!(rendered_with_pr.context.contains("_Review:_"));
+	// Rendered fields are still populated regardless of style.
+	assert_eq!(
+		rendered_with_pr.introduced_commit.as_deref(),
+		Some("abcdef1")
+	);
+	assert_eq!(rendered_with_pr.review_request.as_deref(), Some("PR 42"));
+
+	// Changeset WITHOUT a review request — commits should be included.
+	let changeset_no_pr = PreparedChangeset {
+		path: changeset_path.clone(),
+		summary: Some("summary".to_string()),
+		details: None,
+		targets: vec![PreparedChangesetTarget {
+			id: "pkg-a".to_string(),
+			kind: ChangesetTargetKind::Package,
+			bump: Some(BumpSeverity::Minor),
+			origin: "manual".to_string(),
+			evidence_refs: Vec::new(),
+			change_type: None,
+			caused_by: Vec::new(),
+		}],
+		context: Some(ChangesetContext {
+			provider: HostingProviderKind::GitHub,
+			host: Some("github.com".to_string()),
+			capabilities: HostingCapabilities::default(),
+			introduced: Some(ChangesetRevision {
+				actor: Some(HostedActorRef {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					id: Some("1".to_string()),
+					login: Some("octocat".to_string()),
+					display_name: None,
+					url: Some("https://example.com/octocat".to_string()),
+					source: HostedActorSourceKind::ReviewRequestAuthor,
+				}),
+				commit: Some(HostedCommitRef {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					sha: "abcdef123456".to_string(),
+					short_sha: "abcdef1".to_string(),
+					url: Some("https://example.com/commit/abcdef1".to_string()),
+					authored_at: None,
+					committed_at: None,
+					author_name: None,
+					author_email: None,
+				}),
+				review_request: None,
+			}),
+			last_updated: None,
+			related_issues: vec![],
+		}),
+	};
+
+	let rendered_no_pr =
+		build_rendered_changeset_context(tempdir.path(), &changeset_no_pr, MetadataStyle::Inline);
+
+	// Without a PR, commit links are included.
+	assert!(rendered_no_pr.context.contains("Introduced in"));
+	assert!(rendered_no_pr.context.contains("abcdef1"));
+}
+
+#[test]
 fn render_helpers_cover_actor_labels_links_sections_and_templates() {
 	assert_eq!(
 		render_actor_label(&HostedActorRef {
@@ -789,6 +924,17 @@ fn render_helpers_cover_actor_labels_links_sections_and_templates() {
 	assert_eq!(
 		format_metadata_line(MetadataStyle::Omit, "Owner: @octocat"),
 		""
+	);
+	assert_eq!(
+		format_metadata_line(MetadataStyle::Inline, "Owner: @octocat"),
+		"Owner: @octocat"
+	);
+
+	// Inline metadata style renders context as single paragraph joined with ' · '
+	assert!(
+		ChangelogStyle::default()
+			.rules()
+			.contains("single inline paragraph joined with")
 	);
 
 	let mut empty_summary_change = sample_change("pkg-a", "pkg-a", ".changeset/a.md");

--- a/crates/monochange_changelog/src/__tests__/changelog_tests.rs
+++ b/crates/monochange_changelog/src/__tests__/changelog_tests.rs
@@ -1863,3 +1863,125 @@ fn root_relative_renders_workspace_root_as_dot() {
 
 	assert_eq!(root_relative(root, root), PathBuf::from("."));
 }
+
+#[test]
+fn snapshot_metadata_styles_render_context_blocks() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let changeset_path = tempdir.path().join(".changeset/snapshot-feature.md");
+	fs::create_dir_all(changeset_path.parent().unwrap_or_else(|| Path::new(".")))
+		.unwrap_or_else(|error| panic!("create changeset dir: {error}"));
+	fs::write(&changeset_path, "feature\n")
+		.unwrap_or_else(|error| panic!("write changeset file: {error}"));
+
+	// Changeset with all metadata: owner, review request, commits, issues.
+	let changeset = PreparedChangeset {
+		path: changeset_path.clone(),
+		summary: Some("snapshot feature".to_string()),
+		details: Some("snapshot details".to_string()),
+		targets: vec![PreparedChangesetTarget {
+			id: "pkg-a".to_string(),
+			kind: ChangesetTargetKind::Package,
+			bump: Some(BumpSeverity::Minor),
+			origin: "manual".to_string(),
+			evidence_refs: Vec::new(),
+			change_type: Some("note".to_string()),
+			caused_by: Vec::new(),
+		}],
+		context: Some(ChangesetContext {
+			provider: HostingProviderKind::GitHub,
+			host: Some("github.com".to_string()),
+			capabilities: HostingCapabilities::default(),
+			introduced: Some(ChangesetRevision {
+				actor: Some(HostedActorRef {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					id: Some("1".to_string()),
+					login: Some("octocat".to_string()),
+					display_name: Some("Octo Cat".to_string()),
+					url: Some("https://example.com/octocat".to_string()),
+					source: HostedActorSourceKind::ReviewRequestAuthor,
+				}),
+				commit: Some(HostedCommitRef {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					sha: "abcdef123456".to_string(),
+					short_sha: "abcdef1".to_string(),
+					url: Some("https://example.com/commit/abcdef1".to_string()),
+					authored_at: None,
+					committed_at: None,
+					author_name: None,
+					author_email: None,
+				}),
+				review_request: Some(HostedReviewRequestRef {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					kind: HostedReviewRequestKind::PullRequest,
+					id: "42".to_string(),
+					title: Some("feat: add feature".to_string()),
+					url: Some("https://example.com/pull/42".to_string()),
+					author: None,
+				}),
+			}),
+			last_updated: Some(ChangesetRevision {
+				actor: None,
+				commit: Some(HostedCommitRef {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					sha: "9876543210".to_string(),
+					short_sha: "9876543".to_string(),
+					url: Some("https://example.com/commit/9876543".to_string()),
+					authored_at: None,
+					committed_at: None,
+					author_name: None,
+					author_email: None,
+				}),
+				review_request: None,
+			}),
+			related_issues: vec![
+				HostedIssueRef {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					id: "123".to_string(),
+					relationship: HostedIssueRelationshipKind::ClosedByReviewRequest,
+					title: Some("Bug fix".to_string()),
+					url: Some("https://example.com/issues/123".to_string()),
+				},
+				HostedIssueRef {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					id: "456".to_string(),
+					relationship: HostedIssueRelationshipKind::ReferencedByReviewRequest,
+					title: None,
+					url: None,
+				},
+			],
+		}),
+	};
+
+	// Snapshot each metadata style
+	let blockquote =
+		build_rendered_changeset_context(tempdir.path(), &changeset, MetadataStyle::Blockquote);
+	insta::assert_snapshot!("metadata_style_blockquote", blockquote.context);
+
+	let plain = build_rendered_changeset_context(tempdir.path(), &changeset, MetadataStyle::Plain);
+	insta::assert_snapshot!("metadata_style_plain", plain.context);
+
+	let inline =
+		build_rendered_changeset_context(tempdir.path(), &changeset, MetadataStyle::Inline);
+	insta::assert_snapshot!("metadata_style_inline", inline.context);
+
+	let omit = build_rendered_changeset_context(tempdir.path(), &changeset, MetadataStyle::Omit);
+	insta::assert_snapshot!("metadata_style_omit", omit.context);
+
+	// Inline style without a PR should include commit links
+	let mut changeset_no_pr = changeset.clone();
+	// Remove the review request from the introduced revision to test commit inclusion
+	if let Some(ref mut context) = changeset_no_pr.context {
+		if let Some(ref mut introduced) = context.introduced {
+			introduced.review_request = None;
+		}
+	}
+	let inline_no_pr =
+		build_rendered_changeset_context(tempdir.path(), &changeset_no_pr, MetadataStyle::Inline);
+	insta::assert_snapshot!("metadata_style_inline_no_pr", inline_no_pr.context);
+}

--- a/crates/monochange_changelog/src/__tests__/changelog_tests.rs
+++ b/crates/monochange_changelog/src/__tests__/changelog_tests.rs
@@ -1703,7 +1703,7 @@ fn render_release_notes_document_includes_section_headings_in_markdown() {
 	let markdown = render_release_notes(
 		monochange_core::ChangelogFormat::Monochange,
 		&document,
-		&monochange_core::ChangelogStyle::default(),
+		&ChangelogStyle::default(),
 	);
 	assert!(
 		markdown.contains("### Features"),
@@ -1767,7 +1767,7 @@ fn keep_a_changelog_format_always_includes_section_headings() {
 	let markdown = render_release_notes(
 		monochange_core::ChangelogFormat::KeepAChangelog,
 		&document,
-		&monochange_core::ChangelogStyle::default(),
+		&ChangelogStyle::default(),
 	);
 
 	// Keep-a-changelog always includes section headings, even for single section
@@ -1797,7 +1797,7 @@ fn monochange_format_includes_heading_for_single_changed_section() {
 	let markdown = render_release_notes(
 		monochange_core::ChangelogFormat::Monochange,
 		&document,
-		&monochange_core::ChangelogStyle::default(),
+		&ChangelogStyle::default(),
 	);
 
 	// Monochange format includes section headings even when the only section is
@@ -1847,7 +1847,7 @@ fn monochange_format_includes_heading_for_custom_single_section() {
 	let markdown = render_release_notes(
 		monochange_core::ChangelogFormat::Monochange,
 		&document,
-		&monochange_core::ChangelogStyle::default(),
+		&ChangelogStyle::default(),
 	);
 
 	// Single custom section with non-"Changed" title should include heading

--- a/crates/monochange_changelog/src/__tests__/snapshots/monochange_changelog__tests__metadata_style_blockquote.snap
+++ b/crates/monochange_changelog/src/__tests__/snapshots/monochange_changelog__tests__metadata_style_blockquote.snap
@@ -1,0 +1,10 @@
+---
+source: crates/monochange_changelog/src/__tests__/changelog_tests.rs
+expression: blockquote.context
+---
+> _Owner:_ [@octocat](https://example.com/octocat)
+> _Review:_ [PR 42](https://example.com/pull/42)
+> _Introduced in:_ [`abcdef1`](https://example.com/commit/abcdef1)
+> _Last updated in:_ [`9876543`](https://example.com/commit/9876543)
+> _Closed issues:_ [123](https://example.com/issues/123)
+> _Related issues:_ 456

--- a/crates/monochange_changelog/src/__tests__/snapshots/monochange_changelog__tests__metadata_style_inline.snap
+++ b/crates/monochange_changelog/src/__tests__/snapshots/monochange_changelog__tests__metadata_style_inline.snap
@@ -1,0 +1,5 @@
+---
+source: crates/monochange_changelog/src/__tests__/changelog_tests.rs
+expression: inline.context
+---
+_Owner:_ [@octocat](https://example.com/octocat) · _Review:_ [PR 42](https://example.com/pull/42) · _Closed issues:_ [123](https://example.com/issues/123) · _Related issues:_ 456

--- a/crates/monochange_changelog/src/__tests__/snapshots/monochange_changelog__tests__metadata_style_inline_no_pr.snap
+++ b/crates/monochange_changelog/src/__tests__/snapshots/monochange_changelog__tests__metadata_style_inline_no_pr.snap
@@ -1,0 +1,5 @@
+---
+source: crates/monochange_changelog/src/__tests__/changelog_tests.rs
+expression: inline_no_pr.context
+---
+_Owner:_ [@octocat](https://example.com/octocat) · _Introduced in:_ [`abcdef1`](https://example.com/commit/abcdef1) · _Last updated in:_ [`9876543`](https://example.com/commit/9876543) · _Closed issues:_ [123](https://example.com/issues/123) · _Related issues:_ 456

--- a/crates/monochange_changelog/src/__tests__/snapshots/monochange_changelog__tests__metadata_style_omit.snap
+++ b/crates/monochange_changelog/src/__tests__/snapshots/monochange_changelog__tests__metadata_style_omit.snap
@@ -1,0 +1,5 @@
+---
+source: crates/monochange_changelog/src/__tests__/changelog_tests.rs
+expression: omit.context
+---
+

--- a/crates/monochange_changelog/src/__tests__/snapshots/monochange_changelog__tests__metadata_style_plain.snap
+++ b/crates/monochange_changelog/src/__tests__/snapshots/monochange_changelog__tests__metadata_style_plain.snap
@@ -1,0 +1,10 @@
+---
+source: crates/monochange_changelog/src/__tests__/changelog_tests.rs
+expression: plain.context
+---
+_Owner:_ [@octocat](https://example.com/octocat)
+_Review:_ [PR 42](https://example.com/pull/42)
+_Introduced in:_ [`abcdef1`](https://example.com/commit/abcdef1)
+_Last updated in:_ [`9876543`](https://example.com/commit/9876543)
+_Closed issues:_ [123](https://example.com/issues/123)
+_Related issues:_ 456

--- a/crates/monochange_changelog/src/lib.rs
+++ b/crates/monochange_changelog/src/lib.rs
@@ -617,7 +617,7 @@ fn build_release_note_change(
 fn format_metadata_line(style: MetadataStyle, text: &str) -> String {
 	match style {
 		MetadataStyle::Blockquote => format!("> {text}"),
-		MetadataStyle::Plain => text.to_string(),
+		MetadataStyle::Plain | MetadataStyle::Inline => text.to_string(),
 		MetadataStyle::Omit | _ => String::new(),
 	}
 }
@@ -674,6 +674,11 @@ fn build_rendered_changeset_context(
 		}
 	}
 
+	// In Inline mode, omit commit links when a review request (PR/MR) link is
+	// available — the PR already identifies the change.
+	let include_commits =
+		!matches!(metadata_style, MetadataStyle::Inline) || review_request.is_none();
+
 	if let Some(commit) = context
 		.introduced
 		.as_ref()
@@ -683,7 +688,7 @@ fn build_rendered_changeset_context(
 		let link = render_markdown_link(&format!("`{label}`"), commit.url.as_deref());
 		rendered.introduced_commit = Some(label);
 		rendered.introduced_commit_link = Some(link.clone());
-		if metadata_style != MetadataStyle::Omit {
+		if include_commits && metadata_style != MetadataStyle::Omit {
 			let prefix = format!("_Introduced in:_ {link}");
 			lines.push(format_metadata_line(metadata_style, &prefix));
 		}
@@ -704,7 +709,7 @@ fn build_rendered_changeset_context(
 		let link = render_markdown_link(&format!("`{label}`"), commit.url.as_deref());
 		rendered.last_updated_commit = Some(label);
 		rendered.last_updated_commit_link = Some(link.clone());
-		if metadata_style != MetadataStyle::Omit {
+		if include_commits && metadata_style != MetadataStyle::Omit {
 			let prefix = format!("_Last updated in:_ {link}");
 			lines.push(format_metadata_line(metadata_style, &prefix));
 		}
@@ -742,7 +747,12 @@ fn build_rendered_changeset_context(
 		}
 	}
 
-	rendered.context = lines.join("\n");
+	rendered.context = match metadata_style {
+		MetadataStyle::Inline => lines.join(" · "),
+		MetadataStyle::Blockquote | MetadataStyle::Plain | MetadataStyle::Omit | _ => {
+			lines.join("\n")
+		}
+	};
 	rendered
 }
 

--- a/crates/monochange_core/src/__tests__/lib_tests.rs
+++ b/crates/monochange_core/src/__tests__/lib_tests.rs
@@ -2214,7 +2214,7 @@ fn release_notes_style_overrides_only_replace_configured_fields() {
 		section_separator: SectionSeparator::BlankLine,
 		package_label_style: PackageLabelStyle::Inline,
 		package_label_placement: PackageLabelPlacement::AfterHeading,
-		metadata_style: MetadataStyle::Plain,
+		metadata_style: MetadataStyle::Inline,
 		collapsed_section_style: CollapsedSectionStyle::Details,
 	};
 	let overrides = ReleaseNotesStyleOverrides {

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -1272,8 +1272,14 @@ pub enum MetadataStyle {
 	/// Render metadata as block-quote lines: `> _Owner:_ @user`
 	Blockquote,
 	/// Render metadata as plain lines: `_Owner:_ @user`
-	#[default]
 	Plain,
+	/// Render metadata as an inline paragraph joined with ` · `.
+	///
+	/// When a review request (PR/MR) link is available, commit links are
+	/// omitted since the PR already identifies the change. When no review
+	/// request link exists, commit links are included.
+	#[default]
+	Inline,
 	/// Omit metadata entirely.
 	Omit,
 }
@@ -1373,6 +1379,9 @@ impl ChangelogStyle {
 			}
 			MetadataStyle::Plain => {
 				"Render metadata lines (owner, review link, commit links, issues) as plain text — no block-quote prefix."
+			}
+			MetadataStyle::Inline => {
+				"Render metadata as a single inline paragraph joined with ' · '. When a review request (PR/MR) link is available, omit commit links since the PR already identifies the change. When no review request link exists, include commit links."
 			}
 			MetadataStyle::Omit => "Omit metadata lines entirely from changelog entries.",
 		};

--- a/crates/monochange_schema/schemas/monochange.schema.json
+++ b/crates/monochange_schema/schemas/monochange.schema.json
@@ -77,7 +77,7 @@
 				},
 				"metadataStyle": {
 					"$ref": "#/$defs/MetadataStyle",
-					"default": "plain"
+					"default": "inline"
 				},
 				"packageLabelPlacement": {
 					"$ref": "#/$defs/PackageLabelPlacement",
@@ -1195,6 +1195,11 @@
 					"type": "string"
 				},
 				{
+					"const": "inline",
+					"description": "Render metadata as an inline paragraph joined with ` · `.\n\nWhen a review request (PR/MR) link is available, commit links are\nomitted since the PR already identifies the change. When no review\nrequest link exists, commit links are included.",
+					"type": "string"
+				},
+				{
 					"const": "omit",
 					"description": "Omit metadata entirely.",
 					"type": "string"
@@ -1703,7 +1708,7 @@
 					"$ref": "#/$defs/ChangelogStyle",
 					"default": {
 						"collapsedSectionStyle": "details",
-						"metadataStyle": "plain",
+						"metadataStyle": "inline",
 						"packageLabelPlacement": "after_heading",
 						"packageLabelStyle": "inline",
 						"sectionSeparator": "blank_line"

--- a/docs/src/schemas/monochange.schema.json
+++ b/docs/src/schemas/monochange.schema.json
@@ -77,7 +77,7 @@
 				},
 				"metadataStyle": {
 					"$ref": "#/$defs/MetadataStyle",
-					"default": "plain"
+					"default": "inline"
 				},
 				"packageLabelPlacement": {
 					"$ref": "#/$defs/PackageLabelPlacement",
@@ -1195,6 +1195,11 @@
 					"type": "string"
 				},
 				{
+					"const": "inline",
+					"description": "Render metadata as an inline paragraph joined with ` · `.\n\nWhen a review request (PR/MR) link is available, commit links are\nomitted since the PR already identifies the change. When no review\nrequest link exists, commit links are included.",
+					"type": "string"
+				},
+				{
 					"const": "omit",
 					"description": "Omit metadata entirely.",
 					"type": "string"
@@ -1703,7 +1708,7 @@
 					"$ref": "#/$defs/ChangelogStyle",
 					"default": {
 						"collapsedSectionStyle": "details",
-						"metadataStyle": "plain",
+						"metadataStyle": "inline",
 						"packageLabelPlacement": "after_heading",
 						"packageLabelStyle": "inline",
 						"sectionSeparator": "blank_line"

--- a/docs/src/schemas/monochange.v0.3.schema.json
+++ b/docs/src/schemas/monochange.v0.3.schema.json
@@ -77,7 +77,7 @@
 				},
 				"metadataStyle": {
 					"$ref": "#/$defs/MetadataStyle",
-					"default": "plain"
+					"default": "inline"
 				},
 				"packageLabelPlacement": {
 					"$ref": "#/$defs/PackageLabelPlacement",
@@ -1195,6 +1195,11 @@
 					"type": "string"
 				},
 				{
+					"const": "inline",
+					"description": "Render metadata as an inline paragraph joined with ` · `.\n\nWhen a review request (PR/MR) link is available, commit links are\nomitted since the PR already identifies the change. When no review\nrequest link exists, commit links are included.",
+					"type": "string"
+				},
+				{
 					"const": "omit",
 					"description": "Omit metadata entirely.",
 					"type": "string"
@@ -1703,7 +1708,7 @@
 					"$ref": "#/$defs/ChangelogStyle",
 					"default": {
 						"collapsedSectionStyle": "details",
-						"metadataStyle": "plain",
+						"metadataStyle": "inline",
 						"packageLabelPlacement": "after_heading",
 						"packageLabelStyle": "inline",
 						"sectionSeparator": "blank_line"

--- a/monochange.toml
+++ b/monochange.toml
@@ -143,6 +143,18 @@ templates = [
 	"- {{ summary }}",
 ]
 
+# Style options for changelog rendering.
+# metadata_style controls how metadata lines (owner, review link, commits, issues)
+# appear in context blocks:
+#   "blockquote" — block-quote lines prefixed with >
+#   "plain" — plain text lines
+#   "inline" — single paragraph joined with · (default)
+#     When a review request (PR/MR) link is available, commit links are
+#     omitted since the PR already identifies the change.
+#   "omit" — no metadata at all
+[changelog.style]
+metadata_style = "inline"
+
 [changelog.sections]
 breaking = { heading = "💥 Breaking Change", description = "Breaking changes that require consumer updates or migration", priority = 10 }
 feat = { heading = "🚀 Feature", description = "New features, enhancements, and additions", priority = 20 }


### PR DESCRIPTION
## Summary

Adds a new `Inline` metadata style for changelog context blocks and makes it the default, replacing `Plain`.

### What changed

- **New `MetadataStyle::Inline` variant** — renders context metadata as a single inline paragraph joined with ` · ` instead of separate lines
- **Conditional commit omission** — when a review request (PR/MR) link is available, commit links (`Introduced in:` / `Last updated in:`) are omitted since the PR already identifies the change. When no review request link exists, commit links are included as before.
- **Default changed** from `Plain` to `Inline`
- **`monochange.toml`** updated to explicitly set `metadata_style = "inline"` under `[changelog.style]`

### Before (default: `plain`)

```markdown
#### Add release summary panel

_Owner:_ @user
_Review:_ [PR #123](https://...)
_Introduced in:_ [`abc1234`](https://...)
_Related issues: #456
```

### After (default: `inline`)

```markdown
#### Add release summary panel

_Owner:_ @user · _Review:_ [PR #123](https://...) · _Related issues: #456
```

### Configuration

Set `metadata_style` under `[changelog.style]` in `monochange.toml`:

```toml
[changelog.style]
metadata_style = "inline"   # "blockquote" | "plain" | "inline" (default) | "omit"
```

- `blockquote` — block-quote lines prefixed with `>`
- `plain` — plain text lines (previous default)
- `inline` — single paragraph joined with ` · `, commits omitted when PR link exists (new default)
- `omit` — no metadata at all