### PR TITLE
fix(release): skip gitignored release paths

### DIFF
--- a/.changeset/fix-gitignored-release-paths.md
+++ b/.changeset/fix-gitignored-release-paths.md
@@ -1,0 +1,8 @@
+---
+monochange: patch
+monochange_github: patch
+---
+
+# Skip gitignored release staging paths
+
+Release staging now skips gitignored paths before git inspection, avoiding failures on ignored symlink descendants such as FVM Flutter SDK files.

--- a/crates/monochange/src/__tests__/git_support_tests.rs
+++ b/crates/monochange/src/__tests__/git_support_tests.rs
@@ -144,29 +144,46 @@ untracked.txt"
 async fn git_stage_paths_returns_ok_when_all_paths_are_non_stageable() {
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	let root = tempdir.path();
-	fs::write(root.join(".gitignore"), ".monochange/local/\n")
+	fs::write(root.join(".gitignore"), ".monochange/\n")
 		.unwrap_or_else(|error| panic!("write .gitignore: {error}"));
 	fs::write(root.join("tracked.txt"), "tracked\n")
 		.unwrap_or_else(|error| panic!("write tracked file: {error}"));
+	fs::create_dir_all(root.join(".monochange/releases"))
+		.unwrap_or_else(|error| panic!("create release state: {error}"));
+	fs::write(root.join(".monochange/releases/release.json"), "{}\n")
+		.unwrap_or_else(|error| panic!("write release state: {error}"));
 	init_git_repo(root);
 	git(root, &["add", "."]);
+	git(root, &["add", "-f", ".monochange/releases/release.json"]);
 	git(root, &["commit", "-m", "initial"]);
 	fs::create_dir_all(root.join(".monochange/local"))
 		.unwrap_or_else(|error| panic!("create .monochange: {error}"));
 	fs::write(root.join(".monochange/local/release-manifest.json"), "{}\n")
 		.unwrap_or_else(|error| panic!("write release manifest: {error}"));
+	fs::write(
+		root.join(".monochange/releases/release.json"),
+		"{\"released\":true}\n",
+	)
+	.unwrap_or_else(|error| panic!("update release state: {error}"));
+	fs::write(root.join("untracked.txt"), "untracked\n")
+		.unwrap_or_else(|error| panic!("write untracked file: {error}"));
 
 	git_stage_paths(
 		root,
 		&[
 			PathBuf::from(".monochange/local/release-manifest.json"),
+			PathBuf::from(".monochange/releases/release.json"),
+			PathBuf::from("untracked.txt"),
 			PathBuf::from(".changeset/missing.md"),
 		],
 	)
 	.await
 	.unwrap_or_else(|error| panic!("git stage paths: {error}"));
 
-	assert_eq!(git_output(root, &["diff", "--cached", "--name-only"]), "");
+	assert_eq!(
+		git_output(root, &["diff", "--cached", "--name-only"]),
+		".monochange/releases/release.json\nuntracked.txt"
+	);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/monochange/src/git_support.rs
+++ b/crates/monochange/src/git_support.rs
@@ -6,6 +6,7 @@ use std::process::Command as ProcessCommand;
 use std::process::Stdio;
 
 use monochange_core::CommitMessage;
+use monochange_core::DiscoveryPathFilter;
 use monochange_core::MonochangeError;
 use monochange_core::MonochangeResult;
 use monochange_core::git::git_command_output;
@@ -309,9 +310,10 @@ async fn resolve_stageable_release_paths(
 	tracked_paths: &[PathBuf],
 ) -> MonochangeResult<Vec<PathBuf>> {
 	let mut stageable_paths = Vec::with_capacity(tracked_paths.len());
+	let path_filter = DiscoveryPathFilter::new(root);
 
 	for path in tracked_paths {
-		if release_path_requires_staging(root, path).await? {
+		if release_path_requires_staging(root, path, &path_filter).await? {
 			stageable_paths.push(path.clone());
 		} else {
 			tracing::debug!(path = %path.display(), "skipping non-stageable release path");
@@ -321,27 +323,47 @@ async fn resolve_stageable_release_paths(
 	Ok(stageable_paths)
 }
 
-async fn release_path_requires_staging(root: &Path, path: &Path) -> MonochangeResult<bool> {
-	let absolute_path = root.join(path);
+async fn release_path_requires_staging(
+	root: &Path,
+	path: &Path,
+	path_filter: &DiscoveryPathFilter,
+) -> MonochangeResult<bool> {
+	let relative = root_relative_path(root, path);
+	if !relative.starts_with(".monochange/releases")
+		&& release_path_is_ignored_by_filter(root, relative, path_filter)
+	{
+		return Ok(false);
+	}
 
+	let absolute_path = root.join(path);
 	if !absolute_path.exists() {
 		return git_path_is_tracked(root, path).await;
 	}
 
+	if relative.starts_with(".monochange/releases") {
+		return Ok(true);
+	}
 	if git_path_is_tracked(root, path).await? {
 		return Ok(true);
 	}
 
-	let relative = if path.is_absolute() {
+	Ok(!git_path_is_ignored(root, path).await?)
+}
+
+fn release_path_is_ignored_by_filter(
+	root: &Path,
+	relative: &Path,
+	path_filter: &DiscoveryPathFilter,
+) -> bool {
+	!path_filter.allows(&root.join(relative))
+}
+
+fn root_relative_path<'a>(root: &Path, path: &'a Path) -> &'a Path {
+	if path.is_absolute() {
 		path.strip_prefix(root).unwrap_or(path)
 	} else {
 		path
-	};
-	if relative.starts_with(".monochange/releases") {
-		return Ok(true);
 	}
-
-	Ok(!git_path_is_ignored(root, path).await?)
 }
 
 #[must_use = "the tracked status result must be checked"]

--- a/crates/monochange_github/src/__tests__/lib_tests.rs
+++ b/crates/monochange_github/src/__tests__/lib_tests.rs
@@ -2086,14 +2086,23 @@ fn git_stage_paths_skips_missing_untracked_paths_and_ignored_untracked_files() {
 	git(&repo, &["config", "user.email", "monochange@example.com"]);
 	git(&repo, &["config", "commit.gpgsign", "false"]);
 	must_ok(
-		fs::write(repo.join(".gitignore"), ".monochange/local/\n"),
+		fs::write(repo.join(".gitignore"), ".monochange/\n"),
 		"write gitignore",
 	);
 	must_ok(
 		fs::write(repo.join("release.txt"), "before\n"),
 		"write release file",
 	);
+	must_ok(
+		fs::create_dir_all(repo.join(".monochange/releases")),
+		"create release state dir",
+	);
+	must_ok(
+		fs::write(repo.join(".monochange/releases/release.json"), "{}\n"),
+		"write release state",
+	);
 	git(&repo, &["add", "."]);
+	git(&repo, &["add", "-f", ".monochange/releases/release.json"]);
 	git(&repo, &["commit", "-m", "initial"]);
 	must_ok(
 		fs::create_dir_all(repo.join(".monochange/local")),
@@ -2103,6 +2112,17 @@ fn git_stage_paths_skips_missing_untracked_paths_and_ignored_untracked_files() {
 		fs::write(repo.join(".monochange/local/release-manifest.json"), "{}\n"),
 		"write manifest",
 	);
+	must_ok(
+		fs::write(
+			repo.join(".monochange/releases/release.json"),
+			"{\"released\":true}\n",
+		),
+		"update release state",
+	);
+	must_ok(
+		fs::write(repo.join("release.txt"), "after\n"),
+		"update release file",
+	);
 
 	must_ok(
 		tokio::runtime::Runtime::new()
@@ -2111,8 +2131,65 @@ fn git_stage_paths_skips_missing_untracked_paths_and_ignored_untracked_files() {
 				&repo,
 				&[
 					PathBuf::from(".monochange/local/release-manifest.json"),
+					PathBuf::from(".monochange/releases/release.json"),
+					repo.join("release.txt"),
 					PathBuf::from(".changeset/missing.md"),
 				],
+				false,
+			)),
+		"stage paths",
+	);
+
+	assert_eq!(
+		git_output(&repo, &["diff", "--cached", "--name-only"]).trim(),
+		".monochange/releases/release.json\nrelease.txt"
+	);
+}
+
+#[cfg(unix)]
+#[test]
+fn git_stage_paths_skips_gitignored_symlink_descendants() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let repo = tempdir.path().join("repo");
+	git(tempdir.path(), &["init", repo.to_string_lossy().as_ref()]);
+	git(&repo, &["config", "user.name", "monochange Tests"]);
+	git(&repo, &["config", "user.email", "monochange@example.com"]);
+	git(&repo, &["config", "commit.gpgsign", "false"]);
+	must_ok(
+		fs::write(repo.join(".gitignore"), ".fvm/\n"),
+		"write gitignore",
+	);
+	git(&repo, &["add", ".gitignore"]);
+	git(&repo, &["commit", "-m", "initial"]);
+
+	let sdk_metadata = tempdir
+		.path()
+		.join("flutter-sdk/bin/cache/dart-sdk/lib/_internal/sdk_library_metadata");
+	must_ok(fs::create_dir_all(&sdk_metadata), "create sdk metadata dir");
+	must_ok(
+		fs::write(
+			sdk_metadata.join("pubspec.yaml"),
+			"name: sdk_library_metadata\n",
+		),
+		"write sdk pubspec",
+	);
+	must_ok(fs::create_dir_all(repo.join(".fvm")), "create fvm dir");
+	must_ok(
+		std::os::unix::fs::symlink(
+			tempdir.path().join("flutter-sdk"),
+			repo.join(".fvm/flutter_sdk"),
+		),
+		"create flutter sdk symlink",
+	);
+
+	must_ok(
+		tokio::runtime::Runtime::new()
+			.unwrap()
+			.block_on(git_stage_paths(
+				&repo,
+				&[PathBuf::from(
+					".fvm/flutter_sdk/bin/cache/dart-sdk/lib/_internal/sdk_library_metadata/pubspec.yaml",
+				)],
 				false,
 			)),
 		"stage paths",

--- a/crates/monochange_github/src/lib.rs
+++ b/crates/monochange_github/src/lib.rs
@@ -97,6 +97,7 @@ use std::path::PathBuf;
 use std::sync::OnceLock;
 
 use monochange_core::CommitMessage;
+use monochange_core::DiscoveryPathFilter;
 use monochange_core::HostedActorRef;
 use monochange_core::HostedActorSourceKind;
 use monochange_core::HostedIssueCommentOperation;
@@ -1908,15 +1909,27 @@ async fn resolve_stageable_release_paths(
 	tracked_paths: &[PathBuf],
 ) -> MonochangeResult<Vec<PathBuf>> {
 	let mut stageable_paths = Vec::with_capacity(tracked_paths.len());
+	let path_filter = DiscoveryPathFilter::new(root);
 	for path in tracked_paths {
-		if release_path_requires_staging(root, path).await? {
+		if release_path_requires_staging(root, path, &path_filter).await? {
 			stageable_paths.push(path.clone());
 		}
 	}
 	Ok(stageable_paths)
 }
 
-async fn release_path_requires_staging(root: &Path, path: &Path) -> MonochangeResult<bool> {
+async fn release_path_requires_staging(
+	root: &Path,
+	path: &Path,
+	path_filter: &DiscoveryPathFilter,
+) -> MonochangeResult<bool> {
+	let relative = root_relative_path(root, path);
+	if !relative.starts_with(".monochange/releases")
+		&& release_path_is_ignored_by_filter(root, relative, path_filter)
+	{
+		return Ok(false);
+	}
+
 	let absolute_path = root.join(path);
 	if absolute_path.exists() {
 		if git_path_is_tracked(root, path).await? {
@@ -1925,6 +1938,22 @@ async fn release_path_requires_staging(root: &Path, path: &Path) -> MonochangeRe
 		return Ok(!git_path_is_ignored(root, path).await?);
 	}
 	git_path_is_tracked(root, path).await
+}
+
+fn root_relative_path<'a>(root: &Path, path: &'a Path) -> &'a Path {
+	if path.is_absolute() {
+		path.strip_prefix(root).unwrap_or(path)
+	} else {
+		path
+	}
+}
+
+fn release_path_is_ignored_by_filter(
+	root: &Path,
+	relative: &Path,
+	path_filter: &DiscoveryPathFilter,
+) -> bool {
+	!path_filter.allows(&root.join(relative))
 }
 
 async fn git_path_is_tracked(root: &Path, path: &Path) -> MonochangeResult<bool> {


### PR DESCRIPTION
## Summary
- skip git-ignored paths before release PR and release commit staging inspect git path state
- preserve monochange-owned release record staging under `.monochange/releases`
- add a regression test for ignored `.fvm/flutter_sdk` symlink-descendant paths

Fixes #541.

## Validation
- `devenv shell cargo fmt --check`
- `devenv shell cargo test -p monochange_github`
- `devenv shell cargo test -p monochange git_support`
- `git diff --check`

Note: `devenv shell lint:all` currently reaches the existing `zizmor` workflow audit findings on untouched GitHub workflow files (unpinned actions / permissions), unrelated to this PR.