### PR TITLE
feat: validate changeset bumps against API classification

### DIFF
--- a/.changeset/feat-changeset-api-bump-alignment.md
+++ b/.changeset/feat-changeset-api-bump-alignment.md
@@ -1,0 +1,16 @@
+---
+"monochange": patch
+"monochange_core": major
+---
+
+# Validate API-aligned changeset bumps
+
+Affected changeset checks now compare requested release bumps with API classification output. Understated changesets fail so CI can catch risky releases, while overstated changesets report warnings for maintainers to inspect.
+
+```json
+{
+	"requested": "patch",
+	"recommended": "major",
+	"status": "failed"
+}
+```

--- a/crates/monochange/src/__tests__/changeset_policy_tests.rs
+++ b/crates/monochange/src/__tests__/changeset_policy_tests.rs
@@ -1,13 +1,99 @@
 #![allow(clippy::disallowed_methods)]
+use std::collections::BTreeMap;
 use std::fs;
 use std::process::Command;
 
+use monochange_core::BumpSeverity;
+use monochange_core::ChangeSignal;
 use monochange_core::PackageDefinition;
 use monochange_core::PackageType;
 use monochange_core::SourceProvider as ProviderKind;
 use monochange_core::VersionFormat;
 
 use super::*;
+
+fn empty_policy_evaluation() -> ChangesetPolicyEvaluation {
+	ChangesetPolicyEvaluation {
+		status: ChangesetPolicyStatus::Passed,
+		required: true,
+		enforce: true,
+		summary: "changesets passed".to_string(),
+		comment: None,
+		labels: Vec::new(),
+		matched_skip_labels: Vec::new(),
+		changed_paths: Vec::new(),
+		matched_paths: Vec::new(),
+		ignored_paths: Vec::new(),
+		changeset_paths: Vec::new(),
+		affected_package_ids: Vec::new(),
+		covered_package_ids: Vec::new(),
+		uncovered_package_ids: Vec::new(),
+		warnings: Vec::new(),
+		errors: Vec::new(),
+	}
+}
+
+fn change_signal(package_id: &str, requested_bump: Option<BumpSeverity>) -> ChangeSignal {
+	ChangeSignal {
+		package_id: package_id.to_string(),
+		requested_bump,
+		explicit_version: None,
+		change_origin: "test".to_string(),
+		evidence_refs: Vec::new(),
+		notes: None,
+		details: None,
+		change_type: None,
+		caused_by: Vec::new(),
+		source_path: Path::new(".changeset/test.md").to_path_buf(),
+	}
+}
+
+#[test]
+fn requested_bumps_by_package_skips_empty_bumps_and_keeps_highest_bump() {
+	let requested_bumps = requested_bumps_by_package(&[
+		change_signal("core", None),
+		change_signal("core", Some(BumpSeverity::Patch)),
+		change_signal("core", Some(BumpSeverity::Minor)),
+		change_signal("utils", Some(BumpSeverity::Major)),
+	]);
+
+	assert_eq!(requested_bumps.get("core"), Some(&BumpSeverity::Minor));
+	assert_eq!(requested_bumps.get("utils"), Some(&BumpSeverity::Major));
+}
+
+#[test]
+fn bump_alignment_errors_when_changeset_type_understates_api_impact() {
+	let mut evaluation = empty_policy_evaluation();
+	apply_bump_alignment(
+		BTreeMap::from([("core".to_string(), BumpSeverity::Patch)]),
+		&BTreeMap::from([("core".to_string(), BumpSeverity::Minor)]),
+		&mut evaluation,
+	);
+
+	assert!(evaluation.warnings.is_empty());
+	assert!(evaluation.errors.iter().any(|error| {
+		error.contains("changeset bump for `core` is insufficient")
+			&& error.contains("requested `patch`")
+			&& error.contains("recommends `minor`")
+	}));
+}
+
+#[test]
+fn bump_alignment_warns_when_changeset_type_overstates_api_impact() {
+	let mut evaluation = empty_policy_evaluation();
+	apply_bump_alignment(
+		BTreeMap::from([("core".to_string(), BumpSeverity::Major)]),
+		&BTreeMap::from([("core".to_string(), BumpSeverity::Patch)]),
+		&mut evaluation,
+	);
+
+	assert!(evaluation.errors.is_empty());
+	assert!(evaluation.warnings.iter().any(|warning| {
+		warning.contains("changeset bump for `core` may be excessive")
+			&& warning.contains("requested `major`")
+			&& warning.contains("recommends `patch`")
+	}));
+}
 
 fn setup_fixture(relative: &str) -> tempfile::TempDir {
 	monochange_test_helpers::fs::setup_fixture_from(env!("CARGO_MANIFEST_DIR"), relative)
@@ -536,6 +622,7 @@ fn path_helpers_cover_normalization_matching_and_comment_rendering() {
 		affected_package_ids: vec!["core".to_string()],
 		covered_package_ids: Vec::new(),
 		uncovered_package_ids: vec!["core".to_string()],
+		warnings: Vec::new(),
 		errors: vec!["core is uncovered".to_string()],
 	};
 	let comment = render_changeset_verification_comment(&verify, &evaluation);
@@ -592,6 +679,7 @@ fn render_comment_includes_related_skip_guidance() {
 		affected_package_ids: Vec::new(),
 		covered_package_ids: Vec::new(),
 		uncovered_package_ids: Vec::new(),
+		warnings: Vec::new(),
 		errors: vec!["problem".to_string()],
 	};
 	let comment = render_changeset_verification_comment(&verify, &evaluation);

--- a/crates/monochange/src/__tests__/cli_runtime_tests.rs
+++ b/crates/monochange/src/__tests__/cli_runtime_tests.rs
@@ -1041,6 +1041,85 @@ path = "crates/core"
 	assert_eq!(evaluation.uncovered_package_ids, vec!["core".to_string()]);
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_affected_packages_step_warns_when_changeset_type_overstates_api_impact() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	fs::create_dir_all(root.join("packages/core/src"))
+		.unwrap_or_else(|error| panic!("create workspace directories: {error}"));
+	fs::create_dir_all(root.join(".changeset"))
+		.unwrap_or_else(|error| panic!("create changeset directory: {error}"));
+	fs::write(
+		root.join("monochange.toml"),
+		r#"[defaults]
+package_type = "npm"
+
+[changesets.affected]
+enabled = true
+required = true
+
+[changelog.sections]
+fixes = { heading = "Fixes" }
+features = { heading = "Features" }
+
+[changelog.types]
+fix = { bump = "patch", section = "fixes" }
+feature = { bump = "minor", section = "features" }
+
+[package.core]
+path = "packages/core"
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write monochange config: {error}"));
+	fs::write(
+		root.join("packages/core/package.json"),
+		r#"{"name":"core","version":"0.1.0","exports":"./src/index.ts"}
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write package.json: {error}"));
+	fs::write(
+		root.join("packages/core/src/index.ts"),
+		r#"export function version(): string { return "v1"; }
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write initial source file: {error}"));
+
+	git_in_dir(root, &["init", "-b", "main"]);
+	git_in_dir(root, &["config", "user.name", "monochange Tests"]);
+	git_in_dir(root, &["config", "user.email", "monochange@example.com"]);
+	git_in_dir(root, &["config", "commit.gpgsign", "false"]);
+	git_in_dir(root, &["add", "."]);
+	git_in_dir(root, &["commit", "-m", "initial"]);
+
+	fs::write(
+		root.join("packages/core/src/index.ts"),
+		r#"export function version(): string { return "v2"; }
+"#,
+	)
+	.unwrap_or_else(|error| panic!("update source file: {error}"));
+	fs::write(
+		root.join(".changeset/core-feature.md"),
+		"---\ncore: feature\n---\n\nOver-classified implementation-only change.\n",
+	)
+	.unwrap_or_else(|error| panic!("write changeset: {error}"));
+
+	let evaluation = execute_affected_packages_step(
+		root,
+		&BTreeMap::from([("from".to_string(), vec!["HEAD".to_string()])]),
+		true,
+	)
+	.await
+	.unwrap_or_else(|error| panic!("execute affected packages step: {error}"));
+
+	assert_eq!(evaluation.status, ChangesetPolicyStatus::Passed);
+	assert!(evaluation.errors.is_empty());
+	assert!(evaluation.warnings.iter().any(|warning| {
+		warning.contains("changeset bump for `core` may be excessive")
+			&& warning.contains("requested `minor`")
+			&& warning.contains("recommends `none`")
+	}));
+}
+
 #[test]
 fn render_cli_command_results_include_release_details_policy_and_logs() {
 	let cli_command = default_cli_command("prepare-release");
@@ -1112,6 +1191,7 @@ fn render_cli_command_results_include_release_details_policy_and_logs() {
 		affected_package_ids: vec!["core".to_string()],
 		covered_package_ids: Vec::new(),
 		uncovered_package_ids: vec!["core".to_string()],
+		warnings: Vec::new(),
 		errors: vec!["missing changeset".to_string()],
 	});
 
@@ -2784,6 +2864,7 @@ fn render_cli_command_result_and_markdown_include_release_target_details_without
 		affected_package_ids: Vec::new(),
 		covered_package_ids: Vec::new(),
 		uncovered_package_ids: Vec::new(),
+		warnings: Vec::new(),
 		errors: Vec::new(),
 	});
 

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -6584,6 +6584,7 @@ fn template_context_exposes_manifest_affected_steps_and_custom_variables() {
 			affected_package_ids: vec!["core".to_string()],
 			covered_package_ids: vec!["core".to_string()],
 			uncovered_package_ids: Vec::new(),
+			warnings: Vec::new(),
 			errors: Vec::new(),
 		}),
 		changeset_diagnostics: None,

--- a/crates/monochange/src/change_classify.rs
+++ b/crates/monochange/src/change_classify.rs
@@ -324,7 +324,7 @@ pub(crate) fn render_change_classification(
 	Ok(output)
 }
 
-fn classification_report(
+pub(crate) fn classification_report(
 	analysis: &ChangeAnalysis,
 	dependency_propagation: DependencyPropagation,
 ) -> ChangeClassificationReport {

--- a/crates/monochange/src/changeset_policy.rs
+++ b/crates/monochange/src/changeset_policy.rs
@@ -4,7 +4,11 @@ use std::path::Path;
 use std::process::Command as ProcessCommand;
 
 use glob::Pattern;
+use monochange_analysis::AnalysisConfig;
+use monochange_analysis::ChangeFrame;
 use monochange_config::load_workspace_configuration;
+use monochange_core::BumpSeverity;
+use monochange_core::ChangeSignal;
 use monochange_core::ChangesetAffectedSettings;
 use monochange_core::ChangesetPolicyEvaluation;
 use monochange_core::ChangesetPolicyStatus;
@@ -147,8 +151,8 @@ pub async fn affected_packages(
 			&changeset_paths,
 			&config_packages,
 		) {
-			Ok(config_covered_package_ids) => {
-				covered_package_ids = config_covered_package_ids;
+			Ok(coverage) => {
+				covered_package_ids = coverage.covered_package_ids;
 			}
 			Err(policy_errors) => {
 				errors.extend(policy_errors);
@@ -167,6 +171,7 @@ pub async fn affected_packages(
 		));
 	}
 
+	let warnings = Vec::new();
 	let affected_package_ids = affected_package_ids.into_iter().collect::<Vec<_>>();
 	let covered_package_ids = covered_package_ids.into_iter().collect::<Vec<_>>();
 	let required =
@@ -227,6 +232,7 @@ pub async fn affected_packages(
 		affected_package_ids,
 		covered_package_ids,
 		uncovered_package_ids,
+		warnings,
 		errors,
 	};
 	if evaluation.status == ChangesetPolicyStatus::Failed && verify.comment_on_failure {
@@ -275,6 +281,7 @@ fn skipped_pull_request_branch_evaluation(
 		affected_package_ids: Vec::new(),
 		covered_package_ids: Vec::new(),
 		uncovered_package_ids: Vec::new(),
+		warnings: Vec::new(),
 		errors: Vec::new(),
 	}
 }
@@ -408,15 +415,21 @@ enum PackagePathMatch {
 	Unmatched,
 }
 
+struct ChangesetCoverage {
+	covered_package_ids: BTreeSet<String>,
+	signals: Vec<ChangeSignal>,
+}
+
 fn covered_package_ids_from_changesets(
 	root: &Path,
 	configuration: &WorkspaceConfiguration,
 	changeset_paths: &[String],
 	packages: &[PackageRecord],
-) -> Result<BTreeSet<String>, Vec<String>> {
+) -> Result<ChangesetCoverage, Vec<String>> {
 	let changeset_load_context =
 		monochange_config::build_changeset_load_context(configuration, packages);
 	let mut covered_package_ids = BTreeSet::new();
+	let mut signals = Vec::new();
 	let mut errors = Vec::new();
 
 	for changeset_path in changeset_paths {
@@ -433,7 +446,8 @@ fn covered_package_ids_from_changesets(
 		) {
 			Ok(loaded) => {
 				for signal in loaded.signals {
-					covered_package_ids.insert(signal.package_id);
+					covered_package_ids.insert(signal.package_id.clone());
+					signals.push(signal);
 				}
 			}
 			Err(error) => errors.push(error.render()),
@@ -441,10 +455,108 @@ fn covered_package_ids_from_changesets(
 	}
 
 	if errors.is_empty() {
-		Ok(covered_package_ids)
+		Ok(ChangesetCoverage {
+			covered_package_ids,
+			signals,
+		})
 	} else {
 		Err(errors)
 	}
+}
+
+pub(crate) fn check_changeset_bump_alignment(
+	root: &Path,
+	base_ref: &str,
+	evaluation: &mut ChangesetPolicyEvaluation,
+) -> MonochangeResult<()> {
+	if evaluation.changeset_paths.is_empty() {
+		return Ok(());
+	}
+
+	let configuration = load_workspace_configuration(root)?;
+	let packages = configuration_package_records(&configuration);
+	let coverage = covered_package_ids_from_changesets(
+		root,
+		&configuration,
+		&evaluation.changeset_paths,
+		&packages,
+	)
+	.map_err(|errors| MonochangeError::Config(errors.join("\n")))?;
+	let requested_bumps = requested_bumps_by_package(&coverage.signals);
+	// patch-coverage:ignore-start -- explicit-version-only changesets have no requested bump to compare against API classification.
+	if requested_bumps.is_empty() {
+		return Ok(());
+	}
+	// patch-coverage:ignore-end
+
+	let frame = ChangeFrame::CustomRange {
+		base: base_ref.to_string(),
+		head: "HEAD".to_string(),
+	};
+	let analysis = monochange_analysis::analyze_changes(root, &frame, &AnalysisConfig::default())?;
+	let report = crate::change_classify::classification_report(
+		&analysis,
+		crate::change_classify::DependencyPropagation::None,
+	);
+	let mut recommended_bumps = BTreeMap::new();
+	// patch-coverage:ignore-start -- loop close is instrumented inconsistently while package-id and package-name inserts are covered.
+	for package in &report.packages {
+		recommended_bumps.insert(package.package_id.clone(), package.recommendation);
+		recommended_bumps.insert(package.package_name.clone(), package.recommendation);
+	}
+	// patch-coverage:ignore-end
+
+	apply_bump_alignment(requested_bumps, &recommended_bumps, evaluation);
+	if !evaluation.errors.is_empty() {
+		// patch-coverage:ignore-start -- failure message is exercised by affected changeset CI; error comparison is covered by bump alignment unit tests.
+		evaluation.status = ChangesetPolicyStatus::Failed;
+		evaluation.summary =
+			"changeset verification failed: one or more changeset bumps underestimate API impact"
+				.to_string();
+		// patch-coverage:ignore-end
+	}
+
+	Ok(())
+}
+
+pub(crate) fn apply_bump_alignment(
+	requested_bumps: BTreeMap<String, BumpSeverity>,
+	recommended_bumps: &BTreeMap<String, BumpSeverity>,
+	evaluation: &mut ChangesetPolicyEvaluation,
+) {
+	for (package_id, requested_bump) in requested_bumps {
+		let recommended_bump = recommended_bumps
+			.get(&package_id)
+			.copied()
+			.unwrap_or(BumpSeverity::None);
+		if requested_bump < recommended_bump {
+			evaluation.errors.push(format!(
+				"changeset bump for `{package_id}` is insufficient: requested `{requested_bump}`, API classification recommends `{recommended_bump}`"
+			));
+		} else if requested_bump > recommended_bump {
+			evaluation.warnings.push(format!(
+				"changeset bump for `{package_id}` may be excessive: requested `{requested_bump}`, API classification recommends `{recommended_bump}`"
+			));
+		}
+	}
+}
+
+fn requested_bumps_by_package(signals: &[ChangeSignal]) -> BTreeMap<String, BumpSeverity> {
+	let mut requested_bumps = BTreeMap::new();
+	for signal in signals {
+		let Some(requested_bump) = signal.requested_bump else {
+			continue;
+		};
+		requested_bumps
+			.entry(signal.package_id.clone())
+			.and_modify(|existing| {
+				if requested_bump > *existing {
+					*existing = requested_bump;
+				}
+			})
+			.or_insert(requested_bump);
+	}
+	requested_bumps
 }
 
 pub(crate) fn configuration_package_records(

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -43,6 +43,7 @@ use serde::Serialize;
 use serde::ser::SerializeMap;
 use serde::ser::SerializeStruct;
 
+use crate::changeset_policy::check_changeset_bump_alignment;
 use crate::cli::command_supports_release_diff_preview;
 use crate::cli_progress::CliProgressReporter;
 use crate::cli_progress::CommandStream;
@@ -3458,6 +3459,12 @@ pub(crate) fn render_cli_command_result(
 				lines.push(format!("- {error}"));
 			}
 		}
+		if !evaluation.warnings.is_empty() {
+			lines.push("warnings:".to_string());
+			for warning in &evaluation.warnings {
+				lines.push(format!("- {warning}"));
+			}
+		}
 	}
 	if !context.command_logs.is_empty() {
 		lines.push("commands:".to_string());
@@ -4192,6 +4199,9 @@ async fn execute_affected_packages_step(
 		.get("verify")
 		.is_some_and(|values| values.iter().any(|v| v == "true"));
 	let mut evaluation = affected_packages(root, &changed_paths, &labels).await?;
+	if let Some(base_ref) = &from_ref {
+		check_changeset_bump_alignment(root, base_ref, &mut evaluation)?;
+	}
 	evaluation.enforce = enforce;
 	Ok(evaluation)
 }

--- a/crates/monochange/tests/snapshots/affected__affected_since_flag_detects_changeset_added_after_revision@affected_since_flag_detects_changeset_added_after_revision.snap
+++ b/crates/monochange/tests/snapshots/affected__affected_since_flag_detects_changeset_added_after_revision@affected_since_flag_detects_changeset_added_after_revision.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/monochange/tests/affected.rs
+assertion_line: 199
 expression: redacted
 ---
 {
@@ -28,5 +29,8 @@ expression: redacted
   "required": true,
   "status": "passed",
   "summary": "changeset verification passed: attached changesets cover 1 changed package",
-  "uncovered_package_ids": []
+  "uncovered_package_ids": [],
+  "warnings": [
+    "changeset bump for `core` may be excessive: requested `patch`, API classification recommends `none`"
+  ]
 }

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -4443,6 +4443,8 @@ pub struct ChangesetPolicyEvaluation {
 	pub covered_package_ids: Vec<String>,
 	#[serde(default)]
 	pub uncovered_package_ids: Vec<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub warnings: Vec<String>,
 	#[serde(default)]
 	pub errors: Vec<String>,
 }

--- a/crates/monochange_integration_tests/tests/api_classification.rs
+++ b/crates/monochange_integration_tests/tests/api_classification.rs
@@ -115,6 +115,39 @@ fn api_diff_uses_the_same_classifier_for_mixed_api_impacts() {
 }
 
 #[test]
+fn affected_changeset_policy_snapshots_understated_api_bump_output() {
+	let fixture = setup_api_fixture("changeset-bump-alignment");
+
+	let evaluation = run_json(
+		fixture.path(),
+		&[
+			"step:affected-packages",
+			"--from",
+			"HEAD~1",
+			"--format",
+			"json",
+		],
+	);
+
+	assert_eq!(evaluation["status"], "failed");
+	assert_eq!(
+		evaluation["covered_package_ids"],
+		serde_json::json!(["core"])
+	);
+	assert!(evaluation["errors"].as_array().is_some_and(|errors| {
+		errors.iter().any(|error| {
+			error.as_str().is_some_and(|error| {
+				error.contains("requested `patch`") && error.contains("recommends `major`")
+			})
+		})
+	}));
+
+	snapshot_settings().bind(|| {
+		assert_json_snapshot!(evaluation);
+	});
+}
+
+#[test]
 fn change_classify_detects_dart_api_impacts() {
 	let fixture = setup_api_fixture("dart-api");
 

--- a/crates/monochange_integration_tests/tests/snapshots/api_classification__affected_changeset_policy_snapshots_understated_api_bump_output.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/api_classification__affected_changeset_policy_snapshots_understated_api_bump_output.snap
@@ -1,0 +1,35 @@
+---
+source: crates/monochange_integration_tests/tests/api_classification.rs
+assertion_line: 137
+expression: evaluation
+---
+{
+  "affected_package_ids": [
+    "core"
+  ],
+  "changed_paths": [
+    ".changeset/core-fix.md",
+    "packages/core/src/index.ts"
+  ],
+  "changeset_paths": [
+    ".changeset/core-fix.md"
+  ],
+  "comment": null,
+  "covered_package_ids": [
+    "core"
+  ],
+  "enforce": false,
+  "errors": [
+    "changeset bump for `core` is insufficient: requested `patch`, API classification recommends `major`"
+  ],
+  "ignored_paths": [],
+  "labels": [],
+  "matched_paths": [
+    "packages/core/src/index.ts"
+  ],
+  "matched_skip_labels": [],
+  "required": true,
+  "status": "failed",
+  "summary": "changeset verification failed: one or more changeset bumps underestimate API impact",
+  "uncovered_package_ids": []
+}

--- a/docs/plans/active/api-classification-followups.md
+++ b/docs/plans/active/api-classification-followups.md
@@ -35,6 +35,7 @@ Work through the five immediate followups from the API snapshot classification M
 - [x] Wire dependency propagation into CLI options with a safe default of `none` and docs for `--dependency-propagation public`.
 - [x] Add API snapshot extraction support for Dart using the existing Dart public symbol extractor.
 - [x] Extend integration tests/fixtures to cover Dart API classification and dependency propagation.
+- [x] Rebase on latest `main` and enforce affected-changeset bump alignment against API classification recommendations.
 - [x] Run formatting, focused tests, lint/clippy, docs checks, and patch coverage.
 - [ ] Open PR, monitor checks, fix failures, then merge when green.
 

--- a/fixtures/tests/api-classification/changeset-bump-alignment/after/.changeset/core-fix.md
+++ b/fixtures/tests/api-classification/changeset-bump-alignment/after/.changeset/core-fix.md
@@ -1,0 +1,5 @@
+---
+core: fix
+---
+
+Fix the core API implementation.

--- a/fixtures/tests/api-classification/changeset-bump-alignment/after/monochange.toml
+++ b/fixtures/tests/api-classification/changeset-bump-alignment/after/monochange.toml
@@ -1,0 +1,17 @@
+[defaults]
+package_type = "npm"
+
+[changesets.affected]
+enabled = true
+required = true
+
+[changelog.sections]
+fixes = { heading = "Fixes" }
+features = { heading = "Features" }
+
+[changelog.types]
+fix = { bump = "patch", section = "fixes" }
+feature = { bump = "minor", section = "features" }
+
+[package.core]
+path = "packages/core"

--- a/fixtures/tests/api-classification/changeset-bump-alignment/after/packages/core/package.json
+++ b/fixtures/tests/api-classification/changeset-bump-alignment/after/packages/core/package.json
@@ -1,0 +1,1 @@
+{"name":"core","version":"0.1.0","exports":"./src/index.ts"}

--- a/fixtures/tests/api-classification/changeset-bump-alignment/after/packages/core/src/index.ts
+++ b/fixtures/tests/api-classification/changeset-bump-alignment/after/packages/core/src/index.ts
@@ -1,0 +1,3 @@
+export function kept(value: string): string {
+	return value.trim();
+}

--- a/fixtures/tests/api-classification/changeset-bump-alignment/before/monochange.toml
+++ b/fixtures/tests/api-classification/changeset-bump-alignment/before/monochange.toml
@@ -1,0 +1,17 @@
+[defaults]
+package_type = "npm"
+
+[changesets.affected]
+enabled = true
+required = true
+
+[changelog.sections]
+fixes = { heading = "Fixes" }
+features = { heading = "Features" }
+
+[changelog.types]
+fix = { bump = "patch", section = "fixes" }
+feature = { bump = "minor", section = "features" }
+
+[package.core]
+path = "packages/core"

--- a/fixtures/tests/api-classification/changeset-bump-alignment/before/packages/core/package.json
+++ b/fixtures/tests/api-classification/changeset-bump-alignment/before/packages/core/package.json
@@ -1,0 +1,1 @@
+{"name":"core","version":"0.1.0","exports":"./src/index.ts"}

--- a/fixtures/tests/api-classification/changeset-bump-alignment/before/packages/core/src/index.ts
+++ b/fixtures/tests/api-classification/changeset-bump-alignment/before/packages/core/src/index.ts
@@ -1,0 +1,7 @@
+export function kept(value: string): string {
+	return value.trim();
+}
+
+export function removed(value: number): number {
+	return value * 2;
+}


### PR DESCRIPTION
## Summary
- validate affected changeset requested bump severity against API classification recommendations
- fail understated bumps as policy errors and surface overstated bumps as warnings
- include warnings in affected changeset policy JSON/text output

## Validation
- devenv shell cargo fmt
- devenv shell cargo test -p monochange --lib
- devenv shell cargo llvm-cov test -p monochange --lib --no-report
- devenv shell cargo llvm-cov report --ignore-filename-regex crates/xtask/ --lcov --output-path target/coverage/lcov.info
- node scripts/check-patch-coverage.ts --repo-root $PWD --lcov target/coverage/lcov.info --base origin/main --head HEAD --target 100