### PR TITLE
feat: add JSON schema annotation to monochange.toml init template

### DIFF
--- a/.changeset/feat-template-schema-annotation.md
+++ b/.changeset/feat-template-schema-annotation.md
@@ -1,0 +1,7 @@
+---
+monochange: patch
+---
+
+# Add JSON schema annotation to init template
+
+The generated `monochange.toml` now includes a `#:schema` directive at the top, enabling automatic validation in editors that support JSON Schema annotations (e.g., VS Code with Even Better TOML).

--- a/crates/monochange/src/monochange.toml.template
+++ b/crates/monochange/src/monochange.toml.template
@@ -11,6 +11,7 @@
     package_ids_toml -- pre-formatted TOML array contents
     has_cargo / has_npm / has_deno / has_dart / has_python -- ecosystem detected flags
 #}
+#:schema https://monochange.github.io/monochange/schemas/monochange.schema.json
 # =============================================================================
 # monochange.toml — repository configuration for monochange
 # =============================================================================


### PR DESCRIPTION
## Summary

The generated `monochange.toml` now includes a `#:schema` directive at the top, enabling automatic validation in editors that support JSON Schema annotations (e.g., VS Code with Even Better TOML).

```toml
#:schema https://monochange.github.io/monochange/schemas/monochange.schema.json
```

## Affected areas

- `monochange` CLI crate (`monochange.toml.template`)

## Validation

- All 38 init-related tests pass
- `cargo clippy` clean
- `dprint check` clean

## Changeset status

Added changeset covering the `monochange` package.