### PR TITLE
ci: use monochange actions

### DIFF
--- a/.github/workflows/changeset-policy.yml
+++ b/.github/workflows/changeset-policy.yml
@@ -37,22 +37,9 @@ jobs:
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
 
       - name: run changeset policy
-        env:
-          CHANGED_FILES: ${{ steps.changed.outputs.all_changed_files }}
-          PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
-        run: |
-          set -euo pipefail
-
-          mapfile -t labels < <(jq -r '.[]' <<<"$PR_LABELS_JSON")
-          args=(step affected-packages --format json --verify)
-
-          for path in $CHANGED_FILES; do
-            args+=(--changed-paths "$path")
-          done
-
-          for label in "${labels[@]}"; do
-            args+=(--label "$label")
-          done
-
-          monochange "${args[@]}"
-        shell: devenv shell -- bash -e {0}
+        uses: monochange/actions/changeset-policy@53bd37cbecff25eeefa689bd7ac5fc807dbabac7
+        with:
+          setup-monochange: devenv shell monochange
+          changed-paths: ${{ steps.changed.outputs.all_changed_files }}
+          labels: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,14 +112,14 @@ jobs:
         shell: devenv shell -- bash -e {0}
 
       - name: check publish readiness
+        uses: monochange/actions@53bd37cbecff25eeefa689bd7ac5fc807dbabac7
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-oidc.outputs.token }}
-        run: |
-          "$RUNNER_TEMP/bin/monochange" step publish-readiness \
-            --from HEAD \
-            --output "$RUNNER_TEMP/publish-readiness.json" \
-            --format json
-        shell: devenv shell -- bash -e {0}
+        with:
+          name: publish-readiness
+          setup-monochange: ${{ runner.temp }}/bin/monochange
+          ref: HEAD
+          output: ${{ runner.temp }}/publish-readiness.json
 
       - name: setup cargo stable for publish
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
@@ -137,12 +137,11 @@ jobs:
           version: 10
 
       - name: publish packages
+        uses: monochange/actions@53bd37cbecff25eeefa689bd7ac5fc807dbabac7
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-oidc.outputs.token }}
-        run: |
-          "$RUNNER_TEMP/bin/monochange" step publish-packages \
-            --log-level info \
-            --all \
-            --output "$RUNNER_TEMP/publish-result.json" \
-            --format json
-        shell: bash
+        with:
+          name: publish-packages
+          setup-monochange: ${{ runner.temp }}/bin/monochange
+          all: true
+          output: ${{ runner.temp }}/publish-result.json


### PR DESCRIPTION
## Summary
- replace the changeset policy bash wrapper with monochange/actions/changeset-policy
- use monochange/actions publish-readiness and publish-packages in the publish workflow
- pin monochange/actions to merge commit 53bd37cbecff25eeefa689bd7ac5fc807dbabac7 from monochange/actions#35 instead of a released version

## Verification
- pre-push lint:test passed locally, including workflow linting and monochange manifest lint

No release or tag is created by this change.