### PR TITLE
docs: update mc versions documentation with full ecosystem coverage

### DIFF
--- a/.changeset/docs-versions-command.md
+++ b/.changeset/docs-versions-command.md
@@ -1,0 +1,14 @@
+---
+"@monochange/skill": patch
+monochange: patch
+---
+
+# Document `mc versions` command with full ecosystem coverage
+
+Update documentation and skill to accurately describe the `mc versions` command:
+
+- **All ecosystems supported**: Cargo, Dart, Deno, Go, npm, and Python
+- **Usage examples**: `--dry-run`, `--format json`, `--strategy exact/caret/compatible`
+- **Ecosystem details**: Each adapter's manifest scanning behavior documented
+
+Fix incorrect reference in start-here guide that described `mc versions` as read-only (it actually writes to manifests).

--- a/packages/monochange__skill/SKILL.md
+++ b/packages/monochange__skill/SKILL.md
@@ -61,6 +61,7 @@ Built-in commands in the current CLI:
 - `mc step:validate` — validate `monochange.toml` and changeset targets.
 - `mc step:publish-readiness` — verify publishability from a release record without publishing.
 - `mc step:placeholder-publish` — publish first-time placeholder versions for packages in a release record.
+- `mc versions` — synchronize internal workspace dependency constraints across all supported ecosystems.
 
 Built-in step commands:
 

--- a/packages/monochange__skill/skills/commands.md
+++ b/packages/monochange__skill/skills/commands.md
@@ -113,9 +113,32 @@ A few built-ins are deliberately narrow:
 
 ## Internal dependency version sync
 
-Recent monochange versions include `mc sync versions` for ad hoc internal dependency range repair outside the release flow. Run `mc sync versions --dry-run` first to preview edits, then rerun without `--dry-run` to update supported manifests. The command currently supports Dart and npm packages, with `--strategy <default|exact|caret|compatible>` controlling the generated constraint style.
+`mc versions` synchronizes internal workspace dependency constraints across all supported ecosystems (Cargo, Dart, Deno, Go, npm, and Python). Run `mc versions --dry-run` first to preview edits, then rerun without `--dry-run` to update manifests.
 
-Dart sync scans `dependencies`, `dev_dependencies`, and `dependency_overrides`. When `resolution: workspace` is present, internal `path:` references are converted to version constraints so Dart workspace resolution can resolve local packages without publish-hostile path dependencies. npm sync scans `dependencies`, `devDependencies`, and `peerDependencies`, while leaving `workspace:*` protocol references unchanged.
+```bash
+# Preview dependency version updates
+mc versions --dry-run
+
+# Apply version updates
+mc versions
+
+# JSON output for CI/scripts
+mc versions --dry-run --format json
+
+# Use a specific constraint strategy
+mc versions --strategy exact      # 1.2.3
+mc versions --strategy caret      # ^1.2.3 (npm default)
+mc versions --strategy compatible # >=1.2.3
+```
+
+Each ecosystem adapter scans its native manifest format:
+
+- **Cargo**: `[dependencies]` in `Cargo.toml` (inline table and string forms)
+- **Dart**: `dependencies`, `dev_dependencies`, `dependency_overrides` in `pubspec.yaml`; converts `path:` refs under `resolution: workspace`
+- **Deno**: `imports`, `dependencies` in `deno.json` (strips JSON comments)
+- **Go**: `require` directives in `go.mod`
+- **npm**: `dependencies`, `devDependencies`, `peerDependencies` in `package.json`; preserves `workspace:*` protocol
+- **Python**: `project.dependencies` in `pyproject.toml` (PEP 508 parsing)
 
 ## Built-in step commands
 


### PR DESCRIPTION
## Summary

- Update skill `commands.md` with detailed `mc versions` documentation covering all 6 supported ecosystems
- Add `mc versions` to `SKILL.md` built-in commands list  
- Fix incorrect description in start-here guide (described `mc versions` as read-only when it actually writes to manifests)
- Add changeset for documentation updates

## Supported ecosystems

All ecosystems are fully supported: **Cargo, Dart, Deno, Go, npm, Python**

Each ecosystem adapter scans its native manifest format:
- **Cargo**: `[dependencies]` in `Cargo.toml`
- **Dart**: `dependencies`, `dev_dependencies`, `dependency_overrides` in `pubspec.yaml`
- **Deno**: `imports`, `dependencies` in `deno.json`
- **Go**: `require` directives in `go.mod`
- **npm**: `dependencies`, `devDependencies`, `peerDependencies` in `package.json`
- **Python**: `project.dependencies` in `pyproject.toml`