### PR TITLE
fix: report all summary lint violations instead of stopping at the first failure

### DIFF
--- a/.changeset/fix-lint-gather-all-failures.md
+++ b/.changeset/fix-lint-gather-all-failures.md
@@ -1,0 +1,9 @@
+---
+"monochange_config": patch
+---
+
+Fix summary lint rule to report all violations instead of stopping at the first failure
+
+The `changesets/summary` lint rule previously used early returns that stopped checking after the first structural violation (wrong heading level, missing heading). This meant fixing one issue (e.g. heading level) and re-running would reveal the next issue (e.g. max length), requiring multiple iterations.
+
+Now the rule collects all applicable violations in a single pass and reports them all together, matching user expectations that `mc check` surfaces every problem at once.

--- a/.changeset/fix-lint-gather-all-failures.md
+++ b/.changeset/fix-lint-gather-all-failures.md
@@ -2,8 +2,8 @@
 "monochange_config": patch
 ---
 
-Fix summary lint rule to report all violations instead of stopping at the first failure
+# Fix summary lint to report all violations at once
 
-The `changesets/summary` lint rule previously used early returns that stopped checking after the first structural violation (wrong heading level, missing heading). This meant fixing one issue (e.g. heading level) and re-running would reveal the next issue (e.g. max length), requiring multiple iterations.
+The `changesets/summary` lint rule used early returns that stopped checking after the first structural violation (wrong heading level, missing heading). This meant fixing one issue and re-running would reveal the next, requiring multiple iterations to surface all problems.
 
 Now the rule collects all applicable violations in a single pass and reports them all together, matching user expectations that `mc check` surfaces every problem at once.

--- a/crates/monochange_config/src/__tests__/lints_tests.rs
+++ b/crates/monochange_config/src/__tests__/lints_tests.rs
@@ -453,6 +453,59 @@ fn summary_rule_require_description_fails_when_next_line_is_heading() {
 }
 
 #[test]
+fn summary_rule_reports_heading_level_and_length_issues_together() {
+	let rule = SummaryRule::new();
+	let mut options = BTreeMap::new();
+	options.insert("required".to_string(), json!(true));
+	options.insert("heading_level".to_string(), json!(1));
+	options.insert("max_heading_length".to_string(), json!(5));
+	let results = run_rule(
+		&rule,
+		&lint_file("## This heading is way too long", Vec::new()),
+		&detailed(options),
+	);
+
+	// Should report both: wrong heading level AND heading too long.
+	// Previously only the heading level error was reported due to early return.
+	assert!(results.iter().any(|result| {
+		result
+			.message
+			.contains("changeset summary heading must use level 1, found level 2")
+	}));
+	assert!(results.iter().any(|result| {
+		result
+			.message
+			.contains("changeset summary must be at most 5 characters")
+	}));
+}
+
+#[test]
+fn summary_rule_reports_missing_heading_and_length_issues_together() {
+	let rule = SummaryRule::new();
+	let mut options = BTreeMap::new();
+	options.insert("required".to_string(), json!(true));
+	options.insert("min_length".to_string(), json!(20));
+	let results = run_rule(
+		&rule,
+		&lint_file("short summary", Vec::new()),
+		&detailed(options),
+	);
+
+	// Should report both: must start with heading AND too short.
+	// Previously only the heading error was reported due to early return.
+	assert!(results.iter().any(|result| {
+		result
+			.message
+			.contains("changeset body must start with a summary heading")
+	}));
+	assert!(results.iter().any(|result| {
+		result
+			.message
+			.contains("changeset summary must be at least 20 characters")
+	}));
+}
+
+#[test]
 fn summary_rule_require_description_skipped_when_disabled() {
 	let rule = SummaryRule::new();
 	let mut options = BTreeMap::new();

--- a/crates/monochange_config/src/lints.rs
+++ b/crates/monochange_config/src/lints.rs
@@ -296,7 +296,6 @@ impl LintRuleRunner for SummaryRule {
 				"changeset body must start with a summary heading",
 				severity,
 			));
-			return results;
 		}
 
 		if let (Some(required_level), Some(actual_level)) = (heading_level, heading)
@@ -310,7 +309,6 @@ impl LintRuleRunner for SummaryRule {
 				),
 				severity,
 			));
-			return results;
 		}
 
 		let summary =


### PR DESCRIPTION
## Problem

The `changesets/summary` lint rule used early returns that stopped checking after the first structural violation (wrong heading level, missing heading). This meant:

- Running `mc check` with `## Too-long heading` configured to require level 1 would report **only** the heading-level error
- After fixing the heading level, you had to run `mc check` again to discover the max_length violation
- This iterated one error at a time, requiring multiple runs to fix all issues

## Fix

Remove the two early `return results;` statements in `SummaryRule::run()` that short-circuited after:
1. Missing heading (`required && heading.is_none()`) — now falls through to still check min_length, max_length, trailing period, etc. on the raw text
2. Wrong heading level — now falls through to still check length, trailing period, conventional commit prefix, and require_description

The empty-body early return is preserved since there is literally nothing else to check.

## Testing

- Added `summary_rule_reports_heading_level_and_length_issues_together` — verifies that wrong heading level + too-long heading text are both reported
- Added `summary_rule_reports_missing_heading_and_length_issues_together` — verifies that missing heading + too-short summary text are both reported
- All 250 existing tests continue to pass