### PR TITLE
feat(lint): add manifest-repository rule across all ecosystems

### DIFF
--- a/.changeset/1780859354-monochange-core.md
+++ b/.changeset/1780859354-monochange-core.md
@@ -3,6 +3,7 @@ monochange_core: patch
 monochange_cargo: patch
 monochange_dart: patch
 monochange_npm: patch
+"@monochange/skill": patch
 ---
 
 # Add manifest-repository lint rule across all ecosystems

--- a/.changeset/1780859354-monochange-core.md
+++ b/.changeset/1780859354-monochange-core.md
@@ -1,0 +1,10 @@
+---
+monochange_core: patch
+monochange_cargo: patch
+monochange_dart: patch
+monochange_npm: patch
+---
+
+# Add manifest-repository lint rule across all ecosystems
+
+New lint rule that enforces the `repository` field in manifest files (Cargo.toml, pubspec.yaml, package.json) to point to the correct monorepo subdirectory. All rules are Off by default in every preset.

--- a/.changeset/1780859354-monochange-core.md
+++ b/.changeset/1780859354-monochange-core.md
@@ -8,3 +8,5 @@ monochange_npm: patch
 # Add manifest-repository lint rule across all ecosystems
 
 New lint rule that enforces the `repository` field in manifest files (Cargo.toml, pubspec.yaml, package.json) to point to the correct monorepo subdirectory. All rules are Off by default in every preset.
+
+For Cargo, the `cargo/manifest-repository` rule resolves `repository = { workspace = true }` against the root manifest's `workspace.package.repository` (falling back to `package.repository`) and reports a mismatch with an autofix. Set `allow_workspace_inheritance = true` to skip workspace-inherited values instead of resolving them.

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -1074,12 +1074,14 @@ Preset rules provide the baseline. Explicit entries in `[lints.rules]` override 
 | `cargo/required-package-fields`                  | Cargo          | correctness   | no      | Requires selected `[package]` metadata fields.                                                                                      |
 | `cargo/sorted-dependencies`                      | Cargo          | style         | yes     | Sorts dependency tables alphabetically.                                                                                             |
 | `cargo/unlisted-package-private`                 | Cargo          | correctness   | yes     | Requires unmanaged crates to set `publish = false`.                                                                                 |
+| `cargo/manifest-repository`                      | Cargo          | correctness   | yes     | Requires `package.repository` to point at the root repository or the package subdirectory URL.                                      |
 | `npm/workspace-protocol`                         | npm-family     | correctness   | yes     | Requires internal dependencies to use `workspace:` ranges.                                                                          |
 | `npm/sorted-dependencies`                        | npm-family     | style         | yes     | Sorts dependency sections alphabetically.                                                                                           |
 | `npm/required-package-fields`                    | npm-family     | correctness   | no      | Requires selected `package.json` metadata fields.                                                                                   |
 | `npm/root-no-prod-deps`                          | npm-family     | best practice | yes     | Keeps production dependencies out of the workspace root package.                                                                    |
 | `npm/no-duplicate-dependencies`                  | npm-family     | correctness   | yes     | Prevents the same dependency from appearing in multiple dependency sections.                                                        |
 | `npm/unlisted-package-private`                   | npm-family     | correctness   | yes     | Requires unmanaged packages to set `private: true`.                                                                                 |
+| `npm/manifest-repository`                        | npm-family     | correctness   | yes     | Requires `repository` in `package.json` to point at the root repository or the package subdirectory URL.                            |
 | `dart/sdk-constraint-present`                    | Dart           | correctness   | no      | Requires `environment.sdk` in `pubspec.yaml`.                                                                                       |
 | `dart/sdk-constraint-modern`                     | Dart           | best practice | no      | Enforces a modern SDK lower bound and, by default, an upper bound.                                                                  |
 | `dart/dependency-sorted`                         | Dart           | style         | yes     | Sorts dependency sections in `pubspec.yaml`.                                                                                        |
@@ -1091,6 +1093,7 @@ Preset rules provide the baseline. Explicit entries in `[lints.rules]` override 
 | `dart/workspace-internal-version-consistency`    | Dart           | correctness   | no      | Requires internal hosted dependency ranges to match workspace package versions.                                                     |
 | `dart/flutter-package-metadata-consistent`       | Dart / Flutter | correctness   | no      | Requires Flutter packages to declare the Flutter SDK dependency consistently.                                                       |
 | `dart/assets-sorted`                             | Dart / Flutter | style         | yes     | Sorts Flutter assets and fonts.                                                                                                     |
+| `dart/manifest-repository`                       | Dart           | correctness   | yes     | Requires `repository` in `pubspec.yaml` to point at the root repository or the package subdirectory URL.                            |
 
 ## Changeset lint rules
 
@@ -1325,6 +1328,52 @@ publish = false
 
 - `fix` — defaults to `true`; inserts `publish = false` when safe.
 
+### `cargo/manifest-repository`
+
+**Why:** package registry pages should send readers to the exact source directory for the package they are using. In monorepos, a root repository URL is correct for root-level packages, but packages under subdirectories should link to that subdirectory on the configured default branch.
+
+**What it checks:** the rule compares `[package].repository` with the repository URL derived from `[source]` in `monochange.toml`:
+
+- root-level packages must use the base repository URL, such as `https://github.com/acme/widgets`
+- subdirectory packages must use `{repo_url}/tree/{default_branch}/{relative_package_dir}`, such as `https://github.com/acme/widgets/tree/main/crates/widget_core`
+- if `[source]` is missing, the rule skips because monochange cannot derive the canonical repository URL
+
+Cargo manifests may also use `repository = { workspace = true }`. By default, this rule resolves that inheritance from the root `Cargo.toml`'s `[workspace.package].repository`, falling back to root `[package].repository`. If the inherited root value does not point at the package subdirectory, the rule reports the package manifest and can replace the inherited inline table with an explicit repository URL.
+
+**Without the rule:**
+
+```toml
+[package]
+name = "widget_core"
+version = "0.1.0"
+repository = "https://github.com/acme/widgets"
+```
+
+**With the rule:**
+
+```toml
+[package]
+name = "widget_core"
+version = "0.1.0"
+repository = "https://github.com/acme/widgets/tree/main/crates/widget_core"
+```
+
+**Configuration:**
+
+```toml
+[lints.rules]
+"cargo/manifest-repository" = "error"
+```
+
+Set `allow_workspace_inheritance = true` only when you intentionally want to permit `repository = { workspace = true }` without resolving it against the package path:
+
+```toml
+[lints.rules]
+"cargo/manifest-repository" = { level = "error", allow_workspace_inheritance = true }
+```
+
+**Autofix:** run `monochange check --fix` to insert a missing `repository`, replace an incorrect value, or convert `repository = { workspace = true }` into the explicit URL required for the package directory. There is no per-rule `fix` option; applying fixes is controlled by the CLI flag.
+
 ## npm-family manifest lint rules
 
 npm-family rules apply to `package.json` manifests discovered through npm, pnpm, yarn, Bun, and Deno/npm-style package graphs.
@@ -1489,6 +1538,45 @@ npm-family rules apply to `package.json` manifests discovered through npm, pnpm,
 **Options:**
 
 - `fix` — defaults to `true`; inserts `private: true` when safe.
+
+### `npm/manifest-repository`
+
+**Why:** npm package metadata should link users to the exact source folder for that package. In monorepos, a root repository URL is correct only for root-level packages; packages in subdirectories should link directly to their package directory on the configured default branch.
+
+**What it checks:** the rule compares `repository` in `package.json` with the repository URL derived from `[source]` in `monochange.toml`:
+
+- root-level packages must use the base repository URL, such as `https://github.com/acme/widgets`
+- subdirectory packages must use `{repo_url}/tree/{default_branch}/{relative_package_dir}`, such as `https://github.com/acme/widgets/tree/main/packages/widget-core`
+- if `[source]` is missing, the rule skips because monochange cannot derive the canonical repository URL
+
+**Without the rule:**
+
+```json
+{
+	"name": "@acme/widget-core",
+	"version": "0.1.0",
+	"repository": "https://github.com/acme/widgets"
+}
+```
+
+**With the rule:**
+
+```json
+{
+	"name": "@acme/widget-core",
+	"version": "0.1.0",
+	"repository": "https://github.com/acme/widgets/tree/main/packages/widget-core"
+}
+```
+
+**Configuration:**
+
+```toml
+[lints.rules]
+"npm/manifest-repository" = "error"
+```
+
+**Autofix:** run `monochange check --fix` to insert a missing `repository` or replace an incorrect value. There is no per-rule `fix` option; applying fixes is controlled by the CLI flag.
 
 ## Dart manifest lint rules
 
@@ -1741,6 +1829,41 @@ flutter:
 
 - `fix` — defaults to `true`; rewrites Flutter assets and fonts in sorted order.
 
+### `dart/manifest-repository`
+
+**Why:** Dart and Flutter package metadata should link users to the exact source folder for that package. In monorepos, a root repository URL is correct only for root-level packages; packages in subdirectories should link directly to their package directory on the configured default branch.
+
+**What it checks:** the rule compares `repository` in `pubspec.yaml` with the repository URL derived from `[source]` in `monochange.toml`:
+
+- root-level packages must use the base repository URL, such as `https://github.com/acme/widgets`
+- subdirectory packages must use `{repo_url}/tree/{default_branch}/{relative_package_dir}`, such as `https://github.com/acme/widgets/tree/main/packages/widget_core`
+- if `[source]` is missing, the rule skips because monochange cannot derive the canonical repository URL
+
+**Without the rule:**
+
+```yaml
+name: widget_core
+version: 0.1.0
+repository: https://github.com/acme/widgets
+```
+
+**With the rule:**
+
+```yaml
+name: widget_core
+version: 0.1.0
+repository: https://github.com/acme/widgets/tree/main/packages/widget_core
+```
+
+**Configuration:**
+
+```toml
+[lints.rules]
+"dart/manifest-repository" = "error"
+```
+
+**Autofix:** run `monochange check --fix` to insert a missing `repository` or replace an incorrect value. There is no per-rule `fix` option; applying fixes is controlled by the CLI flag.
+
 ## What `monochange check` looks like in practice
 
 Use plain text for local review:
@@ -1780,3 +1903,29 @@ devenv shell docs:check
 ```
 
 <!-- {/lintingPolicyReference} -->
+
+<!-- {@manifestRepositoryLintReadmeSummary} -->
+
+### Optional repository URL lint rules
+
+monochange includes opt-in repository URL lint rules for Cargo, Dart, and npm-family manifests:
+
+```toml
+[lints.rules]
+"cargo/manifest-repository" = "error"
+"dart/manifest-repository" = "error"
+"npm/manifest-repository" = "error"
+```
+
+These rules compare each manifest's `repository` field with the repository configured under `[source]` in `monochange.toml`. Root-level packages use the base repository URL, while packages in subdirectories use `{repo_url}/tree/{default_branch}/{relative_package_dir}`. Run `monochange check --fix` to insert or update repository fields; there is no per-rule `fix` option.
+
+Cargo also resolves `repository = { workspace = true }` by reading the root manifest's `[workspace.package].repository` (falling back to root `[package].repository`). If you intentionally want to allow workspace inheritance without validating the package-specific URL, configure:
+
+```toml
+[lints.rules]
+"cargo/manifest-repository" = { level = "error", allow_workspace_inheritance = true }
+```
+
+For full rule-by-rule behavior, see the manifest linting reference and `monochange lint explain <rule-id>`.
+
+<!-- {/manifestRepositoryLintReadmeSummary} -->

--- a/crates/monochange/src/__tests__/snapshots/monochange__mcp__tests__lint_catalog_lists_rules_and_presets@lint_catalog_lists_rules_and_presets.snap
+++ b/crates/monochange/src/__tests__/snapshots/monochange__mcp__tests__lint_catalog_lists_rules_and_presets@lint_catalog_lists_rules_and_presets.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/monochange/src/__tests__/mcp_tests.rs
+assertion_line: 688
 expression: content_text(&result)
 ---
 {
@@ -202,9 +203,9 @@ expression: content_text(&result)
       "name": "Manifest repository must point to the correct subdirectory",
       "options": [
         {
-          "description": "apply an autofix that updates the repository field",
+          "description": "skip manifests that use `repository = { workspace = true }` instead of resolving the inherited value and validating it against the expected URL",
           "kind": "boolean",
-          "name": "fix"
+          "name": "allow_workspace_inheritance"
         }
       ]
     },
@@ -377,13 +378,7 @@ expression: content_text(&result)
       "id": "dart/manifest-repository",
       "maturity": "stable",
       "name": "Manifest repository must point to the correct subdirectory",
-      "options": [
-        {
-          "description": "apply an autofix that updates the repository field",
-          "kind": "boolean",
-          "name": "fix"
-        }
-      ]
+      "options": []
     },
     {
       "autofixable": false,
@@ -495,13 +490,7 @@ expression: content_text(&result)
       "id": "npm/manifest-repository",
       "maturity": "stable",
       "name": "Manifest repository must point to the correct subdirectory",
-      "options": [
-        {
-          "description": "apply an autofix that updates the repository field",
-          "kind": "boolean",
-          "name": "fix"
-        }
-      ]
+      "options": []
     },
     {
       "autofixable": true,

--- a/crates/monochange/src/__tests__/snapshots/monochange__mcp__tests__lint_catalog_lists_rules_and_presets@lint_catalog_lists_rules_and_presets.snap
+++ b/crates/monochange/src/__tests__/snapshots/monochange__mcp__tests__lint_catalog_lists_rules_and_presets@lint_catalog_lists_rules_and_presets.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/monochange/src/__tests__/mcp_tests.rs
-assertion_line: 687
 expression: content_text(&result)
 ---
 {
@@ -15,6 +14,7 @@ expression: content_text(&result)
       "rules": {
         "cargo/dependency-field-order": "off",
         "cargo/internal-dependency-workspace": "warning",
+        "cargo/manifest-repository": "off",
         "cargo/publishable-dependencies": "warning",
         "cargo/required-package-fields": "warning",
         "cargo/sorted-dependencies": "off",
@@ -29,6 +29,7 @@ expression: content_text(&result)
       "rules": {
         "cargo/dependency-field-order": "warning",
         "cargo/internal-dependency-workspace": "error",
+        "cargo/manifest-repository": "off",
         "cargo/publishable-dependencies": "error",
         "cargo/required-package-fields": "error",
         "cargo/sorted-dependencies": "warning",
@@ -43,6 +44,7 @@ expression: content_text(&result)
       "rules": {
         "cargo/dependency-field-order": "error",
         "cargo/internal-dependency-workspace": "error",
+        "cargo/manifest-repository": "off",
         "cargo/publishable-dependencies": "error",
         "cargo/required-package-fields": "error",
         "cargo/sorted-dependencies": "error",
@@ -65,6 +67,7 @@ expression: content_text(&result)
       "name": "Dart baseline",
       "rules": {
         "dart/dependency-sorted": "off",
+        "dart/manifest-repository": "off",
         "dart/no-git-dependencies-in-published-packages": "warning",
         "dart/required-package-fields": "warning",
         "dart/sdk-constraint-present": "warning",
@@ -78,6 +81,7 @@ expression: content_text(&result)
       "name": "Dart recommended",
       "rules": {
         "dart/dependency-sorted": "warning",
+        "dart/manifest-repository": "off",
         "dart/no-git-dependencies-in-published-packages": "error",
         "dart/required-package-fields": "error",
         "dart/sdk-constraint-present": "error",
@@ -97,6 +101,7 @@ expression: content_text(&result)
           "level": "error",
           "mode": "path"
         },
+        "dart/manifest-repository": "off",
         "dart/no-git-dependencies-in-published-packages": "error",
         "dart/no-unexpected-dependency-overrides": "error",
         "dart/required-package-fields": "error",
@@ -112,6 +117,7 @@ expression: content_text(&result)
       "maturity": "stable",
       "name": "npm baseline",
       "rules": {
+        "npm/manifest-repository": "off",
         "npm/no-duplicate-dependencies": "warning",
         "npm/required-package-fields": "warning",
         "npm/root-no-prod-deps": "warning",
@@ -126,6 +132,7 @@ expression: content_text(&result)
       "maturity": "stable",
       "name": "npm recommended",
       "rules": {
+        "npm/manifest-repository": "off",
         "npm/no-duplicate-dependencies": "error",
         "npm/required-package-fields": "error",
         "npm/root-no-prod-deps": "error",
@@ -140,6 +147,7 @@ expression: content_text(&result)
       "maturity": "strict",
       "name": "npm strict",
       "rules": {
+        "npm/manifest-repository": "off",
         "npm/no-duplicate-dependencies": "error",
         "npm/required-package-fields": "error",
         "npm/root-no-prod-deps": "error",
@@ -180,6 +188,21 @@ expression: content_text(&result)
         },
         {
           "description": "apply an autofix when a dependency can be rewritten safely",
+          "kind": "boolean",
+          "name": "fix"
+        }
+      ]
+    },
+    {
+      "autofixable": true,
+      "category": "correctness",
+      "description": "Requires the repository field to point to the correct monorepo subdirectory on the default branch. For root-level packages this is the base repository URL; for packages in subdirectories it includes the relative path.",
+      "id": "cargo/manifest-repository",
+      "maturity": "stable",
+      "name": "Manifest repository must point to the correct subdirectory",
+      "options": [
+        {
+          "description": "apply an autofix that updates the repository field",
           "kind": "boolean",
           "name": "fix"
         }
@@ -348,6 +371,21 @@ expression: content_text(&result)
       ]
     },
     {
+      "autofixable": true,
+      "category": "correctness",
+      "description": "Requires the repository field to point to the correct monorepo subdirectory on the default branch. For root-level packages this is the base repository URL; for packages in subdirectories it includes the relative path.",
+      "id": "dart/manifest-repository",
+      "maturity": "stable",
+      "name": "Manifest repository must point to the correct subdirectory",
+      "options": [
+        {
+          "description": "apply an autofix that updates the repository field",
+          "kind": "boolean",
+          "name": "fix"
+        }
+      ]
+    },
+    {
       "autofixable": false,
       "category": "correctness",
       "description": "Prevents published Dart packages from using git: dependencies unless explicitly allowed",
@@ -453,6 +491,21 @@ expression: content_text(&result)
     {
       "autofixable": true,
       "category": "correctness",
+      "description": "Requires the repository field to point to the correct monorepo subdirectory on the default branch. For root-level packages this is the base repository URL; for packages in subdirectories it includes the relative path.",
+      "id": "npm/manifest-repository",
+      "maturity": "stable",
+      "name": "Manifest repository must point to the correct subdirectory",
+      "options": [
+        {
+          "description": "apply an autofix that updates the repository field",
+          "kind": "boolean",
+          "name": "fix"
+        }
+      ]
+    },
+    {
+      "autofixable": true,
+      "category": "correctness",
       "description": "Prevents one dependency from appearing in multiple npm-family dependency sections",
       "id": "npm/no-duplicate-dependencies",
       "maturity": "stable",
@@ -546,5 +599,5 @@ expression: content_text(&result)
       ]
     }
   ],
-  "summary": "Loaded 29 lint rule(s) and 10 preset(s)."
+  "summary": "Loaded 32 lint rule(s) and 10 preset(s)."
 }

--- a/crates/monochange/src/__tests__/snapshots/monochange__mcp__tests__lint_explain_returns_rule_and_preset@lint_explain_returns_rule_and_preset.snap
+++ b/crates/monochange/src/__tests__/snapshots/monochange__mcp__tests__lint_explain_returns_rule_and_preset@lint_explain_returns_rule_and_preset.snap
@@ -13,6 +13,7 @@ expression: redacted
       "rules": {
         "cargo/dependency-field-order": "warning",
         "cargo/internal-dependency-workspace": "error",
+        "cargo/manifest-repository": "off",
         "cargo/publishable-dependencies": "error",
         "cargo/required-package-fields": "error",
         "cargo/sorted-dependencies": "warning",

--- a/crates/monochange_cargo/src/lints/__tests__/mod_tests.rs
+++ b/crates/monochange_cargo/src/lints/__tests__/mod_tests.rs
@@ -49,7 +49,7 @@ fn cargo_target_with_repo(
 fn config() -> LintRuleConfig {
 	LintRuleConfig::Detailed {
 		level: LintSeverity::Error,
-		options: BTreeMap::from([("fix".to_string(), json!(true))]),
+		options: BTreeMap::new(),
 	}
 }
 
@@ -635,10 +635,7 @@ fn manifest_repository_workspace_inherited_opt_out() {
 	};
 	let config = LintRuleConfig::Detailed {
 		level: LintSeverity::Error,
-		options: BTreeMap::from([
-			("fix".to_string(), json!(true)),
-			("allow_workspace_inheritance".to_string(), json!(true)),
-		]),
+		options: BTreeMap::from([("allow_workspace_inheritance".to_string(), json!(true))]),
 	};
 	let results = rule.run(&ctx, &config);
 	assert!(
@@ -727,30 +724,4 @@ fn manifest_repository_no_package_table() {
 	let config = config();
 	let results = rule.run(&ctx, &config);
 	assert!(results.is_empty());
-}
-
-#[test]
-fn manifest_repository_missing_no_fix() {
-	let rule = ManifestRepositoryRule::new();
-	let contents = "[package]\nname = \"hello\"\nversion = \"0.1.0\"\n";
-	let target = cargo_target_with_repo(
-		contents,
-		true,
-		true,
-		"https://github.com/foo/bar".to_string(),
-	);
-	let ctx = LintContext {
-		workspace_root: &target.workspace_root,
-		manifest_path: &target.manifest_path,
-		contents: &target.contents,
-		metadata: &target.metadata,
-		parsed: target.parsed.as_ref(),
-	};
-	let config = LintRuleConfig::Detailed {
-		level: LintSeverity::Error,
-		options: BTreeMap::from([("fix".to_string(), serde_json::json!(false))]),
-	};
-	let results = rule.run(&ctx, &config);
-	assert_eq!(results.len(), 1);
-	assert!(results[0].fix.is_none());
 }

--- a/crates/monochange_cargo/src/lints/__tests__/mod_tests.rs
+++ b/crates/monochange_cargo/src/lints/__tests__/mod_tests.rs
@@ -511,3 +511,25 @@ fn manifest_repository_wrong_value_with_fix() {
 			.contains("https://github.com/foo/bar")
 	);
 }
+
+#[test]
+fn manifest_repository_no_package_table() {
+	let rule = ManifestRepositoryRule::new();
+	let contents = "[dependencies]\nserde = \"1.0\"\n";
+	let target = cargo_target_with_repo(
+		contents,
+		true,
+		true,
+		"https://github.com/foo/bar".to_string(),
+	);
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = config();
+	let results = rule.run(&ctx, &config);
+	assert!(results.is_empty());
+}

--- a/crates/monochange_cargo/src/lints/__tests__/mod_tests.rs
+++ b/crates/monochange_cargo/src/lints/__tests__/mod_tests.rs
@@ -1,3 +1,5 @@
+use std::fs;
+
 use monochange_config::load_workspace_configuration;
 use monochange_test_helpers::fixture_path;
 use serde_json::json;
@@ -460,7 +462,7 @@ fn manifest_repository_correct_with_repo_url() {
 }
 
 #[test]
-fn manifest_repository_workspace_inherited_no_error() {
+fn manifest_repository_workspace_inherited_no_workspace_root_file() {
 	let rule = ManifestRepositoryRule::new();
 	let contents =
 		"[package]\nname = \"hello\"\nversion = \"0.1.0\"\nrepository = { workspace = true }\n";
@@ -479,7 +481,200 @@ fn manifest_repository_workspace_inherited_no_error() {
 	};
 	let config = config();
 	let results = rule.run(&ctx, &config);
-	assert!(results.is_empty());
+	assert!(
+		results.is_empty(),
+		"expected skip when workspace root Cargo.toml cannot be read, got {results:?}"
+	);
+}
+
+#[test]
+fn manifest_repository_workspace_inherited_resolves_correct_value() {
+	let rule = ManifestRepositoryRule::new();
+	let temp = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root_manifest = "[workspace.package]\nrepository = \"https://github.com/foo/bar\"\n";
+	fs::write(temp.path().join("Cargo.toml"), root_manifest)
+		.unwrap_or_else(|error| panic!("write root manifest: {error}"));
+	let contents =
+		"[package]\nname = \"hello\"\nversion = \"0.1.0\"\nrepository = { workspace = true }\n";
+	let target = cargo_target_with_repo(
+		contents,
+		true,
+		true,
+		"https://github.com/foo/bar".to_string(),
+	);
+	let ctx = LintContext {
+		workspace_root: temp.path(),
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = config();
+	let results = rule.run(&ctx, &config);
+	assert!(
+		results.is_empty(),
+		"expected no error when inherited repository matches expected, got {results:?}"
+	);
+}
+
+#[test]
+fn manifest_repository_workspace_inherited_resolves_wrong_value() {
+	let rule = ManifestRepositoryRule::new();
+	let temp = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root_manifest = "[workspace.package]\nrepository = \"https://github.com/foo/bar\"\n";
+	fs::write(temp.path().join("Cargo.toml"), root_manifest)
+		.unwrap_or_else(|error| panic!("write root manifest: {error}"));
+	let subdir = temp.path().join("crates/hello");
+	fs::create_dir_all(&subdir).unwrap_or_else(|error| panic!("create subdir: {error}"));
+	let manifest_path = subdir.join("Cargo.toml");
+	fs::write(
+		&manifest_path,
+		"[package]\nname = \"hello\"\nversion = \"0.1.0\"\nrepository = { workspace = true }\n",
+	)
+	.unwrap_or_else(|error| panic!("write manifest: {error}"));
+	let contents =
+		fs::read_to_string(&manifest_path).unwrap_or_else(|error| panic!("read manifest: {error}"));
+	let target = LintTarget::new(
+		temp.path().to_path_buf(),
+		manifest_path,
+		contents.clone(),
+		LintTargetMetadata {
+			ecosystem: "cargo".to_string(),
+			relative_path: Path::new("crates/hello/Cargo.toml").to_path_buf(),
+			package_name: Some("hello".to_string()),
+			package_id: Some("hello".to_string()),
+			group_id: None,
+			managed: true,
+			private: Some(false),
+			publishable: Some(true),
+		},
+		Box::new(CargoLintFile {
+			document: contents.parse::<DocumentMut>().unwrap(),
+			workspace_package_names: Arc::new(BTreeSet::new()),
+			workspace_package_publishable: Arc::new(BTreeMap::new()),
+			repo_url: Arc::new("https://github.com/foo/bar".to_string()),
+			default_branch: Arc::new(String::from("main")),
+		}),
+	);
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = config();
+	let results = rule.run(&ctx, &config);
+	assert_eq!(results.len(), 1, "expected one error, got {results:?}");
+	assert!(
+		results[0]
+			.message
+			.contains("workspace-inherited repository resolves to"),
+		"unexpected message: {}",
+		results[0].message
+	);
+	assert!(results[0].fix.is_some(), "expected autofix to be offered");
+	let fix = results[0].fix.as_ref().unwrap();
+	assert_eq!(fix.edits.len(), 1);
+	let replacement = &fix.edits[0].replacement;
+	assert!(
+		replacement.contains("https://github.com/foo/bar/tree/main/crates/hello"),
+		"expected replacement to contain expected URL, got: {replacement}"
+	);
+	assert!(
+		!replacement.contains("workspace"),
+		"expected replacement to remove workspace inheritance, got: {replacement}"
+	);
+}
+
+#[test]
+fn manifest_repository_workspace_inherited_opt_out() {
+	let rule = ManifestRepositoryRule::new();
+	let temp = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root_manifest = "[workspace.package]\nrepository = \"https://github.com/foo/bar\"\n";
+	fs::write(temp.path().join("Cargo.toml"), root_manifest)
+		.unwrap_or_else(|error| panic!("write root manifest: {error}"));
+	let subdir = temp.path().join("crates/hello");
+	fs::create_dir_all(&subdir).unwrap_or_else(|error| panic!("create subdir: {error}"));
+	let manifest_path = subdir.join("Cargo.toml");
+	fs::write(
+		&manifest_path,
+		"[package]\nname = \"hello\"\nversion = \"0.1.0\"\nrepository = { workspace = true }\n",
+	)
+	.unwrap_or_else(|error| panic!("write manifest: {error}"));
+	let contents =
+		fs::read_to_string(&manifest_path).unwrap_or_else(|error| panic!("read manifest: {error}"));
+	let target = LintTarget::new(
+		temp.path().to_path_buf(),
+		manifest_path,
+		contents.clone(),
+		LintTargetMetadata {
+			ecosystem: "cargo".to_string(),
+			relative_path: Path::new("crates/hello/Cargo.toml").to_path_buf(),
+			package_name: Some("hello".to_string()),
+			package_id: Some("hello".to_string()),
+			group_id: None,
+			managed: true,
+			private: Some(false),
+			publishable: Some(true),
+		},
+		Box::new(CargoLintFile {
+			document: contents.parse::<DocumentMut>().unwrap(),
+			workspace_package_names: Arc::new(BTreeSet::new()),
+			workspace_package_publishable: Arc::new(BTreeMap::new()),
+			repo_url: Arc::new("https://github.com/foo/bar".to_string()),
+			default_branch: Arc::new(String::from("main")),
+		}),
+	);
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = LintRuleConfig::Detailed {
+		level: LintSeverity::Error,
+		options: BTreeMap::from([
+			("fix".to_string(), json!(true)),
+			("allow_workspace_inheritance".to_string(), json!(true)),
+		]),
+	};
+	let results = rule.run(&ctx, &config);
+	assert!(
+		results.is_empty(),
+		"expected skip when allow_workspace_inheritance=true, got {results:?}"
+	);
+}
+
+#[test]
+fn manifest_repository_workspace_inherited_falls_back_to_package_repository() {
+	let rule = ManifestRepositoryRule::new();
+	let temp = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root_manifest = "[package]\nname = \"root\"\nversion = \"0.1.0\"\nrepository = \"https://github.com/foo/bar\"\n[workspace]\n";
+	fs::write(temp.path().join("Cargo.toml"), root_manifest)
+		.unwrap_or_else(|error| panic!("write root manifest: {error}"));
+	let contents =
+		"[package]\nname = \"hello\"\nversion = \"0.1.0\"\nrepository = { workspace = true }\n";
+	let target = cargo_target_with_repo(
+		contents,
+		true,
+		true,
+		"https://github.com/foo/bar".to_string(),
+	);
+	let ctx = LintContext {
+		workspace_root: temp.path(),
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = config();
+	let results = rule.run(&ctx, &config);
+	assert!(
+		results.is_empty(),
+		"expected no error when root package.repository matches expected, got {results:?}"
+	);
 }
 
 #[test]

--- a/crates/monochange_cargo/src/lints/__tests__/mod_tests.rs
+++ b/crates/monochange_cargo/src/lints/__tests__/mod_tests.rs
@@ -5,6 +5,15 @@ use serde_json::json;
 use super::*;
 
 fn cargo_target(contents: &str, managed: bool, publishable: bool) -> LintTarget {
+	cargo_target_with_repo(contents, managed, publishable, String::new())
+}
+
+fn cargo_target_with_repo(
+	contents: &str,
+	managed: bool,
+	publishable: bool,
+	repo_url: String,
+) -> LintTarget {
 	LintTarget::new(
 		Path::new(".").to_path_buf(),
 		Path::new("Cargo.toml").to_path_buf(),
@@ -29,6 +38,8 @@ fn cargo_target(contents: &str, managed: bool, publishable: bool) -> LintTarget 
 				("internal_dep".to_string(), false),
 				("serde".to_string(), true),
 			])),
+			repo_url: Arc::new(repo_url),
+			default_branch: Arc::new(String::from("main")),
 		}),
 	)
 }
@@ -341,5 +352,162 @@ fn collect_targets_marks_configured_packages_as_managed() {
 		targets
 			.iter()
 			.all(|target| target.metadata.ecosystem == "cargo")
+	);
+}
+
+#[test]
+fn manifest_repository_correct_no_error() {
+	let rule = ManifestRepositoryRule::new();
+	let contents = "[package]\nname = \"hello\"\nversion = \"0.1.0\"\nrepository = \"https://github.com/foo/bar\"\n";
+	let target = cargo_target(contents, true, true);
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = LintRuleConfig::Severity(LintSeverity::Error);
+	let results = rule.run(&ctx, &config);
+	assert!(results.is_empty());
+}
+
+#[test]
+fn manifest_repository_missing() {
+	let rule = ManifestRepositoryRule::new();
+	let contents = "[package]\nname = \"hello\"\nversion = \"0.1.0\"\n";
+	let target = cargo_target_with_repo(
+		contents,
+		true,
+		true,
+		"https://github.com/foo/bar".to_string(),
+	);
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = config();
+	let results = rule.run(&ctx, &config);
+	assert_eq!(results.len(), 1);
+	assert_eq!(results[0].severity, LintSeverity::Error);
+	assert!(results[0].fix.is_some());
+}
+
+#[test]
+fn manifest_repository_wrong_value() {
+	let rule = ManifestRepositoryRule::new();
+	let contents = "[package]\nname = \"hello\"\nversion = \"0.1.0\"\nrepository = \"https://wrong-url.example.com\"\n";
+	let target = cargo_target_with_repo(
+		contents,
+		true,
+		true,
+		"https://github.com/foo/bar".to_string(),
+	);
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = config();
+	let results = rule.run(&ctx, &config);
+	assert_eq!(results.len(), 1);
+}
+
+#[test]
+fn manifest_repository_empty_repo_url_skipped() {
+	let rule = ManifestRepositoryRule::new();
+	let contents =
+		"[package]\nname = \"hello\"\nversion = \"0.1.0\"\nrepository = \"https://example.com\"\n";
+	let target = cargo_target(contents, true, true);
+	// repo_url is empty string (no source config), so rule is skipped
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = config();
+	let results = rule.run(&ctx, &config);
+	assert!(results.is_empty());
+}
+
+#[test]
+fn manifest_repository_correct_with_repo_url() {
+	let rule = ManifestRepositoryRule::new();
+	let contents = "[package]\nname = \"hello\"\nversion = \"0.1.0\"\nrepository = \"https://github.com/foo/bar\"\n";
+	let target = cargo_target_with_repo(
+		contents,
+		true,
+		true,
+		"https://github.com/foo/bar".to_string(),
+	);
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = config();
+	let results = rule.run(&ctx, &config);
+	assert!(results.is_empty());
+}
+
+#[test]
+fn manifest_repository_workspace_inherited_no_error() {
+	let rule = ManifestRepositoryRule::new();
+	let contents =
+		"[package]\nname = \"hello\"\nversion = \"0.1.0\"\nrepository = { workspace = true }\n";
+	let target = cargo_target_with_repo(
+		contents,
+		true,
+		true,
+		"https://github.com/foo/bar".to_string(),
+	);
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = config();
+	let results = rule.run(&ctx, &config);
+	assert!(results.is_empty());
+}
+
+#[test]
+fn manifest_repository_wrong_value_with_fix() {
+	let rule = ManifestRepositoryRule::new();
+	let contents = "[package]\nname = \"hello\"\nversion = \"0.1.0\"\nrepository = \"https://wrong.example.com\"\n";
+	let target = cargo_target_with_repo(
+		contents,
+		true,
+		true,
+		"https://github.com/foo/bar".to_string(),
+	);
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = config();
+	let results = rule.run(&ctx, &config);
+	assert_eq!(results.len(), 1);
+	assert!(results[0].fix.is_some());
+	let fix = results[0].fix.as_ref().unwrap();
+	assert_eq!(fix.edits.len(), 1);
+	assert!(
+		fix.edits[0]
+			.replacement
+			.contains("https://github.com/foo/bar")
 	);
 }

--- a/crates/monochange_cargo/src/lints/__tests__/mod_tests.rs
+++ b/crates/monochange_cargo/src/lints/__tests__/mod_tests.rs
@@ -533,3 +533,29 @@ fn manifest_repository_no_package_table() {
 	let results = rule.run(&ctx, &config);
 	assert!(results.is_empty());
 }
+
+#[test]
+fn manifest_repository_missing_no_fix() {
+	let rule = ManifestRepositoryRule::new();
+	let contents = "[package]\nname = \"hello\"\nversion = \"0.1.0\"\n";
+	let target = cargo_target_with_repo(
+		contents,
+		true,
+		true,
+		"https://github.com/foo/bar".to_string(),
+	);
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = LintRuleConfig::Detailed {
+		level: LintSeverity::Error,
+		options: BTreeMap::from([("fix".to_string(), serde_json::json!(false))]),
+	};
+	let results = rule.run(&ctx, &config);
+	assert_eq!(results.len(), 1);
+	assert!(results[0].fix.is_none());
+}

--- a/crates/monochange_cargo/src/lints/mod.rs
+++ b/crates/monochange_cargo/src/lints/mod.rs
@@ -50,6 +50,8 @@ struct CargoLintFile {
 	workspace_package_names: Arc<BTreeSet<String>>,
 	#[allow(dead_code)]
 	workspace_package_publishable: Arc<BTreeMap<String, bool>>,
+	repo_url: Arc<String>,
+	default_branch: Arc<String>,
 }
 
 impl LintSuite for CargoLintSuite {
@@ -65,6 +67,7 @@ impl LintSuite for CargoLintSuite {
 			Box::new(RequiredPackageFieldsRule::new()),
 			Box::new(SortedDependenciesRule::new()),
 			Box::new(UnlistedPackagePrivateRule::new()),
+			Box::new(ManifestRepositoryRule::new()),
 		]
 	}
 
@@ -101,6 +104,10 @@ impl LintSuite for CargoLintSuite {
 					"cargo/unlisted-package-private".to_string(),
 					LintRuleConfig::Severity(LintSeverity::Warning),
 				),
+				(
+					"cargo/manifest-repository".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Off),
+				),
 			])),
 			LintPreset::new(
 				"cargo/recommended",
@@ -132,6 +139,10 @@ impl LintSuite for CargoLintSuite {
 				(
 					"cargo/unlisted-package-private".to_string(),
 					LintRuleConfig::Severity(LintSeverity::Warning),
+				),
+				(
+					"cargo/manifest-repository".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Off),
 				),
 			])),
 			LintPreset::new(
@@ -165,6 +176,10 @@ impl LintSuite for CargoLintSuite {
 					"cargo/unlisted-package-private".to_string(),
 					LintRuleConfig::Severity(LintSeverity::Warning),
 				),
+				(
+					"cargo/manifest-repository".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Off),
+				),
 			])),
 		]
 	}
@@ -194,6 +209,15 @@ impl LintSuite for CargoLintSuite {
 				})
 				.collect::<BTreeMap<_, _>>(),
 		);
+
+		let repo_url = Arc::new(configuration.source.as_ref().map_or_else(
+			String::new,
+			monochange_core::SourceConfiguration::repository_url,
+		));
+		let default_branch = Arc::new(configuration.source.as_ref().map_or_else(
+			|| String::from("main"),
+			|source| source.default_branch().to_string(),
+		));
 
 		discovery
 			.packages
@@ -246,6 +270,8 @@ impl LintSuite for CargoLintSuite {
 						document,
 						workspace_package_names: Arc::clone(&workspace_package_names),
 						workspace_package_publishable: Arc::clone(&workspace_package_publishable),
+						repo_url: Arc::clone(&repo_url),
+						default_branch: Arc::clone(&default_branch),
 					}),
 				))
 			})
@@ -745,6 +771,121 @@ impl LintRuleRunner for UnlistedPackagePrivateRule {
 		}
 
 		vec![result]
+	}
+}
+
+fn expected_repo_url(repo_url: &str, default_branch: &str, relative_path: &Path) -> String {
+	if relative_path.as_os_str().is_empty() || relative_path == Path::new(".") {
+		repo_url.to_string()
+	} else {
+		format!(
+			"{repo_url}/tree/{default_branch}/{}",
+			relative_path.display()
+		)
+	}
+}
+
+monochange_linting::declare_lint_rule! {
+	ManifestRepositoryRule,
+	id: "cargo/manifest-repository",
+	name: "Manifest repository must point to the correct subdirectory",
+	description: "Requires the repository field to point to the correct monorepo subdirectory on the default branch. For root-level packages this is the base repository URL; for packages in subdirectories it includes the relative path.",
+	category: LintCategory::Correctness,
+	maturity: LintMaturity::Stable,
+	autofixable: true,
+	options: vec![
+		LintOptionDefinition::new(
+			"fix",
+			"apply an autofix that updates the repository field",
+			LintOptionKind::Boolean,
+		),
+	],
+}
+
+impl LintRuleRunner for ManifestRepositoryRule {
+	fn rule(&self) -> &LintRule {
+		&self.rule
+	}
+
+	fn run(&self, ctx: &LintContext<'_>, config: &LintRuleConfig) -> Vec<LintResult> {
+		let Some(file) = cargo_file(ctx) else {
+			return Vec::new();
+		};
+
+		if file.repo_url.is_empty() {
+			return Vec::new();
+		}
+
+		let relative_dir = relative_to_root(ctx.workspace_root, ctx.manifest_path)
+			.and_then(|p| p.parent().map(Path::to_path_buf))
+			.unwrap_or_else(|| Path::new(".").to_path_buf());
+
+		let expected = expected_repo_url(&file.repo_url, &file.default_branch, &relative_dir);
+
+		// Read the current repository value from the Cargo.toml
+		let package = file.document.get("package");
+		let Some(package_table) = package.and_then(|p| p.as_table()) else {
+			return Vec::new();
+		};
+
+		let repo_item = package_table.get("repository");
+
+		match repo_item {
+			None => {
+				// Repository field is missing
+				let location = LintLocation::new(ctx.manifest_path, 1, 1);
+				let mut result = LintResult::new(
+					self.rule.id.clone(),
+					location,
+					"manifest is missing the repository field".to_string(),
+					config.severity(),
+				);
+				if config.bool_option("fix", true) {
+					let mut doc = file.document.clone();
+					if let Some(pkg) = doc.get_mut("package").and_then(|p| p.as_table_mut()) {
+						pkg.insert("repository", toml_value(&expected));
+					}
+					result = result.with_fix(LintFix::single(
+						"insert repository field",
+						(0, ctx.contents.len()),
+						doc.to_string(),
+					));
+				}
+				vec![result]
+			}
+			Some(item) => {
+				// Skip workspace-inherited values (repository.workspace = true)
+				if let Some(table) = item.as_inline_table()
+					&& table.get("workspace").and_then(toml_edit::Value::as_bool) == Some(true)
+				{
+					return Vec::new();
+				}
+
+				let current = item.as_str().unwrap_or("");
+				if current == expected {
+					return Vec::new();
+				}
+
+				let span = item.span().map(|s| (s.start, s.end));
+				let location = location_from_span(ctx.manifest_path, ctx.contents, span);
+				let mut result = LintResult::new(
+					self.rule.id.clone(),
+					location,
+					format!("repository field is \"{current}\" but should be \"{expected}\""),
+					config.severity(),
+				);
+				if config.bool_option("fix", true) {
+					// Replace the whole value
+					let replacement = format!("repository = \"{expected}\"");
+					result = result.with_fix(LintFix::single(
+						"fix repository field",
+						span.unwrap_or((0, ctx.contents.len())),
+						replacement,
+					));
+				}
+				vec![result]
+			}
+		}
 	}
 }
 

--- a/crates/monochange_cargo/src/lints/mod.rs
+++ b/crates/monochange_cargo/src/lints/mod.rs
@@ -825,11 +825,6 @@ monochange_linting::declare_lint_rule! {
 	autofixable: true,
 	options: vec![
 		LintOptionDefinition::new(
-			"fix",
-			"apply an autofix that updates the repository field",
-			LintOptionKind::Boolean,
-		),
-		LintOptionDefinition::new(
 			"allow_workspace_inheritance",
 			"skip manifests that use `repository = { workspace = true }` instead of resolving the inherited value and validating it against the expected URL",
 			LintOptionKind::Boolean,
@@ -869,25 +864,21 @@ impl LintRuleRunner for ManifestRepositoryRule {
 			None => {
 				// Repository field is missing
 				let location = LintLocation::new(ctx.manifest_path, 1, 1);
-				let mut result = LintResult::new(
+				let mut doc = file.document.clone();
+				if let Some(pkg) = doc.get_mut("package").and_then(|p| p.as_table_mut()) {
+					pkg.insert("repository", toml_value(&expected));
+				}
+				let result = LintResult::new(
 					self.rule.id.clone(),
 					location,
 					"manifest is missing the repository field".to_string(),
 					config.severity(),
-				);
-				if let Some(fix) = config.bool_option("fix", true).then(|| {
-					let mut doc = file.document.clone();
-					if let Some(pkg) = doc.get_mut("package").and_then(|p| p.as_table_mut()) {
-						pkg.insert("repository", toml_value(&expected));
-					}
-					LintFix::single(
-						"insert repository field",
-						(0, ctx.contents.len()),
-						doc.to_string(),
-					)
-				}) {
-					result = result.with_fix(fix);
-				}
+				)
+				.with_fix(LintFix::single(
+					"insert repository field",
+					(0, ctx.contents.len()),
+					doc.to_string(),
+				));
 				vec![result]
 			}
 			Some(item) => {
@@ -909,24 +900,20 @@ impl LintRuleRunner for ManifestRepositoryRule {
 					}
 					let span = item.span().map(|s| (s.start, s.end));
 					let location = location_from_span(ctx.manifest_path, ctx.contents, span);
-					let mut result = LintResult::new(
+					let replacement = format!("repository = \"{expected}\"");
+					let result = LintResult::new(
 						self.rule.id.clone(),
 						location,
 						format!(
 							"workspace-inherited repository resolves to \"{inherited}\" but should be \"{expected}\""
 						),
 						config.severity(),
-					);
-					if let Some(fix) = config.bool_option("fix", true).then(|| {
-						let replacement = format!("repository = \"{expected}\"");
-						LintFix::single(
-							"replace workspace-inherited repository with explicit value",
-							span.unwrap_or((0, ctx.contents.len())),
-							replacement,
-						)
-					}) {
-						result = result.with_fix(fix);
-					}
+					)
+					.with_fix(LintFix::single(
+						"replace workspace-inherited repository with explicit value",
+						span.unwrap_or((0, ctx.contents.len())),
+						replacement,
+					));
 					return vec![result];
 				}
 
@@ -937,22 +924,18 @@ impl LintRuleRunner for ManifestRepositoryRule {
 
 				let span = item.span().map(|s| (s.start, s.end));
 				let location = location_from_span(ctx.manifest_path, ctx.contents, span);
-				let mut result = LintResult::new(
+				let replacement = format!("repository = \"{expected}\"");
+				let result = LintResult::new(
 					self.rule.id.clone(),
 					location,
 					format!("repository field is \"{current}\" but should be \"{expected}\""),
 					config.severity(),
-				);
-				if let Some(fix) = config.bool_option("fix", true).then(|| {
-					let replacement = format!("repository = \"{expected}\"");
-					LintFix::single(
-						"fix repository field",
-						span.unwrap_or((0, ctx.contents.len())),
-						replacement,
-					)
-				}) {
-					result = result.with_fix(fix);
-				}
+				)
+				.with_fix(LintFix::single(
+					"fix repository field",
+					span.unwrap_or((0, ctx.contents.len())),
+					replacement,
+				));
 				vec![result]
 			}
 		}

--- a/crates/monochange_cargo/src/lints/mod.rs
+++ b/crates/monochange_cargo/src/lints/mod.rs
@@ -785,6 +785,36 @@ fn expected_repo_url(repo_url: &str, default_branch: &str, relative_path: &Path)
 	}
 }
 
+/// Resolve the repository value that a workspace member would inherit from
+/// the root `Cargo.toml` when using `repository = { workspace = true }`.
+///
+/// Looks for `workspace.package.repository` first, then falls back to
+/// `package.repository` at the root. Returns `None` if the root manifest
+/// cannot be read or does not declare a repository value.
+fn inherited_workspace_repository(workspace_root: &Path) -> Option<String> {
+	let root_manifest = workspace_root.join("Cargo.toml");
+	let contents = fs::read_to_string(&root_manifest).ok()?;
+	let document = contents.parse::<DocumentMut>().ok()?;
+
+	let workspace_package = document
+		.get("workspace")
+		.and_then(|w| w.as_table())
+		.and_then(|w| w.get("package"))
+		.and_then(|p| p.as_table());
+	if let Some(table) = workspace_package
+		&& let Some(repo) = table.get("repository").and_then(Item::as_str)
+	{
+		return Some(repo.to_string());
+	}
+
+	document
+		.get("package")
+		.and_then(|p| p.as_table())
+		.and_then(|p| p.get("repository"))
+		.and_then(Item::as_str)
+		.map(String::from)
+}
+
 monochange_linting::declare_lint_rule! {
 	ManifestRepositoryRule,
 	id: "cargo/manifest-repository",
@@ -797,6 +827,11 @@ monochange_linting::declare_lint_rule! {
 		LintOptionDefinition::new(
 			"fix",
 			"apply an autofix that updates the repository field",
+			LintOptionKind::Boolean,
+		),
+		LintOptionDefinition::new(
+			"allow_workspace_inheritance",
+			"skip manifests that use `repository = { workspace = true }` instead of resolving the inherited value and validating it against the expected URL",
 			LintOptionKind::Boolean,
 		),
 	],
@@ -856,11 +891,43 @@ impl LintRuleRunner for ManifestRepositoryRule {
 				vec![result]
 			}
 			Some(item) => {
-				// Skip workspace-inherited values (repository.workspace = true)
+				// Resolve `repository = { workspace = true }` against the root
+				// manifest's `workspace.package.repository` (falling back to
+				// `package.repository`). Skip when the user opts out via
+				// `allow_workspace_inheritance = true`.
 				if let Some(table) = item.as_inline_table()
 					&& table.get("workspace").and_then(toml_edit::Value::as_bool) == Some(true)
 				{
-					return Vec::new();
+					if config.bool_option("allow_workspace_inheritance", false) {
+						return Vec::new();
+					}
+					let Some(inherited) = inherited_workspace_repository(ctx.workspace_root) else {
+						return Vec::new();
+					};
+					if inherited == expected {
+						return Vec::new();
+					}
+					let span = item.span().map(|s| (s.start, s.end));
+					let location = location_from_span(ctx.manifest_path, ctx.contents, span);
+					let mut result = LintResult::new(
+						self.rule.id.clone(),
+						location,
+						format!(
+							"workspace-inherited repository resolves to \"{inherited}\" but should be \"{expected}\""
+						),
+						config.severity(),
+					);
+					if let Some(fix) = config.bool_option("fix", true).then(|| {
+						let replacement = format!("repository = \"{expected}\"");
+						LintFix::single(
+							"replace workspace-inherited repository with explicit value",
+							span.unwrap_or((0, ctx.contents.len())),
+							replacement,
+						)
+					}) {
+						result = result.with_fix(fix);
+					}
+					return vec![result];
 				}
 
 				let current = item.as_str().unwrap_or("");

--- a/crates/monochange_cargo/src/lints/mod.rs
+++ b/crates/monochange_cargo/src/lints/mod.rs
@@ -840,16 +840,18 @@ impl LintRuleRunner for ManifestRepositoryRule {
 					"manifest is missing the repository field".to_string(),
 					config.severity(),
 				);
-				if config.bool_option("fix", true) {
+				if let Some(fix) = config.bool_option("fix", true).then(|| {
 					let mut doc = file.document.clone();
 					if let Some(pkg) = doc.get_mut("package").and_then(|p| p.as_table_mut()) {
 						pkg.insert("repository", toml_value(&expected));
 					}
-					result = result.with_fix(LintFix::single(
+					LintFix::single(
 						"insert repository field",
 						(0, ctx.contents.len()),
 						doc.to_string(),
-					));
+					)
+				}) {
+					result = result.with_fix(fix);
 				}
 				vec![result]
 			}
@@ -874,14 +876,15 @@ impl LintRuleRunner for ManifestRepositoryRule {
 					format!("repository field is \"{current}\" but should be \"{expected}\""),
 					config.severity(),
 				);
-				if config.bool_option("fix", true) {
-					// Replace the whole value
+				if let Some(fix) = config.bool_option("fix", true).then(|| {
 					let replacement = format!("repository = \"{expected}\"");
-					result = result.with_fix(LintFix::single(
+					LintFix::single(
 						"fix repository field",
 						span.unwrap_or((0, ctx.contents.len())),
 						replacement,
-					));
+					)
+				}) {
+					result = result.with_fix(fix);
 				}
 				vec![result]
 			}

--- a/crates/monochange_core/src/__tests__/lib_tests.rs
+++ b/crates/monochange_core/src/__tests__/lib_tests.rs
@@ -3875,7 +3875,7 @@ fn ecosystem_settings_auto_discover_skips_when_none() -> Result<(), serde_json::
 fn version_format_serializes_custom_templates_as_strings() {
 	let custom = VersionFormat::Custom("{{ name }}/release/{{ version }}".to_string());
 	let encoded = serde_json::to_string(&custom).expect("serialize version format");
-	assert_eq!(encoded, "\"{{ name }}/release/{{ version }}\"");
+	assert_eq!(encoded, ""{{ name }}/release/{{ version }}"");
 	let decoded: VersionFormat =
 		serde_json::from_str(&encoded).expect("deserialize version format");
 	assert_eq!(decoded, custom);
@@ -3936,6 +3936,31 @@ fn version_format_methods_cover_builtin_and_custom_formats() {
 			.render_tag("pkg", "1.2.3", "cargo")
 			.expect("render custom tag"),
 		"pkg/v1.2.3"
+	);
+}
+
+#[test]
+fn source_provider_default_host_returns_correct_hosts() {
+	assert_eq!(SourceProvider::GitHub.default_host(), "github.com");
+	assert_eq!(SourceProvider::GitLab.default_host(), "gitlab.com");
+	assert_eq!(SourceProvider::Gitea.default_host(), "gitea.com");
+	assert_eq!(SourceProvider::Forgejo.default_host(), "forgejo.com");
+}
+
+#[test]
+fn source_configuration_repository_url_uses_configured_host() {
+	let config = SourceConfiguration {
+		provider: SourceProvider::Gitea,
+		owner: "myorg".to_string(),
+		repo: "myrepo".to_string(),
+		host: Some("git.example.com".to_string()),
+		api_url: None,
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings::default(),
+	};
+	assert_eq!(
+		config.repository_url(),
+		"https://git.example.com/myorg/myrepo"
 	);
 }
 
@@ -4008,4 +4033,38 @@ fn version_format_rejects_malformed_template_syntax() {
 			error.render()
 		);
 	}
+}
+
+#[test]
+fn source_configuration_default_branch_falls_back_to_main() {
+	let config = SourceConfiguration {
+		provider: SourceProvider::GitHub,
+		owner: "o".to_string(),
+		repo: "r".to_string(),
+		host: None,
+		api_url: None,
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings {
+			base: String::new(),
+			..ProviderMergeRequestSettings::default()
+		},
+	};
+	assert_eq!(config.default_branch(), "main");
+}
+
+#[test]
+fn source_configuration_default_branch_reads_configured_base() {
+	let config = SourceConfiguration {
+		provider: SourceProvider::GitHub,
+		owner: "o".to_string(),
+		repo: "r".to_string(),
+		host: None,
+		api_url: None,
+		releases: ProviderReleaseSettings::default(),
+		pull_requests: ProviderMergeRequestSettings {
+			base: "develop".to_string(),
+			..ProviderMergeRequestSettings::default()
+		},
+	};
+	assert_eq!(config.default_branch(), "develop");
 }

--- a/crates/monochange_core/src/__tests__/lib_tests.rs
+++ b/crates/monochange_core/src/__tests__/lib_tests.rs
@@ -3875,7 +3875,7 @@ fn ecosystem_settings_auto_discover_skips_when_none() -> Result<(), serde_json::
 fn version_format_serializes_custom_templates_as_strings() {
 	let custom = VersionFormat::Custom("{{ name }}/release/{{ version }}".to_string());
 	let encoded = serde_json::to_string(&custom).expect("serialize version format");
-	assert_eq!(encoded, ""{{ name }}/release/{{ version }}"");
+	assert_eq!(encoded, "\"{{ name }}/release/{{ version }}\"");
 	let decoded: VersionFormat =
 		serde_json::from_str(&encoded).expect("deserialize version format");
 	assert_eq!(decoded, custom);

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -4652,6 +4652,19 @@ impl SourceProvider {
 			Self::Forgejo => "forgejo",
 		}
 	}
+
+	/// Return the default hostname for a provider.
+	///
+	/// Returns e.g. `github.com` for GitHub or `gitlab.com` for GitLab.
+	#[must_use]
+	pub fn default_host(self) -> &'static str {
+		match self {
+			Self::GitHub => "github.com",
+			Self::GitLab => "gitlab.com",
+			Self::Gitea => "gitea.com",
+			Self::Forgejo => "forgejo.com",
+		}
+	}
 }
 
 impl fmt::Display for SourceProvider {
@@ -4686,6 +4699,34 @@ pub struct SourceConfiguration {
 	pub releases: ProviderReleaseSettings,
 	#[serde(default)]
 	pub pull_requests: ProviderMergeRequestSettings,
+}
+
+impl SourceConfiguration {
+	/// Build the canonical repository URL from the source configuration.
+	///
+	/// Returns e.g. `https://github.com/monochange/monochange` for GitHub, or
+	/// `https://gitlab.com/owner/repo` for GitLab. Self-hosted instances use the
+	/// configured `host` field.
+	#[must_use]
+	pub fn repository_url(&self) -> String {
+		let host = self
+			.host
+			.as_deref()
+			.unwrap_or_else(|| self.provider.default_host());
+		format!("https://{host}/{}/{}", self.owner, self.repo)
+	}
+
+	/// Return the default branch name for the repository.
+	///
+	/// Falls back to `"main"` when no pull request base is configured.
+	#[must_use]
+	pub fn default_branch(&self) -> &str {
+		if self.pull_requests.base.is_empty() {
+			"main"
+		} else {
+			&self.pull_requests.base
+		}
+	}
 }
 
 #[allow(clippy::struct_excessive_bools)]

--- a/crates/monochange_dart/src/lints/__tests__/mod_tests.rs
+++ b/crates/monochange_dart/src/lints/__tests__/mod_tests.rs
@@ -546,3 +546,159 @@ fn collect_targets_ignores_fixture_manifests_outside_workspace_packages() {
 			.all(|target| !target.manifest_path.starts_with(root.join("fixtures")))
 	);
 }
+
+#[test]
+fn manifest_repository_missing() {
+	let rule = ManifestRepositoryRule::new();
+	let contents = "name: hello\nversion: 0.1.0\n";
+	let manifest: Mapping = serde_yaml_ng::from_str(contents).unwrap();
+	let target = LintTarget::new(
+		Path::new(".").to_path_buf(),
+		Path::new("pubspec.yaml").to_path_buf(),
+		contents.to_string(),
+		LintTargetMetadata {
+			ecosystem: "dart".to_string(),
+			relative_path: Path::new("pubspec.yaml").to_path_buf(),
+			package_name: Some("hello".to_string()),
+			package_id: Some("hello".to_string()),
+			group_id: None,
+			managed: true,
+			private: Some(false),
+			publishable: Some(true),
+		},
+		Box::new(DartLintFile {
+			manifest,
+			workspace_package_names: Arc::new(BTreeSet::new()),
+			workspace_package_versions: Arc::new(BTreeMap::new()),
+			repo_url: Arc::new("https://github.com/foo/bar".to_string()),
+			default_branch: Arc::new("main".to_string()),
+		}),
+	);
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = config();
+	let results = rule.run(&ctx, &config);
+	assert_eq!(results.len(), 1);
+}
+
+#[test]
+fn manifest_repository_empty_repo_url_skipped() {
+	let rule = ManifestRepositoryRule::new();
+	let contents = "name: hello\nversion: 0.1.0\nrepository: https://example.com\n";
+	let manifest: Mapping = serde_yaml_ng::from_str(contents).unwrap();
+	let target = LintTarget::new(
+		Path::new(".").to_path_buf(),
+		Path::new("pubspec.yaml").to_path_buf(),
+		contents.to_string(),
+		LintTargetMetadata {
+			ecosystem: "dart".to_string(),
+			relative_path: Path::new("pubspec.yaml").to_path_buf(),
+			package_name: Some("hello".to_string()),
+			package_id: Some("hello".to_string()),
+			group_id: None,
+			managed: true,
+			private: Some(false),
+			publishable: Some(true),
+		},
+		Box::new(DartLintFile {
+			manifest,
+			workspace_package_names: Arc::new(BTreeSet::new()),
+			workspace_package_versions: Arc::new(BTreeMap::new()),
+			repo_url: Arc::new(String::new()),
+			default_branch: Arc::new("main".to_string()),
+		}),
+	);
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = config();
+	let results = rule.run(&ctx, &config);
+	assert!(results.is_empty());
+}
+
+#[test]
+fn manifest_repository_wrong_value() {
+	let rule = ManifestRepositoryRule::new();
+	let contents = "name: hello\nversion: 0.1.0\nrepository: https://wrong.example.com\n";
+	let manifest: Mapping = serde_yaml_ng::from_str(contents).unwrap();
+	let target = LintTarget::new(
+		Path::new(".").to_path_buf(),
+		Path::new("pubspec.yaml").to_path_buf(),
+		contents.to_string(),
+		LintTargetMetadata {
+			ecosystem: "dart".to_string(),
+			relative_path: Path::new("pubspec.yaml").to_path_buf(),
+			package_name: Some("hello".to_string()),
+			package_id: Some("hello".to_string()),
+			group_id: None,
+			managed: true,
+			private: Some(false),
+			publishable: Some(true),
+		},
+		Box::new(DartLintFile {
+			manifest,
+			workspace_package_names: Arc::new(BTreeSet::new()),
+			workspace_package_versions: Arc::new(BTreeMap::new()),
+			repo_url: Arc::new("https://github.com/foo/bar".to_string()),
+			default_branch: Arc::new("main".to_string()),
+		}),
+	);
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = config();
+	let results = rule.run(&ctx, &config);
+	assert_eq!(results.len(), 1);
+}
+
+#[test]
+fn manifest_repository_subdirectory_path() {
+	let rule = ManifestRepositoryRule::new();
+	let contents = "name: hello\nversion: 0.1.0\n";
+	let manifest: Mapping = serde_yaml_ng::from_str(contents).unwrap();
+	let target = LintTarget::new(
+		Path::new("/ws").to_path_buf(),
+		Path::new("/ws/packages/pkg/pubspec.yaml").to_path_buf(),
+		contents.to_string(),
+		LintTargetMetadata {
+			ecosystem: "dart".to_string(),
+			relative_path: Path::new("packages/pkg/pubspec.yaml").to_path_buf(),
+			package_name: Some("hello".to_string()),
+			package_id: Some("hello".to_string()),
+			group_id: None,
+			managed: true,
+			private: Some(false),
+			publishable: Some(true),
+		},
+		Box::new(DartLintFile {
+			manifest,
+			workspace_package_names: Arc::new(BTreeSet::new()),
+			workspace_package_versions: Arc::new(BTreeMap::new()),
+			repo_url: Arc::new("https://github.com/foo/bar".to_string()),
+			default_branch: Arc::new("main".to_string()),
+		}),
+	);
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = config();
+	let results = rule.run(&ctx, &config);
+	assert_eq!(results.len(), 1);
+}

--- a/crates/monochange_dart/src/lints/__tests__/mod_tests.rs
+++ b/crates/monochange_dart/src/lints/__tests__/mod_tests.rs
@@ -702,3 +702,42 @@ fn manifest_repository_subdirectory_path() {
 	let results = rule.run(&ctx, &config);
 	assert_eq!(results.len(), 1);
 }
+
+#[test]
+fn manifest_repository_correct_value() {
+	let rule = ManifestRepositoryRule::new();
+	let contents = "name: hello\nversion: 0.1.0\nrepository: https://github.com/foo/bar\n";
+	let manifest: Mapping = serde_yaml_ng::from_str(contents).unwrap();
+	let target = LintTarget::new(
+		Path::new(".").to_path_buf(),
+		Path::new("pubspec.yaml").to_path_buf(),
+		contents.to_string(),
+		LintTargetMetadata {
+			ecosystem: "dart".to_string(),
+			relative_path: Path::new("pubspec.yaml").to_path_buf(),
+			package_name: Some("hello".to_string()),
+			package_id: Some("hello".to_string()),
+			group_id: None,
+			managed: true,
+			private: Some(false),
+			publishable: Some(true),
+		},
+		Box::new(DartLintFile {
+			manifest,
+			workspace_package_names: Arc::new(BTreeSet::new()),
+			workspace_package_versions: Arc::new(BTreeMap::new()),
+			repo_url: Arc::new("https://github.com/foo/bar".to_string()),
+			default_branch: Arc::new("main".to_string()),
+		}),
+	);
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = config();
+	let results = rule.run(&ctx, &config);
+	assert!(results.is_empty());
+}

--- a/crates/monochange_dart/src/lints/__tests__/mod_tests.rs
+++ b/crates/monochange_dart/src/lints/__tests__/mod_tests.rs
@@ -68,7 +68,7 @@ fn ctx(target: &LintTarget) -> LintContext<'_> {
 fn config() -> LintRuleConfig {
 	LintRuleConfig::Detailed {
 		level: LintSeverity::Error,
-		options: BTreeMap::from([("fix".to_string(), json!(true))]),
+		options: BTreeMap::new(),
 	}
 }
 

--- a/crates/monochange_dart/src/lints/mod.rs
+++ b/crates/monochange_dart/src/lints/mod.rs
@@ -1445,12 +1445,7 @@ impl ManifestRepositoryRule {
 				LintCategory::Correctness,
 				LintMaturity::Stable,
 				true,
-			)
-			.with_options(vec![LintOptionDefinition::new(
-				"fix",
-				"apply an autofix that updates the repository field",
-				LintOptionKind::Boolean,
-			)]),
+			),
 		}
 	}
 }
@@ -1480,22 +1475,20 @@ impl LintRuleRunner for ManifestRepositoryRule {
 		match current_value {
 			None => {
 				let loc = location(ctx);
-				let mut result = LintResult::new(
+				let mut manifest = file.manifest.clone();
+				manifest.insert(yaml_key("repository"), Value::String(expected.clone()));
+				let fixed = render_manifest(&manifest, ctx.contents);
+				let result = LintResult::new(
 					self.rule.id.clone(),
 					loc,
 					"manifest is missing the repository field".to_string(),
 					config.severity(),
-				);
-				if config.bool_option("fix", true) {
-					let mut manifest = file.manifest.clone();
-					manifest.insert(yaml_key("repository"), Value::String(expected.clone()));
-					let fixed = render_manifest(&manifest, ctx.contents);
-					result = result.with_fix(LintFix::single(
-						"insert repository field",
-						(0, ctx.contents.len()),
-						fixed,
-					));
-				}
+				)
+				.with_fix(LintFix::single(
+					"insert repository field",
+					(0, ctx.contents.len()),
+					fixed,
+				));
 				vec![result]
 			}
 			Some(value) => {
@@ -1504,22 +1497,20 @@ impl LintRuleRunner for ManifestRepositoryRule {
 					return Vec::new();
 				}
 				let loc = location(ctx);
-				let mut result = LintResult::new(
+				let mut manifest = file.manifest.clone();
+				manifest.insert(yaml_key("repository"), Value::String(expected.clone()));
+				let fixed = render_manifest(&manifest, ctx.contents);
+				let result = LintResult::new(
 					self.rule.id.clone(),
 					loc,
 					format!("repository field is \"{current}\" but should be \"{expected}\""),
 					config.severity(),
-				);
-				if config.bool_option("fix", true) {
-					let mut manifest = file.manifest.clone();
-					manifest.insert(yaml_key("repository"), Value::String(expected.clone()));
-					let fixed = render_manifest(&manifest, ctx.contents);
-					result = result.with_fix(LintFix::single(
-						"fix repository field",
-						(0, ctx.contents.len()),
-						fixed,
-					));
-				}
+				)
+				.with_fix(LintFix::single(
+					"fix repository field",
+					(0, ctx.contents.len()),
+					fixed,
+				));
 				vec![result]
 			}
 		}

--- a/crates/monochange_dart/src/lints/mod.rs
+++ b/crates/monochange_dart/src/lints/mod.rs
@@ -51,6 +51,8 @@ pub(crate) struct DartLintFile {
 	pub manifest: Mapping,
 	pub workspace_package_names: Arc<BTreeSet<String>>,
 	pub workspace_package_versions: Arc<BTreeMap<String, Version>>,
+	pub repo_url: Arc<String>,
+	pub default_branch: Arc<String>,
 }
 
 impl LintSuite for DartLintSuite {
@@ -71,6 +73,7 @@ impl LintSuite for DartLintSuite {
 			Box::new(SdkConstraintPresentRule::new()),
 			Box::new(UnlistedPackagePrivateRule::new()),
 			Box::new(WorkspaceInternalVersionConsistencyRule::new()),
+			Box::new(ManifestRepositoryRule::new()),
 		]
 	}
 
@@ -103,6 +106,10 @@ impl LintSuite for DartLintSuite {
 					"dart/unlisted-package-private".to_string(),
 					LintRuleConfig::Severity(LintSeverity::Warning),
 				),
+				(
+					"dart/manifest-repository".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Off),
+				),
 			])),
 			LintPreset::new(
 				"dart/recommended",
@@ -130,6 +137,10 @@ impl LintSuite for DartLintSuite {
 				(
 					"dart/unlisted-package-private".to_string(),
 					LintRuleConfig::Severity(LintSeverity::Error),
+				),
+				(
+					"dart/manifest-repository".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Off),
 				),
 			])),
 			LintPreset::new(
@@ -186,6 +197,10 @@ impl LintSuite for DartLintSuite {
 					"dart/workspace-internal-version-consistency".to_string(),
 					LintRuleConfig::Severity(LintSeverity::Error),
 				),
+				(
+					"dart/manifest-repository".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Off),
+				),
 			])),
 		]
 	}
@@ -215,6 +230,15 @@ impl LintSuite for DartLintSuite {
 				})
 				.collect::<BTreeMap<_, _>>(),
 		);
+
+		let repo_url = Arc::new(configuration.source.as_ref().map_or_else(
+			String::new,
+			monochange_core::SourceConfiguration::repository_url,
+		));
+		let default_branch = Arc::new(configuration.source.as_ref().map_or_else(
+			|| String::from("main"),
+			|source| source.default_branch().to_string(),
+		));
 
 		discovery
 			.packages
@@ -269,6 +293,8 @@ impl LintSuite for DartLintSuite {
 						manifest,
 						workspace_package_names: Arc::clone(&workspace_package_names),
 						workspace_package_versions: Arc::clone(&workspace_package_versions),
+						repo_url: Arc::clone(&repo_url),
+						default_branch: Arc::clone(&default_branch),
 					}),
 				))
 			})
@@ -1390,6 +1416,113 @@ impl LintRuleRunner for WorkspaceInternalVersionConsistencyRule {
 		}
 
 		results
+	}
+}
+
+fn expected_repo_url(repo_url: &str, default_branch: &str, relative_path: &Path) -> String {
+	if relative_path.as_os_str().is_empty() || relative_path == Path::new(".") {
+		repo_url.to_string()
+	} else {
+		format!(
+			"{repo_url}/tree/{default_branch}/{}",
+			relative_path.display()
+		)
+	}
+}
+
+#[derive(Debug)]
+struct ManifestRepositoryRule {
+	rule: LintRule,
+}
+
+impl ManifestRepositoryRule {
+	fn new() -> Self {
+		Self {
+			rule: LintRule::new(
+				"dart/manifest-repository",
+				"Manifest repository must point to the correct subdirectory",
+				"Requires the repository field to point to the correct monorepo subdirectory on the default branch. For root-level packages this is the base repository URL; for packages in subdirectories it includes the relative path.",
+				LintCategory::Correctness,
+				LintMaturity::Stable,
+				true,
+			)
+			.with_options(vec![LintOptionDefinition::new(
+				"fix",
+				"apply an autofix that updates the repository field",
+				LintOptionKind::Boolean,
+			)]),
+		}
+	}
+}
+
+impl LintRuleRunner for ManifestRepositoryRule {
+	fn rule(&self) -> &LintRule {
+		&self.rule
+	}
+
+	fn run(&self, ctx: &LintContext<'_>, config: &LintRuleConfig) -> Vec<LintResult> {
+		let Some(file) = dart_file(ctx) else {
+			return Vec::new();
+		};
+
+		if file.repo_url.is_empty() {
+			return Vec::new();
+		}
+
+		let relative_dir = relative_to_root(ctx.workspace_root, ctx.manifest_path)
+			.and_then(|p| p.parent().map(Path::to_path_buf))
+			.unwrap_or_else(|| Path::new(".").to_path_buf());
+
+		let expected = expected_repo_url(&file.repo_url, &file.default_branch, &relative_dir);
+
+		let current_value = file.manifest.get(yaml_key("repository"));
+
+		match current_value {
+			None => {
+				let loc = location(ctx);
+				let mut result = LintResult::new(
+					self.rule.id.clone(),
+					loc,
+					"manifest is missing the repository field".to_string(),
+					config.severity(),
+				);
+				if config.bool_option("fix", true) {
+					let mut manifest = file.manifest.clone();
+					manifest.insert(yaml_key("repository"), Value::String(expected.clone()));
+					let fixed = render_manifest(&manifest, ctx.contents);
+					result = result.with_fix(LintFix::single(
+						"insert repository field",
+						(0, ctx.contents.len()),
+						fixed,
+					));
+				}
+				vec![result]
+			}
+			Some(value) => {
+				let current = value_string(value);
+				if current == expected {
+					return Vec::new();
+				}
+				let loc = location(ctx);
+				let mut result = LintResult::new(
+					self.rule.id.clone(),
+					loc,
+					format!("repository field is \"{current}\" but should be \"{expected}\""),
+					config.severity(),
+				);
+				if config.bool_option("fix", true) {
+					let mut manifest = file.manifest.clone();
+					manifest.insert(yaml_key("repository"), Value::String(expected.clone()));
+					let fixed = render_manifest(&manifest, ctx.contents);
+					result = result.with_fix(LintFix::single(
+						"fix repository field",
+						(0, ctx.contents.len()),
+						fixed,
+					));
+				}
+				vec![result]
+			}
+		}
 	}
 }
 

--- a/crates/monochange_npm/src/lints/__tests__/mod_tests.rs
+++ b/crates/monochange_npm/src/lints/__tests__/mod_tests.rs
@@ -514,3 +514,45 @@ fn manifest_repository_correct_value() {
 	let results = rule.run(&ctx, &config);
 	assert!(results.is_empty());
 }
+
+#[test]
+fn manifest_repository_missing_no_fix() {
+	let rule = ManifestRepositoryRule::new();
+	let contents = "{\"name\": \"hello\", \"version\": \"0.1.0\"}";
+	let manifest: Value = serde_json::from_str(contents).unwrap();
+	let target = LintTarget::new(
+		Path::new(".").to_path_buf(),
+		Path::new("package.json").to_path_buf(),
+		contents.to_string(),
+		LintTargetMetadata {
+			ecosystem: "npm".to_string(),
+			relative_path: Path::new("package.json").to_path_buf(),
+			package_name: Some("hello".to_string()),
+			package_id: Some("hello".to_string()),
+			group_id: None,
+			managed: false,
+			private: Some(false),
+			publishable: Some(true),
+		},
+		Box::new(NpmLintFile {
+			manifest,
+			workspace_package_names: Arc::new(BTreeSet::new()),
+			repo_url: Arc::new("https://github.com/foo/bar".to_string()),
+			default_branch: Arc::new("main".to_string()),
+		}),
+	);
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = LintRuleConfig::Detailed {
+		level: LintSeverity::Error,
+		options: BTreeMap::from([("fix".to_string(), serde_json::json!(false))]),
+	};
+	let results = rule.run(&ctx, &config);
+	assert_eq!(results.len(), 1);
+	assert!(results[0].fix.is_none());
+}

--- a/crates/monochange_npm/src/lints/__tests__/mod_tests.rs
+++ b/crates/monochange_npm/src/lints/__tests__/mod_tests.rs
@@ -34,7 +34,7 @@ fn npm_target(contents: &str, managed: bool, private: bool) -> LintTarget {
 fn config() -> LintRuleConfig {
 	LintRuleConfig::Detailed {
 		level: LintSeverity::Error,
-		options: BTreeMap::from([("fix".to_string(), json!(true))]),
+		options: BTreeMap::new(),
 	}
 }
 
@@ -513,46 +513,4 @@ fn manifest_repository_correct_value() {
 	let config = config();
 	let results = rule.run(&ctx, &config);
 	assert!(results.is_empty());
-}
-
-#[test]
-fn manifest_repository_missing_no_fix() {
-	let rule = ManifestRepositoryRule::new();
-	let contents = "{\"name\": \"hello\", \"version\": \"0.1.0\"}";
-	let manifest: Value = serde_json::from_str(contents).unwrap();
-	let target = LintTarget::new(
-		Path::new(".").to_path_buf(),
-		Path::new("package.json").to_path_buf(),
-		contents.to_string(),
-		LintTargetMetadata {
-			ecosystem: "npm".to_string(),
-			relative_path: Path::new("package.json").to_path_buf(),
-			package_name: Some("hello".to_string()),
-			package_id: Some("hello".to_string()),
-			group_id: None,
-			managed: false,
-			private: Some(false),
-			publishable: Some(true),
-		},
-		Box::new(NpmLintFile {
-			manifest,
-			workspace_package_names: Arc::new(BTreeSet::new()),
-			repo_url: Arc::new("https://github.com/foo/bar".to_string()),
-			default_branch: Arc::new("main".to_string()),
-		}),
-	);
-	let ctx = LintContext {
-		workspace_root: &target.workspace_root,
-		manifest_path: &target.manifest_path,
-		contents: &target.contents,
-		metadata: &target.metadata,
-		parsed: target.parsed.as_ref(),
-	};
-	let config = LintRuleConfig::Detailed {
-		level: LintSeverity::Error,
-		options: BTreeMap::from([("fix".to_string(), serde_json::json!(false))]),
-	};
-	let results = rule.run(&ctx, &config);
-	assert_eq!(results.len(), 1);
-	assert!(results[0].fix.is_none());
 }

--- a/crates/monochange_npm/src/lints/__tests__/mod_tests.rs
+++ b/crates/monochange_npm/src/lints/__tests__/mod_tests.rs
@@ -25,6 +25,8 @@ fn npm_target(contents: &str, managed: bool, private: bool) -> LintTarget {
 				"@scope/internal".to_string(),
 				"shared".to_string(),
 			])),
+			repo_url: Arc::new(String::new()),
+			default_branch: Arc::new(String::from("main")),
 		}),
 	)
 }
@@ -320,4 +322,157 @@ fn collect_targets_marks_configured_packages_as_managed() {
 			.all(|target| target.metadata.ecosystem == "npm")
 	);
 	assert!(targets.iter().any(|target| target.metadata.managed));
+}
+
+#[test]
+fn manifest_repository_missing() {
+	let rule = ManifestRepositoryRule::new();
+	let contents = "{\"name\": \"hello\", \"version\": \"0.1.0\"}";
+	let manifest: Value = serde_json::from_str(contents).unwrap();
+	let target = LintTarget::new(
+		Path::new(".").to_path_buf(),
+		Path::new("package.json").to_path_buf(),
+		contents.to_string(),
+		LintTargetMetadata {
+			ecosystem: "npm".to_string(),
+			relative_path: Path::new("package.json").to_path_buf(),
+			package_name: Some("hello".to_string()),
+			package_id: Some("hello".to_string()),
+			group_id: None,
+			managed: false,
+			private: Some(false),
+			publishable: Some(true),
+		},
+		Box::new(NpmLintFile {
+			manifest,
+			workspace_package_names: Arc::new(BTreeSet::new()),
+			repo_url: Arc::new("https://github.com/foo/bar".to_string()),
+			default_branch: Arc::new("main".to_string()),
+		}),
+	);
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = config();
+	let results = rule.run(&ctx, &config);
+	assert_eq!(results.len(), 1);
+}
+
+#[test]
+fn manifest_repository_empty_repo_url_skipped() {
+	let rule = ManifestRepositoryRule::new();
+	let contents =
+		"{\"name\": \"hello\", \"version\": \"0.1.0\", \"repository\": \"https://example.com\"}";
+	let manifest: Value = serde_json::from_str(contents).unwrap();
+	let target = LintTarget::new(
+		Path::new(".").to_path_buf(),
+		Path::new("package.json").to_path_buf(),
+		contents.to_string(),
+		LintTargetMetadata {
+			ecosystem: "npm".to_string(),
+			relative_path: Path::new("package.json").to_path_buf(),
+			package_name: Some("hello".to_string()),
+			package_id: Some("hello".to_string()),
+			group_id: None,
+			managed: false,
+			private: Some(false),
+			publishable: Some(true),
+		},
+		Box::new(NpmLintFile {
+			manifest,
+			workspace_package_names: Arc::new(BTreeSet::new()),
+			repo_url: Arc::new(String::new()),
+			default_branch: Arc::new("main".to_string()),
+		}),
+	);
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = config();
+	let results = rule.run(&ctx, &config);
+	assert!(results.is_empty());
+}
+
+#[test]
+fn manifest_repository_wrong_value() {
+	let rule = ManifestRepositoryRule::new();
+	let contents = "{\"name\": \"hello\", \"version\": \"0.1.0\", \"repository\": \"https://wrong.example.com\"}";
+	let manifest: Value = serde_json::from_str(contents).unwrap();
+	let target = LintTarget::new(
+		Path::new(".").to_path_buf(),
+		Path::new("package.json").to_path_buf(),
+		contents.to_string(),
+		LintTargetMetadata {
+			ecosystem: "npm".to_string(),
+			relative_path: Path::new("package.json").to_path_buf(),
+			package_name: Some("hello".to_string()),
+			package_id: Some("hello".to_string()),
+			group_id: None,
+			managed: false,
+			private: Some(false),
+			publishable: Some(true),
+		},
+		Box::new(NpmLintFile {
+			manifest,
+			workspace_package_names: Arc::new(BTreeSet::new()),
+			repo_url: Arc::new("https://github.com/foo/bar".to_string()),
+			default_branch: Arc::new("main".to_string()),
+		}),
+	);
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = config();
+	let results = rule.run(&ctx, &config);
+	assert_eq!(results.len(), 1);
+}
+
+#[test]
+fn manifest_repository_subdirectory_path() {
+	let rule = ManifestRepositoryRule::new();
+	let contents = "{\"name\": \"hello\", \"version\": \"0.1.0\"}";
+	let manifest: Value = serde_json::from_str(contents).unwrap();
+	let target = LintTarget::new(
+		Path::new("/ws").to_path_buf(),
+		Path::new("/ws/packages/pkg/package.json").to_path_buf(),
+		contents.to_string(),
+		LintTargetMetadata {
+			ecosystem: "npm".to_string(),
+			relative_path: Path::new("packages/pkg/package.json").to_path_buf(),
+			package_name: Some("hello".to_string()),
+			package_id: Some("hello".to_string()),
+			group_id: None,
+			managed: false,
+			private: Some(false),
+			publishable: Some(true),
+		},
+		Box::new(NpmLintFile {
+			manifest,
+			workspace_package_names: Arc::new(BTreeSet::new()),
+			repo_url: Arc::new("https://github.com/foo/bar".to_string()),
+			default_branch: Arc::new("main".to_string()),
+		}),
+	);
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = config();
+	let results = rule.run(&ctx, &config);
+	assert_eq!(results.len(), 1);
 }

--- a/crates/monochange_npm/src/lints/__tests__/mod_tests.rs
+++ b/crates/monochange_npm/src/lints/__tests__/mod_tests.rs
@@ -476,3 +476,41 @@ fn manifest_repository_subdirectory_path() {
 	let results = rule.run(&ctx, &config);
 	assert_eq!(results.len(), 1);
 }
+
+#[test]
+fn manifest_repository_correct_value() {
+	let rule = ManifestRepositoryRule::new();
+	let contents = "{\"name\": \"hello\", \"version\": \"0.1.0\", \"repository\": \"https://github.com/foo/bar\"}";
+	let manifest: Value = serde_json::from_str(contents).unwrap();
+	let target = LintTarget::new(
+		Path::new(".").to_path_buf(),
+		Path::new("package.json").to_path_buf(),
+		contents.to_string(),
+		LintTargetMetadata {
+			ecosystem: "npm".to_string(),
+			relative_path: Path::new("package.json").to_path_buf(),
+			package_name: Some("hello".to_string()),
+			package_id: Some("hello".to_string()),
+			group_id: None,
+			managed: false,
+			private: Some(false),
+			publishable: Some(true),
+		},
+		Box::new(NpmLintFile {
+			manifest,
+			workspace_package_names: Arc::new(BTreeSet::new()),
+			repo_url: Arc::new("https://github.com/foo/bar".to_string()),
+			default_branch: Arc::new("main".to_string()),
+		}),
+	);
+	let ctx = LintContext {
+		workspace_root: &target.workspace_root,
+		manifest_path: &target.manifest_path,
+		contents: &target.contents,
+		metadata: &target.metadata,
+		parsed: target.parsed.as_ref(),
+	};
+	let config = config();
+	let results = rule.run(&ctx, &config);
+	assert!(results.is_empty());
+}

--- a/crates/monochange_npm/src/lints/mod.rs
+++ b/crates/monochange_npm/src/lints/mod.rs
@@ -963,18 +963,16 @@ impl LintRuleRunner for ManifestRepositoryRule {
 					format!("repository field is \"{current}\" but should be \"{expected}\""),
 					config.severity(),
 				);
-				if config.bool_option("fix", true) {
+				if let Some(fix) = config.bool_option("fix", true).then(|| {
 					let mut manifest = file.manifest.clone();
 					if let Some(obj) = manifest_object_mut(&mut manifest) {
 						obj.insert("repository".to_string(), Value::String(expected.clone()));
 					}
 					let fixed = serde_json::to_string_pretty(&manifest)
 						.unwrap_or_else(|_| ctx.contents.to_string());
-					result = result.with_fix(LintFix::single(
-						"fix repository field",
-						(0, ctx.contents.len()),
-						fixed,
-					));
+					LintFix::single("fix repository field", (0, ctx.contents.len()), fixed)
+				}) {
+					result = result.with_fix(fix);
 				}
 				vec![result]
 			}

--- a/crates/monochange_npm/src/lints/mod.rs
+++ b/crates/monochange_npm/src/lints/mod.rs
@@ -895,12 +895,7 @@ impl ManifestRepositoryRule {
 				LintCategory::Correctness,
 				LintMaturity::Stable,
 				true,
-			)
-			.with_options(vec![LintOptionDefinition::new(
-				"fix",
-				"apply an autofix that updates the repository field",
-				LintOptionKind::Boolean,
-			)]),
+			),
 		}
 	}
 }
@@ -930,25 +925,23 @@ impl LintRuleRunner for ManifestRepositoryRule {
 		match repo_value {
 			None => {
 				let loc = location(ctx);
-				let mut result = LintResult::new(
+				let mut manifest = file.manifest.clone();
+				if let Some(obj) = manifest_object_mut(&mut manifest) {
+					obj.insert("repository".to_string(), Value::String(expected.clone()));
+				}
+				let fixed = serde_json::to_string_pretty(&manifest)
+					.unwrap_or_else(|_| ctx.contents.to_string());
+				let result = LintResult::new(
 					self.rule.id.clone(),
 					loc,
 					"manifest is missing the repository field".to_string(),
 					config.severity(),
-				);
-				if config.bool_option("fix", true) {
-					let mut manifest = file.manifest.clone();
-					if let Some(obj) = manifest_object_mut(&mut manifest) {
-						obj.insert("repository".to_string(), Value::String(expected.clone()));
-					}
-					let fixed = serde_json::to_string_pretty(&manifest)
-						.unwrap_or_else(|_| ctx.contents.to_string());
-					result = result.with_fix(LintFix::single(
-						"insert repository field",
-						(0, ctx.contents.len()),
-						fixed,
-					));
-				}
+				)
+				.with_fix(LintFix::single(
+					"insert repository field",
+					(0, ctx.contents.len()),
+					fixed,
+				));
 				vec![result]
 			}
 			Some(value) => {
@@ -957,23 +950,23 @@ impl LintRuleRunner for ManifestRepositoryRule {
 					return Vec::new();
 				}
 				let loc = location(ctx);
-				let mut result = LintResult::new(
+				let mut manifest = file.manifest.clone();
+				if let Some(obj) = manifest_object_mut(&mut manifest) {
+					obj.insert("repository".to_string(), Value::String(expected.clone()));
+				}
+				let fixed = serde_json::to_string_pretty(&manifest)
+					.unwrap_or_else(|_| ctx.contents.to_string());
+				let result = LintResult::new(
 					self.rule.id.clone(),
 					loc,
 					format!("repository field is \"{current}\" but should be \"{expected}\""),
 					config.severity(),
-				);
-				if let Some(fix) = config.bool_option("fix", true).then(|| {
-					let mut manifest = file.manifest.clone();
-					if let Some(obj) = manifest_object_mut(&mut manifest) {
-						obj.insert("repository".to_string(), Value::String(expected.clone()));
-					}
-					let fixed = serde_json::to_string_pretty(&manifest)
-						.unwrap_or_else(|_| ctx.contents.to_string());
-					LintFix::single("fix repository field", (0, ctx.contents.len()), fixed)
-				}) {
-					result = result.with_fix(fix);
-				}
+				)
+				.with_fix(LintFix::single(
+					"fix repository field",
+					(0, ctx.contents.len()),
+					fixed,
+				));
 				vec![result]
 			}
 		}

--- a/crates/monochange_npm/src/lints/mod.rs
+++ b/crates/monochange_npm/src/lints/mod.rs
@@ -48,6 +48,8 @@ pub struct NpmLintSuite;
 struct NpmLintFile {
 	manifest: Value,
 	workspace_package_names: Arc<BTreeSet<String>>,
+	repo_url: Arc<String>,
+	default_branch: Arc<String>,
 }
 
 impl LintSuite for NpmLintSuite {
@@ -63,6 +65,7 @@ impl LintSuite for NpmLintSuite {
 			Box::new(RootNoProdDepsRule::new()),
 			Box::new(NoDuplicateDependenciesRule::new()),
 			Box::new(UnlistedPackagePrivateRule::new()),
+			Box::new(ManifestRepositoryRule::new()),
 		]
 	}
 
@@ -99,6 +102,10 @@ impl LintSuite for NpmLintSuite {
 					"npm/unlisted-package-private".to_string(),
 					LintRuleConfig::Severity(LintSeverity::Warning),
 				),
+				(
+					"npm/manifest-repository".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Off),
+				),
 			])),
 			LintPreset::new(
 				"npm/recommended",
@@ -130,6 +137,10 @@ impl LintSuite for NpmLintSuite {
 				(
 					"npm/unlisted-package-private".to_string(),
 					LintRuleConfig::Severity(LintSeverity::Warning),
+				),
+				(
+					"npm/manifest-repository".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Off),
 				),
 			])),
 			LintPreset::new(
@@ -163,6 +174,10 @@ impl LintSuite for NpmLintSuite {
 					"npm/unlisted-package-private".to_string(),
 					LintRuleConfig::Severity(LintSeverity::Warning),
 				),
+				(
+					"npm/manifest-repository".to_string(),
+					LintRuleConfig::Severity(LintSeverity::Off),
+				),
 			])),
 		]
 	}
@@ -180,6 +195,15 @@ impl LintSuite for NpmLintSuite {
 				.map(|package| package.name.clone())
 				.collect::<BTreeSet<_>>(),
 		);
+
+		let repo_url = Arc::new(configuration.source.as_ref().map_or_else(
+			String::new,
+			monochange_core::SourceConfiguration::repository_url,
+		));
+		let default_branch = Arc::new(configuration.source.as_ref().map_or_else(
+			|| String::from("main"),
+			|source| source.default_branch().to_string(),
+		));
 
 		discovery
 			.packages
@@ -230,6 +254,8 @@ impl LintSuite for NpmLintSuite {
 					Box::new(NpmLintFile {
 						manifest,
 						workspace_package_names: Arc::clone(&workspace_package_names),
+						repo_url: Arc::clone(&repo_url),
+						default_branch: Arc::clone(&default_branch),
 					}),
 				))
 			})
@@ -841,6 +867,118 @@ impl LintRuleRunner for UnlistedPackagePrivateRule {
 			));
 		}
 		vec![result]
+	}
+}
+
+fn expected_repo_url(repo_url: &str, default_branch: &str, relative_path: &Path) -> String {
+	if relative_path.as_os_str().is_empty() || relative_path == Path::new(".") {
+		repo_url.to_string()
+	} else {
+		format!(
+			"{repo_url}/tree/{default_branch}/{}",
+			relative_path.display()
+		)
+	}
+}
+
+struct ManifestRepositoryRule {
+	rule: LintRule,
+}
+
+impl ManifestRepositoryRule {
+	fn new() -> Self {
+		Self {
+			rule: LintRule::new(
+				"npm/manifest-repository",
+				"Manifest repository must point to the correct subdirectory",
+				"Requires the repository field to point to the correct monorepo subdirectory on the default branch. For root-level packages this is the base repository URL; for packages in subdirectories it includes the relative path.",
+				LintCategory::Correctness,
+				LintMaturity::Stable,
+				true,
+			)
+			.with_options(vec![LintOptionDefinition::new(
+				"fix",
+				"apply an autofix that updates the repository field",
+				LintOptionKind::Boolean,
+			)]),
+		}
+	}
+}
+
+impl LintRuleRunner for ManifestRepositoryRule {
+	fn rule(&self) -> &LintRule {
+		&self.rule
+	}
+
+	fn run(&self, ctx: &LintContext<'_>, config: &LintRuleConfig) -> Vec<LintResult> {
+		let Some(file) = npm_file(ctx) else {
+			return Vec::new();
+		};
+
+		if file.repo_url.is_empty() {
+			return Vec::new();
+		}
+
+		let relative_dir = relative_to_root(ctx.workspace_root, ctx.manifest_path)
+			.and_then(|p| p.parent().map(Path::to_path_buf))
+			.unwrap_or_else(|| Path::new(".").to_path_buf());
+
+		let expected = expected_repo_url(&file.repo_url, &file.default_branch, &relative_dir);
+
+		let repo_value = file.manifest.get("repository");
+
+		match repo_value {
+			None => {
+				let loc = location(ctx);
+				let mut result = LintResult::new(
+					self.rule.id.clone(),
+					loc,
+					"manifest is missing the repository field".to_string(),
+					config.severity(),
+				);
+				if config.bool_option("fix", true) {
+					let mut manifest = file.manifest.clone();
+					if let Some(obj) = manifest_object_mut(&mut manifest) {
+						obj.insert("repository".to_string(), Value::String(expected.clone()));
+					}
+					let fixed = serde_json::to_string_pretty(&manifest)
+						.unwrap_or_else(|_| ctx.contents.to_string());
+					result = result.with_fix(LintFix::single(
+						"insert repository field",
+						(0, ctx.contents.len()),
+						fixed,
+					));
+				}
+				vec![result]
+			}
+			Some(value) => {
+				let current = value.as_str().unwrap_or("");
+				if current == expected {
+					return Vec::new();
+				}
+				let loc = location(ctx);
+				let mut result = LintResult::new(
+					self.rule.id.clone(),
+					loc,
+					format!("repository field is \"{current}\" but should be \"{expected}\""),
+					config.severity(),
+				);
+				if config.bool_option("fix", true) {
+					let mut manifest = file.manifest.clone();
+					if let Some(obj) = manifest_object_mut(&mut manifest) {
+						obj.insert("repository".to_string(), Value::String(expected.clone()));
+					}
+					let fixed = serde_json::to_string_pretty(&manifest)
+						.unwrap_or_else(|_| ctx.contents.to_string());
+					result = result.with_fix(LintFix::single(
+						"fix repository field",
+						(0, ctx.contents.len()),
+						fixed,
+					));
+				}
+				vec![result]
+			}
+		}
 	}
 }
 

--- a/docs/src/reference/linting.md
+++ b/docs/src/reference/linting.md
@@ -97,12 +97,14 @@ Preset rules provide the baseline. Explicit entries in `[lints.rules]` override 
 | `cargo/required-package-fields`                  | Cargo          | correctness   | no      | Requires selected `[package]` metadata fields.                                                                                      |
 | `cargo/sorted-dependencies`                      | Cargo          | style         | yes     | Sorts dependency tables alphabetically.                                                                                             |
 | `cargo/unlisted-package-private`                 | Cargo          | correctness   | yes     | Requires unmanaged crates to set `publish = false`.                                                                                 |
+| `cargo/manifest-repository`                      | Cargo          | correctness   | yes     | Requires `package.repository` to point at the root repository or the package subdirectory URL.                                      |
 | `npm/workspace-protocol`                         | npm-family     | correctness   | yes     | Requires internal dependencies to use `workspace:` ranges.                                                                          |
 | `npm/sorted-dependencies`                        | npm-family     | style         | yes     | Sorts dependency sections alphabetically.                                                                                           |
 | `npm/required-package-fields`                    | npm-family     | correctness   | no      | Requires selected `package.json` metadata fields.                                                                                   |
 | `npm/root-no-prod-deps`                          | npm-family     | best practice | yes     | Keeps production dependencies out of the workspace root package.                                                                    |
 | `npm/no-duplicate-dependencies`                  | npm-family     | correctness   | yes     | Prevents the same dependency from appearing in multiple dependency sections.                                                        |
 | `npm/unlisted-package-private`                   | npm-family     | correctness   | yes     | Requires unmanaged packages to set `private: true`.                                                                                 |
+| `npm/manifest-repository`                        | npm-family     | correctness   | yes     | Requires `repository` in `package.json` to point at the root repository or the package subdirectory URL.                            |
 | `dart/sdk-constraint-present`                    | Dart           | correctness   | no      | Requires `environment.sdk` in `pubspec.yaml`.                                                                                       |
 | `dart/sdk-constraint-modern`                     | Dart           | best practice | no      | Enforces a modern SDK lower bound and, by default, an upper bound.                                                                  |
 | `dart/dependency-sorted`                         | Dart           | style         | yes     | Sorts dependency sections in `pubspec.yaml`.                                                                                        |
@@ -114,6 +116,7 @@ Preset rules provide the baseline. Explicit entries in `[lints.rules]` override 
 | `dart/workspace-internal-version-consistency`    | Dart           | correctness   | no      | Requires internal hosted dependency ranges to match workspace package versions.                                                     |
 | `dart/flutter-package-metadata-consistent`       | Dart / Flutter | correctness   | no      | Requires Flutter packages to declare the Flutter SDK dependency consistently.                                                       |
 | `dart/assets-sorted`                             | Dart / Flutter | style         | yes     | Sorts Flutter assets and fonts.                                                                                                     |
+| `dart/manifest-repository`                       | Dart           | correctness   | yes     | Requires `repository` in `pubspec.yaml` to point at the root repository or the package subdirectory URL.                            |
 
 ## Changeset lint rules
 
@@ -348,6 +351,52 @@ publish = false
 
 - `fix` — defaults to `true`; inserts `publish = false` when safe.
 
+### `cargo/manifest-repository`
+
+**Why:** package registry pages should send readers to the exact source directory for the package they are using. In monorepos, a root repository URL is correct for root-level packages, but packages under subdirectories should link to that subdirectory on the configured default branch.
+
+**What it checks:** the rule compares `[package].repository` with the repository URL derived from `[source]` in `monochange.toml`:
+
+- root-level packages must use the base repository URL, such as `https://github.com/acme/widgets`
+- subdirectory packages must use `{repo_url}/tree/{default_branch}/{relative_package_dir}`, such as `https://github.com/acme/widgets/tree/main/crates/widget_core`
+- if `[source]` is missing, the rule skips because monochange cannot derive the canonical repository URL
+
+Cargo manifests may also use `repository = { workspace = true }`. By default, this rule resolves that inheritance from the root `Cargo.toml`'s `[workspace.package].repository`, falling back to root `[package].repository`. If the inherited root value does not point at the package subdirectory, the rule reports the package manifest and can replace the inherited inline table with an explicit repository URL.
+
+**Without the rule:**
+
+```toml
+[package]
+name = "widget_core"
+version = "0.1.0"
+repository = "https://github.com/acme/widgets"
+```
+
+**With the rule:**
+
+```toml
+[package]
+name = "widget_core"
+version = "0.1.0"
+repository = "https://github.com/acme/widgets/tree/main/crates/widget_core"
+```
+
+**Configuration:**
+
+```toml
+[lints.rules]
+"cargo/manifest-repository" = "error"
+```
+
+Set `allow_workspace_inheritance = true` only when you intentionally want to permit `repository = { workspace = true }` without resolving it against the package path:
+
+```toml
+[lints.rules]
+"cargo/manifest-repository" = { level = "error", allow_workspace_inheritance = true }
+```
+
+**Autofix:** run `monochange check --fix` to insert a missing `repository`, replace an incorrect value, or convert `repository = { workspace = true }` into the explicit URL required for the package directory. There is no per-rule `fix` option; applying fixes is controlled by the CLI flag.
+
 ## npm-family manifest lint rules
 
 npm-family rules apply to `package.json` manifests discovered through npm, pnpm, yarn, Bun, and Deno/npm-style package graphs.
@@ -512,6 +561,45 @@ npm-family rules apply to `package.json` manifests discovered through npm, pnpm,
 **Options:**
 
 - `fix` — defaults to `true`; inserts `private: true` when safe.
+
+### `npm/manifest-repository`
+
+**Why:** npm package metadata should link users to the exact source folder for that package. In monorepos, a root repository URL is correct only for root-level packages; packages in subdirectories should link directly to their package directory on the configured default branch.
+
+**What it checks:** the rule compares `repository` in `package.json` with the repository URL derived from `[source]` in `monochange.toml`:
+
+- root-level packages must use the base repository URL, such as `https://github.com/acme/widgets`
+- subdirectory packages must use `{repo_url}/tree/{default_branch}/{relative_package_dir}`, such as `https://github.com/acme/widgets/tree/main/packages/widget-core`
+- if `[source]` is missing, the rule skips because monochange cannot derive the canonical repository URL
+
+**Without the rule:**
+
+```json
+{
+	"name": "@acme/widget-core",
+	"version": "0.1.0",
+	"repository": "https://github.com/acme/widgets"
+}
+```
+
+**With the rule:**
+
+```json
+{
+	"name": "@acme/widget-core",
+	"version": "0.1.0",
+	"repository": "https://github.com/acme/widgets/tree/main/packages/widget-core"
+}
+```
+
+**Configuration:**
+
+```toml
+[lints.rules]
+"npm/manifest-repository" = "error"
+```
+
+**Autofix:** run `monochange check --fix` to insert a missing `repository` or replace an incorrect value. There is no per-rule `fix` option; applying fixes is controlled by the CLI flag.
 
 ## Dart manifest lint rules
 
@@ -763,6 +851,41 @@ flutter:
 **Options:**
 
 - `fix` — defaults to `true`; rewrites Flutter assets and fonts in sorted order.
+
+### `dart/manifest-repository`
+
+**Why:** Dart and Flutter package metadata should link users to the exact source folder for that package. In monorepos, a root repository URL is correct only for root-level packages; packages in subdirectories should link directly to their package directory on the configured default branch.
+
+**What it checks:** the rule compares `repository` in `pubspec.yaml` with the repository URL derived from `[source]` in `monochange.toml`:
+
+- root-level packages must use the base repository URL, such as `https://github.com/acme/widgets`
+- subdirectory packages must use `{repo_url}/tree/{default_branch}/{relative_package_dir}`, such as `https://github.com/acme/widgets/tree/main/packages/widget_core`
+- if `[source]` is missing, the rule skips because monochange cannot derive the canonical repository URL
+
+**Without the rule:**
+
+```yaml
+name: widget_core
+version: 0.1.0
+repository: https://github.com/acme/widgets
+```
+
+**With the rule:**
+
+```yaml
+name: widget_core
+version: 0.1.0
+repository: https://github.com/acme/widgets/tree/main/packages/widget_core
+```
+
+**Configuration:**
+
+```toml
+[lints.rules]
+"dart/manifest-repository" = "error"
+```
+
+**Autofix:** run `monochange check --fix` to insert a missing `repository` or replace an incorrect value. There is no per-rule `fix` option; applying fixes is controlled by the CLI flag.
 
 ## What `monochange check` looks like in practice
 

--- a/packages/monochange__skill/readme.md
+++ b/packages/monochange__skill/readme.md
@@ -19,6 +19,32 @@ monochange discovers packages in a monorepo, reads release intent from `.changes
 - [skills/trusted-publishing.md](./skills/trusted-publishing.md) — OIDC/trusted-publishing notes for package registries.
 - [examples/readme.md](./examples/readme.md) — scenario examples.
 
+<!-- {=manifestRepositoryLintReadmeSummary} -->
+
+### Optional repository URL lint rules
+
+monochange includes opt-in repository URL lint rules for Cargo, Dart, and npm-family manifests:
+
+```toml
+[lints.rules]
+"cargo/manifest-repository" = "error"
+"dart/manifest-repository" = "error"
+"npm/manifest-repository" = "error"
+```
+
+These rules compare each manifest's `repository` field with the repository configured under `[source]` in `monochange.toml`. Root-level packages use the base repository URL, while packages in subdirectories use `{repo_url}/tree/{default_branch}/{relative_package_dir}`. Run `monochange check --fix` to insert or update repository fields; there is no per-rule `fix` option.
+
+Cargo also resolves `repository = { workspace = true }` by reading the root manifest's `[workspace.package].repository` (falling back to root `[package].repository`). If you intentionally want to allow workspace inheritance without validating the package-specific URL, configure:
+
+```toml
+[lints.rules]
+"cargo/manifest-repository" = { level = "error", allow_workspace_inheritance = true }
+```
+
+For full rule-by-rule behavior, see the manifest linting reference and `monochange lint explain <rule-id>`.
+
+<!-- {/manifestRepositoryLintReadmeSummary} -->
+
 ## Important distinction
 
 The CLI has three command classes:

--- a/packages/monochange__skill/skills/linting.md
+++ b/packages/monochange__skill/skills/linting.md
@@ -18,6 +18,32 @@ MCP equivalents:
 - `monochange_lint_catalog` — list rules and presets for an agent UI or planning step.
 - `monochange_lint_explain` — explain why a rule exists, which manifests it applies to, and what remediation usually looks like.
 
+<!-- {=manifestRepositoryLintReadmeSummary} -->
+
+### Optional repository URL lint rules
+
+monochange includes opt-in repository URL lint rules for Cargo, Dart, and npm-family manifests:
+
+```toml
+[lints.rules]
+"cargo/manifest-repository" = "error"
+"dart/manifest-repository" = "error"
+"npm/manifest-repository" = "error"
+```
+
+These rules compare each manifest's `repository` field with the repository configured under `[source]` in `monochange.toml`. Root-level packages use the base repository URL, while packages in subdirectories use `{repo_url}/tree/{default_branch}/{relative_package_dir}`. Run `monochange check --fix` to insert or update repository fields; there is no per-rule `fix` option.
+
+Cargo also resolves `repository = { workspace = true }` by reading the root manifest's `[workspace.package].repository` (falling back to root `[package].repository`). If you intentionally want to allow workspace inheritance without validating the package-specific URL, configure:
+
+```toml
+[lints.rules]
+"cargo/manifest-repository" = { level = "error", allow_workspace_inheritance = true }
+```
+
+For full rule-by-rule behavior, see the manifest linting reference and `monochange lint explain <rule-id>`.
+
+<!-- {/manifestRepositoryLintReadmeSummary} -->
+
 ## Configuration
 
 ```toml

--- a/readme.md
+++ b/readme.md
@@ -153,6 +153,32 @@ If you do not know which package id to target, rerun `monochange step discover -
 - [Advanced: CI, package publishing, and release PR flows](docs/src/guide/13-ci-and-publishing.md) — per-provider CI patterns, trusted publishing, and long-running release PR design notes
 - [Reference: Manifest linting with `monochange check`](docs/src/reference/linting.md) — `[lints]` rules for Cargo and npm-family manifests
 
+<!-- {=manifestRepositoryLintReadmeSummary} -->
+
+### Optional repository URL lint rules
+
+monochange includes opt-in repository URL lint rules for Cargo, Dart, and npm-family manifests:
+
+```toml
+[lints.rules]
+"cargo/manifest-repository" = "error"
+"dart/manifest-repository" = "error"
+"npm/manifest-repository" = "error"
+```
+
+These rules compare each manifest's `repository` field with the repository configured under `[source]` in `monochange.toml`. Root-level packages use the base repository URL, while packages in subdirectories use `{repo_url}/tree/{default_branch}/{relative_package_dir}`. Run `monochange check --fix` to insert or update repository fields; there is no per-rule `fix` option.
+
+Cargo also resolves `repository = { workspace = true }` by reading the root manifest's `[workspace.package].repository` (falling back to root `[package].repository`). If you intentionally want to allow workspace inheritance without validating the package-specific URL, configure:
+
+```toml
+[lints.rules]
+"cargo/manifest-repository" = { level = "error", allow_workspace_inheritance = true }
+```
+
+For full rule-by-rule behavior, see the manifest linting reference and `monochange lint explain <rule-id>`.
+
+<!-- {/manifestRepositoryLintReadmeSummary} -->
+
 <!-- {=projectRecentPublishingImprovements} -->
 
 ### Recent package publishing improvements


### PR DESCRIPTION
## Summary

Adds a new lint rule `manifest-repository` that enforces the `repository` field in manifest files to point to the correct monorepo subdirectory on the default branch.

### Rule behavior

- **Root-level packages**: repository URL should be the base URL (e.g., `https://github.com/owner/repo`)
- **Subdirectory packages**: repository URL includes the relative path (e.g., `https://github.com/owner/repo/tree/main/crates/my-crate`)
- **Skips**: when source configuration is absent (no `repo_url` configured), or when the workspace root manifest cannot be read
- **Autofix**: all three ecosystem rules are autofixable. Whether the fix is applied to files is controlled by the `monochange check --fix` CLI flag, not by a per-rule config option.

### Cargo workspace inheritance

For Cargo manifests using `repository = { workspace = true }`, the rule resolves the inherited value from the root `Cargo.toml`'s `workspace.package.repository` (falling back to `package.repository`) and validates it against the expected URL for the package's location. If the resolved value doesn't match, the rule reports a mismatch and offers an autofix that replaces the inline table with an explicit string value.

To restore the previous skip behavior for workspace-inherited values, set `allow_workspace_inheritance = true`:

```toml
[lint.rules]
"cargo/manifest-repository" = { level = "error", allow_workspace_inheritance = true }
```

### Rules added

| Rule ID | Ecosystem | Autofix |
|---------|-----------|---------|
| `cargo/manifest-repository` | Cargo | ✓ |
| `dart/manifest-repository` | Dart | ✓ |
| `npm/manifest-repository` | npm | ✓ |

### Default state

All three rules are **Off by default** in every preset (baseline, recommended, strict). Users enable them explicitly.

### How to activate

Via `monochange.toml`:
```toml
[lint.rules]
"cargo/manifest-repository" = { level = "error" }
"dart/manifest-repository" = { level = "warning" }
"npm/manifest-repository" = { level = "error" }
```

Apply fixes with:
```bash
monochange check --fix
```

Via CLI (one-off):
```bash
monochange lint --rule "cargo/manifest-repository=error"
```

### Core changes

- `SourceProvider::default_host()` - returns provider default hostname
- `SourceConfiguration::repository_url()` - constructs canonical `https://{host}/{owner}/{repo}`
- `SourceConfiguration::default_branch()` - returns branch, falls back to `"main"`
- Lint file structs carry `repo_url` and `default_branch` from workspace config
- `inherited_workspace_repository()` - reads root manifest's workspace-inherited repository value

### Tests

- 4 core tests for `SourceProvider` and `SourceConfiguration`
- 12 cargo unit tests covering: correct value, missing, wrong value, empty repo URL, workspace inheritance (no root file, correct inherited, wrong inherited with fix, opt-out, `package.repository` fallback), fix contents, no-package-table
- 5 dart unit tests covering: missing, wrong value, empty repo URL, subdirectory path
- 5 npm unit tests covering: missing, wrong value, empty repo URL, subdirectory path