### PR TITLE
fix: soften check onboarding defaults

### DIFF
--- a/.changeset/fix-check-onboarding-lint-defaults.md
+++ b/.changeset/fix-check-onboarding-lint-defaults.md
@@ -1,0 +1,10 @@
+---
+"monochange": patch
+"monochange_cargo": patch
+"monochange_dart": patch
+"monochange_npm": patch
+---
+
+# Improve `mc check` onboarding defaults
+
+Add per-ecosystem `baseline` lint presets and make generated `monochange.toml` files start with those softer presets. Baseline presets keep onboarding diagnostics as warnings or opt out of formatting-style checks so existing repositories can adopt `mc check` before escalating to `recommended` or `strict`.

--- a/crates/monochange/src/__tests__/lint_tests.rs
+++ b/crates/monochange/src/__tests__/lint_tests.rs
@@ -52,11 +52,13 @@ fn test_format_check_report_with_issues() {
 fn render_lint_catalog_lists_rules_and_presets() {
 	let text = render_lint_catalog(OutputFormat::Text).unwrap();
 	assert!(text.contains("cargo/internal-dependency-workspace"));
+	assert!(text.contains("cargo/baseline"));
 	assert!(text.contains("cargo/recommended"));
 	assert!(text.contains("dart/required-package-fields"));
 	assert!(text.contains("dart/sdk-constraint-present"));
 	assert!(text.contains("dart/internal-path-dependency-policy"));
 	assert!(text.contains("dart/flutter-package-metadata-consistent"));
+	assert!(text.contains("dart/baseline"));
 	assert!(text.contains("dart/recommended"));
 	assert!(text.contains("dart/strict"));
 
@@ -71,9 +73,20 @@ fn render_lint_explanation_supports_rules_and_presets() {
 		render_lint_explanation("cargo/internal-dependency-workspace", OutputFormat::Text).unwrap();
 	assert!(rule.contains("Internal dependency workspace"));
 
+	let baseline = render_lint_explanation("cargo/baseline", OutputFormat::Text).unwrap();
+	assert!(baseline.contains("Cargo baseline"));
+	assert!(baseline.contains("cargo/required-package-fields"));
+
 	let preset = render_lint_explanation("cargo/recommended", OutputFormat::Text).unwrap();
 	assert!(preset.contains("Cargo recommended"));
 	assert!(preset.contains("cargo/sorted-dependencies"));
+}
+
+#[test]
+fn generated_config_defaults_to_baseline_lints() {
+	let template = include_str!("../monochange.toml.template");
+	assert!(template.contains("use = [\"cargo/baseline\", \"npm/baseline\", \"dart/baseline\"]"));
+	assert!(template.contains("without turning formatting preferences into blocking errors"));
 }
 
 #[test]

--- a/crates/monochange/src/__tests__/snapshots/monochange__mcp__tests__lint_catalog_lists_rules_and_presets@lint_catalog_lists_rules_and_presets.snap
+++ b/crates/monochange/src/__tests__/snapshots/monochange__mcp__tests__lint_catalog_lists_rules_and_presets@lint_catalog_lists_rules_and_presets.snap
@@ -1,11 +1,26 @@
 ---
 source: crates/monochange/src/__tests__/mcp_tests.rs
+assertion_line: 687
 expression: content_text(&result)
 ---
 {
   "action": "lint_catalog",
   "ok": true,
   "presets": [
+    {
+      "description": "Gentle Cargo manifest linting for onboarding existing workspaces",
+      "id": "cargo/baseline",
+      "maturity": "stable",
+      "name": "Cargo baseline",
+      "rules": {
+        "cargo/dependency-field-order": "off",
+        "cargo/internal-dependency-workspace": "warning",
+        "cargo/publishable-dependencies": "warning",
+        "cargo/required-package-fields": "warning",
+        "cargo/sorted-dependencies": "off",
+        "cargo/unlisted-package-private": "warning"
+      }
+    },
     {
       "description": "Balanced Cargo manifest linting for most workspaces",
       "id": "cargo/recommended",
@@ -44,6 +59,19 @@ expression: content_text(&result)
       }
     },
     {
+      "description": "Gentle Dart manifest linting for onboarding existing workspaces",
+      "id": "dart/baseline",
+      "maturity": "stable",
+      "name": "Dart baseline",
+      "rules": {
+        "dart/dependency-sorted": "off",
+        "dart/no-git-dependencies-in-published-packages": "warning",
+        "dart/required-package-fields": "warning",
+        "dart/sdk-constraint-present": "warning",
+        "dart/unlisted-package-private": "warning"
+      }
+    },
+    {
       "description": "Balanced Dart manifest linting for metadata, publishability, and baseline SDK hygiene",
       "id": "dart/recommended",
       "maturity": "stable",
@@ -76,6 +104,20 @@ expression: content_text(&result)
         "dart/sdk-constraint-present": "error",
         "dart/unlisted-package-private": "error",
         "dart/workspace-internal-version-consistency": "error"
+      }
+    },
+    {
+      "description": "Gentle npm-family manifest linting for onboarding existing workspaces",
+      "id": "npm/baseline",
+      "maturity": "stable",
+      "name": "npm baseline",
+      "rules": {
+        "npm/no-duplicate-dependencies": "warning",
+        "npm/required-package-fields": "warning",
+        "npm/root-no-prod-deps": "warning",
+        "npm/sorted-dependencies": "off",
+        "npm/unlisted-package-private": "warning",
+        "npm/workspace-protocol": "off"
       }
     },
     {
@@ -504,5 +546,5 @@ expression: content_text(&result)
       ]
     }
   ],
-  "summary": "Loaded 29 lint rule(s) and 7 preset(s)."
+  "summary": "Loaded 29 lint rule(s) and 10 preset(s)."
 }

--- a/crates/monochange/src/monochange.toml.template
+++ b/crates/monochange/src/monochange.toml.template
@@ -499,8 +499,11 @@ version_format = "primary"
 # manifests. Lint suites live in ecosystem crates, but configuration lives in
 # this top-level section.
 #
-# [lints]
-# use = ["cargo/recommended", "npm/recommended"]
+[lints]
+# Start with baseline presets so existing repositories can adopt `mc check`
+# without turning formatting preferences into blocking errors. Upgrade to
+# `*/recommended` or `*/strict` when the workspace is ready to enforce policy.
+use = ["cargo/baseline", "npm/baseline", "dart/baseline"]
 # include = ["crates/**", "packages/**"]
 # exclude = ["examples/**"]
 # disable_gitignore = false

--- a/crates/monochange_cargo/src/lints/__tests__/mod_tests.rs
+++ b/crates/monochange_cargo/src/lints/__tests__/mod_tests.rs
@@ -43,14 +43,25 @@ fn config() -> LintRuleConfig {
 #[test]
 fn presets_are_exposed() {
 	let presets = CargoLintSuite.presets();
-	assert_eq!(presets.len(), 2);
+	assert_eq!(presets.len(), 3);
 	assert_eq!(
 		presets.first().map(|preset| preset.id.as_str()),
-		Some("cargo/recommended")
+		Some("cargo/baseline")
 	);
 	assert_eq!(
 		presets.get(1).map(|preset| preset.id.as_str()),
-		Some("cargo/strict")
+		Some("cargo/recommended")
+	);
+	let baseline = presets
+		.first()
+		.unwrap_or_else(|| panic!("expected cargo baseline preset"));
+	assert_eq!(
+		baseline.rules.get("cargo/required-package-fields"),
+		Some(&LintRuleConfig::Severity(LintSeverity::Warning))
+	);
+	assert_eq!(
+		baseline.rules.get("cargo/sorted-dependencies"),
+		Some(&LintRuleConfig::Severity(LintSeverity::Off))
 	);
 }
 

--- a/crates/monochange_cargo/src/lints/mod.rs
+++ b/crates/monochange_cargo/src/lints/mod.rs
@@ -71,6 +71,38 @@ impl LintSuite for CargoLintSuite {
 	fn presets(&self) -> Vec<LintPreset> {
 		vec![
 			LintPreset::new(
+				"cargo/baseline",
+				"Cargo baseline",
+				"Gentle Cargo manifest linting for onboarding existing workspaces",
+				LintMaturity::Stable,
+			)
+			.with_rules(BTreeMap::from([
+				(
+					"cargo/dependency-field-order".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Off),
+				),
+				(
+					"cargo/sorted-dependencies".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Off),
+				),
+				(
+					"cargo/internal-dependency-workspace".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Warning),
+				),
+				(
+					"cargo/publishable-dependencies".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Warning),
+				),
+				(
+					"cargo/required-package-fields".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Warning),
+				),
+				(
+					"cargo/unlisted-package-private".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Warning),
+				),
+			])),
+			LintPreset::new(
 				"cargo/recommended",
 				"Cargo recommended",
 				"Balanced Cargo manifest linting for most workspaces",

--- a/crates/monochange_dart/src/lints/__tests__/mod_tests.rs
+++ b/crates/monochange_dart/src/lints/__tests__/mod_tests.rs
@@ -75,9 +75,24 @@ fn config() -> LintRuleConfig {
 #[test]
 fn presets_are_exposed() {
 	let presets = DartLintSuite.presets();
-	assert_eq!(presets.len(), 2);
+	assert_eq!(presets.len(), 3);
 
-	let recommended = presets.first().expect("expected recommended preset");
+	let baseline = presets
+		.first()
+		.unwrap_or_else(|| panic!("expected baseline preset"));
+	assert_eq!(baseline.id, "dart/baseline");
+	assert_eq!(
+		baseline.rules.get("dart/sdk-constraint-present"),
+		Some(&LintRuleConfig::Severity(LintSeverity::Warning))
+	);
+	assert_eq!(
+		baseline.rules.get("dart/dependency-sorted"),
+		Some(&LintRuleConfig::Severity(LintSeverity::Off))
+	);
+
+	let recommended = presets
+		.get(1)
+		.unwrap_or_else(|| panic!("expected recommended preset"));
 	assert_eq!(recommended.id, "dart/recommended");
 	assert_eq!(
 		recommended.rules.get("dart/dependency-sorted"),
@@ -93,7 +108,9 @@ fn presets_are_exposed() {
 			.contains_key("dart/internal-path-dependency-policy")
 	);
 
-	let strict = presets.get(1).expect("expected strict preset");
+	let strict = presets
+		.get(2)
+		.unwrap_or_else(|| panic!("expected strict preset"));
 	assert_eq!(strict.id, "dart/strict");
 	assert!(strict.rules.contains_key("dart/assets-sorted"));
 	assert!(

--- a/crates/monochange_dart/src/lints/mod.rs
+++ b/crates/monochange_dart/src/lints/mod.rs
@@ -77,6 +77,34 @@ impl LintSuite for DartLintSuite {
 	fn presets(&self) -> Vec<LintPreset> {
 		vec![
 			LintPreset::new(
+				"dart/baseline",
+				"Dart baseline",
+				"Gentle Dart manifest linting for onboarding existing workspaces",
+				LintMaturity::Stable,
+			)
+			.with_rules(BTreeMap::from([
+				(
+					"dart/dependency-sorted".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Off),
+				),
+				(
+					"dart/no-git-dependencies-in-published-packages".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Warning),
+				),
+				(
+					"dart/required-package-fields".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Warning),
+				),
+				(
+					"dart/sdk-constraint-present".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Warning),
+				),
+				(
+					"dart/unlisted-package-private".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Warning),
+				),
+			])),
+			LintPreset::new(
 				"dart/recommended",
 				"Dart recommended",
 				"Balanced Dart manifest linting for metadata, publishability, and baseline SDK hygiene",

--- a/crates/monochange_npm/src/lints/__tests__/mod_tests.rs
+++ b/crates/monochange_npm/src/lints/__tests__/mod_tests.rs
@@ -39,24 +39,31 @@ fn config() -> LintRuleConfig {
 #[test]
 fn presets_are_exposed() {
 	let presets = NpmLintSuite.presets();
-	assert_eq!(presets.len(), 2);
+	assert_eq!(presets.len(), 3);
 	assert_eq!(
 		presets.first().map(|preset| preset.id.as_str()),
-		Some("npm/recommended")
+		Some("npm/baseline")
 	);
 	assert_eq!(
 		presets.get(1).map(|preset| preset.id.as_str()),
-		Some("npm/strict")
+		Some("npm/recommended")
+	);
+	let baseline = presets
+		.first()
+		.unwrap_or_else(|| panic!("expected npm baseline preset"));
+	assert_eq!(
+		baseline.rules.get("npm/required-package-fields"),
+		Some(&LintRuleConfig::Severity(LintSeverity::Warning))
 	);
 	let recommended = presets
-		.first()
+		.get(1)
 		.unwrap_or_else(|| panic!("expected npm recommended preset"));
 	assert_eq!(
 		recommended.rules.get("npm/workspace-protocol"),
 		Some(&LintRuleConfig::Severity(LintSeverity::Off))
 	);
 	let strict = presets
-		.get(1)
+		.get(2)
 		.unwrap_or_else(|| panic!("expected npm strict preset"));
 	assert_eq!(
 		strict.rules.get("npm/workspace-protocol"),

--- a/crates/monochange_npm/src/lints/mod.rs
+++ b/crates/monochange_npm/src/lints/mod.rs
@@ -69,6 +69,38 @@ impl LintSuite for NpmLintSuite {
 	fn presets(&self) -> Vec<LintPreset> {
 		vec![
 			LintPreset::new(
+				"npm/baseline",
+				"npm baseline",
+				"Gentle npm-family manifest linting for onboarding existing workspaces",
+				LintMaturity::Stable,
+			)
+			.with_rules(BTreeMap::from([
+				(
+					"npm/workspace-protocol".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Off),
+				),
+				(
+					"npm/sorted-dependencies".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Off),
+				),
+				(
+					"npm/required-package-fields".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Warning),
+				),
+				(
+					"npm/root-no-prod-deps".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Warning),
+				),
+				(
+					"npm/no-duplicate-dependencies".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Warning),
+				),
+				(
+					"npm/unlisted-package-private".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Warning),
+				),
+			])),
+			LintPreset::new(
 				"npm/recommended",
 				"npm recommended",
 				"Balanced npm-family manifest linting for typical JavaScript workspaces",


### PR DESCRIPTION
## Summary
- add per-ecosystem `baseline` lint presets for cargo, dart, and npm
- make generated `monochange.toml` default to baseline presets
- update lint catalog tests and snapshots for the new presets

Closes #588

## Validation
- cargo test -p monochange_npm --lib
- cargo test -p monochange_cargo --lib
- cargo test -p monochange_dart --lib
- cargo test -p monochange --lib lint
- cargo clippy -p monochange_npm -p monochange_cargo -p monochange_dart -p monochange --all-targets --all-features -- -D warnings
- devenv shell dprint fmt
- devenv shell dprint check