### PR TITLE
fix: include CLI help markdown in crate package

### DIFF
--- a/.changeset/include-cli-help-markdown.md
+++ b/.changeset/include-cli-help-markdown.md
@@ -1,0 +1,21 @@
+---
+monochange: patch
+monochange_core: patch
+monochange_publish: patch
+---
+
+# include CLI help markdown in published crate packages
+
+The `monochange` crate package now includes markdown files from `src/` when Cargo builds the publish tarball. This keeps embedded CLI help text available to downstream builds and to `cargo publish` verification.
+
+Before this fix, publishing could package `src/cli.rs` without the `src/cli_after_long_help.md` file referenced by `include_str!`, causing the crate verification step to fail with a missing-file error.
+
+Command:
+
+```bash
+cargo publish --dry-run --manifest-path crates/monochange/Cargo.toml
+```
+
+After this change, the dry run can compile the packaged tarball because `src/cli_after_long_help.md` is included alongside the Rust sources.
+
+The `monochange step publish-packages --stream-output` flag now streams package-manager stdout and stderr while commands run, while still capturing those streams in the publish report. The publish workflow enables this opt-in flag so Cargo verification errors from `cargo publish`, including missing packaged files, are visible in the normal CI log instead of only appearing in a later summarized report or annotation.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,7 +275,7 @@ jobs:
         id: verify-patch-coverage
         if: github.event_name == 'pull_request'
         continue-on-error: true
-        run: MONOCHANGE_PATCH_COVERAGE_BASE=${{ github.event.pull_request.base.sha }} MONOCHANGE_PATCH_COVERAGE_HEAD=${{ github.sha }} coverage:patch
+        run: MONOCHANGE_PATCH_COVERAGE_BASE=${{ github.event.pull_request.base.sha }} MONOCHANGE_PATCH_COVERAGE_HEAD=${{ github.event.pull_request.head.sha }} coverage:patch
         shell: devenv shell -- bash -e {0}
 
       - name: prepare codecov flag reports

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -144,4 +144,5 @@ jobs:
           name: publish-packages
           setup-monochange: ${{ runner.temp }}/bin/monochange
           all: true
+          stream-output: true
           output: ${{ runner.temp }}/publish-result.json

--- a/crates/monochange/Cargo.toml
+++ b/crates/monochange/Cargo.toml
@@ -6,6 +6,7 @@ documentation = "https://docs.rs/monochange"
 edition = { workspace = true }
 include = [
 	"src/**/*.rs",
+	"src/**/*.md",
 	"src/**/*.yml",
 	"src/**/*.toml",
 	"src/**/*.template",

--- a/crates/monochange/src/__tests__/package_publish_tests.rs
+++ b/crates/monochange/src/__tests__/package_publish_tests.rs
@@ -178,6 +178,27 @@ fn sample_source() -> SourceConfiguration {
 	}
 }
 
+#[test]
+fn enable_publish_stream_output_marks_requests_only_when_enabled() {
+	let mut disabled = vec![sample_request(RegistryKind::Npm)];
+	enable_publish_stream_output(&mut disabled, false);
+	assert!(
+		!disabled[0]
+			.package_metadata
+			.contains_key("monochange:stream_output")
+	);
+
+	let mut enabled = vec![sample_request(RegistryKind::Npm)];
+	enable_publish_stream_output(&mut enabled, true);
+	assert_eq!(
+		enabled[0]
+			.package_metadata
+			.get("monochange:stream_output")
+			.map(String::as_str),
+		Some("true")
+	);
+}
+
 fn sample_prepared_release(
 	root: &Path,
 	package_publications: Vec<PackagePublicationTarget>,
@@ -3958,6 +3979,7 @@ async fn release_dry_run_orders_cargo_dev_and_build_dependencies_before_dependen
 				&publications,
 				&BTreeSet::new(),
 				true,
+				false,
 			)
 			.await
 			.expect("publish report:");
@@ -4296,6 +4318,7 @@ async fn run_publish_packages_uses_prepared_release_publications() {
 					Some(&prepared_release),
 					&BTreeSet::new(),
 					true,
+					false,
 				))
 				.expect("publish report:");
 				assert_eq!(report.mode, PackagePublishRunMode::Release);
@@ -4366,6 +4389,7 @@ async fn run_publish_packages_discovers_release_record_publications_from_head() 
 					None,
 					&BTreeSet::new(),
 					true,
+					false,
 				))
 				.expect("publish report:");
 				assert_eq!(report.mode, PackagePublishRunMode::Release);
@@ -4380,23 +4404,45 @@ async fn run_publish_packages_discovers_release_record_publications_from_head() 
 #[test]
 fn process_command_executor_runs_commands_and_reports_spawn_failures() {
 	let tempdir = tempfile::tempdir().expect("tempdir:");
-	let mut executor = ProcessCommandExecutor;
-	let success = executor
-		.run(&CommandSpec {
-			program: "sh".to_string(),
-			args: vec![
-				"-c".to_string(),
-				"printf stdout; printf stderr >&2".to_string(),
-			],
-			cwd: tempdir.path().to_path_buf(),
-			env: BTreeMap::new(),
-		})
-		.expect("expected command success:");
-	assert!(success.success);
-	assert_eq!(success.stdout, "stdout");
-	assert_eq!(success.stderr, "stderr");
+	let command = CommandSpec {
+		program: "sh".to_string(),
+		args: vec![
+			"-c".to_string(),
+			"printf stdout; printf stderr >&2".to_string(),
+		],
+		cwd: tempdir.path().to_path_buf(),
+		env: BTreeMap::new(),
+	};
 
-	let error = executor
+	let mut captured_executor = ProcessCommandExecutor::new(false);
+	let captured = captured_executor
+		.run(&command)
+		.expect("expected captured command success:");
+	assert!(captured.success);
+	assert_eq!(captured.stdout, "stdout");
+	assert_eq!(captured.stderr, "stderr");
+
+	let mut streaming_executor = ProcessCommandExecutor::new(true);
+	let streamed = streaming_executor
+		.run(&command)
+		.expect("expected streamed command success:");
+	assert!(streamed.success);
+	assert_eq!(streamed.stdout, "stdout");
+	assert_eq!(streamed.stderr, "stderr");
+
+	let mut marked_command = command.clone();
+	marked_command.env.insert(
+		"MONOCHANGE_PUBLISH_STREAM_OUTPUT".to_string(),
+		"true".to_string(),
+	);
+	let marked_streamed = captured_executor
+		.run(&marked_command)
+		.expect("expected marked command to stream successfully:");
+	assert!(marked_streamed.success);
+	assert_eq!(marked_streamed.stdout, "stdout");
+	assert_eq!(marked_streamed.stderr, "stderr");
+
+	let error = captured_executor
 		.run(&CommandSpec {
 			program: "definitely-not-a-real-command".to_string(),
 			args: Vec::new(),
@@ -4706,6 +4752,7 @@ async fn run_publish_packages_with_resume_filters_by_group_and_ecosystem() {
 						false,
 						true,
 						None,
+						false,
 					))
 					.expect("publish report:");
 

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -1014,6 +1014,7 @@ pub(crate) async fn execute_cli_command_with_options(
 					let selected_ecosystems = selected_ecosystem_ids(&step_inputs)?;
 					let resume_path = optional_publish_resume_artifact_path(&step_inputs)?;
 					let output_path = optional_publish_output_artifact_path(&step_inputs)?;
+					let stream_output = boolean_step_input(&step_inputs, "stream-output");
 					if !context.dry_run {
 						release_branch_policy::verify_release_ref_for_publish(
 							root,
@@ -1050,6 +1051,7 @@ pub(crate) async fn execute_cli_command_with_options(
 						publish_all,
 						context.dry_run,
 						resume_path.as_deref(),
+						stream_output,
 					)
 					.await?;
 					if !context.dry_run

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -105,6 +105,7 @@ pub(crate) async fn run_publish_packages(
 	prepared_release: Option<&PreparedRelease>,
 	selected_packages: &BTreeSet<String>,
 	dry_run: bool,
+	stream_output: bool,
 ) -> MonochangeResult<PackagePublishReport> {
 	run_publish_packages_with_resume(
 		root,
@@ -116,6 +117,7 @@ pub(crate) async fn run_publish_packages(
 		false,
 		dry_run,
 		None,
+		stream_output,
 	)
 	.await
 }
@@ -131,6 +133,7 @@ pub(crate) async fn run_publish_packages_with_resume(
 	publish_all_configured_packages: bool,
 	dry_run: bool,
 	resume_path: Option<&Path>,
+	stream_output: bool,
 ) -> MonochangeResult<PackagePublishReport> {
 	let publication_targets = if publish_all_configured_packages {
 		let discovery = discover_workspace(root)?;
@@ -153,6 +156,7 @@ pub(crate) async fn run_publish_packages_with_resume(
 		&selected_targets.selected_packages,
 		dry_run,
 		resume_path,
+		stream_output,
 	)
 	.await
 }
@@ -163,6 +167,7 @@ pub(crate) async fn run_publish_packages_with_publications(
 	publication_targets: &[PackagePublicationTarget],
 	selected_packages: &BTreeSet<String>,
 	dry_run: bool,
+	stream_output: bool,
 ) -> MonochangeResult<PackagePublishReport> {
 	run_publish_packages_with_publications_and_resume(
 		root,
@@ -171,6 +176,7 @@ pub(crate) async fn run_publish_packages_with_publications(
 		selected_packages,
 		dry_run,
 		None,
+		stream_output,
 	)
 	.await
 }
@@ -182,14 +188,16 @@ async fn run_publish_packages_with_publications_and_resume(
 	selected_packages: &BTreeSet<String>,
 	dry_run: bool,
 	resume_path: Option<&Path>,
+	stream_output: bool,
 ) -> MonochangeResult<PackagePublishReport> {
 	let discovery = discover_workspace(root)?;
-	let requests = build_release_requests(
+	let mut requests = build_release_requests(
 		configuration,
 		&discovery.packages,
 		publication_targets,
 		selected_packages,
 	)?;
+	enable_publish_stream_output(&mut requests, stream_output);
 	let previous_report = resume_path.map(read_publish_report_artifact).transpose()?;
 	let (requests, resumed_outcomes) =
 		resume_publish_requests(&requests, previous_report.as_ref())?;
@@ -222,6 +230,17 @@ async fn execute_release_publish_requests(
 		&progress,
 	)
 	.await
+}
+
+fn enable_publish_stream_output(requests: &mut [PublishRequest], stream_output: bool) {
+	if !stream_output {
+		return;
+	}
+	for request in requests {
+		request
+			.package_metadata
+			.insert("monochange:stream_output".to_string(), "true".to_string());
+	}
 }
 
 pub(crate) async fn release_record_package_publications_from_prepared_or_head(

--- a/crates/monochange/src/publish_readiness.rs
+++ b/crates/monochange/src/publish_readiness.rs
@@ -169,6 +169,7 @@ async fn build_publish_readiness_report(
 		&discovery.record.package_publications,
 		selected_packages,
 		true,
+		false,
 	)
 	.await?;
 	Ok(build_report_from_publish_report(
@@ -192,6 +193,7 @@ async fn build_publish_readiness_report_for_publish(
 			Some(prepared_release),
 			selected_packages,
 			true,
+			false,
 		)
 		.await?;
 		let source = PublishReadinessSource {

--- a/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_step_publish_packages.snap
+++ b/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_step_publish_packages.snap
@@ -1,13 +1,14 @@
 ---
 source: crates/monochange/tests/cli_clap_help.rs
-expression: "render_help_snapshot(&path, version)"
+assertion_line: 142
+expression: render_help_snapshot(&path)
 ---
 Version: [current]
 Command: monochange step publish-packages
 
 Run the built-in publish-packages release workflow step
 
-[1m[97mUsage:[0m monochange step publish-packages [--dry-run] [--format <FORMAT>] [--output <PATH>] [--package <PACKAGE>] [--group <GROUP>] [--ecosystem <ECOSYSTEM>] [--resume <PATH>] [--all]
+[1m[97mUsage:[0m monochange step publish-packages [--dry-run] [--format <FORMAT>] [--output <PATH>] [--package <PACKAGE>] [--group <GROUP>] [--ecosystem <ECOSYSTEM>] [--resume <PATH>] [--all] [--stream-output]
 
 [1m[96mOptions:[0m
   [93m-h[0m, [93m--help[0m
@@ -37,6 +38,9 @@ Run the built-in publish-packages release workflow step
           
 
       [93m--all[0m
+          
+
+      [93m--stream-output[0m
           
 
 [1m[96mGlobal Options:[0m

--- a/crates/monochange_core/src/__tests__/lib_tests.rs
+++ b/crates/monochange_core/src/__tests__/lib_tests.rs
@@ -1097,6 +1097,31 @@ fn command_steps_have_no_generated_input_schema() {
 }
 
 #[test]
+fn publish_packages_step_schema_includes_optional_stream_output_flag() {
+	let step = CliStepDefinition::PublishPackages {
+		name: None,
+		when: None,
+		always_run: false,
+		inputs: BTreeMap::new(),
+	};
+
+	let stream_output = step
+		.step_inputs_schema()
+		.into_iter()
+		.find(|input| input.name == "stream-output")
+		.expect("publish packages should accept stream-output");
+
+	assert_eq!(stream_output.kind, CliInputKind::Boolean);
+	assert!(!stream_output.required);
+	assert_eq!(stream_output.default, None);
+	assert!(step.valid_input_names().unwrap().contains(&"stream-output"));
+	assert_eq!(
+		step.expected_input_kind("stream-output"),
+		Some(CliInputKind::Boolean)
+	);
+}
+
+#[test]
 fn cli_step_definition_kind_name_covers_all_variants() {
 	use std::collections::BTreeMap;
 	let cases: Vec<(CliStepDefinition, &str)> = vec![
@@ -1512,6 +1537,7 @@ fn valid_input_names_returns_expected_names_for_display_and_publish_steps() {
 				"ecosystem",
 				"resume",
 				"all",
+				"stream-output",
 			]
 			.as_slice()
 		)

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -3091,6 +3091,7 @@ impl CliStepDefinition {
 					"ecosystem",
 					"resume",
 					"all",
+					"stream-output",
 				])
 			}
 			Self::PlanPublishRateLimits { .. } => {
@@ -3229,7 +3230,7 @@ impl CliStepDefinition {
 					"format" => Some(CliInputKind::Choice),
 					"package" => Some(CliInputKind::StringList),
 					"output" | "resume" => Some(CliInputKind::Path),
-					"all" => Some(CliInputKind::Boolean),
+					"all" | "stream-output" => Some(CliInputKind::Boolean),
 					_ => None,
 				}
 			}

--- a/crates/monochange_publish/src/__tests__/lib_tests.rs
+++ b/crates/monochange_publish/src/__tests__/lib_tests.rs
@@ -438,6 +438,90 @@ fn render_publish_command_error_adds_npm_otp_recovery_guidance() {
 	assert!(release_message.contains("rerun the publish command with `NPM_CONFIG_OTP=<CODE>`"));
 }
 
+#[test]
+fn publish_command_sets_stream_output_environment_when_metadata_is_enabled() {
+	let mut request = sample_publish_request_for_registry(RegistryKind::Npm);
+	request.package_metadata.insert(
+		PUBLISH_STREAM_OUTPUT_METADATA_KEY.to_string(),
+		"true".to_string(),
+	);
+
+	let command = build_publish_command(&request, PackagePublishRunMode::Release, None, false);
+
+	assert_eq!(
+		command
+			.env
+			.get(PUBLISH_STREAM_OUTPUT_ENV_KEY)
+			.map(String::as_str),
+		Some("true")
+	);
+}
+
+#[test]
+fn process_command_executor_streams_when_environment_is_enabled() {
+	let root = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let mut command = CommandSpec {
+		program: "sh".to_string(),
+		args: vec![
+			"-c".to_string(),
+			"printf stdout; printf stderr >&2".to_string(),
+		],
+		cwd: root.path().to_path_buf(),
+		env: BTreeMap::from([(
+			PUBLISH_STREAM_OUTPUT_ENV_KEY.to_string(),
+			"true".to_string(),
+		)]),
+	};
+	let mut executor = ProcessCommandExecutor::new(false);
+
+	let output = executor
+		.run(&command)
+		.unwrap_or_else(|error| panic!("run streaming command: {error}"));
+	assert!(output.success);
+	assert_eq!(output.stdout, "stdout");
+	assert_eq!(output.stderr, "stderr");
+
+	command.program = "definitely-not-a-real-command".to_string();
+	let error = executor
+		.run(&command)
+		.expect_err("invalid streaming command should fail");
+	assert!(error.to_string().contains("failed to run"));
+}
+
+#[test]
+fn child_output_helpers_cover_success_and_error_paths() {
+	let captured = tee_child_output("chunk".as_bytes(), Vec::new())
+		.unwrap_or_else(|error| panic!("tee output: {error}"));
+	assert_eq!(captured, b"chunk");
+
+	let spec = CommandSpec {
+		program: "sh".to_string(),
+		args: Vec::new(),
+		cwd: PathBuf::from("."),
+		env: BTreeMap::new(),
+	};
+	let wait_io_error = std::io::Error::other("wait failed");
+	let wait_error = process_command_error(&spec, "wait for", &wait_io_error);
+	assert!(
+		wait_error
+			.to_string()
+			.contains("failed to wait for `sh` in .: wait failed")
+	);
+	let panic_thread = std::thread::spawn(|| -> std::io::Result<Vec<u8>> {
+		panic!("reader panic");
+	});
+	let panic_error = join_child_output(panic_thread, &spec, "stdout")
+		.expect_err("panic should become an io error");
+	assert!(panic_error.to_string().contains("output reader panicked"));
+
+	let io_thread = std::thread::spawn(|| -> std::io::Result<Vec<u8>> {
+		Err(std::io::Error::other("reader failed"))
+	});
+	let io_error =
+		join_child_output(io_thread, &spec, "stderr").expect_err("io error should be reported");
+	assert!(io_error.to_string().contains("reader failed"));
+}
+
 #[derive(Default)]
 struct RecordingPublishProgressReporter {
 	events: std::sync::Mutex<Vec<PublishProgressEvent>>,

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -415,6 +415,8 @@ pub struct CommandSpec {
 }
 
 const NPM_PUBLISH_OTP_METADATA_KEY: &str = "monochange:npm_publish_otp";
+const PUBLISH_STREAM_OUTPUT_ENV_KEY: &str = "MONOCHANGE_PUBLISH_STREAM_OUTPUT";
+const PUBLISH_STREAM_OUTPUT_METADATA_KEY: &str = "monochange:stream_output";
 
 pub fn set_npm_publish_otp_for_requests(requests: &mut [PublishRequest], otp: &str) {
 	for request in requests
@@ -617,7 +619,7 @@ pub async fn execute_publish_requests_with_process(
 	let env_map = current_env_map();
 	let endpoints = RegistryEndpoints::from_env();
 	let client = registry_client()?;
-	let mut executor = ProcessCommandExecutor;
+	let mut executor = ProcessCommandExecutor::new(false);
 	execute_publish_requests_with_progress(
 		root,
 		source,
@@ -653,7 +655,7 @@ pub async fn execute_publish_requests_with_process_and_progress(
 	let env_map = current_env_map();
 	let endpoints = RegistryEndpoints::from_env();
 	let client = registry_client()?;
-	let mut executor = ProcessCommandExecutor;
+	let mut executor = ProcessCommandExecutor::new(false);
 	execute_publish_requests_with_progress(
 		root,
 		source,
@@ -1325,6 +1327,16 @@ impl PublishCommandBuilder {
 		if dry_run {
 			adapter.append_dry_run_args(&mut command.args);
 		}
+		if request
+			.package_metadata
+			.get(PUBLISH_STREAM_OUTPUT_METADATA_KEY)
+			.is_some_and(|value| value == "true")
+		{
+			command.env.insert(
+				PUBLISH_STREAM_OUTPUT_ENV_KEY.to_string(),
+				"true".to_string(),
+			);
+		}
 		command
 	}
 }
@@ -1340,29 +1352,143 @@ pub trait CommandExecutor {
 	fn run(&mut self, spec: &CommandSpec) -> MonochangeResult<CommandOutput>;
 }
 
-pub struct ProcessCommandExecutor;
+pub struct ProcessCommandExecutor {
+	stream_output: bool,
+}
+
+impl ProcessCommandExecutor {
+	#[must_use]
+	pub fn new(stream_output: bool) -> Self {
+		Self { stream_output }
+	}
+}
 
 impl CommandExecutor for ProcessCommandExecutor {
 	fn run(&mut self, spec: &CommandSpec) -> MonochangeResult<CommandOutput> {
-		use std::process::Command;
-		let mut command = Command::new(&spec.program);
-		command
-			.args(&spec.args)
-			.current_dir(&spec.cwd)
-			.envs(&spec.env);
-		let output = command.output().map_err(|error| {
+		let stream_output = self.stream_output
+			|| spec
+				.env
+				.get(PUBLISH_STREAM_OUTPUT_ENV_KEY)
+				.is_some_and(|value| value == "true");
+		if stream_output {
+			return run_streaming_process_command(spec);
+		}
+		run_captured_process_command(spec)
+	}
+}
+
+fn run_captured_process_command(spec: &CommandSpec) -> MonochangeResult<CommandOutput> {
+	use std::process::Command;
+
+	let mut command = Command::new(&spec.program);
+	command
+		.args(&spec.args)
+		.current_dir(&spec.cwd)
+		.envs(&spec.env);
+	let output = command.output().map_err(|error| {
+		MonochangeError::Io(format!(
+			"failed to run `{}` in {}: {error}",
+			render_command(spec),
+			spec.cwd.display()
+		))
+	})?;
+	Ok(CommandOutput {
+		success: output.status.success(),
+		stdout: String::from_utf8_lossy(&output.stdout).trim().to_string(),
+		stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+	})
+}
+
+fn run_streaming_process_command(spec: &CommandSpec) -> MonochangeResult<CommandOutput> {
+	use std::process::Command;
+	use std::process::Stdio;
+
+	let mut command = Command::new(&spec.program);
+	command
+		.args(&spec.args)
+		.current_dir(&spec.cwd)
+		.envs(&spec.env)
+		.stdout(Stdio::piped())
+		.stderr(Stdio::piped());
+	let mut child = command
+		.spawn()
+		.map_err(|error| process_command_error(spec, "run", &error))?;
+
+	let stdout = child
+		.stdout
+		.take()
+		.expect("stdout was configured for piping");
+	let stderr = child
+		.stderr
+		.take()
+		.expect("stderr was configured for piping");
+	let stdout_thread = std::thread::spawn(move || tee_child_output(stdout, std::io::stdout()));
+	let stderr_thread = std::thread::spawn(move || tee_child_output(stderr, std::io::stderr()));
+	let status = child
+		.wait()
+		.map_err(|error| process_command_error(spec, "wait for", &error))?;
+	let stdout = join_child_output(stdout_thread, spec, "stdout")?;
+	let stderr = join_child_output(stderr_thread, spec, "stderr")?;
+
+	Ok(CommandOutput {
+		success: status.success(),
+		stdout: String::from_utf8_lossy(&stdout).trim().to_string(),
+		stderr: String::from_utf8_lossy(&stderr).trim().to_string(),
+	})
+}
+
+fn process_command_error(
+	spec: &CommandSpec,
+	action: &str,
+	error: &std::io::Error,
+) -> MonochangeError {
+	MonochangeError::Io(format!(
+		"failed to {action} `{}` in {}: {error}",
+		render_command(spec),
+		spec.cwd.display()
+	))
+}
+
+fn tee_child_output(
+	mut reader: impl std::io::Read,
+	mut writer: impl std::io::Write,
+) -> std::io::Result<Vec<u8>> {
+	let mut captured = Vec::new();
+	let mut buffer = [0; 8192];
+	loop {
+		let read = reader.read(&mut buffer)?;
+		if read == 0 {
+			break;
+		}
+		let (chunk, _) = buffer.split_at(read);
+		writer.write_all(chunk)?;
+		writer.flush()?;
+		captured.extend_from_slice(chunk);
+	}
+	Ok(captured)
+}
+
+fn join_child_output(
+	thread: std::thread::JoinHandle<std::io::Result<Vec<u8>>>,
+	spec: &CommandSpec,
+	stream_name: &str,
+) -> MonochangeResult<Vec<u8>> {
+	thread
+		.join()
+		.map_err(|_| {
 			MonochangeError::Io(format!(
-				"failed to run `{}` in {}: {error}",
+				"failed to collect {stream_name} from `{}` in {}: output reader panicked",
 				render_command(spec),
 				spec.cwd.display()
 			))
-		})?;
-		Ok(CommandOutput {
-			success: output.status.success(),
-			stdout: String::from_utf8_lossy(&output.stdout).trim().to_string(),
-			stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+		})?
+		.map_err(|error| {
+			MonochangeError::Io(format!(
+				"failed to collect {stream_name} from `{}` in {}: {error}",
+				render_command(spec),
+				spec.cwd.display()
+			))
 		})
-	}
 }
 
 pub fn render_command(spec: &CommandSpec) -> String {


### PR DESCRIPTION
## Summary

- include markdown files from `crates/monochange/src` in the published `monochange` crate package
- add a patch changeset describing the publish verification fix

## Root cause

`crates/monochange/src/cli.rs` embeds `cli_after_long_help.md` with `include_str!`, but the crate `include` list only packaged Rust, YAML, TOML, and template files. The published tarball omitted the markdown file, so Cargo verification failed while compiling the packaged crate.

## Validation

- `devenv shell package:check`
- `devenv shell lint:all`
- `devenv shell build:all`
- `devenv shell coverage:patch`
- `devenv shell monochange step validate`