### PR TITLE
fix(release): apply default versioned files

### DIFF
--- a/.changeset/default-versioned-files.md
+++ b/.changeset/default-versioned-files.md
@@ -1,0 +1,41 @@
+---
+monochange: patch
+monochange_config: patch
+monochange_core: patch
+monochange_schema: patch
+---
+
+# Honor default versioned files during release preparation
+
+Workspace-level `versioned_files` defaults now apply to manually configured and auto-discovered packages. Release preparation now ignores missing formatted fields by default, and `missing_field_behavior = "add"` can be used for shared version files that should create missing package entries.
+
+For example, this shared `versions.json` file now creates missing package keys during release preparation:
+
+```toml
+[defaults]
+package_type = "npm"
+versioned_files = [
+	{ path = "versions.json", format = "json", fields = ["packages.{{ name }}"], missing_field_behavior = "add" },
+]
+
+[package.app]
+path = "packages/app"
+```
+
+When `versions.json` starts as:
+
+```json
+{
+	"packages": {}
+}
+```
+
+Releasing `app` to `1.2.3` updates it to:
+
+```json
+{
+	"packages": {
+		"app": "1.2.3"
+	}
+}
+```

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -9608,6 +9608,7 @@ fn resolve_versioned_prefix_prefers_explicit_then_ecosystem_then_default() {
 		prefix: Some("~".to_string()),
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	assert_eq!(crate::resolve_versioned_prefix(&explicit, &context), "~");
@@ -9619,6 +9620,7 @@ fn resolve_versioned_prefix_prefers_explicit_then_ecosystem_then_default() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	assert_eq!(
@@ -9633,6 +9635,7 @@ fn resolve_versioned_prefix_prefers_explicit_then_ecosystem_then_default() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	assert_eq!(
@@ -9647,6 +9650,7 @@ fn resolve_versioned_prefix_prefers_explicit_then_ecosystem_then_default() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	assert_eq!(crate::resolve_versioned_prefix(&python, &context), "~=");
@@ -9658,6 +9662,7 @@ fn resolve_versioned_prefix_prefers_explicit_then_ecosystem_then_default() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	assert_eq!(crate::resolve_versioned_prefix(&go, &context), "");
@@ -10297,6 +10302,7 @@ fn expand_versioned_file_fields_supports_name_templates_and_passthrough_fields()
 			"workspace.version".to_string(),
 		]),
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	assert_eq!(
@@ -10314,6 +10320,7 @@ fn expand_versioned_file_fields_supports_name_templates_and_passthrough_fields()
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	assert_eq!(
@@ -10350,6 +10357,7 @@ fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_update
 			prefix: None,
 			fields: None,
 			name: None,
+			missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 			regex: None,
 		};
 		let error = crate::apply_versioned_file_definition(
@@ -10385,6 +10393,7 @@ fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_update
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let error = crate::apply_versioned_file_definition(
@@ -10414,6 +10423,7 @@ fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_update
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let error = crate::apply_versioned_file_definition(
@@ -10444,6 +10454,7 @@ fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_update
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let error = crate::apply_versioned_file_definition(
@@ -10562,6 +10573,7 @@ fn apply_versioned_file_definition_returns_early_without_matching_versions() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let dep_names = vec!["core".to_string()];
@@ -10595,6 +10607,7 @@ fn apply_versioned_file_definition_rejects_invalid_glob_patterns() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let dep_names = vec!["core".to_string()];
@@ -10634,6 +10647,7 @@ fn apply_versioned_file_definition_rejects_unsupported_glob_matches() {
 			prefix: None,
 			fields: None,
 			name: None,
+			missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 			regex: None,
 		};
 		let error = crate::apply_versioned_file_definition(
@@ -10675,6 +10689,7 @@ monochange = { path = "crates/monochange", version = "1.0.0" }
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let mut updates = BTreeMap::new();
@@ -10731,6 +10746,7 @@ extra = { path = "crates/extra", version = "1.0.0" }
 			"workspace.dependencies.{{ name }}.version".to_string(),
 		]),
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let mut updates = BTreeMap::new();
@@ -10782,6 +10798,7 @@ fn apply_versioned_file_definition_updates_bun_lockb_and_deno_text_variants() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let bun_path = bun_tempdir.path().join("packages/app/bun.lockb");
@@ -10819,6 +10836,7 @@ fn apply_versioned_file_definition_updates_bun_lockb_and_deno_text_variants() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let mut deno_updates = BTreeMap::new();
@@ -10859,6 +10877,7 @@ fn apply_versioned_file_definition_updates_regex_versioned_files_from_cached_tex
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: Some(
 			r"https:\/\/example.com\/download\/v(?<version>\d+\.\d+\.\d+)\.tgz".to_string(),
 		),
@@ -10907,6 +10926,7 @@ fn apply_versioned_file_definition_reports_invalid_regex_patterns() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: Some("(".to_string()),
 	};
 	let mut updates = BTreeMap::new();
@@ -10945,6 +10965,7 @@ fn apply_versioned_file_definition_updates_npm_manifest_and_lock_variants() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let manifest_dep_names = vec!["core".to_string()];
@@ -10992,6 +11013,7 @@ fn apply_versioned_file_definition_updates_npm_manifest_and_lock_variants() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let package_lock_dep_names = vec!["app".to_string()];
@@ -11033,6 +11055,7 @@ fn apply_versioned_file_definition_updates_npm_manifest_and_lock_variants() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let pnpm_dep_names = vec!["core".to_string()];
@@ -11071,6 +11094,7 @@ fn apply_versioned_file_definition_updates_npm_manifest_and_lock_variants() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let bun_dep_names = vec!["left-pad".to_string()];
@@ -11124,6 +11148,7 @@ dependencies = ["python-core>=1.0.0"]
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let dep_names = vec!["python-core".to_string()];
@@ -11155,6 +11180,7 @@ dependencies = ["python-core>=1.0.0"]
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	crate::apply_versioned_file_definition(
@@ -11197,6 +11223,7 @@ async fn apply_versioned_file_definition_reports_python_error_paths() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let error = crate::apply_versioned_file_definition(
@@ -11225,6 +11252,7 @@ async fn apply_versioned_file_definition_reports_python_error_paths() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	updates.insert(
@@ -11262,6 +11290,7 @@ fn apply_versioned_file_definition_updates_deno_and_dart_variants() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let deno_manifest_dep_names = vec!["core".to_string()];
@@ -11299,6 +11328,7 @@ fn apply_versioned_file_definition_updates_deno_and_dart_variants() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let deno_lock_dep_names = vec!["app".to_string()];
@@ -11335,6 +11365,7 @@ fn apply_versioned_file_definition_updates_deno_and_dart_variants() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let dart_manifest_dep_names = vec!["shared".to_string()];
@@ -11374,6 +11405,7 @@ fn apply_versioned_file_definition_updates_deno_and_dart_variants() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let dart_lock_dep_names = vec!["nested_dart_app".to_string()];
@@ -13711,6 +13743,7 @@ fn apply_versioned_file_definition_reports_invalid_glob_pattern() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: Some(r"v(?<version>\d+\.\d+\.\d+)".to_string()),
 	};
 	let mut updates = BTreeMap::new();
@@ -13741,6 +13774,7 @@ fn apply_versioned_file_definition_reports_missing_ecosystem_type() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let mut updates = BTreeMap::new();

--- a/crates/monochange/src/__tests__/snapshots/monochange__versioned_files__tests__build_versioned_file_updates_uses_default_versioned_files.snap
+++ b/crates/monochange/src/__tests__/snapshots/monochange__versioned_files__tests__build_versioned_file_updates_uses_default_versioned_files.snap
@@ -1,0 +1,13 @@
+---
+source: crates/monochange/src/__tests__/versioned_files_tests.rs
+assertion_line: 540
+expression: "snapshot_file_updates(&root, updates)"
+---
+## packages/app/package.json
+{
+  "name": "@example/app",
+  "version": "1.2.3",
+  "dependencies": {
+    "@example/app": "^1.2.3"
+  }
+}

--- a/crates/monochange/src/__tests__/snapshots/monochange__versioned_files__tests__build_versioned_file_updates_uses_ecosystem_versioned_files.snap
+++ b/crates/monochange/src/__tests__/snapshots/monochange__versioned_files__tests__build_versioned_file_updates_uses_ecosystem_versioned_files.snap
@@ -1,0 +1,13 @@
+---
+source: crates/monochange/src/__tests__/versioned_files_tests.rs
+assertion_line: 560
+expression: "snapshot_file_updates(&root, updates)"
+---
+## packages/app/package.json
+{
+  "name": "@example/app",
+  "version": "1.2.3",
+  "dependencies": {
+    "@example/app": "^1.2.3"
+  }
+}

--- a/crates/monochange/src/__tests__/versioned_files_tests.rs
+++ b/crates/monochange/src/__tests__/versioned_files_tests.rs
@@ -9,6 +9,9 @@ use monochange_core::EcosystemType;
 use super::CachedDocument;
 use super::FileUpdate;
 use super::VersionedFileUpdateContext;
+use super::add_json_field_path;
+use super::add_toml_field_path;
+use super::add_yaml_field_path;
 use super::apply_versioned_file_definition;
 use super::build_versioned_file_updates_with_base_updates;
 use super::inferred_lockfile_ecosystem_type;
@@ -26,6 +29,71 @@ fn fixture_path(relative: &str) -> PathBuf {
 		.join(relative)
 }
 
+fn npm_package_record(root: &Path, config_id: &str) -> monochange_core::PackageRecord {
+	let manifest_path = root.join("packages/app/package.json");
+	let current_version = "1.0.0"
+		.parse()
+		.unwrap_or_else(|error| panic!("current package version: {error}"));
+	let mut package = monochange_core::PackageRecord::new(
+		Ecosystem::Npm,
+		"@example/app",
+		manifest_path,
+		root.to_path_buf(),
+		Some(current_version),
+		monochange_core::PublishState::Public,
+	);
+
+	package
+		.metadata
+		.insert("config_id".to_string(), config_id.to_string());
+	package
+}
+
+fn package_release_plan(
+	root: &Path,
+	package: &monochange_core::PackageRecord,
+) -> monochange_core::ReleasePlan {
+	monochange_core::ReleasePlan {
+		workspace_root: root.to_path_buf(),
+		decisions: vec![monochange_core::ReleaseDecision {
+			package_id: package.id.clone(),
+			trigger_type: "changeset".to_string(),
+			recommended_bump: monochange_core::BumpSeverity::Minor,
+			planned_version: Some(
+				"1.2.3"
+					.parse()
+					.unwrap_or_else(|error| panic!("planned package version: {error}")),
+			),
+			group_id: None,
+			reasons: Vec::new(),
+			upstream_sources: Vec::new(),
+			warnings: Vec::new(),
+		}],
+		groups: Vec::new(),
+		warnings: Vec::new(),
+		unresolved_items: Vec::new(),
+		compatibility_evidence: Vec::new(),
+	}
+}
+
+fn snapshot_file_updates(root: &Path, updates: Vec<FileUpdate>) -> String {
+	updates
+		.into_iter()
+		.map(|update| {
+			let path = update
+				.path
+				.strip_prefix(root)
+				.unwrap_or(&update.path)
+				.to_string_lossy();
+			let content = String::from_utf8(update.content)
+				.unwrap_or_else(|error| panic!("updated file is utf-8: {error}"));
+
+			format!("## {path}\n{content}")
+		})
+		.collect::<Vec<_>>()
+		.join("\n---\n")
+}
+
 #[test]
 fn format_versioned_file_updates_json_toml_yaml_and_env_fields() {
 	let json = update_format_versioned_file_text(
@@ -34,6 +102,7 @@ fn format_versioned_file_updates_json_toml_yaml_and_env_fields() {
 		&["release.version".to_string()],
 		"1.2.3",
 		None,
+		monochange_core::MissingFieldBehavior::default(),
 	)
 	.unwrap_or_else(|error| panic!("update json: {error}"));
 	assert!(json.contains("\"version\": \"1.2.3\""));
@@ -44,6 +113,7 @@ fn format_versioned_file_updates_json_toml_yaml_and_env_fields() {
 		&["tool.app.version".to_string()],
 		"1.2.3",
 		None,
+		monochange_core::MissingFieldBehavior::default(),
 	)
 	.unwrap_or_else(|error| panic!("update toml: {error}"));
 	assert!(toml.contains("version = \"1.2.3\""));
@@ -54,6 +124,7 @@ fn format_versioned_file_updates_json_toml_yaml_and_env_fields() {
 		&["release.version".to_string()],
 		"1.2.3",
 		None,
+		monochange_core::MissingFieldBehavior::default(),
 	)
 	.unwrap_or_else(|error| panic!("update yaml: {error}"));
 	assert!(yaml.contains("version: 1.2.3"));
@@ -64,6 +135,7 @@ fn format_versioned_file_updates_json_toml_yaml_and_env_fields() {
 		&["VERSION".to_string()],
 		"1.2.3",
 		None,
+		monochange_core::MissingFieldBehavior::default(),
 	)
 	.unwrap_or_else(|error| panic!("update env: {error}"));
 	assert_eq!(env, "APP=demo\nexport VERSION=1.2.3\n");
@@ -77,22 +149,248 @@ fn format_versioned_file_renders_name_and_version_templates_in_fields() {
 		&["packages.{{ name }}.version".to_string()],
 		"1.2.3",
 		Some("app"),
+		monochange_core::MissingFieldBehavior::default(),
 	)
 	.unwrap_or_else(|error| panic!("update templated json field: {error}"));
 	assert!(json.contains("\"version\": \"1.2.3\""));
 }
 
 #[test]
-fn format_versioned_file_reports_missing_fields() {
-	let error = update_format_versioned_file_text(
+fn format_versioned_file_ignores_missing_fields_by_default() {
+	let json = update_format_versioned_file_text(
 		"{\"release\":{\"version\":\"1.0.0\"}}",
 		monochange_core::VersionedFileFormat::Json,
 		&["release.missing".to_string()],
 		"1.2.3",
 		None,
+		monochange_core::MissingFieldBehavior::default(),
 	)
-	.expect_err("missing json field should fail");
-	assert!(error.to_string().contains("missing leaf `missing`"));
+	.unwrap_or_else(|error| panic!("missing json field should be ignored: {error}"));
+	assert!(json.contains("\"version\": \"1.0.0\""));
+}
+
+#[test]
+fn format_versioned_file_adds_missing_fields_when_configured() {
+	let json = update_format_versioned_file_text(
+		"{\"versions\":{\"app\":\"1.0.0\"}}",
+		monochange_core::VersionedFileFormat::Json,
+		&["versions.{{ name }}".to_string()],
+		"1.2.3",
+		Some("utils"),
+		monochange_core::MissingFieldBehavior::Add,
+	)
+	.unwrap_or_else(|error| panic!("add missing json field: {error}"));
+
+	insta::assert_snapshot!(json, @r###"
+	{
+	  "versions": {
+	    "app": "1.0.0",
+	    "utils": "1.2.3"
+	  }
+	}
+	"###);
+
+	let toml = update_format_versioned_file_text(
+		"[versions]\napp = \"1.0.0\"\n",
+		monochange_core::VersionedFileFormat::Toml,
+		&["versions.{{ name }}".to_string()],
+		"1.2.3",
+		Some("utils"),
+		monochange_core::MissingFieldBehavior::Add,
+	)
+	.unwrap_or_else(|error| panic!("add missing toml field: {error}"));
+	insta::assert_snapshot!(toml, @r###"
+	[versions]
+	app = "1.0.0"
+	utils = "1.2.3"
+	"###);
+
+	let yaml = update_format_versioned_file_text(
+		"versions:\n  app: 1.0.0\n",
+		monochange_core::VersionedFileFormat::Yaml,
+		&["versions.{{ name }}".to_string()],
+		"1.2.3",
+		Some("utils"),
+		monochange_core::MissingFieldBehavior::Add,
+	)
+	.unwrap_or_else(|error| panic!("add missing yaml field: {error}"));
+	insta::assert_snapshot!(yaml, @r###"
+	versions:
+	  app: 1.0.0
+	  utils: 1.2.3
+	"###);
+
+	let env = update_format_versioned_file_text(
+		"APP=demo\n",
+		monochange_core::VersionedFileFormat::Env,
+		&["VERSION".to_string()],
+		"1.2.3",
+		None,
+		monochange_core::MissingFieldBehavior::Add,
+	)
+	.unwrap_or_else(|error| panic!("add missing env key: {error}"));
+	assert_eq!(env, "APP=demo\nVERSION=1.2.3\n");
+
+	let env_without_newline = update_format_versioned_file_text(
+		"APP=demo",
+		monochange_core::VersionedFileFormat::Env,
+		&["VERSION".to_string()],
+		"1.2.3",
+		None,
+		monochange_core::MissingFieldBehavior::Add,
+	)
+	.unwrap_or_else(|error| panic!("add missing env key after unterminated line: {error}"));
+	assert_eq!(env_without_newline, "APP=demo\nVERSION=1.2.3\n");
+
+	let json_with_nested_parent = update_format_versioned_file_text(
+		"{}",
+		monochange_core::VersionedFileFormat::Json,
+		&["versions.packages.{{ name }}".to_string()],
+		"1.2.3",
+		Some("utils"),
+		monochange_core::MissingFieldBehavior::Add,
+	)
+	.unwrap_or_else(|error| panic!("add missing nested json field: {error}"));
+	insta::assert_snapshot!(json_with_nested_parent, @r###"
+	{
+	  "versions": {
+	    "packages": {
+	      "utils": "1.2.3"
+	    }
+	  }
+	}
+	"###);
+
+	let toml_with_nested_parent = update_format_versioned_file_text(
+		"",
+		monochange_core::VersionedFileFormat::Toml,
+		&["versions.packages.{{ name }}".to_string()],
+		"1.2.3",
+		Some("utils"),
+		monochange_core::MissingFieldBehavior::Add,
+	)
+	.unwrap_or_else(|error| panic!("add missing nested toml field: {error}"));
+	insta::assert_snapshot!(toml_with_nested_parent, @r###"
+	[versions]
+
+	[versions.packages]
+	utils = "1.2.3"
+	"###);
+
+	let yaml_with_nested_parent = update_format_versioned_file_text(
+		"{}\n",
+		monochange_core::VersionedFileFormat::Yaml,
+		&["versions.packages.{{ name }}".to_string()],
+		"1.2.3",
+		Some("utils"),
+		monochange_core::MissingFieldBehavior::Add,
+	)
+	.unwrap_or_else(|error| panic!("add missing nested yaml field: {error}"));
+	insta::assert_snapshot!(yaml_with_nested_parent, @r###"
+	versions:
+	  packages:
+	    utils: 1.2.3
+	"###);
+}
+
+#[test]
+fn add_missing_field_helpers_reject_non_container_values() {
+	let mut json = serde_json::json!("1.0.0");
+	let json_error = add_json_field_path(&mut json, "version", "1.2.3")
+		.expect_err("json scalar root cannot receive a field");
+	assert!(json_error.to_string().contains("non-object value"));
+
+	let mut nested_json_root = serde_json::json!("1.0.0");
+	let nested_json_root_error =
+		add_json_field_path(&mut nested_json_root, "versions.app", "1.2.3")
+			.expect_err("json scalar root cannot receive a nested field");
+	assert!(
+		nested_json_root_error
+			.to_string()
+			.contains("non-object segment `versions`")
+	);
+
+	let mut nested_json = serde_json::json!({ "versions": "1.0.0" });
+	let nested_json_error = add_json_field_path(&mut nested_json, "versions.app", "1.2.3")
+		.expect_err("json scalar parent cannot receive a child field");
+	assert!(nested_json_error.to_string().contains("non-object value"));
+
+	let mut toml = "[tool]\napp = \"1.0.0\"\n"
+		.parse::<toml_edit::DocumentMut>()
+		.unwrap_or_else(|error| panic!("parse toml: {error}"));
+	let toml_error = add_toml_field_path(&mut toml, "tool.app.version", "1.2.3")
+		.expect_err("toml scalar segment cannot receive a child field");
+	assert!(toml_error.to_string().contains("non-table segment `app`"));
+
+	let mut yaml = serde_yaml_ng::from_str::<serde_yaml_ng::Value>("1.0.0\n")
+		.unwrap_or_else(|error| panic!("parse yaml: {error}"));
+	let yaml_error = add_yaml_field_path(&mut yaml, "version", "1.2.3")
+		.expect_err("yaml scalar root cannot receive a field");
+	assert!(yaml_error.to_string().contains("non-mapping value"));
+
+	let mut nested_yaml_root = serde_yaml_ng::from_str::<serde_yaml_ng::Value>("1.0.0\n")
+		.unwrap_or_else(|error| panic!("parse nested yaml root: {error}"));
+	let nested_yaml_root_error =
+		add_yaml_field_path(&mut nested_yaml_root, "versions.app", "1.2.3")
+			.expect_err("yaml scalar root cannot receive a nested field");
+	assert!(
+		nested_yaml_root_error
+			.to_string()
+			.contains("non-mapping segment `versions`")
+	);
+
+	let mut nested_yaml = serde_yaml_ng::from_str::<serde_yaml_ng::Value>("versions: 1.0.0\n")
+		.unwrap_or_else(|error| panic!("parse nested yaml: {error}"));
+	let nested_yaml_error = add_yaml_field_path(&mut nested_yaml, "versions.app", "1.2.3")
+		.expect_err("yaml scalar parent cannot receive a child field");
+	assert!(nested_yaml_error.to_string().contains("non-mapping value"));
+}
+
+#[test]
+fn format_versioned_file_skips_missing_rendered_name_fields() {
+	let json = update_format_versioned_file_text(
+		"{\"app\":\"1.0.0\"}",
+		monochange_core::VersionedFileFormat::Json,
+		&["{{ name }}".to_string()],
+		"1.2.3",
+		Some("utils"),
+		monochange_core::MissingFieldBehavior::default(),
+	)
+	.unwrap_or_else(|error| panic!("skip missing json name field: {error}"));
+	assert!(json.contains("\"app\": \"1.0.0\""));
+
+	let toml = update_format_versioned_file_text(
+		"app = \"1.0.0\"\n",
+		monochange_core::VersionedFileFormat::Toml,
+		&["{{ name }}".to_string()],
+		"1.2.3",
+		Some("utils"),
+		monochange_core::MissingFieldBehavior::default(),
+	)
+	.unwrap_or_else(|error| panic!("skip missing toml name field: {error}"));
+	assert_eq!(toml, "app = \"1.0.0\"\n");
+
+	let yaml = update_format_versioned_file_text(
+		"app: 1.0.0\n",
+		monochange_core::VersionedFileFormat::Yaml,
+		&["{{ name }}".to_string()],
+		"1.2.3",
+		Some("utils"),
+		monochange_core::MissingFieldBehavior::default(),
+	)
+	.unwrap_or_else(|error| panic!("skip missing yaml name field: {error}"));
+	assert!(yaml.contains("app: 1.0.0"));
+
+	let env = update_format_versioned_file_text(
+		"APP_VERSION=1.0.0\n",
+		monochange_core::VersionedFileFormat::Env,
+		&["{{ name }}".to_string()],
+		"1.2.3",
+		Some("UTILS_VERSION"),
+		monochange_core::MissingFieldBehavior::default(),
+	)
+	.unwrap_or_else(|error| panic!("skip missing env name field: {error}"));
+	assert_eq!(env, "APP_VERSION=1.0.0\n");
 }
 
 #[test]
@@ -103,6 +401,7 @@ fn format_versioned_file_reports_invalid_paths_and_parse_errors() {
 		&["release.version".to_string()],
 		"1.2.3",
 		None,
+		monochange_core::MissingFieldBehavior::default(),
 	)
 	.expect_err("json traversal through a string should fail");
 	assert!(json_non_object.to_string().contains("non-object value"));
@@ -113,6 +412,7 @@ fn format_versioned_file_reports_invalid_paths_and_parse_errors() {
 		&["release.metadata.inner.version".to_string()],
 		"1.2.3",
 		None,
+		monochange_core::MissingFieldBehavior::default(),
 	)
 	.expect_err("json traversal after a string segment should fail");
 	assert!(
@@ -121,26 +421,13 @@ fn format_versioned_file_reports_invalid_paths_and_parse_errors() {
 			.contains("non-object segment `inner`")
 	);
 
-	let json_missing_segment = update_format_versioned_file_text(
-		"{\"release\":{\"version\":\"1.0.0\"}}",
-		monochange_core::VersionedFileFormat::Json,
-		&["missing.version".to_string()],
-		"1.2.3",
-		None,
-	)
-	.expect_err("json missing parent should fail");
-	assert!(
-		json_missing_segment
-			.to_string()
-			.contains("missing segment `missing`")
-	);
-
 	let json_root_scalar = update_format_versioned_file_text(
 		"\"1.0.0\"",
 		monochange_core::VersionedFileFormat::Json,
 		&["version".to_string()],
 		"1.2.3",
 		None,
+		monochange_core::MissingFieldBehavior::default(),
 	)
 	.expect_err("json scalar root should fail");
 	assert!(json_root_scalar.to_string().contains("non-object value"));
@@ -151,23 +438,10 @@ fn format_versioned_file_reports_invalid_paths_and_parse_errors() {
 		&["version".to_string()],
 		"1.2.3",
 		None,
+		monochange_core::MissingFieldBehavior::default(),
 	)
 	.expect_err("invalid json should fail");
 	assert!(json_parse.to_string().contains("failed to parse json"));
-
-	let toml_missing_segment = update_format_versioned_file_text(
-		"[tool.app]\nversion = \"1.0.0\"\n",
-		monochange_core::VersionedFileFormat::Toml,
-		&["tool.missing.version".to_string()],
-		"1.2.3",
-		None,
-	)
-	.expect_err("toml missing parent should fail");
-	assert!(
-		toml_missing_segment
-			.to_string()
-			.contains("missing segment `missing`")
-	);
 
 	let toml_non_table = update_format_versioned_file_text(
 		"[tool]\napp = \"1.0.0\"\n",
@@ -175,6 +449,7 @@ fn format_versioned_file_reports_invalid_paths_and_parse_errors() {
 		&["tool.app.version".to_string()],
 		"1.2.3",
 		None,
+		monochange_core::MissingFieldBehavior::default(),
 	)
 	.expect_err("toml traversal through a string should fail");
 	assert!(
@@ -183,26 +458,13 @@ fn format_versioned_file_reports_invalid_paths_and_parse_errors() {
 			.contains("non-table segment `app`")
 	);
 
-	let toml_missing_leaf = update_format_versioned_file_text(
-		"[tool.app]\nversion = \"1.0.0\"\n",
-		monochange_core::VersionedFileFormat::Toml,
-		&["tool.app.missing".to_string()],
-		"1.2.3",
-		None,
-	)
-	.expect_err("toml missing leaf should fail");
-	assert!(
-		toml_missing_leaf
-			.to_string()
-			.contains("missing leaf `missing`")
-	);
-
 	let toml_parse = update_format_versioned_file_text(
 		"[tool",
 		monochange_core::VersionedFileFormat::Toml,
 		&["tool.version".to_string()],
 		"1.2.3",
 		None,
+		monochange_core::MissingFieldBehavior::default(),
 	)
 	.expect_err("invalid toml should fail");
 	assert!(toml_parse.to_string().contains("failed to parse toml"));
@@ -213,6 +475,7 @@ fn format_versioned_file_reports_invalid_paths_and_parse_errors() {
 		&["release.version".to_string()],
 		"1.2.3",
 		None,
+		monochange_core::MissingFieldBehavior::default(),
 	)
 	.expect_err("yaml traversal through a scalar should fail");
 	assert!(yaml_non_mapping.to_string().contains("non-mapping value"));
@@ -223,6 +486,7 @@ fn format_versioned_file_reports_invalid_paths_and_parse_errors() {
 		&["release.metadata.inner.version".to_string()],
 		"1.2.3",
 		None,
+		monochange_core::MissingFieldBehavior::default(),
 	)
 	.expect_err("yaml traversal after a scalar segment should fail");
 	assert!(
@@ -231,43 +495,16 @@ fn format_versioned_file_reports_invalid_paths_and_parse_errors() {
 			.contains("non-mapping segment `inner`")
 	);
 
-	let yaml_missing_segment = update_format_versioned_file_text(
-		"release:\n  version: 1.0.0\n",
-		monochange_core::VersionedFileFormat::Yaml,
-		&["missing.version".to_string()],
-		"1.2.3",
-		None,
-	)
-	.expect_err("yaml missing parent should fail");
-	assert!(
-		yaml_missing_segment
-			.to_string()
-			.contains("missing segment `missing`")
-	);
-
 	let yaml_root_scalar = update_format_versioned_file_text(
 		"1.0.0\n",
 		monochange_core::VersionedFileFormat::Yml,
 		&["version".to_string()],
 		"1.2.3",
 		None,
+		monochange_core::MissingFieldBehavior::default(),
 	)
 	.expect_err("yaml scalar root should fail");
 	assert!(yaml_root_scalar.to_string().contains("non-mapping value"));
-
-	let yaml_missing_leaf = update_format_versioned_file_text(
-		"release:\n  version: 1.0.0\n",
-		monochange_core::VersionedFileFormat::Yml,
-		&["release.missing".to_string()],
-		"1.2.3",
-		None,
-	)
-	.expect_err("yaml missing leaf should fail");
-	assert!(
-		yaml_missing_leaf
-			.to_string()
-			.contains("missing leaf `missing`")
-	);
 
 	let yaml_parse = update_format_versioned_file_text(
 		"release: [",
@@ -275,6 +512,7 @@ fn format_versioned_file_reports_invalid_paths_and_parse_errors() {
 		&["release.version".to_string()],
 		"1.2.3",
 		None,
+		monochange_core::MissingFieldBehavior::default(),
 	)
 	.expect_err("invalid yaml should fail");
 	assert!(yaml_parse.to_string().contains("failed to parse yaml"));
@@ -285,25 +523,13 @@ fn format_versioned_file_reports_invalid_paths_and_parse_errors() {
 		&["release..version".to_string()],
 		"1.2.3",
 		None,
+		monochange_core::MissingFieldBehavior::default(),
 	)
 	.expect_err("empty path segment should fail");
 	assert!(
 		empty_segment
 			.to_string()
 			.contains("non-empty dot-separated segments")
-	);
-
-	let env = update_format_versioned_file_text(
-		"# comment\nAPP=demo\n",
-		monochange_core::VersionedFileFormat::Env,
-		&["VERSION".to_string()],
-		"1.2.3",
-		None,
-	)
-	.expect_err("missing env key should fail");
-	assert!(
-		env.to_string()
-			.contains("env field `VERSION` was not found")
 	);
 }
 
@@ -333,6 +559,7 @@ fn apply_versioned_file_definition_supports_format_mode_and_reports_format_error
 		prefix: None,
 		fields: Some(vec!["release.version".to_string()]),
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let mut updates = BTreeMap::new();
@@ -350,6 +577,24 @@ fn apply_versioned_file_definition_supports_format_mode_and_reports_format_error
 		updates.get(&root.join("metadata.json")),
 		Some(CachedDocument::Text(contents)) if contents.contains("\"version\": \"1.2.3\"")
 	));
+
+	std::fs::write(root.join("invalid.json"), "{")
+		.unwrap_or_else(|error| panic!("write invalid json: {error}"));
+	let invalid_json = monochange_core::VersionedFileDefinition {
+		path: "invalid.json".to_string(),
+		..definition.clone()
+	};
+	let error = apply_versioned_file_definition(
+		root,
+		&mut updates,
+		&invalid_json,
+		"1.2.3",
+		None,
+		&["invalid".to_string()],
+		&context,
+	)
+	.expect_err("invalid formatted file should fail through apply");
+	assert!(error.to_string().contains("failed to parse json"));
 
 	let missing_fields = monochange_core::VersionedFileDefinition {
 		fields: None,
@@ -413,6 +658,46 @@ fn build_versioned_file_updates_returns_empty_for_empty_configuration() {
 			.unwrap_or_else(|error| panic!("build versioned updates: {error}"));
 
 	assert!(updates.is_empty());
+}
+
+#[test]
+fn build_versioned_file_updates_uses_default_versioned_files() {
+	let root = fixture_path("versioned-files-defaults");
+	let configuration = monochange_config::load_workspace_configuration(&root)
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+	let package = npm_package_record(&root, "app");
+	let plan = package_release_plan(&root, &package);
+
+	let updates = build_versioned_file_updates_with_base_updates(
+		&root,
+		&configuration,
+		&[package],
+		&plan,
+		&[],
+	)
+	.unwrap_or_else(|error| panic!("build versioned updates: {error}"));
+
+	insta::assert_snapshot!(snapshot_file_updates(&root, updates));
+}
+
+#[test]
+fn build_versioned_file_updates_uses_ecosystem_versioned_files() {
+	let root = fixture_path("versioned-files-ecosystems");
+	let configuration = monochange_config::load_workspace_configuration(&root)
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+	let package = npm_package_record(&root, "app");
+	let plan = package_release_plan(&root, &package);
+
+	let updates = build_versioned_file_updates_with_base_updates(
+		&root,
+		&configuration,
+		&[package],
+		&plan,
+		&[],
+	)
+	.unwrap_or_else(|error| panic!("build versioned updates: {error}"));
+
+	insta::assert_snapshot!(snapshot_file_updates(&root, updates));
 }
 
 #[test]
@@ -592,6 +877,7 @@ fn apply_versioned_file_definition_reports_go_for_unsupported_glob_match() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let mut updates = BTreeMap::new();
@@ -638,6 +924,7 @@ fn apply_versioned_file_definition_updates_go_mod_dependencies() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let mut updates = BTreeMap::new();

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -354,6 +354,7 @@ fn apply_inferred_lockfile_updates(
 			prefix: None,
 			fields: None,
 			name: None,
+			missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 			regex: None,
 		};
 
@@ -877,6 +878,40 @@ fn update_json_field_path(
 	Ok(())
 }
 
+fn add_json_field_path(
+	value: &mut serde_json::Value,
+	path: &str,
+	version: &str,
+) -> MonochangeResult<()> {
+	let segments = field_path_segments(path)?;
+	let (leaf, parent_segments) = segments
+		.split_last()
+		.expect("validated field paths contain at least one segment");
+	let mut cursor = value;
+
+	for segment in parent_segments {
+		let object = cursor.as_object_mut().ok_or_else(|| {
+			MonochangeError::Config(format!(
+				"versioned_files field `{path}` cannot traverse non-object segment `{segment}`"
+			))
+		})?;
+		cursor = object
+			.entry((*segment).to_string())
+			.or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+	}
+
+	let object = cursor.as_object_mut().ok_or_else(|| {
+		MonochangeError::Config(format!(
+			"versioned_files field `{path}` cannot set `{leaf}` on a non-object value"
+		))
+	})?;
+	object.insert(
+		(*leaf).to_string(),
+		serde_json::Value::String(version.to_string()),
+	);
+	Ok(())
+}
+
 fn update_toml_field_path(
 	document: &mut toml_edit::DocumentMut,
 	path: &str,
@@ -906,6 +941,39 @@ fn update_toml_field_path(
 			"versioned_files field `{path}` is missing leaf `{leaf}`"
 		)));
 	}
+	table.insert(leaf, toml_edit::value(version));
+	Ok(())
+}
+
+fn add_toml_field_path(
+	document: &mut toml_edit::DocumentMut,
+	path: &str,
+	version: &str,
+) -> MonochangeResult<()> {
+	let segments = field_path_segments(path)?;
+	let (leaf, parent_segments) = segments
+		.split_last()
+		.expect("validated field paths contain at least one segment");
+	let mut table: &mut dyn toml_edit::TableLike = document.as_table_mut();
+
+	for segment in parent_segments {
+		if !table.contains_key(segment) {
+			table.insert(segment, toml_edit::Item::Table(toml_edit::Table::new()));
+		}
+		// patch-coverage:ignore-start -- contains_key/insert above guarantees the segment exists before lookup.
+		let item = table.get_mut(segment).ok_or_else(|| {
+			MonochangeError::Config(format!(
+				"versioned_files field `{path}` is missing segment `{segment}`"
+			))
+		})?;
+		// patch-coverage:ignore-end
+		table = item.as_table_like_mut().ok_or_else(|| {
+			MonochangeError::Config(format!(
+				"versioned_files field `{path}` cannot traverse non-table segment `{segment}`"
+			))
+		})?;
+	}
+
 	table.insert(leaf, toml_edit::value(version));
 	Ok(())
 }
@@ -947,6 +1015,41 @@ fn update_yaml_field_path(
 		)));
 	}
 	mapping.insert(key, serde_yaml_ng::Value::String(version.to_string()));
+	Ok(())
+}
+
+fn add_yaml_field_path(
+	value: &mut serde_yaml_ng::Value,
+	path: &str,
+	version: &str,
+) -> MonochangeResult<()> {
+	let segments = field_path_segments(path)?;
+	let (leaf, parent_segments) = segments
+		.split_last()
+		.expect("validated field paths contain at least one segment");
+	let mut cursor = value;
+
+	for segment in parent_segments {
+		let mapping = cursor.as_mapping_mut().ok_or_else(|| {
+			MonochangeError::Config(format!(
+				"versioned_files field `{path}` cannot traverse non-mapping segment `{segment}`"
+			))
+		})?;
+		let key = serde_yaml_ng::Value::String((*segment).to_string());
+		cursor = mapping
+			.entry(key)
+			.or_insert_with(|| serde_yaml_ng::Value::Mapping(serde_yaml_ng::Mapping::default()));
+	}
+
+	let mapping = cursor.as_mapping_mut().ok_or_else(|| {
+		MonochangeError::Config(format!(
+			"versioned_files field `{path}` cannot set `{leaf}` on a non-mapping value"
+		))
+	})?;
+	mapping.insert(
+		serde_yaml_ng::Value::String((*leaf).to_string()),
+		serde_yaml_ng::Value::String(version.to_string()),
+	);
 	Ok(())
 }
 
@@ -1012,12 +1115,51 @@ fn update_env_key(contents: &str, key: &str, version: &str) -> MonochangeResult<
 	Ok(output)
 }
 
+fn add_env_key(contents: &str, key: &str, version: &str) -> String {
+	let mut output = String::with_capacity(contents.len() + key.len() + version.len() + 2);
+	output.push_str(contents);
+	if !output.is_empty() && !output.ends_with('\n') {
+		output.push('\n');
+	}
+	output.push_str(key);
+	output.push('=');
+	output.push_str(version);
+	output.push('\n');
+	output
+}
+
+fn is_missing_field_error(error: &MonochangeError) -> bool {
+	let message = error.to_string();
+	message.contains(" is missing leaf ")
+		|| message.contains(" is missing segment ")
+		|| message.contains(" was not found")
+}
+
+fn update_format_error_action(
+	field_path: &str,
+	error: MonochangeError,
+	missing_field_behavior: monochange_core::MissingFieldBehavior,
+) -> MonochangeResult<bool> {
+	if !is_missing_field_error(&error) {
+		return Err(error);
+	}
+
+	match missing_field_behavior {
+		monochange_core::MissingFieldBehavior::Ignore => Ok(false),
+		monochange_core::MissingFieldBehavior::Add => {
+			let _ = field_path;
+			Ok(true)
+		}
+	}
+}
+
 fn update_format_versioned_file_text(
 	contents: &str,
 	format: monochange_core::VersionedFileFormat,
 	fields: &[String],
 	version: &str,
 	name: Option<&str>,
+	missing_field_behavior: monochange_core::MissingFieldBehavior,
 ) -> MonochangeResult<String> {
 	match format {
 		monochange_core::VersionedFileFormat::Json => {
@@ -1026,8 +1168,14 @@ fn update_format_versioned_file_text(
 					MonochangeError::Config(format!("failed to parse json versioned file: {error}"))
 				})?;
 			for field in fields {
-				let field = render_versioned_template(field, name, version);
-				update_json_field_path(&mut value, &field, version)?;
+				let rendered_field = render_versioned_template(field, name, version);
+				if let Err(error) = update_json_field_path(&mut value, &rendered_field, version) {
+					let should_add =
+						update_format_error_action(&rendered_field, error, missing_field_behavior)?;
+					if should_add {
+						add_json_field_path(&mut value, &rendered_field, version)?;
+					}
+				}
 			}
 			let mut output = serde_json::to_string_pretty(&value).unwrap_or_else(|error| {
 				// patch-coverage:ignore-start -- serde_json::Value serialization is infallible for supported values.
@@ -1044,8 +1192,15 @@ fn update_format_versioned_file_text(
 					MonochangeError::Config(format!("failed to parse toml versioned file: {error}"))
 				})?;
 			for field in fields {
-				let field = render_versioned_template(field, name, version);
-				update_toml_field_path(&mut document, &field, version)?;
+				let rendered_field = render_versioned_template(field, name, version);
+				if let Err(error) = update_toml_field_path(&mut document, &rendered_field, version)
+				{
+					let should_add =
+						update_format_error_action(&rendered_field, error, missing_field_behavior)?;
+					if should_add {
+						add_toml_field_path(&mut document, &rendered_field, version)?;
+					}
+				}
 			}
 			Ok(document.to_string())
 		}
@@ -1055,8 +1210,14 @@ fn update_format_versioned_file_text(
 					MonochangeError::Config(format!("failed to parse yaml versioned file: {error}"))
 				})?;
 			for field in fields {
-				let field = render_versioned_template(field, name, version);
-				update_yaml_field_path(&mut value, &field, version)?;
+				let rendered_field = render_versioned_template(field, name, version);
+				if let Err(error) = update_yaml_field_path(&mut value, &rendered_field, version) {
+					let should_add =
+						update_format_error_action(&rendered_field, error, missing_field_behavior)?;
+					if should_add {
+						add_yaml_field_path(&mut value, &rendered_field, version)?;
+					}
+				}
 			}
 			Ok(serde_yaml_ng::to_string(&value).unwrap_or_else(|error| {
 				// patch-coverage:ignore-start -- serde_yaml_ng::Value serialization is infallible for supported values.
@@ -1068,7 +1229,14 @@ fn update_format_versioned_file_text(
 			let mut output = contents.to_string();
 			for field in fields {
 				let key = render_versioned_template(field, name, version);
-				output = update_env_key(&output, &key, version)?;
+				match update_env_key(&output, &key, version) {
+					Ok(updated) => output = updated,
+					Err(error) => {
+						if update_format_error_action(&key, error, missing_field_behavior)? {
+							output = add_env_key(&output, &key, version);
+						}
+					}
+				}
 			}
 			Ok(output)
 		}
@@ -1152,8 +1320,14 @@ pub(crate) fn apply_versioned_file_definition(
 			let resolved_path =
 				resolved_path.map_err(|error| MonochangeError::Config(error.to_string()))?;
 			let contents = read_cached_text_document(updates, &resolved_path)?;
-			let changed_text =
-				update_format_versioned_file_text(&contents, format, fields, owner_version, name)?;
+			let changed_text = update_format_versioned_file_text(
+				&contents,
+				format,
+				fields,
+				owner_version,
+				name,
+				definition.missing_field_behavior,
+			)?;
 			updates.insert(resolved_path, CachedDocument::Text(changed_text));
 		}
 		return Ok(());

--- a/crates/monochange_config/src/__tests__/lib_tests.rs
+++ b/crates/monochange_config/src/__tests__/lib_tests.rs
@@ -1439,6 +1439,18 @@ fn load_workspace_configuration_rejects_regex_versioned_files_with_prefix() {
 }
 
 #[test]
+fn load_workspace_configuration_rejects_default_string_versioned_files_without_default_type() {
+	let root = fixture_path("config/rejects-default-string-versioned");
+	let error = load_workspace_configuration(&root)
+		.err()
+		.unwrap_or_else(|| panic!("expected configuration error"));
+	let rendered = error.render();
+
+	assert!(rendered.contains("bare-string `versioned_files`"));
+	assert!(rendered.contains("use `versioned_files = [{ path = \"...\", type = \"cargo\" }]`"));
+}
+
+#[test]
 fn load_workspace_configuration_rejects_group_string_versioned_files_without_explicit_type() {
 	let root = fixture_path("config/rejects-group-string-versioned");
 	let error = load_workspace_configuration(&root)
@@ -1481,6 +1493,62 @@ fn load_workspace_configuration_inherits_ecosystem_versioned_files_unless_packag
 			.map(|definition| definition.path.as_str()),
 		Some("package.json")
 	);
+}
+
+#[test]
+fn load_workspace_configuration_inherits_default_versioned_files() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	std::fs::create_dir_all(root.join("packages/core"))
+		.unwrap_or_else(|error| panic!("create package dir: {error}"));
+	std::fs::create_dir_all(root.join("packages/utils"))
+		.unwrap_or_else(|error| panic!("create package dir: {error}"));
+	std::fs::write(
+		root.join("packages/core/pubspec.yaml"),
+		"name: core\nversion: 1.0.0\n",
+	)
+	.unwrap_or_else(|error| panic!("write pubspec: {error}"));
+	std::fs::write(
+		root.join("packages/utils/pubspec.yaml"),
+		"name: utils\nversion: 1.0.0\n",
+	)
+	.unwrap_or_else(|error| panic!("write pubspec: {error}"));
+	std::fs::write(
+		root.join("monochange.toml"),
+		r#"[defaults]
+package_type = "dart"
+versioned_files = [
+  { path = "versions.json", format = "json", fields = ["{{ name }}"] },
+]
+
+[package.core]
+path = "packages/core"
+
+[package.utils]
+path = "packages/utils"
+"#,
+	)
+	.unwrap_or_else(|error| panic!("write config: {error}"));
+
+	let configuration =
+		load_workspace_configuration(root).unwrap_or_else(|error| panic!("configuration: {error}"));
+
+	for package in &configuration.packages {
+		assert_eq!(package.versioned_files.len(), 1, "{}", package.id);
+		let versioned_file = package
+			.versioned_files
+			.first()
+			.unwrap_or_else(|| panic!("expected versioned file"));
+		assert_eq!(versioned_file.path, "versions.json");
+		assert_eq!(
+			versioned_file.format,
+			Some(monochange_core::VersionedFileFormat::Json)
+		);
+		assert_eq!(
+			versioned_file.fields.as_deref(),
+			Some(&["{{ name }}".to_string()][..])
+		);
+	}
 }
 
 #[test]
@@ -6418,6 +6486,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 			name: None,
 			fields: None,
 			prefix: None,
+			missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 			regex: None,
 		}],
 		&declared_packages,
@@ -6442,6 +6511,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 			name: None,
 			fields: None,
 			prefix: None,
+			missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 			regex: None,
 		}],
 		&declared_packages,
@@ -6471,6 +6541,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 		name: None,
 		fields: None,
 		prefix: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	validate_versioned_files_for_test(
@@ -6501,6 +6572,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 			name: None,
 			fields: None,
 			prefix: None,
+			missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 			regex: None,
 		}],
 		&declared_packages,
@@ -6534,6 +6606,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 			name: None,
 			fields: None,
 			prefix: None,
+			missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 			regex: None,
 		}],
 		&declared_packages,
@@ -6562,6 +6635,7 @@ fn validate_versioned_files_and_release_notes_cover_remaining_validation_paths()
 			name: None,
 			fields: None,
 			prefix: None,
+			missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 			regex: None,
 		}],
 		&declared_packages,
@@ -7484,6 +7558,7 @@ fn validate_versioned_files_accepts_format_mode_and_rejects_invalid_combinations
 		name: None,
 		fields: Some(vec!["release.version".to_string()]),
 		prefix: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	validate_versioned_files_for_test(
@@ -7503,6 +7578,7 @@ fn validate_versioned_files_accepts_format_mode_and_rejects_invalid_combinations
 		name: None,
 		fields: Some(vec!["release.version".to_string()]),
 		prefix: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let error = validate_versioned_files_for_test(
@@ -7523,6 +7599,7 @@ fn validate_versioned_files_accepts_format_mode_and_rejects_invalid_combinations
 		name: None,
 		fields: Some(vec!["release.version".to_string()]),
 		prefix: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: Some("version = (?<version>.*)".to_string()),
 	};
 	let error = validate_versioned_files_for_test(
@@ -7543,6 +7620,7 @@ fn validate_versioned_files_accepts_format_mode_and_rejects_invalid_combinations
 		name: None,
 		fields: None,
 		prefix: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let error = validate_versioned_files_for_test(
@@ -7563,6 +7641,7 @@ fn validate_versioned_files_accepts_format_mode_and_rejects_invalid_combinations
 		name: None,
 		fields: Some(Vec::new()),
 		prefix: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
 	let error = validate_versioned_files_for_test(

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -232,6 +232,8 @@ pub(crate) struct RawWorkspaceDefaults {
 	#[serde(default)]
 	changelog: Option<RawChangelogConfig>,
 	#[serde(default)]
+	versioned_files: Vec<RawVersionedFileDefinition>,
+	#[serde(default)]
 	empty_update_message: Option<String>,
 	#[serde(default)]
 	release_title: Option<String>,
@@ -248,6 +250,7 @@ impl Default for RawWorkspaceDefaults {
 			strict_version_conflicts: false,
 			package_type: None,
 			changelog: None,
+			versioned_files: Vec::new(),
 			empty_update_message: None,
 			release_title: None,
 			changelog_version_title: None,
@@ -907,6 +910,7 @@ fn normalize_versioned_files(
 					prefix: None,
 					fields: None,
 					name: None,
+					missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 					regex: None,
 				})
 			}
@@ -1478,6 +1482,7 @@ fn build_package_definitions(
 	default_package_type: Option<PackageType>,
 	default_package_changelog: Option<&RawChangelogConfig>,
 	default_changelog_format: ChangelogFormat,
+	default_versioned_files: &[VersionedFileDefinition],
 	cargo_ecosystem: &EcosystemSettings,
 	npm_ecosystem: &EcosystemSettings,
 	deno_ecosystem: &EcosystemSettings,
@@ -1541,7 +1546,8 @@ fn build_package_definitions(
 					_ => Vec::new(),
 				}
 			};
-			let mut versioned_files = inherited_versioned_files;
+			let mut versioned_files = default_versioned_files.to_vec();
+			versioned_files.extend(inherited_versioned_files);
 			versioned_files.extend(normalize_versioned_files(
 				contents,
 				package.versioned_files,
@@ -1707,6 +1713,7 @@ fn discover_auto_packages(
 	default_package_type: Option<PackageType>,
 	default_changelog: Option<&RawChangelogConfig>,
 	default_changelog_format: ChangelogFormat,
+	default_versioned_files: &[VersionedFileDefinition],
 	cargo_ecosystem: &EcosystemSettings,
 	npm_ecosystem: &EcosystemSettings,
 	deno_ecosystem: &EcosystemSettings,
@@ -1735,11 +1742,8 @@ fn discover_auto_packages(
 		let package_type = ecosystem_type_to_package_type(ecosystem_type);
 
 		for pkg in discovered {
-			let inherited_versioned_files = if ecosystem_settings.versioned_files.is_empty() {
-				Vec::new()
-			} else {
-				ecosystem_settings.versioned_files.clone()
-			};
+			let mut inherited_versioned_files = default_versioned_files.to_vec();
+			inherited_versioned_files.extend(ecosystem_settings.versioned_files.clone());
 
 			let changelog = default_changelog.and_then(|definition| {
 				definition.resolve_for_package(&pkg.path, true).map(|path| {
@@ -1850,6 +1854,14 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		.changelog
 		.as_ref()
 		.map(RawChangelogConfig::as_defaults_definition);
+	let default_versioned_files = normalize_versioned_files(
+		&contents,
+		defaults.versioned_files,
+		default_package_type.map_or(EcosystemType::Cargo, package_type_to_ecosystem_type),
+		"defaults",
+		"workspace",
+		default_package_type.is_some(),
+	)?;
 	let default_changelog_format = defaults
 		.changelog
 		.as_ref()
@@ -1861,6 +1873,7 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		default_package_type,
 		default_package_changelog.as_ref(),
 		default_changelog_format,
+		&default_versioned_files,
 		&cargo_ecosystem,
 		&npm_ecosystem,
 		&deno_ecosystem,
@@ -1880,6 +1893,7 @@ pub fn load_workspace_configuration(root: &Path) -> MonochangeResult<WorkspaceCo
 		default_package_type,
 		default_package_changelog.as_ref(),
 		default_changelog_format,
+		&default_versioned_files,
 		&cargo_ecosystem,
 		&npm_ecosystem,
 		&deno_ecosystem,

--- a/crates/monochange_core/src/__tests__/lib_tests.rs
+++ b/crates/monochange_core/src/__tests__/lib_tests.rs
@@ -32,6 +32,7 @@ use crate::HostedSourceAdapter;
 use crate::HostedSourceFeatures;
 use crate::HostingProviderKind;
 use crate::MetadataStyle;
+use crate::MissingFieldBehavior;
 use crate::MonochangeError;
 use crate::PackageDefinition;
 use crate::PackageDependency;
@@ -717,6 +718,7 @@ fn versioned_file_definition_uses_regex_returns_true_when_set() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: MissingFieldBehavior::default(),
 		regex: Some(r"v(?<version>\d+\.\d+\.\d+)".to_string()),
 	};
 	assert!(definition.uses_regex());
@@ -731,6 +733,7 @@ fn versioned_file_definition_uses_regex_returns_false_when_unset() {
 		prefix: None,
 		fields: None,
 		name: None,
+		missing_field_behavior: MissingFieldBehavior::default(),
 		regex: None,
 	};
 	assert!(!definition.uses_regex());
@@ -745,6 +748,7 @@ fn versioned_file_definition_uses_format_returns_true_when_set() {
 		prefix: None,
 		fields: Some(vec!["release.version".to_string()]),
 		name: None,
+		missing_field_behavior: MissingFieldBehavior::default(),
 		regex: None,
 	};
 	assert!(definition.uses_format());

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -1113,6 +1113,15 @@ pub enum VersionedFileFormat {
 }
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MissingFieldBehavior {
+	#[default]
+	Ignore,
+	Add,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct VersionedFileDefinition {
 	pub path: String,
@@ -1126,6 +1135,8 @@ pub struct VersionedFileDefinition {
 	pub fields: Option<Vec<String>>,
 	#[serde(default)]
 	pub name: Option<String>,
+	#[serde(default)]
+	pub missing_field_behavior: MissingFieldBehavior,
 	#[serde(default)]
 	pub regex: Option<String>,
 }

--- a/crates/monochange_schema/schemas/monochange.schema.json
+++ b/crates/monochange_schema/schemas/monochange.schema.json
@@ -1206,6 +1206,13 @@
 				}
 			]
 		},
+		"MissingFieldBehavior": {
+			"enum": [
+				"ignore",
+				"add"
+			],
+			"type": "string"
+		},
 		"PackageLabelPlacement": {
 			"description": "Where to place package labels relative to a changelog entry.",
 			"oneOf": [
@@ -1635,6 +1642,10 @@
 					],
 					"default": null
 				},
+				"missing_field_behavior": {
+					"$ref": "#/$defs/MissingFieldBehavior",
+					"default": "ignore"
+				},
 				"name": {
 					"default": null,
 					"type": [
@@ -1963,6 +1974,12 @@
 				"strict_version_conflicts": {
 					"default": false,
 					"type": "boolean"
+				},
+				"versioned_files": {
+					"items": {
+						"$ref": "#/$defs/versioned_file_definition"
+					},
+					"type": "array"
 				},
 				"warn_on_group_mismatch": {
 					"default": true,

--- a/docs/src/schemas/monochange.schema.json
+++ b/docs/src/schemas/monochange.schema.json
@@ -1206,6 +1206,13 @@
 				}
 			]
 		},
+		"MissingFieldBehavior": {
+			"enum": [
+				"ignore",
+				"add"
+			],
+			"type": "string"
+		},
 		"PackageLabelPlacement": {
 			"description": "Where to place package labels relative to a changelog entry.",
 			"oneOf": [
@@ -1635,6 +1642,10 @@
 					],
 					"default": null
 				},
+				"missing_field_behavior": {
+					"$ref": "#/$defs/MissingFieldBehavior",
+					"default": "ignore"
+				},
 				"name": {
 					"default": null,
 					"type": [
@@ -1963,6 +1974,12 @@
 				"strict_version_conflicts": {
 					"default": false,
 					"type": "boolean"
+				},
+				"versioned_files": {
+					"items": {
+						"$ref": "#/$defs/versioned_file_definition"
+					},
+					"type": "array"
 				},
 				"warn_on_group_mismatch": {
 					"default": true,

--- a/docs/src/schemas/monochange.v0.4.schema.json
+++ b/docs/src/schemas/monochange.v0.4.schema.json
@@ -1206,6 +1206,13 @@
 				}
 			]
 		},
+		"MissingFieldBehavior": {
+			"enum": [
+				"ignore",
+				"add"
+			],
+			"type": "string"
+		},
 		"PackageLabelPlacement": {
 			"description": "Where to place package labels relative to a changelog entry.",
 			"oneOf": [
@@ -1635,6 +1642,10 @@
 					],
 					"default": null
 				},
+				"missing_field_behavior": {
+					"$ref": "#/$defs/MissingFieldBehavior",
+					"default": "ignore"
+				},
 				"name": {
 					"default": null,
 					"type": [
@@ -1963,6 +1974,12 @@
 				"strict_version_conflicts": {
 					"default": false,
 					"type": "boolean"
+				},
+				"versioned_files": {
+					"items": {
+						"$ref": "#/$defs/versioned_file_definition"
+					},
+					"type": "array"
 				},
 				"warn_on_group_mismatch": {
 					"default": true,

--- a/fixtures/tests/config/rejects-default-string-versioned/monochange.toml
+++ b/fixtures/tests/config/rejects-default-string-versioned/monochange.toml
@@ -1,0 +1,6 @@
+[defaults]
+versioned_files = ["versions.json"]
+
+[package.app]
+path = "packages/app"
+type = "npm"

--- a/fixtures/tests/versioned-files-defaults/monochange.toml
+++ b/fixtures/tests/versioned-files-defaults/monochange.toml
@@ -1,0 +1,6 @@
+[defaults]
+package_type = "npm"
+versioned_files = ["packages/app/package.json"]
+
+[package.app]
+path = "packages/app"

--- a/fixtures/tests/versioned-files-defaults/packages/app/package.json
+++ b/fixtures/tests/versioned-files-defaults/packages/app/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@example/app",
+  "version": "1.0.0",
+  "dependencies": {
+    "@example/app": "1.0.0"
+  }
+}

--- a/fixtures/tests/versioned-files-ecosystems/monochange.toml
+++ b/fixtures/tests/versioned-files-ecosystems/monochange.toml
@@ -1,0 +1,6 @@
+[ecosystems.npm]
+versioned_files = ["packages/app/package.json"]
+
+[package.app]
+path = "packages/app"
+type = "npm"

--- a/fixtures/tests/versioned-files-ecosystems/packages/app/package.json
+++ b/fixtures/tests/versioned-files-ecosystems/packages/app/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@example/app",
+  "version": "1.0.0",
+  "dependencies": {
+    "@example/app": "1.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

- Inherit workspace-level `defaults.versioned_files` for manually configured and auto-discovered packages, including coverage for default and ecosystem-based versioned-file setup.
- Add configurable missing-field handling for formatted versioned files:
  - missing fields are ignored by default so shared files do not fail when a package entry is absent;
  - `missing_field_behavior = "add"` creates missing JSON, TOML, YAML, and env keys/paths for shared version files such as `versions.json`.
- Update configuration normalization, core types, schemas, and schema fixtures for the new `missing_field_behavior` option.
- Replace the new versioned-file setup coverage with fixture-based tests and Insta snapshots.
- Add regression coverage for missing-field add/error paths and invalid default-level string `versioned_files` configuration.
- Add a patch changeset for `monochange`, `monochange_config`, `monochange_core`, and `monochange_schema`, including an example of `missing_field_behavior = "add"`.

## Validation

- `devenv shell cargo test --package monochange versioned_files --all-features`
- `devenv shell cargo test --package monochange missing_field --all-features`
- `devenv shell cargo test --package monochange apply_versioned_file_definition_supports_format_mode_and_reports_format_errors --all-features`
- `devenv shell cargo test --package monochange_config load_workspace_configuration_rejects_default_string_versioned_files_without_default_type --all-features`
- `devenv shell cargo test --package monochange_integration_tests versioned_schema_assets_use_stable_ids_without_changing_contracts --all-features`
- `devenv shell cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `devenv shell schema:check`
- `devenv shell schema:release:check`
- `devenv shell monochange step validate`
- `devenv shell cargo fmt --all`
- pre-push `lint:push`

Note: a local full `coverage:patch` run was attempted but the local environment failed to link `iconv`; targeted tests and pre-push validation pass locally.
