### PR TITLE
fix: support npm OTP for placeholder publish

### DIFF
--- a/.changeset/npm-placeholder-publish-otp.md
+++ b/.changeset/npm-placeholder-publish-otp.md
@@ -1,0 +1,21 @@
+---
+monochange: patch
+monochange_core: patch
+monochange_publish: patch
+monochange_npm: patch
+---
+
+# Add npm placeholder publish OTP support
+
+Allow npm placeholder publishing to receive a one-time password for accounts that require 2FA during publish operations.
+
+Before, `mc placeholder-publish` and `mc step:placeholder-publish` could only invoke `npm publish` without an OTP, causing npm `EOTP` failures for publish-time 2FA accounts.
+
+After, pass a fresh code with `--otp`:
+
+```sh
+mc placeholder-publish --otp 123456
+mc step:placeholder-publish --from HEAD --otp 123456
+```
+
+The generated npm process receives the code through `NPM_CONFIG_OTP`, keeping it out of command arguments, reports, and failure messages.

--- a/crates/monochange/src/__tests__/package_publish_tests.rs
+++ b/crates/monochange/src/__tests__/package_publish_tests.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeSet;
 use std::collections::VecDeque;
 use std::env;
 use std::fs;
+use std::path::Path;
 use std::path::PathBuf;
 
 use httpmock::Method::GET;
@@ -50,6 +51,7 @@ use monochange_publish::render_command;
 use monochange_publish::render_command_error;
 use monochange_publish::resolve_placeholder_readme;
 use monochange_publish::resolve_registry_kind;
+use monochange_publish::set_npm_publish_otp_for_requests;
 use monochange_publish::write_publish_report_artifact;
 use monochange_test_helpers::git;
 use monochange_test_helpers::install_rustls_ring_provider;
@@ -267,6 +269,7 @@ fn build_npm_trust_list_command(request: &PublishRequest) -> CommandSpec {
 			request.package_name.clone(),
 		],
 		cwd: PathBuf::new(),
+		env: BTreeMap::new(),
 	}
 }
 
@@ -4226,10 +4229,15 @@ async fn run_placeholder_publish_uses_env_overrides_for_registry_endpoints() {
 			Some(server.base_url().as_str()),
 		)],
 		async {
-			let report =
-				run_placeholder_publish(root.path(), &configuration, &BTreeSet::new(), true)
-					.await
-					.expect("placeholder report:");
+			let report = run_placeholder_publish_with_npm_otp(
+				root.path(),
+				&configuration,
+				&BTreeSet::new(),
+				true,
+				Some("123456"),
+			)
+			.await
+			.expect("placeholder report:");
 			assert_eq!(report.mode, PackagePublishRunMode::Placeholder);
 			assert_eq!(report.packages.len(), 1);
 			assert_eq!(report.packages[0].status, PackagePublishStatus::Planned);
@@ -4377,6 +4385,7 @@ fn process_command_executor_runs_commands_and_reports_spawn_failures() {
 				"printf stdout; printf stderr >&2".to_string(),
 			],
 			cwd: tempdir.path().to_path_buf(),
+			env: BTreeMap::new(),
 		})
 		.expect("expected command success:");
 	assert!(success.success);
@@ -4388,6 +4397,7 @@ fn process_command_executor_runs_commands_and_reports_spawn_failures() {
 			program: "definitely-not-a-real-command".to_string(),
 			args: Vec::new(),
 			cwd: tempdir.path().to_path_buf(),
+			env: BTreeMap::new(),
 		})
 		.expect_err("expected command failure");
 	assert!(
@@ -4408,6 +4418,7 @@ fn fake_executor_reports_missing_outputs_and_render_helpers_match() {
 			"public".to_string(),
 		],
 		cwd: PathBuf::from("."),
+		env: BTreeMap::new(),
 	};
 	let error = executor
 		.run(&spec)
@@ -4454,6 +4465,28 @@ fn build_npm_placeholder_publish_command_uses_package_root_as_cwd() {
 	assert_eq!(command.program, "npm");
 	assert_eq!(command.cwd, PathBuf::from("/workspace/pkg"));
 	assert_eq!(command.args[0], "publish");
+}
+
+#[test]
+fn build_npm_placeholder_publish_command_uses_otp_as_environment() {
+	let mut requests = vec![sample_request(RegistryKind::Npm)];
+	set_npm_publish_otp_for_requests(&mut requests, "123456");
+
+	let command =
+		build_npm_placeholder_publish_command(&requests[0], Path::new("/tmp/placeholder"));
+
+	assert_eq!(
+		command.args.iter().map(String::as_str).collect::<Vec<_>>(),
+		vec!["publish", "/tmp/placeholder", "--access", "public"]
+	);
+	assert_eq!(
+		command.env.get("NPM_CONFIG_OTP").map(String::as_str),
+		Some("123456")
+	);
+	assert_eq!(
+		render_command(&command),
+		"npm publish /tmp/placeholder --access public"
+	);
 }
 
 #[test]

--- a/crates/monochange/src/cli_help.rs
+++ b/crates/monochange/src/cli_help.rs
@@ -1025,6 +1025,11 @@ fn builtin_command_helps() -> Vec<CommandHelp> {
 					"Preview placeholder publishing without publishing",
 				),
 				(
+					"--otp",
+					"<CODE>",
+					"Pass an npm one-time password as NPM_CONFIG_OTP",
+				),
+				(
 					"--output",
 					"<PATH>",
 					"Write a JSON publish bootstrap result artifact",
@@ -1078,6 +1083,11 @@ fn builtin_command_helps() -> Vec<CommandHelp> {
 					"",
 					"Include already-published and skipped packages in the report",
 				),
+				(
+					"--otp",
+					"<CODE>",
+					"Pass an npm one-time password as NPM_CONFIG_OTP",
+				),
 				("--dry-run", "", "Preview without publishing"),
 			],
 			examples: &[
@@ -1094,6 +1104,7 @@ fn builtin_command_helps() -> Vec<CommandHelp> {
 			tips: &[
 				"Placeholder versions are 0.0.0 by default.",
 				"Only unpublished packages are included.",
+				"Use --otp for npm accounts that require 2FA for publish operations.",
 			],
 			see_also: &["release", "publish-packages"],
 		},

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -947,6 +947,10 @@ pub(crate) async fn execute_cli_command_with_options(
 				CliStepDefinition::PlaceholderPublish { .. } => {
 					let selected_packages = selected_package_ids(&step_inputs);
 					let show_all_packages = boolean_step_input(&step_inputs, "show-all");
+					let npm_otp = step_inputs
+						.get("otp")
+						.and_then(|values| values.first())
+						.map(String::as_str);
 					let rate_limit_report = publish_rate_limits::plan_publish_rate_limits(
 						root,
 						configuration,
@@ -964,11 +968,12 @@ pub(crate) async fn execute_cli_command_with_options(
 							publish_rate_limits::PublishRateLimitMode::Placeholder,
 						)?;
 					}
-					let report = package_publish::run_placeholder_publish(
+					let report = package_publish::run_placeholder_publish_with_npm_otp(
 						root,
 						configuration,
 						&selected_packages,
 						context.dry_run,
+						npm_otp,
 					)
 					.await?;
 					context.package_publish_report =

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -56,6 +56,7 @@ use monochange_publish::read_publish_report_artifact;
 use monochange_publish::reject_npm_token_environment;
 use monochange_publish::resume_publish_requests;
 use monochange_publish::select_release_publication_targets;
+use monochange_publish::set_npm_publish_otp_for_requests;
 use monochange_publish::trusted_publishing_capability_message;
 use monochange_publish::trusted_publishing_capability_message_for_builtin;
 use monochange_python::write_python_placeholder_manifest;
@@ -69,15 +70,19 @@ use crate::discover_release_record;
 use crate::discover_workspace;
 use crate::publish_progress::StderrPublishProgressReporter;
 
-pub(crate) async fn run_placeholder_publish(
+pub(crate) async fn run_placeholder_publish_with_npm_otp(
 	root: &Path,
 	configuration: &WorkspaceConfiguration,
 	selected_packages: &BTreeSet<String>,
 	dry_run: bool,
+	npm_otp: Option<&str>,
 ) -> MonochangeResult<PackagePublishReport> {
 	let discovery = discover_workspace(root)?;
-	let requests =
+	let mut requests =
 		build_placeholder_requests(root, configuration, &discovery.packages, selected_packages)?;
+	if let Some(otp) = npm_otp.filter(|otp| !otp.is_empty()) {
+		set_npm_publish_otp_for_requests(&mut requests, otp);
+	}
 	let progress = StderrPublishProgressReporter::new(false);
 	execute_publish_requests_with_process_and_progress(
 		root,

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -2911,7 +2911,7 @@ impl CliStepDefinition {
 			}
 			Self::PublishRelease { .. } => Some(&["format", "from-ref", "draft"]),
 			Self::OpenReleaseRequest { .. } => Some(&["format", "no_verify", "stage_all"]),
-			Self::PlaceholderPublish { .. } => Some(&["format", "package", "show-all"]),
+			Self::PlaceholderPublish { .. } => Some(&["format", "package", "show-all", "otp"]),
 			Self::PublishPackages { .. } => {
 				Some(&[
 					"format",
@@ -3042,6 +3042,7 @@ impl CliStepDefinition {
 					"format" => Some(CliInputKind::Choice),
 					"package" => Some(CliInputKind::StringList),
 					"show-all" => Some(CliInputKind::Boolean),
+					"otp" => Some(CliInputKind::String),
 					_ => None,
 				}
 			}

--- a/crates/monochange_npm/src/__tests__/lib_tests.rs
+++ b/crates/monochange_npm/src/__tests__/lib_tests.rs
@@ -6,8 +6,14 @@ use std::path::PathBuf;
 use monochange_core::Ecosystem;
 use monochange_core::EcosystemAdapter;
 use monochange_core::PackageRecord;
+use monochange_core::PublishAttestationSettings;
+use monochange_core::PublishMode;
 use monochange_core::PublishState;
+use monochange_core::RegistryKind;
+use monochange_core::TrustedPublishingSettings;
 use monochange_core::materialize_dependency_edges;
+use monochange_github::GitHubTrustContext;
+use monochange_publish::PublishRequest;
 use semver::Version;
 use serde_json::json;
 use serde_yaml_ng::Value as YamlValue;
@@ -982,4 +988,49 @@ fn workspace_pattern_skips_directories_without_package_json() {
 		!names.contains(&"no-package-json".to_string()),
 		"'no-package-json' should not be discovered since it has no package.json, got {names:?}"
 	);
+}
+
+#[test]
+fn npm_trust_command_wraps_npm_with_pnpm_for_pnpm_managed_packages() {
+	let request = PublishRequest {
+		package_id: "pkg".to_string(),
+		package_name: "pkg".to_string(),
+		ecosystem: Ecosystem::Npm,
+		manifest_path: PathBuf::from("package.json"),
+		package_root: PathBuf::from("."),
+		registry: RegistryKind::Npm,
+		package_manager: Some("pnpm".to_string()),
+		package_metadata: BTreeMap::new(),
+		mode: PublishMode::Builtin,
+		version: "1.0.0".to_string(),
+		placeholder: false,
+		trusted_publishing: TrustedPublishingSettings::default(),
+		attestations: PublishAttestationSettings::default(),
+		placeholder_readme: "placeholder".to_string(),
+	};
+	let context = GitHubTrustContext {
+		repository: "owner/repo".to_string(),
+		workflow: "release.yml".to_string(),
+		environment: None,
+	};
+
+	let command = crate::build_npm_trust_command(&request, &context);
+
+	assert_eq!(command.program, "pnpm");
+	assert_eq!(
+		command.args.iter().map(String::as_str).collect::<Vec<_>>(),
+		vec![
+			"exec",
+			"npm",
+			"trust",
+			"github",
+			"pkg",
+			"--file",
+			"release.yml",
+			"--repo",
+			"owner/repo",
+			"--yes"
+		]
+	);
+	assert!(command.env.is_empty());
 }

--- a/crates/monochange_npm/src/lib.rs
+++ b/crates/monochange_npm/src/lib.rs
@@ -1098,6 +1098,7 @@ fn build_npm_cli_command(request: &PublishRequest, args: Vec<String>) -> Command
 			program: "pnpm".to_string(),
 			args: wrapped_args,
 			cwd: request.package_root.clone(),
+			env: BTreeMap::new(),
 		};
 	}
 
@@ -1105,6 +1106,7 @@ fn build_npm_cli_command(request: &PublishRequest, args: Vec<String>) -> Command
 		program: "npm".to_string(),
 		args,
 		cwd: request.package_root.clone(),
+		env: BTreeMap::new(),
 	}
 }
 

--- a/crates/monochange_publish/src/__tests__/lib_tests.rs
+++ b/crates/monochange_publish/src/__tests__/lib_tests.rs
@@ -415,6 +415,28 @@ fn sample_publish_request_for_registry(registry: RegistryKind) -> PublishRequest
 	}
 }
 
+#[test]
+fn render_publish_command_error_adds_npm_otp_recovery_guidance() {
+	let request = sample_publish_request_for_registry(RegistryKind::Npm);
+	let output = CommandOutput {
+		success: false,
+		stdout: String::new(),
+		stderr: "npm error code EOTP\nnpm error This operation requires a one-time password."
+			.to_string(),
+	};
+
+	let message =
+		render_publish_command_error(&output, &request, PackagePublishRunMode::Placeholder);
+
+	assert!(message.contains("npm error code EOTP"));
+	assert!(message.contains("mc step:placeholder-publish --otp <CODE>"));
+	assert!(message.contains("NPM_CONFIG_OTP=<CODE>"));
+
+	let release_message =
+		render_publish_command_error(&output, &request, PackagePublishRunMode::Release);
+	assert!(release_message.contains("rerun the publish command with `NPM_CONFIG_OTP=<CODE>`"));
+}
+
 #[derive(Default)]
 struct RecordingPublishProgressReporter {
 	events: std::sync::Mutex<Vec<PublishProgressEvent>>,

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -411,6 +411,28 @@ pub struct CommandSpec {
 	pub program: String,
 	pub args: Vec<String>,
 	pub cwd: PathBuf,
+	pub env: BTreeMap<String, String>,
+}
+
+const NPM_PUBLISH_OTP_METADATA_KEY: &str = "monochange:npm_publish_otp";
+
+pub fn set_npm_publish_otp_for_requests(requests: &mut [PublishRequest], otp: &str) {
+	for request in requests
+		.iter_mut()
+		.filter(|request| request.registry == RegistryKind::Npm)
+	{
+		request
+			.package_metadata
+			.insert(NPM_PUBLISH_OTP_METADATA_KEY.to_string(), otp.to_string());
+	}
+}
+
+fn npm_publish_env(request: &PublishRequest) -> BTreeMap<String, String> {
+	let mut env = BTreeMap::new();
+	if let Some(otp) = request.package_metadata.get(NPM_PUBLISH_OTP_METADATA_KEY) {
+		env.insert("NPM_CONFIG_OTP".to_string(), otp.clone());
+	}
+	env
 }
 
 pub type PlaceholderManifestWriter =
@@ -906,7 +928,7 @@ pub async fn execute_publish_requests_with_progress(
 		if !output.success {
 			progress.report(PublishProgressEvent::PackageFailed {
 				package: publish_progress_package(request),
-				message: render_command_error(&output),
+				message: render_publish_command_error(&output, request, mode),
 			});
 			tracing::error!(
 				package_name = request.package_name,
@@ -938,7 +960,7 @@ pub async fn execute_publish_requests_with_progress(
 				format!(
 					"`{}` failed: {}",
 					render_command(&publish_command),
-					render_command_error(&output)
+					render_publish_command_error(&output, request, mode)
 				),
 			);
 			outcome.command = Some(render_command(&publish_command));
@@ -1324,7 +1346,10 @@ impl CommandExecutor for ProcessCommandExecutor {
 	fn run(&mut self, spec: &CommandSpec) -> MonochangeResult<CommandOutput> {
 		use std::process::Command;
 		let mut command = Command::new(&spec.program);
-		command.args(&spec.args).current_dir(&spec.cwd);
+		command
+			.args(&spec.args)
+			.current_dir(&spec.cwd)
+			.envs(&spec.env);
 		let output = command.output().map_err(|error| {
 			MonochangeError::Io(format!(
 				"failed to run `{}` in {}: {error}",
@@ -1352,6 +1377,38 @@ pub fn render_command_error(output: &CommandOutput) -> String {
 		"command failed".to_string()
 	} else {
 		output.stderr.clone()
+	}
+}
+
+fn render_publish_command_error(
+	output: &CommandOutput,
+	request: &PublishRequest,
+	mode: PackagePublishRunMode,
+) -> String {
+	let message = render_command_error(output);
+	if !is_npm_otp_error(output, request) {
+		return message;
+	}
+
+	format!("{message}\n\n{}", npm_otp_recovery_message(mode))
+}
+
+fn is_npm_otp_error(output: &CommandOutput, request: &PublishRequest) -> bool {
+	request.registry == RegistryKind::Npm
+		&& (output.stderr.contains("EOTP")
+			|| output.stderr.contains("one-time password")
+			|| output.stdout.contains("EOTP")
+			|| output.stdout.contains("one-time password"))
+}
+
+fn npm_otp_recovery_message(mode: PackagePublishRunMode) -> &'static str {
+	match mode {
+		PackagePublishRunMode::Placeholder => {
+			"npm requires a publish-time one-time password. Get the current OTP code from your npm authenticator, then rerun with `mc placeholder-publish --otp <CODE>` or `mc step:placeholder-publish --otp <CODE>`. You can also set `NPM_CONFIG_OTP=<CODE>` for the command."
+		}
+		PackagePublishRunMode::Release => {
+			"npm requires a publish-time one-time password. Get the current OTP code from your npm authenticator, then rerun the publish command with `NPM_CONFIG_OTP=<CODE>` set in the environment."
+		}
 	}
 }
 
@@ -1647,6 +1704,7 @@ pub fn build_npm_placeholder_publish_command(
 			"public".to_string(),
 		],
 		cwd: request.package_root.clone(),
+		env: npm_publish_env(request),
 	}
 }
 
@@ -1663,6 +1721,7 @@ pub fn build_npm_release_publish_command(request: &PublishRequest) -> CommandSpe
 		program: npm_publish_program(request).to_string(),
 		args,
 		cwd: request.package_root.clone(),
+		env: npm_publish_env(request),
 	}
 }
 
@@ -1695,6 +1754,7 @@ fn build_cargo_placeholder_publish_command(
 			placeholder_path.join("Cargo.toml").display().to_string(),
 		],
 		cwd: request.package_root.clone(),
+		env: BTreeMap::new(),
 	}
 }
 
@@ -1708,6 +1768,7 @@ fn build_cargo_release_publish_command(request: &PublishRequest) -> CommandSpec 
 			request.manifest_path.display().to_string(),
 		],
 		cwd: request.package_root.clone(),
+		env: BTreeMap::new(),
 	}
 }
 
@@ -1729,6 +1790,7 @@ fn build_dart_publish_command(request: &PublishRequest, cwd: &Path) -> CommandSp
 			"--force".to_string(),
 		],
 		cwd: cwd.to_path_buf(),
+		env: BTreeMap::new(),
 	}
 }
 
@@ -1737,6 +1799,7 @@ fn build_jsr_publish_command(cwd: &Path) -> CommandSpec {
 		program: "deno".to_string(),
 		args: vec!["publish".to_string()],
 		cwd: cwd.to_path_buf(),
+		env: BTreeMap::new(),
 	}
 }
 
@@ -1753,6 +1816,7 @@ fn build_python_publish_command(request: &PublishRequest, cwd: &Path) -> Command
 		program: "sh".to_string(),
 		args: vec!["-c".to_string(), script],
 		cwd: cwd.to_path_buf(),
+		env: BTreeMap::new(),
 	}
 }
 
@@ -1761,6 +1825,7 @@ fn build_go_publish_command(request: &PublishRequest) -> CommandSpec {
 		program: "git".to_string(),
 		args: vec!["tag".to_string(), go_module_tag_name(request)],
 		cwd: request.package_root.clone(),
+		env: BTreeMap::new(),
 	}
 }
 


### PR DESCRIPTION
## Summary
- add an `otp` input for placeholder publish steps and CLI help
- pass npm publish OTP to subprocesses through `NPM_CONFIG_OTP` instead of command args
- cover the command builder so OTP is available in env and absent from rendered commands

## Verification
- `devenv shell cargo test -p monochange build_npm_placeholder_publish_command_uses_otp_as_environment --lib`
- `devenv shell mc step:affected-packages --verify ...`
- `devenv shell env GIT_CONFIG_GLOBAL=/dev/null coverage:patch` → `PATCH_COVERAGE 0/0 (100.00%)`

Note: `devenv shell fix:all` passes Rust/workspace validation but exits on pre-existing zizmor GitHub Actions findings unrelated to this PR.