### PR TITLE
fix: improve check lint diagnostics

### DIFF
--- a/.changeset/fix-check-lint-diagnostics.md
+++ b/.changeset/fix-check-lint-diagnostics.md
@@ -1,0 +1,9 @@
+---
+"monochange": patch
+"monochange_lint": patch
+"monochange_npm": patch
+---
+
+# Improve `mc check` lint diagnostics
+
+Show lint rule IDs first in check output, add `--verbose` details, derive line and column locations from lint spans, avoid running regular package lint rules against unmanaged packages, and keep npm workspace-protocol checks opt-in by default.

--- a/crates/monochange/src/__tests__/lint_tests.rs
+++ b/crates/monochange/src/__tests__/lint_tests.rs
@@ -253,6 +253,15 @@ fn run_check_command_applies_fixes_without_progress_reporter() {
 }
 
 #[test]
+fn run_lint_step_reports_successful_check_output() {
+	let clean_workspace = clean_lint_workspace();
+	let (output, has_errors) = run_lint_step(clean_workspace.path(), false)
+		.unwrap_or_else(|error| panic!("expected lint step to succeed: {error}"));
+	assert!(!has_errors);
+	assert!(output.contains("no issues found"));
+}
+
+#[test]
 fn run_lint_step_supports_fix_write_failures() {
 	let tempdir = readonly_fix_workspace();
 	let cargo_toml = tempdir.path().join("crates/example/Cargo.toml");

--- a/crates/monochange/src/__tests__/lint_tests.rs
+++ b/crates/monochange/src/__tests__/lint_tests.rs
@@ -20,7 +20,7 @@ fn readonly_fix_workspace() -> tempfile::TempDir {
 #[test]
 fn test_format_check_report_empty() {
 	let report = LintReport::new();
-	let output = format_check_report(&report, false);
+	let output = format_check_report(&report, false, false);
 	assert!(output.contains("no issues found"));
 }
 
@@ -40,10 +40,12 @@ fn test_format_check_report_with_issues() {
 		LintSeverity::Warning,
 	));
 
-	let output = format_check_report(&report, false);
+	let output = format_check_report(&report, false, true);
 	assert!(output.contains("1 errors, 1 warnings"));
+	assert!(output.contains("✗ **test/rule** at 1:1"));
 	assert!(output.contains("Test error"));
 	assert!(output.contains("Test warning"));
+	assert!(output.contains("severity: error"));
 }
 
 #[test]
@@ -94,12 +96,26 @@ fn render_lint_explanation_supports_json() {
 #[test]
 fn run_check_command_supports_text_json_and_fix_error_paths() {
 	let clean_workspace = clean_lint_workspace();
-	let json =
-		run_check_command(clean_workspace.path(), false, &[], &[], OutputFormat::Json).unwrap();
+	let json = run_check_command(
+		clean_workspace.path(),
+		false,
+		&[],
+		&[],
+		OutputFormat::Json,
+		false,
+	)
+	.unwrap();
 	assert!(json.contains("\"error_count\": 0"));
 
-	let text =
-		run_check_command(clean_workspace.path(), false, &[], &[], OutputFormat::Text).unwrap();
+	let text = run_check_command(
+		clean_workspace.path(),
+		false,
+		&[],
+		&[],
+		OutputFormat::Text,
+		false,
+	)
+	.unwrap();
 	assert!(text.contains("workspace validation passed"));
 
 	let tempdir = readonly_fix_workspace();
@@ -107,7 +123,7 @@ fn run_check_command_supports_text_json_and_fix_error_paths() {
 	let mut permissions = fs::metadata(&cargo_toml).unwrap().permissions();
 	permissions.set_readonly(true);
 	fs::set_permissions(&cargo_toml, permissions).unwrap();
-	let error = run_check_command(tempdir.path(), true, &[], &[], OutputFormat::Text)
+	let error = run_check_command(tempdir.path(), true, &[], &[], OutputFormat::Text, false)
 		.expect_err("expected fix write to fail for readonly manifest");
 	assert!(error.to_string().contains("Failed to write fixed content"));
 }
@@ -191,19 +207,19 @@ fn run_check_command_reports_all_validation_errors_before_failing() {
 		repository = \"https://github.com/monochange/monochange\"\n",
 	)
 	.unwrap_or_else(|error| panic!("expected warning manifest to be written: {error}"));
-	let warning_text = run_check_command(warning_root, false, &[], &[], OutputFormat::Text)
+	let warning_text = run_check_command(warning_root, false, &[], &[], OutputFormat::Text, false)
 		.unwrap_or_else(|error| panic!("expected warning-only check to pass: {error}"));
 	assert!(warning_text.contains("warning:"));
 	assert!(warning_text.contains("matches no files"));
 
-	let text_error = run_check_command(root, false, &[], &[], OutputFormat::Text)
+	let text_error = run_check_command(root, false, &[], &[], OutputFormat::Text, false)
 		.expect_err("expected text check to fail validation");
 	let text_message = text_error.to_string();
 	assert!(text_message.contains("workspace validation failed"));
 	assert!(text_message.contains("unknown package or group `missing`"));
 	assert!(text_message.contains("missing.toml"));
 
-	let json_error = run_check_command(root, false, &[], &[], OutputFormat::Json)
+	let json_error = run_check_command(root, false, &[], &[], OutputFormat::Json, false)
 		.expect_err("expected json check to fail validation");
 	let json_message = json_error.to_string();
 	assert!(json_message.contains("check failed"));
@@ -213,7 +229,7 @@ fn run_check_command_reports_all_validation_errors_before_failing() {
 #[test]
 fn run_check_command_applies_fixes_and_reports_them() {
 	let tempdir = readonly_fix_workspace();
-	let output = run_check_command(tempdir.path(), true, &[], &[], OutputFormat::Text)
+	let output = run_check_command(tempdir.path(), true, &[], &[], OutputFormat::Text, false)
 		.unwrap_or_else(|error| panic!("expected fixable lint workspace to succeed: {error}"));
 	assert!(output.contains("Fixed all auto-fixable issues."));
 
@@ -225,7 +241,7 @@ fn run_check_command_applies_fixes_and_reports_them() {
 #[test]
 fn run_check_command_applies_fixes_without_progress_reporter() {
 	let tempdir = readonly_fix_workspace();
-	let result = run_check_command(tempdir.path(), true, &[], &[], OutputFormat::Json);
+	let result = run_check_command(tempdir.path(), true, &[], &[], OutputFormat::Json, false);
 	assert!(
 		result.is_ok(),
 		"expected fixable lint workspace to succeed without a reporter: {result:?}"

--- a/crates/monochange/src/__tests__/snapshots/monochange__mcp__tests__lint_catalog_lists_rules_and_presets@lint_catalog_lists_rules_and_presets.snap
+++ b/crates/monochange/src/__tests__/snapshots/monochange__mcp__tests__lint_catalog_lists_rules_and_presets@lint_catalog_lists_rules_and_presets.snap
@@ -89,7 +89,7 @@ expression: content_text(&result)
         "npm/root-no-prod-deps": "error",
         "npm/sorted-dependencies": "warning",
         "npm/unlisted-package-private": "warning",
-        "npm/workspace-protocol": "error"
+        "npm/workspace-protocol": "off"
       }
     },
     {

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -537,6 +537,13 @@ pub(crate) fn build_check_subcommand() -> Command {
 				.value_parser(["text", "json", "markdown", "md"]),
 		)
 		.arg(
+			Arg::new("verbose")
+				.long("verbose")
+				.short('v')
+				.help("Show extra lint diagnostic details")
+				.action(ArgAction::SetTrue),
+		)
+		.arg(
 			Arg::new("sha")
 				.long("sha")
 				.help("Output only the commit SHA of the discovered release record")

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -1091,6 +1091,7 @@ where
 				return Ok(String::new());
 			}
 			let fix = check_matches.get_flag("fix");
+			let verbose = check_matches.get_flag("verbose");
 			let format = check_matches
 				.get_one::<String>("format")
 				.map_or(Ok(OutputFormat::Markdown), |value| {
@@ -1104,7 +1105,7 @@ where
 				.get_many::<String>("only")
 				.map(|values| values.map(String::as_str).map(String::from).collect())
 				.unwrap_or_default();
-			lint::run_check_command(root, fix, &ecosystems, &only_rules, format)
+			lint::run_check_command(root, fix, &ecosystems, &only_rules, format, verbose)
 		}
 		Some(("lint", lint_matches)) => {
 			if quiet {

--- a/crates/monochange/src/lint.rs
+++ b/crates/monochange/src/lint.rs
@@ -113,6 +113,7 @@ pub(crate) fn run_check_command(
 	ecosystems: &[String],
 	only_rules: &[String],
 	format: OutputFormat,
+	verbose: bool,
 ) -> MonochangeResult<String> {
 	let configuration = load_workspace_configuration(root)?;
 	let mut output = String::new();
@@ -209,7 +210,7 @@ pub(crate) fn run_check_command(
 				.unwrap_or_else(|error| panic!("serializing lint reports should succeed: {error}")))
 		}
 		OutputFormat::Text | OutputFormat::Markdown => {
-			output.push_str(&format_check_report(&report, fix));
+			output.push_str(&format_check_report(&report, fix, verbose));
 			if validation_has_errors || lint_has_errors {
 				Err(MonochangeError::Config(format!("check failed:\n{output}")))
 			} else {
@@ -244,7 +245,7 @@ pub(crate) fn run_lint_step(root: &Path, fix: bool) -> MonochangeResult<(String,
 		}
 	}
 
-	Ok((format_check_report(&report, fix), has_errors))
+	Ok((format_check_report(&report, fix, false), has_errors))
 }
 
 #[allow(clippy::unnecessary_wraps)]
@@ -492,7 +493,7 @@ impl LintRuleRunner for {struct_name} {{
 	))
 }
 
-fn format_check_report(report: &LintReport, fixed: bool) -> String {
+fn format_check_report(report: &LintReport, fixed: bool, verbose: bool) -> String {
 	if report.results.is_empty() && report.warnings.is_empty() {
 		return "lint: no issues found\n".to_string();
 	}
@@ -534,13 +535,23 @@ fn format_check_report(report: &LintReport, fixed: bool) -> String {
 			};
 			let _ = writeln!(
 				output,
-				"  {} {} at {}:{}{}",
+				"  {} **{}** at {}:{}{}",
 				severity_icon,
-				result.message,
+				result.rule_id,
 				result.location.line,
 				result.location.column,
 				fix_indicator
 			);
+			let _ = writeln!(output, "     {}", result.message);
+			if verbose {
+				let _ = writeln!(output, "     severity: {}", result.severity);
+				if let Some((start, end)) = result.location.span {
+					let _ = writeln!(output, "     span: {start}..{end}");
+				}
+				if let Some(fix) = result.fix.as_ref() {
+					let _ = writeln!(output, "     fix: {}", fix.description);
+				}
+			}
 		}
 		output.push('\n');
 	}

--- a/crates/monochange_integration_tests/tests/check_lint_output.rs
+++ b/crates/monochange_integration_tests/tests/check_lint_output.rs
@@ -1,0 +1,65 @@
+//! Integration tests for `mc check` lint output.
+
+use std::ffi::OsString;
+use std::path::Path;
+
+use monochange_test_helpers::copy_directory;
+use tempfile::TempDir;
+use tempfile::tempdir;
+
+fn setup_fixture(base: &str, name: &str) -> TempDir {
+	let source =
+		Path::new(env!("CARGO_MANIFEST_DIR")).join(format!("../../fixtures/tests/{base}/{name}"));
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_directory(&source, tempdir.path());
+	tempdir
+}
+
+fn run_check(root: &Path, args: &[&str]) -> String {
+	let mut cli_args = vec![OsString::from("mc"), OsString::from("check")];
+	cli_args.extend(args.iter().map(OsString::from));
+	let runtime = tokio::runtime::Builder::new_current_thread()
+		.enable_all()
+		.build()
+		.unwrap_or_else(|error| panic!("tokio runtime: {error}"));
+	let result = runtime.block_on(monochange::run_with_args_in_dir("mc", cli_args, root));
+	let output = match result {
+		Ok(output) => output,
+		Err(error) => error.to_string(),
+	};
+	normalize_workspace_paths(root, output)
+}
+
+fn normalize_workspace_paths(root: &Path, output: String) -> String {
+	let canonical =
+		std::fs::canonicalize(root).unwrap_or_else(|error| panic!("canonicalize root: {error}"));
+	let canonical_path = canonical.to_string_lossy();
+	let root_path = root.to_string_lossy();
+	output
+		.replace(canonical_path.as_ref(), "[workspace]")
+		.replace(root_path.as_ref(), "[workspace]")
+}
+
+#[test]
+fn check_lint_output_shows_rule_first_and_verbose_details() {
+	let fixture = setup_fixture("check-output", "npm-workspace");
+	let output = run_check(fixture.path(), &["--format", "text", "--verbose"]);
+
+	insta::assert_snapshot!(output);
+}
+
+#[test]
+fn check_fix_preserves_package_json_when_multiple_full_file_fixes_exist() {
+	let fixture = setup_fixture("check-output", "npm-workspace");
+	let output = run_check(fixture.path(), &["--format", "text", "--fix"]);
+	let package_json_path = fixture.path().join("packages/app/package.json");
+	let contents = std::fs::read_to_string(&package_json_path)
+		.unwrap_or_else(|error| panic!("read package.json: {error}"));
+	let parsed: serde_json::Value = serde_json::from_str(&contents).unwrap_or_else(|error| {
+		panic!("package.json should remain valid JSON: {error}\n{contents}")
+	});
+
+	insta::assert_snapshot!(normalize_workspace_paths(fixture.path(), output));
+	insta::assert_snapshot!(contents);
+	assert_eq!(parsed["name"], "app");
+}

--- a/crates/monochange_integration_tests/tests/check_lint_output.rs
+++ b/crates/monochange_integration_tests/tests/check_lint_output.rs
@@ -49,6 +49,52 @@ fn check_lint_output_shows_rule_first_and_verbose_details() {
 }
 
 #[test]
+fn check_sorted_fix_preserves_package_json_field_order() {
+	let fixture = setup_fixture("check-output", "npm-workspace");
+	std::fs::write(
+		fixture.path().join("monochange.toml"),
+		r#"[lints]
+use = ["npm/recommended"]
+
+[package.app]
+path = "packages/app"
+type = "npm"
+version = "0.0.0"
+
+[package.shared]
+path = "packages/shared"
+type = "npm"
+version = "0.0.0"
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write monochange.toml: {error}"));
+	let output = run_check(fixture.path(), &["--format", "text", "--fix"]);
+	let package_json_path = fixture.path().join("packages/app/package.json");
+	let contents = std::fs::read_to_string(&package_json_path)
+		.unwrap_or_else(|error| panic!("read package.json: {error}"));
+	let parsed: serde_json::Value = serde_json::from_str(&contents).unwrap_or_else(|error| {
+		panic!("package.json should remain valid JSON: {error}\n{contents}")
+	});
+
+	insta::assert_snapshot!(normalize_workspace_paths(fixture.path(), output));
+	insta::assert_snapshot!(contents);
+	assert_eq!(parsed["name"], "app");
+	assert!(contents.contains(
+		r#"    "name": "app",
+    "version": "0.0.0",
+    "type": "module",
+    "description": "Application package",
+    "dependencies""#
+	));
+	assert!(contents.contains(
+		r#"    "dependencies": {
+        "shared": "^0.0.0",
+        "zeta": "1.0.0"
+    },"#
+	));
+}
+
+#[test]
 fn check_fix_preserves_package_json_when_multiple_full_file_fixes_exist() {
 	let fixture = setup_fixture("check-output", "npm-workspace");
 	let output = run_check(fixture.path(), &["--format", "text", "--fix"]);
@@ -62,4 +108,11 @@ fn check_fix_preserves_package_json_when_multiple_full_file_fixes_exist() {
 	insta::assert_snapshot!(normalize_workspace_paths(fixture.path(), output));
 	insta::assert_snapshot!(contents);
 	assert_eq!(parsed["name"], "app");
+	assert!(contents.contains(
+		r#"    "name": "app",
+    "version": "0.0.0",
+    "type": "module",
+    "description": "Application package",
+    "dependencies""#
+	));
 }

--- a/crates/monochange_integration_tests/tests/snapshots/check_lint_output__check_fix_preserves_package_json_when_multiple_full_file_fixes_exist-2.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/check_lint_output__check_fix_preserves_package_json_when_multiple_full_file_fixes_exist-2.snap
@@ -1,0 +1,17 @@
+---
+source: crates/monochange_integration_tests/tests/check_lint_output.rs
+expression: contents
+---
+{
+  "dependencies": {
+    "shared": "workspace:*",
+    "zeta": "1.0.0"
+  },
+  "description": "Application package",
+  "devDependencies": {
+    "vitest": "1.0.0"
+  },
+  "name": "app",
+  "type": "module",
+  "version": "0.0.0"
+}

--- a/crates/monochange_integration_tests/tests/snapshots/check_lint_output__check_fix_preserves_package_json_when_multiple_full_file_fixes_exist.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/check_lint_output__check_fix_preserves_package_json_when_multiple_full_file_fixes_exist.snap
@@ -1,0 +1,27 @@
+---
+source: crates/monochange_integration_tests/tests/check_lint_output.rs
+expression: "normalize_workspace_paths(fixture.path(), output)"
+---
+config error: check failed:
+workspace validation passed for [workspace]
+lint: 6 errors, 1 warnings
+
+[workspace]/packages/app/package.json:
+  ✗ **npm/workspace-protocol** at 8:10 [fixable]
+     internal dependency `shared` should use the workspace: protocol (found `^0.0.0`)
+  ⚠ **npm/sorted-dependencies** at 6:6 [fixable]
+     dependencies in `dependencies` are not sorted alphabetically
+  ✗ **npm/required-package-fields** at 1:1
+     missing required package.json field `repository`
+  ✗ **npm/required-package-fields** at 1:1
+     missing required package.json field `license`
+
+[workspace]/packages/shared/package.json:
+  ✗ **npm/required-package-fields** at 1:1
+     missing required package.json field `description`
+  ✗ **npm/required-package-fields** at 1:1
+     missing required package.json field `repository`
+  ✗ **npm/required-package-fields** at 1:1
+     missing required package.json field `license`
+
+Fixed all auto-fixable issues.

--- a/crates/monochange_integration_tests/tests/snapshots/check_lint_output__check_lint_output_shows_rule_first_and_verbose_details.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/check_lint_output__check_lint_output_shows_rule_first_and_verbose_details.snap
@@ -1,0 +1,38 @@
+---
+source: crates/monochange_integration_tests/tests/check_lint_output.rs
+expression: output
+---
+config error: check failed:
+workspace validation passed for [workspace]
+lint: 6 errors, 1 warnings
+
+[workspace]/packages/app/package.json:
+  ✗ **npm/workspace-protocol** at 8:10 [fixable]
+     internal dependency `shared` should use the workspace: protocol (found `^0.0.0`)
+     severity: error
+     span: 165..171
+     fix: rewrite dependency to workspace:*
+  ⚠ **npm/sorted-dependencies** at 6:6 [fixable]
+     dependencies in `dependencies` are not sorted alphabetically
+     severity: warning
+     span: 114..126
+     fix: sort dependency section alphabetically
+  ✗ **npm/required-package-fields** at 1:1
+     missing required package.json field `repository`
+     severity: error
+  ✗ **npm/required-package-fields** at 1:1
+     missing required package.json field `license`
+     severity: error
+
+[workspace]/packages/shared/package.json:
+  ✗ **npm/required-package-fields** at 1:1
+     missing required package.json field `description`
+     severity: error
+  ✗ **npm/required-package-fields** at 1:1
+     missing required package.json field `repository`
+     severity: error
+  ✗ **npm/required-package-fields** at 1:1
+     missing required package.json field `license`
+     severity: error
+
+2 issue(s) can be auto-fixed. Run with --fix to apply.

--- a/crates/monochange_integration_tests/tests/snapshots/check_lint_output__check_sorted_fix_preserves_package_json_field_order-2.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/check_lint_output__check_sorted_fix_preserves_package_json_field_order-2.snap
@@ -8,8 +8,8 @@ expression: contents
     "type": "module",
     "description": "Application package",
     "dependencies": {
-        "zeta": "1.0.0",
-        "shared": "workspace:*"
+        "shared": "^0.0.0",
+        "zeta": "1.0.0"
     },
     "devDependencies": {
         "vitest": "1.0.0"

--- a/crates/monochange_integration_tests/tests/snapshots/check_lint_output__check_sorted_fix_preserves_package_json_field_order.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/check_lint_output__check_sorted_fix_preserves_package_json_field_order.snap
@@ -1,0 +1,25 @@
+---
+source: crates/monochange_integration_tests/tests/check_lint_output.rs
+expression: "normalize_workspace_paths(fixture.path(), output)"
+---
+config error: check failed:
+workspace validation passed for [workspace]
+lint: 5 errors, 1 warnings
+
+[workspace]/packages/app/package.json:
+  ⚠ **npm/sorted-dependencies** at 6:6 [fixable]
+     dependencies in `dependencies` are not sorted alphabetically
+  ✗ **npm/required-package-fields** at 1:1
+     missing required package.json field `repository`
+  ✗ **npm/required-package-fields** at 1:1
+     missing required package.json field `license`
+
+[workspace]/packages/shared/package.json:
+  ✗ **npm/required-package-fields** at 1:1
+     missing required package.json field `description`
+  ✗ **npm/required-package-fields** at 1:1
+     missing required package.json field `repository`
+  ✗ **npm/required-package-fields** at 1:1
+     missing required package.json field `license`
+
+Fixed all auto-fixable issues.

--- a/crates/monochange_lint/src/__tests__/lib_tests.rs
+++ b/crates/monochange_lint/src/__tests__/lib_tests.rs
@@ -441,6 +441,26 @@ fn apply_fixes_skips_missing_files() {
 }
 
 #[test]
+fn apply_fixes_skips_overlapping_full_file_edits() {
+	let contents = "{\n  \"name\": \"example\",\n  \"version\": \"0.0.0\"\n}\n";
+	let first = LintFix::single(
+		"sort manifest",
+		(0, contents.len()),
+		"{\n  \"version\": \"0.0.0\",\n  \"name\": \"example\"\n}\n",
+	);
+	let second = LintFix::single(
+		"rewrite dependency",
+		(0, contents.len()),
+		"{\n  \"name\": \"example\",\n  \"version\": \"0.0.0\",\n  \"dependencies\": {}\n}\n",
+	);
+
+	let fixed = apply_fixes_to_content(contents, &[first, second]);
+	assert!(fixed.ends_with("}\n"));
+	assert_eq!(fixed.matches("\"name\"").count(), 1);
+	assert_eq!(fixed.matches("}\n").count(), 1);
+}
+
+#[test]
 fn merge_config_and_selector_helpers_cover_edge_cases() {
 	assert!(merge_config(None, None).is_none());
 	assert!(!lint_path_pattern_matches(

--- a/crates/monochange_lint/src/__tests__/lib_tests.rs
+++ b/crates/monochange_lint/src/__tests__/lib_tests.rs
@@ -38,10 +38,10 @@ impl LintRuleRunner for ExampleRule {
 	}
 
 	fn run(&self, ctx: &LintContext<'_>, config: &LintRuleConfig) -> Vec<LintResult> {
-		if ctx.contents.contains("bad") {
+		if let Some(start) = ctx.contents.find("bad") {
 			vec![LintResult::new(
 				self.rule.id.clone(),
-				LintLocation::new(ctx.manifest_path, 1, 1),
+				LintLocation::new(ctx.manifest_path, 1, 1).with_span(start, start + 3),
 				"found bad",
 				config.severity(),
 			)]
@@ -83,7 +83,7 @@ impl LintSuite for ExampleSuite {
 		Ok(vec![LintTarget::new(
 			workspace_root.to_path_buf(),
 			workspace_root.join("example.txt"),
-			"this is bad",
+			"first line\nthis is bad",
 			LintTargetMetadata {
 				ecosystem: "example".to_string(),
 				relative_path: PathBuf::from("example.txt"),
@@ -189,6 +189,35 @@ fn linter_runs_preset_backed_rules() {
 	let report = linter.lint_workspace(root.path(), &configuration, &NoopLintProgressReporter);
 	assert_eq!(report.error_count, 1);
 	assert_eq!(report.results.len(), 1);
+	let result = report
+		.results
+		.first()
+		.unwrap_or_else(|| panic!("expected one lint result"));
+	assert_eq!(result.location.line, 2);
+	assert_eq!(result.location.column, 9);
+}
+
+#[test]
+fn linter_skips_regular_rules_for_unmanaged_package_targets() {
+	let root = tempfile::tempdir().unwrap();
+	let configuration = sample_workspace_configuration(root.path());
+	let settings = WorkspaceLintSettings {
+		presets: vec!["example/recommended".to_string()],
+		..WorkspaceLintSettings::default()
+	};
+	let linter = Linter::new(vec![Box::new(ExampleSuite)], settings);
+	let mut target = ExampleSuite
+		.collect_targets(root.path(), &configuration)
+		.unwrap_or_else(|error| panic!("expected example suite targets: {error}"))
+		.into_iter()
+		.next()
+		.unwrap_or_else(|| panic!("expected a target"));
+	target.metadata.package_name = Some("unmanaged".to_string());
+	target.metadata.managed = false;
+
+	let report = linter.lint_target(&target);
+	assert_eq!(report.error_count, 0);
+	assert!(report.results.is_empty());
 }
 
 #[test]

--- a/crates/monochange_lint/src/__tests__/lib_tests.rs
+++ b/crates/monochange_lint/src/__tests__/lib_tests.rs
@@ -421,6 +421,17 @@ fn linter_warns_when_suite_target_collection_fails() {
 }
 
 #[test]
+fn fill_location_from_span_keeps_invalid_span_locations_at_default() {
+	let mut out_of_bounds = LintLocation::new("manifest.json", 1, 1).with_span(99, 100);
+	fill_location_from_span(&mut out_of_bounds, "short");
+	assert_eq!((out_of_bounds.line, out_of_bounds.column), (1, 1));
+
+	let mut non_boundary = LintLocation::new("manifest.json", 1, 1).with_span(1, 2);
+	fill_location_from_span(&mut non_boundary, "éclair");
+	assert_eq!((non_boundary.line, non_boundary.column), (1, 1));
+}
+
+#[test]
 fn apply_fixes_skips_missing_files() {
 	let root = tempfile::tempdir().unwrap();
 	let linter = Linter::new(

--- a/crates/monochange_lint/src/lib.rs
+++ b/crates/monochange_lint/src/lib.rs
@@ -300,6 +300,12 @@ impl Linter {
 			if !self.selection.allows_rule(rule_id) {
 				continue;
 			}
+			if target.metadata.package_name.is_some()
+				&& !target.metadata.managed
+				&& !rule_id.ends_with("/unlisted-package-private")
+			{
+				continue;
+			}
 
 			let config = self
 				.resolve_rule_config(target, rule_id)
@@ -320,6 +326,7 @@ impl Linter {
 			let mut rule_results = Vec::new();
 			for mut result in rule.run(&ctx, &config) {
 				result.severity = config.severity();
+				fill_location_from_span(&mut result.location, &target.contents);
 				rule_results.push(result);
 			}
 			reporter.file_rule_finished(&target.manifest_path, rule_id, rule_results.len());
@@ -416,6 +423,37 @@ impl Linter {
 
 		true
 	}
+}
+
+fn fill_location_from_span(location: &mut monochange_core::lint::LintLocation, contents: &str) {
+	if location.line != 1 || location.column != 1 {
+		return;
+	}
+	let Some((start, _)) = location.span else {
+		return;
+	};
+	let Some((line, column)) = line_column_for_offset(contents, start) else {
+		return;
+	};
+	location.line = line;
+	location.column = column;
+}
+
+fn line_column_for_offset(contents: &str, offset: usize) -> Option<(usize, usize)> {
+	if offset > contents.len() || !contents.is_char_boundary(offset) {
+		return None;
+	}
+	let mut line = 1usize;
+	let mut column = 1usize;
+	for character in contents[..offset].chars() {
+		if character == '\n' {
+			line += 1;
+			column = 1;
+		} else {
+			column += 1;
+		}
+	}
+	Some((line, column))
 }
 
 fn lint_path_pattern_matches(pattern: &str, relative_path: &str, kind: &str) -> bool {

--- a/crates/monochange_lint/src/lib.rs
+++ b/crates/monochange_lint/src/lib.rs
@@ -17,6 +17,7 @@ use ignore::gitignore::Gitignore;
 use ignore::gitignore::GitignoreBuilder;
 use monochange_core::WorkspaceConfiguration;
 use monochange_core::lint::LintContext;
+use monochange_core::lint::LintEdit;
 use monochange_core::lint::LintFix;
 use monochange_core::lint::LintPreset;
 use monochange_core::lint::LintProgressReporter;
@@ -578,16 +579,34 @@ fn selector_matches(selector: &LintSelector, target: &LintTarget) -> bool {
 }
 
 fn apply_fixes_to_content(contents: &str, fixes: &[LintFix]) -> String {
+	let edits = non_overlapping_edits(contents, fixes);
+	let mut result = contents.to_string();
+	for edit in edits {
+		result.replace_range(edit.span.0..edit.span.1, &edit.replacement);
+	}
+	result
+}
+
+fn non_overlapping_edits<'a>(contents: &str, fixes: &'a [LintFix]) -> Vec<&'a LintEdit> {
 	let mut edits: Vec<_> = fixes.iter().flat_map(|fix| fix.edits.iter()).collect();
 	edits.sort_by_key(|edit| std::cmp::Reverse(edit.span.0));
 
-	let mut result = contents.to_string();
+	let mut next_allowed_start = contents.len();
+	let mut retained = Vec::new();
 	for edit in edits {
-		if edit.span.0 < result.len() && edit.span.1 <= result.len() {
-			result.replace_range(edit.span.0..edit.span.1, &edit.replacement);
+		let (start, end) = edit.span;
+		if start > end
+			|| end > contents.len()
+			|| end > next_allowed_start
+			|| !contents.is_char_boundary(start)
+			|| !contents.is_char_boundary(end)
+		{
+			continue;
 		}
+		next_allowed_start = start;
+		retained.push(edit);
 	}
-	result
+	retained
 }
 
 #[cfg(test)]

--- a/crates/monochange_npm/src/lints/__tests__/mod_tests.rs
+++ b/crates/monochange_npm/src/lints/__tests__/mod_tests.rs
@@ -85,6 +85,7 @@ fn workspace_protocol_rule_reports_internal_ranges() {
 	};
 	let fallback_location = location_for_needle(&ctx, "missing-dependency");
 	assert_eq!((fallback_location.line, fallback_location.column), (1, 1));
+	assert_eq!(line_column_for_offset("éclair", 1), None);
 
 	let results = WorkspaceProtocolRule::new().run(&ctx, &config());
 	assert_eq!(results.len(), 1);

--- a/crates/monochange_npm/src/lints/__tests__/mod_tests.rs
+++ b/crates/monochange_npm/src/lints/__tests__/mod_tests.rs
@@ -118,6 +118,57 @@ fn sorted_dependencies_rule_reports_unsorted_sections() {
 }
 
 #[test]
+fn sorted_dependencies_fix_preserves_top_level_package_json_order() {
+	let contents = r#"{
+  "name": "example",
+  "version": "0.0.0",
+  "type": "module",
+  "description": "keep top-level order",
+  "dependencies": {
+    "zeta": "1.0.0",
+    "alpha": "1.0.0"
+  },
+  "devDependencies": {
+    "vitest": "1.0.0"
+  }
+}"#;
+	let target = npm_target(contents, true, false);
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let results = SortedDependenciesRule::new().run(&ctx, &config());
+	let fix = results
+		.first()
+		.and_then(|result| result.fix.as_ref())
+		.unwrap_or_else(|| panic!("expected sorted dependency fix"));
+	let edit = fix
+		.edits
+		.first()
+		.unwrap_or_else(|| panic!("expected sorted dependency edit"));
+	assert_ne!(edit.span, (0, contents.len()));
+
+	let mut fixed = contents.to_string();
+	fixed.replace_range(edit.span.0..edit.span.1, &edit.replacement);
+	assert!(fixed.contains(
+		r#"  "dependencies": {
+    "alpha": "1.0.0",
+    "zeta": "1.0.0"
+  },"#
+	));
+	assert!(fixed.contains(
+		r#"  "name": "example",
+  "version": "0.0.0",
+  "type": "module",
+  "description": "keep top-level order",
+  "dependencies""#
+	));
+}
+
+#[test]
 fn required_package_fields_rule_supports_custom_fields() {
 	let target = npm_target(r#"{"name":"example","description":"ok"}"#, true, false);
 	let ctx = LintContext {

--- a/crates/monochange_npm/src/lints/__tests__/mod_tests.rs
+++ b/crates/monochange_npm/src/lints/__tests__/mod_tests.rs
@@ -48,6 +48,20 @@ fn presets_are_exposed() {
 		presets.get(1).map(|preset| preset.id.as_str()),
 		Some("npm/strict")
 	);
+	let recommended = presets
+		.first()
+		.unwrap_or_else(|| panic!("expected npm recommended preset"));
+	assert_eq!(
+		recommended.rules.get("npm/workspace-protocol"),
+		Some(&LintRuleConfig::Severity(LintSeverity::Off))
+	);
+	let strict = presets
+		.get(1)
+		.unwrap_or_else(|| panic!("expected npm strict preset"));
+	assert_eq!(
+		strict.rules.get("npm/workspace-protocol"),
+		Some(&LintRuleConfig::Severity(LintSeverity::Error))
+	);
 }
 
 #[test]

--- a/crates/monochange_npm/src/lints/__tests__/mod_tests.rs
+++ b/crates/monochange_npm/src/lints/__tests__/mod_tests.rs
@@ -169,6 +169,30 @@ fn sorted_dependencies_fix_preserves_top_level_package_json_order() {
 }
 
 #[test]
+fn dependency_fix_helpers_cover_minimal_and_missing_sections() {
+	let contents = r#"{"dependencies":{"zeta":"1","alpha":"2"}}"#;
+	assert_eq!(
+		dependency_value_span(contents, "dependencies", "zeta", "1"),
+		Some((24, 27))
+	);
+	assert_eq!(dependency_section_object_span(contents, "missing"), None);
+	assert_eq!(
+		dependency_value_span(contents, "dependencies", "missing", "1"),
+		None
+	);
+
+	let empty = Map::new();
+	let replacement =
+		sorted_dependency_section_text(r#"{"dependencies":{}}"#, "dependencies", &empty, &[])
+			.unwrap_or_else(|| panic!("expected replacement for empty dependency section"));
+	assert_eq!(replacement, "{\n}");
+	assert_eq!(
+		dependency_section_object_span(r#"{"dependencies":{"alpha":"1""#, "dependencies"),
+		None
+	);
+}
+
+#[test]
 fn required_package_fields_rule_supports_custom_fields() {
 	let target = npm_target(r#"{"name":"example","description":"ok"}"#, true, false);
 	let ctx = LintContext {

--- a/crates/monochange_npm/src/lints/__tests__/mod_tests.rs
+++ b/crates/monochange_npm/src/lints/__tests__/mod_tests.rs
@@ -83,6 +83,9 @@ fn workspace_protocol_rule_reports_internal_ranges() {
 		metadata: &target.metadata,
 		parsed: target.parsed.as_ref(),
 	};
+	let fallback_location = location_for_needle(&ctx, "missing-dependency");
+	assert_eq!((fallback_location.line, fallback_location.column), (1, 1));
+
 	let results = WorkspaceProtocolRule::new().run(&ctx, &config());
 	assert_eq!(results.len(), 1);
 	assert!(

--- a/crates/monochange_npm/src/lints/mod.rs
+++ b/crates/monochange_npm/src/lints/mod.rs
@@ -4,6 +4,7 @@
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use std::fmt::Write as _;
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
@@ -268,13 +269,18 @@ fn manifest_object_mut(value: &mut Value) -> Option<&mut Map<String, Value>> {
 	value.as_object_mut()
 }
 
-fn source_key_order(contents: &str, section: &str, keys: &[&String]) -> Option<Vec<String>> {
+fn dependency_section_object_span(contents: &str, section: &str) -> Option<(usize, usize)> {
 	let section_anchor = format!("\"{section}\"");
 	let section_start = contents.find(&section_anchor)?;
 	let rest = &contents[section_start..];
 	let open_offset = rest.find('{')? + section_start;
 	let close_offset = matching_brace_offset(contents, open_offset)?;
-	let section_text = &contents[open_offset..=close_offset];
+	Some((open_offset, close_offset + 1))
+}
+
+fn source_key_order(contents: &str, section: &str, keys: &[&String]) -> Option<Vec<String>> {
+	let (open_offset, close_offset) = dependency_section_object_span(contents, section)?;
+	let section_text = &contents[open_offset..close_offset];
 	let mut keyed_positions = keys
 		.iter()
 		.filter_map(|key| {
@@ -290,6 +296,59 @@ fn source_key_order(contents: &str, section: &str, keys: &[&String]) -> Option<V
 			.map(|(key, _)| key)
 			.collect::<Vec<_>>(),
 	)
+}
+
+fn dependency_value_span(
+	contents: &str,
+	section: &str,
+	dep_name: &str,
+	version: &str,
+) -> Option<(usize, usize)> {
+	let (open_offset, close_offset) = dependency_section_object_span(contents, section)?;
+	let section_text = &contents[open_offset..close_offset];
+	let dep_start = section_text.find(&serde_json::to_string(dep_name).ok()?)?;
+	let after_dep = open_offset + dep_start;
+	let value_text = serde_json::to_string(version).ok()?;
+	let value_start = contents[after_dep..close_offset].find(&value_text)? + after_dep;
+	Some((value_start, value_start + value_text.len()))
+}
+
+fn leading_line_indent(contents: &str, offset: usize) -> &str {
+	let line_start = contents[..offset].rfind('\n').map_or(0, |index| index + 1);
+	let indent_end = contents[line_start..]
+		.find(|character: char| !character.is_whitespace() || character == '\n')
+		.map_or(offset, |index| line_start + index);
+	&contents[line_start..indent_end]
+}
+
+fn sorted_dependency_section_text(
+	contents: &str,
+	section: &str,
+	object: &Map<String, Value>,
+	sorted_keys: &[String],
+) -> Option<String> {
+	let (open_offset, close_offset) = dependency_section_object_span(contents, section)?;
+	let section_indent = leading_line_indent(contents, open_offset);
+	let entry_indent = contents[open_offset + 1..close_offset - 1]
+		.find('"')
+		.map_or_else(
+			|| format!("{section_indent}  "),
+			|relative| leading_line_indent(contents, open_offset + 1 + relative).to_string(),
+		);
+	let mut output = String::from("{");
+	for (index, key) in sorted_keys.iter().enumerate() {
+		let value = object.get(key)?;
+		let key_text = serde_json::to_string(key).ok()?;
+		let value_text = serde_json::to_string(value).ok()?;
+		let comma = if index + 1 == sorted_keys.len() {
+			""
+		} else {
+			","
+		};
+		write!(output, "\n{entry_indent}{key_text}: {value_text}{comma}").ok()?;
+	}
+	write!(output, "\n{section_indent}}}").ok()?;
+	Some(output)
 }
 
 fn matching_brace_offset(contents: &str, open_offset: usize) -> Option<usize> {
@@ -378,18 +437,14 @@ impl LintRuleRunner for WorkspaceProtocolRule {
 					config.severity(),
 				);
 
-				if config.bool_option("fix", true) {
-					let mut rewritten = file.manifest.clone();
-					if let Some(root) = manifest_object_mut(&mut rewritten)
-						&& let Some(section) = root.get_mut(section).and_then(Value::as_object_mut)
-					{
-						section.insert(dep_name.clone(), Value::String("workspace:*".to_string()));
-					}
+				if config.bool_option("fix", true)
+					&& let Some(span) =
+						dependency_value_span(ctx.contents, section, dep_name, version)
+				{
 					result = result.with_fix(LintFix::single(
 						"rewrite dependency to workspace:*",
-						(0, ctx.contents.len()),
-						serde_json::to_string_pretty(&rewritten)
-							.unwrap_or_else(|_| ctx.contents.to_string()),
+						span,
+						"\"workspace:*\"".to_string(),
 					));
 				}
 
@@ -456,24 +511,15 @@ impl LintRuleRunner for SortedDependenciesRule {
 				format!("dependencies in `{section}` are not sorted alphabetically"),
 				config.severity(),
 			);
-			if config.bool_option("fix", true) {
-				let mut rewritten = file.manifest.clone();
-				if let Some(root) = manifest_object_mut(&mut rewritten)
-					&& let Some(section_obj) = root.get_mut(section).and_then(Value::as_object_mut)
-				{
-					let current = section_obj.clone();
-					section_obj.clear();
-					for key in sorted_keys {
-						if let Some(value) = current.get(&key) {
-							section_obj.insert(key.clone(), value.clone());
-						}
-					}
-				}
+			if config.bool_option("fix", true)
+				&& let Some(span) = dependency_section_object_span(ctx.contents, section)
+				&& let Some(replacement) =
+					sorted_dependency_section_text(ctx.contents, section, object, &sorted_keys)
+			{
 				result = result.with_fix(LintFix::single(
 					"sort dependency section alphabetically",
-					(0, ctx.contents.len()),
-					serde_json::to_string_pretty(&rewritten)
-						.unwrap_or_else(|_| ctx.contents.to_string()),
+					span,
+					replacement,
 				));
 			}
 			results.push(result);

--- a/crates/monochange_npm/src/lints/mod.rs
+++ b/crates/monochange_npm/src/lints/mod.rs
@@ -239,6 +239,31 @@ fn location(ctx: &LintContext<'_>) -> LintLocation {
 	LintLocation::new(ctx.manifest_path, 1, 1)
 }
 
+fn location_for_needle(ctx: &LintContext<'_>, needle: &str) -> LintLocation {
+	let Some(start) = ctx.contents.find(needle) else {
+		return location(ctx);
+	};
+	let (line, column) = line_column_for_offset(ctx.contents, start).unwrap_or((1, 1));
+	LintLocation::new(ctx.manifest_path, line, column).with_span(start, start + needle.len())
+}
+
+fn line_column_for_offset(contents: &str, offset: usize) -> Option<(usize, usize)> {
+	if offset > contents.len() || !contents.is_char_boundary(offset) {
+		return None;
+	}
+	let mut line = 1usize;
+	let mut column = 1usize;
+	for character in contents[..offset].chars() {
+		if character == '\n' {
+			line += 1;
+			column = 1;
+		} else {
+			column += 1;
+		}
+	}
+	Some((line, column))
+}
+
 fn manifest_object_mut(value: &mut Value) -> Option<&mut Map<String, Value>> {
 	value.as_object_mut()
 }
@@ -346,7 +371,7 @@ impl LintRuleRunner for WorkspaceProtocolRule {
 
 				let mut result = LintResult::new(
 					self.rule.id.clone(),
-					location(ctx),
+					location_for_needle(ctx, dep_name),
 					format!(
 						"internal dependency `{dep_name}` should use the workspace: protocol (found `{version}`)"
 					),
@@ -427,7 +452,7 @@ impl LintRuleRunner for SortedDependenciesRule {
 
 			let mut result = LintResult::new(
 				self.rule.id.clone(),
-				location(ctx),
+				location_for_needle(ctx, section),
 				format!("dependencies in `{section}` are not sorted alphabetically"),
 				config.severity(),
 			);
@@ -561,7 +586,7 @@ impl LintRuleRunner for RootNoProdDepsRule {
 
 		let mut result = LintResult::new(
 			self.rule.id.clone(),
-			location(ctx),
+			location_for_needle(ctx, "dependencies"),
 			"root package.json should not have production dependencies; move them to devDependencies",
 			config.severity(),
 		);
@@ -643,7 +668,7 @@ impl LintRuleRunner for NoDuplicateDependenciesRule {
 			}
 			let mut result = LintResult::new(
 				self.rule.id.clone(),
-				location(ctx),
+				location_for_needle(ctx, &dep_name),
 				format!(
 					"dependency `{dep_name}` appears in multiple sections: {}",
 					sections.join(", ")

--- a/crates/monochange_npm/src/lints/mod.rs
+++ b/crates/monochange_npm/src/lints/mod.rs
@@ -76,7 +76,7 @@ impl LintSuite for NpmLintSuite {
 			.with_rules(BTreeMap::from([
 				(
 					"npm/workspace-protocol".to_string(),
-					LintRuleConfig::Severity(LintSeverity::Error),
+					LintRuleConfig::Severity(LintSeverity::Off),
 				),
 				(
 					"npm/sorted-dependencies".to_string(),

--- a/fixtures/tests/check-output/npm-workspace/monochange.toml
+++ b/fixtures/tests/check-output/npm-workspace/monochange.toml
@@ -1,0 +1,15 @@
+[lints]
+use = ["npm/recommended"]
+
+[lints.rules]
+"npm/workspace-protocol" = { level = "error", fix = true }
+
+[package.app]
+path = "packages/app"
+type = "npm"
+version = "0.0.0"
+
+[package.shared]
+path = "packages/shared"
+type = "npm"
+version = "0.0.0"

--- a/fixtures/tests/check-output/npm-workspace/package.json
+++ b/fixtures/tests/check-output/npm-workspace/package.json
@@ -1,0 +1,1 @@
+{"private":true,"workspaces":["packages/*"]}

--- a/fixtures/tests/check-output/npm-workspace/packages/app/package.json
+++ b/fixtures/tests/check-output/npm-workspace/packages/app/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "app",
+    "version": "0.0.0",
+    "type": "module",
+    "description": "Application package",
+    "dependencies": {
+        "zeta": "1.0.0",
+        "shared": "^0.0.0"
+    },
+    "devDependencies": {
+        "vitest": "1.0.0"
+    }
+}

--- a/fixtures/tests/check-output/npm-workspace/packages/shared/package.json
+++ b/fixtures/tests/check-output/npm-workspace/packages/shared/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "shared",
+  "version": "0.0.0",
+  "private": true
+}


### PR DESCRIPTION
## Summary

- show lint rule IDs first in `mc check` text/markdown diagnostics
- add `mc check --verbose` for severity/span/fix details
- derive line/column from lint spans instead of leaving span-backed results at 1:1
- skip regular package lint rules for unmanaged package manifests while keeping the unlisted-package policy rule available
- make npm workspace-protocol opt-in by disabling it in `npm/recommended` while preserving it in `npm/strict`

## Validation

- cargo test -p monochange_lint --lib
- cargo test -p monochange --lib lint
- cargo test -p monochange_npm --lib
- cargo clippy -p monochange_npm -p monochange -p monochange_lint --all-targets --all-features -- -D warnings
- devenv shell dprint fmt
