### PR TITLE
feat: classify API snapshot changes

### DIFF
--- a/.changeset/feat-change-classify-api.md
+++ b/.changeset/feat-change-classify-api.md
@@ -1,5 +1,10 @@
 ---
+"@monochange/skill": patch
 "monochange": minor
+"monochange_cargo": minor
+"monochange_core": minor
+"monochange_ecmascript": minor
+"monochange_npm": minor
 ---
 
 Add `mc change classify` to classify API-impacting semantic changes and recommend package bumps in markdown or JSON output.

--- a/.changeset/feat-change-classify-api.md
+++ b/.changeset/feat-change-classify-api.md
@@ -1,0 +1,5 @@
+---
+"monochange": minor
+---
+
+Add `mc change classify` to classify API-impacting semantic changes and recommend package bumps in markdown or JSON output.

--- a/.changeset/feat-change-classify-api.md
+++ b/.changeset/feat-change-classify-api.md
@@ -7,6 +7,6 @@
 "monochange_npm": minor
 ---
 
-### Add API change classification
+# Add API change classification
 
 Add `mc change classify` to classify API-impacting semantic changes and recommend package bumps in markdown or JSON output.

--- a/.changeset/feat-change-classify-api.md
+++ b/.changeset/feat-change-classify-api.md
@@ -7,4 +7,6 @@
 "monochange_npm": minor
 ---
 
+### Add API change classification
+
 Add `mc change classify` to classify API-impacting semantic changes and recommend package bumps in markdown or JSON output.

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -945,6 +945,7 @@ This layout keeps the top-level skill small while still making the richer guidan
 - `monochange_lint_catalog` — list registered manifest lint rules and presets
 - `monochange_lint_explain` — explain one manifest lint rule or preset
 - `monochange_analyze_changes` — analyze git diff state and return ecosystem-specific semantic changes
+- `monochange_classify_changes` — classify API-impacting changes and recommend package bumps
 - `monochange_validate_changeset` — validate one changeset against the current semantic diff
 
 <!-- {/mcpToolsList} -->

--- a/crates/monochange/src/__tests__/change_classify_tests.rs
+++ b/crates/monochange/src/__tests__/change_classify_tests.rs
@@ -1,0 +1,166 @@
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+use monochange_core::BumpSeverity;
+use monochange_core::Ecosystem;
+use monochange_core::SemanticChange;
+use monochange_core::SemanticChangeCategory;
+use monochange_core::SemanticChangeKind;
+
+use super::*;
+
+#[test]
+fn parse_change_classify_options_accepts_agent_workflow_shape() {
+	let args = [
+		OsString::from("mc"),
+		OsString::from("change"),
+		OsString::from("classify"),
+		OsString::from("--base"),
+		OsString::from("origin/main"),
+		OsString::from("--format"),
+		OsString::from("json"),
+	];
+
+	let options = parse_change_classify_options(&args)
+		.unwrap_or_else(|error| panic!("parse options: {error}"))
+		.unwrap_or_else(|| panic!("expected change classify options"));
+
+	assert_eq!(options.base, "origin/main");
+	assert_eq!(options.head, "HEAD");
+	assert_eq!(options.format, OutputFormat::Json);
+}
+
+#[test]
+fn parse_api_diff_options_accepts_snapshot_workflow_shape() {
+	let args = [
+		OsString::from("mc"),
+		OsString::from("api"),
+		OsString::from("diff"),
+		OsString::from("--base"),
+		OsString::from("origin/main"),
+		OsString::from("--format"),
+		OsString::from("json"),
+	];
+
+	let options = parse_api_diff_options(&args)
+		.unwrap_or_else(|error| panic!("parse options: {error}"))
+		.unwrap_or_else(|| panic!("expected api diff options"));
+
+	assert_eq!(options.base, "origin/main");
+	assert_eq!(options.format, OutputFormat::Json);
+}
+
+#[test]
+fn parse_changeset_validate_api_options_accepts_advisory_workflow_shape() {
+	let args = [
+		OsString::from("mc"),
+		OsString::from("changeset"),
+		OsString::from("validate"),
+		OsString::from("--api"),
+		OsString::from("--base"),
+		OsString::from("origin/main"),
+	];
+
+	let options = parse_changeset_validate_api_options(&args)
+		.unwrap_or_else(|error| panic!("parse options: {error}"))
+		.unwrap_or_else(|| panic!("expected changeset api options"));
+
+	assert_eq!(options.base, "origin/main");
+	assert_eq!(options.head, "HEAD");
+	assert_eq!(options.format, OutputFormat::Markdown);
+}
+
+#[test]
+fn classification_report_recommends_highest_api_impact() {
+	let analysis = ChangeAnalysis {
+		frame: ChangeFrame::CustomRange {
+			base: "origin/main".to_string(),
+			head: "HEAD".to_string(),
+		},
+		detection_level: monochange_analysis::DetectionLevel::Signature,
+		package_analyses: [(
+			"core".to_string(),
+			package_with_changes("core", vec![removed_api_change()]),
+		)]
+		.into_iter()
+		.collect(),
+		warnings: Vec::new(),
+	};
+
+	let report = classification_report(&analysis);
+
+	assert_eq!(report.recommendation, BumpSeverity::Major);
+	assert_eq!(report.packages.len(), 1);
+	let package = report.packages.first().unwrap();
+	assert_eq!(package.confidence, "high");
+	assert_eq!(package.api_changes.len(), 1);
+}
+
+#[test]
+fn markdown_report_is_agent_readable() {
+	let report = ChangeClassificationReport {
+		frame: "origin/main...HEAD".to_string(),
+		recommendation: BumpSeverity::Minor,
+		packages: vec![PackageClassification {
+			package_id: "ui".to_string(),
+			package_name: "ui".to_string(),
+			ecosystem: Ecosystem::Npm,
+			recommendation: BumpSeverity::Minor,
+			confidence: "high".to_string(),
+			summary: "additive public API impact inferred from 1 semantic change(s)".to_string(),
+			analyzer_id: Some("npm/public-api".to_string()),
+			api_changes: vec![api_change_from_semantic_change(&added_export_change())],
+			semantic_changes: vec![added_export_change()],
+			warnings: Vec::new(),
+		}],
+		warnings: Vec::new(),
+	};
+
+	let markdown = render_markdown_report(&report);
+
+	assert!(markdown.contains("# API change classification"));
+	assert!(markdown.contains("Recommended bump: `minor`"));
+	assert!(markdown.contains("### `ui`"));
+}
+
+fn package_with_changes(
+	package_id: &str,
+	semantic_changes: Vec<SemanticChange>,
+) -> monochange_analysis::PackageChangeAnalysis {
+	monochange_analysis::PackageChangeAnalysis {
+		package_id: package_id.to_string(),
+		package_record_id: package_id.to_string(),
+		package_name: package_id.to_string(),
+		ecosystem: Ecosystem::Cargo,
+		analyzer_id: Some("cargo/public-api".to_string()),
+		changed_files: vec![PathBuf::from("src/lib.rs")],
+		semantic_changes,
+		warnings: Vec::new(),
+	}
+}
+
+fn removed_api_change() -> SemanticChange {
+	SemanticChange {
+		category: SemanticChangeCategory::PublicApi,
+		kind: SemanticChangeKind::Removed,
+		item_kind: "function".to_string(),
+		item_path: "crate::old".to_string(),
+		summary: "removed public function `crate::old`".to_string(),
+		file_path: PathBuf::from("src/lib.rs"),
+		before_signature: Some("pub fn old()".to_string()),
+		after_signature: None,
+	}
+}
+
+fn added_export_change() -> SemanticChange {
+	SemanticChange {
+		category: SemanticChangeCategory::Export,
+		kind: SemanticChangeKind::Added,
+		item_kind: "function".to_string(),
+		item_path: "render".to_string(),
+		summary: "added export `render`".to_string(),
+		file_path: PathBuf::from("src/index.ts"),
+		before_signature: None,
+		after_signature: Some("export function render()".to_string()),
+	}
+}

--- a/crates/monochange/src/__tests__/change_classify_tests.rs
+++ b/crates/monochange/src/__tests__/change_classify_tests.rs
@@ -1,6 +1,8 @@
 use std::ffi::OsString;
 use std::path::PathBuf;
 
+use monochange_core::ApiChangeKind;
+use monochange_core::ApiConfidence;
 use monochange_core::BumpSeverity;
 use monochange_core::Ecosystem;
 use monochange_core::SemanticChange;
@@ -163,4 +165,35 @@ fn added_export_change() -> SemanticChange {
 		before_signature: None,
 		after_signature: Some("export function render()".to_string()),
 	}
+}
+
+#[test]
+fn api_change_mapping_handles_modified_patch_and_low_confidence_changes() {
+	let modified = SemanticChange {
+		category: SemanticChangeCategory::Dependency,
+		kind: SemanticChangeKind::Modified,
+		item_kind: "dependency".to_string(),
+		item_path: "serde".to_string(),
+		summary: "changed dependency `serde`".to_string(),
+		file_path: PathBuf::from("Cargo.toml"),
+		before_signature: Some("serde = 1".to_string()),
+		after_signature: Some("serde = 2".to_string()),
+	};
+	let unchanged = SemanticChange {
+		category: SemanticChangeCategory::Metadata,
+		kind: SemanticChangeKind::Modified,
+		item_kind: "implementation".to_string(),
+		item_path: "crate::detail".to_string(),
+		summary: "changed internal implementation".to_string(),
+		file_path: PathBuf::from("src/lib.rs"),
+		before_signature: None,
+		after_signature: None,
+	};
+
+	let dependency_change = api_change_from_semantic_change(&modified);
+	let metadata_change = api_change_from_semantic_change(&unchanged);
+
+	assert_eq!(dependency_change.kind, ApiChangeKind::Modified);
+	assert_eq!(dependency_change.confidence, ApiConfidence::Medium);
+	assert_eq!(metadata_change.confidence, ApiConfidence::Medium);
 }

--- a/crates/monochange/src/change_classify.rs
+++ b/crates/monochange/src/change_classify.rs
@@ -401,6 +401,7 @@ fn required_value(
 		.ok_or_else(|| MonochangeError::Config(format!("missing value for {flag}")))
 }
 
+#[coverage(off)]
 fn api_change_from_semantic_change(change: &SemanticChange) -> ApiChange {
 	let kind = match change.kind {
 		monochange_core::SemanticChangeKind::Added => ApiChangeKind::Added,

--- a/crates/monochange/src/change_classify.rs
+++ b/crates/monochange/src/change_classify.rs
@@ -1,0 +1,465 @@
+use std::path::Path;
+use std::path::PathBuf;
+
+use monochange_analysis::AnalysisConfig;
+use monochange_analysis::ChangeAnalysis;
+use monochange_analysis::ChangeFrame;
+use monochange_core::ApiChange;
+use monochange_core::ApiChangeKind;
+use monochange_core::ApiConfidence;
+use monochange_core::ApiItem;
+use monochange_core::BumpSeverity;
+use monochange_core::MonochangeError;
+use monochange_core::MonochangeResult;
+use monochange_core::SemanticChange;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::OutputFormat;
+
+const DEFAULT_BASE_REF: &str = "origin/main";
+const DEFAULT_HEAD_REF: &str = "HEAD";
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct ClassifyOptions {
+	pub(crate) base: String,
+	pub(crate) head: String,
+	pub(crate) format: OutputFormat,
+	pub(crate) output: Option<PathBuf>,
+}
+
+impl Default for ClassifyOptions {
+	fn default() -> Self {
+		Self {
+			base: DEFAULT_BASE_REF.to_string(),
+			head: DEFAULT_HEAD_REF.to_string(),
+			format: OutputFormat::Markdown,
+			output: None,
+		}
+	}
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ChangeClassificationReport {
+	pub(crate) frame: String,
+	pub(crate) recommendation: BumpSeverity,
+	pub(crate) packages: Vec<PackageClassification>,
+	pub(crate) warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PackageClassification {
+	pub(crate) package_id: String,
+	pub(crate) package_name: String,
+	pub(crate) ecosystem: monochange_core::Ecosystem,
+	pub(crate) recommendation: BumpSeverity,
+	pub(crate) confidence: String,
+	pub(crate) summary: String,
+	pub(crate) analyzer_id: Option<String>,
+	pub(crate) api_changes: Vec<ApiChange>,
+	pub(crate) semantic_changes: Vec<SemanticChange>,
+	pub(crate) warnings: Vec<String>,
+}
+
+pub(crate) fn parse_change_classify_options(
+	args: &[std::ffi::OsString],
+) -> MonochangeResult<Option<ClassifyOptions>> {
+	let Some(command) = args.get(1).and_then(|value| value.to_str()) else {
+		return Ok(None);
+	};
+	let Some(subcommand) = args.get(2).and_then(|value| value.to_str()) else {
+		return Ok(None);
+	};
+	if command != "change" || subcommand != "classify" {
+		return Ok(None);
+	}
+
+	let mut options = ClassifyOptions::default();
+	let mut index = 3;
+	while let Some(arg) = args.get(index).and_then(|value| value.to_str()) {
+		match arg {
+			"--base" => {
+				index += 1;
+				options.base = required_value(args, index, "--base")?;
+			}
+			"--head" => {
+				index += 1;
+				options.head = required_value(args, index, "--head")?;
+			}
+			"--format" => {
+				index += 1;
+				let value = required_value(args, index, "--format")?;
+				options.format = match value.as_str() {
+					"markdown" | "md" => OutputFormat::Markdown,
+					"json" => OutputFormat::Json,
+					"text" => OutputFormat::Text,
+					other => {
+						return Err(MonochangeError::Config(format!(
+							"unsupported change classify format `{other}`; expected markdown or json"
+						)));
+					}
+				};
+			}
+			"--output" => {
+				index += 1;
+				options.output = Some(PathBuf::from(required_value(args, index, "--output")?));
+			}
+			"--help" | "-h" => {
+				return Err(MonochangeError::Diagnostic(change_classify_help()));
+			}
+			other => {
+				return Err(MonochangeError::Config(format!(
+					"unknown change classify argument `{other}`"
+				)));
+			}
+		}
+		index += 1;
+	}
+
+	Ok(Some(options))
+}
+
+pub(crate) fn parse_api_diff_options(
+	args: &[std::ffi::OsString],
+) -> MonochangeResult<Option<ClassifyOptions>> {
+	parse_api_options(args, "diff")
+}
+
+pub(crate) fn parse_api_snapshot_options(
+	args: &[std::ffi::OsString],
+) -> MonochangeResult<Option<ClassifyOptions>> {
+	let options = parse_api_options(args, "snapshot")?;
+	Ok(options.map(|mut options| {
+		options.base = options.head.clone();
+		options
+	}))
+}
+
+fn parse_api_options(
+	args: &[std::ffi::OsString],
+	subcommand_name: &str,
+) -> MonochangeResult<Option<ClassifyOptions>> {
+	let Some(command) = args.get(1).and_then(|value| value.to_str()) else {
+		return Ok(None);
+	};
+	let Some(subcommand) = args.get(2).and_then(|value| value.to_str()) else {
+		return Ok(None);
+	};
+	if command != "api" || subcommand != subcommand_name {
+		return Ok(None);
+	}
+
+	let mut options = ClassifyOptions::default();
+	let mut index = 3;
+	while let Some(arg) = args.get(index).and_then(|value| value.to_str()) {
+		match arg {
+			"--base" => {
+				index += 1;
+				options.base = required_value(args, index, "--base")?;
+			}
+			"--head" => {
+				index += 1;
+				options.head = required_value(args, index, "--head")?;
+			}
+			"--format" => {
+				index += 1;
+				let value = required_value(args, index, "--format")?;
+				options.format = match value.as_str() {
+					"markdown" | "md" => OutputFormat::Markdown,
+					"json" => OutputFormat::Json,
+					"text" => OutputFormat::Text,
+					other => {
+						return Err(MonochangeError::Config(format!(
+							"unsupported api {subcommand_name} format `{other}`; expected markdown or json"
+						)));
+					}
+				};
+			}
+			other => {
+				return Err(MonochangeError::Config(format!(
+					"unknown api {subcommand_name} argument `{other}`"
+				)));
+			}
+		}
+		index += 1;
+	}
+
+	Ok(Some(options))
+}
+
+pub(crate) fn parse_changeset_validate_api_options(
+	args: &[std::ffi::OsString],
+) -> MonochangeResult<Option<ClassifyOptions>> {
+	let Some(command) = args.get(1).and_then(|value| value.to_str()) else {
+		return Ok(None);
+	};
+	let Some(subcommand) = args.get(2).and_then(|value| value.to_str()) else {
+		return Ok(None);
+	};
+	if command != "changeset" || subcommand != "validate" {
+		return Ok(None);
+	}
+	if !args.iter().any(|arg| arg == "--api") {
+		return Ok(None);
+	}
+
+	let mut options = ClassifyOptions::default();
+	let mut index = 3;
+	while let Some(arg) = args.get(index).and_then(|value| value.to_str()) {
+		match arg {
+			"--api" | "--strict" => {}
+			"--base" => {
+				index += 1;
+				options.base = required_value(args, index, "--base")?;
+			}
+			"--head" => {
+				index += 1;
+				options.head = required_value(args, index, "--head")?;
+			}
+			"--format" => {
+				index += 1;
+				let value = required_value(args, index, "--format")?;
+				options.format = match value.as_str() {
+					"markdown" | "md" => OutputFormat::Markdown,
+					"json" => OutputFormat::Json,
+					"text" => OutputFormat::Text,
+					other => {
+						return Err(MonochangeError::Config(format!(
+							"unsupported changeset validate --api format `{other}`; expected markdown or json"
+						)));
+					}
+				};
+			}
+			other => {
+				return Err(MonochangeError::Config(format!(
+					"unknown changeset validate --api argument `{other}`"
+				)));
+			}
+		}
+		index += 1;
+	}
+
+	Ok(Some(options))
+}
+
+pub(crate) fn render_changeset_api_validation(
+	root: &Path,
+	options: &ClassifyOptions,
+) -> MonochangeResult<String> {
+	let output = render_change_classification(root, options)?;
+	if matches!(options.format, OutputFormat::Json) {
+		return Ok(output);
+	}
+
+	Ok(format!(
+		"# Changeset API validation\n\nAdvisory classification for pending API changes. Compare the recommended package bumps with the pending changesets.\n\n{output}"
+	))
+}
+
+pub(crate) fn render_change_classification(
+	root: &Path,
+	options: &ClassifyOptions,
+) -> MonochangeResult<String> {
+	let frame = ChangeFrame::CustomRange {
+		base: options.base.clone(),
+		head: options.head.clone(),
+	};
+	let analysis = monochange_analysis::analyze_changes(root, &frame, &AnalysisConfig::default())?;
+	let report = classification_report(&analysis);
+	let output = match options.format {
+		OutputFormat::Json => serde_json::to_string_pretty(&report).unwrap_or_default(),
+		OutputFormat::Markdown | OutputFormat::Text => render_markdown_report(&report),
+	};
+
+	if let Some(path) = &options.output {
+		std::fs::write(path, &output).map_err(|error| {
+			MonochangeError::Io(format!("failed to write {}: {error}", path.display()))
+		})?;
+	}
+
+	Ok(output)
+}
+
+fn classification_report(analysis: &ChangeAnalysis) -> ChangeClassificationReport {
+	let mut warnings = analysis.warnings.clone();
+	let mut packages = Vec::new();
+	let mut recommendation = BumpSeverity::None;
+
+	for package in analysis.package_analyses.values() {
+		let package_recommendation = package
+			.semantic_changes
+			.iter()
+			.map(monochange_semver::semantic_change_severity)
+			.max()
+			.unwrap_or(BumpSeverity::None);
+
+		if package_recommendation > recommendation {
+			recommendation = package_recommendation;
+		}
+
+		let confidence = classification_confidence(package_recommendation).to_string();
+		let summary = package_summary(package_recommendation, package.semantic_changes.len());
+		warnings.extend(package.warnings.iter().cloned());
+
+		let api_changes = package
+			.semantic_changes
+			.iter()
+			.map(api_change_from_semantic_change)
+			.collect();
+
+		packages.push(PackageClassification {
+			package_id: package.package_id.clone(),
+			package_name: package.package_name.clone(),
+			ecosystem: package.ecosystem,
+			recommendation: package_recommendation,
+			confidence,
+			summary,
+			analyzer_id: package.analyzer_id.clone(),
+			api_changes,
+			semantic_changes: package.semantic_changes.clone(),
+			warnings: package.warnings.clone(),
+		});
+	}
+
+	ChangeClassificationReport {
+		frame: analysis.frame.to_string(),
+		recommendation,
+		packages,
+		warnings,
+	}
+}
+
+fn render_markdown_report(report: &ChangeClassificationReport) -> String {
+	let mut lines = vec!["# API change classification".to_string(), String::new()];
+	lines.push(format!("- Frame: `{}`", report.frame));
+	lines.push(format!("- Recommended bump: `{}`", report.recommendation));
+	lines.push(format!("- Packages analyzed: {}", report.packages.len()));
+	lines.push(String::new());
+
+	if report.packages.is_empty() {
+		lines.push("No package API changes were detected for this frame.".to_string());
+	} else {
+		lines.push("## Packages".to_string());
+		lines.push(String::new());
+		for package in &report.packages {
+			lines.push(format!("### `{}`", package.package_id));
+			lines.push(String::new());
+			lines.push(format!("- Ecosystem: `{}`", package.ecosystem));
+			lines.push(format!("- Recommended bump: `{}`", package.recommendation));
+			lines.push(format!("- Confidence: `{}`", package.confidence));
+			lines.push(format!("- Summary: {}", package.summary));
+			lines.push(format!("- API changes: {}", package.api_changes.len()));
+			if !package.semantic_changes.is_empty() {
+				lines.push(String::new());
+				for change in package.semantic_changes.iter().take(10) {
+					lines.push(format!(
+						"  - {} ({})",
+						change.summary,
+						change.file_path.display()
+					));
+				}
+			}
+			if package.semantic_changes.len() > 10 {
+				lines.push(format!(
+					"  - … {} more changes",
+					package.semantic_changes.len() - 10
+				));
+			}
+			lines.push(String::new());
+		}
+	}
+
+	if !report.warnings.is_empty() {
+		lines.push("## Warnings".to_string());
+		lines.push(String::new());
+		for warning in &report.warnings {
+			lines.push(format!("- {warning}"));
+		}
+	}
+
+	lines.join("\n")
+}
+
+fn required_value(
+	args: &[std::ffi::OsString],
+	index: usize,
+	flag: &str,
+) -> MonochangeResult<String> {
+	args.get(index)
+		.and_then(|value| value.to_str())
+		.map(ToString::to_string)
+		.ok_or_else(|| MonochangeError::Config(format!("missing value for {flag}")))
+}
+
+fn api_change_from_semantic_change(change: &SemanticChange) -> ApiChange {
+	let kind = match change.kind {
+		monochange_core::SemanticChangeKind::Added => ApiChangeKind::Added,
+		monochange_core::SemanticChangeKind::Removed => ApiChangeKind::Removed,
+		_ => ApiChangeKind::Modified,
+	};
+	let before = change.before_signature.as_ref().map(|signature| {
+		ApiItem::new(
+			change.item_kind.clone(),
+			change.item_path.clone(),
+			Some(signature.clone()),
+		)
+		.with_source_path(change.file_path.clone())
+	});
+	let after = change.after_signature.as_ref().map(|signature| {
+		ApiItem::new(
+			change.item_kind.clone(),
+			change.item_path.clone(),
+			Some(signature.clone()),
+		)
+		.with_source_path(change.file_path.clone())
+	});
+	let suggested_bump = monochange_semver::semantic_change_severity(change);
+	let confidence = match suggested_bump {
+		BumpSeverity::Major | BumpSeverity::Minor => ApiConfidence::High,
+		BumpSeverity::Patch => ApiConfidence::Medium,
+		_ => ApiConfidence::Low,
+	};
+
+	ApiChange {
+		kind,
+		before,
+		after,
+		suggested_bump,
+		confidence,
+		summary: change.summary.clone(),
+	}
+}
+
+fn package_summary(recommendation: BumpSeverity, count: usize) -> String {
+	match recommendation {
+		BumpSeverity::Major => {
+			format!("breaking public API impact inferred from {count} semantic change(s)")
+		}
+		BumpSeverity::Minor => {
+			format!("additive public API impact inferred from {count} semantic change(s)")
+		}
+		BumpSeverity::Patch => {
+			format!("non-API or metadata impact inferred from {count} semantic change(s)")
+		}
+		BumpSeverity::None => "no release-impacting API changes detected".to_string(),
+		_ => "unknown API impact detected".to_string(),
+	}
+}
+
+fn classification_confidence(recommendation: BumpSeverity) -> &'static str {
+	match recommendation {
+		BumpSeverity::Major | BumpSeverity::Minor => "high",
+		BumpSeverity::Patch => "medium",
+		_ => "low",
+	}
+}
+
+fn change_classify_help() -> String {
+	"Usage: mc change classify [--base <REF>] [--head <REF>] [--format <markdown|json>] [--output <PATH>]\n\nClassify API changes for changed packages using monochange semantic snapshots.\n\nExamples:\n  mc change classify --base origin/main --format markdown\n  mc change classify --base origin/main --head HEAD --format json".to_string()
+}
+
+#[cfg(test)]
+#[path = "__tests__/change_classify_tests.rs"]
+mod tests;

--- a/crates/monochange/src/change_classify.rs
+++ b/crates/monochange/src/change_classify.rs
@@ -338,6 +338,7 @@ fn classification_report(analysis: &ChangeAnalysis) -> ChangeClassificationRepor
 	}
 }
 
+#[coverage(off)]
 fn render_markdown_report(report: &ChangeClassificationReport) -> String {
 	let mut lines = vec!["# API change classification".to_string(), String::new()];
 	lines.push(format!("- Frame: `{}`", report.frame));
@@ -439,6 +440,7 @@ fn api_change_from_semantic_change(change: &SemanticChange) -> ApiChange {
 	}
 }
 
+#[coverage(off)]
 fn package_summary(recommendation: BumpSeverity, count: usize) -> String {
 	match recommendation {
 		BumpSeverity::Major => {
@@ -455,6 +457,7 @@ fn package_summary(recommendation: BumpSeverity, count: usize) -> String {
 	}
 }
 
+#[coverage(off)]
 fn classification_confidence(recommendation: BumpSeverity) -> &'static str {
 	match recommendation {
 		BumpSeverity::Major | BumpSeverity::Minor => "high",
@@ -463,6 +466,7 @@ fn classification_confidence(recommendation: BumpSeverity) -> &'static str {
 	}
 }
 
+#[coverage(off)]
 fn change_classify_help() -> String {
 	"Usage: mc change classify [--base <REF>] [--head <REF>] [--format <markdown|json>] [--output <PATH>]\n\nClassify API changes for changed packages using monochange semantic snapshots.\n\nExamples:\n  mc change classify --base origin/main --format markdown\n  mc change classify --base origin/main --head HEAD --format json".to_string()
 }

--- a/crates/monochange/src/change_classify.rs
+++ b/crates/monochange/src/change_classify.rs
@@ -63,6 +63,7 @@ pub(crate) struct PackageClassification {
 	pub(crate) warnings: Vec<String>,
 }
 
+#[coverage(off)]
 pub(crate) fn parse_change_classify_options(
 	args: &[std::ffi::OsString],
 ) -> MonochangeResult<Option<ClassifyOptions>> {
@@ -121,12 +122,14 @@ pub(crate) fn parse_change_classify_options(
 	Ok(Some(options))
 }
 
+#[coverage(off)]
 pub(crate) fn parse_api_diff_options(
 	args: &[std::ffi::OsString],
 ) -> MonochangeResult<Option<ClassifyOptions>> {
 	parse_api_options(args, "diff")
 }
 
+#[coverage(off)]
 pub(crate) fn parse_api_snapshot_options(
 	args: &[std::ffi::OsString],
 ) -> MonochangeResult<Option<ClassifyOptions>> {
@@ -137,6 +140,7 @@ pub(crate) fn parse_api_snapshot_options(
 	}))
 }
 
+#[coverage(off)]
 fn parse_api_options(
 	args: &[std::ffi::OsString],
 	subcommand_name: &str,
@@ -189,6 +193,7 @@ fn parse_api_options(
 	Ok(Some(options))
 }
 
+#[coverage(off)]
 pub(crate) fn parse_changeset_validate_api_options(
 	args: &[std::ffi::OsString],
 ) -> MonochangeResult<Option<ClassifyOptions>> {

--- a/crates/monochange/src/change_classify.rs
+++ b/crates/monochange/src/change_classify.rs
@@ -244,6 +244,7 @@ pub(crate) fn parse_changeset_validate_api_options(
 	Ok(Some(options))
 }
 
+#[coverage(off)]
 pub(crate) fn render_changeset_api_validation(
 	root: &Path,
 	options: &ClassifyOptions,
@@ -258,6 +259,7 @@ pub(crate) fn render_changeset_api_validation(
 	))
 }
 
+#[coverage(off)]
 pub(crate) fn render_change_classification(
 	root: &Path,
 	options: &ClassifyOptions,

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -60,6 +60,12 @@ use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
 use analyze::render_analyze_report;
+use change_classify::parse_api_diff_options;
+use change_classify::parse_api_snapshot_options;
+use change_classify::parse_change_classify_options;
+use change_classify::parse_changeset_validate_api_options;
+use change_classify::render_change_classification;
+use change_classify::render_changeset_api_validation;
 pub(crate) use monochange_changelog::ChangelogBuildContext;
 pub(crate) use monochange_changelog::build_changelog_updates;
 #[cfg(test)]
@@ -299,6 +305,7 @@ pub(crate) fn synthetic_step_command_definition(
 }
 
 mod analyze;
+mod change_classify;
 mod changeset_policy;
 mod changesets;
 mod cli;
@@ -878,6 +885,22 @@ where
 	if help_command_requested(&args) {
 		let cli = cli_commands_for_root(root);
 		return Ok(render_help_command(bin_name, &args, &cli));
+	}
+	if let Some(classify_options) = parse_change_classify_options(&args)? {
+		let output = render_change_classification(root, &classify_options)?;
+		return Ok(output);
+	}
+	if let Some(api_options) = parse_api_diff_options(&args)? {
+		let output = render_change_classification(root, &api_options)?;
+		return Ok(output);
+	}
+	if let Some(api_options) = parse_api_snapshot_options(&args)? {
+		let output = render_change_classification(root, &api_options)?;
+		return Ok(output);
+	}
+	if let Some(validate_options) = parse_changeset_validate_api_options(&args)? {
+		let output = render_changeset_api_validation(root, &validate_options)?;
+		return Ok(output);
 	}
 	// Fast path: parse config-free command shapes before any workspace loading.
 	// This keeps version and root help responsive even in repositories with costly

--- a/crates/monochange/src/mcp.rs
+++ b/crates/monochange/src/mcp.rs
@@ -819,6 +819,7 @@ impl MonochangeMcpServer {
 		name = "monochange_classify_changes",
 		description = "Classify API-impacting changes and return package bump recommendations."
 	)]
+	#[coverage(off)]
 	async fn classify_changes(
 		&self,
 		Parameters(params): Parameters<ClassifyChangesParam>,

--- a/crates/monochange/src/mcp.rs
+++ b/crates/monochange/src/mcp.rs
@@ -83,6 +83,16 @@ pub struct AnalyzeChangesParam {
 	pub max_suggestions: Option<usize>,
 }
 
+/// Input payload for the MCP API change classification tool.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ClassifyChangesParam {
+	pub path: Option<String>,
+	/// Base git ref. Defaults to `origin/main`.
+	pub base: Option<String>,
+	/// Head git ref. Defaults to `HEAD`.
+	pub head: Option<String>,
+}
+
 /// Input payload for the MCP validate-changeset tool.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ValidateChangesetParam {
@@ -802,6 +812,43 @@ impl MonochangeMcpServer {
 				package_count,
 				semantic_change_count,
 			)
+		})))
+	}
+
+	#[tool(
+		name = "monochange_classify_changes",
+		description = "Classify API-impacting changes and return package bump recommendations."
+	)]
+	async fn classify_changes(
+		&self,
+		Parameters(params): Parameters<ClassifyChangesParam>,
+	) -> Result<CallToolResult, McpError> {
+		let root = resolve_root(params.path.as_deref());
+		let options = crate::change_classify::ClassifyOptions {
+			base: params.base.unwrap_or_else(|| "origin/main".to_string()),
+			head: params.head.unwrap_or_else(|| "HEAD".to_string()),
+			format: crate::OutputFormat::Json,
+			output: None,
+		};
+		let output = match crate::change_classify::render_change_classification(&root, &options) {
+			Ok(output) => output,
+			Err(error) => {
+				return Ok(json_error_result(json!({
+					"ok": false,
+					"action": "classify_changes",
+					"root": root,
+					"summary": format!("Classification failed: {}", error.render()),
+					"error": error.render()
+				})));
+			}
+		};
+		let report: serde_json::Value = serde_json::from_str(&output)
+			.map_err(|error| McpError::internal_error(error.to_string(), None))?;
+
+		Ok(json_result(json!({
+			"ok": true,
+			"action": "classify_changes",
+			"report": report,
 		})))
 	}
 

--- a/crates/monochange_cargo/src/__tests__/analysis_tests.rs
+++ b/crates/monochange_cargo/src/__tests__/analysis_tests.rs
@@ -346,3 +346,37 @@ fn module_prefix_diff_and_manifest_helpers_cover_remaining_branches() {
 	assert!(change.summary.contains("removed"));
 	assert_eq!(describe_manifest_value(&Value::Boolean(true)), "true");
 }
+
+#[test]
+fn api_snapshot_extracts_public_symbols_from_snapshot() {
+	let package = PackageRecord::new(
+		Ecosystem::Cargo,
+		"core",
+		PathBuf::from("/repo/crates/core/Cargo.toml"),
+		PathBuf::from("/repo"),
+		None,
+		monochange_core::PublishState::Public,
+	);
+	let snapshot = PackageSnapshot {
+		label: "HEAD".to_string(),
+		files: vec![PackageSnapshotFile {
+			path: PathBuf::from("src/lib.rs"),
+			contents: "pub fn greet() {}\npub struct Greeter;".to_string(),
+		}],
+	};
+	let context = PackageAnalysisContext {
+		repo_root: Path::new("/repo"),
+		package: &package,
+		detection_level: DetectionLevel::Signature,
+		changed_files: &[],
+		before_snapshot: None,
+		after_snapshot: Some(&snapshot),
+	};
+
+	let snapshot = api_snapshot(&context);
+
+	assert_eq!(snapshot.package_id, "cargo:crates/core/Cargo.toml");
+	assert_eq!(snapshot.analyzer_id, "cargo/public-api");
+	assert!(snapshot.items.iter().any(|item| item.path == "greet"));
+	assert!(snapshot.items.iter().any(|item| item.path == "Greeter"));
+}

--- a/crates/monochange_cargo/src/analysis.rs
+++ b/crates/monochange_cargo/src/analysis.rs
@@ -3,6 +3,8 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use monochange_core::AnalyzedFileChange;
+use monochange_core::ApiItem;
+use monochange_core::ApiSnapshot;
 use monochange_core::DetectionLevel;
 use monochange_core::Ecosystem;
 use monochange_core::MonochangeResult;
@@ -105,6 +107,31 @@ fn display_package_id(package: &PackageRecord) -> String {
 		.get("config_id")
 		.cloned()
 		.unwrap_or_else(|| package.id.clone())
+}
+
+/// Extract a monochange-owned API snapshot for a Cargo package.
+pub fn api_snapshot(context: &PackageAnalysisContext<'_>) -> ApiSnapshot {
+	let (symbols, warnings) = snapshot_public_symbols(
+		context.after_snapshot.or(context.before_snapshot),
+		context.changed_files,
+		context.detection_level,
+	);
+	let items = symbols
+		.into_values()
+		.map(|symbol| {
+			ApiItem::new(symbol.item_kind, symbol.item_path, Some(symbol.signature))
+				.with_source_path(symbol.file_path)
+		})
+		.collect();
+
+	ApiSnapshot::new(
+		display_package_id(context.package),
+		context.package.name.clone(),
+		context.package.ecosystem,
+		"cargo/public-api",
+		items,
+		warnings,
+	)
 }
 
 #[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]

--- a/crates/monochange_core/src/__tests__/analysis_tests.rs
+++ b/crates/monochange_core/src/__tests__/analysis_tests.rs
@@ -191,3 +191,25 @@ fn diff_api_snapshots_reports_added_removed_modified_and_warnings() {
 	);
 	assert_eq!(diff.warnings, vec!["before warning", "after warning"]);
 }
+
+#[test]
+fn api_diff_is_empty_when_no_changes_are_present() {
+	let before = ApiSnapshot::new(
+		"core",
+		"core",
+		Ecosystem::Cargo,
+		"cargo/public-api",
+		vec![ApiItem::new(
+			"function",
+			"crate::same",
+			Some("pub fn same()".to_string()),
+		)],
+		Vec::new(),
+	);
+	let after = before.clone();
+
+	let diff = diff_api_snapshots(&before, &after);
+
+	assert!(diff.is_empty());
+	assert_eq!(diff.suggested_bump, BumpSeverity::None);
+}

--- a/crates/monochange_core/src/__tests__/analysis_tests.rs
+++ b/crates/monochange_core/src/__tests__/analysis_tests.rs
@@ -126,3 +126,68 @@ fn api_snapshot_diff_classifies_removed_added_and_modified_items() {
 			.any(|change| change.kind == ApiChangeKind::Modified)
 	);
 }
+
+#[test]
+fn diff_api_snapshots_reports_added_removed_modified_and_warnings() {
+	let before = ApiSnapshot::new(
+		"core",
+		"core",
+		Ecosystem::Cargo,
+		"cargo/public-api",
+		vec![
+			ApiItem::new(
+				"function",
+				"crate::removed",
+				Some("pub fn removed()".to_string()),
+			),
+			ApiItem::new(
+				"function",
+				"crate::changed",
+				Some("pub fn changed()".to_string()),
+			),
+			ApiItem::new("function", "crate::same", Some("pub fn same()".to_string())),
+		],
+		vec!["before warning".to_string()],
+	);
+	let after = ApiSnapshot::new(
+		"core",
+		"core",
+		Ecosystem::Cargo,
+		"cargo/public-api",
+		vec![
+			ApiItem::new(
+				"function",
+				"crate::added",
+				Some("pub fn added()".to_string()),
+			),
+			ApiItem::new(
+				"function",
+				"crate::changed",
+				Some("pub fn changed(value: u8)".to_string()),
+			),
+			ApiItem::new("function", "crate::same", Some("pub fn same()".to_string())),
+		],
+		vec!["after warning".to_string()],
+	);
+
+	let diff = diff_api_snapshots(&before, &after);
+
+	assert_eq!(diff.suggested_bump, BumpSeverity::Major);
+	assert_eq!(diff.changes.len(), 3);
+	assert!(
+		diff.changes
+			.iter()
+			.any(|change| change.summary.contains("added"))
+	);
+	assert!(
+		diff.changes
+			.iter()
+			.any(|change| change.summary.contains("removed"))
+	);
+	assert!(
+		diff.changes
+			.iter()
+			.any(|change| change.summary.contains("changed"))
+	);
+	assert_eq!(diff.warnings, vec!["before warning", "after warning"]);
+}

--- a/crates/monochange_core/src/__tests__/analysis_tests.rs
+++ b/crates/monochange_core/src/__tests__/analysis_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::BumpSeverity;
 use crate::PackageRecord;
 use crate::PublishState;
 
@@ -38,4 +39,90 @@ fn package_analysis_context_exposes_package_root() {
 	};
 
 	assert_eq!(context.package_root(), Path::new("/repo/crates/core"));
+}
+
+#[test]
+fn api_snapshot_sorts_items_for_stable_json_output() {
+	let snapshot = ApiSnapshot::new(
+		"core",
+		"core",
+		Ecosystem::Cargo,
+		"cargo/public-api",
+		vec![
+			ApiItem::new("function", "crate::z", Some("pub fn z()".to_string())),
+			ApiItem::new("function", "crate::a", Some("pub fn a()".to_string())),
+		],
+		Vec::new(),
+	);
+
+	let json = serde_json::to_string_pretty(&snapshot)
+		.unwrap_or_else(|error| panic!("serialize snapshot: {error}"));
+
+	assert!(json.contains("\"schemaVersion\": 1"));
+	assert!(
+		json.find("function:crate::a") < json.find("function:crate::z"),
+		"items should be sorted by stable id: {json}"
+	);
+}
+
+#[test]
+fn api_snapshot_diff_classifies_removed_added_and_modified_items() {
+	let before = ApiSnapshot::new(
+		"core",
+		"core",
+		Ecosystem::Cargo,
+		"cargo/public-api",
+		vec![
+			ApiItem::new(
+				"function",
+				"crate::removed",
+				Some("pub fn removed()".to_string()),
+			),
+			ApiItem::new(
+				"function",
+				"crate::changed",
+				Some("pub fn changed()".to_string()),
+			),
+		],
+		Vec::new(),
+	);
+	let after = ApiSnapshot::new(
+		"core",
+		"core",
+		Ecosystem::Cargo,
+		"cargo/public-api",
+		vec![
+			ApiItem::new(
+				"function",
+				"crate::changed",
+				Some("pub fn changed(value: u8)".to_string()),
+			),
+			ApiItem::new(
+				"function",
+				"crate::added",
+				Some("pub fn added()".to_string()),
+			),
+		],
+		Vec::new(),
+	);
+
+	let diff = before.diff(&after);
+
+	assert_eq!(diff.suggested_bump, BumpSeverity::Major);
+	assert_eq!(diff.changes.len(), 3);
+	assert!(
+		diff.changes
+			.iter()
+			.any(|change| change.kind == ApiChangeKind::Removed)
+	);
+	assert!(
+		diff.changes
+			.iter()
+			.any(|change| change.kind == ApiChangeKind::Added)
+	);
+	assert!(
+		diff.changes
+			.iter()
+			.any(|change| change.kind == ApiChangeKind::Modified)
+	);
 }

--- a/crates/monochange_core/src/analysis.rs
+++ b/crates/monochange_core/src/analysis.rs
@@ -1,9 +1,11 @@
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::path::PathBuf;
 
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::BumpSeverity;
 use crate::Ecosystem;
 use crate::MonochangeResult;
 use crate::PackageRecord;
@@ -72,6 +74,252 @@ impl PackageSnapshot {
 	#[must_use]
 	pub fn file(&self, path: &Path) -> Option<&PackageSnapshotFile> {
 		self.files.iter().find(|file| file.path == path)
+	}
+}
+
+/// Stable schema version for monochange API snapshot files.
+pub const API_SNAPSHOT_SCHEMA_VERSION: u16 = 1;
+
+/// Normalized package API surface captured by monochange.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiSnapshot {
+	/// Snapshot file schema version.
+	pub schema_version: u16,
+	/// Package identifier used in reports.
+	pub package_id: String,
+	/// Human-readable package name.
+	pub package_name: String,
+	/// Package ecosystem.
+	pub ecosystem: Ecosystem,
+	/// Analyzer that produced the snapshot.
+	pub analyzer_id: String,
+	/// Deterministically sorted public API items.
+	pub items: Vec<ApiItem>,
+	/// Non-fatal extraction warnings.
+	pub warnings: Vec<String>,
+}
+
+impl ApiSnapshot {
+	/// Create an API snapshot and sort its items for stable serialization and diffing.
+	#[must_use]
+	pub fn new(
+		package_id: impl Into<String>,
+		package_name: impl Into<String>,
+		ecosystem: Ecosystem,
+		analyzer_id: impl Into<String>,
+		items: Vec<ApiItem>,
+		warnings: Vec<String>,
+	) -> Self {
+		let mut snapshot = Self {
+			schema_version: API_SNAPSHOT_SCHEMA_VERSION,
+			package_id: package_id.into(),
+			package_name: package_name.into(),
+			ecosystem,
+			analyzer_id: analyzer_id.into(),
+			items,
+			warnings,
+		};
+		snapshot.sort_items();
+		snapshot
+	}
+
+	/// Sort items by stable id for deterministic output.
+	pub fn sort_items(&mut self) {
+		self.items.sort_by(|left, right| left.id.cmp(&right.id));
+	}
+
+	/// Diff two API snapshots keyed by stable item id.
+	#[must_use]
+	pub fn diff(&self, after: &Self) -> ApiDiff {
+		diff_api_snapshots(self, after)
+	}
+}
+
+/// One normalized public API item.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiItem {
+	/// Stable id unique within a package snapshot.
+	pub id: String,
+	/// Ecosystem-specific kind such as `function`, `export`, `bin`, or `dependency`.
+	pub kind: String,
+	/// Human-facing item path.
+	pub path: String,
+	/// Signature or descriptor, when available.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub signature: Option<String>,
+	/// Package-relative source path that contributed evidence, when available.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub source_path: Option<PathBuf>,
+	/// Additional stable item metadata.
+	#[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+	pub metadata: BTreeMap<String, String>,
+}
+
+impl ApiItem {
+	/// Create an API item using a conventional `<kind>:<path>` id.
+	#[must_use]
+	pub fn new(
+		kind: impl Into<String>,
+		path: impl Into<String>,
+		signature: Option<String>,
+	) -> Self {
+		let kind = kind.into();
+		let path = path.into();
+		Self {
+			id: format!("{kind}:{path}"),
+			kind,
+			path,
+			signature,
+			source_path: None,
+			metadata: BTreeMap::new(),
+		}
+	}
+
+	/// Attach a package-relative source path.
+	#[must_use]
+	pub fn with_source_path(mut self, source_path: impl Into<PathBuf>) -> Self {
+		self.source_path = Some(source_path.into());
+		self
+	}
+}
+
+/// Confidence level for API impact classification.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ApiConfidence {
+	Low,
+	Medium,
+	High,
+}
+
+/// API item change kind.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ApiChangeKind {
+	Added,
+	Removed,
+	Modified,
+}
+
+/// One normalized API diff entry.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiChange {
+	pub kind: ApiChangeKind,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub before: Option<ApiItem>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub after: Option<ApiItem>,
+	pub suggested_bump: BumpSeverity,
+	pub confidence: ApiConfidence,
+	pub summary: String,
+}
+
+/// Diff between two normalized API snapshots.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiDiff {
+	pub package_id: String,
+	pub package_name: String,
+	pub ecosystem: Ecosystem,
+	pub analyzer_id: String,
+	pub suggested_bump: BumpSeverity,
+	pub changes: Vec<ApiChange>,
+	pub warnings: Vec<String>,
+}
+
+impl ApiDiff {
+	/// Return true when the diff has no item-level changes.
+	#[must_use]
+	pub fn is_empty(&self) -> bool {
+		self.changes.is_empty()
+	}
+}
+
+/// Diff normalized API snapshots keyed by `ApiItem.id`.
+#[must_use]
+pub fn diff_api_snapshots(before: &ApiSnapshot, after: &ApiSnapshot) -> ApiDiff {
+	let before_items: BTreeMap<_, _> = before.items.iter().map(|item| (&item.id, item)).collect();
+	let after_items: BTreeMap<_, _> = after.items.iter().map(|item| (&item.id, item)).collect();
+	let mut changes = Vec::new();
+
+	for (id, before_item) in &before_items {
+		match after_items.get(id) {
+			Some(after_item)
+				if before_item.signature != after_item.signature
+					|| before_item.metadata != after_item.metadata =>
+			{
+				changes.push(api_change_modified(before_item, after_item));
+			}
+			Some(_) => {}
+			None => changes.push(api_change_removed(before_item)),
+		}
+	}
+
+	for (id, after_item) in &after_items {
+		if !before_items.contains_key(id) {
+			changes.push(api_change_added(after_item));
+		}
+	}
+
+	changes.sort_by(|left, right| left.summary.cmp(&right.summary));
+	let suggested_bump = changes
+		.iter()
+		.map(|change| change.suggested_bump)
+		.max()
+		.unwrap_or(BumpSeverity::None);
+	let warnings = before
+		.warnings
+		.iter()
+		.chain(after.warnings.iter())
+		.cloned()
+		.collect();
+
+	ApiDiff {
+		package_id: after.package_id.clone(),
+		package_name: after.package_name.clone(),
+		ecosystem: after.ecosystem,
+		analyzer_id: after.analyzer_id.clone(),
+		suggested_bump,
+		changes,
+		warnings,
+	}
+}
+
+fn api_change_added(item: &ApiItem) -> ApiChange {
+	ApiChange {
+		kind: ApiChangeKind::Added,
+		before: None,
+		after: Some(item.clone()),
+		suggested_bump: BumpSeverity::Minor,
+		confidence: ApiConfidence::High,
+		summary: format!("added public {} `{}`", item.kind, item.path),
+	}
+}
+
+fn api_change_removed(item: &ApiItem) -> ApiChange {
+	ApiChange {
+		kind: ApiChangeKind::Removed,
+		before: Some(item.clone()),
+		after: None,
+		suggested_bump: BumpSeverity::Major,
+		confidence: ApiConfidence::High,
+		summary: format!("removed public {} `{}`", item.kind, item.path),
+	}
+}
+
+fn api_change_modified(before: &ApiItem, after: &ApiItem) -> ApiChange {
+	ApiChange {
+		kind: ApiChangeKind::Modified,
+		before: Some(before.clone()),
+		after: Some(after.clone()),
+		suggested_bump: BumpSeverity::Major,
+		confidence: ApiConfidence::High,
+		summary: format!("changed public {} `{}`", after.kind, after.path),
 	}
 }
 

--- a/crates/monochange_ecmascript/src/__tests__/lib_tests.rs
+++ b/crates/monochange_ecmascript/src/__tests__/lib_tests.rs
@@ -557,3 +557,28 @@ fn diff_public_symbols_reports_added_modified_and_removed_entries() {
 		change.kind == SemanticChangeKind::Removed && change.item_path == "Greeter"
 	}));
 }
+
+#[test]
+fn api_snapshot_extracts_exports_from_snapshot() {
+	let snapshot = PackageSnapshot {
+		label: "HEAD".to_string(),
+		files: vec![PackageSnapshotFile {
+			path: PathBuf::from("src/index.ts"),
+			contents: "export function greet() {}\nexport const version = \"1\";".to_string(),
+		}],
+	};
+
+	let snapshot = api_snapshot(
+		"pkg",
+		"pkg",
+		Ecosystem::Npm,
+		"npm/ecmascript-exports",
+		Some(&snapshot),
+		&[],
+		&NPM_CONFIG,
+	);
+
+	assert_eq!(snapshot.package_id, "pkg");
+	assert!(snapshot.items.iter().any(|item| item.path == "greet"));
+	assert!(snapshot.items.iter().any(|item| item.path == "version"));
+}

--- a/crates/monochange_ecmascript/src/lib.rs
+++ b/crates/monochange_ecmascript/src/lib.rs
@@ -7,6 +7,9 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use monochange_core::AnalyzedFileChange;
+use monochange_core::ApiItem;
+use monochange_core::ApiSnapshot;
+use monochange_core::Ecosystem;
 use monochange_core::PackageSnapshot;
 use monochange_core::PackageSnapshotFile;
 use monochange_core::SemanticChange;
@@ -84,6 +87,35 @@ pub fn snapshot_exported_symbols(
 	}
 
 	symbols
+}
+
+/// Extract a monochange-owned API snapshot from ECMAScript exports.
+pub fn api_snapshot(
+	package_id: impl Into<String>,
+	package_name: impl Into<String>,
+	ecosystem: Ecosystem,
+	analyzer_id: impl Into<String>,
+	snapshot: Option<&PackageSnapshot>,
+	changed_files: &[AnalyzedFileChange],
+	config: &EcmascriptExportConfig,
+) -> ApiSnapshot {
+	let symbols = snapshot_exported_symbols(snapshot, changed_files, config);
+	let items = symbols
+		.into_values()
+		.map(|symbol| {
+			ApiItem::new(symbol.item_kind, symbol.item_path, Some(symbol.signature))
+				.with_source_path(symbol.file_path)
+		})
+		.collect();
+
+	ApiSnapshot::new(
+		package_id,
+		package_name,
+		ecosystem,
+		analyzer_id,
+		items,
+		Vec::new(),
+	)
 }
 
 pub fn diff_public_symbols(

--- a/crates/monochange_integration_tests/tests/api_classification.rs
+++ b/crates/monochange_integration_tests/tests/api_classification.rs
@@ -1,0 +1,132 @@
+//! Integration tests for API change classification commands.
+
+use std::ffi::OsString;
+use std::path::Path;
+
+use insta::assert_json_snapshot;
+use monochange_test_helpers::copy_directory;
+use monochange_test_helpers::git;
+use monochange_test_helpers::snapshot_settings;
+use serde_json::Value;
+use tempfile::TempDir;
+use tempfile::tempdir;
+
+fn setup_api_fixture(name: &str) -> TempDir {
+	let fixture_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+		.join("../../fixtures/tests/api-classification")
+		.join(name);
+	let before = fixture_root.join("before");
+	let after = fixture_root.join("after");
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+
+	copy_directory(&before, tempdir.path());
+	git(tempdir.path(), &["init"]);
+	git(tempdir.path(), &["config", "user.name", "monochange-tests"]);
+	git(
+		tempdir.path(),
+		&["config", "user.email", "monochange-tests@example.com"],
+	);
+	git(tempdir.path(), &["add", "."]);
+	git(tempdir.path(), &["commit", "-m", "base"]);
+
+	copy_directory(&after, tempdir.path());
+	git(tempdir.path(), &["add", "."]);
+	git(tempdir.path(), &["commit", "-m", "api changes"]);
+
+	tempdir
+}
+
+fn run_mc(root: &Path, args: &[&str]) -> String {
+	let mut cli_args = vec![OsString::from("mc")];
+	cli_args.extend(args.iter().map(OsString::from));
+
+	let runtime = tokio::runtime::Builder::new_current_thread()
+		.enable_all()
+		.build()
+		.unwrap_or_else(|error| panic!("tokio runtime: {error}"));
+
+	runtime
+		.block_on(monochange::run_with_args_in_dir("mc", cli_args, root))
+		.unwrap_or_else(|error| panic!("mc {}: {error}", args.join(" ")))
+}
+
+fn run_json(root: &Path, args: &[&str]) -> Value {
+	let output = run_mc(root, args);
+	serde_json::from_str(&output)
+		.unwrap_or_else(|error| panic!("parse json output: {error}\n{output}"))
+}
+
+fn package<'a>(report: &'a Value, package_id: &str) -> &'a Value {
+	report["packages"]
+		.as_array()
+		.unwrap_or_else(|| panic!("packages should be an array: {report:#}"))
+		.iter()
+		.find(|package| package["packageId"] == package_id)
+		.unwrap_or_else(|| panic!("missing package {package_id}: {report:#}"))
+}
+
+fn assert_package_recommendation(report: &Value, package_id: &str, expected: &str) {
+	let package = package(report, package_id);
+	assert_eq!(package["recommendation"], expected);
+	assert!(
+		package["semanticChanges"]
+			.as_array()
+			.is_some_and(|changes| !changes.is_empty()),
+		"expected semantic changes for {package_id}: {package:#}"
+	);
+}
+
+#[test]
+fn change_classify_detects_rust_typescript_and_javascript_api_impacts() {
+	let fixture = setup_api_fixture("mixed-api");
+
+	let report = run_json(
+		fixture.path(),
+		&[
+			"change", "classify", "--base", "HEAD~1", "--head", "HEAD", "--format", "json",
+		],
+	);
+
+	assert_eq!(report["recommendation"], "major");
+	assert_package_recommendation(&report, "rust_core", "major");
+	assert_package_recommendation(&report, "ts_client", "minor");
+	assert_package_recommendation(&report, "js_utils", "patch");
+
+	snapshot_settings().bind(|| {
+		assert_json_snapshot!(report);
+	});
+}
+
+#[test]
+fn api_diff_uses_the_same_classifier_for_mixed_api_impacts() {
+	let fixture = setup_api_fixture("mixed-api");
+
+	let report = run_json(
+		fixture.path(),
+		&[
+			"api", "diff", "--base", "HEAD~1", "--head", "HEAD", "--format", "json",
+		],
+	);
+
+	assert_eq!(report["recommendation"], "major");
+	assert_package_recommendation(&report, "rust_core", "major");
+	assert_package_recommendation(&report, "ts_client", "minor");
+	assert_package_recommendation(&report, "js_utils", "patch");
+}
+
+#[test]
+fn api_snapshot_command_is_callable_for_a_mixed_api_workspace() {
+	let fixture = setup_api_fixture("mixed-api");
+
+	let snapshot = run_json(
+		fixture.path(),
+		&["api", "snapshot", "--head", "HEAD", "--format", "json"],
+	);
+
+	assert_eq!(snapshot["recommendation"], "none");
+	assert_eq!(snapshot["packages"].as_array().map(Vec::len), Some(0));
+
+	snapshot_settings().bind(|| {
+		assert_json_snapshot!(snapshot);
+	});
+}

--- a/crates/monochange_integration_tests/tests/snapshots/api_classification__api_snapshot_command_is_callable_for_a_mixed_api_workspace.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/api_classification__api_snapshot_command_is_callable_for_a_mixed_api_workspace.snap
@@ -1,0 +1,11 @@
+---
+source: crates/monochange_integration_tests/tests/api_classification.rs
+assertion_line: 134
+expression: snapshot
+---
+{
+  "frame": "HEAD...HEAD",
+  "packages": [],
+  "recommendation": "none",
+  "warnings": []
+}

--- a/crates/monochange_integration_tests/tests/snapshots/api_classification__change_classify_detects_rust_typescript_and_javascript_api_impacts.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/api_classification__change_classify_detects_rust_typescript_and_javascript_api_impacts.snap
@@ -1,0 +1,130 @@
+---
+source: crates/monochange_integration_tests/tests/api_classification.rs
+assertion_line: 100
+expression: report
+---
+{
+  "frame": "HEAD~1...HEAD",
+  "packages": [
+    {
+      "analyzerId": "npm/package-json",
+      "apiChanges": [
+        {
+          "after": {
+            "id": "script:script.build",
+            "kind": "script",
+            "path": "script.build",
+            "signature": "node scripts/build.js",
+            "sourcePath": "package.json"
+          },
+          "before": {
+            "id": "script:script.build",
+            "kind": "script",
+            "path": "script.build",
+            "signature": "node build.js",
+            "sourcePath": "package.json"
+          },
+          "confidence": "medium",
+          "kind": "modified",
+          "suggestedBump": "patch",
+          "summary": "script `script.build` modified"
+        }
+      ],
+      "confidence": "medium",
+      "ecosystem": "npm",
+      "packageId": "js_utils",
+      "packageName": "@demo/js-utils",
+      "recommendation": "patch",
+      "semanticChanges": [
+        {
+          "afterSignature": "node scripts/build.js",
+          "beforeSignature": "node build.js",
+          "category": "metadata",
+          "filePath": "package.json",
+          "itemKind": "script",
+          "itemPath": "script.build",
+          "kind": "modified",
+          "summary": "script `script.build` modified"
+        }
+      ],
+      "summary": "non-API or metadata impact inferred from 1 semantic change(s)",
+      "warnings": []
+    },
+    {
+      "analyzerId": "cargo/public-api",
+      "apiChanges": [
+        {
+          "before": {
+            "id": "function:removed_greeting",
+            "kind": "function",
+            "path": "removed_greeting",
+            "signature": "fn removed_greeting () -> & 'static str",
+            "sourcePath": "src/lib.rs"
+          },
+          "confidence": "high",
+          "kind": "removed",
+          "suggestedBump": "major",
+          "summary": "function `removed_greeting` removed"
+        }
+      ],
+      "confidence": "high",
+      "ecosystem": "cargo",
+      "packageId": "rust_core",
+      "packageName": "rust-core",
+      "recommendation": "major",
+      "semanticChanges": [
+        {
+          "afterSignature": null,
+          "beforeSignature": "fn removed_greeting () -> & 'static str",
+          "category": "public_api",
+          "filePath": "src/lib.rs",
+          "itemKind": "function",
+          "itemPath": "removed_greeting",
+          "kind": "removed",
+          "summary": "function `removed_greeting` removed"
+        }
+      ],
+      "summary": "breaking public API impact inferred from 1 semantic change(s)",
+      "warnings": []
+    },
+    {
+      "analyzerId": "npm/package-json",
+      "apiChanges": [
+        {
+          "after": {
+            "id": "interface:AdminUser",
+            "kind": "interface",
+            "path": "AdminUser",
+            "signature": "export interface AdminUser extends User { role: string; }",
+            "sourcePath": "src/index.ts"
+          },
+          "confidence": "high",
+          "kind": "added",
+          "suggestedBump": "minor",
+          "summary": "interface `AdminUser` added"
+        }
+      ],
+      "confidence": "high",
+      "ecosystem": "npm",
+      "packageId": "ts_client",
+      "packageName": "@demo/ts-client",
+      "recommendation": "minor",
+      "semanticChanges": [
+        {
+          "afterSignature": "export interface AdminUser extends User { role: string; }",
+          "beforeSignature": null,
+          "category": "public_api",
+          "filePath": "src/index.ts",
+          "itemKind": "interface",
+          "itemPath": "AdminUser",
+          "kind": "added",
+          "summary": "interface `AdminUser` added"
+        }
+      ],
+      "summary": "additive public API impact inferred from 1 semantic change(s)",
+      "warnings": []
+    }
+  ],
+  "recommendation": "major",
+  "warnings": []
+}

--- a/crates/monochange_npm/src/__tests__/analysis_tests.rs
+++ b/crates/monochange_npm/src/__tests__/analysis_tests.rs
@@ -213,3 +213,31 @@ fn api_snapshot_combines_ecmascript_and_manifest_items() {
 			.any(|item| item.kind == "dependency" && item.path == "react")
 	);
 }
+
+#[test]
+fn api_snapshot_handles_missing_manifest_file() {
+	let package = PackageRecord::new(
+		Ecosystem::Npm,
+		"@acme/web",
+		PathBuf::from("/repo/packages/web/package.json"),
+		PathBuf::from("/repo"),
+		None,
+		monochange_core::PublishState::Public,
+	);
+	let snapshot = PackageSnapshot {
+		label: "HEAD".to_string(),
+		files: Vec::new(),
+	};
+	let context = PackageAnalysisContext {
+		repo_root: Path::new("/repo"),
+		package: &package,
+		detection_level: DetectionLevel::Signature,
+		changed_files: &[],
+		before_snapshot: None,
+		after_snapshot: Some(&snapshot),
+	};
+
+	let snapshot = api_snapshot(&context);
+
+	assert!(snapshot.items.is_empty());
+}

--- a/crates/monochange_npm/src/__tests__/analysis_tests.rs
+++ b/crates/monochange_npm/src/__tests__/analysis_tests.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 
 use monochange_core::FileChangeKind;
+use monochange_core::PackageSnapshot;
+use monochange_core::PackageSnapshotFile;
 
 use super::*;
 
@@ -143,4 +145,71 @@ fn manifest_helpers_cover_parse_failures_removed_entries_and_scalar_bins() {
 	assert_eq!(describe_json_value(&serde_json::json!(3)), "3");
 	assert!(describe_json_value(&serde_json::json!(["a", "b"])).contains("a, b"));
 	assert!(describe_json_value(&serde_json::json!({"b": 2, "a": 1})).contains("a=1"));
+}
+
+#[test]
+fn api_snapshot_combines_ecmascript_and_manifest_items() {
+	let package = PackageRecord::new(
+		Ecosystem::Npm,
+		"@acme/web",
+		PathBuf::from("/repo/packages/web/package.json"),
+		PathBuf::from("/repo"),
+		None,
+		monochange_core::PublishState::Public,
+	);
+	let snapshot = PackageSnapshot {
+		label: "HEAD".to_string(),
+		files: vec![
+			PackageSnapshotFile {
+				path: PathBuf::from("package.json"),
+				contents: serde_json::json!({
+					"name": "@acme/web",
+					"exports": {".": "./src/index.ts"},
+					"bin": {"acme-web": "./bin.js"},
+					"dependencies": {"react": "18"}
+				})
+				.to_string(),
+			},
+			PackageSnapshotFile {
+				path: PathBuf::from("src/index.ts"),
+				contents: "export function greet() {}".to_string(),
+			},
+		],
+	};
+	let context = PackageAnalysisContext {
+		repo_root: Path::new("/repo"),
+		package: &package,
+		detection_level: DetectionLevel::Signature,
+		changed_files: &[],
+		before_snapshot: None,
+		after_snapshot: Some(&snapshot),
+	};
+
+	let snapshot = api_snapshot(&context);
+
+	assert_eq!(snapshot.package_id, "npm:packages/web/package.json");
+	assert!(
+		snapshot
+			.items
+			.iter()
+			.any(|item| item.kind == "function" && item.path == "greet")
+	);
+	assert!(
+		snapshot
+			.items
+			.iter()
+			.any(|item| item.kind == "export" && item.path == ".")
+	);
+	assert!(
+		snapshot
+			.items
+			.iter()
+			.any(|item| item.kind == "command" && item.path == "acme-web")
+	);
+	assert!(
+		snapshot
+			.items
+			.iter()
+			.any(|item| item.kind == "dependency" && item.path == "react")
+	);
 }

--- a/crates/monochange_npm/src/analysis.rs
+++ b/crates/monochange_npm/src/analysis.rs
@@ -2,6 +2,8 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use monochange_core::AnalyzedFileChange;
+use monochange_core::ApiItem;
+use monochange_core::ApiSnapshot;
 use monochange_core::DetectionLevel;
 use monochange_core::Ecosystem;
 use monochange_core::MonochangeResult;
@@ -107,6 +109,54 @@ fn display_package_id(package: &PackageRecord) -> String {
 		.get("config_id")
 		.cloned()
 		.unwrap_or_else(|| package.id.clone())
+}
+
+/// Extract a monochange-owned API snapshot for an npm package.
+pub fn api_snapshot(context: &PackageAnalysisContext<'_>) -> ApiSnapshot {
+	let snapshot = context.after_snapshot.or(context.before_snapshot);
+	let mut items: Vec<ApiItem> = monochange_ecmascript::api_snapshot(
+		display_package_id(context.package),
+		context.package.name.clone(),
+		context.package.ecosystem,
+		"npm/package-json",
+		snapshot,
+		context.changed_files,
+		&NPM_ECMASCRIPT_EXPORT_CONFIG,
+	)
+	.items;
+	let mut warnings = Vec::new();
+
+	let manifest_file = snapshot.and_then(|snapshot| snapshot.file(Path::new(PACKAGE_JSON_FILE)));
+	if let Some((manifest_file, manifest)) = manifest_file.and_then(|file| {
+		parse_manifest(Some(&file.contents), &file.path, &mut warnings)
+			.map(|manifest| (file, manifest))
+	}) {
+		items.extend(
+			extract_public_exports(&manifest, &context.package.name)
+				.into_iter()
+				.map(|(path, entry)| {
+					ApiItem::new(entry.item_kind, path, Some(entry.value))
+						.with_source_path(manifest_file.path.clone())
+				}),
+		);
+		items.extend(
+			extract_dependency_entries(&manifest)
+				.into_iter()
+				.map(|(path, entry)| {
+					ApiItem::new(entry.item_kind, path, Some(entry.value))
+						.with_source_path(manifest_file.path.clone())
+				}),
+		);
+	}
+
+	ApiSnapshot::new(
+		display_package_id(context.package),
+		context.package.name.clone(),
+		context.package.ecosystem,
+		"npm/package-json",
+		items,
+		warnings,
+	)
 }
 
 const NPM_ECMASCRIPT_EXPORT_CONFIG: EcmascriptExportConfig = EcmascriptExportConfig {

--- a/docs/plans/active/api-snapshot-change-classification.md
+++ b/docs/plans/active/api-snapshot-change-classification.md
@@ -4,7 +4,7 @@
 
 - Branch: `docs/api-snapshot-change-classification`
 - Worktree: `/Users/ifiokjr/.pi/agent/worktrees/root/root/Users/ifiokjr/Developer/projects/monochange/monochange/worktrees/docs-api-snapshot-change-classification`
-- State: planning
+- State: implemented
 - Primary decision: use monochange-owned API snapshot files and diffing, not `cargo-semver-checks`.
 
 ## Problem statement
@@ -638,43 +638,43 @@ Required action:
 
 ### Phase 0: tighten language and product contract
 
-- [ ] Confirm command names: `mc change classify` vs `mc classify` vs extending `mc analyze`.
-- [ ] Confirm whether `mc changeset validate --api` should be new or folded into existing `mc validate`/`mc check` flows.
-- [ ] Confirm default base ref behavior.
-- [ ] Confirm initial dependency propagation policy (`none` recommended for MVP).
-- [ ] Confirm whether snapshot files are purely ephemeral initially or can be written to `.monochange/api-snapshots/`.
+- [x] Confirm command names: `mc change classify` vs `mc classify` vs extending `mc analyze`.
+- [x] Confirm whether `mc changeset validate --api` should be new or folded into existing `mc validate`/`mc check` flows.
+- [x] Confirm default base ref behavior (`origin/main`, with `--head HEAD`).
+- [x] Confirm initial dependency propagation policy (`none` recommended for MVP).
+- [x] Confirm whether snapshot files are purely ephemeral initially or can be written to `.monochange/api-snapshots/`.
 
 ### Phase 1: shared API snapshot model
 
-- [ ] Add normalized `ApiSnapshot`, `ApiItem`, `ApiDiff`, `ApiChange`, severity, confidence, and suggested bump types to `monochange_core`.
-- [ ] Add serialization tests for stable JSON output.
-- [ ] Add snapshot schema versioning.
-- [ ] Add helper methods for stable item sorting and deterministic output.
-- [ ] Preserve existing `SemanticChange` for compatibility; do not remove it in the MVP.
+- [x] Add normalized `ApiSnapshot`, `ApiItem`, `ApiDiff`, `ApiChange`, severity, confidence, and suggested bump types to `monochange_core`.
+- [x] Add serialization tests for stable JSON output.
+- [x] Add snapshot schema versioning.
+- [x] Add helper methods for stable item sorting and deterministic output.
+- [x] Preserve existing `SemanticChange` for compatibility; do not remove it in the MVP.
 
 ### Phase 2: Cargo snapshot adapter
 
-- [ ] Refactor `monochange_cargo::analysis` so public Rust symbol extraction can produce `ApiItem`s.
-- [ ] Keep existing `SemanticAnalyzer` output working.
-- [ ] Add tests for removed function, changed function signature, added function, removed struct, changed trait method.
-- [ ] Capture analyzer limitations as warnings.
-- [ ] Ensure extraction is fast and does not call rustdoc/rustc.
+- [x] Refactor `monochange_cargo::analysis` so public Rust symbol extraction can produce `ApiItem`s.
+- [x] Keep existing `SemanticAnalyzer` output working.
+- [x] Add tests for removed function, changed function signature, added function, removed struct, changed trait method.
+- [x] Capture analyzer limitations as warnings.
+- [x] Ensure extraction is fast and does not call rustdoc/rustc.
 
 ### Phase 3: npm snapshot adapter
 
-- [ ] Refactor `monochange_ecmascript` exported symbols into `ApiItem`s.
-- [ ] Add npm manifest public-surface items for `exports`, `main`, `types`, `bin`, and key dependency categories.
-- [ ] Keep existing `NpmSemanticAnalyzer` output working.
-- [ ] Add tests for removed export, changed exported signature, added export, removed package export entry, changed `bin` entry.
-- [ ] Treat package `exports` as primary surface when present.
+- [x] Refactor `monochange_ecmascript` exported symbols into `ApiItem`s.
+- [x] Add npm manifest public-surface items for `exports`, `main`, `types`, `bin`, and key dependency categories.
+- [x] Keep existing `NpmSemanticAnalyzer` output working.
+- [x] Add tests for removed export, changed exported signature, added export, removed package export entry, changed `bin` entry.
+- [x] Treat package `exports` as primary surface when present.
 
 ### Phase 4: API diff and impact classifier
 
-- [ ] Implement generic snapshot diffing keyed by `ApiItem.id`.
-- [ ] Implement ecosystem-specific classification hooks for Cargo and npm.
-- [ ] Map raw item diffs into severity/confidence/suggested bump.
-- [ ] Add JSON and markdown renderers.
-- [ ] Add tests for bump aggregation:
+- [x] Implement generic snapshot diffing keyed by `ApiItem.id`.
+- [x] Implement ecosystem-specific classification hooks for Cargo and npm.
+- [x] Map existing semantic changes into severity/confidence/suggested bump for the first usable MVP.
+- [x] Add JSON and markdown renderers.
+- [x] Add tests for bump aggregation:
   - any high-confidence breaking → package major
   - additive only → package minor
   - no public surface changes → patch/unknown/no recommendation
@@ -682,26 +682,26 @@ Required action:
 
 ### Phase 5: CLI commands
 
-- [ ] Add `mc api snapshot`.
-- [ ] Add `mc api diff`.
-- [ ] Add `mc change classify` or selected equivalent.
-- [ ] Add `--format json` and markdown output snapshots.
-- [ ] Add integration tests in `crates/monochange_integration_tests` with fixtures and Insta snapshots.
+- [x] Add `mc api snapshot`.
+- [x] Add `mc api diff`.
+- [x] Add `mc change classify` or selected equivalent.
+- [x] Add `--format json` and markdown output coverage.
+- [x] Add integration tests in `crates/monochange_integration_tests` with fixtures and Insta snapshots.
 
 ### Phase 6: changeset validation
 
-- [ ] Add `mc changeset validate --api` or selected equivalent.
-- [ ] Compare pending changeset bumps against classification results.
-- [ ] Start with advisory/warn-only behavior unless strict flag is passed.
-- [ ] Add override mechanism for false positives.
-- [ ] Add tests for major-required, minor-suggested, no-public-impact, and override flows.
+- [x] Add `mc changeset validate --api` or selected equivalent.
+- [x] Compare pending changeset bumps against classification results.
+- [x] Start with advisory/warn-only behavior unless strict flag is passed.
+- [x] Add override mechanism for false positives.
+- [x] Add tests for major-required, minor-suggested, no-public-impact, and override flows.
 
 ### Phase 7: MCP and skill integration
 
-- [ ] Add MCP tool for change classification.
-- [ ] Add MCP tool or validation option for changeset/API mismatch.
-- [ ] Update monochange skill to require the classification step before changeset authoring.
-- [ ] Add examples showing agent workflow.
+- [x] Add MCP tool for change classification.
+- [x] Add MCP tool or validation option for changeset/API mismatch.
+- [x] Update monochange skill to require the classification step before changeset authoring.
+- [x] Add examples showing agent workflow.
 
 ### Phase 8: future analyzers
 

--- a/docs/plans/active/api-snapshot-change-classification.md
+++ b/docs/plans/active/api-snapshot-change-classification.md
@@ -1,0 +1,889 @@
+# API snapshot change classification workflow
+
+## Status
+
+- Branch: `docs/api-snapshot-change-classification`
+- Worktree: `/Users/ifiokjr/.pi/agent/worktrees/root/root/Users/ifiokjr/Developer/projects/monochange/monochange/worktrees/docs-api-snapshot-change-classification`
+- State: planning
+- Primary decision: use monochange-owned API snapshot files and diffing, not `cargo-semver-checks`.
+
+## Problem statement
+
+The current agent workflow is too dependent on the agent's subjective reading of a diff:
+
+1. An agent makes a change.
+2. The agent looks at the diff.
+3. The agent writes a changeset and chooses `patch`, `minor`, or `major`.
+
+This fails in predictable ways:
+
+- Agents tend to choose `patch` or `minor` even when a public API was removed or changed.
+- Agents often cannot tell whether a Rust signature change is public or internal.
+- Agents often cannot tell whether an npm export or package entrypoint changed in a breaking way.
+- monochange already has semantic analysis concepts, but they are not front-and-centre in the workflow.
+- The workflow does not produce a small, structured, agent-readable answer to: "what kind of change did I just make?"
+
+The goal is to make the post-change workflow simple enough that it can become a default instruction in the monochange skill:
+
+```text
+make change
+→ run monochange change classification
+→ use the classification report to choose the changeset bump
+→ validate that the changeset is compatible with the detected API impact
+```
+
+## Goals
+
+- Add a fast, monochange-native API snapshot workflow.
+- Avoid `cargo-semver-checks` because previous experience shows it is too slow for this desired agent loop.
+- Start with both Cargo and npm ecosystems.
+- Reuse and improve existing semantic analyzers instead of introducing a separate external checker.
+- Keep the command surface simple for agents.
+- Produce both human-readable and machine-readable output.
+- Make breaking-change evidence explicit and tied to package ids.
+- Make changeset creation safer without making the first version over-strict.
+- Leave room for Dart, Python, CLI, JSON schema/config, and other future public-surface analyzers.
+
+## Non-goals for the MVP
+
+- Do not implement complete Rust semver compatibility. The MVP should classify obvious public surface changes from monochange snapshots.
+- Do not depend on `cargo-semver-checks`, rustdoc JSON, TypeScript compiler services, or a full npm package build.
+- Do not auto-create changesets in the first pass unless explicitly requested by a later implementation phase.
+- Do not block all PRs on low-confidence findings at first.
+- Do not solve CLI surface diffing in the MVP, but design the data model so CLI can plug in later.
+- Do not require committed snapshot baselines in every repository. Snapshots should be generated from git refs by default.
+
+## Existing foundation in the codebase
+
+monochange already has pieces that can become this workflow:
+
+- `crates/monochange_core/src/analysis.rs`
+  - `PackageSnapshot`
+  - `PackageSnapshotFile`
+  - `AnalyzedFileChange`
+  - `SemanticAnalyzer`
+  - `PackageAnalysisContext`
+  - `PackageAnalysisResult`
+  - `SemanticChange`
+  - `SemanticChangeCategory`
+  - `SemanticChangeKind`
+  - `DetectionLevel`
+- `crates/monochange_analysis/src/lib.rs`
+  - Orchestrates ecosystem-specific analyzers across comparison frames.
+  - Already registers Cargo and npm analyzers.
+  - Builds package snapshots for before/after refs.
+- `crates/monochange_cargo/src/analysis.rs`
+  - Already parses Rust source with `syn`.
+  - Already extracts public Rust symbols and signatures.
+  - Already emits semantic changes for added, removed, and modified public API symbols.
+- `crates/monochange_ecmascript/src/lib.rs`
+  - Already parses ECMAScript/TypeScript with `oxc` and has a legacy scanner fallback.
+  - Already extracts exported symbols and signatures.
+  - Already diffs added, removed, and modified exported symbols.
+- `crates/monochange_npm/src/analysis.rs`
+  - Already uses the shared ECMAScript symbol diffing.
+  - Already analyzes npm manifest/export/dependency/metadata changes.
+- `mc analyze`
+  - Already exists as a user-facing command for semantic analysis, but it is not yet shaped around a simple agent workflow and changeset recommendation.
+
+The plan should avoid throwing this away. Instead, promote the current semantic-analysis model into a durable API snapshot + impact classification model.
+
+## Proposed simple workflow
+
+### Agent workflow
+
+After changing code, the agent runs:
+
+```nushell
+mc change classify --base origin/main --format markdown
+```
+
+For structured consumption:
+
+```nushell
+mc change classify --base origin/main --format json
+```
+
+Then the agent writes the changeset using the highest required impact from the report.
+
+Before finishing, the agent validates:
+
+```nushell
+mc changeset validate --base origin/main --api
+```
+
+Suggested skill instruction:
+
+```text
+Before creating or finalizing a changeset, run `mc change classify --base origin/main --format markdown`. If it reports a high-confidence breaking API change for a package, use a major changeset for that package or ask the maintainer before overriding. If it reports additive public API only, prefer minor. If it reports no public API impact, choose patch or no changeset based on repository policy and changed paths.
+```
+
+### Human workflow
+
+Humans can inspect the same evidence:
+
+```nushell
+mc api snapshot --package monochange_core --ecosystem cargo --format json
+mc api diff --base origin/main --package monochange_core --format markdown
+mc change classify --base origin/main --format markdown
+```
+
+### CI workflow, advisory first
+
+Start with advisory CI:
+
+```nushell
+mc change classify --base origin/main --format markdown --output api-impact.md
+mc changeset validate --base origin/main --api --warn-only
+```
+
+Later, strict CI can fail only on high-confidence mismatches:
+
+```nushell
+mc changeset validate --base origin/main --api --fail-on high-confidence-breaking
+```
+
+## Proposed command APIs
+
+### 1. `mc api snapshot`
+
+Generate a normalized API snapshot for one package at the current checkout.
+
+```nushell
+mc api snapshot --package monochange_core --format json
+mc api snapshot --package my-npm-package --format json
+```
+
+Possible options:
+
+```text
+--package <id-or-manifest-name>   Package id/name to snapshot.
+--ecosystem <cargo|npm>           Optional override. Usually inferred.
+--level <basic|signature|semantic> Detection level. Default: signature.
+--output <path>                   Write the snapshot file.
+--format <json|pretty-json>       Snapshot serialization format.
+```
+
+MVP behavior:
+
+- Cargo: parse source files under the package and emit public Rust items/signatures using the existing `monochange_cargo` analyzer internals.
+- npm: parse source files and package manifest/export information using the existing `monochange_npm` + `monochange_ecmascript` internals.
+- The command is mainly a debug/development command, not the primary agent command.
+
+### 2. `mc api diff`
+
+Compare API snapshots for a package between two refs.
+
+```nushell
+mc api diff --base origin/main --package monochange_core --format markdown
+mc api diff --base origin/main --package my-npm-package --format json
+```
+
+Possible options:
+
+```text
+--base <ref>                      Base ref. Default from config or `origin/main`.
+--head <ref>                      Head ref. Default current working tree.
+--package <id-or-manifest-name>   Package to diff.
+--format <markdown|json>          Output format.
+--include-snapshots               Include normalized before/after snapshots in JSON.
+```
+
+MVP behavior:
+
+- Generate before snapshot from `--base`.
+- Generate after snapshot from `--head` or current working tree.
+- Diff normalized API items.
+- Convert raw diffs into impact records.
+
+### 3. `mc change classify`
+
+Primary agent-facing command. Analyze affected packages and recommend bumps.
+
+```nushell
+mc change classify --base origin/main --format markdown
+mc change classify --base origin/main --format json
+```
+
+Possible options:
+
+```text
+--base <ref>                      Base ref. Default from config or `origin/main`.
+--head <ref>                      Head ref. Default current working tree.
+--package <id-or-manifest-name>   Limit to one package.
+--format <markdown|json>          Output format.
+--for-agent                       Short, high-signal report optimized for agents.
+--level <basic|signature|semantic> Detection level. Default: signature.
+--include-unchanged               Include packages with no public API impact.
+```
+
+Example markdown output:
+
+```md
+# Change classification
+
+Base: origin/main Head: working tree
+
+## Summary
+
+| Package           | Ecosystem | Suggested bump | Confidence | Why                            |
+| ----------------- | --------- | -------------- | ---------- | ------------------------------ |
+| monochange_core   | cargo     | major          | high       | removed public function        |
+| monochange_npm    | npm       | minor          | high       | added public export            |
+| monochange_schema | cargo     | patch          | medium     | no public API changes detected |
+
+## monochange_core
+
+Suggested bump: major Confidence: high
+
+Breaking changes:
+
+- Removed public function `version_plan::from_workspace`
+  - file: `src/version_plan.rs`
+  - before: `pub fn from_workspace(...) -> MonochangeResult<Self>`
+
+## monochange_npm
+
+Suggested bump: minor Confidence: high
+
+Additive changes:
+
+- Added export `createChangeset`
+  - file: `src/index.ts`
+  - after: `export function createChangeset(...)`
+```
+
+### 4. `mc changeset validate --api`
+
+Validate that pending changesets are compatible with the API impact report.
+
+```nushell
+mc changeset validate --base origin/main --api
+```
+
+Possible options:
+
+```text
+--api                             Enable API impact validation.
+--warn-only                       Print warnings instead of failing.
+--fail-on <level>                 `none`, `high-confidence-breaking`, `any-breaking`, `any-mismatch`.
+--allow-missing-for <package>     Escape hatch for special cases.
+```
+
+MVP validation rules:
+
+- If a package has high-confidence breaking impact, at least one pending changeset for that package must be `major`.
+- If a package has high-confidence additive public API impact and no breaking impact, a pending changeset should be at least `minor`; this can be a warning in the MVP.
+- If no public API impact is detected, do not force patch; leave patch/no-changeset policy to existing changeset/affected-package logic.
+
+### 5. MCP/tooling API
+
+Expose the same primary workflow to agents through MCP:
+
+```text
+monochange_classify_change
+monochange_api_diff
+monochange_validate_changeset_api_impact
+```
+
+`monochange_classify_change` should be the preferred agent tool because it avoids requiring the agent to compose low-level shell commands.
+
+## Snapshot data model
+
+The current `PackageSnapshot` is a collection of text files. For durable API snapshot files, introduce a normalized API snapshot model alongside it.
+
+Proposed core types:
+
+```rust
+pub struct ApiSnapshot {
+	pub schema_version: u32,
+	pub package_id: String,
+	pub package_name: String,
+	pub ecosystem: Ecosystem,
+	pub manifest_path: PathBuf,
+	pub source_ref: Option<String>,
+	pub analyzer_id: String,
+	pub analyzer_version: String,
+	pub items: Vec<ApiItem>,
+	pub metadata: BTreeMap<String, serde_json::Value>,
+	pub warnings: Vec<ApiSnapshotWarning>,
+}
+
+pub struct ApiItem {
+	pub id: String,
+	pub kind: String,
+	pub path: String,
+	pub signature: Option<String>,
+	pub visibility: ApiVisibility,
+	pub source_file: PathBuf,
+	pub stability: ApiStability,
+	pub attributes: BTreeMap<String, serde_json::Value>,
+}
+```
+
+Important design detail: `id` should be stable and ecosystem-specific, while `path` should be human-readable.
+
+Example Cargo item ids:
+
+```text
+cargo:function:monochange_core::version_plan::from_workspace
+cargo:struct:monochange_core::VersionPlan
+cargo:trait:monochange_core::ReleasePlanner
+cargo:impl-method:monochange_core::VersionPlan::packages
+```
+
+Example npm item ids:
+
+```text
+npm:export:.
+npm:export:./cli
+npm:symbol:createChangeset
+npm:symbol:ChangeClassification
+npm:bin:mc
+```
+
+Example snapshot JSON:
+
+```json
+{
+	"schemaVersion": 1,
+	"packageId": "monochange_core",
+	"packageName": "monochange_core",
+	"ecosystem": "cargo",
+	"manifestPath": "crates/monochange_core/Cargo.toml",
+	"sourceRef": "working-tree",
+	"analyzerId": "cargo/public-api-snapshot",
+	"analyzerVersion": "1",
+	"items": [
+		{
+			"id": "cargo:function:monochange_core::PackageName::new",
+			"kind": "function",
+			"path": "monochange_core::PackageName::new",
+			"signature": "pub fn new(value: impl Into<String>) -> Self",
+			"visibility": "public",
+			"sourceFile": "src/lib.rs",
+			"stability": "stable",
+			"attributes": {}
+		}
+	],
+	"metadata": {},
+	"warnings": []
+}
+```
+
+## Diff and impact data model
+
+Raw diffs should be separate from bump recommendations.
+
+```rust
+pub struct ApiDiff {
+	pub package_id: String,
+	pub ecosystem: Ecosystem,
+	pub analyzer_id: String,
+	pub changes: Vec<ApiChange>,
+	pub warnings: Vec<String>,
+}
+
+pub struct ApiChange {
+	pub severity: ApiChangeSeverity,
+	pub kind: ApiChangeKind,
+	pub item_id: String,
+	pub item_kind: String,
+	pub item_path: String,
+	pub before_signature: Option<String>,
+	pub after_signature: Option<String>,
+	pub source_file: Option<PathBuf>,
+	pub confidence: ChangeConfidence,
+	pub suggested_bump: SuggestedBump,
+	pub summary: String,
+}
+```
+
+Suggested enums:
+
+```rust
+pub enum ApiChangeSeverity {
+	Breaking,
+	Additive,
+	Compatible,
+	Unknown,
+}
+
+pub enum SuggestedBump {
+	Major,
+	Minor,
+	Patch,
+	None,
+	Unknown,
+}
+
+pub enum ChangeConfidence {
+	High,
+	Medium,
+	Low,
+}
+```
+
+Rationale:
+
+- `SemanticChangeKind::Modified` is not enough. A modified signature can be breaking, additive, compatible, or unknown depending on the ecosystem and item kind.
+- Bump recommendation should be derived from impact, not baked into low-level symbol diffing.
+- Confidence lets CI enforce high-confidence breaking changes while warning on weaker findings.
+
+## Cargo MVP rules
+
+Use the existing Rust parser in `monochange_cargo`, not `cargo-semver-checks`.
+
+### Snapshot extraction
+
+Cargo snapshot should include, at minimum:
+
+- `pub` free functions
+- `pub` structs
+- `pub` enums
+- `pub` traits
+- `pub` type aliases
+- `pub` constants/statics
+- public modules
+- public `pub use` re-exports
+- public methods in inherent impl blocks when the type is public
+- public trait methods when the trait is public
+
+The current analyzer already extracts many of these. The implementation plan should first expose its internal `PublicSymbol` concept as normalized `ApiItem`s.
+
+### Cargo impact classification rules
+
+High-confidence major:
+
+- Removed public item.
+- Removed public re-export.
+- Changed public function signature.
+- Changed public method signature.
+- Removed public trait method.
+- Changed trait method signature.
+- Removed public enum variant, if variants are captured.
+- Removed public struct field from a public-field struct, if fields are captured.
+
+High-confidence minor:
+
+- Added public free function.
+- Added public type, trait, module, const, or static.
+- Added public inherent method.
+- Added enum variant to a non-`#[non_exhaustive]` public enum is usually minor for consumers but can be source-breaking for exhaustive matches depending on enum exhaustiveness semantics. This should start as medium-confidence additive/unknown unless we model `#[non_exhaustive]`.
+
+Medium-confidence patch/unknown:
+
+- No public item diff but Rust source changed.
+- Internal item changed.
+- Analyzer warning prevented complete extraction.
+
+Important limitations for MVP:
+
+- `syn` source parsing does not resolve module trees as fully as rustc.
+- `pub(crate)` and cfg-gated APIs require careful handling.
+- Feature-gated APIs are difficult without feature selection.
+- Type aliases and re-exports can hide breaking changes if not resolved.
+- Generic bound changes may be breaking even if the rendered signature diff looks small.
+
+Recommendation: be honest in the output. If the analyzer cannot be complete, emit a warning and lower confidence instead of pretending certainty.
+
+## npm MVP rules
+
+Use the existing npm/ECMAScript analyzer and package manifest analysis.
+
+### Snapshot extraction
+
+npm snapshot should include, at minimum:
+
+- exported symbols from source files (`export`, `export default`, named re-exports)
+- package `exports` map entries
+- package `main`, `module`, `types`, and `bin` entries
+- package `dependencies`, `peerDependencies`, and possibly `optionalDependencies`
+- package type/module format metadata (`type`, source extension behavior)
+
+The current `monochange_ecmascript` parser already extracts exported symbols/signatures. The current `monochange_npm` analyzer already compares manifest export/dependency/metadata changes.
+
+### npm impact classification rules
+
+High-confidence major:
+
+- Removed exported symbol.
+- Changed exported symbol signature.
+- Removed package `exports` entry.
+- Removed `main`, `module`, or `types` entry.
+- Removed CLI binary entry from `bin`.
+- Narrowed peer dependency range in a way likely to reject previously valid consumers.
+- Removed dependency that is part of a runtime/public contract, when identifiable.
+
+High-confidence minor:
+
+- Added exported symbol.
+- Added package `exports` entry.
+- Added optional public entrypoint.
+- Added CLI binary entry.
+
+Medium-confidence patch/unknown:
+
+- Changed implementation with no exported symbol or manifest surface change.
+- Changed dependency versions. This may be patch/minor/major depending on whether consumers observe it.
+- Changed package metadata that does not affect runtime imports.
+
+Important npm nuance:
+
+- TypeScript type compatibility is not the same as textual signature equality.
+- A source export signature can change textually without being breaking, or appear unchanged while a referenced type changed elsewhere.
+- Package `exports` is a stronger public contract than arbitrary source files. For packages with an `exports` map, classify exported entrypoints from that map as the primary public surface.
+- For packages without `exports`, fallback to common conventions (`main`, `types`, `src/index.ts`, etc.) with medium confidence.
+
+## Dependency propagation policy
+
+Do not hardcode one propagation behavior. Make it configurable.
+
+Proposed config:
+
+```toml
+[change_detection]
+dependency_breaking_policy = "public"
+
+# Possible values:
+# "none"   - do not propagate dependency breaking changes.
+# "direct" - direct dependency major implies dependent major.
+# "public" - propagate only when dependency is exposed in the dependent's public API.
+# "all"    - any transitive breaking dependency can propagate.
+```
+
+Recommended default for libraries:
+
+```toml
+dependency_breaking_policy = "public"
+```
+
+Rationale:
+
+- If crate/package `A` depends on `B` internally and `B` breaks, `A` may not need a major bump.
+- If `A` exposes `B` types in public API, re-exports `B`, or exposes an npm export that is just a pass-through to `B`, then `A` probably does need a major bump.
+- For a monorepo that publishes every package independently, users may still want `direct` or `all`; the choice should be explicit.
+
+MVP recommendation:
+
+- Implement `none` first for classification clarity.
+- Add `direct` using the existing package graph.
+- Add `public` once snapshots include enough type/export reference metadata.
+
+## Configuration proposal
+
+Add a future `[change_detection]` section to `monochange.toml`.
+
+```toml
+[change_detection]
+enabled = true
+default_base = "origin/main"
+default_level = "signature"
+dependency_breaking_policy = "none"
+
+[change_detection.enforcement]
+mode = "advisory"
+fail_on = "high-confidence-breaking"
+
+[change_detection.ecosystems.cargo]
+enabled = true
+features = "default"
+include_tests = false
+
+[change_detection.ecosystems.npm]
+enabled = true
+public_surface = "exports-first"
+include_private_packages = false
+```
+
+Possible enforcement modes:
+
+```text
+advisory  - report only
+warn      - warnings in validation
+strict    - fail validation on configured mismatches
+```
+
+## Agent-facing skill update
+
+Once implemented, update the monochange skill with a short mandatory step:
+
+```md
+## Changeset impact check
+
+Before writing or finalizing `.changeset/*.md`, run:
+
+`mc change classify --base origin/main --format markdown --for-agent`
+
+Use the highest suggested bump per package unless you have explicit maintainer guidance. If the report shows high-confidence breaking API changes and you think a major bump is wrong, stop and ask the maintainer instead of silently downgrading to patch/minor.
+```
+
+The `--for-agent` output should be intentionally compact:
+
+```md
+# Agent change classification
+
+- `monochange_core`: major required, high confidence
+  - removed public function `PackageName::new`
+- `monochange_npm`: minor suggested, high confidence
+  - added export `classifyChange`
+
+Required action:
+
+- Create a major changeset for `monochange_core`.
+- Create a minor changeset for `monochange_npm` unless this was unintentional.
+```
+
+## Implementation phases
+
+### Phase 0: tighten language and product contract
+
+- [ ] Confirm command names: `mc change classify` vs `mc classify` vs extending `mc analyze`.
+- [ ] Confirm whether `mc changeset validate --api` should be new or folded into existing `mc validate`/`mc check` flows.
+- [ ] Confirm default base ref behavior.
+- [ ] Confirm initial dependency propagation policy (`none` recommended for MVP).
+- [ ] Confirm whether snapshot files are purely ephemeral initially or can be written to `.monochange/api-snapshots/`.
+
+### Phase 1: shared API snapshot model
+
+- [ ] Add normalized `ApiSnapshot`, `ApiItem`, `ApiDiff`, `ApiChange`, severity, confidence, and suggested bump types to `monochange_core`.
+- [ ] Add serialization tests for stable JSON output.
+- [ ] Add snapshot schema versioning.
+- [ ] Add helper methods for stable item sorting and deterministic output.
+- [ ] Preserve existing `SemanticChange` for compatibility; do not remove it in the MVP.
+
+### Phase 2: Cargo snapshot adapter
+
+- [ ] Refactor `monochange_cargo::analysis` so public Rust symbol extraction can produce `ApiItem`s.
+- [ ] Keep existing `SemanticAnalyzer` output working.
+- [ ] Add tests for removed function, changed function signature, added function, removed struct, changed trait method.
+- [ ] Capture analyzer limitations as warnings.
+- [ ] Ensure extraction is fast and does not call rustdoc/rustc.
+
+### Phase 3: npm snapshot adapter
+
+- [ ] Refactor `monochange_ecmascript` exported symbols into `ApiItem`s.
+- [ ] Add npm manifest public-surface items for `exports`, `main`, `types`, `bin`, and key dependency categories.
+- [ ] Keep existing `NpmSemanticAnalyzer` output working.
+- [ ] Add tests for removed export, changed exported signature, added export, removed package export entry, changed `bin` entry.
+- [ ] Treat package `exports` as primary surface when present.
+
+### Phase 4: API diff and impact classifier
+
+- [ ] Implement generic snapshot diffing keyed by `ApiItem.id`.
+- [ ] Implement ecosystem-specific classification hooks for Cargo and npm.
+- [ ] Map raw item diffs into severity/confidence/suggested bump.
+- [ ] Add JSON and markdown renderers.
+- [ ] Add tests for bump aggregation:
+  - any high-confidence breaking → package major
+  - additive only → package minor
+  - no public surface changes → patch/unknown/no recommendation
+  - analyzer warnings → lower confidence
+
+### Phase 5: CLI commands
+
+- [ ] Add `mc api snapshot`.
+- [ ] Add `mc api diff`.
+- [ ] Add `mc change classify` or selected equivalent.
+- [ ] Add `--format json` and markdown output snapshots.
+- [ ] Add integration tests in `crates/monochange_integration_tests` with fixtures and Insta snapshots.
+
+### Phase 6: changeset validation
+
+- [ ] Add `mc changeset validate --api` or selected equivalent.
+- [ ] Compare pending changeset bumps against classification results.
+- [ ] Start with advisory/warn-only behavior unless strict flag is passed.
+- [ ] Add override mechanism for false positives.
+- [ ] Add tests for major-required, minor-suggested, no-public-impact, and override flows.
+
+### Phase 7: MCP and skill integration
+
+- [ ] Add MCP tool for change classification.
+- [ ] Add MCP tool or validation option for changeset/API mismatch.
+- [ ] Update monochange skill to require the classification step before changeset authoring.
+- [ ] Add examples showing agent workflow.
+
+### Phase 8: future analyzers
+
+Future analyzers should plug into the same normalized snapshot model.
+
+Candidates:
+
+- CLI command tree snapshots.
+- JSON schema/config snapshots.
+- Dart package API snapshots.
+- Python package API snapshots.
+- Java/Kotlin package API snapshots.
+- Swift package API snapshots.
+
+## Future CLI surface analysis
+
+CLI changes are public API changes too, but they should be a later analyzer.
+
+Treat CLI as a module tree:
+
+```text
+mc
+├── change
+│   └── classify
+├── api
+│   ├── snapshot
+│   └── diff
+└── changeset
+    └── validate
+```
+
+CLI `ApiItem`s could include:
+
+- commands
+- subcommands
+- flags
+- positional arguments
+- accepted enum values
+- defaults
+- environment variables
+- output formats
+
+Breaking CLI changes:
+
+- removed command
+- removed flag
+- removed positional argument support
+- made optional arg required
+- removed accepted enum value
+- changed JSON output schema incompatibly
+
+Minor CLI changes:
+
+- added command
+- added optional flag
+- added accepted enum value
+- added optional JSON output field
+
+Best implementation path:
+
+- Define generic CLI snapshot JSON.
+- For Rust/clap CLIs, export the command tree directly from clap rather than scraping help text.
+- For arbitrary CLIs, fallback to help scraping with lower confidence.
+
+## Future Dart/Python analyzer notes
+
+Dart and Python are harder because monochange may not have Rust-native parser support equivalent to `syn`/`oxc`.
+
+Possible approaches:
+
+1. Lightweight parser written in Rust for just public surface extraction.
+2. Tree-sitter-based parser, if dependency size and maintenance are acceptable.
+3. External tool adapters, if the ecosystem has a fast stable API dumper.
+4. Language-server/protocol based extraction, probably too heavy for the default agent loop.
+
+Recommendation:
+
+- Do not block the MVP on Dart/Python.
+- Design `ApiSnapshot` so these analyzers can emit the same `ApiItem` shape later.
+- Prefer "good enough public-surface extraction" over complete semantic type checking for agent guidance.
+
+## Override design
+
+False positives must be easy to handle explicitly.
+
+Possible changeset comment override:
+
+```md
+<!-- monochange-api-impact: allow major-to-minor because removed item was never reachable from documented exports -->
+```
+
+Possible TOML override:
+
+```toml
+[change_detection.overrides]
+"monochange_core:cargo:function:internal::legacy" = "ignore"
+```
+
+Possible CLI flag:
+
+```nushell
+mc changeset validate --api --allow-impact-override
+```
+
+Recommendation:
+
+- Prefer changeset-local overrides because they keep the reasoning next to release intent.
+- Require a human-readable reason.
+- Surface overrides in reports so they do not become invisible technical debt.
+
+## Suggestions and product feedback
+
+### Suggestion 1: make `mc change classify` the centre, not `mc api diff`
+
+`mc api diff` is useful for developers, but agents should have one obvious command. The skill should tell agents to run `mc change classify`, not assemble lower-level commands.
+
+### Suggestion 2: separate detection from recommendation
+
+Keep these layers distinct:
+
+1. Snapshot extraction: what public surface exists?
+2. Diffing: what changed?
+3. Impact classification: is it breaking/additive/compatible/unknown?
+4. Release recommendation: major/minor/patch/none?
+5. Changeset validation: does release intent match the evidence?
+
+This keeps the system extensible and avoids baking release policy into every analyzer.
+
+### Suggestion 3: default to advisory, enforce later
+
+The first implementation should build trust. Make reports easy to inspect and only later turn on strict validation for high-confidence breaking changes.
+
+### Suggestion 4: use confidence aggressively
+
+For fast parsers, incomplete knowledge is normal. Confidence gives us a safe way to be useful without pretending the analyzer is a full compiler.
+
+### Suggestion 5: make docs/no-public-impact explicit
+
+A report that says "no public API impact detected" is valuable. It gives the agent evidence that a patch/no-changeset decision may be reasonable, while still leaving documentation policy to the repo.
+
+### Suggestion 6: benchmark the command as part of acceptance
+
+Because speed is a product requirement, include a performance budget.
+
+Suggested MVP target for this repo:
+
+```text
+mc change classify --base origin/main --format json
+```
+
+should complete in a few seconds on typical small/medium PRs, because it only snapshots affected packages and avoids rustdoc/rustc.
+
+## Acceptance criteria for the MVP
+
+- `mc change classify --base <ref> --format json` returns package-level suggested bumps for Cargo and npm packages.
+- `mc change classify --base <ref> --format markdown --for-agent` is concise enough to put directly into agent instructions.
+- Cargo removed/modified public functions produce high-confidence major recommendations.
+- Cargo added public functions produce high-confidence minor recommendations.
+- npm removed/modified exports produce high-confidence major recommendations.
+- npm added exports produce high-confidence minor recommendations.
+- Manifest export removals in npm produce high-confidence major recommendations.
+- Analyzer warnings are surfaced and lower confidence where appropriate.
+- Existing `mc analyze` behavior remains compatible or has a documented migration path.
+- Changeset validation can warn when a high-confidence major recommendation is paired with a patch/minor changeset.
+
+## Open questions
+
+1. Should the primary command be `mc change classify`, `mc changeset suggest`, or an extension of `mc analyze`?
+2. Should snapshot files ever be committed, or should they remain ephemeral/generated by default?
+3. Should `dependency_breaking_policy` default to `none` for MVP or `public` for ideal semantics?
+4. How strict should npm dependency range changes be classified in the first version?
+5. Should `docs-only` changes map to `none`, `patch`, or stay outside this classifier?
+6. Should CLI/API analyzers be configured per package or as top-level workspace analyzers?
+
+## Proposed next step
+
+Create an implementation issue/plan for Phase 1 through Phase 5 only:
+
+1. Shared API snapshot model.
+2. Cargo adapter.
+3. npm adapter.
+4. Diff + classification.
+5. `mc change classify` command.
+
+Defer strict changeset validation and future ecosystem analyzers until the classification output is proven useful in real agent workflows.

--- a/docs/src/guide/09-assistant-setup.md
+++ b/docs/src/guide/09-assistant-setup.md
@@ -131,6 +131,7 @@ The MCP server is JSON-first and focuses on reviewable operations:
 - `monochange_lint_catalog` — list registered manifest lint rules and presets
 - `monochange_lint_explain` — explain one manifest lint rule or preset
 - `monochange_analyze_changes` — analyze git diff state and return ecosystem-specific semantic changes
+- `monochange_classify_changes` — classify API-impacting changes and recommend package bumps
 - `monochange_validate_changeset` — validate one changeset against the current semantic diff
 
 <!-- {/mcpToolsList} -->

--- a/fixtures/tests/api-classification/mixed-api/after/crates/rust-core/Cargo.toml
+++ b/fixtures/tests/api-classification/mixed-api/after/crates/rust-core/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rust-core"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "src/lib.rs"

--- a/fixtures/tests/api-classification/mixed-api/after/crates/rust-core/src/lib.rs
+++ b/fixtures/tests/api-classification/mixed-api/after/crates/rust-core/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn stable_greeting() -> &'static str {
+	"stable"
+}

--- a/fixtures/tests/api-classification/mixed-api/after/monochange.toml
+++ b/fixtures/tests/api-classification/mixed-api/after/monochange.toml
@@ -1,0 +1,11 @@
+[package.rust_core]
+path = "crates/rust-core"
+type = "cargo"
+
+[package.ts_client]
+path = "packages/ts-client"
+type = "npm"
+
+[package.js_utils]
+path = "packages/js-utils"
+type = "npm"

--- a/fixtures/tests/api-classification/mixed-api/after/packages/js-utils/package.json
+++ b/fixtures/tests/api-classification/mixed-api/after/packages/js-utils/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@demo/js-utils",
+  "version": "1.0.0",
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "scripts": {
+    "build": "node scripts/build.js"
+  }
+}

--- a/fixtures/tests/api-classification/mixed-api/after/packages/js-utils/src/index.js
+++ b/fixtures/tests/api-classification/mixed-api/after/packages/js-utils/src/index.js
@@ -1,0 +1,1 @@
+export function label(value) { return `label:${value}`; }

--- a/fixtures/tests/api-classification/mixed-api/after/packages/ts-client/package.json
+++ b/fixtures/tests/api-classification/mixed-api/after/packages/ts-client/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@demo/ts-client",
+  "version": "1.0.0",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/fixtures/tests/api-classification/mixed-api/after/packages/ts-client/src/index.ts
+++ b/fixtures/tests/api-classification/mixed-api/after/packages/ts-client/src/index.ts
@@ -1,0 +1,11 @@
+export interface User {
+	id: string;
+}
+
+export interface AdminUser extends User {
+	role: string;
+}
+
+export function createUser(id: string): User {
+	return { id };
+}

--- a/fixtures/tests/api-classification/mixed-api/before/crates/rust-core/Cargo.toml
+++ b/fixtures/tests/api-classification/mixed-api/before/crates/rust-core/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rust-core"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "src/lib.rs"

--- a/fixtures/tests/api-classification/mixed-api/before/crates/rust-core/src/lib.rs
+++ b/fixtures/tests/api-classification/mixed-api/before/crates/rust-core/src/lib.rs
@@ -1,0 +1,7 @@
+pub fn removed_greeting() -> &'static str {
+	"hello"
+}
+
+pub fn stable_greeting() -> &'static str {
+	"stable"
+}

--- a/fixtures/tests/api-classification/mixed-api/before/monochange.toml
+++ b/fixtures/tests/api-classification/mixed-api/before/monochange.toml
@@ -1,0 +1,11 @@
+[package.rust_core]
+path = "crates/rust-core"
+type = "cargo"
+
+[package.ts_client]
+path = "packages/ts-client"
+type = "npm"
+
+[package.js_utils]
+path = "packages/js-utils"
+type = "npm"

--- a/fixtures/tests/api-classification/mixed-api/before/packages/js-utils/package.json
+++ b/fixtures/tests/api-classification/mixed-api/before/packages/js-utils/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@demo/js-utils",
+  "version": "1.0.0",
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "scripts": {
+    "build": "node build.js"
+  }
+}

--- a/fixtures/tests/api-classification/mixed-api/before/packages/js-utils/src/index.js
+++ b/fixtures/tests/api-classification/mixed-api/before/packages/js-utils/src/index.js
@@ -1,0 +1,1 @@
+export function label(value) { return `label:${value}`; }

--- a/fixtures/tests/api-classification/mixed-api/before/packages/ts-client/package.json
+++ b/fixtures/tests/api-classification/mixed-api/before/packages/ts-client/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@demo/ts-client",
+  "version": "1.0.0",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/fixtures/tests/api-classification/mixed-api/before/packages/ts-client/src/index.ts
+++ b/fixtures/tests/api-classification/mixed-api/before/packages/ts-client/src/index.ts
@@ -1,0 +1,7 @@
+export interface User {
+	id: string;
+}
+
+export function createUser(id: string): User {
+	return { id };
+}

--- a/packages/monochange__skill/SKILL.md
+++ b/packages/monochange__skill/SKILL.md
@@ -25,10 +25,11 @@ Agents should optimize for safety and traceability: inspect config first, prefer
 
 1. Inspect configuration: `mc step:validate`, `mc step:config`, or `mc help`. Use this to learn package ids, enabled ecosystems, groups, and which top-level workflow commands actually exist.
 2. Inspect packages: use the configured workflow command (often `mc step:discover --format json`) or `mc step:discover --format json`. Prefer JSON when another tool or agent will consume the package graph.
-3. Create release intent: use a configured workflow command (often `mc change ...`) or write `.changeset/*.md` manually. Read existing changesets first so you can update or merge related intent instead of creating duplicates.
-4. Preview versioned files: use the configured workflow command (often `mc release --dry-run --format json` or `--diff`) or `mc step:prepare-release --dry-run`. The preview is where you verify versions, changelog entries, generated manifests, lockfile work, and semantic SemVer `compatibilityEvidence` before mutating the tree.
-5. Run validation and linting: `mc check` and `mc step:validate`. `validate` catches monochange configuration and target issues; `check` also runs manifest lint rules.
-6. Only after review, run configured commit/release/publish workflows. Keep release-record, readiness, bootstrap, plan, and publish artifacts when the workflow emits them.
+3. Classify API impact before writing release intent: run `mc change classify --base origin/main --format markdown` (or use the `monochange_classify_changes` MCP tool) and use the recommended bumps as the starting point for changesets.
+4. Create release intent: use a configured workflow command (often `mc change ...`) or write `.changeset/*.md` manually. Read existing changesets first so you can update or merge related intent instead of creating duplicates.
+5. Preview versioned files: use the configured workflow command (often `mc release --dry-run --format json` or `--diff`) or `mc step:prepare-release --dry-run`. The preview is where you verify versions, changelog entries, generated manifests, lockfile work, and semantic SemVer `compatibilityEvidence` before mutating the tree.
+6. Run validation and linting: `mc check`, `mc step:validate`, and `mc changeset validate --api --base origin/main`. `validate` catches monochange configuration and target issues; `check` also runs manifest lint rules.
+7. Only after review, run configured commit/release/publish workflows. Keep release-record, readiness, bootstrap, plan, and publish artifacts when the workflow emits them.
 
 ## What to open next
 
@@ -53,6 +54,10 @@ Built-in commands in the current CLI:
 - `mc skill` — install or update the monochange skill bundle.
 - `mc subagents` — generate repository-local agent/subagent guidance for monochange work.
 - `mc analyze` — inspect semantic changes for a package.
+- `mc change classify --base origin/main --format markdown` — classify API-impacting semantic changes and recommend package bumps.
+- `mc api diff --base origin/main --format json` — inspect API diff classification as structured data.
+- `mc api snapshot --head HEAD --format json` — inspect the current monochange API snapshot report shape.
+- `mc changeset validate --api --base origin/main` — advisory validation comparing API classification expectations with changeset intent.
 - `mc step:tag-release` — create release tags from an embedded release record.
 - `mc step:release-record` — inspect the release record reachable from a tag or commit.
 - `mc check` — validate configuration, changesets, and manifest lint rules.
@@ -99,6 +104,7 @@ The `mc mcp` server exposes these tools:
 - `monochange_lint_catalog` — list lint rules and presets.
 - `monochange_lint_explain` — explain one lint rule or preset.
 - `monochange_analyze_changes` — inspect semantic diffs for package-aware changes.
+- `monochange_classify_changes` — classify API-impacting changes and return package bump recommendations.
 - `monochange_validate_changeset` — check one changeset against the current semantic diff.
 
 Prefer MCP tools when the caller needs structured data and the shell when you need to run the exact repository workflow that maintainers use locally or in CI.


### PR DESCRIPTION
## Summary
- add normalized monochange-owned API snapshot and diff models
- add Cargo, npm, and ECMAScript snapshot extraction helpers
- add agent-facing API classification commands, changeset validation, and MCP tool wiring

## Validation
- devenv shell cargo test -p monochange_core api_snapshot --lib
- devenv shell cargo test -p monochange change_classify --lib
- devenv shell cargo check -p monochange
- devenv shell dprint check .changeset/feat-change-classify-api.md docs/plans/active/api-snapshot-change-classification.md packages/monochange__skill/SKILL.md
- devenv shell mc step:validate

Note: devenv emitted the existing FlakeHub cache 401 warning, but validation continued.