### PR TITLE
fix: filter group-propagated changes from per-package changelogs

### DIFF
--- a/.changeset/filter-per-package-changelog-group-changes.md
+++ b/.changeset/filter-per-package-changelog-group-changes.md
@@ -1,0 +1,7 @@
+---
+monochange_changelog: fix
+---
+
+# Filter group-propagated changes from per-package changelogs
+
+When a package is a member of a version group, its per-package changelog now only includes changes from changesets that directly target that package (kind=Package), not changes propagated from group-level targeting (kind=Group). Group-level changes appear exclusively in the group changelog, eliminating content duplication across member changelogs.

--- a/crates/monochange_changelog/src/__tests__/changelog_tests.rs
+++ b/crates/monochange_changelog/src/__tests__/changelog_tests.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 
+use monochange_core::BumpSeverity;
 use monochange_core::ChangeSignal;
 use monochange_core::ChangelogFormat;
 use monochange_core::ChangelogSectionDef;
@@ -1984,4 +1985,280 @@ fn snapshot_metadata_styles_render_context_blocks() {
 	let inline_no_pr =
 		build_rendered_changeset_context(tempdir.path(), &changeset_no_pr, MetadataStyle::Inline);
 	insta::assert_snapshot!("metadata_style_inline_no_pr", inline_no_pr.context);
+}
+
+// --- filter_direct_package_changes tests ---
+
+#[test]
+fn filter_direct_package_changes_includes_changes_from_package_targeted_changeset() {
+	// A changeset that directly targets "pkg-a" (kind=Package) should be included
+	let changes = Some(vec![sample_change(
+		"pkg-a-record",
+		"pkg-a",
+		".changeset/feature.md",
+	)]);
+
+	let targets_by_path = BTreeMap::from([(
+		PathBuf::from(".changeset/feature.md"),
+		vec![PreparedChangesetTarget {
+			id: "pkg-a".to_string(),
+			kind: ChangesetTargetKind::Package,
+			bump: Some(BumpSeverity::Minor),
+			origin: "changeset".to_string(),
+			evidence_refs: Vec::new(),
+			change_type: None,
+			caused_by: Vec::new(),
+		}],
+	)]);
+
+	let result = filter_direct_package_changes(changes.as_ref(), "pkg-a", &targets_by_path);
+	let filtered = result.expect("should return Some");
+	assert_eq!(
+		filtered.len(),
+		1,
+		"direct package change should be included"
+	);
+	assert_eq!(filtered[0].package_name, "pkg-a");
+}
+
+#[test]
+fn filter_direct_package_changes_excludes_changes_from_group_targeted_changeset() {
+	// A changeset that targets the group "sdk" (kind=Group) should be excluded
+	// from the per-package changelog — group changes go in the group changelog.
+	let changes = Some(vec![sample_change(
+		"pkg-a-record",
+		"pkg-a",
+		".changeset/group.md",
+	)]);
+
+	let targets_by_path = BTreeMap::from([(
+		PathBuf::from(".changeset/group.md"),
+		vec![PreparedChangesetTarget {
+			id: "sdk".to_string(),
+			kind: ChangesetTargetKind::Group,
+			bump: Some(BumpSeverity::Minor),
+			origin: "changeset".to_string(),
+			evidence_refs: Vec::new(),
+			change_type: None,
+			caused_by: Vec::new(),
+		}],
+	)]);
+
+	let result = filter_direct_package_changes(changes.as_ref(), "pkg-a", &targets_by_path);
+	let filtered = result.expect("should return Some");
+	assert!(
+		filtered.is_empty(),
+		"group-targeted change should be excluded from per-package changelog"
+	);
+}
+
+#[test]
+fn filter_direct_package_changes_excludes_changes_targeting_different_package() {
+	// A changeset targeting "pkg-b" (kind=Package) should NOT be included in
+	// pkg-a's per-package changelog.
+	let changes = Some(vec![sample_change(
+		"pkg-a-record",
+		"pkg-a",
+		".changeset/other.md",
+	)]);
+
+	let targets_by_path = BTreeMap::from([(
+		PathBuf::from(".changeset/other.md"),
+		vec![PreparedChangesetTarget {
+			id: "pkg-b".to_string(),
+			kind: ChangesetTargetKind::Package,
+			bump: Some(BumpSeverity::Minor),
+			origin: "changeset".to_string(),
+			evidence_refs: Vec::new(),
+			change_type: None,
+			caused_by: Vec::new(),
+		}],
+	)]);
+
+	let result = filter_direct_package_changes(changes.as_ref(), "pkg-a", &targets_by_path);
+	let filtered = result.expect("should return Some");
+	assert!(
+		filtered.is_empty(),
+		"change targeting a different package should be excluded"
+	);
+}
+
+#[test]
+fn filter_direct_package_changes_includes_changes_with_no_source_path() {
+	// Changes without a source_path should be included by default (defensive)
+	let mut change = sample_change("pkg-a-record", "pkg-a", ".changeset/feature.md");
+	change.source_path = None;
+	let changes = Some(vec![change]);
+
+	let targets_by_path = BTreeMap::new();
+
+	let result = filter_direct_package_changes(changes.as_ref(), "pkg-a", &targets_by_path);
+	let filtered = result.expect("should return Some");
+	assert_eq!(
+		filtered.len(),
+		1,
+		"change with no source_path should be included"
+	);
+}
+
+#[test]
+fn filter_direct_package_changes_includes_changes_with_unknown_source_path() {
+	// Changes with a source_path not found in changeset_targets_by_path should be
+	// included by default (defensive — this shouldn't normally happen)
+	let changes = Some(vec![sample_change(
+		"pkg-a-record",
+		"pkg-a",
+		".changeset/unknown.md",
+	)]);
+
+	let targets_by_path = BTreeMap::new();
+
+	let result = filter_direct_package_changes(changes.as_ref(), "pkg-a", &targets_by_path);
+	let filtered = result.expect("should return Some");
+	assert_eq!(
+		filtered.len(),
+		1,
+		"change with unknown source_path should be included"
+	);
+}
+
+#[test]
+fn filter_direct_package_changes_returns_none_when_changes_is_none() {
+	let targets_by_path = BTreeMap::<PathBuf, Vec<PreparedChangesetTarget>>::new();
+
+	let result = filter_direct_package_changes(None, "pkg-a", &targets_by_path);
+	assert!(result.is_none(), "should return None when changes is None");
+}
+
+#[test]
+fn filter_direct_package_changes_returns_empty_vec_for_empty_changes() {
+	let changes = Some(vec![]);
+	let targets_by_path = BTreeMap::<PathBuf, Vec<PreparedChangesetTarget>>::new();
+
+	let result = filter_direct_package_changes(changes.as_ref(), "pkg-a", &targets_by_path);
+	let filtered = result.expect("should return Some");
+	assert!(
+		filtered.is_empty(),
+		"should return empty vec for empty input"
+	);
+}
+
+#[test]
+fn filter_direct_package_changes_filters_mixed_changes() {
+	// A package that has both direct changes (kind=Package) and group-propagated
+	// changes (kind=Group) should only retain the direct changes.
+	let direct_change = sample_change("pkg-a-record", "pkg-a", ".changeset/direct.md");
+	let group_change = sample_change("pkg-a-record", "pkg-a", ".changeset/group.md");
+	let changes = Some(vec![direct_change.clone(), group_change]);
+
+	let targets_by_path = BTreeMap::from([
+		(
+			PathBuf::from(".changeset/direct.md"),
+			vec![PreparedChangesetTarget {
+				id: "pkg-a".to_string(),
+				kind: ChangesetTargetKind::Package,
+				bump: Some(BumpSeverity::Minor),
+				origin: "changeset".to_string(),
+				evidence_refs: Vec::new(),
+				change_type: None,
+				caused_by: Vec::new(),
+			}],
+		),
+		(
+			PathBuf::from(".changeset/group.md"),
+			vec![PreparedChangesetTarget {
+				id: "sdk".to_string(),
+				kind: ChangesetTargetKind::Group,
+				bump: Some(BumpSeverity::Minor),
+				origin: "changeset".to_string(),
+				evidence_refs: Vec::new(),
+				change_type: None,
+				caused_by: Vec::new(),
+			}],
+		),
+	]);
+
+	let result = filter_direct_package_changes(changes.as_ref(), "pkg-a", &targets_by_path);
+	let filtered = result.expect("should return Some");
+	assert_eq!(filtered.len(), 1, "only direct change should remain");
+	assert_eq!(filtered[0].source_path, direct_change.source_path);
+}
+
+#[test]
+fn filter_direct_package_changes_with_multi_target_changeset() {
+	// A changeset that targets both pkg-a and pkg-b directly (kind=Package)
+	// should be included for pkg-a.
+	let change = sample_change("pkg-a-record", "pkg-a", ".changeset/multi.md");
+	let changes = Some(vec![change]);
+
+	let targets_by_path = BTreeMap::from([(
+		PathBuf::from(".changeset/multi.md"),
+		vec![
+			PreparedChangesetTarget {
+				id: "pkg-a".to_string(),
+				kind: ChangesetTargetKind::Package,
+				bump: Some(BumpSeverity::Minor),
+				origin: "changeset".to_string(),
+				evidence_refs: Vec::new(),
+				change_type: None,
+				caused_by: Vec::new(),
+			},
+			PreparedChangesetTarget {
+				id: "pkg-b".to_string(),
+				kind: ChangesetTargetKind::Package,
+				bump: Some(BumpSeverity::Patch),
+				origin: "changeset".to_string(),
+				evidence_refs: Vec::new(),
+				change_type: None,
+				caused_by: Vec::new(),
+			},
+		],
+	)]);
+
+	let result = filter_direct_package_changes(changes.as_ref(), "pkg-a", &targets_by_path);
+	let filtered = result.expect("should return Some");
+	assert_eq!(
+		filtered.len(),
+		1,
+		"multi-target changeset should be included for pkg-a"
+	);
+}
+
+#[test]
+fn filter_direct_package_changes_skips_multi_target_changeset_for_non_target() {
+	// A changeset that targets both pkg-a and pkg-b should NOT be included
+	// for pkg-c's per-package changelog.
+	let change = sample_change("pkg-c-record", "pkg-c", ".changeset/multi.md");
+	let changes = Some(vec![change]);
+
+	let targets_by_path = BTreeMap::from([(
+		PathBuf::from(".changeset/multi.md"),
+		vec![
+			PreparedChangesetTarget {
+				id: "pkg-a".to_string(),
+				kind: ChangesetTargetKind::Package,
+				bump: Some(BumpSeverity::Minor),
+				origin: "changeset".to_string(),
+				evidence_refs: Vec::new(),
+				change_type: None,
+				caused_by: Vec::new(),
+			},
+			PreparedChangesetTarget {
+				id: "pkg-b".to_string(),
+				kind: ChangesetTargetKind::Package,
+				bump: Some(BumpSeverity::Patch),
+				origin: "changeset".to_string(),
+				evidence_refs: Vec::new(),
+				change_type: None,
+				caused_by: Vec::new(),
+			},
+		],
+	)]);
+
+	let result = filter_direct_package_changes(changes.as_ref(), "pkg-c", &targets_by_path);
+	let filtered = result.expect("should return Some");
+	assert!(
+		filtered.is_empty(),
+		"changeset targeting pkg-a and pkg-b should not appear in pkg-c's changelog"
+	);
 }

--- a/crates/monochange_changelog/src/lib.rs
+++ b/crates/monochange_changelog/src/lib.rs
@@ -235,13 +235,26 @@ pub fn build_changelog_updates(
 			.group_id
 			.as_deref()
 			.and_then(|group_id| group_definitions_by_id.get(group_id).copied());
+		// For group members, per-package changelogs should only include changes
+		// from changesets that directly target this package (kind=Package),
+		// not changes propagated from group-level targeting (kind=Group).
+		// Changes from group-targeted changesets appear in the group changelog instead.
+		let package_changes = if group_definition.is_some() {
+			filter_direct_package_changes(
+				release_note_changes.get(&decision.package_id),
+				&package_id,
+				&changeset_targets_by_path,
+			)
+		} else {
+			release_note_changes.get(&decision.package_id).cloned()
+		};
 		let changes = package_release_note_changes(
 			context.configuration,
 			package_definition,
 			group_definition,
 			decision,
 			package,
-			release_note_changes.get(&decision.package_id),
+			package_changes.as_ref(),
 			&planned_version.to_string(),
 		);
 		let changelog_title = context
@@ -1148,6 +1161,46 @@ pub fn group_changelog_include_allows(
 				.all(|package_id| selected.contains(package_id))
 		}
 	}
+}
+
+/// Filter changes for a per-package changelog to only include changes from
+/// changesets that directly target this package (kind=Package), excluding
+/// changes propagated from group-level targeting (kind=Group).
+///
+/// Group-level changes are already rendered in the group changelog, so
+/// including them in each member's per-package changelog would duplicate
+/// content across all member changelogs.
+///
+/// `config_id` is the package's configuration ID (e.g., "core" from
+/// `[package.core]`), used to match against `PreparedChangesetTarget.id`
+/// which also uses config IDs.
+pub fn filter_direct_package_changes(
+	changes: Option<&Vec<ReleaseNoteChange>>,
+	config_id: &str,
+	changeset_targets_by_path: &BTreeMap<PathBuf, Vec<PreparedChangesetTarget>>,
+) -> Option<Vec<ReleaseNoteChange>> {
+	let changes = changes?;
+	let mut filtered = Vec::new();
+	for change in changes {
+		let is_direct = match change.source_path.as_ref() {
+			Some(source_path) => {
+				let path = PathBuf::from(source_path);
+				match changeset_targets_by_path.get(&path) {
+					Some(targets) => {
+						targets
+							.iter()
+							.any(|t| t.kind == ChangesetTargetKind::Package && t.id == config_id)
+					}
+					None => true, // Unknown source: include by default
+				}
+			}
+			None => true, // No source path: include by default
+		};
+		if is_direct {
+			filtered.push(change.clone());
+		}
+	}
+	Some(filtered)
 }
 
 pub fn render_group_filtered_update_message(group_id: &str) -> String {


### PR DESCRIPTION
## Problem

When a package is a member of a version group, its per-package changelog contains ALL group-level changes, duplicating the content across every member's changelog. This means a group with 30 members would have 30 copies of the same 2800+ line changelog content.

Reported in #548.

## Root Cause

In `build_changelog_updates`, when a changeset targets a group (e.g., `main: minor`), each group member receives a `ChangeSignal` with their own `package_id` but `change_origin: "direct-change"`. This means `release_note_changes.get(package_id)` returns ALL changes for that package — both direct and group-propagated — with no way to distinguish them.

## Solution

Add `filter_direct_package_changes()` which checks `changeset_targets_by_path` to determine whether each change came from a changeset that directly targets this package (`kind=Package`) vs. the group (`kind=Group`). For group members, per-package changelogs now only include changes from changesets that directly target that package. Group-level changes appear exclusively in the group changelog.

### Key Implementation Detail

`PreparedChangesetTarget.id` uses config IDs (e.g., `"core"` from `[package.core]`), not discovered record IDs (e.g., `"workflow-core"` from `Cargo.toml`). The filter must compare against `config_package_id(package)` (the config ID), not `decision.package_id` (the record ID).

## Test Coverage

9 new unit tests covering all branches of `filter_direct_package_changes`:

- `includes_changes_from_package_targeted_changeset` — Direct package changes are included
- `excludes_changes_from_group_targeted_changeset` — Group-targeted changes are excluded
- `excludes_changes_targeting_different_package` — Different-package changes are excluded
- `includes_changes_with_no_source_path` — Defensive: no source_path → include
- `includes_changes_with_unknown_source_path` — Defensive: unknown source → include
- `returns_none_when_changes_is_none` — None input
- `returns_empty_vec_for_empty_changes` — Empty input
- `filters_mixed_changes` — Mixed direct + group: only direct retained
- `with_multi_target_changeset` — Multi-target: included for targeted, excluded for non-targeted

Plus existing integration tests exercise the `if group_definition.is_some()` branch in `build_changelog_updates`.

Closes #548
