### PR TITLE
fix: skip empty release records

### DIFF
--- a/.changeset/fix-release-record-empty-plan.md
+++ b/.changeset/fix-release-record-empty-plan.md
@@ -1,0 +1,8 @@
+---
+"monochange": patch
+"monochange_core": patch
+---
+
+# Skip empty release records by default
+
+Avoid writing release record artifacts for empty release plans unless `write_empty_release_record` is enabled.

--- a/crates/monochange/src/__tests__/command_wizard_tests.rs
+++ b/crates/monochange/src/__tests__/command_wizard_tests.rs
@@ -283,12 +283,18 @@ fn command_step_with_default_inputs_adds_and_inherits_expected_inputs() {
 	let step = command_step_with_default_inputs("PrepareRelease", &mut command_inputs)
 		.unwrap_or_else(|error| panic!("step should be created: {error}"));
 
-	assert_eq!(command_inputs.len(), 1);
+	assert_eq!(command_inputs.len(), 2);
 	assert_eq!(command_inputs[0].name, "format");
 	assert_eq!(command_inputs[0].kind, "choice");
 	assert_eq!(command_inputs[0].choices[0], "text");
+	assert_eq!(command_inputs[1].name, "write_empty_release_record");
+	assert_eq!(command_inputs[1].kind, "boolean");
 	assert_eq!(
 		step.inputs.get("format"),
+		Some(&CliStepInputValue::Inherited)
+	);
+	assert_eq!(
+		step.inputs.get("write_empty_release_record"),
 		Some(&CliStepInputValue::Inherited)
 	);
 	assert_config_error(

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -3094,6 +3094,35 @@ fn command_release_dry_run_discovers_changesets_without_mutating_files() {
 	assert!(tempdir.path().join(".changeset/feature.md").exists());
 }
 
+fn release_record_json_paths(root: &Path) -> Vec<PathBuf> {
+	let release_dir = root.join(".monochange/releases");
+	let Ok(entries) = fs::read_dir(&release_dir) else {
+		return Vec::new();
+	};
+
+	entries
+		.filter_map(Result::ok)
+		.map(|entry| entry.path().join("release.json"))
+		.filter(|path| path.exists())
+		.collect()
+}
+
+fn configure_release_command_for_empty_release_records(root: &Path) {
+	let config_path = root.join("monochange.toml");
+	let config = fs::read_to_string(&config_path)
+		.unwrap_or_else(|error| panic!("read release fixture config: {error}"));
+	let config = config.replace(
+		"default = \"text\"\n\n[[cli.release.steps]]",
+		"default = \"text\"\n\n[[cli.release.inputs]]\nname = \"write_empty_release_record\"\ntype = \"boolean\"\ndefault = false\n\n[[cli.release.steps]]",
+	);
+	let config = config.replace(
+		"type = \"PrepareRelease\"\ninputs = [\"format\"]",
+		"type = \"PrepareRelease\"\nallow_empty_changesets = true\ninputs = { format = \"{{ inputs.format }}\", write_empty_release_record = \"{{ inputs.write_empty_release_record }}\" }",
+	);
+	fs::write(config_path, config)
+		.unwrap_or_else(|error| panic!("write release fixture config: {error}"));
+}
+
 #[test]
 fn prepare_release_allows_empty_changesets_when_configured() {
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
@@ -3126,6 +3155,56 @@ fn prepare_release_allows_empty_changesets_when_configured() {
 	assert!(execution.prepared_release.released_packages.is_empty());
 	assert!(execution.prepared_release.changed_files.is_empty());
 	assert!(execution.file_diffs.is_empty());
+}
+
+#[test]
+fn release_command_skips_release_json_when_no_packages_are_released() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	seed_release_fixture(tempdir.path(), None, false);
+	fs::remove_dir_all(tempdir.path().join(".changeset"))
+		.unwrap_or_else(|error| panic!("remove changesets: {error}"));
+	configure_release_command_for_empty_release_records(tempdir.path());
+
+	run_cli(
+		tempdir.path(),
+		[OsString::from("mc"), OsString::from("release")],
+	)
+	.unwrap_or_else(|error| panic!("release command: {error}"));
+
+	assert!(release_record_json_paths(tempdir.path()).is_empty());
+	assert!(
+		!tempdir
+			.path()
+			.join(".monochange/local/release-manifest.json")
+			.exists()
+	);
+}
+
+#[test]
+fn release_command_writes_release_json_for_empty_plan_when_requested() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	seed_release_fixture(tempdir.path(), None, false);
+	fs::remove_dir_all(tempdir.path().join(".changeset"))
+		.unwrap_or_else(|error| panic!("remove changesets: {error}"));
+	configure_release_command_for_empty_release_records(tempdir.path());
+
+	run_cli(
+		tempdir.path(),
+		[
+			OsString::from("mc"),
+			OsString::from("release"),
+			OsString::from("--write-empty-release-record"),
+		],
+	)
+	.unwrap_or_else(|error| panic!("release command: {error}"));
+
+	assert_eq!(release_record_json_paths(tempdir.path()).len(), 1);
+	assert!(
+		tempdir
+			.path()
+			.join(".monochange/local/release-manifest.json")
+			.exists()
+	);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -364,6 +364,13 @@ async fn write_default_release_manifest_file(
 	write_release_manifest_file(root, Path::new(DEFAULT_RELEASE_MANIFEST_PATH), manifest).await
 }
 
+fn should_write_release_record_for_prepared_release(
+	prepared_release: &PreparedRelease,
+	write_empty_release_record: bool,
+) -> bool {
+	write_empty_release_record || !prepared_release.released_packages.is_empty()
+}
+
 async fn ensure_prepared_release_for_consumer_step(
 	root: &Path,
 	configuration: &monochange_core::WorkspaceConfiguration,
@@ -835,6 +842,9 @@ pub(crate) async fn execute_cli_command_with_options(
 					allow_empty_changesets,
 					..
 				} => {
+					let write_empty_release_record =
+						parse_boolean_step_input(&step_inputs, "write_empty_release_record")?
+							.unwrap_or(false);
 					let build_file_diffs = context.show_diff
 						|| cli_command
 							.steps
@@ -873,12 +883,25 @@ pub(crate) async fn execute_cli_command_with_options(
 						prepared_release,
 						&context.command_logs,
 					);
-					let _record_path =
-						write_release_record_file(root, configuration.source.as_ref(), &manifest)?;
+					if should_write_release_record_for_prepared_release(
+						prepared_release,
+						write_empty_release_record,
+					) {
+						let _record_path = write_release_record_file(
+							root,
+							configuration.source.as_ref(),
+							&manifest,
+						)?;
+						context.release_manifest_path =
+							Some(write_default_release_manifest_file(root, &manifest).await?);
+					} else {
+						context
+							.command_logs
+							.push("skipped release record: no packages were released".to_string());
+						context.release_manifest_path = None;
+					}
 					let updated_prepared_release = context.prepared_release.take().unwrap();
 					context.prepared_release = Some(updated_prepared_release);
-					context.release_manifest_path =
-						Some(write_default_release_manifest_file(root, &manifest).await?);
 					output = None;
 					Ok(())
 				}

--- a/crates/monochange_core/src/__tests__/lib_tests.rs
+++ b/crates/monochange_core/src/__tests__/lib_tests.rs
@@ -1803,6 +1803,10 @@ fn expected_input_kind_returns_correct_types_for_display_and_publish_steps() {
 		prepare.expected_input_kind("format"),
 		Some(CliInputKind::Choice)
 	);
+	assert_eq!(
+		prepare.expected_input_kind("write_empty_release_record"),
+		Some(CliInputKind::Boolean)
+	);
 	assert_eq!(prepare.expected_input_kind("versions"), None);
 	assert_eq!(prepare.expected_input_kind("unknown"), None);
 

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -2903,9 +2903,8 @@ impl CliStepDefinition {
 			Self::Config { .. } | Self::Validate { .. } => Some(&[]),
 			Self::CommitRelease { .. } => Some(&["no_verify", "update_release_json", "stage_all"]),
 			Self::VerifyReleaseBranch { .. } => Some(&["from"]),
-			Self::Discover { .. } | Self::DisplayVersions { .. } | Self::PrepareRelease { .. } => {
-				Some(&["format"])
-			}
+			Self::Discover { .. } | Self::DisplayVersions { .. } => Some(&["format"]),
+			Self::PrepareRelease { .. } => Some(&["format", "write_empty_release_record"]),
 			Self::CommentReleasedIssues { .. } => {
 				Some(&["format", "from-ref", "auto-close-issues"])
 			}
@@ -3011,8 +3010,15 @@ impl CliStepDefinition {
 				}
 			}
 			Self::Config { .. } | Self::Command { .. } | Self::Validate { .. } => None,
-			Self::Discover { .. } | Self::DisplayVersions { .. } | Self::PrepareRelease { .. } => {
+			Self::Discover { .. } | Self::DisplayVersions { .. } => {
 				matches!(name, "format").then_some(CliInputKind::Choice)
+			}
+			Self::PrepareRelease { .. } => {
+				match name {
+					"format" => Some(CliInputKind::Choice),
+					"write_empty_release_record" => Some(CliInputKind::Boolean),
+					_ => None,
+				}
 			}
 			Self::CommentReleasedIssues { .. } => {
 				match name {

--- a/crates/monochange_integration_tests/tests/release_record_artifacts.rs
+++ b/crates/monochange_integration_tests/tests/release_record_artifacts.rs
@@ -53,17 +53,53 @@ fn prepare_release(root: &Path) -> Value {
 
 fn release_record_paths(root: &Path) -> Vec<PathBuf> {
 	let releases_dir = root.join(".monochange/releases");
-	let mut paths = std::fs::read_dir(&releases_dir)
-		.unwrap_or_else(|error| panic!("read {}: {error}", releases_dir.display()))
+	let Ok(entries) = std::fs::read_dir(&releases_dir) else {
+		return Vec::new();
+	};
+	let mut paths = entries
 		.map(|entry| {
 			entry
 				.unwrap_or_else(|error| panic!("read release entry: {error}"))
 				.path()
 				.join("release.json")
 		})
+		.filter(|path| path.exists())
 		.collect::<Vec<_>>();
 	paths.sort();
 	paths
+}
+
+fn configure_release_command_for_empty_release_records(root: &Path) {
+	let config_path = root.join("monochange.toml");
+	let config = std::fs::read_to_string(&config_path)
+		.unwrap_or_else(|error| panic!("read config: {error}"));
+	let config = config.replace(
+		"default = \"text\"\n\n[[cli.release.steps]]",
+		"default = \"text\"\n\n[[cli.release.inputs]]\nname = \"write_empty_release_record\"\ntype = \"boolean\"\ndefault = false\n\n[[cli.release.steps]]",
+	);
+	let config = config.replace(
+		"type = \"PrepareRelease\"\ninputs = [\"format\"]",
+		"type = \"PrepareRelease\"\nallow_empty_changesets = true\ninputs = { format = \"{{ inputs.format }}\", write_empty_release_record = \"{{ inputs.write_empty_release_record }}\" }",
+	);
+	std::fs::write(&config_path, config).unwrap_or_else(|error| panic!("write config: {error}"));
+}
+
+fn run_release(root: &Path, args: &[&str]) {
+	let output = Command::new(get_cargo_bin("mc"))
+		.current_dir(root)
+		.env("NO_COLOR", "1")
+		.env_remove("RUST_LOG")
+		.env("MONOCHANGE_RELEASE_DATE", "2026-04-07")
+		.arg("release")
+		.args(args)
+		.output()
+		.unwrap_or_else(|error| panic!("run release: {error}"));
+	assert!(
+		output.status.success(),
+		"release failed\nstdout:\n{}\nstderr:\n{}",
+		String::from_utf8_lossy(&output.stdout),
+		String::from_utf8_lossy(&output.stderr)
+	);
 }
 
 fn check_failure(root: &Path) -> String {
@@ -179,6 +215,45 @@ fn check_rejects_stale_prerelease_state_when_mode_is_off() {
 	assert_json_snapshot!(serde_json::json!({
 		"relevantLines": relevant_lines,
 	}));
+}
+
+#[test]
+fn release_skips_record_artifacts_for_empty_plan_by_default() {
+	let tempdir = setup_release_fixture("monochange/release-base");
+	let root = tempdir.path();
+	std::fs::remove_dir_all(root.join(".changeset"))
+		.unwrap_or_else(|error| panic!("remove changesets: {error}"));
+	configure_release_command_for_empty_release_records(root);
+	git(root, &["add", "."]);
+	git(root, &["commit", "-m", "remove changesets"]);
+
+	run_release(root, &[]);
+
+	assert!(release_record_paths(root).is_empty());
+	assert!(
+		!root
+			.join(".monochange/local/release-manifest.json")
+			.exists()
+	);
+}
+
+#[test]
+fn release_writes_record_artifacts_for_empty_plan_when_requested() {
+	let tempdir = setup_release_fixture("monochange/release-base");
+	let root = tempdir.path();
+	std::fs::remove_dir_all(root.join(".changeset"))
+		.unwrap_or_else(|error| panic!("remove changesets: {error}"));
+	configure_release_command_for_empty_release_records(root);
+	git(root, &["add", "."]);
+	git(root, &["commit", "-m", "remove changesets"]);
+
+	run_release(root, &["--write-empty-release-record"]);
+
+	assert_eq!(release_record_paths(root).len(), 1);
+	assert!(
+		root.join(".monochange/local/release-manifest.json")
+			.exists()
+	);
 }
 
 #[test]

--- a/monochange.toml
+++ b/monochange.toml
@@ -757,9 +757,10 @@ inputs = [
 	{ name = "no_verify", type = "boolean", default = true },
 	{ name = "commit", help_text = "Whether to commit the changes", type = "boolean", default = false },
 	{ name = "create_pr", help_text = "Whether to create the PR after the commit", type = "boolean", default = false },
+	{ name = "write_empty_release_record", help_text = "Whether to write release records when no packages are released", type = "boolean", default = false },
 ]
 steps = [
-	{ type = "PrepareRelease", name = "plan release", allow_empty_changesets = true },
+	{ type = "PrepareRelease", name = "plan release", allow_empty_changesets = true, inputs = { format = "{{ inputs.format }}", write_empty_release_record = "{{ inputs.write_empty_release_record }}" } },
 	{ type = "Command", name = "generate cargo lockfile", when = "{{ number_of_changesets > 0 }}", command = "cargo generate-lockfile" },
 	{ type = "Command", name = "generate pnpm lockfile", when = "{{ number_of_changesets > 0 }}", command = "pnpm install --lockfile-only --no-frozen-lockfile --link-workspace-packages" },
 	{ type = "Command", name = "update json schemas", when = "{{ number_of_changesets > 0 }}", command = "cargo xtask schema release update --versioned" },


### PR DESCRIPTION
## Summary
- Skip release record and release-manifest artifact writes when `PrepareRelease` produces no released packages.
- Add `write_empty_release_record` as an opt-in PrepareRelease input/CLI flag.
- Wire the repository `release` workflow to keep empty release records opt-in.
- Add integration coverage for default skip behavior and explicit opt-in artifact writes.

## Validation
- `devenv shell cargo test -p monochange --lib release_command`
- `devenv shell cargo test -p monochange_core --lib expected_input_kind`
- `devenv shell cargo test -p monochange_integration_tests --test release_record_artifacts release_`
- `devenv shell cargo clippy -p monochange -p monochange_core --all-targets --all-features -- -D warnings`
- `devenv shell dprint check`
- `target/debug/mc step:validate`
