### PR TITLE
fix(publish): include required placeholder files

### DIFF
--- a/.changeset/fix-dart-placeholder-required-files.md
+++ b/.changeset/fix-dart-placeholder-required-files.md
@@ -1,0 +1,7 @@
+---
+monochange_publish: patch
+---
+
+# Include required files in placeholder publish directories
+
+Placeholder publish directories now include a `LICENSE` and `CHANGELOG.md` alongside the placeholder `README.md` and registry manifest. This lets Dart placeholder packages pass pub.dev's required-file validation during `mc step:placeholder-publish`.

--- a/crates/monochange_publish/src/__tests__/lib_tests.rs
+++ b/crates/monochange_publish/src/__tests__/lib_tests.rs
@@ -616,7 +616,9 @@ fn publish_readiness_registry_push_checker_and_missing_checker_paths() {
 #[test]
 fn placeholder_manifest_registry_push_writer_and_directory_builder_write_files() {
 	let request = sample_publish_request_for_registry(RegistryKind::Npm);
-	let root = Path::new(".");
+	let root = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	fs::write(root.path().join("LICENSE"), "source license")
+		.unwrap_or_else(|error| panic!("write source license: {error}"));
 	let mut registry = PlaceholderManifestWriterRegistry::new();
 
 	registry.push_writer(
@@ -630,15 +632,43 @@ fn placeholder_manifest_registry_push_writer_and_directory_builder_write_files()
 		}),
 	);
 
-	let tempdir = build_placeholder_directory(root, &request, None, &registry).unwrap();
+	let tempdir = build_placeholder_directory(root.path(), &request, None, &registry).unwrap();
 
 	assert_eq!(
 		fs::read_to_string(tempdir.path().join("README.md")).unwrap(),
 		"placeholder"
 	);
 	assert_eq!(
+		fs::read_to_string(tempdir.path().join("LICENSE")).unwrap(),
+		"source license"
+	);
+	assert_eq!(
+		fs::read_to_string(tempdir.path().join("CHANGELOG.md")).unwrap(),
+		"## 1.0.0\n\n- Placeholder release.\n"
+	);
+	assert_eq!(
 		fs::read_to_string(tempdir.path().join("package.json")).unwrap(),
 		"{\"name\":\"pkg\"}"
+	);
+
+	let root_without_license =
+		tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let fallback_tempdir =
+		build_placeholder_directory(root_without_license.path(), &request, None, &registry)
+			.unwrap();
+	assert_eq!(
+		fs::read_to_string(fallback_tempdir.path().join("LICENSE")).unwrap(),
+		"Placeholder package published by monochange. See the source repository for license terms.\n"
+	);
+
+	let placeholder_file =
+		tempfile::NamedTempFile::new().unwrap_or_else(|error| panic!("placeholder file: {error}"));
+	let error = write_placeholder_license(root_without_license.path(), placeholder_file.path())
+		.expect_err("expected placeholder license write error");
+	assert!(
+		error
+			.to_string()
+			.contains("failed to write placeholder LICENSE")
 	);
 }
 

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -513,10 +513,36 @@ pub fn build_placeholder_directory(
 		&request.placeholder_readme,
 	)
 	.map_err(|error| MonochangeError::Io(format!("failed to write placeholder README: {error}")))?;
+	write_placeholder_license(root, tempdir.path())?;
+	write_placeholder_changelog(tempdir.path(), request)?;
 
 	manifest_writers.write_manifest(tempdir.path(), request, root, source)?;
 
 	Ok(tempdir)
+}
+
+fn write_placeholder_license(root: &Path, placeholder_dir: &Path) -> MonochangeResult<()> {
+	let license = ["LICENSE", "LICENSE.md"]
+		.into_iter()
+		.find_map(|file_name| fs::read_to_string(root.join(file_name)).ok())
+		.unwrap_or_else(|| {
+			"Placeholder package published by monochange. See the source repository for license terms.\n"
+				.to_string()
+		});
+	fs::write(placeholder_dir.join("LICENSE"), license).map_err(|error| {
+		MonochangeError::Io(format!("failed to write placeholder LICENSE: {error}"))
+	})
+}
+
+fn write_placeholder_changelog(
+	placeholder_dir: &Path,
+	request: &PublishRequest,
+) -> MonochangeResult<()> {
+	fs::write(
+		placeholder_dir.join("CHANGELOG.md"),
+		format!("## {}\n\n- Placeholder release.\n", request.version),
+	)
+	.map_err(|error| MonochangeError::Io(format!("failed to write placeholder CHANGELOG: {error}")))
 }
 
 fn placeholder_tempdir_error(error: &std::io::Error) -> MonochangeError {


### PR DESCRIPTION
## Summary

- Write LICENSE and CHANGELOG.md into placeholder publish directories.
- Reuse the workspace root LICENSE when present, otherwise write a fallback placeholder license note.
- Cover the generated files in placeholder directory tests.

## Validation

- cargo test -p monochange_publish
- cargo clippy -p monochange_publish --all-targets --all-features -- -D warnings
- mc step:validate
- cargo fmt --check
- Solana Kit placeholder publish dry-run for solana_kit_associated_token_account
