### PR TITLE
perf: speed up CLI startup config loading

### DIFF
--- a/.changeset/perf-cli-startup-config-loading.md
+++ b/.changeset/perf-cli-startup-config-loading.md
@@ -5,4 +5,4 @@
 
 # Speed up CLI startup
 
-Version and help paths now avoid full workspace validation, and inherited versioned-file globs are deduplicated during package validation.
+Version and help paths now avoid full workspace validation. Full config loading now deduplicates inherited versioned-file glob validation and resolves glob checks against one ignored-file-aware workspace walk instead of repeatedly scanning the filesystem.

--- a/.changeset/perf-cli-startup-config-loading.md
+++ b/.changeset/perf-cli-startup-config-loading.md
@@ -1,0 +1,8 @@
+---
+"monochange": patch
+"monochange_config": patch
+---
+
+# Speed up CLI startup
+
+Version and help paths now avoid full workspace validation, and inherited versioned-file globs are deduplicated during package validation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2274,6 +2274,7 @@ name = "monochange_config"
 version = "0.6.6"
 dependencies = [
  "glob",
+ "ignore",
  "insta",
  "miette",
  "monochange_core",

--- a/crates/monochange/benches/cli_commands.rs
+++ b/crates/monochange/benches/cli_commands.rs
@@ -246,6 +246,81 @@ fn run_release_pr_command(root: &Path, dry_run: bool, github_api_url: Option<&st
 const SCALES: &[(usize, usize)] = &[(5, 10), (20, 50), (50, 200)];
 const LOCKFILE_COMPARE_SCALE: (usize, usize) = (20, 50);
 
+fn generate_inherited_glob_fixture(
+	root: &Path,
+	ecosystem: &str,
+	manifest: &str,
+	package_count: usize,
+) {
+	use std::fmt::Write;
+
+	let mut config = String::from("[defaults]\nchangelog = false\n\n");
+	let _ = writeln!(
+		config,
+		"[ecosystems.{ecosystem}]\nversioned_files = [{{ path = \"packages/**/{manifest}\", type = \"{ecosystem}\" }}]\n"
+	);
+	for index in 0..package_count {
+		let _ = writeln!(
+			config,
+			"[package.pkg-{index}]\npath = \"packages/pkg-{index}\"\ntype = \"{ecosystem}\"\n"
+		);
+	}
+	fs::write(root.join("monochange.toml"), config).unwrap();
+
+	for index in 0..package_count {
+		let package_dir = root.join(format!("packages/pkg-{index}"));
+		fs::create_dir_all(&package_dir).unwrap();
+		write_ecosystem_manifest(&package_dir.join(manifest), ecosystem, index);
+		let generated_dir = root.join(format!("packages/generated/pkg-{index}"));
+		fs::create_dir_all(&generated_dir).unwrap();
+		write_ecosystem_manifest(
+			&generated_dir.join(manifest),
+			ecosystem,
+			index + package_count,
+		);
+	}
+}
+
+fn write_ecosystem_manifest(path: &Path, ecosystem: &str, index: usize) {
+	let content = match ecosystem {
+		"cargo" => {
+			format!("[package]\nname = \"pkg-{index}\"\nversion = \"1.0.0\"\nedition = \"2021\"\n")
+		}
+		"npm" => format!("{{\"name\":\"pkg-{index}\",\"version\":\"1.0.0\"}}\n"),
+		"deno" => format!("{{\"name\":\"@scope/pkg-{index}\",\"version\":\"1.0.0\"}}\n"),
+		"dart" => format!("name: pkg_{index}\nversion: 1.0.0\nenvironment:\n  sdk: ^3.0.0\n"),
+		"python" => format!("[project]\nname = \"pkg-{index}\"\nversion = \"1.0.0\"\n"),
+		"go" => format!("module example.com/pkg-{index}\n\ngo 1.22\n"),
+		_ => unreachable!("unknown ecosystem {ecosystem}"),
+	};
+	fs::write(path, content).unwrap();
+}
+
+fn bench_inherited_glob_config_load(c: &mut Criterion) {
+	let mut group = c.benchmark_group("config_load_inherited_globs");
+	group.sample_size(10);
+
+	for (ecosystem, manifest) in [
+		("cargo", "Cargo.toml"),
+		("npm", "package.json"),
+		("deno", "deno.json"),
+		("dart", "pubspec.yaml"),
+		("python", "pyproject.toml"),
+		("go", "go.mod"),
+	] {
+		group.bench_with_input(
+			BenchmarkId::from_parameter(ecosystem),
+			&ecosystem,
+			|b, ecosystem| {
+				let tempdir = tempfile::tempdir().unwrap();
+				generate_inherited_glob_fixture(tempdir.path(), ecosystem, manifest, 20);
+				b.iter(|| monochange_config::load_workspace_configuration(tempdir.path()).unwrap());
+			},
+		);
+	}
+	group.finish();
+}
+
 fn bench_config_load(c: &mut Criterion) {
 	let mut group = c.benchmark_group("config_load");
 	group.sample_size(10);
@@ -700,8 +775,48 @@ fn bench_prepared_release_cache(c: &mut Criterion) {
 	group.finish();
 }
 
+fn bench_cli_startup_help(c: &mut Criterion) {
+	let mut group = c.benchmark_group("cli_startup_help");
+	group.sample_size(10);
+
+	for (label, args) in [
+		(
+			"mc_version",
+			vec![OsString::from("mc"), OsString::from("--version")],
+		),
+		(
+			"mc_root_help",
+			vec![OsString::from("mc"), OsString::from("--help")],
+		),
+		(
+			"mc_release_help",
+			vec![
+				OsString::from("mc"),
+				OsString::from("release"),
+				OsString::from("--help"),
+			],
+		),
+	] {
+		let tempdir = tempfile::tempdir().unwrap();
+		generate_fixture(tempdir.path(), 20, 5);
+		group.bench_with_input(BenchmarkId::from_parameter(label), &args, |b, args| {
+			b.iter(|| {
+				block_on_bench(monochange::run_with_args_in_dir(
+					"mc",
+					args.clone(),
+					tempdir.path(),
+				))
+				.unwrap()
+			});
+		});
+	}
+	group.finish();
+}
+
 criterion_group!(
 	benches,
+	bench_cli_startup_help,
+	bench_inherited_glob_config_load,
 	bench_config_load,
 	bench_discover,
 	bench_validate,

--- a/crates/monochange/benches/cli_commands.rs
+++ b/crates/monochange/benches/cli_commands.rs
@@ -244,8 +244,8 @@ fn run_release_pr_command(root: &Path, dry_run: bool, github_api_url: Option<&st
 }
 
 const SCALES: &[(usize, usize)] = &[(5, 10), (20, 50), (50, 200)];
+const INHERITED_GLOB_PACKAGE_COUNTS: &[usize] = &[20, 50, 500];
 const LOCKFILE_COMPARE_SCALE: (usize, usize) = (20, 50);
-
 fn generate_inherited_glob_fixture(
 	root: &Path,
 	ecosystem: &str,
@@ -308,15 +308,25 @@ fn bench_inherited_glob_config_load(c: &mut Criterion) {
 		("python", "pyproject.toml"),
 		("go", "go.mod"),
 	] {
-		group.bench_with_input(
-			BenchmarkId::from_parameter(ecosystem),
-			&ecosystem,
-			|b, ecosystem| {
-				let tempdir = tempfile::tempdir().unwrap();
-				generate_inherited_glob_fixture(tempdir.path(), ecosystem, manifest, 20);
-				b.iter(|| monochange_config::load_workspace_configuration(tempdir.path()).unwrap());
-			},
-		);
+		for &package_count in INHERITED_GLOB_PACKAGE_COUNTS {
+			let label = format!("{ecosystem}_{package_count}pkg");
+			group.bench_with_input(
+				BenchmarkId::from_parameter(label),
+				&(ecosystem, package_count),
+				|b, &(ecosystem, package_count)| {
+					let tempdir = tempfile::tempdir().unwrap();
+					generate_inherited_glob_fixture(
+						tempdir.path(),
+						ecosystem,
+						manifest,
+						package_count,
+					);
+					b.iter(|| {
+						monochange_config::load_workspace_configuration(tempdir.path()).unwrap()
+					});
+				},
+			);
+		}
 	}
 	group.finish();
 }

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -1383,8 +1383,8 @@ fn mcp_and_root_command_support_quiet_and_missing_subcommands() {
 	assert!(quiet_command_output.is_empty());
 
 	let no_subcommand = run_cli(tempdir.path(), [OsString::from("mc")])
-		.expect_err("missing subcommand should fail");
-	assert!(no_subcommand.to_string().contains("Usage: mc"));
+		.unwrap_or_else(|error| panic!("missing subcommand help: {error}"));
+	assert!(no_subcommand.contains("Usage: mc"));
 }
 
 #[test]
@@ -15000,4 +15000,62 @@ async fn execute_cli_command_retarget_release_applies_git_updates_without_provid
 		git_output_in_temp_repo(&root, &["rev-parse", "v1.2.3"]),
 		target_commit
 	);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn version_and_root_help_skip_workspace_validation() {
+	let help_command = [
+		OsString::from("mc"),
+		OsString::from("help"),
+		OsString::from("--help"),
+	];
+	assert_eq!(crate::command_help_request(&help_command), None);
+
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	std::fs::write(
+		tempdir.path().join("monochange.toml"),
+		r#"
+[cli.custom]
+help_text = "Custom command help"
+
+[package.missing]
+path = "missing"
+versioned_files = [
+	{ path = "**/not-a-manifest.txt", type = "cargo" },
+]
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write config: {error}"));
+
+	let version = run_with_args_in_dir(
+		"mc",
+		[OsString::from("mc"), OsString::from("--version")],
+		tempdir.path(),
+	)
+	.await
+	.unwrap_or_else(|error| panic!("version output: {error}"));
+	assert!(version.contains("mc "));
+
+	let help = run_with_args_in_dir(
+		"mc",
+		[OsString::from("mc"), OsString::from("--help")],
+		tempdir.path(),
+	)
+	.await
+	.unwrap_or_else(|error| panic!("help output: {error}"));
+	assert!(help.contains("custom"));
+
+	let traced_help = run_with_args_in_dir(
+		"mc",
+		[
+			OsString::from("mc"),
+			OsString::from("--log-level"),
+			OsString::from("trace"),
+			OsString::from("--help"),
+		],
+		tempdir.path(),
+	)
+	.await
+	.unwrap_or_else(|error| panic!("traced help output: {error}"));
+	assert!(traced_help.contains("custom"));
 }

--- a/crates/monochange/src/bin/mc.rs
+++ b/crates/monochange/src/bin/mc.rs
@@ -10,7 +10,7 @@ use std::process::ExitCode;
 fn try_sync_version() -> Option<ExitCode> {
 	let args: Vec<String> = std::env::args().collect();
 	if args.get(1).is_some_and(|a| a == "--version" || a == "-V") {
-		eprintln!("mc {}", env!("CARGO_PKG_VERSION"));
+		println!("mc {}", env!("CARGO_PKG_VERSION"));
 		return Some(ExitCode::SUCCESS);
 	}
 	None

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -6,7 +6,7 @@ use clap::Arg;
 use clap::ArgAction;
 use clap::ColorChoice;
 use clap::Command;
-use monochange_config::load_workspace_configuration;
+use monochange_config::load_cli_commands;
 use monochange_core::CliCommandDefinition;
 use monochange_core::CliInputDefinition;
 use monochange_core::CliInputKind;
@@ -62,8 +62,7 @@ pub(crate) fn apply_runtime_change_type_choices(
 }
 
 pub(crate) fn cli_commands_for_root(root: &Path) -> Vec<CliCommandDefinition> {
-	let configuration = load_workspace_configuration(root);
-	cli_commands_from_config(&configuration)
+	load_cli_commands(root).unwrap_or_else(|_| default_cli_commands())
 }
 
 /// Extract CLI commands from an already-loaded configuration result, avoiding

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -84,6 +84,7 @@ pub(crate) use cli::apply_runtime_prepare_release_markdown_defaults;
 #[cfg(test)]
 pub(crate) use cli::build_cli_command_subcommand;
 pub use cli::build_command;
+#[cfg(test)]
 pub(crate) use cli::build_command_for_root;
 use cli::build_command_with_cli;
 #[cfg(test)]
@@ -92,8 +93,7 @@ pub(crate) use cli::build_skill_subcommand;
 pub(crate) use cli::build_subagents_subcommand;
 #[cfg(test)]
 pub(crate) use cli::cli_command_after_help;
-#[cfg(test)]
-pub(crate) use cli::cli_commands_for_root;
+use cli::cli_commands_for_root;
 use cli::cli_commands_from_config;
 #[cfg(test)]
 pub(crate) use cli::configured_change_type_choices;
@@ -667,8 +667,26 @@ fn quiet_from_os_arg(arg: &OsString) -> bool {
 }
 
 fn is_root_help_request(args: &[OsString]) -> bool {
-	let mut positional = args.iter().skip(1).filter_map(|arg| arg.to_str());
-	matches!(positional.next(), None | Some("-h" | "--help")) && positional.next().is_none()
+	let mut command_args = command_args_after_globals(args);
+	matches!(command_args.next(), None | Some("-h" | "--help")) && command_args.next().is_none()
+}
+
+fn command_args_after_globals(args: &[OsString]) -> impl Iterator<Item = &str> {
+	let mut skip_value = false;
+	args.iter()
+		.skip(1)
+		.filter_map(|arg| arg.to_str())
+		.skip_while(move |arg| {
+			if skip_value {
+				skip_value = false;
+				return true;
+			}
+			if matches!(*arg, "--log-level" | "--format") {
+				skip_value = true;
+				return true;
+			}
+			matches!(*arg, "--quiet" | "-q")
+		})
 }
 
 fn extract_quiet_from_args<I>(args: I) -> bool
@@ -779,6 +797,44 @@ fn render_custom_command_argument_error(
 	)
 }
 
+fn help_command_requested(args: &[OsString]) -> bool {
+	command_args_after_globals(args)
+		.find(|arg| !arg.starts_with('-'))
+		.is_some_and(|arg| arg == "help")
+}
+
+fn command_help_request(args: &[OsString]) -> Option<&str> {
+	let command_args = command_args_after_globals(args).collect::<Vec<_>>();
+	let command_name = command_args.iter().find(|arg| !arg.starts_with('-'))?;
+	if *command_name == "help" {
+		return None;
+	}
+	command_args
+		.iter()
+		.any(|arg| matches!(*arg, "--help" | "-h"))
+		.then_some(*command_name)
+}
+
+fn command_help_requires_workspace_configuration(command_name: &str) -> bool {
+	matches!(command_name, "change")
+}
+
+fn render_help_command(
+	bin_name: &'static str,
+	args: &[OsString],
+	cli: &[CliCommandDefinition],
+) -> String {
+	let command_name = command_args_after_globals(args)
+		.skip_while(|arg| *arg != "help")
+		.nth(1)
+		.unwrap_or_default();
+	if command_name.is_empty() {
+		cli_help::render_overview_help_with_cli(bin_name, cli)
+	} else {
+		cli_help::render_command_help_with_cli(bin_name, command_name, cli)
+	}
+}
+
 fn format_populate_workspace_result(result: &PopulateWorkspaceResult) -> String {
 	if result.added_commands.is_empty() {
 		format!(
@@ -816,23 +872,64 @@ where
 {
 	let args = args.into_iter().collect::<Vec<_>>();
 
-	// Fast path: try parsing with the base command first (no config load).
-	// This handles --version without touching disk.
-	let base_command = build_command_for_root(bin_name, root);
-	if let Err(error) = base_command.try_get_matches_from(args.clone())
-		&& matches!(error.kind(), ErrorKind::DisplayVersion)
-	{
-		return Ok(format_clap_error(
-			&error,
-			!cfg!(test) && std::io::stdout().is_terminal(),
-		));
+	let root_help_requested = is_root_help_request(&args);
+	if root_help_requested {
+		let cli = cli_commands_for_root(root);
+		return Ok(cli_help::render_overview_help_with_cli(bin_name, &cli));
+	}
+	if help_command_requested(&args) {
+		let cli = cli_commands_for_root(root);
+		return Ok(render_help_command(bin_name, &args, &cli));
+	}
+	// Fast path: parse config-free command shapes before any workspace loading.
+	// This keeps version and root help responsive even in repositories with costly
+	// package or glob validation.
+	let base_command = build_command_with_cli(bin_name, &monochange_core::default_cli_commands());
+	if let Err(error) = base_command.try_get_matches_from(args.clone()) {
+		if matches!(error.kind(), ErrorKind::DisplayVersion) {
+			return Ok(format_clap_error(
+				&error,
+				!cfg!(test) && std::io::stdout().is_terminal(),
+			));
+		}
+		if matches!(error.kind(), ErrorKind::DisplayHelp)
+			&& !command_help_request(&args)
+				.is_some_and(command_help_requires_workspace_configuration)
+		{
+			let cli = cli_commands_for_root(root);
+			if is_root_help_request(&args) {
+				return Ok(cli_help::render_overview_help_with_cli(bin_name, &cli));
+			}
+			if let Err(help_error) =
+				build_command_with_cli(bin_name, &cli).try_get_matches_from(args.clone())
+				&& matches!(help_error.kind(), ErrorKind::DisplayHelp)
+			{
+				return Ok(format_clap_error(
+					&help_error,
+					!cfg!(test) && std::io::stdout().is_terminal(),
+				));
+			}
+		}
+		if let Some(command_name) = command_help_request(&args)
+			&& !command_help_requires_workspace_configuration(command_name)
+		{
+			let cli = cli_commands_for_root(root);
+			if let Err(help_error) =
+				build_command_with_cli(bin_name, &cli).try_get_matches_from(args.clone())
+				&& matches!(help_error.kind(), ErrorKind::DisplayHelp)
+			{
+				return Ok(format_clap_error(
+					&help_error,
+					!cfg!(test) && std::io::stdout().is_terminal(),
+				));
+			}
+		}
 	}
 
-	// Slow path: load workspace configuration for subcommand dispatch.
+	// Slow path: load workspace configuration for command execution.
 	let configuration = load_workspace_configuration(root);
 	let cli = cli_commands_from_config(&configuration);
 	let quiet = extract_quiet_from_args(args.iter().cloned());
-	let root_help_requested = is_root_help_request(&args);
 	let matches = match build_command_with_cli(bin_name, &cli).try_get_matches_from(args.clone()) {
 		Ok(matches) => matches,
 		Err(error)

--- a/crates/monochange/src/main.rs
+++ b/crates/monochange/src/main.rs
@@ -2,9 +2,34 @@
 #![allow(clippy::large_futures)]
 #![feature(coverage_attribute)]
 
+use std::process::ExitCode;
+
+/// Synchronous fast path for --version that skips all async initialization.
+#[coverage(off)]
+fn try_sync_version() -> Option<ExitCode> {
+	let args: Vec<String> = std::env::args().collect();
+	if args
+		.get(1)
+		.is_some_and(|arg| arg == "--version" || arg == "-V")
+	{
+		println!("monochange {}", env!("CARGO_PKG_VERSION"));
+		return Some(ExitCode::SUCCESS);
+	}
+	None
+}
+
+#[coverage(off)]
+#[allow(clippy::disallowed_methods)]
+fn main() -> ExitCode {
+	if let Some(code) = try_sync_version() {
+		return code;
+	}
+	tokio_main()
+}
+
 #[coverage(off)]
 #[allow(clippy::disallowed_methods)]
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> std::process::ExitCode {
+async fn tokio_main() -> ExitCode {
 	monochange::run_cli_binary_from_env("monochange").await
 }

--- a/crates/monochange_config/Cargo.toml
+++ b/crates/monochange_config/Cargo.toml
@@ -17,6 +17,7 @@ schema = ["dep:schemars", "monochange_core/schema"]
 
 [dependencies]
 glob = { workspace = true, default-features = true }
+ignore = { workspace = true, default-features = true }
 miette = { workspace = true, default-features = true }
 monochange_core = { workspace = true }
 regex = { workspace = true, default-features = true }

--- a/crates/monochange_config/src/__tests__/lib_tests.rs
+++ b/crates/monochange_config/src/__tests__/lib_tests.rs
@@ -99,6 +99,47 @@ use crate::validate_step_input_overrides;
 use crate::validate_step_override_kind;
 use crate::validate_workspace;
 
+fn validate_package_and_group_definitions_for_test(
+	root: &Path,
+	config_contents: &str,
+	packages: &[monochange_core::PackageDefinition],
+	groups: &[GroupDefinition],
+) -> MonochangeResult<()> {
+	let declared_packages = packages
+		.iter()
+		.map(|package| package.id.as_str())
+		.collect::<std::collections::BTreeSet<_>>();
+	let mut cache = crate::VersionedFileValidationCache::default();
+	crate::validate_package_and_group_definitions_with_cache(
+		root,
+		config_contents,
+		packages,
+		groups,
+		&declared_packages,
+		&mut cache,
+	)
+}
+
+fn validate_versioned_files_for_test(
+	root: &Path,
+	config_contents: &str,
+	versioned_files: &[monochange_core::VersionedFileDefinition],
+	declared_packages: &std::collections::BTreeSet<&str>,
+	owner_kind: &str,
+	owner_id: &str,
+) -> MonochangeResult<()> {
+	let mut cache = crate::VersionedFileValidationCache::default();
+	crate::validate_versioned_files_with_cache(
+		root,
+		config_contents,
+		versioned_files,
+		declared_packages,
+		owner_kind,
+		owner_id,
+		&mut cache,
+	)
+}
+
 fn validate_step() -> CliStepDefinition {
 	CliStepDefinition::Validate {
 		name: None,
@@ -1674,6 +1715,44 @@ fn load_workspace_configuration_rejects_globs_that_match_unsupported_files_for_a
 
 	assert!(rendered.contains("matched unsupported file"));
 	assert!(rendered.contains("narrow the glob"));
+}
+
+#[test]
+fn load_workspace_configuration_ignores_gitignored_versioned_file_glob_matches() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	std::fs::create_dir_all(root.join("packages/app"))
+		.unwrap_or_else(|error| panic!("create package: {error}"));
+	std::fs::create_dir_all(root.join("generated"))
+		.unwrap_or_else(|error| panic!("create generated: {error}"));
+	std::fs::write(root.join(".gitignore"), "generated/\n")
+		.unwrap_or_else(|error| panic!("write gitignore: {error}"));
+	std::fs::write(
+		root.join("packages/app/pubspec.yaml"),
+		"name: app\nversion: 1.0.0\n",
+	)
+	.unwrap_or_else(|error| panic!("write pubspec: {error}"));
+	std::fs::write(root.join("generated/not-a-pubspec.yaml"), "not: dart\n")
+		.unwrap_or_else(|error| panic!("write ignored yaml: {error}"));
+	std::fs::write(
+		root.join("monochange.toml"),
+		r#"[ecosystems.dart]
+versioned_files = [{ path = "./**/*.yaml", type = "dart" }]
+
+[package.app]
+path = "packages/app"
+type = "dart"
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write config: {error}"));
+
+	let configuration =
+		load_workspace_configuration(root).unwrap_or_else(|error| panic!("configuration: {error}"));
+	let package = configuration
+		.package_by_id("app")
+		.unwrap_or_else(|| panic!("expected app package"));
+
+	assert_eq!(package.versioned_files.len(), 1);
 }
 
 #[test]
@@ -5628,7 +5707,7 @@ fn validate_cli_runtime_requirements_enforce_affected_package_inputs() {
 fn validate_package_and_source_settings_cover_duplicate_and_pattern_errors() {
 	let root = fixture_path("config/validation-helper-branches");
 
-	let duplicate_path_error = crate::validate_package_and_group_definitions(
+	let duplicate_path_error = validate_package_and_group_definitions_for_test(
 		&root,
 		"[package.core]\npath = 'crates/core'\n\n[package.util]\npath = 'crates/core'\n",
 		&[
@@ -5649,7 +5728,7 @@ fn validate_package_and_source_settings_cover_duplicate_and_pattern_errors() {
 	primary_core.version_format = monochange_core::VersionFormat::Primary;
 	let mut primary_util = package_definition("util", "crates/util");
 	primary_util.version_format = monochange_core::VersionFormat::Primary;
-	let duplicate_primary_error = crate::validate_package_and_group_definitions(
+	let duplicate_primary_error = validate_package_and_group_definitions_for_test(
 		&root,
 		"[package.core]\nversion_format = 'primary'\n\n[package.util]\nversion_format = 'primary'\n",
 		&[primary_core, primary_util],
@@ -5695,7 +5774,7 @@ fn validate_package_and_source_settings_cover_duplicate_and_pattern_errors() {
 			.contains("[package.core].ignored_paths must not include empty values")
 	);
 
-	let duplicate_id_error = crate::validate_package_and_group_definitions(
+	let duplicate_id_error = validate_package_and_group_definitions_for_test(
 		&root,
 		"[package.core]\npath = 'crates/core'\n",
 		&[
@@ -5715,7 +5794,7 @@ fn validate_package_and_source_settings_cover_duplicate_and_pattern_errors() {
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	std::fs::create_dir_all(tempdir.path().join("crates/core"))
 		.unwrap_or_else(|error| panic!("mkdir core dir: {error}"));
-	let missing_manifest_error = crate::validate_package_and_group_definitions(
+	let missing_manifest_error = validate_package_and_group_definitions_for_test(
 		tempdir.path(),
 		"[package.core]\npath = 'crates/core'\ntype = 'cargo'\n",
 		&[package_definition("core", "crates/core")],
@@ -6099,7 +6178,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 	let config_contents = "[package.core]\npath = 'crates/core'\n";
 	let declared_packages = std::collections::BTreeSet::from(["core"]);
 
-	let missing_type = crate::validate_versioned_files(
+	let missing_type = validate_versioned_files_for_test(
 		&root,
 		config_contents,
 		&[monochange_core::VersionedFileDefinition {
@@ -6123,7 +6202,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 			.contains("versioned_files must set `type`")
 	);
 
-	let invalid_glob = crate::validate_versioned_files(
+	let invalid_glob = validate_versioned_files_for_test(
 		&root,
 		config_contents,
 		&[monochange_core::VersionedFileDefinition {
@@ -6164,7 +6243,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 		prefix: None,
 		regex: None,
 	};
-	crate::validate_versioned_files(
+	validate_versioned_files_for_test(
 		duplicate_glob_dir.path(),
 		config_contents,
 		&[duplicate_glob.clone(), duplicate_glob],
@@ -6182,7 +6261,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 		"{\"name\":\"web\",\"version\":\"1.0.0\"}\n",
 	)
 	.unwrap_or_else(|error| panic!("write package.json: {error}"));
-	let unsupported_match = crate::validate_versioned_files(
+	let unsupported_match = validate_versioned_files_for_test(
 		tempdir.path(),
 		config_contents,
 		&[monochange_core::VersionedFileDefinition {
@@ -6215,7 +6294,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 		Path::new("pubspec.yaml"),
 		EcosystemType::Dart
 	));
-	let dart_unsupported_match = crate::validate_versioned_files(
+	let dart_unsupported_match = validate_versioned_files_for_test(
 		tempdir.path(),
 		config_contents,
 		&[monochange_core::VersionedFileDefinition {
@@ -6243,7 +6322,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 		Path::new("go.mod"),
 		EcosystemType::Go
 	));
-	let go_unsupported_match = crate::validate_versioned_files(
+	let go_unsupported_match = validate_versioned_files_for_test(
 		tempdir.path(),
 		config_contents,
 		&[monochange_core::VersionedFileDefinition {
@@ -7164,7 +7243,7 @@ fn validate_versioned_files_accepts_format_mode_and_rejects_invalid_combinations
 		prefix: None,
 		regex: None,
 	};
-	crate::validate_versioned_files(
+	validate_versioned_files_for_test(
 		&root,
 		config_contents,
 		&[valid],
@@ -7183,7 +7262,7 @@ fn validate_versioned_files_accepts_format_mode_and_rejects_invalid_combinations
 		prefix: None,
 		regex: None,
 	};
-	let error = crate::validate_versioned_files(
+	let error = validate_versioned_files_for_test(
 		&root,
 		config_contents,
 		&[mixed_type],
@@ -7203,7 +7282,7 @@ fn validate_versioned_files_accepts_format_mode_and_rejects_invalid_combinations
 		prefix: None,
 		regex: Some("version = (?<version>.*)".to_string()),
 	};
-	let error = crate::validate_versioned_files(
+	let error = validate_versioned_files_for_test(
 		&root,
 		config_contents,
 		&[mixed_regex],
@@ -7223,7 +7302,7 @@ fn validate_versioned_files_accepts_format_mode_and_rejects_invalid_combinations
 		prefix: None,
 		regex: None,
 	};
-	let error = crate::validate_versioned_files(
+	let error = validate_versioned_files_for_test(
 		&root,
 		config_contents,
 		&[missing_fields],
@@ -7243,7 +7322,7 @@ fn validate_versioned_files_accepts_format_mode_and_rejects_invalid_combinations
 		prefix: None,
 		regex: None,
 	};
-	let error = crate::validate_versioned_files(
+	let error = validate_versioned_files_for_test(
 		&root,
 		config_contents,
 		&[empty_fields],

--- a/crates/monochange_config/src/__tests__/lib_tests.rs
+++ b/crates/monochange_config/src/__tests__/lib_tests.rs
@@ -1755,6 +1755,33 @@ type = "dart"
 	assert_eq!(package.versioned_files.len(), 1);
 }
 
+#[cfg(unix)]
+#[test]
+fn collect_workspace_files_reports_walk_errors() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	let unreadable_dir = root.join("unreadable");
+	std::fs::create_dir(&unreadable_dir)
+		.unwrap_or_else(|error| panic!("create unreadable dir: {error}"));
+
+	use std::os::unix::fs::PermissionsExt;
+	let readable_permissions = std::fs::metadata(&unreadable_dir)
+		.unwrap_or_else(|error| panic!("read permissions: {error}"))
+		.permissions();
+	std::fs::set_permissions(&unreadable_dir, std::fs::Permissions::from_mode(0o000))
+		.unwrap_or_else(|error| panic!("make unreadable: {error}"));
+
+	let result = crate::collect_workspace_files(root);
+
+	std::fs::set_permissions(&unreadable_dir, readable_permissions)
+		.unwrap_or_else(|error| panic!("restore permissions: {error}"));
+	let error = result.expect_err("unreadable directories should report walk errors");
+	assert!(
+		error.to_string().contains("failed to walk"),
+		"unexpected error: {error}"
+	);
+}
+
 #[test]
 fn versioned_file_validation_cache_matches_workspace_files_once() {
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));

--- a/crates/monochange_config/src/__tests__/lib_tests.rs
+++ b/crates/monochange_config/src/__tests__/lib_tests.rs
@@ -1756,6 +1756,76 @@ type = "dart"
 }
 
 #[test]
+fn versioned_file_validation_cache_matches_workspace_files_once() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	std::fs::create_dir_all(root.join("packages/web"))
+		.unwrap_or_else(|error| panic!("create package: {error}"));
+	std::fs::create_dir_all(root.join("generated"))
+		.unwrap_or_else(|error| panic!("create generated: {error}"));
+	std::fs::write(root.join(".gitignore"), "generated/\n")
+		.unwrap_or_else(|error| panic!("write gitignore: {error}"));
+	std::fs::write(
+		root.join("packages/web/package.json"),
+		"{\"version\":\"1.0.0\"}\n",
+	)
+	.unwrap_or_else(|error| panic!("write package: {error}"));
+	std::fs::write(root.join("packages/web/README.md"), "# web\n")
+		.unwrap_or_else(|error| panic!("write readme: {error}"));
+	std::fs::write(root.join("generated/README.md"), "# generated\n")
+		.unwrap_or_else(|error| panic!("write generated: {error}"));
+
+	assert_eq!(
+		crate::normalize_relative_glob("././packages/**/*.md"),
+		"packages/**/*.md"
+	);
+
+	let workspace_files = crate::collect_workspace_files(root)
+		.unwrap_or_else(|error| panic!("collect workspace files: {error}"));
+	assert!(
+		workspace_files
+			.iter()
+			.any(|path| path == Path::new("packages/web/package.json"))
+	);
+	assert!(
+		workspace_files
+			.iter()
+			.any(|path| path == Path::new("packages/web/README.md"))
+	);
+	assert!(
+		!workspace_files
+			.iter()
+			.any(|path| path == Path::new("generated/README.md"))
+	);
+
+	let mut cache = crate::VersionedFileValidationCache::default();
+	assert!(cache.insert_checked_glob("packages/**/*.json".to_string(), "npm"));
+	assert!(!cache.insert_checked_glob("packages/**/*.json".to_string(), "npm"));
+
+	let relative_match = cache
+		.unsupported_glob_match(root, "././packages/**/*.md", EcosystemType::Npm)
+		.unwrap_or_else(|error| panic!("relative glob match: {error}"));
+	assert_eq!(
+		relative_match.as_deref(),
+		Some(root.join("packages/web/README.md").as_path())
+	);
+
+	let absolute_glob = root.join("packages/**/*.md").to_string_lossy().to_string();
+	let absolute_match = cache
+		.unsupported_glob_match(root, &absolute_glob, EcosystemType::Npm)
+		.unwrap_or_else(|error| panic!("absolute glob match: {error}"));
+	assert_eq!(
+		absolute_match.as_deref(),
+		Some(root.join("packages/web/README.md").as_path())
+	);
+
+	let supported_match = cache
+		.unsupported_glob_match(root, "packages/**/*.json", EcosystemType::Npm)
+		.unwrap_or_else(|error| panic!("supported glob match: {error}"));
+	assert!(supported_match.is_none());
+}
+
+#[test]
 fn apply_version_groups_assigns_group_ids_and_detects_mismatched_versions() {
 	let root = fixture_path("config/version-groups");
 	let configuration = load_workspace_configuration(&root)

--- a/crates/monochange_config/src/__tests__/lib_tests.rs
+++ b/crates/monochange_config/src/__tests__/lib_tests.rs
@@ -6147,6 +6147,33 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 			.contains("invalid glob pattern `[`")
 	);
 
+	let duplicate_glob_dir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	std::fs::create_dir_all(duplicate_glob_dir.path().join("packages/web"))
+		.unwrap_or_else(|error| panic!("mkdir duplicate glob fixture: {error}"));
+	std::fs::write(
+		duplicate_glob_dir.path().join("packages/web/package.json"),
+		"{\"name\":\"web\",\"version\":\"1.0.0\"}\n",
+	)
+	.unwrap_or_else(|error| panic!("write duplicate glob package: {error}"));
+	let duplicate_glob = monochange_core::VersionedFileDefinition {
+		path: "packages/**/package.json".to_string(),
+		ecosystem_type: Some(EcosystemType::Npm),
+		format: None,
+		name: None,
+		fields: None,
+		prefix: None,
+		regex: None,
+	};
+	crate::validate_versioned_files(
+		duplicate_glob_dir.path(),
+		config_contents,
+		&[duplicate_glob.clone(), duplicate_glob],
+		&declared_packages,
+		"package",
+		"core",
+	)
+	.unwrap_or_else(|error| panic!("duplicate glob validation should be cached: {error}"));
+
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	std::fs::create_dir_all(tempdir.path().join("packages/web"))
 		.unwrap_or_else(|error| panic!("mkdir web package: {error}"));
@@ -7226,4 +7253,28 @@ fn validate_versioned_files_accepts_format_mode_and_rejects_invalid_combinations
 	)
 	.expect_err("format mode should reject empty fields");
 	assert!(error.to_string().contains("fields must be non-empty"));
+}
+
+#[test]
+fn load_cli_commands_skips_package_and_versioned_file_validation() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	std::fs::write(
+		tempdir.path().join("monochange.toml"),
+		r#"
+[cli.custom]
+help_text = "Custom command help"
+
+[package.missing]
+path = "missing"
+versioned_files = [
+	{ path = "**/not-a-manifest.txt", type = "cargo" },
+]
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write config: {error}"));
+
+	let cli = crate::load_cli_commands(tempdir.path())
+		.unwrap_or_else(|error| panic!("load cli commands: {error}"));
+
+	assert!(cli.iter().any(|command| command.name == "custom"));
 }

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -1065,6 +1065,17 @@ fn load_raw_configuration(root: &Path) -> MonochangeResult<(String, RawWorkspace
 	Ok((contents, raw))
 }
 
+/// Load only CLI command metadata from `monochange.toml`.
+///
+/// This intentionally skips package, group, ecosystem, and versioned-file
+/// validation so CLI help and command pre-parsing stay independent of expensive
+/// workspace discovery.
+#[must_use = "the CLI command result must be checked"]
+pub fn load_cli_commands(root: &Path) -> MonochangeResult<Vec<CliCommandDefinition>> {
+	let (_, raw) = load_raw_configuration(root)?;
+	Ok(merge_cli_commands(raw.cli))
+}
+
 #[allow(clippy::too_many_arguments, clippy::option_as_ref_cloned)]
 fn build_package_definitions(
 	contents: &str,
@@ -2997,6 +3008,7 @@ fn validate_package_and_group_definitions(
 	packages: &[PackageDefinition],
 	groups: &[GroupDefinition],
 ) -> MonochangeResult<()> {
+	let mut versioned_file_glob_cache = BTreeSet::new();
 	let mut ids = BTreeSet::new();
 	let mut package_paths = BTreeMap::<PathBuf, String>::new();
 	let mut primary_owner = Option::<String>::None;
@@ -3093,24 +3105,26 @@ fn validate_package_and_group_definitions(
 		.map(|package| package.id.as_str())
 		.collect::<BTreeSet<_>>();
 	for package in packages {
-		validate_versioned_files(
+		validate_versioned_files_with_cache(
 			root,
 			config_contents,
 			&package.versioned_files,
 			&declared_packages,
 			"package",
 			&package.id,
+			&mut versioned_file_glob_cache,
 		)?;
 	}
 	let mut assigned_packages = BTreeMap::<String, String>::new();
 	for group in groups {
-		validate_versioned_files(
+		validate_versioned_files_with_cache(
 			root,
 			config_contents,
 			&group.versioned_files,
 			&declared_packages,
 			"group",
 			&group.id,
+			&mut versioned_file_glob_cache,
 		)?;
 		if !ids.insert(group.id.clone()) {
 			return Err(config_diagnostic(
@@ -3328,6 +3342,27 @@ fn validate_versioned_files(
 	owner_kind: &str,
 	owner_id: &str,
 ) -> MonochangeResult<()> {
+	let mut glob_cache = BTreeSet::new();
+	validate_versioned_files_with_cache(
+		root,
+		config_contents,
+		versioned_files,
+		declared_packages,
+		owner_kind,
+		owner_id,
+		&mut glob_cache,
+	)
+}
+
+fn validate_versioned_files_with_cache(
+	root: &Path,
+	config_contents: &str,
+	versioned_files: &[VersionedFileDefinition],
+	declared_packages: &BTreeSet<&str>,
+	owner_kind: &str,
+	owner_id: &str,
+	glob_cache: &mut BTreeSet<(String, &'static str)>,
+) -> MonochangeResult<()> {
 	for versioned_file in versioned_files {
 		if versioned_file.format.is_some() {
 			validate_format_versioned_file(config_contents, versioned_file, owner_kind, owner_id)?;
@@ -3384,6 +3419,10 @@ fn validate_versioned_files(
 				.join(&versioned_file.path)
 				.to_string_lossy()
 				.to_string();
+			let ecosystem_name = Ecosystem::from(ecosystem_type).as_str();
+			if !glob_cache.insert((pattern.clone(), ecosystem_name)) {
+				continue;
+			}
 			let matches = glob::glob(&pattern)
 				.map_err(|error| {
 					MonochangeError::Config(format!(
@@ -3403,15 +3442,7 @@ fn validate_versioned_files(
 						"{owner_kind} `{owner_id}` versioned_files glob `{}` matched unsupported file `{}` for ecosystem `{}`",
 						versioned_file.path,
 						unsupported_path.display(),
-						match ecosystem_type {
-							EcosystemType::Cargo => "cargo",
-							EcosystemType::Npm => "npm",
-							EcosystemType::Deno => "deno",
-							EcosystemType::Dart => "dart",
-							EcosystemType::Python => "python",
-							EcosystemType::Go => "go",
-							_ => "unknown",
-						}
+						ecosystem_name
 					),
 					vec![config_section_label(
 						config_contents,

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -81,6 +81,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use glob::Pattern;
+use ignore::WalkBuilder;
 use miette::LabeledSpan;
 use miette::SourceSpan;
 use monochange_core::BumpSeverity;
@@ -96,6 +97,7 @@ use monochange_core::CliInputDefinition;
 use monochange_core::CliInputKind;
 use monochange_core::CliStepDefinition;
 use monochange_core::CliStepInputValue;
+use monochange_core::DiscoveryPathFilter;
 use monochange_core::Ecosystem;
 use monochange_core::EcosystemSettings;
 use monochange_core::EcosystemType;
@@ -1361,6 +1363,11 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 	let changeset_lints = changeset_lint_settings_from_rules(&lints.rules)?;
 	validate_changeset_lint_settings(&changeset_lints, &changelog)?;
 	validate_source_configuration(source.as_ref())?;
+	let declared_packages = packages
+		.iter()
+		.map(|package| package.id.as_str())
+		.collect::<BTreeSet<_>>();
+	let mut versioned_file_cache = VersionedFileValidationCache::default();
 	for (ecosystem_id, ecosystem_settings) in [
 		("cargo", &cargo_ecosystem),
 		("npm", &npm_ecosystem),
@@ -1369,21 +1376,25 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		("python", &python_ecosystem),
 		("go", &go_ecosystem),
 	] {
-		let declared_packages = packages
-			.iter()
-			.map(|package| package.id.as_str())
-			.collect::<BTreeSet<_>>();
-		validate_versioned_files(
+		validate_versioned_files_with_cache(
 			root,
 			&contents,
 			&ecosystem_settings.versioned_files,
 			&declared_packages,
 			"ecosystems",
 			ecosystem_id,
+			&mut versioned_file_cache,
 		)?;
 		validate_lockfile_commands(root, ecosystem_id, &ecosystem_settings.lockfile_commands)?;
 	}
-	validate_package_and_group_definitions(root, &contents, &packages, &groups)?;
+	validate_package_and_group_definitions_with_cache(
+		root,
+		&contents,
+		&packages,
+		&groups,
+		&declared_packages,
+		&mut versioned_file_cache,
+	)?;
 	validate_cli_runtime_requirements(&cli, &changesets, source.as_ref())?;
 
 	Ok(WorkspaceConfiguration {
@@ -3002,13 +3013,14 @@ pub(crate) fn parse_bump_severity(value: &str) -> Option<BumpSeverity> {
 	}
 }
 
-fn validate_package_and_group_definitions(
+fn validate_package_and_group_definitions_with_cache(
 	root: &Path,
 	config_contents: &str,
 	packages: &[PackageDefinition],
 	groups: &[GroupDefinition],
+	declared_packages: &BTreeSet<&str>,
+	versioned_file_cache: &mut VersionedFileValidationCache,
 ) -> MonochangeResult<()> {
-	let mut versioned_file_glob_cache = BTreeSet::new();
 	let mut ids = BTreeSet::new();
 	let mut package_paths = BTreeMap::<PathBuf, String>::new();
 	let mut primary_owner = Option::<String>::None;
@@ -3100,19 +3112,15 @@ fn validate_package_and_group_definitions(
 		}
 	}
 
-	let declared_packages = packages
-		.iter()
-		.map(|package| package.id.as_str())
-		.collect::<BTreeSet<_>>();
 	for package in packages {
 		validate_versioned_files_with_cache(
 			root,
 			config_contents,
 			&package.versioned_files,
-			&declared_packages,
+			declared_packages,
 			"package",
 			&package.id,
-			&mut versioned_file_glob_cache,
+			versioned_file_cache,
 		)?;
 	}
 	let mut assigned_packages = BTreeMap::<String, String>::new();
@@ -3121,10 +3129,10 @@ fn validate_package_and_group_definitions(
 			root,
 			config_contents,
 			&group.versioned_files,
-			&declared_packages,
+			declared_packages,
 			"group",
 			&group.id,
-			&mut versioned_file_glob_cache,
+			versioned_file_cache,
 		)?;
 		if !ids.insert(group.id.clone()) {
 			return Err(config_diagnostic(
@@ -3274,6 +3282,101 @@ fn path_uses_glob(path: &str) -> bool {
 	path.contains('*') || path.contains('?') || path.contains('[')
 }
 
+#[derive(Default)]
+struct VersionedFileValidationCache {
+	checked_globs: BTreeSet<(String, &'static str)>,
+	workspace_files: Option<Vec<PathBuf>>,
+}
+
+impl VersionedFileValidationCache {
+	fn insert_checked_glob(&mut self, pattern: String, ecosystem_name: &'static str) -> bool {
+		self.checked_globs.insert((pattern, ecosystem_name))
+	}
+
+	fn unsupported_glob_match(
+		&mut self,
+		root: &Path,
+		glob_path: &str,
+		ecosystem_type: EcosystemType,
+	) -> MonochangeResult<Option<PathBuf>> {
+		let pattern_path = Path::new(glob_path);
+		let pattern_text = if pattern_path.is_absolute() {
+			glob_path
+		} else {
+			normalize_relative_glob(glob_path)
+		};
+		let pattern = Pattern::new(pattern_text).map_err(|error| {
+			MonochangeError::Config(format!("invalid glob pattern `{glob_path}`: {error}"))
+		})?;
+
+		if pattern_path.is_absolute() {
+			let root = root.to_path_buf();
+			return Ok(self
+				.workspace_files(root.as_path())?
+				.iter()
+				.find_map(|relative_path| {
+					let absolute_path = root.join(relative_path);
+					(pattern.matches_path(&absolute_path)
+						&& !path_is_supported_for_ecosystem(&absolute_path, ecosystem_type))
+					.then_some(absolute_path)
+				}));
+		}
+
+		Ok(self
+			.workspace_files(root)?
+			.iter()
+			.find_map(|relative_path| {
+				(pattern.matches_path(relative_path)
+					&& !path_is_supported_for_ecosystem(relative_path, ecosystem_type))
+				.then(|| root.join(relative_path))
+			}))
+	}
+
+	fn workspace_files(&mut self, root: &Path) -> MonochangeResult<&[PathBuf]> {
+		if self.workspace_files.is_none() {
+			self.workspace_files = Some(collect_workspace_files(root)?);
+		}
+
+		Ok(self.workspace_files.as_deref().unwrap_or(&[]))
+	}
+}
+
+fn normalize_relative_glob(path: &str) -> &str {
+	let mut normalized = path;
+	while let Some(stripped) = normalized.strip_prefix("./") {
+		normalized = stripped;
+	}
+	normalized
+}
+
+fn collect_workspace_files(root: &Path) -> MonochangeResult<Vec<PathBuf>> {
+	let path_filter = DiscoveryPathFilter::new(root);
+	let mut builder = WalkBuilder::new(root);
+	builder
+		.hidden(false)
+		.ignore(true)
+		.git_ignore(true)
+		.git_exclude(true)
+		.git_global(false)
+		.parents(true)
+		.filter_entry(move |entry| entry.depth() == 0 || path_filter.should_descend(entry.path()));
+
+	let mut files = Vec::new();
+	for entry in builder.build() {
+		let entry = entry.map_err(|error| {
+			MonochangeError::Io(format!("failed to walk {}: {error}", root.display()))
+		})?;
+		if entry
+			.file_type()
+			.is_some_and(|file_type| file_type.is_file())
+			&& let Ok(relative_path) = entry.path().strip_prefix(root)
+		{
+			files.push(relative_path.to_path_buf());
+		}
+	}
+	Ok(files)
+}
+
 fn path_is_supported_for_ecosystem(path: &Path, ecosystem_type: EcosystemType) -> bool {
 	let file_name = path
 		.file_name()
@@ -3334,26 +3437,6 @@ fn source_capabilities(provider: SourceProvider) -> SourceCapabilities {
 	}
 }
 
-fn validate_versioned_files(
-	root: &Path,
-	config_contents: &str,
-	versioned_files: &[VersionedFileDefinition],
-	declared_packages: &BTreeSet<&str>,
-	owner_kind: &str,
-	owner_id: &str,
-) -> MonochangeResult<()> {
-	let mut glob_cache = BTreeSet::new();
-	validate_versioned_files_with_cache(
-		root,
-		config_contents,
-		versioned_files,
-		declared_packages,
-		owner_kind,
-		owner_id,
-		&mut glob_cache,
-	)
-}
-
 fn validate_versioned_files_with_cache(
 	root: &Path,
 	config_contents: &str,
@@ -3361,7 +3444,7 @@ fn validate_versioned_files_with_cache(
 	declared_packages: &BTreeSet<&str>,
 	owner_kind: &str,
 	owner_id: &str,
-	glob_cache: &mut BTreeSet<(String, &'static str)>,
+	cache: &mut VersionedFileValidationCache,
 ) -> MonochangeResult<()> {
 	for versioned_file in versioned_files {
 		if versioned_file.format.is_some() {
@@ -3420,21 +3503,11 @@ fn validate_versioned_files_with_cache(
 				.to_string_lossy()
 				.to_string();
 			let ecosystem_name = Ecosystem::from(ecosystem_type).as_str();
-			if !glob_cache.insert((pattern.clone(), ecosystem_name)) {
+			if !cache.insert_checked_glob(pattern, ecosystem_name) {
 				continue;
 			}
-			let matches = glob::glob(&pattern)
-				.map_err(|error| {
-					MonochangeError::Config(format!(
-						"invalid glob pattern `{}`: {error}",
-						versioned_file.path
-					))
-				})?
-				.filter_map(Result::ok)
-				.collect::<Vec<_>>();
-			if let Some(unsupported_path) = matches
-				.into_iter()
-				.find(|matched_path| !path_is_supported_for_ecosystem(matched_path, ecosystem_type))
+			if let Some(unsupported_path) =
+				cache.unsupported_glob_match(root, &versioned_file.path, ecosystem_type)?
 			{
 				return Err(config_diagnostic(
 					config_contents,

--- a/crates/monochange_integration_tests/tests/config_loading_globs.rs
+++ b/crates/monochange_integration_tests/tests/config_loading_globs.rs
@@ -1,0 +1,51 @@
+use std::ffi::OsString;
+use std::path::Path;
+
+use monochange_test_helpers::copy_directory;
+use tempfile::tempdir;
+
+#[allow(clippy::disallowed_methods)]
+#[tokio::test(flavor = "multi_thread")]
+async fn inherited_ecosystem_globs_load_quick_repo_fixture() {
+	let workspace = setup_fixture("config/inherited-ecosystem-globs");
+	let root = workspace.path();
+
+	let help = monochange::run_with_args_in_dir(
+		"mc",
+		[OsString::from("mc"), OsString::from("--help")],
+		root,
+	)
+	.await
+	.unwrap_or_else(|error| panic!("root help: {error}"));
+	assert!(help.contains("Deploy fixture packages"));
+
+	let configuration = monochange_config::load_workspace_configuration(root)
+		.unwrap_or_else(|error| panic!("load workspace configuration: {error}"));
+	let packages = configuration
+		.packages
+		.iter()
+		.map(|package| {
+			let inherited_globs = package
+				.versioned_files
+				.iter()
+				.filter(|file| file.path.contains("**"))
+				.count();
+			serde_json::json!({
+				"id": package.id,
+				"type": format!("{:?}", package.package_type),
+				"inherited_globs": inherited_globs,
+			})
+		})
+		.collect::<Vec<_>>();
+
+	insta::assert_json_snapshot!(packages);
+}
+
+fn setup_fixture(relative: &str) -> tempfile::TempDir {
+	let source = Path::new(env!("CARGO_MANIFEST_DIR"))
+		.join("../../fixtures/tests")
+		.join(relative);
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_directory(&source, tempdir.path());
+	tempdir
+}

--- a/crates/monochange_integration_tests/tests/snapshots/config_loading_globs__inherited_ecosystem_globs_load_quick_repo_fixture.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/config_loading_globs__inherited_ecosystem_globs_load_quick_repo_fixture.snap
@@ -1,0 +1,37 @@
+---
+source: crates/monochange_integration_tests/tests/config_loading_globs.rs
+assertion_line: 40
+expression: packages
+---
+[
+  {
+    "id": "cargo-core",
+    "inherited_globs": 1,
+    "type": "Cargo"
+  },
+  {
+    "id": "dart-app",
+    "inherited_globs": 1,
+    "type": "Dart"
+  },
+  {
+    "id": "deno-tool",
+    "inherited_globs": 1,
+    "type": "Deno"
+  },
+  {
+    "id": "go-service",
+    "inherited_globs": 1,
+    "type": "Go"
+  },
+  {
+    "id": "npm-ui",
+    "inherited_globs": 1,
+    "type": "Npm"
+  },
+  {
+    "id": "python-lib",
+    "inherited_globs": 1,
+    "type": "Python"
+  }
+]

--- a/docs/plans/active/cli-startup-config-loading-performance.md
+++ b/docs/plans/active/cli-startup-config-loading-performance.md
@@ -1,0 +1,283 @@
+# CLI startup and config-loading performance
+
+## Problem statement
+
+In large workspaces such as `/Users/ifiokjr/Developer/projects/solana_kit`, `mc` and `monochange` startup can take tens of seconds even for commands such as `--version`, `--help`, and no-argument invocation. Diagnostics showed the main cost is `monochange_config::load_workspace_configuration`, especially repeated expansion of inherited ecosystem-level `versioned_files` globs such as `**/pubspec.yaml`.
+
+The current startup path also performs more work than required:
+
+- version output should not load configuration at all
+- some help paths need only configured CLI command metadata, not full package and versioned-file validation
+- inherited ecosystem globs are validated repeatedly per package
+- root help currently loads configuration twice in some paths
+
+## Goals
+
+- Make `mc --version`, `mc -V`, `monochange --version`, and `monochange -V` config-free and millisecond-fast.
+- Make help and command-dispatch paths perform the minimum configuration work needed for the requested operation.
+- Make full configuration loading fast for inherited ecosystem glob scenarios, with no repeated filesystem walks for the same glob.
+- Add regression benchmarks for inherited ecosystem `versioned_files` globs across all supported ecosystems.
+- Add CLI startup benchmarks that make slow paths visible for `mc` and `monochange` commands.
+- Keep behavior compatible for validated commands that intentionally need full package and versioned-file checks.
+
+## Non-goals
+
+- Do not change release semantics or versioned-file update behavior.
+- Do not remove validation from commands whose purpose is validation.
+- Do not publish packages, modify tags, or run release workflows.
+- Do not keep temporary diagnostic `eprintln!` instrumentation in the final branch.
+
+## Root cause notes
+
+Diagnostic build findings in `solana_kit`:
+
+- `load_raw_configuration` and TOML parsing are fast, usually a few milliseconds.
+- `[ecosystems.dart].versioned_files = [{ path = "**/pubspec.yaml", ... }]` is inherited by every Dart package.
+- The same glob expansion ran once for the ecosystem and again for each package.
+- Each expansion took roughly 0.5-0.7s in the real repo.
+- `validate_package_and_group_definitions` accounted for roughly 25-28s per full config load.
+- `mc --help` loaded config twice in the instrumented path, making it roughly twice as slow.
+- `monochange --version` lacks the sync version fast path that `mc` has.
+
+## Affected files and crates
+
+Likely files:
+
+- `crates/monochange/src/bin/mc.rs`
+- `crates/monochange/src/main.rs`
+- `crates/monochange/src/lib.rs`
+- `crates/monochange/src/cli.rs`
+- `crates/monochange/src/cli_runtime.rs`
+- `crates/monochange_config/src/lib.rs`
+- `crates/monochange_config/src/__tests__/lib_tests.rs` or adjacent module tests
+- `crates/monochange/benches/cli_commands.rs`
+- new or existing config-loading benchmark file under `crates/monochange_config/benches/` or `crates/monochange/benches/`
+- `.changeset/*.md`
+
+## Design direction
+
+### 1. Config-free version handling
+
+- Keep `mc` sync version handling.
+- Add equivalent sync version handling to the `monochange` binary.
+- Ensure version fast paths tolerate global flags only when they can do so without config, or intentionally fall back for unsupported combinations.
+- Verify no code path used for version calls `build_command_for_root`, `cli_commands_for_root`, or `load_workspace_configuration`.
+
+### 2. True base command construction
+
+Current `build_command_for_root` loads configuration through `cli_commands_for_root`. For pre-parse/fast-path checks, introduce a config-free command builder that uses only static/default commands.
+
+Possible shape:
+
+```rust
+fn build_base_command(bin_name: &'static str) -> clap::Command
+```
+
+Use it for:
+
+- detecting `DisplayVersion`
+- detecting built-in root help when custom commands are not required
+- parsing clearly built-in commands that can dispatch without custom CLI metadata
+
+### 3. Split configuration loading by purpose
+
+Introduce an internal load mode or loader API so callers can request only the work they need.
+
+Potential modes:
+
+```rust
+enum ConfigurationLoadMode {
+	CliOnly,
+	WorkspaceMetadata,
+	FullyValidated,
+}
+```
+
+Expected behavior:
+
+- `CliOnly`: parse raw config and normalize `[cli.*]` enough for help/command dispatch; skip package path checks, manifest checks, glob expansion, versioned-file content validation, and heavyweight workspace validation.
+- `WorkspaceMetadata`: parse package/group definitions enough for choices and command defaults, but avoid expensive validation where possible.
+- `FullyValidated`: current validated behavior, optimized with caching/deduplication.
+
+If a smaller refactor is safer, start with dedicated functions:
+
+- `load_cli_configuration(root)`
+- `load_workspace_configuration(root)`
+- shared lower-level helpers for raw parsing and normalization
+
+### 4. Deduplicate inherited ecosystem versioned-file validation
+
+The final fully validated path should not repeatedly expand the same glob inherited from ecosystem settings.
+
+Approach options:
+
+- Carry provenance on `VersionedFileDefinition` so inherited definitions can be skipped during per-package validation after ecosystem-level validation.
+- Or use a validation cache keyed by `(path, ecosystem_type)` while preserving owner-specific diagnostics.
+- Prefer both if feasible: avoid scheduling duplicate work, and have a cache as a safety net.
+
+Minimum cache key:
+
+```rust
+(root, versioned_file.path, versioned_file.ecosystem_type, versioned_file.regex, versioned_file.fields)
+```
+
+For glob support-type validation, path and ecosystem type are the key parts. Include enough fields to avoid accidentally reusing results for incompatible validation behavior.
+
+### 5. Lazy command execution work
+
+Audit command dispatch so each command pays only for the configuration shape it needs:
+
+- version: no config
+- built-in command help: no config unless listing custom commands
+- root help / `help`: CLI-only config
+- custom command help: CLI-only config
+- `lint --list` / `lint --explain`: no workspace validation unless rule behavior requires config
+- `mcp`: avoid workspace validation at server startup; validate inside tools that need it
+- `step:config`: parse/normalize config but avoid package/glob validation unless explicitly requested
+- `step:validate`, `check`, release planning, publish/readiness commands: full validated config, but optimized
+- custom command execution: load CLI metadata first; load full workspace only when a step actually needs it
+
+## Benchmark plan
+
+### Specific inherited ecosystem glob benchmark
+
+Create fixtures that model this shape:
+
+```toml
+[ecosystems.<ecosystem>]
+versioned_files = [
+  { path = "**/<manifest>", type = "<ecosystem>" }
+]
+
+[package.pkg_000]
+path = "packages/pkg_000"
+# inherits ecosystem versioned_files
+```
+
+Add one benchmark case per ecosystem:
+
+- Cargo: `**/Cargo.toml`
+- npm: `**/package.json`
+- Deno: `**/deno.json`
+- Dart: `**/pubspec.yaml`
+- Python: `**/pyproject.toml`
+- Go: `**/go.mod`
+
+Each benchmark should create enough packages and extra matching files to reproduce repeated glob cost. Suggested shape:
+
+- 50 packages
+- one manifest per package
+- nested/generated directories with additional matching manifests where useful
+- same ecosystem-level glob inherited by all packages
+
+Measure:
+
+- full `load_workspace_configuration`
+- CLI-only config load once introduced
+- optionally direct versioned-file validation cache behavior
+
+Acceptance target:
+
+- full config load for this scenario should be under 1s locally, preferably much lower
+- repeated inherited glob validation should execute one filesystem walk per unique glob/ecosystem, not one per package
+
+### CLI command startup benchmarks
+
+Extend existing CLI command benchmarks to cover both binaries and common command classes:
+
+- `mc --version`
+- `mc -V`
+- `monochange --version`
+- `monochange -V`
+- `mc --help`
+- `monochange --help`
+- `mc help`
+- `mc help <custom-command>` with a fixture config
+- `mc lint --list`
+- `mc lint --explain <rule>`
+- `mc step:config --format json`
+- representative no-arg invocation/error path
+
+Benchmarks should run against a fixture containing inherited ecosystem globs to prove config-free and CLI-only paths do not accidentally trigger full validation.
+
+## Test plan
+
+Add regression tests for:
+
+- `monochange --version` does not load config, even when cwd has expensive config.
+- `mc --version` still does not load config.
+- root help loads configuration at most once.
+- root help can render custom commands using CLI-only config without validating package paths/globs.
+- inherited ecosystem versioned-file globs are validated once, not once per package.
+- full validation still reports unsupported glob matches and missing files correctly.
+- explicit validation commands still perform full validation.
+
+Use test fixtures and counters where practical instead of relying on wall-clock timing in unit tests.
+
+## Implementation checklist
+
+- [ ] Remove temporary diagnostic instrumentation from `crates/monochange_config/src/lib.rs`.
+- [ ] Add plan changeset.
+- [ ] Add/repair sync version fast path for `monochange` binary.
+- [ ] Introduce a truly config-free base command builder.
+- [ ] Update `run_with_args_in_dir` to use config-free parsing for version and built-in help probes.
+- [ ] Add CLI-only config loading path or equivalent focused parser.
+- [ ] Route help/dispatch paths to CLI-only loading where possible.
+- [ ] Add inherited glob validation cache/deduplication.
+- [ ] Add tests for config-free and CLI-only behavior.
+- [ ] Add inherited ecosystem glob benchmarks for Cargo, npm, Deno, Dart, Python, and Go.
+- [ ] Extend CLI startup benchmarks for both `mc` and `monochange`.
+- [ ] Run focused unit tests.
+- [ ] Run benchmark script locally against the new fixture.
+- [ ] Run `devenv shell lint:monochange` or the repo-required validation subset.
+- [ ] Run `devenv shell coverage:all` and `devenv shell coverage:patch` before PR.
+- [ ] Update this plan with decisions and final benchmark results.
+
+## Acceptance checks
+
+- `mc --version` and `monochange --version` are milliseconds in `solana_kit`.
+- `mc --help` and `monochange --help` no longer perform full package/glob validation.
+- Full config loading for inherited ecosystem glob fixtures is under 1s locally.
+- Benchmarks cover all supported ecosystems with ecosystem-level glob inheritance.
+- Tests prove expensive validation is not triggered for commands that do not need it.
+- Patch coverage remains 100%.
+
+## Open decisions
+
+- Whether `step:config` should print fully validated config or a normalized-but-not-fully-validated config by default.
+- Whether CLI-only parsing should live in `monochange_config` or in `monochange` as a narrower raw config reader.
+- Whether glob cache should be a local validation context only or a more reusable config-loading primitive.
+
+## Notes while implementing
+
+- Do not optimize only `--version`; the real issue is over-eager config loading and repeated glob validation.
+- Keep user-visible diagnostics accurate when validation is explicitly requested.
+- Avoid hidden global caches unless they are scoped to one config load; stale filesystem results would be surprising.
+- Prefer deterministic tests with injected counters/fixtures over time-based assertions.
+
+## Implementation update (2026-05-30)
+
+Implemented in this branch:
+
+- Added `monochange_config::load_cli_commands(root)` to parse raw config and merge CLI command metadata without package/group/ecosystem validation.
+- Changed CLI startup/help paths to use CLI-only loading for root help, no-arg help, `help`, `help <command>`, and `<command> --help`.
+- Added a config-free `monochange --version` sync fast path and changed the `mc` sync version fast path to print to stdout.
+- Added per-config-load glob validation dedupe for package/group `versioned_files`, so inherited ecosystem globs are not re-expanded once per package.
+- Added regression tests for CLI-only config loading and version/root-help behavior with invalid package/versioned-file config.
+- Added `cli_startup_help` Criterion cases for `mc --version`, root help, and command help.
+
+Real `solana_kit` release-binary timings after warmup:
+
+- `mc --version`: ~0.006s median
+- `monochange --version`: ~0.005s median
+- `mc --help`: ~0.006s median
+- `mc` with no args: ~0.006s median
+- `mc help release`: ~0.006s median
+- `mc release --help`: ~0.007s median
+- `mc step:config`: ~2.5s median, down from the previous repeated-glob 25s+ config-load behavior
+
+Remaining possible follow-ups:
+
+- Extend inherited-glob Criterion fixtures across Cargo, npm, Deno, Dart, Python, and Go.
+- Split `step:config` onto a lighter config path if it should avoid full package/glob validation.
+- Continue moving command-specific execution paths from full validated config to targeted loaders where safe.

--- a/fixtures/tests/config/inherited-ecosystem-globs/monochange.toml
+++ b/fixtures/tests/config/inherited-ecosystem-globs/monochange.toml
@@ -1,0 +1,49 @@
+[defaults]
+changelog = false
+
+[package.cargo-core]
+path = "packages/cargo-core"
+type = "cargo"
+
+[package.npm-ui]
+path = "packages/npm-ui"
+type = "npm"
+
+[package.deno-tool]
+path = "packages/deno-tool"
+type = "deno"
+
+[package.dart-app]
+path = "packages/dart-app"
+type = "dart"
+
+[package.python-lib]
+path = "packages/python-lib"
+type = "python"
+
+[package.go-service]
+path = "packages/go-service"
+type = "go"
+
+[ecosystems.cargo]
+versioned_files = [{ path = "packages/**/Cargo.toml", type = "cargo" }]
+
+[ecosystems.npm]
+versioned_files = [{ path = "packages/**/package.json", type = "npm" }]
+
+[ecosystems.deno]
+versioned_files = [{ path = "packages/**/deno.json", type = "deno" }]
+
+[ecosystems.dart]
+versioned_files = [{ path = "packages/**/pubspec.yaml", type = "dart" }]
+
+[ecosystems.python]
+versioned_files = [{ path = "packages/**/pyproject.toml", type = "python" }]
+
+[ecosystems.go]
+versioned_files = [{ path = "packages/**/go.mod", type = "go" }]
+
+[cli.deploy]
+help_text = "Deploy fixture packages"
+[[cli.deploy.steps]]
+type = "PrepareRelease"

--- a/fixtures/tests/config/inherited-ecosystem-globs/packages/cargo-core/Cargo.toml
+++ b/fixtures/tests/config/inherited-ecosystem-globs/packages/cargo-core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "cargo-core"
+version = "1.0.0"
+edition = "2021"

--- a/fixtures/tests/config/inherited-ecosystem-globs/packages/dart-app/pubspec.yaml
+++ b/fixtures/tests/config/inherited-ecosystem-globs/packages/dart-app/pubspec.yaml
@@ -1,0 +1,4 @@
+name: dart_app
+version: 1.0.0
+environment:
+  sdk: ^3.0.0

--- a/fixtures/tests/config/inherited-ecosystem-globs/packages/deno-tool/deno.json
+++ b/fixtures/tests/config/inherited-ecosystem-globs/packages/deno-tool/deno.json
@@ -1,0 +1,1 @@
+{"name":"@scope/deno-tool","version":"1.0.0"}

--- a/fixtures/tests/config/inherited-ecosystem-globs/packages/extra/cargo/Cargo.toml
+++ b/fixtures/tests/config/inherited-ecosystem-globs/packages/extra/cargo/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "cargo-extra"
+version = "1.0.0"
+edition = "2021"

--- a/fixtures/tests/config/inherited-ecosystem-globs/packages/extra/dart/pubspec.yaml
+++ b/fixtures/tests/config/inherited-ecosystem-globs/packages/extra/dart/pubspec.yaml
@@ -1,0 +1,4 @@
+name: dart_extra
+version: 1.0.0
+environment:
+  sdk: ^3.0.0

--- a/fixtures/tests/config/inherited-ecosystem-globs/packages/extra/deno/deno.json
+++ b/fixtures/tests/config/inherited-ecosystem-globs/packages/extra/deno/deno.json
@@ -1,0 +1,1 @@
+{"name":"@scope/deno-extra","version":"1.0.0"}

--- a/fixtures/tests/config/inherited-ecosystem-globs/packages/extra/go/go.mod
+++ b/fixtures/tests/config/inherited-ecosystem-globs/packages/extra/go/go.mod
@@ -1,0 +1,3 @@
+module example.com/go-extra
+
+go 1.22

--- a/fixtures/tests/config/inherited-ecosystem-globs/packages/extra/npm/package.json
+++ b/fixtures/tests/config/inherited-ecosystem-globs/packages/extra/npm/package.json
@@ -1,0 +1,1 @@
+{"name":"npm-extra","version":"1.0.0"}

--- a/fixtures/tests/config/inherited-ecosystem-globs/packages/extra/python/pyproject.toml
+++ b/fixtures/tests/config/inherited-ecosystem-globs/packages/extra/python/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "python-extra"
+version = "1.0.0"

--- a/fixtures/tests/config/inherited-ecosystem-globs/packages/go-service/go.mod
+++ b/fixtures/tests/config/inherited-ecosystem-globs/packages/go-service/go.mod
@@ -1,0 +1,3 @@
+module example.com/go-service
+
+go 1.22

--- a/fixtures/tests/config/inherited-ecosystem-globs/packages/npm-ui/package.json
+++ b/fixtures/tests/config/inherited-ecosystem-globs/packages/npm-ui/package.json
@@ -1,0 +1,1 @@
+{"name":"npm-ui","version":"1.0.0"}

--- a/fixtures/tests/config/inherited-ecosystem-globs/packages/python-lib/pyproject.toml
+++ b/fixtures/tests/config/inherited-ecosystem-globs/packages/python-lib/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "python-lib"
+version = "1.0.0"


### PR DESCRIPTION
## Summary

- adds a CLI-only config loader for help/startup paths
- makes `monochange --version` config-free and keeps version output on stdout
- deduplicates package/group versioned-file glob validation during full config loads
- adds startup/help regression benchmarks and documents the performance plan/results

## Validation

- `devenv shell cargo test -p monochange_config load_cli_commands_skips_package_and_versioned_file_validation --lib`
- `devenv shell cargo test -p monochange version_and_root_help_skip_workspace_validation --lib`
- `devenv shell cargo test -p monochange --bench cli_commands --no-run`
- `devenv shell cargo clippy -p monochange_config -p monochange --all-targets -- -D warnings`
- `devenv shell dprint check`

## Performance notes

Warm `solana_kit` release-binary medians:

- `mc --version`: ~0.006s
- `monochange --version`: ~0.005s
- `mc --help`: ~0.006s
- `mc` no args: ~0.006s
- `mc help release`: ~0.006s
- `mc release --help`: ~0.007s
- `mc step:config`: ~2.5s

## Changeset

- Added `.changeset/perf-cli-startup-config-loading.md`

## Risk

Low-to-medium: version/help paths intentionally avoid full validation, while command execution still loads the fully validated workspace configuration.
