### PR TITLE
feat: add top-level step aliases

### DIFF
--- a/.changeset/1780750400-top-level-step-aliases.md
+++ b/.changeset/1780750400-top-level-step-aliases.md
@@ -1,0 +1,7 @@
+---
+monochange: patch
+---
+
+# Promote common workflow steps to top-level CLI commands
+
+Add top-level aliases for commonly used built-in workflow steps, including `create`, `discover`, `config`, `preview`, `prepare`, `affected`, and `diagnose`. The new `preview` command runs the prepare-release workflow in dry-run mode so users can inspect planned release artifacts without writing files.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,7 @@ jobs:
           files: ./target/coverage/lcov.info
           disable_search: true
           fail_ci_if_error: true
+          skip_validation: true
           name: monochange-rust-workspace
           verbose: true
 
@@ -344,6 +345,7 @@ jobs:
           files: ./target/coverage/flags/${{ matrix.flag }}.lcov
           disable_search: true
           fail_ci_if_error: true
+          skip_validation: true
           flags: ${{ matrix.flag }}
           name: ${{ matrix.flag }}
           verbose: true

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -219,6 +219,7 @@ where
 			.map(|command| (index, command))
 	}) {
 		let builtins = [
+			"affected",
 			"analyze",
 			"api",
 			"audit",
@@ -226,6 +227,10 @@ where
 			"changeset",
 			"check",
 			"command",
+			"config",
+			"create",
+			"diagnose",
+			"discover",
 			"explain",
 			"help",
 			"init",
@@ -235,6 +240,8 @@ where
 			"migrate",
 			"new",
 			"populate",
+			"prepare",
+			"preview",
 			"release-records",
 			"run",
 			"skill",
@@ -937,6 +944,46 @@ fn generated_step_commands_cover_all_builtin_steps_except_command() {
 		);
 	}
 	assert!(step_command.find_subcommand("command").is_none());
+}
+
+#[test]
+fn generated_top_level_step_aliases_parse_as_builtins() {
+	let command = crate::cli::build_command_with_cli("monochange", &[]);
+	let expected = [
+		"create", "discover", "config", "preview", "prepare", "affected", "diagnose",
+	];
+
+	for command_name in expected {
+		let subcommand = command
+			.find_subcommand(command_name)
+			.unwrap_or_else(|| panic!("expected top-level {command_name} command"));
+		assert!(
+			subcommand
+				.get_arguments()
+				.any(|argument| argument.get_id() == "dry-run"),
+			"expected {command_name} to accept the shared dry-run flag"
+		);
+	}
+
+	let matches = command
+		.clone()
+		.try_get_matches_from(["monochange", "create", "--package", "core"])
+		.unwrap_or_else(|error| panic!("create matches: {error}"));
+	assert_eq!(matches.subcommand_name(), Some("create"));
+}
+
+#[test]
+fn top_level_preview_alias_forces_prepare_release_dry_run() {
+	let alias = crate::cli::top_level_step_alias("preview")
+		.unwrap_or_else(|| panic!("expected preview alias"));
+	assert_eq!(alias.step, "prepare-release");
+	assert!(alias.force_dry_run);
+
+	let synthetic = crate::cli::top_level_step_alias_command_definition(alias)
+		.unwrap_or_else(|| panic!("expected preview command definition"));
+	assert_eq!(synthetic.name, "preview");
+	assert_eq!(synthetic.steps.len(), 1);
+	assert_eq!(synthetic.steps[0].step_kebab_name(), "prepare-release");
 }
 
 #[test]

--- a/crates/monochange/src/cli.rs
+++ b/crates/monochange/src/cli.rs
@@ -335,6 +335,7 @@ When provided, the generated config includes:\n\
 		.subcommand(build_migrate_subcommand())
 		.subcommand(build_lint_subcommand())
 		.subcommand(build_versions_subcommand())
+		.subcommands(build_top_level_step_alias_subcommands())
 		.subcommand({
 			#[cfg(feature = "mcp")]
 			{
@@ -725,6 +726,93 @@ pub(crate) fn command_supports_release_diff_preview(cli_command: &CliCommandDefi
 		.any(|step| matches!(step, CliStepDefinition::PrepareRelease { .. }))
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct TopLevelStepAlias {
+	pub(crate) command: &'static str,
+	pub(crate) step: &'static str,
+	pub(crate) help_text: &'static str,
+	pub(crate) force_dry_run: bool,
+}
+
+pub(crate) const TOP_LEVEL_STEP_ALIASES: &[TopLevelStepAlias] = &[
+	TopLevelStepAlias {
+		command: "create",
+		step: "create-change-file",
+		help_text: "Create a changeset file for one or more packages",
+		force_dry_run: false,
+	},
+	TopLevelStepAlias {
+		command: "discover",
+		step: "discover",
+		help_text: "Discover packages across supported ecosystems",
+		force_dry_run: false,
+	},
+	TopLevelStepAlias {
+		command: "config",
+		step: "config",
+		help_text: "Render resolved monochange configuration and workspace metadata",
+		force_dry_run: false,
+	},
+	TopLevelStepAlias {
+		command: "preview",
+		step: "prepare-release",
+		help_text: "Preview planned version bumps, changelogs, and release artifacts without writing files",
+		force_dry_run: true,
+	},
+	TopLevelStepAlias {
+		command: "prepare",
+		step: "prepare-release",
+		help_text: "Prepare version bumps, changelogs, and release artifacts",
+		force_dry_run: false,
+	},
+	TopLevelStepAlias {
+		command: "affected",
+		step: "affected-packages",
+		help_text: "Evaluate affected packages and changeset coverage",
+		force_dry_run: false,
+	},
+	TopLevelStepAlias {
+		command: "diagnose",
+		step: "diagnose-changesets",
+		help_text: "Inspect changeset provenance and review metadata",
+		force_dry_run: false,
+	},
+];
+
+pub(crate) fn top_level_step_alias(command: &str) -> Option<TopLevelStepAlias> {
+	TOP_LEVEL_STEP_ALIASES
+		.iter()
+		.copied()
+		.find(|alias| alias.command == command)
+}
+
+pub(crate) fn top_level_step_alias_command_definition(
+	alias: TopLevelStepAlias,
+) -> Option<CliCommandDefinition> {
+	let step = monochange_core::all_step_variants()
+		.into_iter()
+		.find(|step| step.step_kebab_name() == alias.step)?;
+
+	Some(CliCommandDefinition {
+		name: alias.command.to_string(),
+		help_text: Some(alias.help_text.to_string()),
+		inputs: step.step_inputs_schema(),
+		steps: vec![step.with_inherited_step_inputs()],
+		dry_run: false,
+	})
+}
+
+fn build_top_level_step_alias_subcommands() -> Vec<Command> {
+	TOP_LEVEL_STEP_ALIASES
+		.iter()
+		.map(|alias| {
+			let synthetic = top_level_step_alias_command_definition(*alias)
+				.unwrap_or_else(|| panic!("missing step command alias target `{}`", alias.step));
+			build_cli_command_subcommand_with_prefix(&synthetic, "monochange")
+		})
+		.collect()
+}
+
 fn step_command_summary(step: &CliStepDefinition) -> String {
 	match step.step_kebab_name().as_str() {
 		"affected-packages" => "Compute affected packages from a prepared release plan".to_string(),
@@ -959,8 +1047,8 @@ Commit notes:
 		"affected" => {
 			Some(
 				r"Examples:
-  monochange step affected-packages --changed-paths crates/core/src/lib.rs --format json
-  monochange step affected-packages --from origin/main --verify
+  monochange affected --changed-paths crates/core/src/lib.rs --format json
+  monochange affected --from origin/main --verify
 
 Verification reminders:
   - Prefer package ids in .changeset files.

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -1455,6 +1455,23 @@ where
 			let dry_run = quiet || step_command_matches.get_flag("dry-run");
 			execute_cli_command(root, &configuration, &synthetic, dry_run, inputs).await
 		}
+		Some((cli_command_name, cli_command_matches))
+			if cli::top_level_step_alias(cli_command_name).is_some() =>
+		{
+			let alias = cli::top_level_step_alias(cli_command_name)
+				.expect("alias was checked in match guard");
+			let configuration = configuration?;
+			let synthetic =
+				cli::top_level_step_alias_command_definition(alias).ok_or_else(|| {
+					MonochangeError::Config(format!(
+						"unknown step command alias target `{}`",
+						alias.step
+					))
+				})?;
+			let inputs = collect_cli_command_inputs(&synthetic, cli_command_matches);
+			let dry_run = quiet || alias.force_dry_run || cli_command_matches.get_flag("dry-run");
+			execute_cli_command(root, &configuration, &synthetic, dry_run, inputs).await
+		}
 		Some(("run", run_matches)) => {
 			let Some((cli_command_name, cli_command_matches)) = run_matches.subcommand() else {
 				return Err(MonochangeError::Config(

--- a/crates/monochange/src/lib.rs
+++ b/crates/monochange/src/lib.rs
@@ -1461,13 +1461,8 @@ where
 			let alias = cli::top_level_step_alias(cli_command_name)
 				.expect("alias was checked in match guard");
 			let configuration = configuration?;
-			let synthetic =
-				cli::top_level_step_alias_command_definition(alias).ok_or_else(|| {
-					MonochangeError::Config(format!(
-						"unknown step command alias target `{}`",
-						alias.step
-					))
-				})?;
+			let synthetic = cli::top_level_step_alias_command_definition(alias)
+				.expect("top-level step alias target exists");
 			let inputs = collect_cli_command_inputs(&synthetic, cli_command_matches);
 			let dry_run = quiet || alias.force_dry_run || cli_command_matches.get_flag("dry-run");
 			execute_cli_command(root, &configuration, &synthetic, dry_run, inputs).await

--- a/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange.snap
+++ b/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/monochange/tests/cli_clap_help.rs
-expression: "render_help_snapshot(&path, version)"
+assertion_line: 142
+expression: render_help_snapshot(&path)
 ---
 Version: [current]
 Command: monochange
@@ -20,6 +21,13 @@ monochange discovers packages across Cargo, npm/pnpm/Bun, Deno, and Dart/Flutter
   [93mmigrate[0m    Audit or migrate release metadata for monochange repositories
   [93mlint[0m       Inspect and scaffold manifest lint rules
   [93mversions[0m   List package and group versions or sync internal dependency constraints
+  [93mcreate[0m     Create a changeset file for one or more packages
+  [93mdiscover[0m   Discover packages across supported ecosystems
+  [93mconfig[0m     Render resolved monochange configuration and workspace metadata
+  [93mpreview[0m    Preview planned version bumps, changelogs, and release artifacts without writing files
+  [93mprepare[0m    Prepare version bumps, changelogs, and release artifacts
+  [93maffected[0m   Evaluate affected packages and changeset coverage
+  [93mdiagnose[0m   Inspect changeset provenance and review metadata
   [93mmcp[0m        Start the monochange MCP (Model Context Protocol) server over stdin/stdout
   [93mcheck[0m      Validate configuration, changesets, and run manifest lint rules
   [93mhelp[0m       Show detailed help for a command

--- a/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_affected.snap
+++ b/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_affected.snap
@@ -1,0 +1,59 @@
+---
+source: crates/monochange/tests/cli_clap_help.rs
+assertion_line: 142
+expression: render_help_snapshot(&path)
+---
+Version: [current]
+Command: monochange affected
+
+Evaluate affected packages and changeset coverage
+
+[1m[97mUsage:[0m monochange affected [--dry-run] [--format <FORMAT>] [--changed-paths <CHANGED_PATHS>] [--from <FROM>] [--verify] [--label <LABEL>]
+
+[1m[96mOptions:[0m
+  [93m-h[0m, [93m--help[0m
+          Print help
+
+[1m[96mRelease Options:[0m
+      [93m--dry-run[0m
+          Run the command in dry-run mode when supported
+
+[1m[96mOptions:[0m
+      [93m--format[0m[95m [0m[95m<FORMAT>[0m
+          [possible values: text, json, md]
+
+      [93m--changed-paths[0m[95m [0m[95m<CHANGED_PATHS>[0m
+          
+
+      [93m--from[0m[95m [0m[95m<FROM>[0m
+          
+
+      [93m--verify[0m
+          
+
+      [93m--label[0m[95m [0m[95m<LABEL>[0m
+          
+
+[1m[96mGlobal Options:[0m
+  [93m-q[0m, [93m--quiet[0m
+          Suppress stdout/stderr output and run in dry-run mode when supported
+
+      [93m--progress-format[0m[95m [0m[95m<FORMAT>[0m
+          Control progress output on stderr
+          
+          [possible values: auto, unicode, ascii, json]
+
+      [93m--jq[0m[95m [0m[95m<EXPRESSION>[0m
+          Filter JSON output with a jq-style expression, such as `.assets[].name`
+
+      [93m--snapshot[0m
+          Print a normalized JSON snapshot for this command subtree
+
+Examples:
+  monochange affected --changed-paths crates/core/src/lib.rs --format json
+  monochange affected --from origin/main --verify
+
+Verification reminders:
+  - Prefer package ids in .changeset files.
+  - Group-owned changesets cover all members of that group.
+  - Ignored paths and skip labels are controlled from [changesets.affected].

--- a/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_config.snap
+++ b/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_config.snap
@@ -1,0 +1,38 @@
+---
+source: crates/monochange/tests/cli_clap_help.rs
+assertion_line: 142
+expression: render_help_snapshot(&path)
+---
+Version: [current]
+Command: monochange config
+
+Render resolved monochange configuration and workspace metadata
+
+[1m[97mUsage:[0m monochange config [--dry-run] [--format <FORMAT>]
+
+[1m[96mOptions:[0m
+  [93m-h[0m, [93m--help[0m
+          Print help
+
+[1m[96mRelease Options:[0m
+      [93m--dry-run[0m
+          Run the command in dry-run mode when supported
+
+[1m[96mOptions:[0m
+      [93m--format[0m[95m [0m[95m<FORMAT>[0m
+          [possible values: text, json, md]
+
+[1m[96mGlobal Options:[0m
+  [93m-q[0m, [93m--quiet[0m
+          Suppress stdout/stderr output and run in dry-run mode when supported
+
+      [93m--progress-format[0m[95m [0m[95m<FORMAT>[0m
+          Control progress output on stderr
+          
+          [possible values: auto, unicode, ascii, json]
+
+      [93m--jq[0m[95m [0m[95m<EXPRESSION>[0m
+          Filter JSON output with a jq-style expression, such as `.assets[].name`
+
+      [93m--snapshot[0m
+          Print a normalized JSON snapshot for this command subtree

--- a/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_create.snap
+++ b/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_create.snap
@@ -1,0 +1,59 @@
+---
+source: crates/monochange/tests/cli_clap_help.rs
+assertion_line: 142
+expression: render_help_snapshot(&path)
+---
+Version: [current]
+Command: monochange create
+
+Create a changeset file for one or more packages
+
+[1m[97mUsage:[0m monochange create [--dry-run] [--interactive] [--package <PACKAGE>] [--bump <BUMP>] [--version <VERSION>] [--reason <REASON>] [--type <TYPE>] [--details <DETAILS>] [--output <PATH>]
+
+[1m[96mOptions:[0m
+  [93m-h[0m, [93m--help[0m
+          Print help
+
+[1m[96mRelease Options:[0m
+      [93m--dry-run[0m
+          Run the command in dry-run mode when supported
+
+[1m[96mOptions:[0m
+      [93m--interactive[0m
+          
+
+      [93m--package[0m[95m [0m[95m<PACKAGE>[0m
+          
+
+      [93m--bump[0m[95m [0m[95m<BUMP>[0m
+          [possible values: major, minor, patch, none]
+
+      [93m--version[0m[95m [0m[95m<VERSION>[0m
+          
+
+      [93m--reason[0m[95m [0m[95m<REASON>[0m
+          
+
+      [93m--type[0m[95m [0m[95m<TYPE>[0m
+          
+
+      [93m--details[0m[95m [0m[95m<DETAILS>[0m
+          
+
+      [93m--output[0m[95m [0m[95m<PATH>[0m
+          
+
+[1m[96mGlobal Options:[0m
+  [93m-q[0m, [93m--quiet[0m
+          Suppress stdout/stderr output and run in dry-run mode when supported
+
+      [93m--progress-format[0m[95m [0m[95m<FORMAT>[0m
+          Control progress output on stderr
+          
+          [possible values: auto, unicode, ascii, json]
+
+      [93m--jq[0m[95m [0m[95m<EXPRESSION>[0m
+          Filter JSON output with a jq-style expression, such as `.assets[].name`
+
+      [93m--snapshot[0m
+          Print a normalized JSON snapshot for this command subtree

--- a/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_diagnose.snap
+++ b/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_diagnose.snap
@@ -1,0 +1,41 @@
+---
+source: crates/monochange/tests/cli_clap_help.rs
+assertion_line: 142
+expression: render_help_snapshot(&path)
+---
+Version: [current]
+Command: monochange diagnose
+
+Inspect changeset provenance and review metadata
+
+[1m[97mUsage:[0m monochange diagnose [--dry-run] [--format <FORMAT>] [--changeset <CHANGESET>]
+
+[1m[96mOptions:[0m
+  [93m-h[0m, [93m--help[0m
+          Print help
+
+[1m[96mRelease Options:[0m
+      [93m--dry-run[0m
+          Run the command in dry-run mode when supported
+
+[1m[96mOptions:[0m
+      [93m--format[0m[95m [0m[95m<FORMAT>[0m
+          [possible values: text, json, md]
+
+      [93m--changeset[0m[95m [0m[95m<CHANGESET>[0m
+          
+
+[1m[96mGlobal Options:[0m
+  [93m-q[0m, [93m--quiet[0m
+          Suppress stdout/stderr output and run in dry-run mode when supported
+
+      [93m--progress-format[0m[95m [0m[95m<FORMAT>[0m
+          Control progress output on stderr
+          
+          [possible values: auto, unicode, ascii, json]
+
+      [93m--jq[0m[95m [0m[95m<EXPRESSION>[0m
+          Filter JSON output with a jq-style expression, such as `.assets[].name`
+
+      [93m--snapshot[0m
+          Print a normalized JSON snapshot for this command subtree

--- a/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_discover.snap
+++ b/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_discover.snap
@@ -1,0 +1,38 @@
+---
+source: crates/monochange/tests/cli_clap_help.rs
+assertion_line: 142
+expression: render_help_snapshot(&path)
+---
+Version: [current]
+Command: monochange discover
+
+Discover packages across supported ecosystems
+
+[1m[97mUsage:[0m monochange discover [--dry-run] [--format <FORMAT>]
+
+[1m[96mOptions:[0m
+  [93m-h[0m, [93m--help[0m
+          Print help
+
+[1m[96mRelease Options:[0m
+      [93m--dry-run[0m
+          Run the command in dry-run mode when supported
+
+[1m[96mOptions:[0m
+      [93m--format[0m[95m [0m[95m<FORMAT>[0m
+          [possible values: text, json, md]
+
+[1m[96mGlobal Options:[0m
+  [93m-q[0m, [93m--quiet[0m
+          Suppress stdout/stderr output and run in dry-run mode when supported
+
+      [93m--progress-format[0m[95m [0m[95m<FORMAT>[0m
+          Control progress output on stderr
+          
+          [possible values: auto, unicode, ascii, json]
+
+      [93m--jq[0m[95m [0m[95m<EXPRESSION>[0m
+          Filter JSON output with a jq-style expression, such as `.assets[].name`
+
+      [93m--snapshot[0m
+          Print a normalized JSON snapshot for this command subtree

--- a/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_prepare.snap
+++ b/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_prepare.snap
@@ -1,0 +1,47 @@
+---
+source: crates/monochange/tests/cli_clap_help.rs
+assertion_line: 142
+expression: render_help_snapshot(&path)
+---
+Version: [current]
+Command: monochange prepare
+
+Prepare version bumps, changelogs, and release artifacts
+
+[1m[97mUsage:[0m monochange prepare [--dry-run] [--diff] [--prepared-release <PATH>] [--format <FORMAT>] [--write-empty-release-record]
+
+[1m[96mOptions:[0m
+  [93m-h[0m, [93m--help[0m
+          Print help
+
+[1m[96mRelease Options:[0m
+      [93m--dry-run[0m
+          Run the command in dry-run mode when supported
+
+      [93m--diff[0m
+          Show unified file diffs for prepared release changes
+
+      [93m--prepared-release[0m[95m [0m[95m<PATH>[0m
+          Read or write the prepared release artifact at a specific path
+
+[1m[96mOptions:[0m
+      [93m--format[0m[95m [0m[95m<FORMAT>[0m
+          [possible values: text, json, md]
+
+      [93m--write-empty-release-record[0m
+          
+
+[1m[96mGlobal Options:[0m
+  [93m-q[0m, [93m--quiet[0m
+          Suppress stdout/stderr output and run in dry-run mode when supported
+
+      [93m--progress-format[0m[95m [0m[95m<FORMAT>[0m
+          Control progress output on stderr
+          
+          [possible values: auto, unicode, ascii, json]
+
+      [93m--jq[0m[95m [0m[95m<EXPRESSION>[0m
+          Filter JSON output with a jq-style expression, such as `.assets[].name`
+
+      [93m--snapshot[0m
+          Print a normalized JSON snapshot for this command subtree

--- a/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_preview.snap
+++ b/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_preview.snap
@@ -1,0 +1,47 @@
+---
+source: crates/monochange/tests/cli_clap_help.rs
+assertion_line: 142
+expression: render_help_snapshot(&path)
+---
+Version: [current]
+Command: monochange preview
+
+Preview planned version bumps, changelogs, and release artifacts without writing files
+
+[1m[97mUsage:[0m monochange preview [--dry-run] [--diff] [--prepared-release <PATH>] [--format <FORMAT>] [--write-empty-release-record]
+
+[1m[96mOptions:[0m
+  [93m-h[0m, [93m--help[0m
+          Print help
+
+[1m[96mRelease Options:[0m
+      [93m--dry-run[0m
+          Run the command in dry-run mode when supported
+
+      [93m--diff[0m
+          Show unified file diffs for prepared release changes
+
+      [93m--prepared-release[0m[95m [0m[95m<PATH>[0m
+          Read or write the prepared release artifact at a specific path
+
+[1m[96mOptions:[0m
+      [93m--format[0m[95m [0m[95m<FORMAT>[0m
+          [possible values: text, json, md]
+
+      [93m--write-empty-release-record[0m
+          
+
+[1m[96mGlobal Options:[0m
+  [93m-q[0m, [93m--quiet[0m
+          Suppress stdout/stderr output and run in dry-run mode when supported
+
+      [93m--progress-format[0m[95m [0m[95m<FORMAT>[0m
+          Control progress output on stderr
+          
+          [possible values: auto, unicode, ascii, json]
+
+      [93m--jq[0m[95m [0m[95m<EXPRESSION>[0m
+          Filter JSON output with a jq-style expression, such as `.assets[].name`
+
+      [93m--snapshot[0m
+          Print a normalized JSON snapshot for this command subtree

--- a/crates/monochange/tests/snapshots/cli_help__help_overview_lists_all_commands@help_overview_lists_all_commands.snap
+++ b/crates/monochange/tests/snapshots/cli_help__help_overview_lists_all_commands@help_overview_lists_all_commands.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/monochange/tests/cli_help.rs
+assertion_line: 33
 info:
   program: monochange
   args:
@@ -26,6 +27,13 @@ Built-in Commands:
   migrate    Audit or migrate release metadata for monochange repositories
   lint       Inspect and scaffold manifest lint rules
   versions   List package and group versions or sync internal dependency constraints
+  create     Create a changeset file for one or more packages
+  discover   Discover packages across supported ecosystems
+  config     Render resolved monochange configuration and workspace metadata
+  preview    Preview planned version bumps, changelogs, and release artifacts without writing files
+  prepare    Prepare version bumps, changelogs, and release artifacts
+  affected   Evaluate affected packages and changeset coverage
+  diagnose   Inspect changeset provenance and review metadata
   mcp        Start the monochange MCP (Model Context Protocol) server over stdin/stdout
   check      Validate configuration, changesets, and run manifest lint rules
   help       Show detailed help for a command

--- a/crates/monochange/tests/snapshots/cli_help__help_unknown_command_shows_error_and_list@help_unknown_command_shows_error_and_list.snap
+++ b/crates/monochange/tests/snapshots/cli_help__help_unknown_command_shows_error_and_list@help_unknown_command_shows_error_and_list.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/monochange/tests/cli_help.rs
+assertion_line: 60
 info:
   program: monochange
   args:
@@ -19,15 +20,22 @@ Run one of these commands to inspect available help paths:
   monochange help
 
 Visible top-level commands:
+  affected
   analyze
   check
   command
+  config
+  create
+  diagnose
+  discover
   help
   init
   lint
   mcp
   migrate
   populate
+  prepare
+  preview
   run
   skill
   snapshot

--- a/crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_prints_help.snap
+++ b/crates/monochange/tests/snapshots/cli_main_binary__monochange_binary_prints_help.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/monochange/tests/cli_main_binary.rs
+assertion_line: 21
 info:
   program: monochange
   args:
@@ -25,6 +26,13 @@ Built-in Commands:
   migrate    Audit or migrate release metadata for monochange repositories
   lint       Inspect and scaffold manifest lint rules
   versions   List package and group versions or sync internal dependency constraints
+  create     Create a changeset file for one or more packages
+  discover   Discover packages across supported ecosystems
+  config     Render resolved monochange configuration and workspace metadata
+  preview    Preview planned version bumps, changelogs, and release artifacts without writing files
+  prepare    Prepare version bumps, changelogs, and release artifacts
+  affected   Evaluate affected packages and changeset coverage
+  diagnose   Inspect changeset provenance and review metadata
   mcp        Start the monochange MCP (Model Context Protocol) server over stdin/stdout
   check      Validate configuration, changesets, and run manifest lint rules
   help       Show detailed help for a command

--- a/crates/monochange_integration_tests/tests/snapshots/cli_snapshot__snapshot_index_output_is_agent_readable.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/cli_snapshot__snapshot_index_output_is_agent_readable.snap
@@ -270,6 +270,111 @@ expression: value
         "options_must_precede_arguments": false
       },
       "path": [
+        "create"
+      ]
+    },
+    {
+      "hidden": false,
+      "max_bump": "major",
+      "parser": {
+        "flags_are_posix_noncompliant": false,
+        "option_arg_separators": [
+          " ",
+          "="
+        ],
+        "options_must_precede_arguments": false
+      },
+      "path": [
+        "discover"
+      ]
+    },
+    {
+      "hidden": false,
+      "max_bump": "major",
+      "parser": {
+        "flags_are_posix_noncompliant": false,
+        "option_arg_separators": [
+          " ",
+          "="
+        ],
+        "options_must_precede_arguments": false
+      },
+      "path": [
+        "config"
+      ]
+    },
+    {
+      "hidden": false,
+      "max_bump": "major",
+      "parser": {
+        "flags_are_posix_noncompliant": false,
+        "option_arg_separators": [
+          " ",
+          "="
+        ],
+        "options_must_precede_arguments": false
+      },
+      "path": [
+        "preview"
+      ]
+    },
+    {
+      "hidden": false,
+      "max_bump": "major",
+      "parser": {
+        "flags_are_posix_noncompliant": false,
+        "option_arg_separators": [
+          " ",
+          "="
+        ],
+        "options_must_precede_arguments": false
+      },
+      "path": [
+        "prepare"
+      ]
+    },
+    {
+      "hidden": false,
+      "max_bump": "major",
+      "parser": {
+        "flags_are_posix_noncompliant": false,
+        "option_arg_separators": [
+          " ",
+          "="
+        ],
+        "options_must_precede_arguments": false
+      },
+      "path": [
+        "affected"
+      ]
+    },
+    {
+      "hidden": false,
+      "max_bump": "major",
+      "parser": {
+        "flags_are_posix_noncompliant": false,
+        "option_arg_separators": [
+          " ",
+          "="
+        ],
+        "options_must_precede_arguments": false
+      },
+      "path": [
+        "diagnose"
+      ]
+    },
+    {
+      "hidden": false,
+      "max_bump": "major",
+      "parser": {
+        "flags_are_posix_noncompliant": false,
+        "option_arg_separators": [
+          " ",
+          "="
+        ],
+        "options_must_precede_arguments": false
+      },
+      "path": [
         "mcp"
       ]
     },


### PR DESCRIPTION
## Summary
- add top-level aliases for common built-in workflow steps: create, discover, config, preview, prepare, affected, and diagnose
- make preview force prepare-release dry-run behavior
- update CLI help snapshots and command coverage tests

## Testing
- devenv shell cargo fmt --all
- devenv shell cargo test -p monochange
- devenv shell monochange step validate