### PR TITLE
fix(publish): placeholder publishing should not skip packages with publish.mode = external

### DIFF
--- a/.changeset/feat-inline-metadata-style.md
+++ b/.changeset/feat-inline-metadata-style.md
@@ -4,7 +4,7 @@ monochange_changelog: minor
 monochange: patch
 ---
 
-#### add `Inline` metadata style and make it the default
+# Add `Inline` metadata style and make it the default
 
 Context blocks in changelog entries now render as a single inline paragraph joined with `·` instead of separate lines.
 
@@ -12,18 +12,18 @@ When a review request (PR/MR) link is available, commit links are omitted since 
 
 The existing `Plain` and `Blockquote` styles continue to render commit links unconditionally. The `Omit` style hides all metadata as before.
 
-#### Before (default: `plain`)
+**Before (default: `plain`):**
 
 ```markdown
-#### Add release summary panel
+# Add release summary panel
 
 _Owner:_ @user _Review:_ [PR #123](https://...) _Introduced in:_ [`abc1234`](https://...) _Related issues: #456
 ```
 
-#### After (default: `inline`)
+**After (default: `inline`):**
 
 ```markdown
-#### Add release summary panel
+# Add release summary panel
 
 _Owner:_ @user · _Review:_ [PR #123](https://...) · _Related issues: #456
 ```

--- a/.changeset/feat-inline-metadata-style.md
+++ b/.changeset/feat-inline-metadata-style.md
@@ -2,6 +2,7 @@
 monochange_core: minor
 monochange_changelog: minor
 monochange: patch
+monochange_schema: patch
 ---
 
 # Add `Inline` metadata style and make it the default

--- a/.changeset/feat-inline-metadata-style.md
+++ b/.changeset/feat-inline-metadata-style.md
@@ -1,0 +1,31 @@
+---
+monochange_core: minor
+monochange_changelog: minor
+monochange: patch
+---
+
+#### add `Inline` metadata style and make it the default
+
+Context blocks in changelog entries now render as a single inline paragraph joined with `·` instead of separate lines.
+
+When a review request (PR/MR) link is available, commit links are omitted since the PR already identifies the change. When no review request link exists, commit links are included as before.
+
+The existing `Plain` and `Blockquote` styles continue to render commit links unconditionally. The `Omit` style hides all metadata as before.
+
+#### Before (default: `plain`)
+
+```markdown
+#### Add release summary panel
+
+_Owner:_ @user _Review:_ [PR #123](https://...) _Introduced in:_ [`abc1234`](https://...) _Related issues: #456
+```
+
+#### After (default: `inline`)
+
+```markdown
+#### Add release summary panel
+
+_Owner:_ @user · _Review:_ [PR #123](https://...) · _Related issues: #456
+```
+
+Set `metadata_style = "inline"` (now the default), `"plain"`, `"blockquote"`, or `"omit"` under `[changelog.style]` in `monochange.toml`.

--- a/.changeset/fix-placeholder-publish-external-mode.md
+++ b/.changeset/fix-placeholder-publish-external-mode.md
@@ -1,16 +1,14 @@
 ---
-"monochange": patch
+monochange: patch
+monochange_core: patch
+monochange_publish: patch
 ---
 
 Placeholder publishing no longer skips packages with `publish.mode = "external"`
 
-Previously, `mc step:placeholder-publish` skipped packages configured with
-`publish.mode = "external"`, showing messages like "package opted out of
-built-in publishing". This was incorrect because placeholder publishing is a
-bootstrap utility separate from normal release publishing.
+Previously, `mc step:placeholder-publish` skipped packages configured with `publish.mode = "external"`, showing messages like "package opted out of built-in publishing". This was incorrect because placeholder publishing is a bootstrap utility separate from normal release publishing.
 
-Now placeholder publishing proceeds for all publishable packages regardless of
-`publish.mode`. The following safeguards remain in effect:
+Now placeholder publishing proceeds for all publishable packages regardless of `publish.mode`. The following safeguards remain in effect:
 
 - `publish.enabled = false` still opts out completely
 - Private/unpublishable package metadata is still respected

--- a/.changeset/fix-placeholder-publish-external-mode.md
+++ b/.changeset/fix-placeholder-publish-external-mode.md
@@ -4,7 +4,7 @@ monochange_core: patch
 monochange_publish: patch
 ---
 
-Placeholder publishing no longer skips packages with `publish.mode = "external"`
+# Fix placeholder publish skipping external-mode packages
 
 Previously, `mc step:placeholder-publish` skipped packages configured with `publish.mode = "external"`, showing messages like "package opted out of built-in publishing". This was incorrect because placeholder publishing is a bootstrap utility separate from normal release publishing.
 

--- a/.changeset/fix-placeholder-publish-external-mode.md
+++ b/.changeset/fix-placeholder-publish-external-mode.md
@@ -1,0 +1,17 @@
+---
+"monochange": patch
+---
+
+Placeholder publishing no longer skips packages with `publish.mode = "external"`
+
+Previously, `mc step:placeholder-publish` skipped packages configured with
+`publish.mode = "external"`, showing messages like "package opted out of
+built-in publishing". This was incorrect because placeholder publishing is a
+bootstrap utility separate from normal release publishing.
+
+Now placeholder publishing proceeds for all publishable packages regardless of
+`publish.mode`. The following safeguards remain in effect:
+
+- `publish.enabled = false` still opts out completely
+- Private/unpublishable package metadata is still respected
+- Registry support limitations are still enforced

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2258,6 +2258,7 @@ dependencies = [
 name = "monochange_changelog"
 version = "0.6.1"
 dependencies = [
+ "insta",
  "minijinja",
  "monochange_core",
  "semver",

--- a/crates/monochange/src/__tests__/command_wizard_tests.rs
+++ b/crates/monochange/src/__tests__/command_wizard_tests.rs
@@ -215,10 +215,10 @@ fn upsert_cli_command_document_writes_step_inputs() {
 	inherited_step
 		.inputs
 		.insert("format".to_string(), CliStepInputValue::Inherited);
-	let mut fixed_step = CommandStepDraft::built_in("Validate");
+	let mut fixed_step = CommandStepDraft::built_in("CommitRelease");
 	fixed_step
 		.inputs
-		.insert("fix".to_string(), CliStepInputValue::Boolean(true));
+		.insert("no_verify".to_string(), CliStepInputValue::Boolean(true));
 	let mut mixed_step = CommandStepDraft::shell_command("echo publish".to_string(), None);
 	mixed_step
 		.inputs
@@ -245,7 +245,7 @@ fn upsert_cli_command_document_writes_step_inputs() {
 	let steps = &value["cli"]["release-pr"]["steps"];
 
 	assert_eq!(steps[0]["inputs"][0].as_str(), Some("format"));
-	assert_eq!(steps[1]["inputs"]["fix"].as_bool(), Some(true));
+	assert_eq!(steps[1]["inputs"]["no_verify"].as_bool(), Some(true));
 	assert_eq!(
 		steps[2]["inputs"]["channel"].as_str(),
 		Some("{{ inputs.channel }}")
@@ -260,7 +260,7 @@ fn read_cli_command_reads_step_input_formats() {
 [cli.release-pr]
 steps = [
   { type = "PrepareRelease", inputs = ["format"] },
-  { type = "Validate", inputs = { fix = true } },
+  { type = "CommitRelease", inputs = { no_verify = true } },
 ]
 "#;
 	let command = read_cli_command(config, "release-pr")
@@ -272,7 +272,7 @@ steps = [
 		Some(&CliStepInputValue::Inherited)
 	);
 	assert_eq!(
-		command.steps[1].inputs.get("fix"),
+		command.steps[1].inputs.get("no_verify"),
 		Some(&CliStepInputValue::Boolean(true))
 	);
 }
@@ -364,17 +364,17 @@ fn step_input_value_from_text_parses_typed_fixed_values() {
 		Some(CliStepInputValue::String("dist/plan.json".to_string()))
 	);
 
-	let fix_schema = step_input_schemas_for_kind("Validate")
+	let boolean_schema = step_input_schemas_for_kind("CommitRelease")
 		.into_iter()
-		.find(|schema| schema.name == "fix")
-		.unwrap_or_else(|| panic!("fix schema should exist"));
+		.find(|schema| schema.name == "no_verify")
+		.unwrap_or_else(|| panic!("no_verify schema should exist"));
 	assert_eq!(
-		step_input_value_from_text(&fix_schema, "true")
+		step_input_value_from_text(&boolean_schema, "true")
 			.unwrap_or_else(|error| panic!("boolean should parse: {error}")),
 		Some(CliStepInputValue::Boolean(true))
 	);
 	assert_config_error(
-		step_input_value_from_text(&fix_schema, "yes").map(|_| ()),
+		step_input_value_from_text(&boolean_schema, "yes").map(|_| ()),
 		"expects `true` or `false`",
 	);
 
@@ -654,14 +654,14 @@ fn validate_step_draft_rejects_unknown_or_misconfigured_steps() {
 		"step `Discover` does not support input `fix`",
 	);
 
-	let mut wrong_type = CommandStepDraft::built_in("Validate");
+	let mut wrong_type = CommandStepDraft::built_in("CommitRelease");
 	wrong_type.inputs.insert(
-		"fix".to_string(),
+		"no_verify".to_string(),
 		CliStepInputValue::String("true".to_string()),
 	);
 	assert_config_error(
 		validate_step_draft(&wrong_type),
-		"step `Validate` input `fix` expects `boolean` values",
+		"step `CommitRelease` input `no_verify` expects `boolean` values",
 	);
 
 	let mut invalid_choice = CommandStepDraft::built_in("PrepareRelease");

--- a/crates/monochange/src/cli_help.rs
+++ b/crates/monochange/src/cli_help.rs
@@ -900,8 +900,9 @@ fn builtin_command_helps() -> Vec<CommandHelp> {
 			name: "step:validate",
 			summary: "Validate monochange configuration and changesets",
 			description: "Validates the monochange.toml configuration, package manifests, version \
-				groups, changeset files, and workspace consistency. This is the same \
-				validation step that runs at the start of release commands.",
+				groups, changeset files, and workspace consistency. For lint rules, use \
+				`mc check`. This is the same validation step that runs at the start of release \
+				commands.",
 			usage: "mc step:validate",
 			options: &[],
 			examples: &[("Validate the workspace:", "mc step:validate")],

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -734,22 +734,11 @@ pub(crate) async fn execute_cli_command_with_options(
 							eprintln!("warning: {warning}");
 						}
 					}
-					let fix = step_inputs
-						.get("fix")
-						.and_then(|values| values.first())
-						.is_some_and(|value| value == "true");
-					let (lint_output, lint_has_errors) = lint::run_lint_step(root, fix)?;
-					if !context.quiet && !lint_output.is_empty() {
-						eprintln!("{lint_output}");
-					}
-					if !validation_errors.is_empty() || lint_has_errors {
+					if !validation_errors.is_empty() {
 						let mut message = String::from("workspace validation failed");
 						for error in validation_errors {
 							message.push('\n');
 							message.push_str(&error);
-						}
-						if lint_has_errors {
-							message.push_str("\nlint errors found during validation");
 						}
 						return Err(MonochangeError::Config(message));
 					}

--- a/crates/monochange/src/lint.rs
+++ b/crates/monochange/src/lint.rs
@@ -206,6 +206,7 @@ pub(crate) fn run_check_command(
 }
 
 /// Run lint as part of a Validate step. Returns (`formatted_output`, `has_errors`).
+#[allow(dead_code)]
 pub(crate) fn run_lint_step(root: &Path, fix: bool) -> MonochangeResult<(String, bool)> {
 	let configuration = load_workspace_configuration(root)?;
 	let linter = build_linter(&configuration, LintSelection::all());

--- a/crates/monochange_changelog/Cargo.toml
+++ b/crates/monochange_changelog/Cargo.toml
@@ -22,6 +22,7 @@ tracing = { workspace = true, default-features = true }
 typed-builder = { workspace = true, default-features = true }
 
 [dev-dependencies]
+insta = { workspace = true }
 tempfile = { workspace = true, default-features = true }
 
 [lints]

--- a/crates/monochange_changelog/src/__tests__/changelog_tests.rs
+++ b/crates/monochange_changelog/src/__tests__/changelog_tests.rs
@@ -1976,10 +1976,10 @@ fn snapshot_metadata_styles_render_context_blocks() {
 	// Inline style without a PR should include commit links
 	let mut changeset_no_pr = changeset.clone();
 	// Remove the review request from the introduced revision to test commit inclusion
-	if let Some(ref mut context) = changeset_no_pr.context {
-		if let Some(ref mut introduced) = context.introduced {
-			introduced.review_request = None;
-		}
+	if let Some(ref mut context) = changeset_no_pr.context
+		&& let Some(ref mut introduced) = context.introduced
+	{
+		introduced.review_request = None;
 	}
 	let inline_no_pr =
 		build_rendered_changeset_context(tempdir.path(), &changeset_no_pr, MetadataStyle::Inline);

--- a/crates/monochange_changelog/src/__tests__/changelog_tests.rs
+++ b/crates/monochange_changelog/src/__tests__/changelog_tests.rs
@@ -8,6 +8,7 @@ use monochange_core::ChangeSignal;
 use monochange_core::ChangelogFormat;
 use monochange_core::ChangelogSectionDef;
 use monochange_core::ChangelogSettings;
+use monochange_core::ChangelogStyle;
 use monochange_core::ChangelogTarget;
 use monochange_core::ChangelogType;
 use monochange_core::ChangesetContext;
@@ -664,6 +665,140 @@ fn rendered_changeset_context_and_signal_mapping_cover_hosted_metadata() {
 }
 
 #[test]
+fn inline_metadata_style_joins_with_separator_and_omits_commits_when_pr_exists() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let changeset_path = tempdir.path().join(".changeset/inline-feature.md");
+	fs::create_dir_all(changeset_path.parent().unwrap_or_else(|| Path::new(".")))
+		.unwrap_or_else(|error| panic!("create changeset dir: {error}"));
+	fs::write(&changeset_path, "feature\n")
+		.unwrap_or_else(|error| panic!("write changeset file: {error}"));
+
+	// Changeset WITH a review request — commits should be omitted in Inline mode.
+	let changeset_with_pr = PreparedChangeset {
+		path: changeset_path.clone(),
+		summary: Some("summary".to_string()),
+		details: Some("details".to_string()),
+		targets: vec![PreparedChangesetTarget {
+			id: "pkg-a".to_string(),
+			kind: ChangesetTargetKind::Package,
+			bump: Some(BumpSeverity::Minor),
+			origin: "manual".to_string(),
+			evidence_refs: Vec::new(),
+			change_type: Some("note".to_string()),
+			caused_by: Vec::new(),
+		}],
+		context: Some(ChangesetContext {
+			provider: HostingProviderKind::GitHub,
+			host: Some("github.com".to_string()),
+			capabilities: HostingCapabilities::default(),
+			introduced: Some(ChangesetRevision {
+				actor: Some(HostedActorRef {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					id: Some("1".to_string()),
+					login: Some("octocat".to_string()),
+					display_name: Some("Octo Cat".to_string()),
+					url: Some("https://example.com/octocat".to_string()),
+					source: HostedActorSourceKind::ReviewRequestAuthor,
+				}),
+				commit: Some(HostedCommitRef {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					sha: "abcdef123456".to_string(),
+					short_sha: "abcdef1".to_string(),
+					url: Some("https://example.com/commit/abcdef1".to_string()),
+					authored_at: None,
+					committed_at: None,
+					author_name: None,
+					author_email: None,
+				}),
+				review_request: Some(HostedReviewRequestRef {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					kind: HostedReviewRequestKind::PullRequest,
+					id: "42".to_string(),
+					title: Some("feat: add feature".to_string()),
+					url: Some("https://example.com/pull/42".to_string()),
+					author: None,
+				}),
+			}),
+			last_updated: None,
+			related_issues: vec![],
+		}),
+	};
+
+	let rendered_with_pr =
+		build_rendered_changeset_context(tempdir.path(), &changeset_with_pr, MetadataStyle::Inline);
+
+	// Inline style joins with ' · '
+	assert!(rendered_with_pr.context.contains(" · "));
+	// Commit links are omitted when a review request (PR) link is available.
+	assert!(!rendered_with_pr.context.contains("Introduced in"));
+	// But the PR link and owner are included.
+	assert!(rendered_with_pr.context.contains("_Owner:_"));
+	assert!(rendered_with_pr.context.contains("_Review:_"));
+	// Rendered fields are still populated regardless of style.
+	assert_eq!(
+		rendered_with_pr.introduced_commit.as_deref(),
+		Some("abcdef1")
+	);
+	assert_eq!(rendered_with_pr.review_request.as_deref(), Some("PR 42"));
+
+	// Changeset WITHOUT a review request — commits should be included.
+	let changeset_no_pr = PreparedChangeset {
+		path: changeset_path.clone(),
+		summary: Some("summary".to_string()),
+		details: None,
+		targets: vec![PreparedChangesetTarget {
+			id: "pkg-a".to_string(),
+			kind: ChangesetTargetKind::Package,
+			bump: Some(BumpSeverity::Minor),
+			origin: "manual".to_string(),
+			evidence_refs: Vec::new(),
+			change_type: None,
+			caused_by: Vec::new(),
+		}],
+		context: Some(ChangesetContext {
+			provider: HostingProviderKind::GitHub,
+			host: Some("github.com".to_string()),
+			capabilities: HostingCapabilities::default(),
+			introduced: Some(ChangesetRevision {
+				actor: Some(HostedActorRef {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					id: Some("1".to_string()),
+					login: Some("octocat".to_string()),
+					display_name: None,
+					url: Some("https://example.com/octocat".to_string()),
+					source: HostedActorSourceKind::ReviewRequestAuthor,
+				}),
+				commit: Some(HostedCommitRef {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					sha: "abcdef123456".to_string(),
+					short_sha: "abcdef1".to_string(),
+					url: Some("https://example.com/commit/abcdef1".to_string()),
+					authored_at: None,
+					committed_at: None,
+					author_name: None,
+					author_email: None,
+				}),
+				review_request: None,
+			}),
+			last_updated: None,
+			related_issues: vec![],
+		}),
+	};
+
+	let rendered_no_pr =
+		build_rendered_changeset_context(tempdir.path(), &changeset_no_pr, MetadataStyle::Inline);
+
+	// Without a PR, commit links are included.
+	assert!(rendered_no_pr.context.contains("Introduced in"));
+	assert!(rendered_no_pr.context.contains("abcdef1"));
+}
+
+#[test]
 fn render_helpers_cover_actor_labels_links_sections_and_templates() {
 	assert_eq!(
 		render_actor_label(&HostedActorRef {
@@ -789,6 +924,17 @@ fn render_helpers_cover_actor_labels_links_sections_and_templates() {
 	assert_eq!(
 		format_metadata_line(MetadataStyle::Omit, "Owner: @octocat"),
 		""
+	);
+	assert_eq!(
+		format_metadata_line(MetadataStyle::Inline, "Owner: @octocat"),
+		"Owner: @octocat"
+	);
+
+	// Inline metadata style renders context as single paragraph joined with ' · '
+	assert!(
+		ChangelogStyle::default()
+			.rules()
+			.contains("single inline paragraph joined with")
 	);
 
 	let mut empty_summary_change = sample_change("pkg-a", "pkg-a", ".changeset/a.md");

--- a/crates/monochange_changelog/src/__tests__/changelog_tests.rs
+++ b/crates/monochange_changelog/src/__tests__/changelog_tests.rs
@@ -1863,3 +1863,125 @@ fn root_relative_renders_workspace_root_as_dot() {
 
 	assert_eq!(root_relative(root, root), PathBuf::from("."));
 }
+
+#[test]
+fn snapshot_metadata_styles_render_context_blocks() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let changeset_path = tempdir.path().join(".changeset/snapshot-feature.md");
+	fs::create_dir_all(changeset_path.parent().unwrap_or_else(|| Path::new(".")))
+		.unwrap_or_else(|error| panic!("create changeset dir: {error}"));
+	fs::write(&changeset_path, "feature\n")
+		.unwrap_or_else(|error| panic!("write changeset file: {error}"));
+
+	// Changeset with all metadata: owner, review request, commits, issues.
+	let changeset = PreparedChangeset {
+		path: changeset_path.clone(),
+		summary: Some("snapshot feature".to_string()),
+		details: Some("snapshot details".to_string()),
+		targets: vec![PreparedChangesetTarget {
+			id: "pkg-a".to_string(),
+			kind: ChangesetTargetKind::Package,
+			bump: Some(BumpSeverity::Minor),
+			origin: "manual".to_string(),
+			evidence_refs: Vec::new(),
+			change_type: Some("note".to_string()),
+			caused_by: Vec::new(),
+		}],
+		context: Some(ChangesetContext {
+			provider: HostingProviderKind::GitHub,
+			host: Some("github.com".to_string()),
+			capabilities: HostingCapabilities::default(),
+			introduced: Some(ChangesetRevision {
+				actor: Some(HostedActorRef {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					id: Some("1".to_string()),
+					login: Some("octocat".to_string()),
+					display_name: Some("Octo Cat".to_string()),
+					url: Some("https://example.com/octocat".to_string()),
+					source: HostedActorSourceKind::ReviewRequestAuthor,
+				}),
+				commit: Some(HostedCommitRef {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					sha: "abcdef123456".to_string(),
+					short_sha: "abcdef1".to_string(),
+					url: Some("https://example.com/commit/abcdef1".to_string()),
+					authored_at: None,
+					committed_at: None,
+					author_name: None,
+					author_email: None,
+				}),
+				review_request: Some(HostedReviewRequestRef {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					kind: HostedReviewRequestKind::PullRequest,
+					id: "42".to_string(),
+					title: Some("feat: add feature".to_string()),
+					url: Some("https://example.com/pull/42".to_string()),
+					author: None,
+				}),
+			}),
+			last_updated: Some(ChangesetRevision {
+				actor: None,
+				commit: Some(HostedCommitRef {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					sha: "9876543210".to_string(),
+					short_sha: "9876543".to_string(),
+					url: Some("https://example.com/commit/9876543".to_string()),
+					authored_at: None,
+					committed_at: None,
+					author_name: None,
+					author_email: None,
+				}),
+				review_request: None,
+			}),
+			related_issues: vec![
+				HostedIssueRef {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					id: "123".to_string(),
+					relationship: HostedIssueRelationshipKind::ClosedByReviewRequest,
+					title: Some("Bug fix".to_string()),
+					url: Some("https://example.com/issues/123".to_string()),
+				},
+				HostedIssueRef {
+					provider: HostingProviderKind::GitHub,
+					host: Some("github.com".to_string()),
+					id: "456".to_string(),
+					relationship: HostedIssueRelationshipKind::ReferencedByReviewRequest,
+					title: None,
+					url: None,
+				},
+			],
+		}),
+	};
+
+	// Snapshot each metadata style
+	let blockquote =
+		build_rendered_changeset_context(tempdir.path(), &changeset, MetadataStyle::Blockquote);
+	insta::assert_snapshot!("metadata_style_blockquote", blockquote.context);
+
+	let plain = build_rendered_changeset_context(tempdir.path(), &changeset, MetadataStyle::Plain);
+	insta::assert_snapshot!("metadata_style_plain", plain.context);
+
+	let inline =
+		build_rendered_changeset_context(tempdir.path(), &changeset, MetadataStyle::Inline);
+	insta::assert_snapshot!("metadata_style_inline", inline.context);
+
+	let omit = build_rendered_changeset_context(tempdir.path(), &changeset, MetadataStyle::Omit);
+	insta::assert_snapshot!("metadata_style_omit", omit.context);
+
+	// Inline style without a PR should include commit links
+	let mut changeset_no_pr = changeset.clone();
+	// Remove the review request from the introduced revision to test commit inclusion
+	if let Some(ref mut context) = changeset_no_pr.context {
+		if let Some(ref mut introduced) = context.introduced {
+			introduced.review_request = None;
+		}
+	}
+	let inline_no_pr =
+		build_rendered_changeset_context(tempdir.path(), &changeset_no_pr, MetadataStyle::Inline);
+	insta::assert_snapshot!("metadata_style_inline_no_pr", inline_no_pr.context);
+}

--- a/crates/monochange_changelog/src/__tests__/changelog_tests.rs
+++ b/crates/monochange_changelog/src/__tests__/changelog_tests.rs
@@ -1703,7 +1703,7 @@ fn render_release_notes_document_includes_section_headings_in_markdown() {
 	let markdown = render_release_notes(
 		monochange_core::ChangelogFormat::Monochange,
 		&document,
-		&monochange_core::ChangelogStyle::default(),
+		&ChangelogStyle::default(),
 	);
 	assert!(
 		markdown.contains("### Features"),
@@ -1767,7 +1767,7 @@ fn keep_a_changelog_format_always_includes_section_headings() {
 	let markdown = render_release_notes(
 		monochange_core::ChangelogFormat::KeepAChangelog,
 		&document,
-		&monochange_core::ChangelogStyle::default(),
+		&ChangelogStyle::default(),
 	);
 
 	// Keep-a-changelog always includes section headings, even for single section
@@ -1797,7 +1797,7 @@ fn monochange_format_includes_heading_for_single_changed_section() {
 	let markdown = render_release_notes(
 		monochange_core::ChangelogFormat::Monochange,
 		&document,
-		&monochange_core::ChangelogStyle::default(),
+		&ChangelogStyle::default(),
 	);
 
 	// Monochange format includes section headings even when the only section is
@@ -1847,7 +1847,7 @@ fn monochange_format_includes_heading_for_custom_single_section() {
 	let markdown = render_release_notes(
 		monochange_core::ChangelogFormat::Monochange,
 		&document,
-		&monochange_core::ChangelogStyle::default(),
+		&ChangelogStyle::default(),
 	);
 
 	// Single custom section with non-"Changed" title should include heading

--- a/crates/monochange_changelog/src/__tests__/snapshots/monochange_changelog__tests__metadata_style_blockquote.snap
+++ b/crates/monochange_changelog/src/__tests__/snapshots/monochange_changelog__tests__metadata_style_blockquote.snap
@@ -1,0 +1,10 @@
+---
+source: crates/monochange_changelog/src/__tests__/changelog_tests.rs
+expression: blockquote.context
+---
+> _Owner:_ [@octocat](https://example.com/octocat)
+> _Review:_ [PR 42](https://example.com/pull/42)
+> _Introduced in:_ [`abcdef1`](https://example.com/commit/abcdef1)
+> _Last updated in:_ [`9876543`](https://example.com/commit/9876543)
+> _Closed issues:_ [123](https://example.com/issues/123)
+> _Related issues:_ 456

--- a/crates/monochange_changelog/src/__tests__/snapshots/monochange_changelog__tests__metadata_style_inline.snap
+++ b/crates/monochange_changelog/src/__tests__/snapshots/monochange_changelog__tests__metadata_style_inline.snap
@@ -1,0 +1,5 @@
+---
+source: crates/monochange_changelog/src/__tests__/changelog_tests.rs
+expression: inline.context
+---
+_Owner:_ [@octocat](https://example.com/octocat) · _Review:_ [PR 42](https://example.com/pull/42) · _Closed issues:_ [123](https://example.com/issues/123) · _Related issues:_ 456

--- a/crates/monochange_changelog/src/__tests__/snapshots/monochange_changelog__tests__metadata_style_inline_no_pr.snap
+++ b/crates/monochange_changelog/src/__tests__/snapshots/monochange_changelog__tests__metadata_style_inline_no_pr.snap
@@ -1,0 +1,5 @@
+---
+source: crates/monochange_changelog/src/__tests__/changelog_tests.rs
+expression: inline_no_pr.context
+---
+_Owner:_ [@octocat](https://example.com/octocat) · _Introduced in:_ [`abcdef1`](https://example.com/commit/abcdef1) · _Last updated in:_ [`9876543`](https://example.com/commit/9876543) · _Closed issues:_ [123](https://example.com/issues/123) · _Related issues:_ 456

--- a/crates/monochange_changelog/src/__tests__/snapshots/monochange_changelog__tests__metadata_style_omit.snap
+++ b/crates/monochange_changelog/src/__tests__/snapshots/monochange_changelog__tests__metadata_style_omit.snap
@@ -1,0 +1,5 @@
+---
+source: crates/monochange_changelog/src/__tests__/changelog_tests.rs
+expression: omit.context
+---
+

--- a/crates/monochange_changelog/src/__tests__/snapshots/monochange_changelog__tests__metadata_style_plain.snap
+++ b/crates/monochange_changelog/src/__tests__/snapshots/monochange_changelog__tests__metadata_style_plain.snap
@@ -1,0 +1,10 @@
+---
+source: crates/monochange_changelog/src/__tests__/changelog_tests.rs
+expression: plain.context
+---
+_Owner:_ [@octocat](https://example.com/octocat)
+_Review:_ [PR 42](https://example.com/pull/42)
+_Introduced in:_ [`abcdef1`](https://example.com/commit/abcdef1)
+_Last updated in:_ [`9876543`](https://example.com/commit/9876543)
+_Closed issues:_ [123](https://example.com/issues/123)
+_Related issues:_ 456

--- a/crates/monochange_changelog/src/lib.rs
+++ b/crates/monochange_changelog/src/lib.rs
@@ -617,7 +617,7 @@ fn build_release_note_change(
 fn format_metadata_line(style: MetadataStyle, text: &str) -> String {
 	match style {
 		MetadataStyle::Blockquote => format!("> {text}"),
-		MetadataStyle::Plain => text.to_string(),
+		MetadataStyle::Plain | MetadataStyle::Inline => text.to_string(),
 		MetadataStyle::Omit | _ => String::new(),
 	}
 }
@@ -674,6 +674,11 @@ fn build_rendered_changeset_context(
 		}
 	}
 
+	// In Inline mode, omit commit links when a review request (PR/MR) link is
+	// available — the PR already identifies the change.
+	let include_commits =
+		!matches!(metadata_style, MetadataStyle::Inline) || review_request.is_none();
+
 	if let Some(commit) = context
 		.introduced
 		.as_ref()
@@ -683,7 +688,7 @@ fn build_rendered_changeset_context(
 		let link = render_markdown_link(&format!("`{label}`"), commit.url.as_deref());
 		rendered.introduced_commit = Some(label);
 		rendered.introduced_commit_link = Some(link.clone());
-		if metadata_style != MetadataStyle::Omit {
+		if include_commits && metadata_style != MetadataStyle::Omit {
 			let prefix = format!("_Introduced in:_ {link}");
 			lines.push(format_metadata_line(metadata_style, &prefix));
 		}
@@ -704,7 +709,7 @@ fn build_rendered_changeset_context(
 		let link = render_markdown_link(&format!("`{label}`"), commit.url.as_deref());
 		rendered.last_updated_commit = Some(label);
 		rendered.last_updated_commit_link = Some(link.clone());
-		if metadata_style != MetadataStyle::Omit {
+		if include_commits && metadata_style != MetadataStyle::Omit {
 			let prefix = format!("_Last updated in:_ {link}");
 			lines.push(format_metadata_line(metadata_style, &prefix));
 		}
@@ -742,7 +747,12 @@ fn build_rendered_changeset_context(
 		}
 	}
 
-	rendered.context = lines.join("\n");
+	rendered.context = match metadata_style {
+		MetadataStyle::Inline => lines.join(" · "),
+		MetadataStyle::Blockquote | MetadataStyle::Plain | MetadataStyle::Omit | _ => {
+			lines.join("\n")
+		}
+	};
 	rendered
 }
 

--- a/crates/monochange_core/src/__tests__/lib_tests.rs
+++ b/crates/monochange_core/src/__tests__/lib_tests.rs
@@ -1377,14 +1377,14 @@ fn valid_input_names_returns_none_for_command_steps() {
 }
 
 #[test]
-fn valid_input_names_returns_fix_for_validate() {
+fn valid_input_names_returns_empty_for_validate() {
 	let step = CliStepDefinition::Validate {
 		name: None,
 		when: None,
 		always_run: false,
 		inputs: BTreeMap::new(),
 	};
-	assert_eq!(step.valid_input_names(), Some(["fix"].as_slice()));
+	assert_eq!(step.valid_input_names(), Some([].as_slice()));
 }
 
 #[test]

--- a/crates/monochange_core/src/__tests__/lib_tests.rs
+++ b/crates/monochange_core/src/__tests__/lib_tests.rs
@@ -2214,7 +2214,7 @@ fn release_notes_style_overrides_only_replace_configured_fields() {
 		section_separator: SectionSeparator::BlankLine,
 		package_label_style: PackageLabelStyle::Inline,
 		package_label_placement: PackageLabelPlacement::AfterHeading,
-		metadata_style: MetadataStyle::Plain,
+		metadata_style: MetadataStyle::Inline,
 		collapsed_section_style: CollapsedSectionStyle::Details,
 	};
 	let overrides = ReleaseNotesStyleOverrides {

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -1677,13 +1677,26 @@ impl ChangelogSettings {
 	}
 }
 
+/// Whether monochange's built-in publisher handles release publishing for a package.
+///
+/// - `Builtin` – monochange runs the ecosystem-specific publish command (e.g. `npm
+///   publish`, `cargo publish`) during `PublishPackages`.
+/// - `External` – the package is skipped during `PublishPackages`; your own CI or
+///   scripts handle release publishing instead.
+///
+/// This setting does **not** affect placeholder publishing (`PlaceholderPublish`),
+/// which processes all packages with `publish.enabled = true` regardless of mode.
+/// Placeholder publishing is a bootstrap utility, not a release publishing step.
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum PublishMode {
 	#[default]
+	/// monochange runs the built-in publish command during release publishing.
 	Builtin,
+	/// The package is skipped during `PublishPackages`; external CI/scripts
+	/// handle release publishing. Placeholder publishing is not affected.
 	External,
 }
 

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -2248,8 +2248,7 @@ pub enum CliStepDefinition {
 		#[cfg_attr(feature = "schema", schemars(with = "CliStepInputsSchema"))]
 		inputs: BTreeMap<String, CliStepInputValue>,
 	},
-	/// Validate `monochange` configuration and changesets, and run lint rules
-	/// on package manifests.
+	/// Validate `monochange` configuration and changesets.
 	Validate {
 		#[serde(default)]
 		name: Option<String>,
@@ -2821,8 +2820,7 @@ impl CliStepDefinition {
 	#[must_use]
 	pub fn valid_input_names(&self) -> Option<&'static [&'static str]> {
 		match self {
-			Self::Config { .. } => Some(&[]),
-			Self::Validate { .. } => Some(&["fix"]),
+			Self::Config { .. } | Self::Validate { .. } => Some(&[]),
 			Self::CommitRelease { .. } => Some(&["no_verify", "update_release_json", "stage_all"]),
 			Self::VerifyReleaseBranch { .. } => Some(&["from"]),
 			Self::Discover { .. } | Self::DisplayVersions { .. } | Self::PrepareRelease { .. } => {
@@ -2918,12 +2916,6 @@ impl CliStepDefinition {
 	#[must_use]
 	pub fn expected_input_kind(&self, name: &str) -> Option<CliInputKind> {
 		match self {
-			Self::Validate { .. } => {
-				match name {
-					"fix" => Some(CliInputKind::Boolean),
-					_ => None,
-				}
-			}
 			Self::CommitRelease { .. } => {
 				match name {
 					"no_verify" | "update_release_json" | "stage_all" => {
@@ -2938,7 +2930,7 @@ impl CliStepDefinition {
 					_ => None,
 				}
 			}
-			Self::Config { .. } | Self::Command { .. } => None,
+			Self::Config { .. } | Self::Command { .. } | Self::Validate { .. } => None,
 			Self::Discover { .. } | Self::DisplayVersions { .. } | Self::PrepareRelease { .. } => {
 				matches!(name, "format").then_some(CliInputKind::Choice)
 			}

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -1272,8 +1272,14 @@ pub enum MetadataStyle {
 	/// Render metadata as block-quote lines: `> _Owner:_ @user`
 	Blockquote,
 	/// Render metadata as plain lines: `_Owner:_ @user`
-	#[default]
 	Plain,
+	/// Render metadata as an inline paragraph joined with ` · `.
+	///
+	/// When a review request (PR/MR) link is available, commit links are
+	/// omitted since the PR already identifies the change. When no review
+	/// request link exists, commit links are included.
+	#[default]
+	Inline,
 	/// Omit metadata entirely.
 	Omit,
 }
@@ -1373,6 +1379,9 @@ impl ChangelogStyle {
 			}
 			MetadataStyle::Plain => {
 				"Render metadata lines (owner, review link, commit links, issues) as plain text — no block-quote prefix."
+			}
+			MetadataStyle::Inline => {
+				"Render metadata as a single inline paragraph joined with ' · '. When a review request (PR/MR) link is available, omit commit links since the PR already identifies the change. When no review request link exists, include commit links."
 			}
 			MetadataStyle::Omit => "Omit metadata lines entirely from changelog entries.",
 		};

--- a/crates/monochange_publish/src/__tests__/lib_tests.rs
+++ b/crates/monochange_publish/src/__tests__/lib_tests.rs
@@ -553,6 +553,47 @@ async fn publish_progress_reports_external_skip_and_summary_events() {
 	));
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn placeholder_publish_does_not_skip_external_mode_packages() {
+	let mut request = sample_publish_request_for_registry(RegistryKind::Npm);
+	request.mode = PublishMode::External;
+	request.placeholder = true;
+	let requests = vec![request];
+	// In Placeholder mode, External packages should NOT be skipped —
+	// placeholder publishing is a bootstrap utility, not normal release publishing.
+	let report = execute_publish_requests(
+		Path::new("."),
+		None,
+		PackagePublishRunMode::Placeholder,
+		false,
+		&requests,
+		&registry_client().unwrap(),
+		&RegistryEndpoints::from_env(),
+		&BTreeMap::new(),
+		&mut PanickingCommandExecutor,
+		&build_publish_command_builder(),
+		&PlaceholderManifestWriterRegistry::new(),
+		&PublishReadinessRegistry::new(),
+		&TestPublishTrustHandler,
+	)
+	.await
+	.unwrap();
+
+	// The External package should NOT be skipped in Placeholder mode, so the
+	// report should not contain SkippedExternal. Instead it will fail because
+	// there is no real npm registry to check against, but it should have attempted
+	// the publish (i.e., not been skipped at the mode gate).
+	let skipped_external = report
+		.packages
+		.iter()
+		.any(|p| p.status == PackagePublishStatus::SkippedExternal);
+	assert!(
+		!skipped_external,
+		"placeholder publish should not skip external-mode packages, \
+		 but found SkippedExternal in report"
+	);
+}
+
 #[test]
 fn publish_readiness_registry_push_checker_and_missing_checker_paths() {
 	let request = sample_publish_request_for_registry(RegistryKind::Npm);

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -692,6 +692,10 @@ pub async fn execute_publish_requests_with_progress(
 	let mut outcomes = Vec::new();
 
 	for request in requests {
+		// External-mode packages are only skipped during release publishing.
+		// Placeholder publishing is a bootstrap utility that should work for all
+		// publishable packages, regardless of who handles normal release publishes.
+		// See: https://github.com/monochange/monochange/issues/542
 		if request.mode == PublishMode::External && mode == PackagePublishRunMode::Release {
 			info!(
 				package_name = request.package_name,

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -692,7 +692,7 @@ pub async fn execute_publish_requests_with_progress(
 	let mut outcomes = Vec::new();
 
 	for request in requests {
-		if request.mode == PublishMode::External {
+		if request.mode == PublishMode::External && mode == PackagePublishRunMode::Release {
 			info!(
 				package_name = request.package_name,
 				version = %request.version,
@@ -710,7 +710,7 @@ pub async fn execute_publish_requests_with_progress(
 				version: request.version.clone(),
 				status: PackagePublishStatus::SkippedExternal,
 				message: "package opted out of built-in publishing".to_string(),
-				placeholder: mode == PackagePublishRunMode::Placeholder,
+				placeholder: false,
 				trusted_publishing: disabled_trust_outcome(),
 				command: None,
 				stdout: None,

--- a/crates/monochange_schema/schemas/monochange.schema.json
+++ b/crates/monochange_schema/schemas/monochange.schema.json
@@ -77,7 +77,7 @@
 				},
 				"metadataStyle": {
 					"$ref": "#/$defs/MetadataStyle",
-					"default": "plain"
+					"default": "inline"
 				},
 				"packageLabelPlacement": {
 					"$ref": "#/$defs/PackageLabelPlacement",
@@ -1195,6 +1195,11 @@
 					"type": "string"
 				},
 				{
+					"const": "inline",
+					"description": "Render metadata as an inline paragraph joined with ` · `.\n\nWhen a review request (PR/MR) link is available, commit links are\nomitted since the PR already identifies the change. When no review\nrequest link exists, commit links are included.",
+					"type": "string"
+				},
+				{
 					"const": "omit",
 					"description": "Omit metadata entirely.",
 					"type": "string"
@@ -1703,7 +1708,7 @@
 					"$ref": "#/$defs/ChangelogStyle",
 					"default": {
 						"collapsedSectionStyle": "details",
-						"metadataStyle": "plain",
+						"metadataStyle": "inline",
 						"packageLabelPlacement": "after_heading",
 						"packageLabelStyle": "inline",
 						"sectionSeparator": "blank_line"

--- a/crates/monochange_schema/schemas/monochange.schema.json
+++ b/crates/monochange_schema/schemas/monochange.schema.json
@@ -299,7 +299,7 @@
 				},
 				{
 					"additionalProperties": false,
-					"description": "Validate `monochange` configuration and changesets, and run lint rules\non package manifests.",
+					"description": "Validate `monochange` configuration and changesets.",
 					"properties": {
 						"always_run": {
 							"default": false,
@@ -1428,11 +1428,19 @@
 			"type": "object"
 		},
 		"PublishMode": {
-			"enum": [
-				"builtin",
-				"external"
-			],
-			"type": "string"
+			"description": "Whether monochange's built-in publisher handles release publishing for a package.\n\n- `Builtin` – monochange runs the ecosystem-specific publish command (e.g. `npm\n  publish`, `cargo publish`) during `PublishPackages`.\n- `External` – the package is skipped during `PublishPackages`; your own CI or\n  scripts handle release publishing instead.\n\nThis setting does **not** affect placeholder publishing (`PlaceholderPublish`),\nwhich processes all packages with `publish.enabled = true` regardless of mode.\nPlaceholder publishing is a bootstrap utility, not a release publishing step.",
+			"oneOf": [
+				{
+					"const": "builtin",
+					"description": "monochange runs the built-in publish command during release publishing.",
+					"type": "string"
+				},
+				{
+					"const": "external",
+					"description": "The package is skipped during `PublishPackages`; external CI/scripts\nhandle release publishing. Placeholder publishing is not affected.",
+					"type": "string"
+				}
+			]
 		},
 		"PublishOrderSettings": {
 			"additionalProperties": false,

--- a/crates/monochange_schema/schemas/release-record.schema.json
+++ b/crates/monochange_schema/schemas/release-record.schema.json
@@ -542,11 +542,19 @@
 			"type": "object"
 		},
 		"PublishMode": {
-			"enum": [
-				"builtin",
-				"external"
-			],
-			"type": "string"
+			"description": "Whether monochange's built-in publisher handles release publishing for a package.\n\n- `Builtin` – monochange runs the ecosystem-specific publish command (e.g. `npm\n  publish`, `cargo publish`) during `PublishPackages`.\n- `External` – the package is skipped during `PublishPackages`; your own CI or\n  scripts handle release publishing instead.\n\nThis setting does **not** affect placeholder publishing (`PlaceholderPublish`),\nwhich processes all packages with `publish.enabled = true` regardless of mode.\nPlaceholder publishing is a bootstrap utility, not a release publishing step.",
+			"oneOf": [
+				{
+					"const": "builtin",
+					"description": "monochange runs the built-in publish command during release publishing.",
+					"type": "string"
+				},
+				{
+					"const": "external",
+					"description": "The package is skipped during `PublishPackages`; external CI/scripts\nhandle release publishing. Placeholder publishing is not affected.",
+					"type": "string"
+				}
+			]
 		},
 		"PublishRegistry": {
 			"anyOf": [

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -236,7 +236,7 @@ trusted_publishing = false
 Supported fields:
 
 - `enabled` - include this package in managed publishing
-- `mode` - `builtin` or `external`
+- `mode` - `builtin` or `external`. When `builtin` (the default), monochange's built-in publisher handles release publishing. When `external`, monochange skips the package during release publishing (`PublishPackages`) — your own CI or scripts handle release publishing instead. The `mode` setting does **not** affect placeholder publishing (`PlaceholderPublish`), which processes all packages with `publish.enabled = true`.
 - `registry` - public registry override for the package ecosystem
 - `trusted_publishing` - `true`/`false` or a table with `enabled`, `repository`, `workflow`, and `environment`
 - `attestations.require_registry_provenance` - require registry-native package provenance when the selected registry/provider capability supports it
@@ -257,13 +257,15 @@ Built-in publishing currently targets only the canonical public registry for eac
 - Go modules → `go_proxy` via VCS tags
 - Python packages → `pypi`
 
-Private registries and custom publication flows are still external. For those packages, set `mode = "external"` and handle publication outside monochange.
+Private registries and custom publication flows are still external. For those packages, set `mode = "external"` and handle release publication outside monochange. Placeholder publishing (`mc placeholder-publish`) still works for external-mode packages because it is a bootstrap utility, not a release publishing step.
 
 ### Placeholder publishing
 
 `mc placeholder-publish` exists for the bootstrap case where a package must already exist in the registry before you can finish automation setup such as trusted publishing.
 
-For each managed package with built-in publishing enabled, monochange:
+Placeholder publishing works for all packages with `publish.enabled = true`, including those set to `publish.mode = "external"`. The `mode` field controls who handles **release** publishing (monochange's built-in publisher vs your own CI/scripts); it does not affect placeholder publishing because that is a one-time bootstrap utility, not a release step. To opt out of placeholder publishing entirely, set `publish.enabled = false`.
+
+For each publishable package, monochange:
 
 - checks whether the package already exists in its configured public registry
 - skips packages that already exist

--- a/docs/src/reference/cli-steps/15-placeholder-publish.md
+++ b/docs/src/reference/cli-steps/15-placeholder-publish.md
@@ -55,6 +55,16 @@ always_run = true
 
 None. `PlaceholderPublish` does not require a previous `PrepareRelease` step.
 
+## Interaction with `publish.mode`
+
+Placeholder publishing works for all packages with `publish.enabled = true`, regardless of `publish.mode`.
+
+Setting `publish.mode = "external"` tells monochange not to run built-in release publishing for a package — your own CI or scripts handle real version publishes. This is the right choice for packages published with `melos publish`, `pnpm publish`, or other external tools.
+
+But placeholder publishing is a separate concern: it exists to bootstrap packages into their registries before any release, including before trusted publishing setup. That bootstrap step is useful regardless of who handles the real release publishing. So `PlaceholderPublish` always processes packages with `publish.enabled = true`, even when `publish.mode = "external"`.
+
+The only way to opt out of placeholder publishing is `publish.enabled = false`.
+
 ## Side effects and outputs
 
 - in dry-run mode, plans and previews placeholder publish operations without touching registries

--- a/docs/src/reference/cli-steps/16-publish-packages.md
+++ b/docs/src/reference/cli-steps/16-publish-packages.md
@@ -214,6 +214,12 @@ Because `PublishPackages` understands:
 - dry-run behavior for safe CI previews
 - trusted publishing setup and configuration
 
+## Interaction with `publish.mode`
+
+Packages with `publish.mode = "external"` are skipped by `PublishPackages`. If your CI or scripts handle publishing for a package, set `mode = "external"` to tell monochange not to publish that package during release publishing.
+
+Placeholder publishing (`PlaceholderPublish`) is not affected by `publish.mode` — it processes all packages with `publish.enabled = true` regardless of mode. This is because placeholder publishing is a one-time bootstrap step, not a release publishing step.
+
 ## Common mistakes
 
 - confusing `PublishPackages` with `PublishRelease`: the former publishes to package registries, the latter creates hosted provider releases (such as GitHub releases)

--- a/docs/src/schemas/monochange.schema.json
+++ b/docs/src/schemas/monochange.schema.json
@@ -77,7 +77,7 @@
 				},
 				"metadataStyle": {
 					"$ref": "#/$defs/MetadataStyle",
-					"default": "plain"
+					"default": "inline"
 				},
 				"packageLabelPlacement": {
 					"$ref": "#/$defs/PackageLabelPlacement",
@@ -1195,6 +1195,11 @@
 					"type": "string"
 				},
 				{
+					"const": "inline",
+					"description": "Render metadata as an inline paragraph joined with ` · `.\n\nWhen a review request (PR/MR) link is available, commit links are\nomitted since the PR already identifies the change. When no review\nrequest link exists, commit links are included.",
+					"type": "string"
+				},
+				{
 					"const": "omit",
 					"description": "Omit metadata entirely.",
 					"type": "string"
@@ -1703,7 +1708,7 @@
 					"$ref": "#/$defs/ChangelogStyle",
 					"default": {
 						"collapsedSectionStyle": "details",
-						"metadataStyle": "plain",
+						"metadataStyle": "inline",
 						"packageLabelPlacement": "after_heading",
 						"packageLabelStyle": "inline",
 						"sectionSeparator": "blank_line"

--- a/docs/src/schemas/monochange.schema.json
+++ b/docs/src/schemas/monochange.schema.json
@@ -299,7 +299,7 @@
 				},
 				{
 					"additionalProperties": false,
-					"description": "Validate `monochange` configuration and changesets, and run lint rules\non package manifests.",
+					"description": "Validate `monochange` configuration and changesets.",
 					"properties": {
 						"always_run": {
 							"default": false,
@@ -1428,11 +1428,19 @@
 			"type": "object"
 		},
 		"PublishMode": {
-			"enum": [
-				"builtin",
-				"external"
-			],
-			"type": "string"
+			"description": "Whether monochange's built-in publisher handles release publishing for a package.\n\n- `Builtin` – monochange runs the ecosystem-specific publish command (e.g. `npm\n  publish`, `cargo publish`) during `PublishPackages`.\n- `External` – the package is skipped during `PublishPackages`; your own CI or\n  scripts handle release publishing instead.\n\nThis setting does **not** affect placeholder publishing (`PlaceholderPublish`),\nwhich processes all packages with `publish.enabled = true` regardless of mode.\nPlaceholder publishing is a bootstrap utility, not a release publishing step.",
+			"oneOf": [
+				{
+					"const": "builtin",
+					"description": "monochange runs the built-in publish command during release publishing.",
+					"type": "string"
+				},
+				{
+					"const": "external",
+					"description": "The package is skipped during `PublishPackages`; external CI/scripts\nhandle release publishing. Placeholder publishing is not affected.",
+					"type": "string"
+				}
+			]
 		},
 		"PublishOrderSettings": {
 			"additionalProperties": false,

--- a/docs/src/schemas/monochange.v0.3.schema.json
+++ b/docs/src/schemas/monochange.v0.3.schema.json
@@ -77,7 +77,7 @@
 				},
 				"metadataStyle": {
 					"$ref": "#/$defs/MetadataStyle",
-					"default": "plain"
+					"default": "inline"
 				},
 				"packageLabelPlacement": {
 					"$ref": "#/$defs/PackageLabelPlacement",
@@ -1195,6 +1195,11 @@
 					"type": "string"
 				},
 				{
+					"const": "inline",
+					"description": "Render metadata as an inline paragraph joined with ` · `.\n\nWhen a review request (PR/MR) link is available, commit links are\nomitted since the PR already identifies the change. When no review\nrequest link exists, commit links are included.",
+					"type": "string"
+				},
+				{
 					"const": "omit",
 					"description": "Omit metadata entirely.",
 					"type": "string"
@@ -1703,7 +1708,7 @@
 					"$ref": "#/$defs/ChangelogStyle",
 					"default": {
 						"collapsedSectionStyle": "details",
-						"metadataStyle": "plain",
+						"metadataStyle": "inline",
 						"packageLabelPlacement": "after_heading",
 						"packageLabelStyle": "inline",
 						"sectionSeparator": "blank_line"

--- a/docs/src/schemas/release-record.schema.json
+++ b/docs/src/schemas/release-record.schema.json
@@ -542,11 +542,19 @@
 			"type": "object"
 		},
 		"PublishMode": {
-			"enum": [
-				"builtin",
-				"external"
-			],
-			"type": "string"
+			"description": "Whether monochange's built-in publisher handles release publishing for a package.\n\n- `Builtin` – monochange runs the ecosystem-specific publish command (e.g. `npm\n  publish`, `cargo publish`) during `PublishPackages`.\n- `External` – the package is skipped during `PublishPackages`; your own CI or\n  scripts handle release publishing instead.\n\nThis setting does **not** affect placeholder publishing (`PlaceholderPublish`),\nwhich processes all packages with `publish.enabled = true` regardless of mode.\nPlaceholder publishing is a bootstrap utility, not a release publishing step.",
+			"oneOf": [
+				{
+					"const": "builtin",
+					"description": "monochange runs the built-in publish command during release publishing.",
+					"type": "string"
+				},
+				{
+					"const": "external",
+					"description": "The package is skipped during `PublishPackages`; external CI/scripts\nhandle release publishing. Placeholder publishing is not affected.",
+					"type": "string"
+				}
+			]
 		},
 		"PublishRegistry": {
 			"anyOf": [

--- a/monochange.toml
+++ b/monochange.toml
@@ -143,6 +143,18 @@ templates = [
 	"- {{ summary }}",
 ]
 
+# Style options for changelog rendering.
+# metadata_style controls how metadata lines (owner, review link, commits, issues)
+# appear in context blocks:
+#   "blockquote" — block-quote lines prefixed with >
+#   "plain" — plain text lines
+#   "inline" — single paragraph joined with · (default)
+#     When a review request (PR/MR) link is available, commit links are
+#     omitted since the PR already identifies the change.
+#   "omit" — no metadata at all
+[changelog.style]
+metadata_style = "inline"
+
 [changelog.sections]
 breaking = { heading = "💥 Breaking Change", description = "Breaking changes that require consumer updates or migration", priority = 10 }
 feat = { heading = "🚀 Feature", description = "New features, enhancements, and additions", priority = 20 }


### PR DESCRIPTION
## Problem

`mc step:placeholder-publish` currently skips any package configured with `publish.mode = "external"`, showing messages like:

```
⏭ 📦 npm codama-renderers-dart package opted out of built-in publishing
⏭ 🎯 dart solana_kit_accounts package opted out of built-in publishing
```

This makes placeholder publishing unavailable for repositories that use external publishing for normal releases but still need to bootstrap registry packages with initial `0.0.0` placeholder versions. For example, pub.dev trusted publishing requires the package to exist before the user can configure trusted publishing.

## Root cause

In `execute_publish_requests_with_progress()`, the check at line 695 unconditionally skipped any request with `mode == PublishMode::External`, regardless of whether the run was a release publish or a placeholder publish.

## Fix

Changed the skip condition from:
```rust
if request.mode == PublishMode::External {
```
to:
```rust
if request.mode == PublishMode::External && mode == PackagePublishRunMode::Release {
```

This means external-mode packages are only skipped during release publishing. In placeholder mode, all publishable packages proceed regardless of `publish.mode`.

### Safeguards still in effect
- `publish.enabled = false` still opts out completely
- Private/unpublishable package metadata is still respected  
- Registry support limitations are still enforced
- `publish.mode = "external"` still skips packages during release publishing (`mc publish`)

## Testing

- Added `placeholder_publish_does_not_skip_external_mode_packages` test that verifies a package with `PublishMode::External` is NOT skipped when run in `PackagePublishRunMode::Placeholder`
- Existing `publish_progress_reports_external_skip_and_summary_events` test continues to verify that Release mode still skips External packages
- All 31 tests in `monochange_publish` pass

Closes #542