### PR TITLE
fix: never update version field via versioned_files unless in fields

### DIFF
--- a/.changeset/fix-native-manifest-versioned-files.md
+++ b/.changeset/fix-native-manifest-versioned-files.md
@@ -1,0 +1,7 @@
+---
+monochange: patch
+---
+
+# Preserve native manifest updates before versioned_files
+
+Apply `versioned_files` changes on top of native manifest updates so dependency constraints can be rewritten without clobbering package version fields.

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -3362,8 +3362,8 @@ fn command_release_updates_manifests_changelogs_and_deletes_changesets() {
 	assert!(!group_changelog.contains("Changed members:"));
 	assert!(!group_changelog.contains("Synchronized members:"));
 	assert!(group_versioned_file.contains("version = \"1.1.0\""));
-	// Package versioned file has version updated because it's a package-level versioned file
-	assert!(package_versioned_file.contains("version = \"1.1.0\""));
+	// Package versioned file should NOT have version updated because "version" is not in fields
+	assert!(package_versioned_file.contains("version = \"1.0.0\""));
 	assert!(!tempdir.path().join(".changeset/feature.md").exists());
 }
 

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -3362,8 +3362,8 @@ fn command_release_updates_manifests_changelogs_and_deletes_changesets() {
 	assert!(!group_changelog.contains("Changed members:"));
 	assert!(!group_changelog.contains("Synchronized members:"));
 	assert!(group_versioned_file.contains("version = \"1.1.0\""));
-	// Package versioned file should NOT have version updated because "version" is not in fields
-	assert!(package_versioned_file.contains("version = \"1.0.0\""));
+	// Package versioned file has version updated because it's a package-level versioned file
+	assert!(package_versioned_file.contains("version = \"1.1.0\""));
 	assert!(!tempdir.path().join(".changeset/feature.md").exists());
 }
 

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -3362,8 +3362,8 @@ fn command_release_updates_manifests_changelogs_and_deletes_changesets() {
 	assert!(!group_changelog.contains("Changed members:"));
 	assert!(!group_changelog.contains("Synchronized members:"));
 	assert!(group_versioned_file.contains("version = \"1.1.0\""));
-	// Package versioned file has version updated because it's a package-level versioned file
-	assert!(package_versioned_file.contains("version = \"1.1.0\""));
+	// Package versioned file does NOT have version updated because 'version' is not in fields
+	assert!(package_versioned_file.contains("version = \"1.0.0\""));
 	assert!(!tempdir.path().join(".changeset/feature.md").exists());
 }
 
@@ -10041,7 +10041,6 @@ fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_update
 			None,
 			&["core".to_string()],
 			&context,
-			true,
 		)
 		.err()
 		.unwrap_or_else(|| panic!("expected parse error for {file_name}"));
@@ -10076,7 +10075,6 @@ fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_update
 		None,
 		&["core".to_string()],
 		&context,
-		true,
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected cached cargo parse error"));
@@ -10105,7 +10103,6 @@ fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_update
 		None,
 		&["core".to_string()],
 		&context,
-		true,
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected cached pnpm parse error"));
@@ -10135,7 +10132,6 @@ fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_update
 		None,
 		&["core".to_string()],
 		&context,
-		true,
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected cached dart parse error"));
@@ -10255,7 +10251,6 @@ fn apply_versioned_file_definition_returns_early_without_matching_versions() {
 		None,
 		&dep_names,
 		&context,
-		true,
 	)
 	.unwrap_or_else(|error| panic!("no-op versioned file update: {error}"));
 	assert!(updates.is_empty());
@@ -10287,7 +10282,6 @@ fn apply_versioned_file_definition_rejects_invalid_glob_patterns() {
 		None,
 		&dep_names,
 		&context,
-		true,
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected invalid glob error"));
@@ -10325,7 +10319,6 @@ fn apply_versioned_file_definition_rejects_unsupported_glob_matches() {
 			None,
 			&dep_names,
 			&context,
-			true,
 		)
 		.err()
 		.unwrap_or_else(|| panic!("expected unsupported match error"));
@@ -10367,7 +10360,6 @@ monochange = { path = "crates/monochange", version = "1.0.0" }
 		None,
 		&["monochange".to_string()],
 		&context,
-		true,
 	)
 	.unwrap_or_else(|error| panic!("cargo shorthand update: {error}"));
 	let document = updates
@@ -10424,7 +10416,6 @@ extra = { path = "crates/extra", version = "1.0.0" }
 		Some(&shared_version),
 		&["core".to_string(), "extra".to_string()],
 		&context,
-		true,
 	)
 	.unwrap_or_else(|error| panic!("cargo field template update: {error}"));
 	let document = updates
@@ -10477,7 +10468,6 @@ fn apply_versioned_file_definition_updates_bun_lockb_and_deno_text_variants() {
 		None,
 		&["app".to_string()],
 		&bun_context,
-		true,
 	)
 	.unwrap_or_else(|error| panic!("bun lockb update: {error}"));
 	let bun_document = bun_updates
@@ -10511,7 +10501,6 @@ fn apply_versioned_file_definition_updates_bun_lockb_and_deno_text_variants() {
 		None,
 		&["core".to_string()],
 		&deno_context,
-		true,
 	)
 	.unwrap_or_else(|error| panic!("deno manifest text update: {error}"));
 	let deno_document = deno_updates
@@ -10558,7 +10547,6 @@ fn apply_versioned_file_definition_updates_regex_versioned_files_from_cached_tex
 		None,
 		&[] as &[&str],
 		&context,
-		true,
 	)
 	.unwrap_or_else(|error| panic!("regex versioned file update: {error}"));
 	let updated_document = updates
@@ -10599,7 +10587,6 @@ fn apply_versioned_file_definition_reports_invalid_regex_patterns() {
 		None,
 		&[] as &[&str],
 		&context,
-		true,
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected invalid regex error"));
@@ -10638,7 +10625,6 @@ fn apply_versioned_file_definition_updates_npm_manifest_and_lock_variants() {
 		None,
 		&manifest_dep_names,
 		&manifest_context,
-		true,
 	)
 	.unwrap_or_else(|error| panic!("npm manifest update: {error}"));
 	let manifest_path = manifest_tempdir.path().join("package.json");
@@ -10685,7 +10671,6 @@ fn apply_versioned_file_definition_updates_npm_manifest_and_lock_variants() {
 		None,
 		&package_lock_dep_names,
 		&package_lock_context,
-		true,
 	)
 	.unwrap_or_else(|error| panic!("package lock update: {error}"));
 	let package_lock_path = package_lock_tempdir
@@ -10726,7 +10711,6 @@ fn apply_versioned_file_definition_updates_npm_manifest_and_lock_variants() {
 		None,
 		&pnpm_dep_names,
 		&pnpm_context,
-		true,
 	)
 	.unwrap_or_else(|error| panic!("pnpm lock update: {error}"));
 	let pnpm_path = pnpm_tempdir.path().join("pnpm-lock.yaml");
@@ -10764,7 +10748,6 @@ fn apply_versioned_file_definition_updates_npm_manifest_and_lock_variants() {
 		None,
 		&bun_dep_names,
 		&bun_context,
-		true,
 	)
 	.unwrap_or_else(|error| panic!("bun lock update: {error}"));
 	let bun_path = bun_tempdir.path().join("packages/app/bun.lock");
@@ -10817,7 +10800,6 @@ dependencies = ["python-core>=1.0.0"]
 		None,
 		&dep_names,
 		&context,
-		false,
 	)
 	.unwrap_or_else(|error| panic!("python manifest update: {error}"));
 	let manifest_document = updates
@@ -10846,7 +10828,6 @@ dependencies = ["python-core>=1.0.0"]
 		None,
 		&dep_names,
 		&context,
-		true,
 	)
 	.unwrap_or_else(|error| panic!("python lock update: {error}"));
 	let lock_document = updates
@@ -10888,7 +10869,6 @@ async fn apply_versioned_file_definition_reports_python_error_paths() {
 		None,
 		&dep_names,
 		&context,
-		true,
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected unsupported python path error"));
@@ -10920,7 +10900,6 @@ async fn apply_versioned_file_definition_reports_python_error_paths() {
 		None,
 		&dep_names,
 		&context,
-		true,
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected invalid python manifest error"));
@@ -10955,7 +10934,6 @@ fn apply_versioned_file_definition_updates_deno_and_dart_variants() {
 		None,
 		&deno_manifest_dep_names,
 		&deno_manifest_context,
-		true,
 	)
 	.unwrap_or_else(|error| panic!("deno manifest update: {error}"));
 	let deno_manifest_path = deno_manifest_tempdir.path().join("deno.json");
@@ -10992,7 +10970,6 @@ fn apply_versioned_file_definition_updates_deno_and_dart_variants() {
 		None,
 		&deno_lock_dep_names,
 		&deno_lock_context,
-		true,
 	)
 	.unwrap_or_else(|error| panic!("deno lock update: {error}"));
 	let deno_lock_path = deno_lock_tempdir.path().join("packages/app/deno.lock");
@@ -11028,7 +11005,6 @@ fn apply_versioned_file_definition_updates_deno_and_dart_variants() {
 		None,
 		&dart_manifest_dep_names,
 		&dart_manifest_context,
-		true,
 	)
 	.unwrap_or_else(|error| panic!("dart manifest update: {error}"));
 	let dart_manifest_path = dart_manifest_tempdir
@@ -11067,7 +11043,6 @@ fn apply_versioned_file_definition_updates_deno_and_dart_variants() {
 		None,
 		&dart_lock_dep_names,
 		&dart_lock_context,
-		true,
 	)
 	.unwrap_or_else(|error| panic!("dart lock update: {error}"));
 	let dart_lock_path = dart_lock_tempdir.path().join("packages/app/pubspec.lock");
@@ -13370,7 +13345,6 @@ fn apply_versioned_file_definition_reports_invalid_glob_pattern() {
 		None,
 		&[] as &[&str],
 		&context,
-		true,
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected glob error"));
@@ -13400,7 +13374,6 @@ fn apply_versioned_file_definition_reports_missing_ecosystem_type() {
 		None,
 		&[] as &[&str],
 		&context,
-		true,
 	)
 	.err()
 	.unwrap_or_else(|| panic!("expected missing ecosystem type error"));

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -9388,11 +9388,12 @@ fn build_versioned_file_updates_skips_unreleased_package_definitions() {
 		compatibility_evidence: Vec::new(),
 	};
 
-	let updates = crate::build_versioned_file_updates(
+	let updates = crate::build_versioned_file_updates_with_base_updates(
 		tempdir.path(),
 		&configuration,
 		&discovery.packages,
 		&plan,
+		&[],
 	)
 	.unwrap_or_else(|error| panic!("versioned file updates: {error}"));
 

--- a/crates/monochange/src/__tests__/versioned_files_tests.rs
+++ b/crates/monochange/src/__tests__/versioned_files_tests.rs
@@ -7,18 +7,103 @@ use monochange_core::Ecosystem;
 use monochange_core::EcosystemType;
 
 use super::CachedDocument;
+use super::FileUpdate;
 use super::VersionedFileUpdateContext;
 use super::apply_versioned_file_definition;
-use super::build_versioned_file_updates;
+use super::build_versioned_file_updates_with_base_updates;
 use super::inferred_lockfile_ecosystem_type;
 use super::inferred_lockfile_paths;
 use super::read_cached_document;
+use super::released_versions_by_package_id;
+use super::released_versions_by_record_id;
+use super::seed_cached_text_updates;
 use super::versioned_file_kind;
 
 fn fixture_path(relative: &str) -> PathBuf {
 	PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 		.join("../../fixtures/tests")
 		.join(relative)
+}
+
+#[test]
+fn build_versioned_file_updates_returns_empty_for_empty_configuration() {
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	std::fs::write(
+		root.join("monochange.toml"),
+		"[defaults]\npackage_type = \"npm\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write monochange config: {error}"));
+	let configuration = monochange_config::load_workspace_configuration(root)
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+	let plan = monochange_core::ReleasePlan {
+		workspace_root: root.to_path_buf(),
+		decisions: Vec::new(),
+		groups: Vec::new(),
+		warnings: Vec::new(),
+		unresolved_items: Vec::new(),
+		compatibility_evidence: Vec::new(),
+	};
+
+	let updates =
+		build_versioned_file_updates_with_base_updates(root, &configuration, &[], &plan, &[])
+			.unwrap_or_else(|error| panic!("build versioned updates: {error}"));
+
+	assert!(updates.is_empty());
+}
+
+#[test]
+fn seed_cached_text_updates_rejects_invalid_utf8_and_resolves_relative_paths() {
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	let relative_update = FileUpdate {
+		path: PathBuf::from("pubspec.yaml"),
+		content: b"name: app\n".to_vec(),
+	};
+	let mut updates = BTreeMap::new();
+
+	seed_cached_text_updates(root, &mut updates, &[relative_update])
+		.unwrap_or_else(|error| panic!("seed relative update: {error}"));
+
+	assert!(matches!(
+		updates.get(&root.join("pubspec.yaml")),
+		Some(CachedDocument::Text(contents)) if contents == "name: app\n"
+	));
+
+	let invalid_update = FileUpdate {
+		path: PathBuf::from("invalid.yaml"),
+		content: vec![0xff, 0xfe],
+	};
+	let error = seed_cached_text_updates(root, &mut updates, &[invalid_update])
+		.expect_err("invalid seeded text update should fail");
+
+	assert!(
+		error
+			.to_string()
+			.contains("failed to parse invalid.yaml as text")
+	);
+}
+
+#[test]
+fn released_version_maps_skip_unplanned_groups() {
+	let plan = monochange_core::ReleasePlan {
+		workspace_root: PathBuf::from("/workspace"),
+		decisions: Vec::new(),
+		groups: vec![monochange_core::PlannedVersionGroup {
+			group_id: "sdk".to_string(),
+			display_name: "SDK".to_string(),
+			members: vec!["core".to_string()],
+			mismatch_detected: false,
+			planned_version: None,
+			recommended_bump: monochange_core::BumpSeverity::None,
+		}],
+		warnings: Vec::new(),
+		unresolved_items: Vec::new(),
+		compatibility_evidence: Vec::new(),
+	};
+
+	assert!(released_versions_by_record_id(&plan).is_empty());
+	assert!(released_versions_by_package_id(&plan, &[]).is_empty());
 }
 
 #[test]
@@ -281,9 +366,14 @@ enabled = true
 		compatibility_evidence: Vec::new(),
 	};
 
-	let updates =
-		build_versioned_file_updates(root, &configuration, std::slice::from_ref(&package), &plan)
-			.unwrap_or_else(|error| panic!("build versioned updates: {error}"));
+	let updates = build_versioned_file_updates_with_base_updates(
+		root,
+		&configuration,
+		std::slice::from_ref(&package),
+		&plan,
+		&[],
+	)
+	.unwrap_or_else(|error| panic!("build versioned updates: {error}"));
 
 	assert_eq!(updates.len(), 1);
 	assert_eq!(updates[0].path, manifest_path);
@@ -294,8 +384,14 @@ enabled = true
 
 	std::fs::write(&manifest_path, "{")
 		.unwrap_or_else(|error| panic!("write invalid package manifest: {error}"));
-	let error = build_versioned_file_updates(root, &configuration, &[package], &plan)
-		.expect_err("invalid overridden versioned file should fail");
+	let error = build_versioned_file_updates_with_base_updates(
+		root,
+		&configuration,
+		&[package],
+		&plan,
+		&[],
+	)
+	.expect_err("invalid overridden versioned file should fail");
 	assert!(error.to_string().contains("failed to parse"));
 }
 

--- a/crates/monochange/src/__tests__/versioned_files_tests.rs
+++ b/crates/monochange/src/__tests__/versioned_files_tests.rs
@@ -155,7 +155,6 @@ fn apply_versioned_file_definition_reports_go_for_unsupported_glob_match() {
 		None,
 		&["lib".to_string()],
 		&context,
-		true,
 	)
 	.expect_err("unsupported go glob match");
 
@@ -201,7 +200,6 @@ fn apply_versioned_file_definition_updates_go_mod_dependencies() {
 		None,
 		&["lib".to_string()],
 		&context,
-		true,
 	)
 	.unwrap_or_else(|error| panic!("apply go update: {error}"));
 	let updated_document = updates

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -718,7 +718,7 @@ pub(crate) fn build_npm_manifest_updates(
 ) -> MonochangeResult<Vec<FileUpdate>> {
 	use rayon::prelude::*;
 
-	let released_versions = released_versions_by_record_id(plan);
+	let released_versions = released_versions_by_package_id(plan, packages);
 	packages
 		.iter()
 		.filter(|package| package.ecosystem == Ecosystem::Npm)
@@ -762,7 +762,7 @@ pub(crate) fn build_deno_manifest_updates(
 ) -> MonochangeResult<Vec<FileUpdate>> {
 	use rayon::prelude::*;
 
-	let released_versions = released_versions_by_record_id(plan);
+	let released_versions = released_versions_by_package_id(plan, packages);
 	packages
 		.iter()
 		.filter(|package| package.ecosystem == Ecosystem::Deno)
@@ -806,7 +806,7 @@ pub(crate) fn build_dart_manifest_updates(
 ) -> MonochangeResult<Vec<FileUpdate>> {
 	use rayon::prelude::*;
 
-	let released_versions = released_versions_by_record_id(plan);
+	let released_versions = released_versions_by_package_id(plan, packages);
 	packages
 		.iter()
 		.filter(|package| package.ecosystem == Ecosystem::Dart)

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -97,13 +97,59 @@ fn dedup_versioned_file_definitions(
 		.collect()
 }
 
-pub(crate) fn build_versioned_file_updates(
+fn cached_document_key(path: &Path) -> PathBuf {
+	fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn take_cached_document(
+	updates: &mut BTreeMap<PathBuf, CachedDocument>,
+	path: &Path,
+) -> Option<CachedDocument> {
+	if let Some(cached) = updates.remove(path) {
+		return Some(cached);
+	}
+
+	let cache_key = cached_document_key(path);
+	let equivalent_path = updates
+		.keys()
+		.find(|cached_path| cached_document_key(cached_path) == cache_key)
+		.cloned();
+	equivalent_path.and_then(|path| updates.remove(&path))
+}
+
+fn seed_cached_text_updates(
+	root: &Path,
+	updates: &mut BTreeMap<PathBuf, CachedDocument>,
+	base_updates: &[FileUpdate],
+) -> MonochangeResult<()> {
+	for update in base_updates {
+		let contents = String::from_utf8(update.content.clone()).map_err(|error| {
+			MonochangeError::Config(format!(
+				"failed to parse {} as text: {error}",
+				update.path.display()
+			))
+		})?;
+		let path = if update.path.is_absolute() {
+			update.path.clone()
+		} else {
+			root.join(&update.path)
+		};
+		updates.insert(path, CachedDocument::Text(contents));
+	}
+	Ok(())
+}
+
+pub(crate) fn build_versioned_file_updates_with_base_updates(
 	root: &Path,
 	configuration: &monochange_core::WorkspaceConfiguration,
 	packages: &[PackageRecord],
 	plan: &ReleasePlan,
+	base_updates: &[FileUpdate],
 ) -> MonochangeResult<Vec<FileUpdate>> {
-	if configuration.packages.is_empty() && configuration.groups.is_empty() {
+	if configuration.packages.is_empty()
+		&& configuration.groups.is_empty()
+		&& base_updates.is_empty()
+	{
 		return Ok(Vec::new());
 	}
 
@@ -165,6 +211,7 @@ pub(crate) fn build_versioned_file_updates(
 	};
 
 	let mut updates = BTreeMap::<PathBuf, CachedDocument>::new();
+	seed_cached_text_updates(root, &mut updates, base_updates)?;
 
 	for package_definition in &configuration.packages {
 		let Some(version) = released_versions_by_config_id.get(package_definition.id.as_str())
@@ -427,7 +474,7 @@ pub(crate) fn read_cached_text_document(
 	updates: &mut BTreeMap<PathBuf, CachedDocument>,
 	path: &Path,
 ) -> MonochangeResult<String> {
-	if let Some(cached) = updates.remove(path) {
+	if let Some(cached) = take_cached_document(updates, path) {
 		return render_cached_document_text(path, cached);
 	}
 	let contents = fs::read(path).map_err(|error| {
@@ -446,7 +493,7 @@ pub(crate) fn read_cached_document(
 	path: &Path,
 	ecosystem_type: monochange_core::EcosystemType,
 ) -> MonochangeResult<CachedDocument> {
-	if let Some(cached) = updates.remove(path) {
+	if let Some(cached) = take_cached_document(updates, path) {
 		return Ok(cached);
 	}
 
@@ -1099,7 +1146,8 @@ pub(crate) fn apply_versioned_file_definition(
 }
 
 pub(crate) fn released_versions_by_record_id(plan: &ReleasePlan) -> BTreeMap<String, String> {
-	plan.decisions
+	let mut released_versions = plan
+		.decisions
 		.iter()
 		.filter(|decision| decision.recommended_bump.is_release())
 		.filter_map(|decision| {
@@ -1108,7 +1156,50 @@ pub(crate) fn released_versions_by_record_id(plan: &ReleasePlan) -> BTreeMap<Str
 				.as_ref()
 				.map(|version| (decision.package_id.clone(), version.to_string()))
 		})
-		.collect()
+		.collect::<BTreeMap<_, _>>();
+
+	for group in &plan.groups {
+		let Some(version) = group.planned_version.as_ref() else {
+			continue;
+		};
+		for member in &group.members {
+			released_versions.insert(member.clone(), version.to_string());
+		}
+	}
+
+	released_versions
+}
+
+pub(crate) fn released_versions_by_package_id(
+	plan: &ReleasePlan,
+	packages: &[PackageRecord],
+) -> BTreeMap<String, String> {
+	let mut released_versions = released_versions_by_record_id(plan);
+	let mut package_id_by_member_name = packages
+		.iter()
+		.map(|package| (package.name.as_str(), package.id.as_str()))
+		.collect::<BTreeMap<_, _>>();
+	package_id_by_member_name.extend(packages.iter().filter_map(|package| {
+		package
+			.metadata
+			.get("config_id")
+			.map(|config_id| (config_id.as_str(), package.id.as_str()))
+	}));
+
+	for group in &plan.groups {
+		let Some(version) = group.planned_version.as_ref() else {
+			continue;
+		};
+		for member in &group.members {
+			let package_id = package_id_by_member_name
+				.get(member.as_str())
+				.copied()
+				.unwrap_or(member.as_str());
+			released_versions.insert(package_id.to_string(), version.to_string());
+		}
+	}
+
+	released_versions
 }
 
 #[cfg(test)]

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -194,7 +194,6 @@ pub(crate) fn build_versioned_file_updates(
 					shared_release_version.as_ref(),
 					&effective_dep_names,
 					&context,
-					true,
 				)?;
 				continue;
 			}
@@ -207,7 +206,6 @@ pub(crate) fn build_versioned_file_updates(
 				shared_release_version.as_ref(),
 				&dep_names,
 				&context,
-				true,
 			)?;
 		}
 	}
@@ -249,7 +247,6 @@ pub(crate) fn build_versioned_file_updates(
 				Some(&group_version),
 				&group_dep_names,
 				&context,
-				false,
 			)?;
 		}
 	}
@@ -324,7 +321,6 @@ fn apply_inferred_lockfile_updates(
 			shared_release_version,
 			&dep_names,
 			context,
-			true,
 		)?;
 	}
 
@@ -817,7 +813,6 @@ fn update_versioned_file_regex(
 		.into_owned())
 }
 
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn apply_versioned_file_definition(
 	root: &Path,
 	updates: &mut BTreeMap<PathBuf, CachedDocument>,
@@ -826,7 +821,6 @@ pub(crate) fn apply_versioned_file_definition(
 	shared_release_version: Option<&String>,
 	dep_names: &[impl AsRef<str>],
 	context: &VersionedFileUpdateContext<'_>,
-	force_version_update: bool,
 ) -> MonochangeResult<()> {
 	if let Some(pattern) = &definition.regex {
 		let glob_pattern = root.join(&definition.path).to_string_lossy().to_string();
@@ -867,7 +861,9 @@ pub(crate) fn apply_versioned_file_definition(
 	// Only update the version field if explicitly requested in fields.
 	// The version field should never be updated by versioned_files unless
 	// the user explicitly specifies it in the fields configuration.
-	let update_version = force_version_update || fields.contains(&"version");
+	// Only update the version field if 'version' is explicitly in the fields configuration.
+	// This applies to ALL versioned files (both package-level and group-level).
+	let update_version = fields.contains(&"version");
 	let effective_owner_version = if update_version {
 		Some(owner_version)
 	} else {
@@ -1030,7 +1026,7 @@ pub(crate) fn apply_versioned_file_definition(
 			) => {
 				*contents = monochange_core::update_json_manifest_text(
 					contents,
-					effective_owner_version.or_else(|| shared_release_version.map(String::as_str)),
+					effective_owner_version,
 					&fields,
 					&versioned_deps,
 				)
@@ -1055,7 +1051,7 @@ pub(crate) fn apply_versioned_file_definition(
 			) => {
 				*contents = monochange_dart::update_manifest_text(
 					contents,
-					effective_owner_version.or_else(|| shared_release_version.map(String::as_str)),
+					effective_owner_version,
 					&fields,
 					&versioned_deps,
 				)

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -867,7 +867,7 @@ pub(crate) fn apply_versioned_file_definition(
 	// Only update the version field if explicitly requested in fields.
 	// The version field should never be updated by versioned_files unless
 	// the user explicitly specifies it in the fields configuration.
-	let update_version = fields.contains(&"version");
+	let update_version = force_version_update || fields.contains(&"version");
 	let effective_owner_version = if update_version {
 		Some(owner_version)
 	} else {

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -867,7 +867,7 @@ pub(crate) fn apply_versioned_file_definition(
 	// Only update the version field if explicitly requested in fields.
 	// The version field should never be updated by versioned_files unless
 	// the user explicitly specifies it in the fields configuration.
-	let update_version = force_version_update || fields.contains(&"version");
+	let update_version = fields.contains(&"version");
 	let effective_owner_version = if update_version {
 		Some(owner_version)
 	} else {

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -2052,13 +2052,8 @@ pub(crate) async fn prepare_release_execution_with_file_diffs(
 		|| {
 			rayon::join(
 				|| {
-					capture_prepare_phase("build versioned file updates", || {
-						build_versioned_file_updates(
-							root,
-							&configuration,
-							&discovery.packages,
-							&plan,
-						)
+					capture_prepare_phase("defer versioned file updates", || {
+						Ok(Vec::<FileUpdate>::new())
 					})
 				},
 				|| {
@@ -2091,7 +2086,16 @@ pub(crate) async fn prepare_release_execution_with_file_diffs(
 		if configuration.prerelease.enabled && !configuration.prerelease.write_manifests {
 			Vec::new()
 		} else {
-			versioned_file_updates_result.0?
+			let _deferred_versioned_file_updates = versioned_file_updates_result.0?;
+			measure_prepare_phase(&mut phase_timings, "build versioned file updates", || {
+				build_versioned_file_updates_with_base_updates(
+					root,
+					&configuration,
+					&discovery.packages,
+					&plan,
+					&manifest_updates,
+				)
+			})?
 		};
 	let release_targets = measure_async_prepare_phase(
 		&mut phase_timings,
@@ -2173,7 +2177,6 @@ pub(crate) async fn prepare_release_execution_with_file_diffs(
 		.map(|prepared| vec![prepared.state_update.clone()])
 		.unwrap_or_default();
 	let base_updates = [
-		manifest_updates.clone(),
 		versioned_file_updates.clone(),
 		changelog_file_updates.clone(),
 		prerelease_state_updates,

--- a/crates/monochange/tests/release_apply.rs
+++ b/crates/monochange/tests/release_apply.rs
@@ -43,8 +43,8 @@ fn release_apply_with_github_source_updates_workspace_and_deletes_changesets() {
 	assert!(
 		fs::read_to_string(root.join("crates/core/extra.toml"))
 			.unwrap_or_else(|error| panic!("read crates/core/extra.toml: {error}"))
-			.contains("version = \"1.1.0\""),
-		"expected release apply to update configured package versioned files"
+			.contains("version = \"1.0.0\""),
+		"expected release apply to preserve implicit package versioned file version fields"
 	);
 	assert!(
 		fs::read_to_string(root.join("group.toml"))

--- a/crates/monochange/tests/snapshots/cli_progress__json_progress_emits_structured_events_for_machine_consumers@json_progress_emits_structured_events_for_machine_consumers.snap
+++ b/crates/monochange/tests/snapshots/cli_progress__json_progress_emits_structured_events_for_machine_consumers@json_progress_emits_structured_events_for_machine_consumers.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/monochange/tests/cli_progress.rs
+assertion_line: 325
 expression: redacted
 ---
 [
@@ -86,6 +87,10 @@ expression: redacted
       {
         "durationMs": "[duration_ms]",
         "label": "load prerelease state"
+      },
+      {
+        "durationMs": "[duration_ms]",
+        "label": "defer versioned file updates"
       }
     ],
     "sequence": "[sequence:2]",

--- a/crates/monochange/tests/snapshots/manifest_formatting__extra_file@preserve_cargo.snap
+++ b/crates/monochange/tests/snapshots/manifest_formatting__extra_file@preserve_cargo.snap
@@ -5,7 +5,7 @@ expression: extra_file
 ---
 [package]
 name = "workflow-core"
-version = "1.1.0"
+version = "1.0.0"
 
 [dependencies]
 workflow-app = { version = "1.0.0", path = "../app" }

--- a/crates/monochange/tests/snapshots/manifest_formatting__extra_file@preserve_cargo.snap
+++ b/crates/monochange/tests/snapshots/manifest_formatting__extra_file@preserve_cargo.snap
@@ -5,7 +5,7 @@ expression: extra_file
 ---
 [package]
 name = "workflow-core"
-version = "1.0.0"
+version = "1.1.0"
 
 [dependencies]
 workflow-app = { version = "1.0.0", path = "../app" }

--- a/crates/monochange_integration_tests/tests/dart_group_version_clobber.rs
+++ b/crates/monochange_integration_tests/tests/dart_group_version_clobber.rs
@@ -23,32 +23,44 @@ fn init_git_repo(root: &Path) {
 		.args(["init", "-b", "main"])
 		.current_dir(root)
 		.output()
+
 		.unwrap_or_else(|error| panic!("git init: {error}"));
+
 	std::process::Command::new("git")
 		.args(["config", "user.name", "Test"])
 		.current_dir(root)
 		.output()
+
 		.unwrap_or_else(|error| panic!("git config: {error}"));
+
 	std::process::Command::new("git")
 		.args(["config", "user.email", "test@test.com"])
 		.current_dir(root)
 		.output()
+
 		.unwrap_or_else(|error| panic!("git config: {error}"));
+
 	std::process::Command::new("git")
 		.args(["config", "commit.gpgsign", "false"])
 		.current_dir(root)
 		.output()
+
 		.unwrap_or_else(|error| panic!("git config: {error}"));
+
 	std::process::Command::new("git")
 		.args(["add", "."])
 		.current_dir(root)
 		.output()
+
 		.unwrap_or_else(|error| panic!("git add: {error}"));
+
 	std::process::Command::new("git")
 		.args(["commit", "-m", "initial"])
 		.current_dir(root)
 		.output()
+
 		.unwrap_or_else(|error| panic!("git commit: {error}"));
+
 }
 
 fn create_changeset(root: &Path, package: &str, bump: &str, summary: &str) {

--- a/crates/monochange_integration_tests/tests/dart_group_version_clobber.rs
+++ b/crates/monochange_integration_tests/tests/dart_group_version_clobber.rs
@@ -23,44 +23,37 @@ fn init_git_repo(root: &Path) {
 		.args(["init", "-b", "main"])
 		.current_dir(root)
 		.output()
-
 		.unwrap_or_else(|error| panic!("git init: {error}"));
 
 	std::process::Command::new("git")
 		.args(["config", "user.name", "Test"])
 		.current_dir(root)
 		.output()
-
 		.unwrap_or_else(|error| panic!("git config: {error}"));
 
 	std::process::Command::new("git")
 		.args(["config", "user.email", "test@test.com"])
 		.current_dir(root)
 		.output()
-
 		.unwrap_or_else(|error| panic!("git config: {error}"));
 
 	std::process::Command::new("git")
 		.args(["config", "commit.gpgsign", "false"])
 		.current_dir(root)
 		.output()
-
 		.unwrap_or_else(|error| panic!("git config: {error}"));
 
 	std::process::Command::new("git")
 		.args(["add", "."])
 		.current_dir(root)
 		.output()
-
 		.unwrap_or_else(|error| panic!("git add: {error}"));
 
 	std::process::Command::new("git")
 		.args(["commit", "-m", "initial"])
 		.current_dir(root)
 		.output()
-
 		.unwrap_or_else(|error| panic!("git commit: {error}"));
-
 }
 
 fn create_changeset(root: &Path, package: &str, bump: &str, summary: &str) {


### PR DESCRIPTION
## Summary

Fix a bug where the  field in native manifests was still being updated by  logic even when  was not in the  configuration.

The issue was that when  was , the code fell back to , which would still update the version field.

## Fix

Now the version field is NEVER updated by  unless  is explicitly in the  array:

```toml
# Version NOT updated (default)
versioned_files = [{ path = "pubspec.yaml", type = "dart" }]

# Version IS updated (explicit)
versioned_files = [{ path = "pubspec.yaml", type = "dart", fields = ["version"] }]
```

## Verified

Tested against https://github.com/openbudgetfun/solana_kit - `docs/site/pubspec.yaml` version field is no longer clobbered by `**/pubspec.yaml` glob.