### PR TITLE
ci: authenticate release PR branch pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -753,7 +753,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN  }}
           GITHUB_COMMIT_TOKEN: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
-        run: monochange --log-level=debug run release --commit --create-pr
+        run: |
+          set -euo pipefail
+          export GIT_CONFIG_COUNT=1
+          export GIT_CONFIG_KEY_0=http.https://github.com/.extraheader
+          export GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GITHUB_COMMIT_TOKEN" | base64 -w 0)"
+          monochange --log-level=debug run release --commit --create-pr
         shell: devenv shell -- bash -e {0}
 
       - name: skip refresh on merged release commit


### PR DESCRIPTION
## Summary
- configure a temporary GitHub HTTP authorization header before the release PR refresh command
- remove the temporary header when the step exits so checkout cleanup still has no persisted credentials

## Verification
- devenv shell zizmor .github/workflows/ci.yml
- devenv shell dprint check .github/workflows/ci.yml
- git push pre-push lint:test