### PR TITLE
perf: cache versioned file glob scans

### DIFF
--- a/.changeset/perf-cli-startup-config-loading.md
+++ b/.changeset/perf-cli-startup-config-loading.md
@@ -5,4 +5,4 @@
 
 # Speed up CLI startup
 
-Version and help paths now avoid full workspace validation, and inherited versioned-file globs are deduplicated during package validation.
+Version and help paths now avoid full workspace validation. Full config loading now deduplicates inherited versioned-file glob validation and resolves glob checks against one ignored-file-aware workspace walk instead of repeatedly scanning the filesystem.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2274,6 +2274,7 @@ name = "monochange_config"
 version = "0.6.6"
 dependencies = [
  "glob",
+ "ignore",
  "insta",
  "miette",
  "monochange_core",

--- a/crates/monochange/benches/cli_commands.rs
+++ b/crates/monochange/benches/cli_commands.rs
@@ -244,8 +244,8 @@ fn run_release_pr_command(root: &Path, dry_run: bool, github_api_url: Option<&st
 }
 
 const SCALES: &[(usize, usize)] = &[(5, 10), (20, 50), (50, 200)];
+const INHERITED_GLOB_PACKAGE_COUNTS: &[usize] = &[20, 50, 500];
 const LOCKFILE_COMPARE_SCALE: (usize, usize) = (20, 50);
-
 fn generate_inherited_glob_fixture(
 	root: &Path,
 	ecosystem: &str,
@@ -308,15 +308,25 @@ fn bench_inherited_glob_config_load(c: &mut Criterion) {
 		("python", "pyproject.toml"),
 		("go", "go.mod"),
 	] {
-		group.bench_with_input(
-			BenchmarkId::from_parameter(ecosystem),
-			&ecosystem,
-			|b, ecosystem| {
-				let tempdir = tempfile::tempdir().unwrap();
-				generate_inherited_glob_fixture(tempdir.path(), ecosystem, manifest, 20);
-				b.iter(|| monochange_config::load_workspace_configuration(tempdir.path()).unwrap());
-			},
-		);
+		for &package_count in INHERITED_GLOB_PACKAGE_COUNTS {
+			let label = format!("{ecosystem}_{package_count}pkg");
+			group.bench_with_input(
+				BenchmarkId::from_parameter(label),
+				&(ecosystem, package_count),
+				|b, &(ecosystem, package_count)| {
+					let tempdir = tempfile::tempdir().unwrap();
+					generate_inherited_glob_fixture(
+						tempdir.path(),
+						ecosystem,
+						manifest,
+						package_count,
+					);
+					b.iter(|| {
+						monochange_config::load_workspace_configuration(tempdir.path()).unwrap()
+					});
+				},
+			);
+		}
 	}
 	group.finish();
 }

--- a/crates/monochange_config/Cargo.toml
+++ b/crates/monochange_config/Cargo.toml
@@ -17,6 +17,7 @@ schema = ["dep:schemars", "monochange_core/schema"]
 
 [dependencies]
 glob = { workspace = true, default-features = true }
+ignore = { workspace = true, default-features = true }
 miette = { workspace = true, default-features = true }
 monochange_core = { workspace = true }
 regex = { workspace = true, default-features = true }

--- a/crates/monochange_config/src/__tests__/lib_tests.rs
+++ b/crates/monochange_config/src/__tests__/lib_tests.rs
@@ -99,6 +99,47 @@ use crate::validate_step_input_overrides;
 use crate::validate_step_override_kind;
 use crate::validate_workspace;
 
+fn validate_package_and_group_definitions_for_test(
+	root: &Path,
+	config_contents: &str,
+	packages: &[monochange_core::PackageDefinition],
+	groups: &[GroupDefinition],
+) -> MonochangeResult<()> {
+	let declared_packages = packages
+		.iter()
+		.map(|package| package.id.as_str())
+		.collect::<std::collections::BTreeSet<_>>();
+	let mut cache = crate::VersionedFileValidationCache::default();
+	crate::validate_package_and_group_definitions_with_cache(
+		root,
+		config_contents,
+		packages,
+		groups,
+		&declared_packages,
+		&mut cache,
+	)
+}
+
+fn validate_versioned_files_for_test(
+	root: &Path,
+	config_contents: &str,
+	versioned_files: &[monochange_core::VersionedFileDefinition],
+	declared_packages: &std::collections::BTreeSet<&str>,
+	owner_kind: &str,
+	owner_id: &str,
+) -> MonochangeResult<()> {
+	let mut cache = crate::VersionedFileValidationCache::default();
+	crate::validate_versioned_files_with_cache(
+		root,
+		config_contents,
+		versioned_files,
+		declared_packages,
+		owner_kind,
+		owner_id,
+		&mut cache,
+	)
+}
+
 fn validate_step() -> CliStepDefinition {
 	CliStepDefinition::Validate {
 		name: None,
@@ -1674,6 +1715,44 @@ fn load_workspace_configuration_rejects_globs_that_match_unsupported_files_for_a
 
 	assert!(rendered.contains("matched unsupported file"));
 	assert!(rendered.contains("narrow the glob"));
+}
+
+#[test]
+fn load_workspace_configuration_ignores_gitignored_versioned_file_glob_matches() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	std::fs::create_dir_all(root.join("packages/app"))
+		.unwrap_or_else(|error| panic!("create package: {error}"));
+	std::fs::create_dir_all(root.join("generated"))
+		.unwrap_or_else(|error| panic!("create generated: {error}"));
+	std::fs::write(root.join(".gitignore"), "generated/\n")
+		.unwrap_or_else(|error| panic!("write gitignore: {error}"));
+	std::fs::write(
+		root.join("packages/app/pubspec.yaml"),
+		"name: app\nversion: 1.0.0\n",
+	)
+	.unwrap_or_else(|error| panic!("write pubspec: {error}"));
+	std::fs::write(root.join("generated/not-a-pubspec.yaml"), "not: dart\n")
+		.unwrap_or_else(|error| panic!("write ignored yaml: {error}"));
+	std::fs::write(
+		root.join("monochange.toml"),
+		r#"[ecosystems.dart]
+versioned_files = [{ path = "./**/*.yaml", type = "dart" }]
+
+[package.app]
+path = "packages/app"
+type = "dart"
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write config: {error}"));
+
+	let configuration =
+		load_workspace_configuration(root).unwrap_or_else(|error| panic!("configuration: {error}"));
+	let package = configuration
+		.package_by_id("app")
+		.unwrap_or_else(|| panic!("expected app package"));
+
+	assert_eq!(package.versioned_files.len(), 1);
 }
 
 #[test]
@@ -5628,7 +5707,7 @@ fn validate_cli_runtime_requirements_enforce_affected_package_inputs() {
 fn validate_package_and_source_settings_cover_duplicate_and_pattern_errors() {
 	let root = fixture_path("config/validation-helper-branches");
 
-	let duplicate_path_error = crate::validate_package_and_group_definitions(
+	let duplicate_path_error = validate_package_and_group_definitions_for_test(
 		&root,
 		"[package.core]\npath = 'crates/core'\n\n[package.util]\npath = 'crates/core'\n",
 		&[
@@ -5649,7 +5728,7 @@ fn validate_package_and_source_settings_cover_duplicate_and_pattern_errors() {
 	primary_core.version_format = monochange_core::VersionFormat::Primary;
 	let mut primary_util = package_definition("util", "crates/util");
 	primary_util.version_format = monochange_core::VersionFormat::Primary;
-	let duplicate_primary_error = crate::validate_package_and_group_definitions(
+	let duplicate_primary_error = validate_package_and_group_definitions_for_test(
 		&root,
 		"[package.core]\nversion_format = 'primary'\n\n[package.util]\nversion_format = 'primary'\n",
 		&[primary_core, primary_util],
@@ -5695,7 +5774,7 @@ fn validate_package_and_source_settings_cover_duplicate_and_pattern_errors() {
 			.contains("[package.core].ignored_paths must not include empty values")
 	);
 
-	let duplicate_id_error = crate::validate_package_and_group_definitions(
+	let duplicate_id_error = validate_package_and_group_definitions_for_test(
 		&root,
 		"[package.core]\npath = 'crates/core'\n",
 		&[
@@ -5715,7 +5794,7 @@ fn validate_package_and_source_settings_cover_duplicate_and_pattern_errors() {
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	std::fs::create_dir_all(tempdir.path().join("crates/core"))
 		.unwrap_or_else(|error| panic!("mkdir core dir: {error}"));
-	let missing_manifest_error = crate::validate_package_and_group_definitions(
+	let missing_manifest_error = validate_package_and_group_definitions_for_test(
 		tempdir.path(),
 		"[package.core]\npath = 'crates/core'\ntype = 'cargo'\n",
 		&[package_definition("core", "crates/core")],
@@ -6099,7 +6178,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 	let config_contents = "[package.core]\npath = 'crates/core'\n";
 	let declared_packages = std::collections::BTreeSet::from(["core"]);
 
-	let missing_type = crate::validate_versioned_files(
+	let missing_type = validate_versioned_files_for_test(
 		&root,
 		config_contents,
 		&[monochange_core::VersionedFileDefinition {
@@ -6123,7 +6202,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 			.contains("versioned_files must set `type`")
 	);
 
-	let invalid_glob = crate::validate_versioned_files(
+	let invalid_glob = validate_versioned_files_for_test(
 		&root,
 		config_contents,
 		&[monochange_core::VersionedFileDefinition {
@@ -6164,7 +6243,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 		prefix: None,
 		regex: None,
 	};
-	crate::validate_versioned_files(
+	validate_versioned_files_for_test(
 		duplicate_glob_dir.path(),
 		config_contents,
 		&[duplicate_glob.clone(), duplicate_glob],
@@ -6182,7 +6261,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 		"{\"name\":\"web\",\"version\":\"1.0.0\"}\n",
 	)
 	.unwrap_or_else(|error| panic!("write package.json: {error}"));
-	let unsupported_match = crate::validate_versioned_files(
+	let unsupported_match = validate_versioned_files_for_test(
 		tempdir.path(),
 		config_contents,
 		&[monochange_core::VersionedFileDefinition {
@@ -6215,7 +6294,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 		Path::new("pubspec.yaml"),
 		EcosystemType::Dart
 	));
-	let dart_unsupported_match = crate::validate_versioned_files(
+	let dart_unsupported_match = validate_versioned_files_for_test(
 		tempdir.path(),
 		config_contents,
 		&[monochange_core::VersionedFileDefinition {
@@ -6243,7 +6322,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 		Path::new("go.mod"),
 		EcosystemType::Go
 	));
-	let go_unsupported_match = crate::validate_versioned_files(
+	let go_unsupported_match = validate_versioned_files_for_test(
 		tempdir.path(),
 		config_contents,
 		&[monochange_core::VersionedFileDefinition {
@@ -7164,7 +7243,7 @@ fn validate_versioned_files_accepts_format_mode_and_rejects_invalid_combinations
 		prefix: None,
 		regex: None,
 	};
-	crate::validate_versioned_files(
+	validate_versioned_files_for_test(
 		&root,
 		config_contents,
 		&[valid],
@@ -7183,7 +7262,7 @@ fn validate_versioned_files_accepts_format_mode_and_rejects_invalid_combinations
 		prefix: None,
 		regex: None,
 	};
-	let error = crate::validate_versioned_files(
+	let error = validate_versioned_files_for_test(
 		&root,
 		config_contents,
 		&[mixed_type],
@@ -7203,7 +7282,7 @@ fn validate_versioned_files_accepts_format_mode_and_rejects_invalid_combinations
 		prefix: None,
 		regex: Some("version = (?<version>.*)".to_string()),
 	};
-	let error = crate::validate_versioned_files(
+	let error = validate_versioned_files_for_test(
 		&root,
 		config_contents,
 		&[mixed_regex],
@@ -7223,7 +7302,7 @@ fn validate_versioned_files_accepts_format_mode_and_rejects_invalid_combinations
 		prefix: None,
 		regex: None,
 	};
-	let error = crate::validate_versioned_files(
+	let error = validate_versioned_files_for_test(
 		&root,
 		config_contents,
 		&[missing_fields],
@@ -7243,7 +7322,7 @@ fn validate_versioned_files_accepts_format_mode_and_rejects_invalid_combinations
 		prefix: None,
 		regex: None,
 	};
-	let error = crate::validate_versioned_files(
+	let error = validate_versioned_files_for_test(
 		&root,
 		config_contents,
 		&[empty_fields],

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -81,6 +81,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use glob::Pattern;
+use ignore::WalkBuilder;
 use miette::LabeledSpan;
 use miette::SourceSpan;
 use monochange_core::BumpSeverity;
@@ -96,6 +97,7 @@ use monochange_core::CliInputDefinition;
 use monochange_core::CliInputKind;
 use monochange_core::CliStepDefinition;
 use monochange_core::CliStepInputValue;
+use monochange_core::DiscoveryPathFilter;
 use monochange_core::Ecosystem;
 use monochange_core::EcosystemSettings;
 use monochange_core::EcosystemType;
@@ -1361,6 +1363,11 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 	let changeset_lints = changeset_lint_settings_from_rules(&lints.rules)?;
 	validate_changeset_lint_settings(&changeset_lints, &changelog)?;
 	validate_source_configuration(source.as_ref())?;
+	let declared_packages = packages
+		.iter()
+		.map(|package| package.id.as_str())
+		.collect::<BTreeSet<_>>();
+	let mut versioned_file_cache = VersionedFileValidationCache::default();
 	for (ecosystem_id, ecosystem_settings) in [
 		("cargo", &cargo_ecosystem),
 		("npm", &npm_ecosystem),
@@ -1369,21 +1376,25 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		("python", &python_ecosystem),
 		("go", &go_ecosystem),
 	] {
-		let declared_packages = packages
-			.iter()
-			.map(|package| package.id.as_str())
-			.collect::<BTreeSet<_>>();
-		validate_versioned_files(
+		validate_versioned_files_with_cache(
 			root,
 			&contents,
 			&ecosystem_settings.versioned_files,
 			&declared_packages,
 			"ecosystems",
 			ecosystem_id,
+			&mut versioned_file_cache,
 		)?;
 		validate_lockfile_commands(root, ecosystem_id, &ecosystem_settings.lockfile_commands)?;
 	}
-	validate_package_and_group_definitions(root, &contents, &packages, &groups)?;
+	validate_package_and_group_definitions_with_cache(
+		root,
+		&contents,
+		&packages,
+		&groups,
+		&declared_packages,
+		&mut versioned_file_cache,
+	)?;
 	validate_cli_runtime_requirements(&cli, &changesets, source.as_ref())?;
 
 	Ok(WorkspaceConfiguration {
@@ -3002,13 +3013,14 @@ pub(crate) fn parse_bump_severity(value: &str) -> Option<BumpSeverity> {
 	}
 }
 
-fn validate_package_and_group_definitions(
+fn validate_package_and_group_definitions_with_cache(
 	root: &Path,
 	config_contents: &str,
 	packages: &[PackageDefinition],
 	groups: &[GroupDefinition],
+	declared_packages: &BTreeSet<&str>,
+	versioned_file_cache: &mut VersionedFileValidationCache,
 ) -> MonochangeResult<()> {
-	let mut versioned_file_glob_cache = BTreeSet::new();
 	let mut ids = BTreeSet::new();
 	let mut package_paths = BTreeMap::<PathBuf, String>::new();
 	let mut primary_owner = Option::<String>::None;
@@ -3100,19 +3112,15 @@ fn validate_package_and_group_definitions(
 		}
 	}
 
-	let declared_packages = packages
-		.iter()
-		.map(|package| package.id.as_str())
-		.collect::<BTreeSet<_>>();
 	for package in packages {
 		validate_versioned_files_with_cache(
 			root,
 			config_contents,
 			&package.versioned_files,
-			&declared_packages,
+			declared_packages,
 			"package",
 			&package.id,
-			&mut versioned_file_glob_cache,
+			versioned_file_cache,
 		)?;
 	}
 	let mut assigned_packages = BTreeMap::<String, String>::new();
@@ -3121,10 +3129,10 @@ fn validate_package_and_group_definitions(
 			root,
 			config_contents,
 			&group.versioned_files,
-			&declared_packages,
+			declared_packages,
 			"group",
 			&group.id,
-			&mut versioned_file_glob_cache,
+			versioned_file_cache,
 		)?;
 		if !ids.insert(group.id.clone()) {
 			return Err(config_diagnostic(
@@ -3274,6 +3282,101 @@ fn path_uses_glob(path: &str) -> bool {
 	path.contains('*') || path.contains('?') || path.contains('[')
 }
 
+#[derive(Default)]
+struct VersionedFileValidationCache {
+	checked_globs: BTreeSet<(String, &'static str)>,
+	workspace_files: Option<Vec<PathBuf>>,
+}
+
+impl VersionedFileValidationCache {
+	fn insert_checked_glob(&mut self, pattern: String, ecosystem_name: &'static str) -> bool {
+		self.checked_globs.insert((pattern, ecosystem_name))
+	}
+
+	fn unsupported_glob_match(
+		&mut self,
+		root: &Path,
+		glob_path: &str,
+		ecosystem_type: EcosystemType,
+	) -> MonochangeResult<Option<PathBuf>> {
+		let pattern_path = Path::new(glob_path);
+		let pattern_text = if pattern_path.is_absolute() {
+			glob_path
+		} else {
+			normalize_relative_glob(glob_path)
+		};
+		let pattern = Pattern::new(pattern_text).map_err(|error| {
+			MonochangeError::Config(format!("invalid glob pattern `{glob_path}`: {error}"))
+		})?;
+
+		if pattern_path.is_absolute() {
+			let root = root.to_path_buf();
+			return Ok(self
+				.workspace_files(root.as_path())?
+				.iter()
+				.find_map(|relative_path| {
+					let absolute_path = root.join(relative_path);
+					(pattern.matches_path(&absolute_path)
+						&& !path_is_supported_for_ecosystem(&absolute_path, ecosystem_type))
+					.then_some(absolute_path)
+				}));
+		}
+
+		Ok(self
+			.workspace_files(root)?
+			.iter()
+			.find_map(|relative_path| {
+				(pattern.matches_path(relative_path)
+					&& !path_is_supported_for_ecosystem(relative_path, ecosystem_type))
+				.then(|| root.join(relative_path))
+			}))
+	}
+
+	fn workspace_files(&mut self, root: &Path) -> MonochangeResult<&[PathBuf]> {
+		if self.workspace_files.is_none() {
+			self.workspace_files = Some(collect_workspace_files(root)?);
+		}
+
+		Ok(self.workspace_files.as_deref().unwrap_or(&[]))
+	}
+}
+
+fn normalize_relative_glob(path: &str) -> &str {
+	let mut normalized = path;
+	while let Some(stripped) = normalized.strip_prefix("./") {
+		normalized = stripped;
+	}
+	normalized
+}
+
+fn collect_workspace_files(root: &Path) -> MonochangeResult<Vec<PathBuf>> {
+	let path_filter = DiscoveryPathFilter::new(root);
+	let mut builder = WalkBuilder::new(root);
+	builder
+		.hidden(false)
+		.ignore(true)
+		.git_ignore(true)
+		.git_exclude(true)
+		.git_global(false)
+		.parents(true)
+		.filter_entry(move |entry| entry.depth() == 0 || path_filter.should_descend(entry.path()));
+
+	let mut files = Vec::new();
+	for entry in builder.build() {
+		let entry = entry.map_err(|error| {
+			MonochangeError::Io(format!("failed to walk {}: {error}", root.display()))
+		})?;
+		if entry
+			.file_type()
+			.is_some_and(|file_type| file_type.is_file())
+			&& let Ok(relative_path) = entry.path().strip_prefix(root)
+		{
+			files.push(relative_path.to_path_buf());
+		}
+	}
+	Ok(files)
+}
+
 fn path_is_supported_for_ecosystem(path: &Path, ecosystem_type: EcosystemType) -> bool {
 	let file_name = path
 		.file_name()
@@ -3334,26 +3437,6 @@ fn source_capabilities(provider: SourceProvider) -> SourceCapabilities {
 	}
 }
 
-fn validate_versioned_files(
-	root: &Path,
-	config_contents: &str,
-	versioned_files: &[VersionedFileDefinition],
-	declared_packages: &BTreeSet<&str>,
-	owner_kind: &str,
-	owner_id: &str,
-) -> MonochangeResult<()> {
-	let mut glob_cache = BTreeSet::new();
-	validate_versioned_files_with_cache(
-		root,
-		config_contents,
-		versioned_files,
-		declared_packages,
-		owner_kind,
-		owner_id,
-		&mut glob_cache,
-	)
-}
-
 fn validate_versioned_files_with_cache(
 	root: &Path,
 	config_contents: &str,
@@ -3361,7 +3444,7 @@ fn validate_versioned_files_with_cache(
 	declared_packages: &BTreeSet<&str>,
 	owner_kind: &str,
 	owner_id: &str,
-	glob_cache: &mut BTreeSet<(String, &'static str)>,
+	cache: &mut VersionedFileValidationCache,
 ) -> MonochangeResult<()> {
 	for versioned_file in versioned_files {
 		if versioned_file.format.is_some() {
@@ -3420,21 +3503,11 @@ fn validate_versioned_files_with_cache(
 				.to_string_lossy()
 				.to_string();
 			let ecosystem_name = Ecosystem::from(ecosystem_type).as_str();
-			if !glob_cache.insert((pattern.clone(), ecosystem_name)) {
+			if !cache.insert_checked_glob(pattern, ecosystem_name) {
 				continue;
 			}
-			let matches = glob::glob(&pattern)
-				.map_err(|error| {
-					MonochangeError::Config(format!(
-						"invalid glob pattern `{}`: {error}",
-						versioned_file.path
-					))
-				})?
-				.filter_map(Result::ok)
-				.collect::<Vec<_>>();
-			if let Some(unsupported_path) = matches
-				.into_iter()
-				.find(|matched_path| !path_is_supported_for_ecosystem(matched_path, ecosystem_type))
+			if let Some(unsupported_path) =
+				cache.unsupported_glob_match(root, &versioned_file.path, ecosystem_type)?
 			{
 				return Err(config_diagnostic(
 					config_contents,


### PR DESCRIPTION
## Summary

- Cache versioned-file glob validation during full workspace config loading.
- Resolve glob checks against one ignored-file-aware workspace walk instead of repeatedly scanning the filesystem.
- Extend inherited-glob benchmarks with 50- and 500-package cases.

## Why

Large workspaces with inherited ecosystem `versioned_files` globs were still slow on full config-loading paths such as `mc step:config`, even after CLI startup/help paths were made fast in #568.

This PR is stacked on #568 and is rebased onto the latest `origin/main` through that branch.

## Validation

- `devenv shell cargo test -p monochange_config`
- `devenv shell dprint check`

Measured in `/Users/ifiokjr/Developer/projects/solana_kit` with a release binary before the rebase:

- First `mc step:config`: ~1.27s
- Warm `mc step:config`: ~0.06–0.07s

## Changeset

- Updated `.changeset/perf-cli-startup-config-loading.md`.

## Risk

Low. The cache is scoped to one config load and preserves validation behavior. The workspace walk uses ignore-aware traversal and the existing discovery path filter so ignored/excluded files do not cause false unsupported-file errors.
