### PR TITLE
test: cover group regex versioned files

### DIFF
--- a/.changeset/test-group-regex-versioned-files.md
+++ b/.changeset/test-group-regex-versioned-files.md
@@ -1,0 +1,7 @@
+---
+"monochange": patch
+---
+
+# Cover group regex versioned files
+
+Add integration coverage for group-level regex `versioned_files` updates alongside Dart manifest versioned files.

--- a/crates/monochange_integration_tests/tests/dart_group_version_clobber.rs
+++ b/crates/monochange_integration_tests/tests/dart_group_version_clobber.rs
@@ -142,3 +142,35 @@ fn dart_group_versioned_files_updates_version_when_explicitly_in_fields() {
 		"version field should be updated when explicitly in fields. Got: {updated_contents}"
 	);
 }
+
+#[test]
+fn dart_group_regex_versioned_files_updates_readme() {
+	let fixture = setup_fixture("with-regex");
+	let root = fixture.path();
+	init_git_repo(root);
+
+	create_changeset(root, "core", "minor", "Add new feature to core");
+
+	let readme_path = root.join("README.md");
+	let original_readme =
+		std::fs::read_to_string(&readme_path).unwrap_or_else(|error| panic!("read: {error}"));
+
+	assert!(
+		original_readme.contains("sdk@1.0.0"),
+		"README should start with sdk@1.0.0, got: {original_readme}"
+	);
+
+	let _release_output = run_prepare_release(root);
+
+	let updated_readme =
+		std::fs::read_to_string(&readme_path).unwrap_or_else(|error| panic!("read: {error}"));
+
+	assert!(
+		updated_readme.contains("sdk@1.1.0"),
+		"README should contain sdk@1.1.0 after group minor bump, got: {updated_readme}"
+	);
+	assert!(
+		!updated_readme.contains("sdk@1.0.0"),
+		"README should not retain the old SDK version, got: {updated_readme}"
+	);
+}

--- a/fixtures/tests/dart-group-version-clobber/with-regex/README.md
+++ b/fixtures/tests/dart-group-version-clobber/with-regex/README.md
@@ -1,0 +1,11 @@
+# SDK
+
+Install the SDK:
+
+```bash
+dart pub add sdk@1.0.0
+```
+
+## Usage
+
+Import the SDK in your Dart project.

--- a/fixtures/tests/dart-group-version-clobber/with-regex/monochange.toml
+++ b/fixtures/tests/dart-group-version-clobber/with-regex/monochange.toml
@@ -1,0 +1,19 @@
+[defaults]
+parent_bump = "patch"
+package_type = "dart"
+
+[ecosystems.dart]
+enabled = true
+
+[package.app]
+path = "packages/app"
+
+[package.core]
+path = "packages/core"
+
+[group.sdk]
+packages = ["app", "core"]
+versioned_files = [
+	{ path = "packages/app/pubspec.yaml", type = "dart" },
+	{ path = "README.md", regex = 'sdk@(?<version>\d+\.\d+\.\d+)' },
+]

--- a/fixtures/tests/dart-group-version-clobber/with-regex/packages/app/pubspec.yaml
+++ b/fixtures/tests/dart-group-version-clobber/with-regex/packages/app/pubspec.yaml
@@ -1,0 +1,8 @@
+name: app
+version: 1.0.0
+
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+
+dependencies:
+  core: ^1.0.0

--- a/fixtures/tests/dart-group-version-clobber/with-regex/packages/core/pubspec.yaml
+++ b/fixtures/tests/dart-group-version-clobber/with-regex/packages/core/pubspec.yaml
@@ -1,0 +1,5 @@
+name: core
+version: 1.0.0
+
+environment:
+  sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary

- add a dedicated Dart group fixture with a README regex versioned file
- cover group-level regex versioned_files updating text files during prepare-release
- supersede the remaining useful coverage from #559 against current main

## Tests

- devenv shell cargo test -p monochange_integration_tests dart_group_regex_versioned_files_updates_readme
- devenv shell cargo test -p monochange_integration_tests --test dart_group_version_clobber
- devenv shell cargo fmt --check
- dprint check