### PR TITLE
perf: speed up release command evaluation

### DIFF
--- a/.changeset/perf-release-command-profiling.md
+++ b/.changeset/perf-release-command-profiling.md
@@ -1,0 +1,7 @@
+---
+"monochange": patch
+---
+
+# Speed up release command step evaluation
+
+Avoid building full template contexts for simple release command steps, literal commands, and direct input forwarding. This makes dry-run releases in large workspaces surface progress immediately and evaluate skipped command steps much faster.

--- a/crates/monochange/src/__tests__/cli_runtime_tests.rs
+++ b/crates/monochange/src/__tests__/cli_runtime_tests.rs
@@ -146,6 +146,46 @@ fn resolve_step_inputs_returns_empty_without_template_context_for_empty_inputs()
 }
 
 #[test]
+fn resolve_step_inputs_uses_lazy_template_context_for_overrides() {
+	let mut context = cli_context();
+	context
+		.inputs
+		.insert("from_cli".to_string(), vec!["cli-value".to_string()]);
+	let step = CliStepDefinition::Command {
+		show_progress: None,
+		name: None,
+		when: None,
+		always_run: false,
+		command: "echo ok".to_string(),
+		dry_run_command: None,
+		shell: ShellConfig::Default,
+		id: None,
+		variables: None,
+		inputs: BTreeMap::from([
+			(
+				"literal".to_string(),
+				CliStepInputValue::String("HEAD".to_string()),
+			),
+			(
+				"list".to_string(),
+				CliStepInputValue::List(vec![
+					"{{ inputs.from_cli }}".to_string(),
+					"tail".to_string(),
+				]),
+			),
+		]),
+	};
+
+	let resolved = resolve_step_inputs(&context, &step)
+		.unwrap_or_else(|error| panic!("resolve step inputs: {error}"));
+	assert_eq!(resolved["literal"], vec!["HEAD".to_string()]);
+	assert_eq!(
+		resolved["list"],
+		vec!["cli-value".to_string(), "tail".to_string()]
+	);
+}
+
+#[test]
 fn evaluate_fast_cli_step_condition_handles_changeset_count_and_inputs() {
 	let mut context = cli_context();
 	let mut prepared_release = sample_prepared_release();
@@ -165,6 +205,30 @@ fn evaluate_fast_cli_step_condition_handles_changeset_count_and_inputs() {
 			&context,
 			&step_inputs,
 		),
+		Some(true)
+	);
+	assert_eq!(
+		evaluate_fast_cli_step_condition("{{ changeset_count <= 1 }}", &context, &step_inputs),
+		Some(true)
+	);
+	assert_eq!(
+		evaluate_fast_cli_step_condition("{{ changeset_count == 1 }}", &context, &step_inputs),
+		Some(true)
+	);
+	assert_eq!(
+		evaluate_fast_cli_step_condition("{{ changeset_count != 0 }}", &context, &step_inputs),
+		Some(true)
+	);
+	assert_eq!(
+		evaluate_fast_cli_step_condition("{{ changeset_count < 2 }}", &context, &step_inputs),
+		Some(true)
+	);
+	assert_eq!(
+		evaluate_fast_cli_step_condition("{{ !inputs.push }}", &context, &step_inputs),
+		Some(true)
+	);
+	assert_eq!(
+		evaluate_fast_cli_step_condition("{{ not inputs.push }}", &context, &step_inputs),
 		Some(true)
 	);
 	assert_eq!(
@@ -211,6 +275,26 @@ fn evaluate_fast_cli_step_condition_falls_back_for_complex_conditions() {
 		None
 	);
 	assert_eq!(
+		evaluate_fast_cli_step_condition("{{ (inputs.commit) }}", &context, &BTreeMap::new()),
+		None
+	);
+	assert_eq!(
+		evaluate_fast_cli_step_condition("{{ inputs.commit && }}", &context, &BTreeMap::new()),
+		None
+	);
+	assert_eq!(
+		evaluate_fast_cli_step_condition("{{ releases > 0 }}", &context, &BTreeMap::new()),
+		None
+	);
+	assert_eq!(
+		evaluate_fast_cli_step_condition("{{ release }}", &context, &BTreeMap::new()),
+		None
+	);
+	assert_eq!(
+		evaluate_fast_cli_step_condition("{{ inputs.commit }}", &context, &BTreeMap::new()),
+		None
+	);
+	assert_eq!(
 		evaluate_fast_cli_step_condition("{{ inputs.missing }}", &context, &BTreeMap::new()),
 		None
 	);
@@ -225,6 +309,22 @@ fn evaluate_fast_cli_step_condition_falls_back_for_complex_conditions() {
 		),
 		None
 	);
+}
+
+#[test]
+fn evaluate_cli_step_condition_returns_fast_path_result() {
+	let mut context = cli_context();
+	let mut prepared_release = sample_prepared_release();
+	prepared_release
+		.changeset_paths
+		.push(PathBuf::from(".changeset/release.md"));
+	context.prepared_release = Some(prepared_release);
+
+	let result =
+		evaluate_cli_step_condition("{{ changeset_count > 0 }}", &context, &BTreeMap::new())
+			.unwrap_or_else(|error| panic!("evaluate condition: {error}"));
+
+	assert!(result);
 }
 
 #[test]

--- a/crates/monochange/src/__tests__/cli_runtime_tests.rs
+++ b/crates/monochange/src/__tests__/cli_runtime_tests.rs
@@ -59,10 +59,182 @@ fn cli_context() -> CliContext {
 
 #[test]
 fn resolve_step_input_override_treats_inherited_as_empty() {
-	let template_context = serde_json::Map::new();
-	let values = resolve_step_input_override(&CliStepInputValue::Inherited, &template_context)
-		.unwrap_or_else(|error| panic!("resolve inherited step input: {error}"));
+	let context = cli_context();
+	let mut template_context = None;
+	let values = resolve_step_input_override(
+		&CliStepInputValue::Inherited,
+		&context,
+		&mut template_context,
+	)
+	.unwrap_or_else(|error| panic!("resolve inherited step input: {error}"));
 	assert!(values.is_empty());
+}
+
+#[test]
+fn resolve_step_input_override_handles_boolean_and_list_values() {
+	let context = cli_context();
+	let mut template_context = None;
+	let values = resolve_step_input_override(
+		&CliStepInputValue::Boolean(true),
+		&context,
+		&mut template_context,
+	)
+	.unwrap_or_else(|error| panic!("resolve boolean step input: {error}"));
+
+	assert_eq!(values, vec!["true".to_string()]);
+	assert!(template_context.is_none());
+
+	let values = resolve_step_input_override(
+		&CliStepInputValue::List(vec!["HEAD".to_string()]),
+		&context,
+		&mut template_context,
+	)
+	.unwrap_or_else(|error| panic!("resolve list step input: {error}"));
+
+	assert_eq!(values, vec!["HEAD".to_string()]);
+	assert!(template_context.is_none());
+}
+
+#[test]
+fn resolve_step_input_template_uses_fast_paths_for_literals_and_inputs() {
+	let mut context = cli_context();
+	context
+		.inputs
+		.insert("no_verify".to_string(), vec!["true".to_string()]);
+	let mut template_context = None;
+
+	let literal = resolve_step_input_template("HEAD", &context, &mut template_context)
+		.unwrap_or_else(|error| panic!("resolve literal input: {error}"));
+	assert_eq!(literal, vec!["HEAD".to_string()]);
+	assert!(template_context.is_none());
+
+	let inherited =
+		resolve_step_input_template("{{ inputs.no_verify }}", &context, &mut template_context)
+			.unwrap_or_else(|error| panic!("resolve direct input template: {error}"));
+	assert_eq!(inherited, vec!["true".to_string()]);
+	assert!(template_context.is_none());
+
+	let nested_input_path = resolve_step_input_template(
+		"{{ inputs.no_verify.enabled }}",
+		&context,
+		&mut template_context,
+	)
+	.unwrap_or_else(|error| panic!("resolve nested input path template: {error}"));
+	assert!(nested_input_path.is_empty());
+	assert!(template_context.is_some());
+}
+
+#[test]
+fn resolve_step_inputs_returns_empty_without_template_context_for_empty_inputs() {
+	let context = cli_context();
+	let step = CliStepDefinition::Command {
+		show_progress: None,
+		name: None,
+		when: None,
+		always_run: false,
+		command: "echo ok".to_string(),
+		dry_run_command: None,
+		shell: ShellConfig::Default,
+		id: None,
+		variables: None,
+		inputs: BTreeMap::new(),
+	};
+
+	let resolved = resolve_step_inputs(&context, &step)
+		.unwrap_or_else(|error| panic!("resolve empty step inputs: {error}"));
+	assert!(resolved.is_empty());
+}
+
+#[test]
+fn evaluate_fast_cli_step_condition_handles_changeset_count_and_inputs() {
+	let mut context = cli_context();
+	let mut prepared_release = sample_prepared_release();
+	prepared_release
+		.changeset_paths
+		.push(PathBuf::from(".changeset/release.md"));
+	context.prepared_release = Some(prepared_release);
+	context
+		.inputs
+		.insert("commit".to_string(), vec!["true".to_string()]);
+	let step_inputs = BTreeMap::from([("push".to_string(), vec!["false".to_string()])]);
+	context.inputs.insert("tag".to_string(), Vec::new());
+
+	assert_eq!(
+		evaluate_fast_cli_step_condition(
+			"{{ number_of_changesets > 0 && inputs.commit }}",
+			&context,
+			&step_inputs,
+		),
+		Some(true)
+	);
+	assert_eq!(
+		evaluate_fast_cli_step_condition(
+			"{{ number_of_changesets > 0 && inputs.commit && inputs.push }}",
+			&context,
+			&step_inputs,
+		),
+		Some(false)
+	);
+	assert_eq!(
+		evaluate_fast_cli_step_condition(
+			"{{ number_of_changesets > 0 && inputs.tag }}",
+			&context,
+			&step_inputs,
+		),
+		Some(false)
+	);
+	context
+		.prepared_release
+		.as_mut()
+		.unwrap()
+		.changeset_paths
+		.clear();
+	assert_eq!(
+		evaluate_fast_cli_step_condition(
+			"{{ number_of_changesets > 0 && inputs.missing }}",
+			&context,
+			&BTreeMap::new(),
+		),
+		Some(false)
+	);
+}
+
+#[test]
+fn evaluate_fast_cli_step_condition_falls_back_for_complex_conditions() {
+	let context = cli_context();
+	assert_eq!(
+		evaluate_fast_cli_step_condition(
+			"{{ release.targets | length > 0 }}",
+			&context,
+			&BTreeMap::new(),
+		),
+		None
+	);
+	assert_eq!(
+		evaluate_fast_cli_step_condition("{{ inputs.missing }}", &context, &BTreeMap::new()),
+		None
+	);
+	assert_eq!(
+		evaluate_fast_cli_step_condition(
+			"{{ inputs.multi }}",
+			&context,
+			&BTreeMap::from([(
+				"multi".to_string(),
+				vec!["true".to_string(), "false".to_string()],
+			)]),
+		),
+		None
+	);
+}
+
+#[test]
+fn command_contains_template_detects_jinja_delimiters() {
+	assert!(!command_contains_template("pnpm install --lockfile-only"));
+	assert!(command_contains_template("echo {{ version }}"));
+	assert!(command_contains_template(
+		"{% if true %}echo yes{% endif %}"
+	));
+	assert!(command_contains_template("echo {# comment #}"));
 }
 
 fn sample_source_configuration() -> SourceConfiguration {

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -209,14 +209,18 @@ fn resolve_step_inputs(
 	context: &CliContext,
 	step: &CliStepDefinition,
 ) -> MonochangeResult<BTreeMap<String, Vec<String>>> {
+	if step.inputs().is_empty() {
+		return Ok(BTreeMap::new());
+	}
+
 	let mut resolved = BTreeMap::new();
-	let template_context = build_cli_template_context(context, &context.inputs, None);
+	let mut template_context = None;
 	for (input_name, input_value) in step.inputs() {
 		let values = match input_value {
 			CliStepInputValue::Inherited => {
 				context.inputs.get(input_name).cloned().unwrap_or_default()
 			}
-			_ => resolve_step_input_override(input_value, &template_context)?,
+			_ => resolve_step_input_override(input_value, context, &mut template_context)?,
 		};
 		resolved.insert(input_name.clone(), values);
 	}
@@ -226,7 +230,8 @@ fn resolve_step_inputs(
 
 fn resolve_step_input_override(
 	input_value: &CliStepInputValue,
-	template_context: &serde_json::Map<String, serde_json::Value>,
+	context: &CliContext,
+	template_context: &mut Option<serde_json::Map<String, serde_json::Value>>,
 ) -> MonochangeResult<Vec<String>> {
 	match input_value {
 		CliStepInputValue::Inherited => Ok(Vec::new()),
@@ -234,18 +239,31 @@ fn resolve_step_input_override(
 		CliStepInputValue::List(values) => {
 			let mut resolved = Vec::new();
 			for value in values {
-				resolved.extend(resolve_step_input_template(value, template_context)?);
+				let values = resolve_step_input_template(value, context, template_context)?;
+				resolved.extend(values);
 			}
 			Ok(resolved)
 		}
-		CliStepInputValue::String(value) => resolve_step_input_template(value, template_context),
+		CliStepInputValue::String(value) => {
+			resolve_step_input_template(value, context, template_context)
+		}
 	}
 }
 
 fn resolve_step_input_template(
 	template: &str,
-	template_context: &serde_json::Map<String, serde_json::Value>,
+	context: &CliContext,
+	template_context: &mut Option<serde_json::Map<String, serde_json::Value>>,
 ) -> MonochangeResult<Vec<String>> {
+	if !command_contains_template(template) {
+		return Ok(vec![template.to_string()]);
+	}
+	if let Some(input_name) = parse_direct_input_template_reference(template) {
+		return Ok(context.inputs.get(input_name).cloned().unwrap_or_default());
+	}
+
+	let template_context = template_context
+		.get_or_insert_with(|| build_cli_template_context(context, &context.inputs, None));
 	if let Some(path) = parse_direct_template_reference(template) {
 		return Ok(lookup_template_value(
 			&serde_json::Value::Object(template_context.clone()),
@@ -257,6 +275,15 @@ fn resolve_step_input_template(
 	let jinja_context =
 		minijinja::Value::from_serialize(serde_json::Value::Object(template_context.clone()));
 	Ok(vec![render_jinja_template(template, &jinja_context)?])
+}
+
+fn parse_direct_input_template_reference(template: &str) -> Option<&str> {
+	let input_name = parse_direct_template_reference(template)?.strip_prefix("inputs.")?;
+	if input_name.contains('.') {
+		None
+	} else {
+		Some(input_name)
+	}
 }
 
 pub(crate) fn parse_direct_template_reference(template: &str) -> Option<&str> {
@@ -630,6 +657,12 @@ pub(crate) async fn execute_cli_command_with_options(
 	let mut output = None;
 	let command_started_at = Instant::now();
 	let mut progress = CliProgressReporter::new(cli_command, dry_run, quiet, progress_format);
+	// Release can spend noticeable time resolving early steps before the first
+	// step-level progress event, so show the command header immediately without
+	// changing interactive command output.
+	if cli_command.name == "release" {
+		progress.command_started();
+	}
 	let telemetry = CliTelemetry::new(
 		TelemetrySink::from_env(),
 		cli_command,
@@ -1557,6 +1590,10 @@ fn evaluate_cli_step_condition(
 	if trimmed.is_empty() {
 		return Ok(false);
 	}
+	if let Some(result) = evaluate_fast_cli_step_condition(trimmed, context, step_inputs) {
+		return Ok(result);
+	}
+
 	let condition_inputs = cli_step_condition_inputs(context, step_inputs);
 	let template_context = build_cli_template_context(context, &condition_inputs, None);
 	let template_context_json = serde_json::Value::Object(template_context.clone());
@@ -1582,6 +1619,107 @@ fn cli_step_condition_inputs(
 	let mut inputs = context.inputs.clone();
 	inputs.extend(step_inputs.clone());
 	inputs
+}
+
+fn evaluate_fast_cli_step_condition(
+	condition: &str,
+	context: &CliContext,
+	step_inputs: &BTreeMap<String, Vec<String>>,
+) -> Option<bool> {
+	let expression = trim_template_expression(condition)?;
+	if expression.contains('(') || expression.contains(')') {
+		return None;
+	}
+
+	let inputs = cli_step_condition_inputs(context, step_inputs);
+	let mut saw_operand = false;
+	for or_group in expression.split("||") {
+		let mut group_value = true;
+		for operand in or_group.split("&&") {
+			saw_operand = true;
+			if !group_value {
+				break;
+			}
+			group_value = evaluate_fast_cli_condition_operand(operand, context, &inputs)?;
+		}
+		if group_value {
+			return Some(true);
+		}
+	}
+
+	if saw_operand { Some(false) } else { None }
+}
+
+fn trim_template_expression(condition: &str) -> Option<&str> {
+	let trimmed = condition.trim();
+	let inner = trimmed
+		.strip_prefix("{{")
+		.and_then(|value| value.strip_suffix("}}"))
+		.unwrap_or(trimmed)
+		.trim();
+
+	if inner.is_empty() { None } else { Some(inner) }
+}
+
+fn evaluate_fast_cli_condition_operand(
+	operand: &str,
+	context: &CliContext,
+	inputs: &BTreeMap<String, Vec<String>>,
+) -> Option<bool> {
+	let operand = operand.trim();
+	if operand.is_empty() {
+		return None;
+	}
+	if let Some(operand) = operand.strip_prefix('!') {
+		return Some(!evaluate_fast_cli_condition_operand(
+			operand, context, inputs,
+		)?);
+	}
+	if let Some(operand) = operand.strip_prefix("not ") {
+		return Some(!evaluate_fast_cli_condition_operand(
+			operand, context, inputs,
+		)?);
+	}
+	if let Some(name) = operand.strip_prefix("inputs.") {
+		return parse_fast_condition_input(name, inputs);
+	}
+
+	evaluate_fast_changeset_count_comparison(operand, context)
+}
+
+fn parse_fast_condition_input(name: &str, inputs: &BTreeMap<String, Vec<String>>) -> Option<bool> {
+	let values = inputs.get(name)?;
+	match values.as_slice() {
+		[] => Some(false),
+		[value] => parse_string_as_boolean(value, name).ok(),
+		_ => None,
+	}
+}
+
+fn evaluate_fast_changeset_count_comparison(operand: &str, context: &CliContext) -> Option<bool> {
+	let prepared = context.prepared_release.as_ref()?;
+	let count = prepared.changeset_paths.len() as u64;
+	for operator in [">=", "<=", "==", "!=", ">", "<"] {
+		let Some((left, right)) = operand.split_once(operator) else {
+			continue;
+		};
+		let variable = left.trim();
+		if !matches!(variable, "number_of_changesets" | "changeset_count") {
+			return None;
+		}
+		let expected = right.trim().parse::<u64>().ok()?;
+		return match operator {
+			">=" => Some(count >= expected),
+			"<=" => Some(count <= expected),
+			"==" => Some(count == expected),
+			"!=" => Some(count != expected),
+			">" => Some(count > expected),
+			"<" => Some(count < expected),
+			_ => None,
+		};
+	}
+
+	None
 }
 
 fn parse_template_as_boolean(value: &serde_json::Value, condition: &str) -> MonochangeResult<bool> {
@@ -3048,10 +3186,18 @@ fn interpolate_cli_command_command(
 	variables: Option<&BTreeMap<String, CommandVariable>>,
 	step_inputs: &BTreeMap<String, Vec<String>>,
 ) -> String {
+	if !command_contains_template(command) {
+		return command.to_string();
+	}
+
 	let template_context = build_cli_template_context(context, step_inputs, variables);
 	let jinja_context =
 		minijinja::Value::from_serialize(serde_json::Value::Object(template_context));
 	render_jinja_template(command, &jinja_context).unwrap_or_else(|_| command.to_string())
+}
+
+fn command_contains_template(command: &str) -> bool {
+	command.contains("{{") || command.contains("{#") || command.contains("{%")
 }
 
 fn cli_command_variable_value(context: &CliContext, variable: CommandVariable) -> String {

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -1708,15 +1708,20 @@ fn evaluate_fast_changeset_count_comparison(operand: &str, context: &CliContext)
 			return None;
 		}
 		let expected = right.trim().parse::<u64>().ok()?;
-		return match operator {
-			">=" => Some(count >= expected),
-			"<=" => Some(count <= expected),
-			"==" => Some(count == expected),
-			"!=" => Some(count != expected),
-			">" => Some(count > expected),
-			"<" => Some(count < expected),
-			_ => None,
+		let matches = if operator == ">=" {
+			count >= expected
+		} else if operator == "<=" {
+			count <= expected
+		} else if operator == "==" {
+			count == expected
+		} else if operator == "!=" {
+			count != expected
+		} else if operator == ">" {
+			count > expected
+		} else {
+			count < expected
 		};
+		return Some(matches);
 	}
 
 	None


### PR DESCRIPTION
## Summary
- start release progress output before expensive release step resolution
- add fast paths for simple release step conditions, command interpolation, and step input resolution
- avoid building full template contexts for literal/direct-input step inputs

## Validation
- cargo test -p monochange --lib
- cargo test -p monochange --test cli_progress interactive_change_cli_hides_progress_output_on_tty -- --nocapture
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- dprint check
- devenv shell coverage:patch (PATCH_COVERAGE 0/0, 100.00%)
- cargo build --release -p monochange
- /tmp/solana_kit release dry-run warm runs: internal 51-52ms, real 0.30-0.33s
