### PR TITLE
fix: add --version flag support to mc CLI

### DIFF
--- a/.changeset/fix-cli-version-flag.md
+++ b/.changeset/fix-cli-version-flag.md
@@ -1,0 +1,7 @@
+---
+monochange: fix
+---
+
+# Support `--version` flag on mc CLI
+
+The root clap command was missing `.version()`, causing `mc --version` to be rejected as an unexpected argument. Added `CARGO_PKG_VERSION` registration so the flag now works correctly.

--- a/crates/monochange/src/__tests__/cli_help_tests.rs
+++ b/crates/monochange/src/__tests__/cli_help_tests.rs
@@ -626,3 +626,17 @@ fn multiline_indent_indents_continuation_lines() {
 fn multiline_indent_with_single_line() {
 	assert_eq!(multiline_indent("hello", 4), "hello");
 }
+
+#[test]
+fn version_flag_outputs_version() {
+	let command = crate::cli::build_command_with_cli("mc", &[]);
+	let error = command
+		.try_get_matches_from(["mc", "--version"])
+		.err()
+		.unwrap_or_else(|| panic!("expected version output"));
+	assert_eq!(error.kind(), clap::error::ErrorKind::DisplayVersion);
+	assert!(
+		error.to_string().contains(env!("CARGO_PKG_VERSION")),
+		"version output should contain the crate version"
+	);
+}

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -144,6 +144,7 @@ pub(crate) fn build_command_with_cli(
 	cli: &[CliCommandDefinition],
 ) -> Command {
 	let mut command = Command::new(bin_name)
+		.version(env!("CARGO_PKG_VERSION"))
 		.about("Manage versions and releases for your multiplatform, multilanguage monorepo")
 		.styles(monochange_styles())
 		.color(ColorChoice::Auto)


### PR DESCRIPTION
## Summary

`mc --version` was rejected as an unexpected argument because the root clap `Command` was missing `.version()`. With `subcommand_required(true)` set, clap treats `--version` as an unrecognized flag rather than a built-in.

## Changes

- Added `.version(env!("CARGO_PKG_VERSION"))` to the root `Command::new(bin_name)` builder in `build_command_with_cli()` (`crates/monochange/src/cli.rs`)
- Added `version_flag_outputs_version` test in `cli_help_tests.rs` that verifies `--version` produces the expected output

## Affected areas

- CLI commands

## Validation

- `cargo test -p monochange --lib cli_help::tests` — all 51 tests pass
- `cargo test -p monochange --lib` — all 1048 tests pass
- Patch coverage: 1/1 executable changed lines covered (100%)

## Changeset status

Added `.changeset/fix-cli-version-flag.md` covering the `monochange` package.