### PR TITLE
fix: add SDK constraint to Dart placeholder manifests

### DIFF
--- a/.changeset/1779804126-monochange-dart.md
+++ b/.changeset/1779804126-monochange-dart.md
@@ -1,0 +1,7 @@
+---
+monochange_dart: patch
+---
+
+# Add environment constraints to Dart placeholder manifests
+
+Generated Dart and Flutter placeholder `pubspec.yaml` files now reuse the source package's `environment` block when available, falling back to safe Dart/Flutter SDK constraints when it is missing.

--- a/crates/monochange_dart/src/__tests__/lib_tests.rs
+++ b/crates/monochange_dart/src/__tests__/lib_tests.rs
@@ -5,7 +5,12 @@ use std::path::Path;
 use monochange_core::Ecosystem;
 use monochange_core::EcosystemAdapter;
 use monochange_core::PackageRecord;
+use monochange_core::PublishAttestationSettings;
+use monochange_core::PublishMode;
 use monochange_core::PublishState;
+use monochange_core::RegistryKind;
+use monochange_core::TrustedPublishingSettings;
+use monochange_publish::PublishRequest;
 use semver::Version;
 use serde_yaml_ng::Mapping;
 use serde_yaml_ng::Value;
@@ -30,6 +35,7 @@ use crate::supported_versioned_file_kind;
 use crate::update_dependency_fields;
 use crate::update_manifest_text;
 use crate::update_pubspec_lock;
+use crate::write_dart_placeholder_manifest;
 use crate::yaml_array_strings;
 use crate::yaml_mapping;
 use crate::yaml_string;
@@ -74,6 +80,75 @@ fn marks_flutter_packages_with_dart_ecosystem_and_metadata() {
 #[test]
 fn adapter_reports_dart_ecosystem() {
 	assert_eq!(adapter().ecosystem(), Ecosystem::Dart);
+}
+
+fn sample_publish_request(root: &Path) -> PublishRequest {
+	PublishRequest {
+		package_id: "dart-package".to_string(),
+		package_name: "dart_package".to_string(),
+		ecosystem: Ecosystem::Dart,
+		manifest_path: root.join("source-pubspec.yaml"),
+		package_root: root.to_path_buf(),
+		registry: RegistryKind::PubDev,
+		package_manager: None,
+		package_metadata: BTreeMap::new(),
+		mode: PublishMode::Builtin,
+		version: "0.0.0".to_string(),
+		placeholder: true,
+		trusted_publishing: TrustedPublishingSettings::default(),
+		attestations: PublishAttestationSettings::default(),
+		placeholder_readme: String::new(),
+	}
+}
+
+#[test]
+fn dart_placeholder_manifest_uses_source_environment() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let request = sample_publish_request(tempdir.path());
+	fs::write(
+		&request.manifest_path,
+		"name: dart_package\nenvironment:\n  sdk: ^3.11.0\n  flutter: '>=3.30.0'\n",
+	)
+	.unwrap_or_else(|error| panic!("write source pubspec: {error}"));
+
+	write_dart_placeholder_manifest(tempdir.path(), &request, None)
+		.unwrap_or_else(|error| panic!("write placeholder manifest: {error}"));
+
+	let manifest = fs::read_to_string(tempdir.path().join("pubspec.yaml"))
+		.unwrap_or_else(|error| panic!("read pubspec: {error}"));
+
+	assert!(manifest.contains("environment:\n  sdk: ^3.11.0\n  flutter: '>=3.30.0'\n"));
+}
+
+#[test]
+fn dart_placeholder_manifest_falls_back_to_default_sdk_constraint() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let request = sample_publish_request(tempdir.path());
+
+	write_dart_placeholder_manifest(tempdir.path(), &request, None)
+		.unwrap_or_else(|error| panic!("write placeholder manifest: {error}"));
+
+	let manifest = fs::read_to_string(tempdir.path().join("pubspec.yaml"))
+		.unwrap_or_else(|error| panic!("read pubspec: {error}"));
+
+	assert!(manifest.contains("environment:\n  sdk: '>=3.0.0 <4.0.0'\n"));
+}
+
+#[test]
+fn flutter_placeholder_manifest_falls_back_to_default_flutter_constraint() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let mut request = sample_publish_request(tempdir.path());
+	request
+		.package_metadata
+		.insert("is_flutter".to_string(), "true".to_string());
+
+	write_dart_placeholder_manifest(tempdir.path(), &request, None)
+		.unwrap_or_else(|error| panic!("write placeholder manifest: {error}"));
+
+	let manifest = fs::read_to_string(tempdir.path().join("pubspec.yaml"))
+		.unwrap_or_else(|error| panic!("read pubspec: {error}"));
+
+	assert!(manifest.contains("environment:\n  sdk: '>=3.0.0 <4.0.0'\n  flutter: '>=3.0.0'\n"));
 }
 
 #[test]

--- a/crates/monochange_dart/src/lib.rs
+++ b/crates/monochange_dart/src/lib.rs
@@ -83,14 +83,46 @@ pub fn write_dart_placeholder_manifest(
 	let repository =
 		source.map(|source| format!("https://github.com/{}/{}", source.owner, source.repo));
 	let mut rendered = format!(
-		"name: {}\nversion: {}\ndescription: Placeholder package published by monochange.\n",
-		request.package_name, request.version
+		"name: {}\nversion: {}\ndescription: Placeholder package published by monochange.\n{}",
+		request.package_name,
+		request.version,
+		dart_placeholder_environment(request)
 	);
 	if let Some(repository) = repository {
 		let _ = writeln!(rendered, "repository: {repository}");
 	}
 	fs::write(dir.join("pubspec.yaml"), rendered).map_err(|error| {
 		MonochangeError::Io(format!("failed to write placeholder pubspec.yaml: {error}"))
+	})
+}
+
+fn dart_placeholder_environment(request: &PublishRequest) -> String {
+	let environment = fs::read_to_string(&request.manifest_path)
+		.ok()
+		.and_then(|contents| serde_yaml_ng::from_str::<Mapping>(&contents).ok())
+		.and_then(|manifest| {
+			manifest
+				.get(Value::String("environment".to_string()))
+				.cloned()
+		})
+		.and_then(|environment| serde_yaml_ng::to_string(&environment).ok())
+		.map(|environment| format!("environment:\n{}", indent_yaml_block(&environment)));
+
+	environment.unwrap_or_else(|| default_dart_placeholder_environment(request))
+}
+
+fn default_dart_placeholder_environment(request: &PublishRequest) -> String {
+	let mut environment = "environment:\n  sdk: '>=3.0.0 <4.0.0'\n".to_string();
+	if request.package_metadata.contains_key("is_flutter") {
+		environment.push_str("  flutter: '>=3.0.0'\n");
+	}
+	environment
+}
+
+fn indent_yaml_block(contents: &str) -> String {
+	contents.lines().fold(String::new(), |mut output, line| {
+		let _ = writeln!(output, "  {line}");
+		output
 	})
 }
 


### PR DESCRIPTION
## Summary
- reuse the source Dart/Flutter package `environment` block when generating placeholder pubspecs
- fall back to a valid default Dart SDK constraint when the source package has no environment block
- add a Flutter fallback constraint for Flutter packages without a source environment block
- cover source environment reuse, Dart fallback, and Flutter fallback with regression tests

## Why
`dart pub publish` rejects placeholder pubspecs without an `environment.sdk` lower bound, which blocks `mc step:placeholder-publish` for new Dart packages.

The generated placeholder should mirror the real package's environment when possible so Flutter/Dart SDK constraints match the package being bootstrapped. Defaults are only used when the source package does not provide an environment block.

## Validation
- `cargo test -p monochange_dart`
