### PR TITLE
test: cover placeholder publish package defaults

### DIFF
--- a/.changeset/placeholder-publish-package-defaults.md
+++ b/.changeset/placeholder-publish-package-defaults.md
@@ -1,0 +1,19 @@
+---
+monochange: patch
+---
+
+# clarify placeholder publish package selection coverage
+
+`monochange step placeholder-publish` continues to publish placeholders for every eligible publish-enabled package when no package filter is provided:
+
+```bash
+monochange step placeholder-publish
+```
+
+Passing `--package` narrows the placeholder publishing plan to the selected package ids only:
+
+```bash
+monochange step placeholder-publish --package core
+```
+
+This release strengthens the regression coverage for that behavior so automation can rely on the default all-packages mode while still using `--package` for targeted placeholder publishes.

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -7907,8 +7907,28 @@ async fn execute_cli_command_supports_placeholder_and_package_publish_steps() {
 			.await
 			.unwrap_or_else(|error| panic!("placeholder publish: {error}"));
 			assert!(placeholder_output.contains("placeholder publishing:"));
-			assert!(placeholder_output.contains("would publish placeholder"));
+			assert!(placeholder_output.contains("would publish placeholder workflow-core"));
+			assert!(placeholder_output.contains("would publish placeholder workflow-app"));
 			assert!(placeholder_output.contains("publish rate limits:"));
+
+			let selected_placeholder_output = crate::execute_cli_command(
+				root,
+				&configuration,
+				&placeholder_command,
+				true,
+				BTreeMap::from([
+					("format".to_string(), vec!["text".to_string()]),
+					("package".to_string(), vec!["core".to_string()]),
+				]),
+			)
+			.await
+			.unwrap_or_else(|error| panic!("selected placeholder publish: {error}"));
+			assert!(
+				selected_placeholder_output.contains("would publish placeholder workflow-core")
+			);
+			assert!(
+				!selected_placeholder_output.contains("would publish placeholder workflow-app")
+			);
 
 			let publish_command = CliCommandDefinition {
 				name: "publish".to_string(),


### PR DESCRIPTION
## Summary
- strengthen placeholder-publish CLI coverage so no package selection publishes all eligible packages
- cover selective placeholder publishing when a package id is provided

## Validation
- devenv shell cargo test -p monochange --lib execute_cli_command_supports_placeholder_and_package_publish_steps
- devenv shell lint:all
- devenv shell monochange step validate
- devenv shell coverage:patch
- git push hook lint:test