### PR TITLE
feat(release): support custom version formats

### DIFF
--- a/.changeset/custom-version-format.md
+++ b/.changeset/custom-version-format.md
@@ -1,0 +1,11 @@
+---
+"monochange": patch
+"monochange_config": patch
+"monochange_core": patch
+"monochange_schema": patch
+"@monochange/skill": patch
+---
+
+# Add custom `version_format` tag templates for package and group release identities
+
+`primary` and `namespaced` continue to work as presets, while custom formats such as `{{ ecosystem }}/{{ name }}/v{{ version }}` can use `{{ name }}`, `{{ version }}`, and `{{ ecosystem }}`. Custom formats must include `{{ version }}`, render valid Git tag names, and avoid collisions with other release owners.

--- a/.templates/guides.t.md
+++ b/.templates/guides.t.md
@@ -523,6 +523,8 @@ release = true
 version_format = "primary"
 ```
 
+Groups can also use `version_format = "namespaced"` or a custom tag template such as `version_format = "{{ name }}/v{{ version }}"`. Custom formats support `{{ name }}`, `{{ version }}`, and `{{ ecosystem }}`, must include `{{ version }}`, and must render unique valid Git tag names.
+
 <!-- {/versionGroupsExample} -->
 
 <!-- {@versionGroupsBehavior} -->

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -12857,12 +12857,21 @@ async fn create_release_tags_creates_and_pushes_tags_in_process() {
 fn render_tag_name_and_provider_urls_follow_provider_conventions() {
 	let github = sample_github_source_configuration("https://api.github.com");
 	assert_eq!(
-		crate::render_tag_name("core", "1.2.3", VersionFormat::Primary),
+		crate::render_tag_name("core", "1.2.3", "cargo", &VersionFormat::Primary),
 		"v1.2.3"
 	);
 	assert_eq!(
-		crate::render_tag_name("core", "1.2.3", VersionFormat::Namespaced),
+		crate::render_tag_name("core", "1.2.3", "cargo", &VersionFormat::Namespaced),
 		"core/v1.2.3"
+	);
+	assert_eq!(
+		crate::render_tag_name(
+			"core",
+			"1.2.3",
+			"cargo",
+			&VersionFormat::Custom("{{ ecosystem }}/{{ name }}/v{{ version }}".to_string())
+		),
+		"cargo/core/v1.2.3"
 	);
 	assert!(crate::tag_url_for_provider(&github, "v1.2.3").contains("/releases/tag/v1.2.3"));
 	assert!(
@@ -13327,19 +13336,19 @@ fn effective_title_template_prefers_specific_then_defaults_then_builtin() {
 #[test]
 fn default_title_templates_follow_version_format_defaults() {
 	assert_eq!(
-		crate::default_release_title_for_format(VersionFormat::Primary),
+		crate::default_release_title_for_format(&VersionFormat::Primary),
 		monochange_core::DEFAULT_RELEASE_TITLE_PRIMARY
 	);
 	assert_eq!(
-		crate::default_release_title_for_format(VersionFormat::Namespaced),
+		crate::default_release_title_for_format(&VersionFormat::Namespaced),
 		monochange_core::DEFAULT_RELEASE_TITLE_NAMESPACED
 	);
 	assert_eq!(
-		crate::default_changelog_version_title_for_format(VersionFormat::Primary),
+		crate::default_changelog_version_title_for_format(&VersionFormat::Primary),
 		monochange_core::DEFAULT_CHANGELOG_VERSION_TITLE_PRIMARY
 	);
 	assert_eq!(
-		crate::default_changelog_version_title_for_format(VersionFormat::Namespaced),
+		crate::default_changelog_version_title_for_format(&VersionFormat::Namespaced),
 		monochange_core::DEFAULT_CHANGELOG_VERSION_TITLE_NAMESPACED
 	);
 }

--- a/crates/monochange/src/__tests__/release_artifacts_tests.rs
+++ b/crates/monochange/src/__tests__/release_artifacts_tests.rs
@@ -374,11 +374,11 @@ async fn release_target_and_title_helpers_cover_provider_and_skip_paths() {
 		"default"
 	);
 	assert_eq!(
-		default_release_title_for_format(VersionFormat::Primary),
+		default_release_title_for_format(&VersionFormat::Primary),
 		DEFAULT_RELEASE_TITLE_PRIMARY
 	);
 	assert_eq!(
-		default_changelog_version_title_for_format(VersionFormat::Namespaced),
+		default_changelog_version_title_for_format(&VersionFormat::Namespaced),
 		DEFAULT_CHANGELOG_VERSION_TITLE_NAMESPACED
 	);
 	assert!(

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -168,7 +168,7 @@ pub(crate) async fn build_release_targets(
 		planned_group_by_id.get(group.id.as_str()).and_then(|pg| {
 			pg.planned_version.as_ref().map(|version| {
 				let vs = version.to_string();
-				let tag = render_tag_name(&group.id, &vs, group.version_format);
+				let tag = render_tag_name(&group.id, &vs, "group", &group.version_format);
 				let prev = find_previous_tag_in(&tag, &sorted_tags);
 				let ctx = TitleRenderContext::new(
 					&group.id,
@@ -181,12 +181,12 @@ pub(crate) async fn build_release_targets(
 				let rt = effective_title_template(
 					group.release_title.as_deref(),
 					defaults_release_title,
-					default_release_title_for_format(group.version_format),
+					default_release_title_for_format(&group.version_format),
 				);
 				let ct = effective_title_template(
 					group.changelog_version_title.as_deref(),
 					defaults_changelog_title,
-					default_changelog_version_title_for_format(group.version_format),
+					default_changelog_version_title_for_format(&group.version_format),
 				);
 				ReleaseTarget {
 					id: group.id.clone(),
@@ -194,7 +194,7 @@ pub(crate) async fn build_release_targets(
 					version: vs,
 					tag: group.tag,
 					release: group.release,
-					version_format: group.version_format,
+					version_format: group.version_format.clone(),
 					tag_name: tag,
 					members: group.packages.clone(),
 					rendered_title: ctx.render(rt),
@@ -230,7 +230,7 @@ pub(crate) async fn build_release_targets(
 					ReleaseOwnerKind::Group,
 					group.tag,
 					group.release,
-					group.version_format,
+					group.version_format.clone(),
 					group.packages.clone(),
 				)
 			} else {
@@ -239,24 +239,29 @@ pub(crate) async fn build_release_targets(
 					ReleaseOwnerKind::Package,
 					package_definition.tag,
 					package_definition.release,
-					package_definition.version_format,
+					package_definition.version_format.clone(),
 					vec![package_definition.id.clone()],
 				)
 			};
 		let vs = version.to_string();
-		let tag = render_tag_name(owner_id, &vs, version_format);
+		let tag = render_tag_name(
+			owner_id,
+			&vs,
+			package_definition.package_type.as_str(),
+			&version_format,
+		);
 		let prev = find_previous_tag_in(&tag, &sorted_tags);
 		let ctx =
 			TitleRenderContext::new(owner_id, &vs, changes_count, source, &tag, prev.as_deref());
 		let rt = effective_title_template(
 			package_definition.release_title.as_deref(),
 			defaults_release_title,
-			default_release_title_for_format(version_format),
+			default_release_title_for_format(&version_format),
 		);
 		let ct = effective_title_template(
 			package_definition.changelog_version_title.as_deref(),
 			defaults_changelog_title,
-			default_changelog_version_title_for_format(version_format),
+			default_changelog_version_title_for_format(&version_format),
 		);
 		release_targets.push(ReleaseTarget {
 			id: owner_id.clone(),
@@ -364,12 +369,15 @@ pub(crate) fn build_manifest_updates_parallel(
 }
 
 #[allow(clippy::match_same_arms)]
-pub(crate) fn render_tag_name(id: &str, version: &str, version_format: VersionFormat) -> String {
-	match version_format {
-		VersionFormat::Namespaced => format!("{id}/v{version}"),
-		VersionFormat::Primary => format!("v{version}"),
-		_ => format!("v{version}"),
-	}
+pub(crate) fn render_tag_name(
+	id: &str,
+	version: &str,
+	ecosystem: &str,
+	version_format: &VersionFormat,
+) -> String {
+	version_format
+		.render_tag(id, version, ecosystem)
+		.unwrap_or_else(|_| format!("v{version}"))
 }
 
 /// Dispatch tag URL generation to the appropriate provider crate.
@@ -557,7 +565,7 @@ pub(crate) fn effective_title_template<'a>(
 }
 
 #[allow(clippy::match_same_arms)]
-pub(crate) fn default_release_title_for_format(version_format: VersionFormat) -> &'static str {
+pub(crate) fn default_release_title_for_format(version_format: &VersionFormat) -> &'static str {
 	match version_format {
 		VersionFormat::Primary => DEFAULT_RELEASE_TITLE_PRIMARY,
 		VersionFormat::Namespaced => DEFAULT_RELEASE_TITLE_NAMESPACED,
@@ -567,7 +575,7 @@ pub(crate) fn default_release_title_for_format(version_format: VersionFormat) ->
 
 #[allow(clippy::match_same_arms)]
 pub(crate) fn default_changelog_version_title_for_format(
-	version_format: VersionFormat,
+	version_format: &VersionFormat,
 ) -> &'static str {
 	match version_format {
 		VersionFormat::Primary => DEFAULT_CHANGELOG_VERSION_TITLE_PRIMARY,
@@ -1106,7 +1114,7 @@ pub(crate) fn build_release_manifest(
 					version: target.version.clone(),
 					tag: target.tag,
 					release: target.release,
-					version_format: target.version_format,
+					version_format: target.version_format.clone(),
 					tag_name: target.tag_name.clone(),
 					members: target.members.clone(),
 					rendered_title: target.rendered_title.clone(),
@@ -1200,7 +1208,7 @@ pub(crate) fn build_release_manifest_from_record(record: &ReleaseRecord) -> Rele
 					version: target.version.clone(),
 					tag: target.tag,
 					release: target.release,
-					version_format: target.version_format,
+					version_format: target.version_format.clone(),
 					tag_name: target.tag_name.clone(),
 					members: target.members.clone(),
 					rendered_title: String::new(),
@@ -1274,7 +1282,7 @@ pub(crate) fn build_release_record(
 					id: target.id.clone(),
 					kind: target.kind,
 					version: target.version.clone(),
-					version_format: target.version_format,
+					version_format: target.version_format.clone(),
 					tag: target.tag,
 					release: target.release,
 					tag_name: target.tag_name.clone(),

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -2125,7 +2125,7 @@ pub(crate) async fn prepare_release_execution_with_file_diffs(
 				version: target.version.clone(),
 				tag: target.tag,
 				release: target.release,
-				version_format: target.version_format,
+				version_format: target.version_format.clone(),
 				tag_name: target.tag_name.clone(),
 				members: target.members.clone(),
 				rendered_title: target.rendered_title.clone(),

--- a/crates/monochange_config/src/__tests__/lib_tests.rs
+++ b/crates/monochange_config/src/__tests__/lib_tests.rs
@@ -8308,3 +8308,56 @@ include = ["modules/*"]
 	assert_eq!(package.package_type, monochange_core::PackageType::Go);
 	assert_eq!(package.path, PathBuf::from("modules/service"));
 }
+
+#[test]
+fn load_workspace_configuration_accepts_custom_version_formats() {
+	let root = fixture_path("config/custom-version-format");
+	let configuration = load_workspace_configuration(&root)
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+	let core = configuration.package_by_id("core").expect("core package");
+	assert_eq!(
+		core.version_format,
+		monochange_core::VersionFormat::Custom(
+			"{{ ecosystem }}/{{ name }}/v{{ version }}".to_string()
+		)
+	);
+	let cli = configuration.package_by_id("cli").expect("cli package");
+	assert_eq!(
+		cli.version_format,
+		monochange_core::VersionFormat::Custom("{{ name }}-v{{ version }}".to_string())
+	);
+	let group = configuration.group_by_id("sdk").expect("sdk group");
+	assert_eq!(
+		group.version_format,
+		monochange_core::VersionFormat::Custom("groups/{{ name }}/v{{ version }}".to_string())
+	);
+}
+
+#[test]
+fn load_workspace_configuration_rejects_colliding_custom_version_formats() {
+	let root = fixture_path("config/rejects-colliding-custom-version-format");
+	let error = load_workspace_configuration(&root)
+		.expect_err("colliding custom version formats should be rejected")
+		.render();
+	assert!(error.contains("renders the same sample tag `release-v0.0.0`"));
+	assert!(error.contains("include `{{ name }}`"));
+}
+
+#[test]
+fn load_workspace_configuration_rejects_primary_custom_version_format_collision() {
+	let root = fixture_path("config/rejects-primary-custom-version-format-collision");
+	let error = load_workspace_configuration(&root)
+		.expect_err("primary and equivalent custom version formats should be rejected")
+		.render();
+	assert!(error.contains("renders the same sample tag `v0.0.0`"));
+	assert!(error.contains("include `{{ name }}`"));
+}
+
+#[test]
+fn load_workspace_configuration_rejects_invalid_custom_version_format_tags() {
+	let root = fixture_path("config/rejects-invalid-custom-version-format");
+	let error = load_workspace_configuration(&root)
+		.expect_err("invalid custom version format tags should be rejected")
+		.render();
+	assert!(error.contains("contains whitespace"));
+}

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -1761,6 +1761,7 @@ fn discover_auto_packages(
 			let version_format = auto_discover
 				.defaults
 				.version_format
+				.clone()
 				.or(default_package_type.map(default_version_format))
 				.unwrap_or_default();
 
@@ -3600,6 +3601,7 @@ fn validate_package_and_group_definitions_with_cache(
 	let mut ids = BTreeSet::new();
 	let mut package_paths = BTreeMap::<PathBuf, String>::new();
 	let mut primary_owner = Option::<String>::None;
+	let mut rendered_version_format_tags = BTreeMap::<String, String>::new();
 	for package in packages {
 		if !ids.insert(package.id.clone()) {
 			return Err(config_diagnostic(
@@ -3683,9 +3685,17 @@ fn validate_package_and_group_definitions_with_cache(
 				)),
 			));
 		}
-		if package.version_format == VersionFormat::Primary {
+		if package.version_format.is_primary() {
 			assign_primary_release_owner(config_contents, &mut primary_owner, &package.id)?;
 		}
+		validate_release_owner_version_format(
+			config_contents,
+			&mut rendered_version_format_tags,
+			"package",
+			&package.id,
+			package.package_type.as_str(),
+			&package.version_format,
+		)?;
 	}
 
 	for package in packages {
@@ -3726,9 +3736,19 @@ fn validate_package_and_group_definitions_with_cache(
 				Some("package and group ids share one namespace; rename one of them".to_string()),
 			));
 		}
-		if group.version_format == VersionFormat::Primary {
+		if group.version_format.is_primary() {
 			assign_primary_release_owner(config_contents, &mut primary_owner, &group.id)?;
 		}
+		// patch-coverage:ignore-start -- group custom format validation is covered by fixture loading; llvm-cov attributes the `?` line inconsistently.
+		validate_release_owner_version_format(
+			config_contents,
+			&mut rendered_version_format_tags,
+			"group",
+			&group.id,
+			"group",
+			&group.version_format,
+		)?;
+		// patch-coverage:ignore-end
 		for package_id in &group.packages {
 			if !declared_packages.contains(package_id.as_str()) {
 				return Err(config_diagnostic(
@@ -5296,6 +5316,58 @@ fn config_primary_label(config_contents: &str, owner_id: &str) -> LabeledSpan {
 		Some("primary release identity".to_string()),
 		range_to_span(span),
 	)
+}
+
+fn validate_release_owner_version_format(
+	config_contents: &str,
+	rendered_tags: &mut BTreeMap<String, String>,
+	section: &str,
+	owner_id: &str,
+	ecosystem: &str,
+	version_format: &VersionFormat,
+) -> MonochangeResult<()> {
+	let rendered_tag = version_format
+		.render_tag(owner_id, "0.0.0", ecosystem)
+		.map_err(|error| {
+			config_diagnostic(
+				config_contents,
+				format!("invalid version_format for `{owner_id}`: {}", error.render()),
+				vec![config_field_label(
+					config_contents,
+					section,
+					owner_id,
+					"version_format",
+					"invalid version_format",
+				)],
+				Some(
+					"use `primary`, `namespaced`, or a custom tag template with `{{ version }}` and only valid Git tag characters"
+						.to_string(),
+				),
+			)
+		})?;
+	if let Some(existing_owner) = rendered_tags.insert(rendered_tag.clone(), owner_id.to_string()) {
+		return Err(config_diagnostic(
+			config_contents,
+			format!(
+				"version_format for `{owner_id}` renders the same sample tag `{rendered_tag}` as `{existing_owner}`"
+			),
+			vec![
+				config_primary_label(config_contents, &existing_owner),
+				config_field_label(
+					config_contents,
+					section,
+					owner_id,
+					"version_format",
+					"colliding version_format",
+				),
+			],
+			Some(
+				"include `{{ name }}` in custom version formats shared by multiple release owners so generated tags stay unique"
+					.to_string(),
+			),
+		));
+	}
+	Ok(())
 }
 
 fn assign_primary_release_owner(

--- a/crates/monochange_core/src/__tests__/lib_tests.rs
+++ b/crates/monochange_core/src/__tests__/lib_tests.rs
@@ -3870,3 +3870,142 @@ fn ecosystem_settings_auto_discover_skips_when_none() -> Result<(), serde_json::
 	assert!(!json.contains("auto_discover"));
 	Ok(())
 }
+
+#[test]
+fn version_format_serializes_custom_templates_as_strings() {
+	let custom = VersionFormat::Custom("{{ name }}/release/{{ version }}".to_string());
+	let encoded = serde_json::to_string(&custom).expect("serialize version format");
+	assert_eq!(encoded, "\"{{ name }}/release/{{ version }}\"");
+	let decoded: VersionFormat =
+		serde_json::from_str(&encoded).expect("deserialize version format");
+	assert_eq!(decoded, custom);
+}
+
+#[test]
+fn version_format_renders_supported_template_variables() {
+	let rendered = crate::render_version_format_template(
+		"{{ ecosystem }}/{{ name }}/v{{ version }}",
+		"cli",
+		"1.2.3",
+		"cargo",
+	)
+	.expect("render custom version format");
+	assert_eq!(rendered, "cargo/cli/v1.2.3");
+
+	let compact = crate::render_version_format_template(
+		"{{ecosystem}}/{{name}}/v{{version}}",
+		"cli",
+		"1.2.3",
+		"cargo",
+	)
+	.expect("render compact custom version format");
+	assert_eq!(compact, "cargo/cli/v1.2.3");
+}
+
+#[test]
+fn version_format_methods_cover_builtin_and_custom_formats() {
+	let namespaced = VersionFormat::Namespaced;
+	let primary = VersionFormat::Primary;
+	let custom = VersionFormat::Custom("{{name}}/v{{version}}".to_string());
+	let ecosystem_custom =
+		VersionFormat::Custom("{{ ecosystem }}/release/v{{ version }}".to_string());
+
+	assert_eq!(namespaced.as_template(), "{{ name }}/v{{ version }}");
+	assert_eq!(primary.as_template(), "v{{ version }}");
+	assert_eq!(custom.as_template(), "{{name}}/v{{version}}");
+	assert!(!namespaced.is_primary());
+	assert!(primary.is_primary());
+	assert!(namespaced.contains_unique_name_variable());
+	assert!(!primary.contains_unique_name_variable());
+	assert!(custom.contains_unique_name_variable());
+	assert!(!ecosystem_custom.contains_unique_name_variable());
+	assert_eq!(
+		namespaced
+			.render_tag("pkg:with-colon", "1.2.3", "cargo")
+			.expect("render namespaced tag"),
+		"pkg:with-colon/v1.2.3"
+	);
+	assert_eq!(
+		primary
+			.render_tag("pkg", "1.2.3", "cargo")
+			.expect("render primary tag"),
+		"v1.2.3"
+	);
+	assert_eq!(
+		custom
+			.render_tag("pkg", "1.2.3", "cargo")
+			.expect("render custom tag"),
+		"pkg/v1.2.3"
+	);
+}
+
+#[test]
+fn version_format_rejects_unknown_template_variables() {
+	let error = crate::render_version_format_template(
+		"{{ package }}/v{{ version }}",
+		"cli",
+		"1.2.3",
+		"cargo",
+	)
+	.expect_err("unknown variables are rejected");
+	assert!(error.render().contains("unsupported variable"));
+}
+
+#[test]
+fn version_format_rejects_invalid_git_tag_characters() {
+	let error = crate::render_version_format_template(
+		"{{ name }}/bad tag/v{{ version }}",
+		"cli",
+		"1.2.3",
+		"cargo",
+	)
+	.expect_err("whitespace is rejected");
+	assert!(error.render().contains("contains whitespace"));
+}
+
+#[test]
+fn version_format_rejects_each_invalid_git_tag_shape() {
+	let cases = [
+		("", "tag is empty"),
+		("/v1.2.3", "starts or ends with `/`"),
+		("v1.2.3/", "starts or ends with `/`"),
+		("-v1.2.3", "starts with `-`"),
+		("pkg//v1.2.3", "empty path component"),
+		("pkg/../v1.2.3", "contains `..`"),
+		("pkg/@{upstream}/v1.2.3", "contains `@{`"),
+		("pkg/v1.2.3.", "ends with `.`"),
+		("pkg/file.lock/v1.2.3", "ends with `.lock`"),
+		("pkg/file.LOCK/v1.2.3", "ends with `.lock`"),
+		("pkg/v1.2.3~", "not valid in a Git ref"),
+	];
+
+	for (tag, reason) in cases {
+		let error = crate::validate_version_format_tag(tag)
+			.expect_err("expected invalid version format tag");
+		assert!(
+			error.render().contains(reason),
+			"expected `{}` to contain `{reason}`",
+			error.render()
+		);
+	}
+}
+
+#[test]
+fn version_format_rejects_malformed_template_syntax() {
+	let cases = [
+		("   ", "must not be empty"),
+		("release", "must include the `{{ version }}` variable"),
+		("{{ version }}/{{ name", "unterminated template variable"),
+		("{{ name }}/v{{ version }}}}", "unopened template variable"),
+	];
+
+	for (template, reason) in cases {
+		let error = crate::render_version_format_template(template, "cli", "1.2.3", "cargo")
+			.expect_err("expected invalid version format template");
+		assert!(
+			error.render().contains(reason),
+			"expected `{}` to contain `{reason}`",
+			error.render()
+		);
+	}
+}

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -601,13 +601,169 @@ impl PackageType {
 }
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", schemars(with = "String"))]
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
 #[non_exhaustive]
 pub enum VersionFormat {
 	#[default]
 	Namespaced,
 	Primary,
+	Custom(String),
+}
+
+impl VersionFormat {
+	#[must_use]
+	pub fn as_template(&self) -> &str {
+		match self {
+			Self::Namespaced => "{{ name }}/v{{ version }}",
+			Self::Primary => "v{{ version }}",
+			Self::Custom(template) => template,
+		}
+	}
+
+	#[must_use]
+	pub fn is_primary(&self) -> bool {
+		matches!(self, Self::Primary)
+	}
+
+	#[must_use]
+	pub fn contains_unique_name_variable(&self) -> bool {
+		self.as_template().contains("{{ name }}") || self.as_template().contains("{{name}}")
+	}
+
+	pub fn render_tag(
+		&self,
+		name: &str,
+		version: &str,
+		ecosystem: &str,
+	) -> MonochangeResult<String> {
+		match self {
+			Self::Namespaced => Ok(format!("{name}/v{version}")),
+			Self::Primary => Ok(format!("v{version}")),
+			Self::Custom(template) => {
+				render_version_format_template(template, name, version, ecosystem)
+			}
+		}
+	}
+}
+
+impl Serialize for VersionFormat {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		match self {
+			Self::Namespaced => serializer.serialize_str("namespaced"),
+			Self::Primary => serializer.serialize_str("primary"),
+			Self::Custom(template) => serializer.serialize_str(template),
+		}
+	}
+}
+
+impl<'de> Deserialize<'de> for VersionFormat {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		let value = String::deserialize(deserializer)?;
+		match value.as_str() {
+			"namespaced" => Ok(Self::Namespaced),
+			"primary" => Ok(Self::Primary),
+			_ => Ok(Self::Custom(value)),
+		}
+	}
+}
+
+pub fn render_version_format_template(
+	template: &str,
+	name: &str,
+	version: &str,
+	ecosystem: &str,
+) -> MonochangeResult<String> {
+	validate_version_format_template(template)?;
+	let rendered = template
+		.replace("{{ name }}", name)
+		.replace("{{name}}", name)
+		.replace("{{ version }}", version)
+		.replace("{{version}}", version)
+		.replace("{{ ecosystem }}", ecosystem)
+		.replace("{{ecosystem}}", ecosystem);
+	validate_version_format_tag(&rendered)?;
+	Ok(rendered)
+}
+
+pub fn validate_version_format_template(template: &str) -> MonochangeResult<()> {
+	if template.trim().is_empty() {
+		return Err(MonochangeError::Config(
+			"version_format must not be empty".to_string(),
+		));
+	}
+	if !template.contains("{{ version }}") && !template.contains("{{version}}") {
+		return Err(MonochangeError::Config(
+			"custom version_format must include the `{{ version }}` variable".to_string(),
+		));
+	}
+	let mut rest = template;
+	while let Some(start) = rest.find("{{") {
+		let after_start = &rest[start + 2..];
+		let Some(end) = after_start.find("}}") else {
+			return Err(MonochangeError::Config(
+				"custom version_format has an unterminated template variable".to_string(),
+			));
+		};
+		let variable = after_start[..end].trim();
+		if !matches!(variable, "name" | "version" | "ecosystem") {
+			return Err(MonochangeError::Config(format!(
+				"custom version_format uses unsupported variable `{{{{ {variable} }}}}`; supported variables are `{{{{ name }}}}`, `{{{{ version }}}}`, and `{{{{ ecosystem }}}}`"
+			)));
+		}
+		rest = &after_start[end + 2..];
+	}
+	if rest.contains("}}") {
+		return Err(MonochangeError::Config(
+			"custom version_format has an unopened template variable".to_string(),
+		));
+	}
+	Ok(())
+}
+
+pub fn validate_version_format_tag(tag: &str) -> MonochangeResult<()> {
+	let invalid_reason = if tag.is_empty() {
+		Some("tag is empty")
+	} else if tag.chars().any(char::is_whitespace) {
+		Some("tag contains whitespace")
+	} else if tag.starts_with('/') || tag.ends_with('/') {
+		Some("tag starts or ends with `/`")
+	} else if tag.starts_with('-') {
+		Some("tag starts with `-`")
+	} else if tag.contains("//") {
+		Some("tag contains an empty path component")
+	} else if tag.contains("..") {
+		Some("tag contains `..`")
+	} else if tag.contains("@{") {
+		Some("tag contains `@{`")
+	} else if tag.ends_with('.') {
+		Some("tag ends with `.`")
+	} else if tag.split('/').any(|component| {
+		component
+			.rsplit_once('.')
+			.is_some_and(|(_, extension)| extension.eq_ignore_ascii_case("lock"))
+	}) {
+		Some("tag component ends with `.lock`")
+	} else if tag
+		.chars()
+		.any(|ch| matches!(ch, '~' | '^' | ':' | '?' | '*' | '[' | '\\') || ch.is_control())
+	{
+		Some("tag contains a character that is not valid in a Git ref")
+	} else {
+		None
+	};
+	if let Some(reason) = invalid_reason {
+		return Err(MonochangeError::Config(format!(
+			"invalid version_format tag `{tag}`: {reason}"
+		)));
+	}
+	Ok(())
 }
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -4884,7 +5040,7 @@ impl WorkspaceConfiguration {
 				group_id: Some(group.id.clone()),
 				tag: group.tag,
 				release: group.release,
-				version_format: group.version_format,
+				version_format: group.version_format.clone(),
 				members: group.packages.clone(),
 			});
 		}
@@ -4895,7 +5051,7 @@ impl WorkspaceConfiguration {
 			group_id: None,
 			tag: package.tag,
 			release: package.release,
-			version_format: package.version_format,
+			version_format: package.version_format.clone(),
 			members: vec![package.id.clone()],
 		})
 	}

--- a/crates/monochange_schema/schemas/monochange.schema.json
+++ b/crates/monochange_schema/schemas/monochange.schema.json
@@ -1611,13 +1611,6 @@
 			],
 			"type": "string"
 		},
-		"VersionFormat": {
-			"enum": [
-				"namespaced",
-				"primary"
-			],
-			"type": "string"
-		},
 		"VersionedFileDefinition": {
 			"additionalProperties": false,
 			"properties": {
@@ -1715,15 +1708,11 @@
 					]
 				},
 				"version_format": {
-					"anyOf": [
-						{
-							"$ref": "#/$defs/VersionFormat"
-						},
-						{
-							"type": "null"
-						}
-					],
-					"default": null
+					"default": null,
+					"type": [
+						"string",
+						"null"
+					]
 				}
 			},
 			"type": "object"
@@ -2147,8 +2136,8 @@
 					"type": "boolean"
 				},
 				"version_format": {
-					"$ref": "#/$defs/VersionFormat",
-					"default": "namespaced"
+					"default": "namespaced",
+					"type": "string"
 				},
 				"versioned_files": {
 					"items": {
@@ -2272,8 +2261,8 @@
 					]
 				},
 				"version_format": {
-					"$ref": "#/$defs/VersionFormat",
-					"default": "namespaced"
+					"default": "namespaced",
+					"type": "string"
 				},
 				"versioned_files": {
 					"items": {

--- a/crates/monochange_schema/schemas/release-record.schema.json
+++ b/crates/monochange_schema/schemas/release-record.schema.json
@@ -716,7 +716,7 @@
 					"type": "string"
 				},
 				"version_format": {
-					"$ref": "#/$defs/VersionFormat"
+					"type": "string"
 				}
 			},
 			"required": [
@@ -768,13 +768,6 @@
 				}
 			},
 			"type": "object"
-		},
-		"VersionFormat": {
-			"enum": [
-				"namespaced",
-				"primary"
-			],
-			"type": "string"
 		}
 	},
 	"$id": "https://monochange.github.io/monochange/schemas/release-record.schema.json",

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -100,6 +100,17 @@ Optional package fields:
 - `release`
 - `version_format`
 
+`version_format` controls the Git tag identity used for package and group releases. It defaults to `namespaced` when no configuration is set, which produces collision-safe tags like `my-package/v1.2.3`. Set it to `primary` for the single top-level release identity that should use tags like `v1.2.3`. You can also provide a custom tag template with `{{ name }}`, `{{ version }}`, and `{{ ecosystem }}`:
+
+```toml
+[package.cli]
+path = "crates/cli"
+type = "cargo"
+version_format = "{{ ecosystem }}/{{ name }}/v{{ version }}"
+```
+
+Custom formats must include `{{ version }}`, render to valid Git tag names without whitespace or other invalid ref characters, and must not collide with another release owner for the same sample version. If several packages share a custom format, include `{{ name }}` so the generated tags remain unique.
+
 `changelog` accepts three forms on packages:
 
 - `true` → use `{{ path }}/CHANGELOG.md`
@@ -398,6 +409,7 @@ Rules:
 - package and group ids share one namespace
 - a package may belong to only one group
 - only one package or group may use `version_format = "primary"`
+- custom `version_format` templates must include `{{ version }}` and render unique, valid Git tag names; include `{{ name }}` when sharing a template across release owners
 - group `tag`, `release`, and `version_format` override member package release identity
 - package changelogs and package `versioned_files` still apply when grouped
 - grouped packages can customize fallback changelog entries with `empty_update_message` when no direct package notes are present

--- a/docs/src/guide/05-version-groups.md
+++ b/docs/src/guide/05-version-groups.md
@@ -20,6 +20,8 @@ release = true
 version_format = "primary"
 ```
 
+Groups can also use `version_format = "namespaced"` or a custom tag template such as `version_format = "{{ name }}/v{{ version }}"`. Custom formats support `{{ name }}`, `{{ version }}`, and `{{ ecosystem }}`, must include `{{ version }}`, and must render unique valid Git tag names.
+
 <!-- {/versionGroupsExample} -->
 
 When any member releases:

--- a/docs/src/schemas/monochange.schema.json
+++ b/docs/src/schemas/monochange.schema.json
@@ -1611,13 +1611,6 @@
 			],
 			"type": "string"
 		},
-		"VersionFormat": {
-			"enum": [
-				"namespaced",
-				"primary"
-			],
-			"type": "string"
-		},
 		"VersionedFileDefinition": {
 			"additionalProperties": false,
 			"properties": {
@@ -1715,15 +1708,11 @@
 					]
 				},
 				"version_format": {
-					"anyOf": [
-						{
-							"$ref": "#/$defs/VersionFormat"
-						},
-						{
-							"type": "null"
-						}
-					],
-					"default": null
+					"default": null,
+					"type": [
+						"string",
+						"null"
+					]
 				}
 			},
 			"type": "object"
@@ -2147,8 +2136,8 @@
 					"type": "boolean"
 				},
 				"version_format": {
-					"$ref": "#/$defs/VersionFormat",
-					"default": "namespaced"
+					"default": "namespaced",
+					"type": "string"
 				},
 				"versioned_files": {
 					"items": {
@@ -2272,8 +2261,8 @@
 					]
 				},
 				"version_format": {
-					"$ref": "#/$defs/VersionFormat",
-					"default": "namespaced"
+					"default": "namespaced",
+					"type": "string"
 				},
 				"versioned_files": {
 					"items": {

--- a/docs/src/schemas/monochange.v0.4.schema.json
+++ b/docs/src/schemas/monochange.v0.4.schema.json
@@ -1611,13 +1611,6 @@
 			],
 			"type": "string"
 		},
-		"VersionFormat": {
-			"enum": [
-				"namespaced",
-				"primary"
-			],
-			"type": "string"
-		},
 		"VersionedFileDefinition": {
 			"additionalProperties": false,
 			"properties": {
@@ -1715,15 +1708,11 @@
 					]
 				},
 				"version_format": {
-					"anyOf": [
-						{
-							"$ref": "#/$defs/VersionFormat"
-						},
-						{
-							"type": "null"
-						}
-					],
-					"default": null
+					"default": null,
+					"type": [
+						"string",
+						"null"
+					]
 				}
 			},
 			"type": "object"
@@ -2147,8 +2136,8 @@
 					"type": "boolean"
 				},
 				"version_format": {
-					"$ref": "#/$defs/VersionFormat",
-					"default": "namespaced"
+					"default": "namespaced",
+					"type": "string"
 				},
 				"versioned_files": {
 					"items": {
@@ -2272,8 +2261,8 @@
 					]
 				},
 				"version_format": {
-					"$ref": "#/$defs/VersionFormat",
-					"default": "namespaced"
+					"default": "namespaced",
+					"type": "string"
 				},
 				"versioned_files": {
 					"items": {

--- a/docs/src/schemas/release-record.schema.json
+++ b/docs/src/schemas/release-record.schema.json
@@ -716,7 +716,7 @@
 					"type": "string"
 				},
 				"version_format": {
-					"$ref": "#/$defs/VersionFormat"
+					"type": "string"
 				}
 			},
 			"required": [
@@ -768,13 +768,6 @@
 				}
 			},
 			"type": "object"
-		},
-		"VersionFormat": {
-			"enum": [
-				"namespaced",
-				"primary"
-			],
-			"type": "string"
 		}
 	},
 	"$id": "https://monochange.github.io/monochange/schemas/release-record.schema.json",

--- a/docs/src/schemas/release-record.v0.4.schema.json
+++ b/docs/src/schemas/release-record.v0.4.schema.json
@@ -716,7 +716,7 @@
 					"type": "string"
 				},
 				"version_format": {
-					"$ref": "#/$defs/VersionFormat"
+					"type": "string"
 				}
 			},
 			"required": [
@@ -768,13 +768,6 @@
 				}
 			},
 			"type": "object"
-		},
-		"VersionFormat": {
-			"enum": [
-				"namespaced",
-				"primary"
-			],
-			"type": "string"
 		}
 	},
 	"$id": "https://monochange.github.io/monochange/schemas/release-record.v0.4.schema.json",

--- a/fixtures/tests/config/custom-version-format/monochange.toml
+++ b/fixtures/tests/config/custom-version-format/monochange.toml
@@ -1,0 +1,13 @@
+[package.core]
+path = "packages/core"
+type = "cargo"
+version_format = "{{ ecosystem }}/{{ name }}/v{{ version }}"
+
+[package.cli]
+path = "packages/cli"
+type = "cargo"
+version_format = "{{ name }}-v{{ version }}"
+
+[group.sdk]
+packages = ["core", "cli"]
+version_format = "groups/{{ name }}/v{{ version }}"

--- a/fixtures/tests/config/custom-version-format/packages/cli/Cargo.toml
+++ b/fixtures/tests/config/custom-version-format/packages/cli/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "fixture"
+version = "0.1.0"
+edition = "2021"

--- a/fixtures/tests/config/custom-version-format/packages/core/Cargo.toml
+++ b/fixtures/tests/config/custom-version-format/packages/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "fixture"
+version = "0.1.0"
+edition = "2021"

--- a/fixtures/tests/config/rejects-colliding-custom-version-format/monochange.toml
+++ b/fixtures/tests/config/rejects-colliding-custom-version-format/monochange.toml
@@ -1,0 +1,9 @@
+[package.core]
+path = "packages/core"
+type = "cargo"
+version_format = "release-v{{ version }}"
+
+[package.cli]
+path = "packages/cli"
+type = "cargo"
+version_format = "release-v{{ version }}"

--- a/fixtures/tests/config/rejects-colliding-custom-version-format/packages/cli/Cargo.toml
+++ b/fixtures/tests/config/rejects-colliding-custom-version-format/packages/cli/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "fixture"
+version = "0.1.0"
+edition = "2021"

--- a/fixtures/tests/config/rejects-colliding-custom-version-format/packages/core/Cargo.toml
+++ b/fixtures/tests/config/rejects-colliding-custom-version-format/packages/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "fixture"
+version = "0.1.0"
+edition = "2021"

--- a/fixtures/tests/config/rejects-invalid-custom-version-format/monochange.toml
+++ b/fixtures/tests/config/rejects-invalid-custom-version-format/monochange.toml
@@ -1,0 +1,4 @@
+[package.core]
+path = "packages/core"
+type = "cargo"
+version_format = "{{ name }}/bad tag/v{{ version }}"

--- a/fixtures/tests/config/rejects-invalid-custom-version-format/packages/core/Cargo.toml
+++ b/fixtures/tests/config/rejects-invalid-custom-version-format/packages/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "fixture"
+version = "0.1.0"
+edition = "2021"

--- a/fixtures/tests/config/rejects-primary-custom-version-format-collision/monochange.toml
+++ b/fixtures/tests/config/rejects-primary-custom-version-format-collision/monochange.toml
@@ -1,0 +1,9 @@
+[package.core]
+path = "packages/core"
+type = "cargo"
+version_format = "primary"
+
+[package.cli]
+path = "packages/cli"
+type = "cargo"
+version_format = "v{{ version }}"

--- a/fixtures/tests/config/rejects-primary-custom-version-format-collision/packages/cli/Cargo.toml
+++ b/fixtures/tests/config/rejects-primary-custom-version-format-collision/packages/cli/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "fixture"
+version = "0.1.0"
+edition = "2021"

--- a/fixtures/tests/config/rejects-primary-custom-version-format-collision/packages/core/Cargo.toml
+++ b/fixtures/tests/config/rejects-primary-custom-version-format-collision/packages/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "fixture"
+version = "0.1.0"
+edition = "2021"

--- a/packages/monochange__skill/skills/configuration.md
+++ b/packages/monochange__skill/skills/configuration.md
@@ -57,6 +57,8 @@ changelog = { path = "CHANGELOG.md", format = "keep_a_changelog", include = "all
 
 Use package ids in changesets when a specific package changed. Use the group id only when the change is intentionally group-owned.
 
+`version_format` defaults to `namespaced` when omitted, which renders tags like `<name>/v<version>` and avoids collisions. Use `primary` only for the one release owner that should claim top-level tags like `v1.2.3`. Custom templates are also accepted, for example `version_format = "{{ ecosystem }}/{{ name }}/v{{ version }}"`; they can use only `{{ name }}`, `{{ version }}`, and `{{ ecosystem }}`, must include `{{ version }}`, and must render unique valid Git tags.
+
 Groups are best for products released as a unit: SDKs made of several packages, plugins that must stay version-aligned, or cross-language distributions that share one public changelog. Keep unrelated packages out of a group even if they live in the same workspace, because a group turns multiple package releases into one outward release identity.
 
 ## Versioned files


### PR DESCRIPTION
## Summary
- add custom `version_format` templates with `{{ name }}`, `{{ version }}`, and `{{ ecosystem }}` variables
- validate custom formats for required version variables, supported placeholders, Git tag safety, and release-owner collisions
- update tag rendering, schemas, docs, fixtures, and the monochange skill guidance

## Verification
- `devenv shell cargo check -p monochange_core -p monochange_config -p monochange --all-features`
- `devenv shell cargo test -p monochange_core version_format --all-features`
- `devenv shell cargo test -p monochange_config custom_version_format --all-features`
- `devenv shell cargo test -p monochange render_tag_name_and_provider_urls_follow_provider_conventions --all-features`
- `devenv shell dprint fmt .`
- `devenv shell cargo fmt --all`
- `devenv shell schema:check`
- `devenv shell mdt check`
- `devenv shell coverage:patch` → `PATCH_COVERAGE 214/214 (100.00%)`
- pre-push `lint:test` hook
