### PR TITLE
fix: include mc in release archives

### DIFF
--- a/.changeset/fix-cargo-binstall-mc-binary.md
+++ b/.changeset/fix-cargo-binstall-mc-binary.md
@@ -1,0 +1,7 @@
+---
+monochange: patch
+---
+
+# Include mc in release archives for cargo-binstall
+
+Ship both `monochange` and `mc` binaries in GitHub release archives so `cargo binstall monochange` can install the non-optional `mc` binary.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,11 +114,11 @@ jobs:
       - name: upload binaries
         uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1.30.2
         with:
-          bin: monochange
+          bin: monochange,mc
           manifest-path: crates/monochange/Cargo.toml
           profile: dist
           ref: refs/tags/${{ env.RELEASE_TAG }}
-          archive: $bin-$target-$tag
+          archive: monochange-$target-$tag
           target: ${{ matrix.target }}
           tar: all
           zip: windows

--- a/docs/agents/release-checklist.md
+++ b/docs/agents/release-checklist.md
@@ -73,7 +73,7 @@ npm packages are handled differently from cargo crates. Platform-specific npm pa
 ## 9. Asset build and attestation
 
 - [ ] `release.yml` cross-compiles for all targets in the matrix. Verify the target list matches what npm platform packages expect (`darwin-arm64`, `darwin-x64`, `linux-arm64-gnu`, `linux-arm64-musl`, `linux-x64-gnu`, `linux-x64-musl`, `win32-x64-msvc`, `win32-arm64-msvc`).
-- [ ] Verify `taiki-e/upload-rust-binary-action` is configured with `archive: "$bin-$target-$tag"` — the download step in `publish.yml` matches this pattern (`monochange-*-${RELEASE_TAG}.tar.gz` / `.zip`).
+- [ ] Verify `taiki-e/upload-rust-binary-action` is configured with `bin: monochange,mc` and `archive: "monochange-$target-$tag"` — the download step in `publish.yml` matches this pattern (`monochange-*-${RELEASE_TAG}.tar.gz` / `.zip`) and cargo-binstall can find both package binaries in each archive.
 - [ ] Build attestations (`actions/attest-build-provenance@v3`) and verification steps exist and pass.
 
 ## 10. Post-release verification


### PR DESCRIPTION
## Summary

- build both `monochange` and `mc` in GitHub release archives
- keep the existing `monochange-$target-$tag` archive naming expected by publish asset downloads
- add a changeset and update the release checklist so cargo-binstall coverage stays explicit

## Diagnosis

`cargo binstall monochange` reads the crate manifest and sees two non-optional binaries: the implicit `monochange` binary from `src/main.rs` and the explicit `mc` binary from `[[bin]]`. The published v0.6.6 archive only contains `monochange`, because `release.yml` configured `taiki-e/upload-rust-binary-action` with `bin: monochange`. Binstall therefore downloads the right archive but fails resolving the required `mc` binary.

## Validation

- `devenv shell cargo build --profile dist --package monochange --bin monochange --bin mc`
- local archive smoke test contains `mc` and `monochange`, both print `0.6.6`
- `devenv shell mc check`
- `devenv shell zizmor .github/workflows/release.yml`
- `git diff --check`

Note: full local `fix:all` reaches unrelated repository-wide zizmor findings outside this change; the release workflow-specific zizmor check passes.
