### PR TITLE
feat: support generic versioned file formats

### DIFF
--- a/.changeset/feat-versioned-file-formats.md
+++ b/.changeset/feat-versioned-file-formats.md
@@ -1,0 +1,10 @@
+---
+monochange: minor
+monochange_config: minor
+monochange_core: minor
+monochange_schema: minor
+---
+
+# Add generic format versioned files
+
+Add `versioned_files` format mode for explicit version updates in JSON, TOML, YAML/YML, and env files without ecosystem-specific dependency handling.

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -9294,6 +9294,7 @@ fn resolve_versioned_prefix_prefers_explicit_then_ecosystem_then_default() {
 	let explicit = monochange_core::VersionedFileDefinition {
 		path: "packages/app/package.json".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Npm),
+		format: None,
 		prefix: Some("~".to_string()),
 		fields: None,
 		name: None,
@@ -9304,6 +9305,7 @@ fn resolve_versioned_prefix_prefers_explicit_then_ecosystem_then_default() {
 	let ecosystem = monochange_core::VersionedFileDefinition {
 		path: "packages/app/package.json".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Npm),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -9317,6 +9319,7 @@ fn resolve_versioned_prefix_prefers_explicit_then_ecosystem_then_default() {
 	let fallback = monochange_core::VersionedFileDefinition {
 		path: "packages/app/deno.json".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Deno),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -9330,6 +9333,7 @@ fn resolve_versioned_prefix_prefers_explicit_then_ecosystem_then_default() {
 	let python = monochange_core::VersionedFileDefinition {
 		path: "packages/app/pyproject.toml".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Python),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -9340,6 +9344,7 @@ fn resolve_versioned_prefix_prefers_explicit_then_ecosystem_then_default() {
 	let go = monochange_core::VersionedFileDefinition {
 		path: "packages/app/go.mod".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Go),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -9975,6 +9980,7 @@ fn expand_versioned_file_fields_supports_name_templates_and_passthrough_fields()
 	let definition = monochange_core::VersionedFileDefinition {
 		path: "Cargo.toml".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Cargo),
+		format: None,
 		prefix: None,
 		fields: Some(vec![
 			"workspace.dependencies.{{name}}.version".to_string(),
@@ -9994,6 +10000,7 @@ fn expand_versioned_file_fields_supports_name_templates_and_passthrough_fields()
 	let go = monochange_core::VersionedFileDefinition {
 		path: "go.mod".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Go),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -10029,6 +10036,7 @@ fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_update
 		let definition = monochange_core::VersionedFileDefinition {
 			path: file_name.to_string(),
 			ecosystem_type: Some(ecosystem_type),
+			format: None,
 			prefix: None,
 			fields: None,
 			name: None,
@@ -10063,6 +10071,7 @@ fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_update
 	let definition = monochange_core::VersionedFileDefinition {
 		path: "Cargo.toml".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Cargo),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -10091,6 +10100,7 @@ fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_update
 	let pnpm_definition = monochange_core::VersionedFileDefinition {
 		path: "pnpm-lock.yaml".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Npm),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -10120,6 +10130,7 @@ fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_update
 	let definition = monochange_core::VersionedFileDefinition {
 		path: "pubspec.yaml".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Dart),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -10237,6 +10248,7 @@ fn apply_versioned_file_definition_returns_early_without_matching_versions() {
 	let definition = monochange_core::VersionedFileDefinition {
 		path: "package.json".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Npm),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -10269,6 +10281,7 @@ fn apply_versioned_file_definition_rejects_invalid_glob_patterns() {
 	let definition = monochange_core::VersionedFileDefinition {
 		path: "[".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Npm),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -10307,6 +10320,7 @@ fn apply_versioned_file_definition_rejects_unsupported_glob_matches() {
 		let definition = monochange_core::VersionedFileDefinition {
 			path: "*.txt".to_string(),
 			ecosystem_type: Some(ecosystem_type),
+			format: None,
 			prefix: None,
 			fields: None,
 			name: None,
@@ -10347,6 +10361,7 @@ monochange = { path = "crates/monochange", version = "1.0.0" }
 	let definition = monochange_core::VersionedFileDefinition {
 		path: "Cargo.toml".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Cargo),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -10399,6 +10414,7 @@ extra = { path = "crates/extra", version = "1.0.0" }
 	let definition = monochange_core::VersionedFileDefinition {
 		path: "Cargo.toml".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Cargo),
+		format: None,
 		prefix: None,
 		fields: Some(vec![
 			"workspace.version".to_string(),
@@ -10452,6 +10468,7 @@ fn apply_versioned_file_definition_updates_bun_lockb_and_deno_text_variants() {
 	let bun_definition = monochange_core::VersionedFileDefinition {
 		path: "packages/app/bun.lockb".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Npm),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -10488,6 +10505,7 @@ fn apply_versioned_file_definition_updates_bun_lockb_and_deno_text_variants() {
 	let deno_definition = monochange_core::VersionedFileDefinition {
 		path: "deno.json".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Deno),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -10527,6 +10545,7 @@ fn apply_versioned_file_definition_updates_regex_versioned_files_from_cached_tex
 	let definition = monochange_core::VersionedFileDefinition {
 		path: "README.md".to_string(),
 		ecosystem_type: None,
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -10574,6 +10593,7 @@ fn apply_versioned_file_definition_reports_invalid_regex_patterns() {
 	let definition = monochange_core::VersionedFileDefinition {
 		path: "README.md".to_string(),
 		ecosystem_type: None,
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -10611,6 +10631,7 @@ fn apply_versioned_file_definition_updates_npm_manifest_and_lock_variants() {
 	let manifest_definition = monochange_core::VersionedFileDefinition {
 		path: "package.json".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Npm),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -10657,6 +10678,7 @@ fn apply_versioned_file_definition_updates_npm_manifest_and_lock_variants() {
 	let package_lock_definition = monochange_core::VersionedFileDefinition {
 		path: "packages/app/package-lock.json".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Npm),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -10697,6 +10719,7 @@ fn apply_versioned_file_definition_updates_npm_manifest_and_lock_variants() {
 	let pnpm_definition = monochange_core::VersionedFileDefinition {
 		path: "pnpm-lock.yaml".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Npm),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -10734,6 +10757,7 @@ fn apply_versioned_file_definition_updates_npm_manifest_and_lock_variants() {
 	let bun_definition = monochange_core::VersionedFileDefinition {
 		path: "packages/app/bun.lock".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Npm),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -10786,6 +10810,7 @@ dependencies = ["python-core>=1.0.0"]
 	let manifest_definition = monochange_core::VersionedFileDefinition {
 		path: "pyproject.toml".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Python),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -10816,6 +10841,7 @@ dependencies = ["python-core>=1.0.0"]
 	let lock_definition = monochange_core::VersionedFileDefinition {
 		path: "uv.lock".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Python),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -10857,6 +10883,7 @@ async fn apply_versioned_file_definition_reports_python_error_paths() {
 	let unsupported_definition = monochange_core::VersionedFileDefinition {
 		path: "unknown.txt".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Python),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -10884,6 +10911,7 @@ async fn apply_versioned_file_definition_reports_python_error_paths() {
 	let manifest_definition = monochange_core::VersionedFileDefinition {
 		path: "pyproject.toml".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Python),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -10920,6 +10948,7 @@ fn apply_versioned_file_definition_updates_deno_and_dart_variants() {
 	let deno_manifest_definition = monochange_core::VersionedFileDefinition {
 		path: "deno.json".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Deno),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -10956,6 +10985,7 @@ fn apply_versioned_file_definition_updates_deno_and_dart_variants() {
 	let deno_lock_definition = monochange_core::VersionedFileDefinition {
 		path: "packages/app/deno.lock".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Deno),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -10991,6 +11021,7 @@ fn apply_versioned_file_definition_updates_deno_and_dart_variants() {
 	let dart_manifest_definition = monochange_core::VersionedFileDefinition {
 		path: "packages/app/pubspec.yaml".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Dart),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -11029,6 +11060,7 @@ fn apply_versioned_file_definition_updates_deno_and_dart_variants() {
 	let dart_lock_definition = monochange_core::VersionedFileDefinition {
 		path: "packages/app/pubspec.lock".to_string(),
 		ecosystem_type: Some(monochange_core::EcosystemType::Dart),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -13332,6 +13364,7 @@ fn apply_versioned_file_definition_reports_invalid_glob_pattern() {
 	let definition = monochange_core::VersionedFileDefinition {
 		path: "[invalid".to_string(),
 		ecosystem_type: None,
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -13361,6 +13394,7 @@ fn apply_versioned_file_definition_reports_missing_ecosystem_type() {
 	let definition = monochange_core::VersionedFileDefinition {
 		path: "Cargo.toml".to_string(),
 		ecosystem_type: None,
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,

--- a/crates/monochange/src/__tests__/versioned_files_tests.rs
+++ b/crates/monochange/src/__tests__/versioned_files_tests.rs
@@ -107,6 +107,20 @@ fn format_versioned_file_reports_invalid_paths_and_parse_errors() {
 	.expect_err("json traversal through a string should fail");
 	assert!(json_non_object.to_string().contains("non-object value"));
 
+	let json_non_object_segment = update_format_versioned_file_text(
+		"{\"release\":{\"metadata\":\"1.0.0\"}}",
+		monochange_core::VersionedFileFormat::Json,
+		&["release.metadata.inner.version".to_string()],
+		"1.2.3",
+		None,
+	)
+	.expect_err("json traversal after a string segment should fail");
+	assert!(
+		json_non_object_segment
+			.to_string()
+			.contains("non-object segment `inner`")
+	);
+
 	let json_missing_segment = update_format_versioned_file_text(
 		"{\"release\":{\"version\":\"1.0.0\"}}",
 		monochange_core::VersionedFileFormat::Json,
@@ -202,6 +216,20 @@ fn format_versioned_file_reports_invalid_paths_and_parse_errors() {
 	)
 	.expect_err("yaml traversal through a scalar should fail");
 	assert!(yaml_non_mapping.to_string().contains("non-mapping value"));
+
+	let yaml_non_mapping_segment = update_format_versioned_file_text(
+		"release:\n  metadata: 1.0.0\n",
+		monochange_core::VersionedFileFormat::Yaml,
+		&["release.metadata.inner.version".to_string()],
+		"1.2.3",
+		None,
+	)
+	.expect_err("yaml traversal after a scalar segment should fail");
+	assert!(
+		yaml_non_mapping_segment
+			.to_string()
+			.contains("non-mapping segment `inner`")
+	);
 
 	let yaml_missing_segment = update_format_versioned_file_text(
 		"release:\n  version: 1.0.0\n",

--- a/crates/monochange/src/__tests__/versioned_files_tests.rs
+++ b/crates/monochange/src/__tests__/versioned_files_tests.rs
@@ -17,12 +17,347 @@ use super::read_cached_document;
 use super::released_versions_by_package_id;
 use super::released_versions_by_record_id;
 use super::seed_cached_text_updates;
+use super::update_format_versioned_file_text;
 use super::versioned_file_kind;
 
 fn fixture_path(relative: &str) -> PathBuf {
 	PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 		.join("../../fixtures/tests")
 		.join(relative)
+}
+
+#[test]
+fn format_versioned_file_updates_json_toml_yaml_and_env_fields() {
+	let json = update_format_versioned_file_text(
+		"{\"release\":{\"version\":\"1.0.0\"}}",
+		monochange_core::VersionedFileFormat::Json,
+		&["release.version".to_string()],
+		"1.2.3",
+		None,
+	)
+	.unwrap_or_else(|error| panic!("update json: {error}"));
+	assert!(json.contains("\"version\": \"1.2.3\""));
+
+	let toml = update_format_versioned_file_text(
+		"[tool.app]\nversion = \"1.0.0\"\n",
+		monochange_core::VersionedFileFormat::Toml,
+		&["tool.app.version".to_string()],
+		"1.2.3",
+		None,
+	)
+	.unwrap_or_else(|error| panic!("update toml: {error}"));
+	assert!(toml.contains("version = \"1.2.3\""));
+
+	let yaml = update_format_versioned_file_text(
+		"release:\n  version: 1.0.0\n",
+		monochange_core::VersionedFileFormat::Yaml,
+		&["release.version".to_string()],
+		"1.2.3",
+		None,
+	)
+	.unwrap_or_else(|error| panic!("update yaml: {error}"));
+	assert!(yaml.contains("version: 1.2.3"));
+
+	let env = update_format_versioned_file_text(
+		"APP=demo\nexport VERSION=1.0.0\n",
+		monochange_core::VersionedFileFormat::Env,
+		&["VERSION".to_string()],
+		"1.2.3",
+		None,
+	)
+	.unwrap_or_else(|error| panic!("update env: {error}"));
+	assert_eq!(env, "APP=demo\nexport VERSION=1.2.3\n");
+}
+
+#[test]
+fn format_versioned_file_renders_name_and_version_templates_in_fields() {
+	let json = update_format_versioned_file_text(
+		"{\"packages\":{\"app\":{\"version\":\"1.0.0\"}}}",
+		monochange_core::VersionedFileFormat::Json,
+		&["packages.{{ name }}.version".to_string()],
+		"1.2.3",
+		Some("app"),
+	)
+	.unwrap_or_else(|error| panic!("update templated json field: {error}"));
+	assert!(json.contains("\"version\": \"1.2.3\""));
+}
+
+#[test]
+fn format_versioned_file_reports_missing_fields() {
+	let error = update_format_versioned_file_text(
+		"{\"release\":{\"version\":\"1.0.0\"}}",
+		monochange_core::VersionedFileFormat::Json,
+		&["release.missing".to_string()],
+		"1.2.3",
+		None,
+	)
+	.expect_err("missing json field should fail");
+	assert!(error.to_string().contains("missing leaf `missing`"));
+}
+
+#[test]
+fn format_versioned_file_reports_invalid_paths_and_parse_errors() {
+	let json_non_object = update_format_versioned_file_text(
+		"{\"release\":\"1.0.0\"}",
+		monochange_core::VersionedFileFormat::Json,
+		&["release.version".to_string()],
+		"1.2.3",
+		None,
+	)
+	.expect_err("json traversal through a string should fail");
+	assert!(json_non_object.to_string().contains("non-object value"));
+
+	let json_missing_segment = update_format_versioned_file_text(
+		"{\"release\":{\"version\":\"1.0.0\"}}",
+		monochange_core::VersionedFileFormat::Json,
+		&["missing.version".to_string()],
+		"1.2.3",
+		None,
+	)
+	.expect_err("json missing parent should fail");
+	assert!(
+		json_missing_segment
+			.to_string()
+			.contains("missing segment `missing`")
+	);
+
+	let json_root_scalar = update_format_versioned_file_text(
+		"\"1.0.0\"",
+		monochange_core::VersionedFileFormat::Json,
+		&["version".to_string()],
+		"1.2.3",
+		None,
+	)
+	.expect_err("json scalar root should fail");
+	assert!(json_root_scalar.to_string().contains("non-object value"));
+
+	let json_parse = update_format_versioned_file_text(
+		"{",
+		monochange_core::VersionedFileFormat::Json,
+		&["version".to_string()],
+		"1.2.3",
+		None,
+	)
+	.expect_err("invalid json should fail");
+	assert!(json_parse.to_string().contains("failed to parse json"));
+
+	let toml_missing_segment = update_format_versioned_file_text(
+		"[tool.app]\nversion = \"1.0.0\"\n",
+		monochange_core::VersionedFileFormat::Toml,
+		&["tool.missing.version".to_string()],
+		"1.2.3",
+		None,
+	)
+	.expect_err("toml missing parent should fail");
+	assert!(
+		toml_missing_segment
+			.to_string()
+			.contains("missing segment `missing`")
+	);
+
+	let toml_non_table = update_format_versioned_file_text(
+		"[tool]\napp = \"1.0.0\"\n",
+		monochange_core::VersionedFileFormat::Toml,
+		&["tool.app.version".to_string()],
+		"1.2.3",
+		None,
+	)
+	.expect_err("toml traversal through a string should fail");
+	assert!(
+		toml_non_table
+			.to_string()
+			.contains("non-table segment `app`")
+	);
+
+	let toml_missing_leaf = update_format_versioned_file_text(
+		"[tool.app]\nversion = \"1.0.0\"\n",
+		monochange_core::VersionedFileFormat::Toml,
+		&["tool.app.missing".to_string()],
+		"1.2.3",
+		None,
+	)
+	.expect_err("toml missing leaf should fail");
+	assert!(
+		toml_missing_leaf
+			.to_string()
+			.contains("missing leaf `missing`")
+	);
+
+	let toml_parse = update_format_versioned_file_text(
+		"[tool",
+		monochange_core::VersionedFileFormat::Toml,
+		&["tool.version".to_string()],
+		"1.2.3",
+		None,
+	)
+	.expect_err("invalid toml should fail");
+	assert!(toml_parse.to_string().contains("failed to parse toml"));
+
+	let yaml_non_mapping = update_format_versioned_file_text(
+		"release: 1.0.0\n",
+		monochange_core::VersionedFileFormat::Yaml,
+		&["release.version".to_string()],
+		"1.2.3",
+		None,
+	)
+	.expect_err("yaml traversal through a scalar should fail");
+	assert!(yaml_non_mapping.to_string().contains("non-mapping value"));
+
+	let yaml_missing_segment = update_format_versioned_file_text(
+		"release:\n  version: 1.0.0\n",
+		monochange_core::VersionedFileFormat::Yaml,
+		&["missing.version".to_string()],
+		"1.2.3",
+		None,
+	)
+	.expect_err("yaml missing parent should fail");
+	assert!(
+		yaml_missing_segment
+			.to_string()
+			.contains("missing segment `missing`")
+	);
+
+	let yaml_root_scalar = update_format_versioned_file_text(
+		"1.0.0\n",
+		monochange_core::VersionedFileFormat::Yml,
+		&["version".to_string()],
+		"1.2.3",
+		None,
+	)
+	.expect_err("yaml scalar root should fail");
+	assert!(yaml_root_scalar.to_string().contains("non-mapping value"));
+
+	let yaml_missing_leaf = update_format_versioned_file_text(
+		"release:\n  version: 1.0.0\n",
+		monochange_core::VersionedFileFormat::Yml,
+		&["release.missing".to_string()],
+		"1.2.3",
+		None,
+	)
+	.expect_err("yaml missing leaf should fail");
+	assert!(
+		yaml_missing_leaf
+			.to_string()
+			.contains("missing leaf `missing`")
+	);
+
+	let yaml_parse = update_format_versioned_file_text(
+		"release: [",
+		monochange_core::VersionedFileFormat::Yaml,
+		&["release.version".to_string()],
+		"1.2.3",
+		None,
+	)
+	.expect_err("invalid yaml should fail");
+	assert!(yaml_parse.to_string().contains("failed to parse yaml"));
+
+	let empty_segment = update_format_versioned_file_text(
+		"{\"release\":{\"version\":\"1.0.0\"}}",
+		monochange_core::VersionedFileFormat::Json,
+		&["release..version".to_string()],
+		"1.2.3",
+		None,
+	)
+	.expect_err("empty path segment should fail");
+	assert!(
+		empty_segment
+			.to_string()
+			.contains("non-empty dot-separated segments")
+	);
+
+	let env = update_format_versioned_file_text(
+		"# comment\nAPP=demo\n",
+		monochange_core::VersionedFileFormat::Env,
+		&["VERSION".to_string()],
+		"1.2.3",
+		None,
+	)
+	.expect_err("missing env key should fail");
+	assert!(
+		env.to_string()
+			.contains("env field `VERSION` was not found")
+	);
+}
+
+#[test]
+fn apply_versioned_file_definition_supports_format_mode_and_reports_format_errors() {
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	std::fs::write(
+		root.join("metadata.json"),
+		"{\"release\":{\"version\":\"1.0.0\"}}",
+	)
+	.unwrap_or_else(|error| panic!("write metadata: {error}"));
+	let configuration =
+		monochange_config::load_workspace_configuration(&fixture_path("monochange/release-base"))
+			.unwrap_or_else(|error| panic!("configuration: {error}"));
+	let context = VersionedFileUpdateContext {
+		package_by_config_id: BTreeMap::new(),
+		package_by_native_name: BTreeMap::new(),
+		current_versions_by_native_name: BTreeMap::new(),
+		released_versions_by_native_name: BTreeMap::new(),
+		configuration: &configuration,
+	};
+	let definition = monochange_core::VersionedFileDefinition {
+		path: "*.json".to_string(),
+		ecosystem_type: None,
+		format: Some(monochange_core::VersionedFileFormat::Json),
+		prefix: None,
+		fields: Some(vec!["release.version".to_string()]),
+		name: None,
+		regex: None,
+	};
+	let mut updates = BTreeMap::new();
+	apply_versioned_file_definition(
+		root,
+		&mut updates,
+		&definition,
+		"1.2.3",
+		None,
+		&["metadata".to_string()],
+		&context,
+	)
+	.unwrap_or_else(|error| panic!("apply format definition: {error}"));
+	assert!(matches!(
+		updates.get(&root.join("metadata.json")),
+		Some(CachedDocument::Text(contents)) if contents.contains("\"version\": \"1.2.3\"")
+	));
+
+	let missing_fields = monochange_core::VersionedFileDefinition {
+		fields: None,
+		..definition.clone()
+	};
+	let error = apply_versioned_file_definition(
+		root,
+		&mut updates,
+		&missing_fields,
+		"1.2.3",
+		None,
+		&["metadata".to_string()],
+		&context,
+	)
+	.expect_err("format definition without fields should fail");
+	assert!(
+		error
+			.to_string()
+			.contains("with format mode is missing fields")
+	);
+
+	let invalid_glob = monochange_core::VersionedFileDefinition {
+		path: "[".to_string(),
+		..definition
+	};
+	let error = apply_versioned_file_definition(
+		root,
+		&mut updates,
+		&invalid_glob,
+		"1.2.3",
+		None,
+		&["metadata".to_string()],
+		&context,
+	)
+	.expect_err("invalid format glob should fail");
+	assert!(error.to_string().contains("invalid glob pattern"));
 }
 
 #[test]
@@ -225,6 +560,7 @@ fn apply_versioned_file_definition_reports_go_for_unsupported_glob_match() {
 	let definition = monochange_core::VersionedFileDefinition {
 		path: "*.txt".to_string(),
 		ecosystem_type: Some(EcosystemType::Go),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -270,6 +606,7 @@ fn apply_versioned_file_definition_updates_go_mod_dependencies() {
 	let definition = monochange_core::VersionedFileDefinition {
 		path: "go.mod".to_string(),
 		ecosystem_type: Some(EcosystemType::Go),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -350,6 +350,7 @@ fn apply_inferred_lockfile_updates(
 		let definition = VersionedFileDefinition {
 			path: lockfile_path.display().to_string(),
 			ecosystem_type: Some(ecosystem_type),
+			format: None,
 			prefix: None,
 			fields: None,
 			name: None,
@@ -835,6 +836,241 @@ pub(crate) fn expand_versioned_file_fields<N: AsRef<str>>(
 }
 // patch-coverage:ignore-end
 
+fn update_json_field_path(
+	value: &mut serde_json::Value,
+	path: &str,
+	version: &str,
+) -> MonochangeResult<()> {
+	let segments = field_path_segments(path)?;
+	let (leaf, parent_segments) = segments
+		.split_last()
+		.expect("validated field paths contain at least one segment");
+	let leaf = *leaf;
+	let mut cursor = value;
+	for segment in parent_segments {
+		let object = cursor.as_object_mut().ok_or_else(|| {
+			MonochangeError::Config(format!(
+				"versioned_files field `{path}` cannot traverse non-object segment `{segment}`"
+			))
+		})?;
+		cursor = object.get_mut(*segment).ok_or_else(|| {
+			MonochangeError::Config(format!(
+				"versioned_files field `{path}` is missing segment `{segment}`"
+			))
+		})?;
+	}
+
+	let object = cursor.as_object_mut().ok_or_else(|| {
+		MonochangeError::Config(format!(
+			"versioned_files field `{path}` cannot set `{leaf}` on a non-object value"
+		))
+	})?;
+	if !object.contains_key(leaf) {
+		return Err(MonochangeError::Config(format!(
+			"versioned_files field `{path}` is missing leaf `{leaf}`"
+		)));
+	}
+	object.insert(
+		leaf.to_string(),
+		serde_json::Value::String(version.to_string()),
+	);
+	Ok(())
+}
+
+fn update_toml_field_path(
+	document: &mut toml_edit::DocumentMut,
+	path: &str,
+	version: &str,
+) -> MonochangeResult<()> {
+	let segments = field_path_segments(path)?;
+	let (leaf, parent_segments) = segments
+		.split_last()
+		.expect("validated field paths contain at least one segment");
+	let leaf = *leaf;
+	let mut table: &mut dyn toml_edit::TableLike = document.as_table_mut();
+	for segment in parent_segments {
+		let item = table.get_mut(segment).ok_or_else(|| {
+			MonochangeError::Config(format!(
+				"versioned_files field `{path}` is missing segment `{segment}`"
+			))
+		})?;
+		table = item.as_table_like_mut().ok_or_else(|| {
+			MonochangeError::Config(format!(
+				"versioned_files field `{path}` cannot traverse non-table segment `{segment}`"
+			))
+		})?;
+	}
+
+	if !table.contains_key(leaf) {
+		return Err(MonochangeError::Config(format!(
+			"versioned_files field `{path}` is missing leaf `{leaf}`"
+		)));
+	}
+	table.insert(leaf, toml_edit::value(version));
+	Ok(())
+}
+
+fn update_yaml_field_path(
+	value: &mut serde_yaml_ng::Value,
+	path: &str,
+	version: &str,
+) -> MonochangeResult<()> {
+	let segments = field_path_segments(path)?;
+	let (leaf, parent_segments) = segments
+		.split_last()
+		.expect("validated field paths contain at least one segment");
+	let leaf = *leaf;
+	let mut cursor = value;
+	for segment in parent_segments {
+		let mapping = cursor.as_mapping_mut().ok_or_else(|| {
+			MonochangeError::Config(format!(
+				"versioned_files field `{path}` cannot traverse non-mapping segment `{segment}`"
+			))
+		})?;
+		let key = serde_yaml_ng::Value::String((*segment).to_string());
+		cursor = mapping.get_mut(&key).ok_or_else(|| {
+			MonochangeError::Config(format!(
+				"versioned_files field `{path}` is missing segment `{segment}`"
+			))
+		})?;
+	}
+
+	let mapping = cursor.as_mapping_mut().ok_or_else(|| {
+		MonochangeError::Config(format!(
+			"versioned_files field `{path}` cannot set `{leaf}` on a non-mapping value"
+		))
+	})?;
+	let key = serde_yaml_ng::Value::String(leaf.to_string());
+	if !mapping.contains_key(&key) {
+		return Err(MonochangeError::Config(format!(
+			"versioned_files field `{path}` is missing leaf `{leaf}`"
+		)));
+	}
+	mapping.insert(key, serde_yaml_ng::Value::String(version.to_string()));
+	Ok(())
+}
+
+fn field_path_segments(path: &str) -> MonochangeResult<Vec<&str>> {
+	let segments = path.split('.').map(str::trim).collect::<Vec<_>>();
+	if segments.is_empty() || segments.iter().any(|segment| segment.is_empty()) {
+		return Err(MonochangeError::Config(format!(
+			"versioned_files field path `{path}` must contain non-empty dot-separated segments"
+		)));
+	}
+	Ok(segments)
+}
+
+fn render_versioned_template(template: &str, name: Option<&str>, version: &str) -> String {
+	template
+		.replace("{{ version }}", version)
+		.replace("{{version}}", version)
+		.replace("{{ name }}", name.unwrap_or_default())
+		.replace("{{name}}", name.unwrap_or_default())
+}
+
+fn update_env_key(contents: &str, key: &str, version: &str) -> MonochangeResult<String> {
+	let mut found = false;
+	let mut output = String::with_capacity(contents.len());
+	for line in contents.split_inclusive('\n') {
+		let (body, ending) = line
+			.strip_suffix('\n')
+			.map_or((line, ""), |body| (body, "\n"));
+		let trimmed_start = body.trim_start();
+		let export_prefix = "export ";
+		let assignment = trimmed_start
+			.strip_prefix(export_prefix)
+			.unwrap_or(trimmed_start);
+		let Some((candidate, _old_value)) = assignment.split_once('=') else {
+			output.push_str(body);
+			output.push_str(ending);
+			continue;
+		};
+
+		if candidate.trim() != key {
+			output.push_str(body);
+			output.push_str(ending);
+			continue;
+		}
+
+		found = true;
+		let leading_len = body.len() - trimmed_start.len();
+		output.push_str(&body[..leading_len]);
+		if trimmed_start.starts_with(export_prefix) {
+			output.push_str(export_prefix);
+		}
+		output.push_str(candidate);
+		output.push('=');
+		output.push_str(version);
+		output.push_str(ending);
+	}
+
+	if !found {
+		return Err(MonochangeError::Config(format!(
+			"versioned_files env field `{key}` was not found"
+		)));
+	}
+	Ok(output)
+}
+
+fn update_format_versioned_file_text(
+	contents: &str,
+	format: monochange_core::VersionedFileFormat,
+	fields: &[String],
+	version: &str,
+	name: Option<&str>,
+) -> MonochangeResult<String> {
+	match format {
+		monochange_core::VersionedFileFormat::Json => {
+			let mut value =
+				serde_json::from_str::<serde_json::Value>(contents).map_err(|error| {
+					MonochangeError::Config(format!("failed to parse json versioned file: {error}"))
+				})?;
+			for field in fields {
+				let field = render_versioned_template(field, name, version);
+				update_json_field_path(&mut value, &field, version)?;
+			}
+			let mut output = serde_json::to_string_pretty(&value).unwrap_or_else(|error| {
+				panic!("serializing serde_json::Value should not fail: {error}")
+			});
+			output.push('\n');
+			Ok(output)
+		}
+		monochange_core::VersionedFileFormat::Toml => {
+			let mut document = contents
+				.parse::<toml_edit::DocumentMut>()
+				.map_err(|error| {
+					MonochangeError::Config(format!("failed to parse toml versioned file: {error}"))
+				})?;
+			for field in fields {
+				let field = render_versioned_template(field, name, version);
+				update_toml_field_path(&mut document, &field, version)?;
+			}
+			Ok(document.to_string())
+		}
+		monochange_core::VersionedFileFormat::Yaml | monochange_core::VersionedFileFormat::Yml => {
+			let mut value =
+				serde_yaml_ng::from_str::<serde_yaml_ng::Value>(contents).map_err(|error| {
+					MonochangeError::Config(format!("failed to parse yaml versioned file: {error}"))
+				})?;
+			for field in fields {
+				let field = render_versioned_template(field, name, version);
+				update_yaml_field_path(&mut value, &field, version)?;
+			}
+			Ok(serde_yaml_ng::to_string(&value).unwrap_or_else(|error| {
+				panic!("serializing serde_yaml_ng::Value should not fail: {error}")
+			}))
+		}
+		monochange_core::VersionedFileFormat::Env => {
+			let mut output = contents.to_string();
+			for field in fields {
+				let key = render_versioned_template(field, name, version);
+				output = update_env_key(&output, &key, version)?;
+			}
+			Ok(output)
+		}
+	}
+}
+
 fn update_versioned_file_regex(
 	contents: &str,
 	pattern: &str,
@@ -889,6 +1125,32 @@ pub(crate) fn apply_versioned_file_definition(
 					owner_version,
 				)?),
 			);
+		}
+		return Ok(());
+	}
+
+	if let Some(format) = definition.format {
+		let fields = definition.fields.as_ref().ok_or_else(|| {
+			MonochangeError::Config(format!(
+				"versioned file `{}` with format mode is missing fields",
+				definition.path
+			))
+		})?;
+		let name = dep_names.first().map(AsRef::as_ref);
+		let glob_pattern = root.join(&definition.path).to_string_lossy().to_string();
+		let matched_paths = glob::glob(&glob_pattern).map_err(|error| {
+			MonochangeError::Config(format!(
+				"invalid glob pattern `{}`: {error}",
+				definition.path
+			))
+		})?;
+		for resolved_path in matched_paths {
+			let resolved_path =
+				resolved_path.map_err(|error| MonochangeError::Config(error.to_string()))?;
+			let contents = read_cached_text_document(updates, &resolved_path)?;
+			let changed_text =
+				update_format_versioned_file_text(&contents, format, fields, owner_version, name)?;
+			updates.insert(resolved_path, CachedDocument::Text(changed_text));
 		}
 		return Ok(());
 	}

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -1030,7 +1030,9 @@ fn update_format_versioned_file_text(
 				update_json_field_path(&mut value, &field, version)?;
 			}
 			let mut output = serde_json::to_string_pretty(&value).unwrap_or_else(|error| {
+				// patch-coverage:ignore-start -- serde_json::Value serialization is infallible for supported values.
 				panic!("serializing serde_json::Value should not fail: {error}")
+				// patch-coverage:ignore-end
 			});
 			output.push('\n');
 			Ok(output)
@@ -1057,7 +1059,9 @@ fn update_format_versioned_file_text(
 				update_yaml_field_path(&mut value, &field, version)?;
 			}
 			Ok(serde_yaml_ng::to_string(&value).unwrap_or_else(|error| {
+				// patch-coverage:ignore-start -- serde_yaml_ng::Value serialization is infallible for supported values.
 				panic!("serializing serde_yaml_ng::Value should not fail: {error}")
+				// patch-coverage:ignore-end
 			}))
 		}
 		monochange_core::VersionedFileFormat::Env => {

--- a/crates/monochange_config/src/__tests__/lib_tests.rs
+++ b/crates/monochange_config/src/__tests__/lib_tests.rs
@@ -6105,6 +6105,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 		&[monochange_core::VersionedFileDefinition {
 			path: "README.md".to_string(),
 			ecosystem_type: None,
+			format: None,
 			name: None,
 			fields: None,
 			prefix: None,
@@ -6128,6 +6129,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 		&[monochange_core::VersionedFileDefinition {
 			path: "[".to_string(),
 			ecosystem_type: Some(EcosystemType::Cargo),
+			format: None,
 			name: None,
 			fields: None,
 			prefix: None,
@@ -6159,6 +6161,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 		&[monochange_core::VersionedFileDefinition {
 			path: "packages/*/package.json".to_string(),
 			ecosystem_type: Some(EcosystemType::Cargo),
+			format: None,
 			name: None,
 			fields: None,
 			prefix: None,
@@ -6191,6 +6194,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 		&[monochange_core::VersionedFileDefinition {
 			path: "packages/*/package.json".to_string(),
 			ecosystem_type: Some(EcosystemType::Dart),
+			format: None,
 			name: None,
 			fields: None,
 			prefix: None,
@@ -6218,6 +6222,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 		&[monochange_core::VersionedFileDefinition {
 			path: "packages/*/package.json".to_string(),
 			ecosystem_type: Some(EcosystemType::Go),
+			format: None,
 			name: None,
 			fields: None,
 			prefix: None,
@@ -7116,4 +7121,109 @@ fn validate_workspace_configuration_rejects_leftover_prerelease_state_when_disab
 		error.to_string().contains("prerelease state exists"),
 		"error: {error}"
 	);
+}
+
+#[test]
+fn validate_versioned_files_accepts_format_mode_and_rejects_invalid_combinations() {
+	let root = fixture_path("config/validation-helper-branches");
+	let config_contents = "[package.core]\npath = 'crates/core'\n";
+	let declared_packages = std::collections::BTreeSet::from(["core"]);
+	let valid = monochange_core::VersionedFileDefinition {
+		path: "metadata.json".to_string(),
+		ecosystem_type: None,
+		format: Some(monochange_core::VersionedFileFormat::Json),
+		name: None,
+		fields: Some(vec!["release.version".to_string()]),
+		prefix: None,
+		regex: None,
+	};
+	crate::validate_versioned_files(
+		&root,
+		config_contents,
+		&[valid],
+		&declared_packages,
+		"package",
+		"core",
+	)
+	.unwrap_or_else(|error| panic!("format versioned file should validate: {error}"));
+
+	let mixed_type = monochange_core::VersionedFileDefinition {
+		path: "metadata.json".to_string(),
+		ecosystem_type: Some(EcosystemType::Npm),
+		format: Some(monochange_core::VersionedFileFormat::Json),
+		name: None,
+		fields: Some(vec!["release.version".to_string()]),
+		prefix: None,
+		regex: None,
+	};
+	let error = crate::validate_versioned_files(
+		&root,
+		config_contents,
+		&[mixed_type],
+		&declared_packages,
+		"package",
+		"core",
+	)
+	.expect_err("format and type should be mutually exclusive");
+	assert!(error.to_string().contains("cannot also set `type`"));
+
+	let mixed_regex = monochange_core::VersionedFileDefinition {
+		path: "metadata.json".to_string(),
+		ecosystem_type: None,
+		format: Some(monochange_core::VersionedFileFormat::Json),
+		name: None,
+		fields: Some(vec!["release.version".to_string()]),
+		prefix: None,
+		regex: Some("version = (?<version>.*)".to_string()),
+	};
+	let error = crate::validate_versioned_files(
+		&root,
+		config_contents,
+		&[mixed_regex],
+		&declared_packages,
+		"package",
+		"core",
+	)
+	.expect_err("format and regex should be mutually exclusive");
+	assert!(error.to_string().contains("cannot also set `regex`"));
+
+	let missing_fields = monochange_core::VersionedFileDefinition {
+		path: ".env".to_string(),
+		ecosystem_type: None,
+		format: Some(monochange_core::VersionedFileFormat::Env),
+		name: None,
+		fields: None,
+		prefix: None,
+		regex: None,
+	};
+	let error = crate::validate_versioned_files(
+		&root,
+		config_contents,
+		&[missing_fields],
+		&declared_packages,
+		"package",
+		"core",
+	)
+	.expect_err("format mode should require fields");
+	assert!(error.to_string().contains("must set `fields`"));
+
+	let empty_fields = monochange_core::VersionedFileDefinition {
+		path: ".env".to_string(),
+		ecosystem_type: None,
+		format: Some(monochange_core::VersionedFileFormat::Env),
+		name: None,
+		fields: Some(Vec::new()),
+		prefix: None,
+		regex: None,
+	};
+	let error = crate::validate_versioned_files(
+		&root,
+		config_contents,
+		&[empty_fields],
+		&declared_packages,
+		"package",
+		"core",
+	)
+	.expect_err("format mode should reject empty fields");
+	assert!(error.to_string().contains("fields must be non-empty"));
 }

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -845,6 +845,7 @@ fn normalize_versioned_files(
 				Ok(VersionedFileDefinition {
 					path,
 					ecosystem_type: Some(inferred_ecosystem_type),
+					format: None,
 					prefix: None,
 					fields: None,
 					name: None,
@@ -3328,6 +3329,11 @@ fn validate_versioned_files(
 	owner_id: &str,
 ) -> MonochangeResult<()> {
 	for versioned_file in versioned_files {
+		if versioned_file.format.is_some() {
+			validate_format_versioned_file(config_contents, versioned_file, owner_kind, owner_id)?;
+			continue;
+		}
+
 		if let Some(regex) = versioned_file.regex.as_deref() {
 			validate_regex_versioned_file(
 				config_contents,
@@ -4000,6 +4006,71 @@ fn validate_changeset_scoped_lint_settings(
 }
 
 #[allow(clippy::match_same_arms)]
+fn validate_format_versioned_file(
+	config_contents: &str,
+	versioned_file: &VersionedFileDefinition,
+	owner_kind: &str,
+	owner_id: &str,
+) -> MonochangeResult<()> {
+	if versioned_file.ecosystem_type.is_some() {
+		return Err(config_diagnostic(
+			config_contents,
+			format!("{owner_kind} `{owner_id}` format versioned_files cannot also set `type`"),
+			vec![config_section_label(
+				config_contents,
+				owner_kind,
+				owner_id,
+				"format versioned_files cannot set `type`",
+			)],
+			Some("remove `type` when using `format`; format versioned_files update explicit fields without ecosystem-specific parsing".to_string()),
+		));
+	}
+
+	if versioned_file.regex.is_some() {
+		return Err(config_diagnostic(
+			config_contents,
+			format!("{owner_kind} `{owner_id}` format versioned_files cannot also set `regex`"),
+			vec![config_section_label(
+				config_contents,
+				owner_kind,
+				owner_id,
+				"format versioned_files cannot set `regex`",
+			)],
+			Some("choose either `format` with explicit `fields`, or `regex` with a named version capture".to_string()),
+		));
+	}
+
+	let Some(fields) = versioned_file.fields.as_ref() else {
+		return Err(config_diagnostic(
+			config_contents,
+			format!("{owner_kind} `{owner_id}` format versioned_files must set `fields`"),
+			vec![config_section_label(
+				config_contents,
+				owner_kind,
+				owner_id,
+				"format versioned_files must set `fields`",
+			)],
+			Some("add at least one explicit field path, such as `fields = [\"release.version\"]` or `fields = [\"VERSION\"]` for env files".to_string()),
+		));
+	};
+
+	if fields.is_empty() || fields.iter().any(|field| field.trim().is_empty()) {
+		return Err(config_diagnostic(
+			config_contents,
+			format!("{owner_kind} `{owner_id}` format versioned_files fields must be non-empty"),
+			vec![config_section_label(
+				config_contents,
+				owner_kind,
+				owner_id,
+				"format versioned_files fields must be non-empty",
+			)],
+			Some("remove empty field entries or replace them with explicit keys like `version` or `release.version`".to_string()),
+		));
+	}
+
+	Ok(())
+}
+
 fn validate_regex_versioned_file(
 	config_contents: &str,
 	versioned_file: &VersionedFileDefinition,
@@ -4007,17 +4078,17 @@ fn validate_regex_versioned_file(
 	owner_id: &str,
 	regex: &str,
 ) -> MonochangeResult<()> {
-	if versioned_file.ecosystem_type.is_some() {
+	if versioned_file.ecosystem_type.is_some() || versioned_file.format.is_some() {
 		return Err(config_diagnostic(
 			config_contents,
-			format!("{owner_kind} `{owner_id}` regex versioned_files cannot also set `type`"),
+			format!("{owner_kind} `{owner_id}` regex versioned_files cannot also set `type` or `format`"),
 			vec![config_section_label(
 				config_contents,
 				owner_kind,
 				owner_id,
-				"regex versioned_files cannot set `type`",
+				"regex versioned_files cannot set `type` or `format`",
 			)],
-			Some("remove `type` when using `regex`; regex versioned_files operate on plain text files without ecosystem-specific parsing".to_string()),
+			Some("remove `type` and `format` when using `regex`; regex versioned_files operate on plain text files without ecosystem-specific parsing".to_string()),
 		));
 	}
 

--- a/crates/monochange_core/src/__tests__/lib_tests.rs
+++ b/crates/monochange_core/src/__tests__/lib_tests.rs
@@ -73,6 +73,7 @@ use crate::SourceConfiguration;
 use crate::SourceProvider;
 use crate::VersionFormat;
 use crate::VersionedFileDefinition;
+use crate::VersionedFileFormat;
 use crate::WorkspaceConfiguration;
 use crate::WorkspaceDefaults;
 use crate::default_cli_commands;
@@ -709,6 +710,7 @@ fn versioned_file_definition_uses_regex_returns_true_when_set() {
 	let definition = VersionedFileDefinition {
 		path: "README.md".to_string(),
 		ecosystem_type: None,
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
@@ -722,12 +724,27 @@ fn versioned_file_definition_uses_regex_returns_false_when_unset() {
 	let definition = VersionedFileDefinition {
 		path: "Cargo.toml".to_string(),
 		ecosystem_type: Some(EcosystemType::Cargo),
+		format: None,
 		prefix: None,
 		fields: None,
 		name: None,
 		regex: None,
 	};
 	assert!(!definition.uses_regex());
+}
+
+#[test]
+fn versioned_file_definition_uses_format_returns_true_when_set() {
+	let definition = VersionedFileDefinition {
+		path: "metadata.json".to_string(),
+		ecosystem_type: None,
+		format: Some(VersionedFileFormat::Json),
+		prefix: None,
+		fields: Some(vec!["release.version".to_string()]),
+		name: None,
+		regex: None,
+	};
+	assert!(definition.uses_format());
 }
 
 #[test]

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -1101,11 +1101,25 @@ fn json_span_is_object(contents: &str, span: JsonSpan) -> bool {
 }
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VersionedFileFormat {
+	Json,
+	Toml,
+	Yaml,
+	#[serde(alias = "yml")]
+	Yml,
+	Env,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct VersionedFileDefinition {
 	pub path: String,
 	#[serde(rename = "type", default)]
 	pub ecosystem_type: Option<EcosystemType>,
+	#[serde(default)]
+	pub format: Option<VersionedFileFormat>,
 	#[serde(default)]
 	pub prefix: Option<String>,
 	#[serde(default)]
@@ -1121,6 +1135,12 @@ impl VersionedFileDefinition {
 	#[must_use]
 	pub fn uses_regex(&self) -> bool {
 		self.regex.is_some()
+	}
+
+	/// Return `true` when the definition uses generic format mode.
+	#[must_use]
+	pub fn uses_format(&self) -> bool {
+		self.format.is_some()
 	}
 }
 

--- a/crates/monochange_schema/schemas/monochange.schema.json
+++ b/crates/monochange_schema/schemas/monochange.schema.json
@@ -1624,6 +1624,17 @@
 						"null"
 					]
 				},
+				"format": {
+					"anyOf": [
+						{
+							"$ref": "#/$defs/VersionedFileFormat"
+						},
+						{
+							"type": "null"
+						}
+					],
+					"default": null
+				},
 				"name": {
 					"default": null,
 					"type": [
@@ -1664,6 +1675,16 @@
 				"path"
 			],
 			"type": "object"
+		},
+		"VersionedFileFormat": {
+			"enum": [
+				"json",
+				"toml",
+				"yaml",
+				"yml",
+				"env"
+			],
+			"type": "string"
 		},
 		"changelogConfig": {
 			"anyOf": [

--- a/docs/plans/active/feat-versioned-file-formats.md
+++ b/docs/plans/active/feat-versioned-file-formats.md
@@ -1,0 +1,151 @@
+# Generic format-based versioned files
+
+## Status
+
+- Branch/worktree: `feat/versioned-file-formats` at `worktrees/feat-versioned-file-formats`
+- Owner: Uche
+- Started: 2026-05-30
+
+## Problem statement
+
+`versioned_files` currently has two modes:
+
+1. Ecosystem-aware mode via `type = "cargo"`, `type = "npm"`, `type = "dart"`, etc. The ecosystem type controls which file kinds are supported and which dependency/version fields are updated by default.
+2. Regex replacement mode via `regex`, for raw text replacement with a named `version` capture.
+
+This leaves no first-class way to update arbitrary structured or simple key/value files such as custom JSON metadata, TOML config, YAML config, or `.env` files without pretending they are an ecosystem manifest or writing a regex.
+
+## Desired user-facing shape
+
+Add a mutually exclusive generic format mode for versioned files:
+
+```toml
+versioned_files = [
+	{ path = "metadata.json", format = "json", fields = ["release.version"] },
+	{ path = ".env", format = "env", fields = ["VERSION"] },
+	{ path = "tools.toml", format = "toml", fields = ["tool.my_package.version"] },
+]
+```
+
+Rules:
+
+- `format` is mutually exclusive with ecosystem `type`.
+- `format` is mutually exclusive with `regex` replacement mode.
+- `format` requires at least one explicit field.
+- `format` does not infer dependency sections or ecosystem-specific behavior.
+- Each configured field is updated to the planned version for the owning package/group.
+- Field paths should be deterministic and easy to document:
+  - JSON/TOML/YAML: dot-separated path segments like `x.y.z` for object/table keys.
+  - env: exact key names like `VERSION`.
+- Templating can be layered in after the basic feature is reliable. Initial implementation should reserve the design and avoid blocking future support for `{{ name }}` / `{{ version }}` style templates.
+
+## Scope
+
+### In scope for the first implementation
+
+- Add shared config/domain types for generic versioned file formats.
+- Support `format = "json"`, `format = "toml"`, `format = "yaml"`, `format = "yml"`, and `format = "env"`.
+- Validate invalid combinations and missing fields in `monochange_config`.
+- Apply version updates in `crates/monochange/src/versioned_files.rs`.
+- Preserve existing ecosystem `type` and `regex` behavior.
+- Add fixture-first tests for config loading and release/update behavior.
+- Update schema/docs/templates/config comments and add a changeset.
+
+### Non-goals for the first implementation
+
+- Generic dependency-aware updates by package name for arbitrary formats.
+- Wildcard paths, array indexing, JSONPath/JMESPath, or recursive search.
+- Creating missing nested fields unless the existing codebase already has a clear precedent. Prefer requiring configured fields to exist for safety.
+- Rich value templating beyond writing the planned version string. Keep the model extensible for a later `value`/`template` field.
+- Lossless preservation for every YAML/TOML nuance if existing serializers cannot guarantee it; document current behavior and add snapshots for the chosen output.
+
+## Affected areas
+
+- `crates/monochange_core/src/lib.rs`
+  - `VersionedFileDefinition`
+  - new `VersionedFileFormat` enum if appropriate
+- `crates/monochange_config/src/lib.rs`
+  - normalize and validate versioned file definitions
+  - schema generation annotations
+- `crates/monochange_config/src/__tests__/lib_tests.rs`
+  - config validation tests
+- `crates/monochange/src/versioned_files.rs`
+  - generic format mutation logic
+  - cached document handling for JSON/YAML/TOML/env/text
+- `crates/monochange/src/__tests__/versioned_files_tests.rs`
+  - release/update behavior tests
+- `fixtures/tests/...`
+  - fixture-first scenarios for generic format files
+- Documentation/config artifacts
+  - `monochange.toml` comments/examples
+  - docs reference pages for config/versioned files
+  - generated schema snapshots/artifacts if affected
+- `.changeset/*.md`
+  - user-facing release note for new config feature
+
+## Design notes and open decisions
+
+- Use `format` rather than `formats`; each versioned file entry describes one concrete file format. If the public API must match the prompt's plural wording, revisit before implementation.
+- Reuse existing `fields` for generic mode so the config remains compact. In ecosystem mode, fields keep their existing ecosystem-specific meaning.
+- Prefer a typed enum in core (`VersionedFileFormat`) over free strings to keep validation, schema, and CLI JSON stable.
+- Treat `yaml` and `yml` as aliases during deserialization, but emit one canonical value if serialized.
+- For env files, update only existing `KEY=value` / `export KEY=value` style entries at first. Preserve comments and unrelated lines.
+- For JSON/TOML/YAML, require object/table traversal. If a segment is missing or points at a non-container, produce a diagnostic that names the path and field.
+- String values should be written as strings. If an existing field is numeric or boolean, replace it with a string version because semver versions are strings.
+- Templating follow-up: model could later add `value = "{{ version }}"` and field templates with context `{ id, name, version, owner_kind }`.
+
+## Execution checklist
+
+- [x] Create isolated worktree and branch.
+- [x] Capture this implementation plan under `docs/plans/active/`.
+- [x] Inspect current versioned file validation/update flow in detail.
+- [x] Add failing config tests for accepted generic formats and rejected invalid combinations.
+- [x] Add failing versioned file update tests with fixture files for JSON, TOML, YAML, and env.
+- [x] Add core types/config fields for generic formats.
+- [x] Implement validation rules for `format` mode.
+- [x] Implement generic format update dispatch.
+- [x] Implement JSON field-path mutation.
+- [x] Implement TOML field-path mutation.
+- [x] Implement YAML field-path mutation.
+- [x] Implement env key mutation.
+- [x] Update docs/config examples/schema artifacts.
+- [x] Add a changeset describing the new `versioned_files.format` mode.
+- [x] Run targeted tests.
+- [ ] Run `fix:all`.
+- [ ] Run `mc step:validate`, relevant lint/build checks, and patch coverage.
+- [x] Mark completed steps and record any deferred follow-ups.
+
+## Execution notes
+
+- Targeted tests passed for `monochange_core`, `monochange_config`, and `monochange` versioned file coverage.
+- `cargo clippy --package monochange --lib --all-targets -- -D warnings` passed after addressing format-mode warnings.
+- `cargo xtask schema check` passed after regenerating the monochange config schema.
+- `mc step:validate` passed.
+- `build:all` passed.
+- `fix:all` was attempted; it completed formatting/schema/config validation stages but failed in the existing GitHub Actions audit (`zizmor`) on pre-existing workflow findings unrelated to `versioned_files.format`.
+
+## Validation plan
+
+Targeted while developing:
+
+```nushell
+devenv shell test:cargo --package monochange_config versioned_file
+devenv shell test:cargo --package monochange versioned_files
+```
+
+Final local validation:
+
+```nushell
+devenv shell fix:all
+devenv shell mc step:validate
+devenv shell lint:all
+devenv shell build:all
+devenv shell coverage:patch
+```
+
+## Risks
+
+- Format-preserving writes can be tricky, especially for TOML/YAML comments. Keep output explicit in snapshots.
+- Existing `fields` semantics may be ecosystem-specific in some adapters. Generic mode must not alter ecosystem behavior.
+- Schema updates may affect generated artifacts beyond the immediate Rust crates.
+- Regex mode currently allows type-less entries; new validation must keep regex compatibility intact.

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -438,12 +438,41 @@ versioned_files = [
 	{ path = "package.json", type = "npm", fields = ["metadata.bin.monochange.version"] },
 ]
 
+# generic format entries update explicit fields in non-ecosystem files
+versioned_files = [
+	{ path = "metadata.json", format = "json", fields = ["release.version"] },
+	{ path = "tools.toml", format = "toml", fields = ["tool.sdk.version"] },
+	{ path = "pubspec-overrides.yaml", format = "yaml", fields = ["metadata.sdkVersion"] },
+	{ path = ".env", format = "env", fields = ["VERSION"] },
+]
+
 # ecosystem-level defaults inherited by matching packages
 [ecosystems.npm]
 versioned_files = ["**/packages/*/package.json"]
 ```
 
 Typed manifest entries can update dependency sections and arbitrary string fields inside TOML or JSON manifests. Dependency targets in `versioned_files` must reference declared package ids. Groups must use explicit typed entries because monochange cannot infer a group ecosystem from a bare string.
+
+### Format versioned files
+
+Use `format` when a version lives in a structured or key/value file that should not receive ecosystem-specific dependency handling. Supported values are `json`, `toml`, `yaml`, `yml`, and `env`.
+
+```toml
+[package.core]
+path = "crates/core"
+versioned_files = [
+	{ path = "metadata.json", format = "json", fields = ["release.version"] },
+	{ path = ".env", format = "env", fields = ["VERSION"] },
+]
+```
+
+Key rules:
+
+- `format` entries cannot set `type` or `regex`
+- `fields` is required and must name every value to update; monochange does not infer ecosystem defaults in format mode
+- JSON, TOML, YAML, and YML fields use dot-separated object/table paths such as `release.version`
+- env fields use exact keys such as `VERSION` and update existing `KEY=value` or `export KEY=value` lines
+- field names can include `{{ name }}` and `{{ version }}` placeholders for simple context-aware paths or keys
 
 ### Regex versioned files
 
@@ -912,7 +941,7 @@ mc step:validate
 - package and group declarations
 - manifest presence for each package type
 - group membership rules
-- `versioned_files` structural rules (type/regex conflicts, capture groups)
+- `versioned_files` structural rules (type/format/regex conflicts, required format fields, capture groups)
 - `versioned_files` content checks: file existence, version field readability, regex pattern matching
 - `.changeset/*.md` targets and overlap rules
 - Cargo workspace version-group constraints

--- a/docs/src/schemas/monochange.schema.json
+++ b/docs/src/schemas/monochange.schema.json
@@ -1624,6 +1624,17 @@
 						"null"
 					]
 				},
+				"format": {
+					"anyOf": [
+						{
+							"$ref": "#/$defs/VersionedFileFormat"
+						},
+						{
+							"type": "null"
+						}
+					],
+					"default": null
+				},
 				"name": {
 					"default": null,
 					"type": [
@@ -1664,6 +1675,16 @@
 				"path"
 			],
 			"type": "object"
+		},
+		"VersionedFileFormat": {
+			"enum": [
+				"json",
+				"toml",
+				"yaml",
+				"yml",
+				"env"
+			],
+			"type": "string"
 		},
 		"changelogConfig": {
 			"anyOf": [

--- a/docs/src/schemas/monochange.v0.3.schema.json
+++ b/docs/src/schemas/monochange.v0.3.schema.json
@@ -1624,6 +1624,17 @@
 						"null"
 					]
 				},
+				"format": {
+					"anyOf": [
+						{
+							"$ref": "#/$defs/VersionedFileFormat"
+						},
+						{
+							"type": "null"
+						}
+					],
+					"default": null
+				},
 				"name": {
 					"default": null,
 					"type": [
@@ -1664,6 +1675,16 @@
 				"path"
 			],
 			"type": "object"
+		},
+		"VersionedFileFormat": {
+			"enum": [
+				"json",
+				"toml",
+				"yaml",
+				"yml",
+				"env"
+			],
+			"type": "string"
 		},
 		"changelogConfig": {
 			"anyOf": [


### PR DESCRIPTION
## Summary
- add `format` mode for generic versioned files (`json`, `toml`, `yaml`, `yml`, `env`)
- require explicit `fields` for format mode and reject ambiguous `type`/`regex` combinations
- update JSON/TOML/YAML dot paths and `.env` keys with `{{ name }}` / `{{ version }}` templating
- document the configuration and regenerate the monochange schema

## Validation
- [x] `cargo test --package monochange_core --package monochange_config --package monochange versioned_file`
- [x] `cargo clippy --package monochange --lib --all-targets -- -D warnings`
- [x] `cargo clippy --package monochange_config --lib --all-targets -- -D warnings`
- [x] `cargo xtask schema check`
- [x] `mc step:validate`
- [x] `build:all`
- [ ] `coverage:patch` — attempted locally, blocked by network timeout resolving `cargo-llvm-cov@0.8.5` from crates.io; will monitor CI/patch coverage and fix any failures

## Notes
`fix:all` was attempted. Formatting/schema/config validation stages passed, but the existing GitHub Actions audit (`zizmor`) reported unrelated workflow findings.