### PR TITLE
fix: clean up lint warnings

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,5 @@
 [alias]
 deny = ["bin", "cargo-deny"]
-insta = ["bin", "cargo-insta"]
 llvm-cov = ["bin", "cargo-llvm-cov"]
-nextest = ["bin", "cargo-nextest"]
 semver-checks = ["bin", "cargo-semver-checks"]
 xtask = ["run", "--package", "xtask", "--"]

--- a/.changeset/clean-up-lint-warnings.md
+++ b/.changeset/clean-up-lint-warnings.md
@@ -1,0 +1,7 @@
+---
+monochange: none
+---
+
+# Clean up lint warning sources
+
+Tighten local and CI lint tooling so workflow security scans, cargo-deny checks, and snapshot test commands run without actionable warning noise.

--- a/.github/actions/devenv/action.yml
+++ b/.github/actions/devenv/action.yml
@@ -12,10 +12,6 @@ inputs:
     description: Free Ubuntu runner disk space for jobs with large Nix, Cargo, or coverage footprints.
     required: false
     default: "false"
-  activate:
-    description: Whether to activate the devenv environment for the entire job.
-    required: false
-    default: "false"
 
 runs:
   using: composite
@@ -108,23 +104,6 @@ runs:
           sleep_seconds=$((attempt * 10))
           echo "::warning::setup nix environment failed (attempt $attempt/$max_attempts). Retrying in ${sleep_seconds}s..."
           sleep "$sleep_seconds"
-        done
-
-    - name: load devenv environment
-      shell: bash
-      if: inputs.activate == 'true'
-      run: |
-        # Dump the devenv environment into KEY=VALUE format
-        devenv shell -- env | while IFS= read -r line; do
-          # Skip PATH and empty lines; write the rest to GITHUB_ENV
-          [[ "$line" =~ ^PATH= ]] && continue
-          [[ -z "$line" ]] && continue
-          echo "$line" >> "$GITHUB_ENV"
-        done
-
-        # Extract PATH additions and write them to GITHUB_PATH
-        devenv shell -- printenv PATH | tr ':' '\n' | while read -r dir; do
-          [[ -d "$dir" ]] && echo "$dir" >> "$GITHUB_PATH"
         done
 
     - name: install dependencies

--- a/.github/workflows/changeset-policy.yml
+++ b/.github/workflows/changeset-policy.yml
@@ -23,7 +23,9 @@ jobs:
       pull-requests: read
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -32,7 +34,7 @@ jobs:
 
       - name: collect changed files
         id: changed
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
 
       - name: run changeset policy
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -25,7 +28,9 @@ jobs:
       actions: read
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
@@ -38,7 +43,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -86,7 +93,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -114,9 +123,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: setup devenv
         if: runner.os != 'Windows'
@@ -127,7 +137,7 @@ jobs:
 
       - name: setup rust
         if: runner.os == 'Windows'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: build on macOS
         if: runner.os == 'macOS'
@@ -184,6 +194,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -219,6 +230,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -240,9 +252,10 @@ jobs:
       id-token: write
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -277,7 +290,7 @@ jobs:
 
       - name: upload codecov flag reports artifact
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: codecov-flag-reports
           path: target/coverage/flags/*.lcov
@@ -286,7 +299,7 @@ jobs:
 
       - name: upload coverage to codecov
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.1
         with:
           use_oidc: true
           files: ./target/coverage/lcov.info
@@ -314,16 +327,18 @@ jobs:
         flag: ${{ fromJson(needs.coverage.outputs.codecov-flags) }}
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: download codecov flag reports artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: codecov-flag-reports
           path: target/coverage/flags
 
       - name: upload crate coverage flag to codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.1
         with:
           use_oidc: true
           files: ./target/coverage/flags/${{ matrix.flag }}.lcov
@@ -342,7 +357,9 @@ jobs:
       pull-requests: write
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -365,7 +382,7 @@ jobs:
 
       - name: upload benchmark results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: criterion-benchmark-results
           path: target/benchmark-results.txt
@@ -381,9 +398,10 @@ jobs:
       pull-requests: write
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -423,16 +441,18 @@ jobs:
 
       - name: comment benchmark results on PR
         if: always() && steps.bench.outcome == 'success'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           header: binary-benchmark
           message: ${{ steps.bench.outputs.results }}
 
       - name: fail on phase budget regressions
         if: always() && steps.bench.outcome == 'success' && env.MONOCHANGE_ALLOW_BENCHMARK_BUDGET_FAILURES != 'true'
+        env:
+          BENCHMARK_VIOLATIONS: ${{ steps.bench.outputs.violations }}
         run: |
-          if [ "${{ steps.bench.outputs.violations }}" -gt 0 ]; then
-            echo "benchmark phase budget regressions detected: ${{ steps.bench.outputs.violations }}"
+          if [ "$BENCHMARK_VIOLATIONS" -gt 0 ]; then
+            echo "benchmark phase budget regressions detected: $BENCHMARK_VIOLATIONS"
             exit 1
           fi
         shell: devenv shell -- bash -e {0}
@@ -446,9 +466,10 @@ jobs:
       pull-requests: write
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -486,7 +507,7 @@ jobs:
 
       - name: comment binary size on PR
         if: always() && steps.size.outcome == 'success'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           header: binary-size
           message: ${{ steps.size.outputs.results }}
@@ -497,9 +518,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -542,9 +564,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -590,9 +613,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -668,10 +692,11 @@ jobs:
       pull-requests: write
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
+          persist-credentials: false
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -746,10 +771,11 @@ jobs:
       issues: write
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.1
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: setup
         uses: ./.github/actions/devenv

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -8,8 +8,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: docs-release
@@ -21,16 +19,18 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: setup rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: install mdbook
         run: cargo install --locked mdbook
 
       - name: configure pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
         with:
           enablement: true
 
@@ -38,7 +38,7 @@ jobs:
         run: mdbook build docs
 
       - name: upload pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: docs/book
 
@@ -46,10 +46,13 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: deploy to github pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -115,7 +115,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          mutation_crate='${{ matrix.crate }}'
+          mutation_crate='${MATRIX_CRATE}'
           report_dir="mutants-report/$mutation_crate"
           mkdir -p "$(dirname "$report_dir")"
 
@@ -128,6 +128,8 @@ jobs:
 
           echo "status=$status" >> "$GITHUB_OUTPUT"
         timeout-minutes: 90
+        env:
+          MATRIX_CRATE: ${{ matrix.crate }}
 
       - name: upload mutants report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -143,11 +145,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          mutation_crate='${{ matrix.crate }}'
-          mutation_profile='${{ needs.discover-crates.outputs.profile }}'
+          mutation_crate='${MATRIX_CRATE}'
+          mutation_profile='${NEEDS_DISCOVER_CRATES_OUTPUTS_PROFILE}'
           report_dir="mutants-report/$mutation_crate"
-          status='${{ steps.run-mutants.outputs.status || '1' }}'
-          fail_on_missed='${{ github.event.inputs.fail_on_missed || 'true' }}'
+          status='${STEPS_RUN_MUTANTS_OUTPUTS_STATUS}'
+          fail_on_missed='${GITHUB_EVENT_INPUTS_FAIL_ON_MISSED}'
 
           report_data_dir="$report_dir/mutants.out"
 
@@ -204,3 +206,8 @@ jobs:
             echo "::error::cargo-mutants exited with status $status without reporting missed or timed-out mutants"
             exit "$status"
           fi
+        env:
+          MATRIX_CRATE: ${{ matrix.crate }}
+          NEEDS_DISCOVER_CRATES_OUTPUTS_PROFILE: ${{ needs.discover-crates.outputs.profile }}
+          STEPS_RUN_MUTANTS_OUTPUTS_STATUS: ${{ steps.run-mutants.outputs.status || '1' }}
+          GITHUB_EVENT_INPUTS_FAIL_ON_MISSED: ${{ github.event.inputs.fail_on_missed || 'true' }}

--- a/changelog.md
+++ b/changelog.md
@@ -324,7 +324,7 @@ Avoid building full template contexts for simple release command steps, literal 
 _Owner:_ [@ifiokjr](https://github.com/ifiokjr) · _Review:_ [PR #565](https://github.com/monochange/monochange/pull/565)
 
 <details>
-<summary><strong>📖 Documentation</strong></summary>
+<summary><strong>Documentation</strong></summary>
 
 #### Document lint rule catalog
 

--- a/crates/monochange/changelog.md
+++ b/crates/monochange/changelog.md
@@ -197,7 +197,7 @@ Avoid building full template contexts for simple release command steps, literal 
 _Owner:_ [@ifiokjr](https://github.com/ifiokjr) · _Review:_ [PR #565](https://github.com/monochange/monochange/pull/565)
 
 <details>
-<summary><strong>📖 Documentation</strong></summary>
+<summary><strong>Documentation</strong></summary>
 
 #### Document lint rule catalog
 

--- a/deny.toml
+++ b/deny.toml
@@ -36,14 +36,17 @@ skip = [
 	# These remain duplicated through transitive dependencies outside the workspace's
 	# direct control. Track them explicitly so cargo-deny stays focused on new
 	# duplicate introductions.
-	"core-foundation@0.9.4",
 	"getrandom@0.2.17",
 	"getrandom@0.4.2",
 	"r-efi@5.3.0",
-	"thiserror@1.0.69",
-	"thiserror-impl@1.0.69",
+	"rand@0.8.6",
+	"rand_chacha@0.3.1",
+	"rand_core@0.6.4",
+	"shlex@1.3.0",
+	"similar@2.7.0",
 	"unicode-width@0.1.14",
-	"windows-sys@0.45.0",
+	"windows-sys@0.52.0",
+	"wit-bindgen@0.51.0",
 ]
 
 [sources]

--- a/devenv.nix
+++ b/devenv.nix
@@ -7,6 +7,7 @@
 }:
 
 let
+  currentDir = builtins.dirOf __curPos.file;
   custom = inputs.ifiokjr-nixpkgs.packages.${pkgs.stdenv.system};
 in
 {
@@ -58,22 +59,22 @@ in
         entry = "${pkgs.gitleaks}/bin/gitleaks protect --staged --verbose --redact";
         stages = [ "pre-commit" ];
       };
-      dprint = {
+      "lint:format" = {
         enable = true;
         verbose = true;
         pass_filenames = true;
-        name = "dprint check";
+        name = "lint:format";
         description = "Run workspace autofixes before commit and restage the results.";
-        entry = "${pkgs.dprint}/bin/dprint check --allow-no-files";
+        entry = "${config.env.DEVENV_PROFILE}/bin/lint:format";
         stages = [ "pre-commit" ];
       };
       "lint:test" = {
         enable = true;
         verbose = true;
         pass_filenames = false;
-        name = "lint and test";
+        name = "lint:push";
         description = "Run the local CI lint rules and test suite before push.";
-        entry = "${config.env.DEVENV_PROFILE}/bin/lint:test";
+        entry = "${config.env.DEVENV_PROFILE}/bin/lint:push";
         stages = [ "pre-push" ];
       };
     };
@@ -212,7 +213,9 @@ in
     "test:cargo" = {
       exec = ''
         set -euo pipefail
-        cargo insta test --workspace --exclude xtask --all-features --test-runner nextest --unreferenced=reject
+        cargo bin --install
+        export PATH="$PWD/.bin/rust-nightly/cargo-nextest/0.9.132/bin:$PATH"
+        cargo bin cargo-insta test --workspace --exclude xtask --all-features --test-runner nextest --disable-nextest-doctest --unreferenced=reject
       '';
       description = "Run cargo tests with nextest and reject unreferenced snapshots.";
       binary = "bash";
@@ -220,7 +223,9 @@ in
     "test:cargo:expensive" = {
       exec = ''
         set -euo pipefail
-        MONOCHANGE_EXPENSIVE_TESTS=1 cargo insta test --workspace --exclude xtask --all-features --test-runner nextest --unreferenced=reject
+        cargo bin --install
+        export PATH="$PWD/.bin/rust-nightly/cargo-nextest/0.9.132/bin:$PATH"
+        MONOCHANGE_EXPENSIVE_TESTS=1 cargo bin cargo-insta test --workspace --exclude xtask --all-features --test-runner nextest --disable-nextest-doctest --unreferenced=reject
       '';
       description = "Run cargo tests with CI-only large-fixture cases enabled and reject unreferenced snapshots.";
       binary = "bash";
@@ -375,11 +380,29 @@ in
       description = "Run cargo-deny checks for security advisories and license compliance.";
       binary = "bash";
     };
-    "lint:test" = {
+    "lint:push" = {
       exec = ''
         set -euo pipefail
 
-        ${pkgs.gitleaks}/bin/gitleaks detect --verbose --redact;
+        run_step() {
+          local name="$1"
+          shift
+          echo "Currently running: $name"
+          "$@"
+        }
+
+        run_step "gitleaks detect" ${pkgs.gitleaks}/bin/gitleaks detect --verbose --redact
+        run_step "lint:clippy" ${currentDir}/.devenv/profile/bin/lint:clippy
+        run_step "schema:check" ${currentDir}/.devenv/profile/bin/schema:check
+        run_step "lint:format" ${currentDir}/.devenv/profile/bin/lint:format
+        run_step "lint:architecture" ${currentDir}/.devenv/profile/bin/lint:architecture
+        run_step "lint:root-git-config" ${currentDir}/.devenv/profile/bin/lint:root-git-config
+        run_step "lint:js" ${currentDir}/.devenv/profile/bin/lint:js
+        run_step "lint:js:types" ${currentDir}/.devenv/profile/bin/lint:js:types
+        run_step "lint:workflows" ${currentDir}/.devenv/profile/bin/lint:workflows
+        run_step "deny:check" ${currentDir}/.devenv/profile/bin/deny:check
+        run_step "docs:check" ${currentDir}/.devenv/profile/bin/docs:check
+        run_step "lint:monochange" ${currentDir}/.devenv/profile/bin/lint:monochange
       '';
       description = "Used for the pre push checks";
       binary = "bash";
@@ -387,17 +410,25 @@ in
     "lint:all" = {
       exec = ''
         set -euo pipefail
-        lint:clippy
-        schema:check
-        lint:format
-        lint:architecture
-        lint:root-git-config
-        lint:js
-        lint:js:types
-        lint:workflows
-        deny:check
-        docs:check
-        lint:monochange
+
+        run_step() {
+          local name="$1"
+          shift
+          echo "Currently running: $name"
+          "$@"
+        }
+
+        run_step "lint:clippy" lint:clippy
+        run_step "schema:check" schema:check
+        run_step "lint:format" lint:format
+        run_step "lint:architecture" lint:architecture
+        run_step "lint:root-git-config" lint:root-git-config
+        run_step "lint:js" lint:js
+        run_step "lint:js:types" lint:js:types
+        run_step "lint:workflows" lint:workflows
+        run_step "deny:check" deny:check
+        run_step "docs:check" docs:check
+        run_step "lint:monochange" lint:monochange
       '';
       description = "Run all checks.";
       binary = "bash";
@@ -405,7 +436,7 @@ in
     "lint:format" = {
       exec = ''
         set -euo pipefail
-        dprint check
+        ${pkgs.dprint}/bin/dprint check
       '';
       description = "Check that all files are formatted.";
       binary = "bash";
@@ -531,7 +562,7 @@ in
       exec = ''
         set -euo pipefail
         mdt check
-        skill:commands:check
+        cargo xtask skill commands check
         pnpm node scripts/check-agent-surface.ts
       '';
       description = "Check that shared documentation blocks are synchronized and agent-facing docs stay aligned with the repo surface.";
@@ -541,7 +572,7 @@ in
       exec = ''
         set -euo pipefail
         mdt update
-        skill:commands:update
+        cargo xtask skill commands update
       '';
       description = "Update shared documentation blocks and generated skill command inventory.";
       binary = "bash";
@@ -549,7 +580,8 @@ in
     "snapshot:review" = {
       exec = ''
         set -euo pipefail
-        cargo insta review
+        cargo bin --install
+        cargo bin cargo-insta review
       '';
       description = "Review insta snapshots.";
       binary = "bash";
@@ -557,7 +589,9 @@ in
     "snapshot:check" = {
       exec = ''
         set -euo pipefail
-        cargo insta test --workspace --exclude xtask --all-features --test-runner nextest --unreferenced=reject
+        cargo bin --install
+        export PATH="$PWD/.bin/rust-nightly/cargo-nextest/0.9.132/bin:$PATH"
+        cargo bin cargo-insta test --workspace --exclude xtask --all-features --test-runner nextest --disable-nextest-doctest --unreferenced=reject
       '';
       description = "Check insta snapshots and fail on unreferenced snapshot files.";
       binary = "bash";
@@ -565,7 +599,9 @@ in
     "snapshot:update" = {
       exec = ''
         set -euo pipefail
-        cargo insta test --workspace --exclude xtask --all-features --test-runner nextest --force-update-snapshots --unreferenced=delete
+        cargo bin --install
+        export PATH="$PWD/.bin/rust-nightly/cargo-nextest/0.9.132/bin:$PATH"
+        cargo bin cargo-insta test --workspace --exclude xtask --all-features --test-runner nextest --disable-nextest-doctest --force-update-snapshots --unreferenced=delete
       '';
       description = "Update insta snapshots and delete unreferenced snapshot files.";
       binary = "bash";


### PR DESCRIPTION
## Summary
- add clear `Currently running: <step>` logging to lint task orchestration
- resolve zizmor workflow findings by pinning actions, tightening permissions, and removing unsafe env activation
- clean up lint warnings from cargo-deny duplicates, Cargo aliases, docs checks, and changelog details output

## Validation
- `devenv shell docs:check`
- `devenv shell lint:push`
- pre-push hook passed during `git push -u origin fix/lint-warning-cleanup`