### PR TITLE
fix(dart): allow versioned internal deps with resolution workspace

### DIFF
--- a/.changeset/fix-dart-workspace-resolution.md
+++ b/.changeset/fix-dart-workspace-resolution.md
@@ -1,0 +1,8 @@
+---
+monochange_dart: patch
+monochange: patch
+---
+
+# Allow Dart workspace resolution for internal dependencies
+
+Dart linting now treats `resolution: workspace` as a valid internal package resolution mode, so versioned internal dependencies in `pubspec.yaml` files no longer fail the internal path dependency policy when Dart will resolve them from the workspace.

--- a/crates/monochange_dart/src/lints/__tests__/mod_tests.rs
+++ b/crates/monochange_dart/src/lints/__tests__/mod_tests.rs
@@ -297,10 +297,16 @@ fn internal_path_dependency_policy_rule_supports_path_and_hosted_modes() {
 	let targets = advanced_workspace_flutter_targets();
 	let path_ok = find_target(&targets, "path_ok");
 	let path_fail = find_target(&targets, "path_fail");
+	let workspace_resolution = find_target(&targets, "workspace_resolution");
 
 	assert!(
 		InternalPathDependencyPolicyRule::new()
 			.run(&ctx(path_ok), &config())
+			.is_empty()
+	);
+	assert!(
+		InternalPathDependencyPolicyRule::new()
+			.run(&ctx(workspace_resolution), &config())
 			.is_empty()
 	);
 	let failing = InternalPathDependencyPolicyRule::new().run(&ctx(path_fail), &config());

--- a/crates/monochange_dart/src/lints/mod.rs
+++ b/crates/monochange_dart/src/lints/mod.rs
@@ -293,6 +293,13 @@ fn manifest_declares_private(mapping: &Mapping) -> bool {
 	)
 }
 
+fn manifest_uses_workspace_resolution(mapping: &Mapping) -> bool {
+	mapping
+		.get(yaml_key("resolution"))
+		.and_then(Value::as_str)
+		.is_some_and(|resolution| resolution.trim() == "workspace")
+}
+
 fn dependency_sections() -> [&'static str; 3] {
 	["dependencies", "dev_dependencies", "dependency_overrides"]
 }
@@ -855,6 +862,7 @@ impl LintRuleRunner for InternalPathDependencyPolicyRule {
 			.string_option("mode")
 			.unwrap_or_else(|| "path".to_string());
 		let require_path = mode != "hosted";
+		let workspace_resolution = manifest_uses_workspace_resolution(&file.manifest);
 		let mut results = Vec::new();
 
 		for section in ["dependencies", "dev_dependencies"] {
@@ -869,7 +877,9 @@ impl LintRuleRunner for InternalPathDependencyPolicyRule {
 					continue;
 				}
 				let uses_path = dependency_uses_path(value);
-				if (require_path && uses_path) || (!require_path && !uses_path) {
+				if (require_path && (uses_path || workspace_resolution))
+					|| (!require_path && !uses_path)
+				{
 					continue;
 				}
 				let expectation = if require_path {

--- a/fixtures/tests/dart-lints/advanced-workspace-flutter/workspace/monochange.toml
+++ b/fixtures/tests/dart-lints/advanced-workspace-flutter/workspace/monochange.toml
@@ -14,6 +14,9 @@ path = "packages/path_fail"
 [package.version_mismatch]
 path = "packages/version_mismatch"
 
+[package.workspace_resolution]
+path = "packages/workspace_resolution"
+
 [package.flutter_ok]
 path = "packages/flutter_ok"
 

--- a/fixtures/tests/dart-lints/advanced-workspace-flutter/workspace/packages/workspace_resolution/pubspec.yaml
+++ b/fixtures/tests/dart-lints/advanced-workspace-flutter/workspace/packages/workspace_resolution/pubspec.yaml
@@ -1,0 +1,9 @@
+name: workspace_resolution
+version: 1.0.0
+resolution: workspace
+environment:
+  sdk: ^3.6.0
+dependencies:
+  core: ^1.2.3
+dev_dependencies:
+  path_fail: ^1.0.0


### PR DESCRIPTION
## Summary

Internal path dependency policy now recognizes Dart workspace resolution. When a `pubspec.yaml` declares `resolution: workspace`, versioned internal dependencies no longer fail the path-reference check because Dart resolves them to workspace packages automatically.

## Changes

- Add `manifest_uses_workspace_resolution()` helper to detect top-level `resolution: workspace` in pubspec files
- Update `InternalPathDependencyPolicyRule` to skip the path-requirement when the manifest uses workspace resolution
- Add `workspace_resolution` fixture package for regression testing
- Extend unit test to assert workspace-resolved deps produce no lint failures

## Test plan

- [x] `cargo test -p monochange_dart` passes
- [x] `cargo clippy -p monochange_dart -p monochange --tests -- -D warnings` passes
- [x] `mc step:validate` passes in monochange repo
- [x] Verified against external Dart workspace (`solana_kit`) — `mc step:validate` now passes where it previously failed
- [x] `coverage:patch` at 100%
- [x] Regression fixture covers both with and without `resolution: workspace`