### PR TITLE
feat: add require_description option and default max_length to changesets/summary lint rule

### DIFF
--- a/.changeset/feat-summary-require-description.md
+++ b/.changeset/feat-summary-require-description.md
@@ -2,7 +2,7 @@
 monochange_config: minor
 ---
 
-# Add `require_description` option and default `max_length` to `changesets/summary` lint rule
+# Add require_description to summary lint rule
 
 The `changesets/summary` lint rule now supports a `require_description` option that ensures the summary heading is followed by at least one non-empty paragraph (not another heading). When enabled, a changeset with only a heading and no description body will fail validation.
 

--- a/.changeset/feat-summary-require-description.md
+++ b/.changeset/feat-summary-require-description.md
@@ -1,0 +1,9 @@
+---
+monochange_config: minor
+---
+
+# Add `require_description` option and default `max_length` to `changesets/summary` lint rule
+
+The `changesets/summary` lint rule now supports a `require_description` option that ensures the summary heading is followed by at least one non-empty paragraph (not another heading). When enabled, a changeset with only a heading and no description body will fail validation.
+
+Additionally, `max_length` now defaults to 60 characters when the rule is activated. Users can override this by setting `max_length` explicitly in the rule options.

--- a/crates/monochange_config/src/__tests__/lints_tests.rs
+++ b/crates/monochange_config/src/__tests__/lints_tests.rs
@@ -345,6 +345,117 @@ fn summary_rule_reports_length_period_and_prefix_issues_together() {
 }
 
 #[test]
+fn summary_rule_enforces_default_max_length_of_60() {
+	let rule = SummaryRule::new();
+	let long_heading = format!("# {}", "a".repeat(61));
+	let results = run_rule(
+		&rule,
+		&lint_file(&long_heading, Vec::new()),
+		&severity(LintSeverity::Error),
+	);
+
+	assert!(
+		results
+			.iter()
+			.any(|result| { result.message == "changeset summary must be at most 60 characters" }),
+		"expected default max_length of 60, got: {results:?}"
+	);
+}
+
+#[test]
+fn summary_rule_allows_explicit_max_length_override() {
+	let rule = SummaryRule::new();
+	let heading = format!("# {}", "a".repeat(61));
+	let mut options = BTreeMap::new();
+	options.insert("max_length".to_string(), json!(80));
+	let results = run_rule(&rule, &lint_file(&heading, Vec::new()), &detailed(options));
+
+	assert!(
+		!results
+			.iter()
+			.any(|result| { result.message.contains("at most") }),
+		"explicit max_length should override default"
+	);
+}
+
+#[test]
+fn summary_rule_require_description_passes_with_paragraph_after_heading() {
+	let rule = SummaryRule::new();
+	let mut options = BTreeMap::new();
+	options.insert("require_description".to_string(), json!(true));
+	let body = "# Fix CLI version flag\n\nThe root clap command was missing.";
+	let results = run_rule(&rule, &lint_file(body, Vec::new()), &detailed(options));
+
+	assert!(
+		results
+			.iter()
+			.all(|result| { !result.message.contains("description") }),
+		"should pass when description follows heading, got: {results:?}"
+	);
+}
+
+#[test]
+fn summary_rule_require_description_fails_when_only_heading() {
+	let rule = SummaryRule::new();
+	let mut options = BTreeMap::new();
+	options.insert("require_description".to_string(), json!(true));
+	let results = run_rule(
+		&rule,
+		&lint_file("# Fix CLI version flag", Vec::new()),
+		&detailed(options),
+	);
+
+	assert!(results.iter().any(|result| {
+		result.message == "changeset summary must be followed by a description paragraph"
+	}));
+}
+
+#[test]
+fn summary_rule_require_description_fails_when_only_empty_lines_after_heading() {
+	let rule = SummaryRule::new();
+	let mut options = BTreeMap::new();
+	options.insert("require_description".to_string(), json!(true));
+	let body = "# Fix CLI version flag\n\n\n";
+	let results = run_rule(&rule, &lint_file(body, Vec::new()), &detailed(options));
+
+	assert!(results.iter().any(|result| {
+		result.message == "changeset summary must be followed by a description paragraph"
+	}));
+}
+
+#[test]
+fn summary_rule_require_description_fails_when_next_line_is_heading() {
+	let rule = SummaryRule::new();
+	let mut options = BTreeMap::new();
+	options.insert("require_description".to_string(), json!(true));
+	let body = "# Summary\n\n## Details";
+	let results = run_rule(&rule, &lint_file(body, Vec::new()), &detailed(options));
+
+	assert!(results.iter().any(|result| {
+		result.message == "changeset summary must be followed by a description paragraph"
+	}));
+}
+
+#[test]
+fn summary_rule_require_description_skipped_when_disabled() {
+	let rule = SummaryRule::new();
+	let mut options = BTreeMap::new();
+	options.insert("require_description".to_string(), json!(false));
+	let results = run_rule(
+		&rule,
+		&lint_file("# Fix CLI version flag", Vec::new()),
+		&detailed(options),
+	);
+
+	assert!(
+		!results
+			.iter()
+			.any(|result| { result.message.contains("description") }),
+		"should not check for description when disabled"
+	);
+}
+
+#[test]
 fn no_section_headings_rule_reports_unique_change_type_headings() {
 	let rule = NoSectionHeadingsRule::new();
 	let file = lint_file(

--- a/crates/monochange_config/src/lints.rs
+++ b/crates/monochange_config/src/lints.rs
@@ -257,7 +257,9 @@ impl LintRuleRunner for SummaryRule {
 		let max_length = config
 			.option("max_length")
 			.and_then(serde_json::Value::as_u64)
-			.map(|v| v as usize);
+			.map(|v| v as usize)
+			.or(Some(60));
+		let require_description = config.bool_option("require_description", false);
 		let forbid_trailing_period = config.bool_option("forbid_trailing_period", false);
 		let forbid_conventional_commit_prefix =
 			config.bool_option("forbid_conventional_commit_prefix", false);
@@ -348,6 +350,25 @@ impl LintRuleRunner for SummaryRule {
 				"changeset summary must not use a conventional-commit prefix",
 				severity,
 			));
+		}
+
+		if require_description {
+			let has_description = body
+				.lines()
+				.skip(1) // skip the heading line itself
+				.any(|line| {
+					let trimmed = line.trim();
+					!trimmed.is_empty() && !trimmed.starts_with('#')
+				});
+
+			if !has_description {
+				results.push(LintResult::new(
+					self.rule.id.clone(),
+					LintLocation::new(ctx.manifest_path, 1, 1),
+					"changeset summary must be followed by a description paragraph",
+					severity,
+				));
+			}
 		}
 
 		results


### PR DESCRIPTION
## Summary

Extends the `changesets/summary` lint rule with two changes:

1. **`require_description` option** — When enabled, ensures the summary heading is followed by at least one non-empty paragraph that is not another heading. A changeset with only a heading and no description body will fail validation.

2. **Default `max_length` of 60** — When the rule is activated, `max_length` now defaults to 60 characters. Users can override this by setting `max_length` explicitly.

## Affected areas

- Changeset linting (`monochange_config`)

## Validation

- `cargo test -p monochange_config --lib lints` — all 24 tests pass
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean
- `dprint check` — clean

## Changeset status

Added changeset covering the `monochange_config` package.