### PR TITLE
perf: batch workspace glob expansion and prewarm versioned-file paths

### DIFF
--- a/.changeset/centralize-workspace-globs.md
+++ b/.changeset/centralize-workspace-globs.md
@@ -1,0 +1,13 @@
+---
+monochange: patch
+---
+
+# speed up versioned-file glob expansion
+
+Versioned-file and workspace-member glob expansion now goes through one shared workspace-aware glob helper. Broad globs such as `**/pubspec.yaml` skip ignored local tooling, dependency, and vendor trees including `.fvm`, `.repos`, `node_modules`, and `target`, while explicit literal paths can still target ignored directories when that is intentional.
+
+This prevents release planning from scanning and rewriting unrelated checked-out toolchains or nested repositories, and adds regression coverage plus a benchmark for the ignored-tree case.
+
+## batch glob expansion
+
+Release planning now prewarms a versioned-file path cache and expands all configured globs in a single workspace walk using `workspace_glob_files_many`. Configs with many broad patterns (e.g. 20 `**/metadata-*.json` rules) no longer pay one walk per pattern — the batch API collapses N walks into one shared traversal, matching each candidate path against all compiled patterns in a single pass.

--- a/.changeset/centralize-workspace-globs.md
+++ b/.changeset/centralize-workspace-globs.md
@@ -1,5 +1,13 @@
 ---
 monochange: patch
+monochange_cargo: patch
+monochange_config: patch
+monochange_core: patch
+monochange_dart: patch
+monochange_deno: patch
+monochange_go: patch
+monochange_npm: patch
+monochange_python: patch
 ---
 
 # speed up versioned-file glob expansion

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2211,7 +2211,6 @@ dependencies = [
 name = "monochange_cargo"
 version = "0.8.2"
 dependencies = [
- "glob",
  "insta",
  "monochange_config",
  "monochange_core",
@@ -2280,6 +2279,7 @@ name = "monochange_core"
 version = "0.8.2"
 dependencies = [
  "async-trait",
+ "glob",
  "ignore",
  "insta",
  "monochange_schema",
@@ -2302,7 +2302,6 @@ dependencies = [
 name = "monochange_dart"
 version = "0.8.2"
 dependencies = [
- "glob",
  "insta",
  "monochange_config",
  "monochange_core",
@@ -2325,7 +2324,6 @@ dependencies = [
 name = "monochange_deno"
 version = "0.8.2"
 dependencies = [
- "glob",
  "insta",
  "monochange_core",
  "monochange_ecmascript",
@@ -2446,7 +2444,6 @@ dependencies = [
 name = "monochange_go"
 version = "0.8.2"
 dependencies = [
- "glob",
  "insta",
  "monochange_core",
  "monochange_publish",
@@ -2532,7 +2529,6 @@ dependencies = [
 name = "monochange_npm"
 version = "0.8.2"
 dependencies = [
- "glob",
  "insta",
  "monochange_config",
  "monochange_core",
@@ -2573,7 +2569,6 @@ dependencies = [
 name = "monochange_python"
 version = "0.8.2"
 dependencies = [
- "glob",
  "insta",
  "monochange_core",
  "monochange_publish",

--- a/crates/monochange/benches/cli_commands.rs
+++ b/crates/monochange/benches/cli_commands.rs
@@ -204,7 +204,7 @@ fn release_pr_args(dry_run: bool) -> Vec<OsString> {
 
 fn command_args(command: &str, dry_run: bool) -> Vec<OsString> {
 	let mut args = vec![OsString::from("monochange")];
-	if matches!(command, "commit-release" | "release-pr") {
+	if matches!(command, "commit-release" | "release-pr" | "release") {
 		args.push(OsString::from("run"));
 	}
 	args.push(OsString::from(command));
@@ -253,6 +253,7 @@ fn run_release_pr_command(root: &Path, dry_run: bool, github_api_url: Option<&st
 
 const SCALES: &[(usize, usize)] = &[(5, 10), (20, 50), (50, 200)];
 const INHERITED_GLOB_PACKAGE_COUNTS: &[usize] = &[20, 50, 500];
+const IGNORED_VERSIONED_FILE_COUNT: usize = 2_000;
 const LOCKFILE_COMPARE_SCALE: (usize, usize) = (20, 50);
 fn generate_inherited_glob_fixture(
 	root: &Path,
@@ -336,6 +337,136 @@ fn bench_inherited_glob_config_load(c: &mut Criterion) {
 			);
 		}
 	}
+	group.finish();
+}
+
+fn generate_ignored_versioned_file_glob_fixture(root: &Path) {
+	let config = r#"
+[defaults]
+package_type = "cargo"
+changelog = false
+
+[package.app]
+path = "packages/app"
+versioned_files = [{ path = "**/metadata.json", format = "json", fields = ["release.version"] }]
+
+[cli.release]
+[[cli.release.steps]]
+type = "PrepareRelease"
+"#;
+	fs::write(root.join("monochange.toml"), config.trim_start()).unwrap();
+	fs::create_dir_all(root.join("packages/app/src")).unwrap();
+	fs::write(
+		root.join("packages/app/Cargo.toml"),
+		"[package]\nname = \"app\"\nversion = \"1.0.0\"\nedition = \"2021\"\n",
+	)
+	.unwrap();
+	fs::write(root.join("packages/app/src/lib.rs"), "pub fn app() {}\n").unwrap();
+	fs::write(
+		root.join("packages/app/metadata.json"),
+		"{\"release\":{\"version\":\"1.0.0\"}}\n",
+	)
+	.unwrap();
+	fs::create_dir_all(root.join(".changeset")).unwrap();
+	fs::write(
+		root.join(".changeset/app.md"),
+		"---\napp: patch\n---\n\nUpdate app.\n",
+	)
+	.unwrap();
+
+	for index in 0..IGNORED_VERSIONED_FILE_COUNT {
+		let fvm_file = root.join(format!(".fvm/versions/3.44.1/pkg-{index}/metadata.json"));
+		fs::create_dir_all(fvm_file.parent().unwrap()).unwrap();
+		fs::write(&fvm_file, "{\"release\":{\"version\":\"0.0.0\"}}\n").unwrap();
+
+		let repo_file = root.join(format!(".repos/external/pkg-{index}/metadata.json"));
+		fs::create_dir_all(repo_file.parent().unwrap()).unwrap();
+		fs::write(&repo_file, "{\"release\":{\"version\":\"0.0.0\"}}\n").unwrap();
+	}
+}
+
+const MULTI_GLOB_PATTERN_COUNT: usize = 20;
+
+fn generate_multi_glob_versioned_file_fixture(root: &Path) {
+	use std::fmt::Write as _;
+
+	let mut config = String::from("[defaults]\npackage_type = \"cargo\"\nchangelog = false\n\n");
+	for i in 0..MULTI_GLOB_PATTERN_COUNT {
+		let _ = write!(
+			config,
+			"[package.app{i}]\npath = \"packages/app{i}\"\nversioned_files = [{{ path = \"**/metadata-{i}.json\", format = \"json\", fields = [\"release.version\"] }}]\n\n"
+		);
+	}
+	config.push_str("[cli.release]\n[[cli.release.steps]]\ntype = \"PrepareRelease\"\n");
+	fs::write(root.join("monochange.toml"), &config).unwrap();
+
+	for i in 0..MULTI_GLOB_PATTERN_COUNT {
+		let pkg_dir = root.join(format!("packages/app{i}"));
+		fs::create_dir_all(pkg_dir.join("src")).unwrap();
+		fs::write(
+			pkg_dir.join("Cargo.toml"),
+			format!("[package]\nname = \"app{i}\"\nversion = \"1.0.0\"\nedition = \"2021\"\n"),
+		)
+		.unwrap();
+		fs::write(pkg_dir.join("src/lib.rs"), "pub fn app() {}\n").unwrap();
+		fs::write(
+			pkg_dir.join(format!("metadata-{i}.json")),
+			"{\"release\":{\"version\":\"1.0.0\"}}\n",
+		)
+		.unwrap();
+	}
+	fs::create_dir_all(root.join(".changeset")).unwrap();
+	for i in 0..MULTI_GLOB_PATTERN_COUNT {
+		fs::write(
+			root.join(format!(".changeset/app{i}.md")),
+			format!("---\napp{i}: patch\n---\n\nUpdate app{i}.\n"),
+		)
+		.unwrap();
+	}
+
+	for index in 0..IGNORED_VERSIONED_FILE_COUNT {
+		let fvm_file = root.join(format!(".fvm/versions/3.44.1/pkg-{index}/metadata.json"));
+		fs::create_dir_all(fvm_file.parent().unwrap()).unwrap();
+		fs::write(&fvm_file, "{\"release\":{\"version\":\"0.0.0\"}}\n").unwrap();
+
+		let repo_file = root.join(format!(".repos/external/pkg-{index}/metadata.json"));
+		fs::create_dir_all(repo_file.parent().unwrap()).unwrap();
+		fs::write(&repo_file, "{\"release\":{\"version\":\"0.0.0\"}}\n").unwrap();
+	}
+}
+
+fn bench_versioned_file_globs_skip_ignored_trees(c: &mut Criterion) {
+	let mut group = c.benchmark_group("versioned_file_globs");
+	group.sample_size(10);
+
+	group.bench_function("prepare_release_skips_ignored_trees", |b| {
+		b.iter_batched(
+			|| {
+				let tempdir = tempfile::tempdir().unwrap();
+				generate_ignored_versioned_file_glob_fixture(tempdir.path());
+				tempdir
+			},
+			|tempdir| {
+				block_on_bench(monochange::prepare_release(tempdir.path(), false)).unwrap();
+			},
+			BatchSize::LargeInput,
+		);
+	});
+
+	group.bench_function("prepare_release_multi_glob_batch_walk", |b| {
+		b.iter_batched(
+			|| {
+				let tempdir = tempfile::tempdir().unwrap();
+				generate_multi_glob_versioned_file_fixture(tempdir.path());
+				tempdir
+			},
+			|tempdir| {
+				block_on_bench(monochange::prepare_release(tempdir.path(), false)).unwrap();
+			},
+			BatchSize::LargeInput,
+		);
+	});
+
 	group.finish();
 }
 
@@ -810,6 +941,7 @@ fn bench_cli_startup_help(c: &mut Criterion) {
 			"mc_release_help",
 			vec![
 				OsString::from("monochange"),
+				OsString::from("run"),
 				OsString::from("release"),
 				OsString::from("--help"),
 			],
@@ -840,6 +972,7 @@ criterion_group!(
 	bench_validate,
 	bench_changeset_loading,
 	bench_versions_dry_run_json,
+	bench_versioned_file_globs_skip_ignored_trees,
 	bench_prepare_release_dry_run,
 	bench_prepare_release_apply,
 	bench_prepare_release_apply_cargo_lockfile_refresh,

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -94,6 +94,28 @@ use crate::workspace_ops::change_type_default_bump;
 use crate::workspace_ops::render_cli_commands_toml;
 use crate::workspace_ops::render_interactive_changeset_markdown;
 
+fn apply_versioned_file_definition(
+	root: &Path,
+	updates: &mut BTreeMap<PathBuf, crate::CachedDocument>,
+	definition: &monochange_core::VersionedFileDefinition,
+	owner_version: &str,
+	shared_release_version: Option<&String>,
+	dep_names: &[impl AsRef<str>],
+	context: &crate::VersionedFileUpdateContext<'_>,
+) -> monochange_core::MonochangeResult<()> {
+	let resolved_paths = monochange_core::workspace_glob_files(root, &definition.path)?;
+	crate::apply_versioned_file_definition_to_paths(
+		root,
+		updates,
+		definition,
+		&resolved_paths,
+		owner_version,
+		shared_release_version,
+		dep_names,
+		context,
+	)
+}
+
 fn render_change_target_markdown(
 	configuration: &monochange_core::WorkspaceConfiguration,
 	target_id: &str,
@@ -10431,7 +10453,7 @@ fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_update
 			missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 			regex: None,
 		};
-		let error = crate::apply_versioned_file_definition(
+		let error = apply_versioned_file_definition(
 			tempdir.path(),
 			&mut BTreeMap::new(),
 			&definition,
@@ -10467,7 +10489,7 @@ fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_update
 		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
-	let error = crate::apply_versioned_file_definition(
+	let error = apply_versioned_file_definition(
 		tempdir.path(),
 		&mut BTreeMap::from([(path, crate::CachedDocument::Text("{".to_string()))]),
 		&definition,
@@ -10497,7 +10519,7 @@ fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_update
 		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
-	let error = crate::apply_versioned_file_definition(
+	let error = apply_versioned_file_definition(
 		pnpm_tempdir.path(),
 		&mut BTreeMap::from([(pnpm_path, crate::CachedDocument::Text(": bad".to_string()))]),
 		&pnpm_definition,
@@ -10528,7 +10550,7 @@ fn apply_versioned_file_definition_reports_manifest_parse_errors_for_text_update
 		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
-	let error = crate::apply_versioned_file_definition(
+	let error = apply_versioned_file_definition(
 		cached_dart_tempdir.path(),
 		&mut BTreeMap::from([(path, crate::CachedDocument::Text(": bad".to_string()))]),
 		&definition,
@@ -10649,7 +10671,7 @@ fn apply_versioned_file_definition_returns_early_without_matching_versions() {
 	};
 	let dep_names = vec!["core".to_string()];
 	let mut updates = BTreeMap::new();
-	crate::apply_versioned_file_definition(
+	apply_versioned_file_definition(
 		tempdir.path(),
 		&mut updates,
 		&definition,
@@ -10682,7 +10704,7 @@ fn apply_versioned_file_definition_rejects_invalid_glob_patterns() {
 		regex: None,
 	};
 	let dep_names = vec!["core".to_string()];
-	let error = crate::apply_versioned_file_definition(
+	let error = apply_versioned_file_definition(
 		tempdir.path(),
 		&mut BTreeMap::new(),
 		&definition,
@@ -10721,7 +10743,7 @@ fn apply_versioned_file_definition_rejects_unsupported_glob_matches() {
 			missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 			regex: None,
 		};
-		let error = crate::apply_versioned_file_definition(
+		let error = apply_versioned_file_definition(
 			tempdir.path(),
 			&mut BTreeMap::new(),
 			&definition,
@@ -10764,7 +10786,7 @@ monochange = { path = "crates/monochange", version = "1.0.0" }
 		regex: None,
 	};
 	let mut updates = BTreeMap::new();
-	crate::apply_versioned_file_definition(
+	apply_versioned_file_definition(
 		tempdir.path(),
 		&mut updates,
 		&definition,
@@ -10822,7 +10844,7 @@ extra = { path = "crates/extra", version = "1.0.0" }
 	};
 	let mut updates = BTreeMap::new();
 	let shared_version = "4.0.0".to_string();
-	crate::apply_versioned_file_definition(
+	apply_versioned_file_definition(
 		tempdir.path(),
 		&mut updates,
 		&definition,
@@ -10876,7 +10898,7 @@ fn apply_versioned_file_definition_updates_bun_lockb_and_deno_text_variants() {
 	let original_bun =
 		fs::read(&bun_path).unwrap_or_else(|error| panic!("read bun lockb: {error}"));
 	let mut bun_updates = BTreeMap::new();
-	crate::apply_versioned_file_definition(
+	apply_versioned_file_definition(
 		bun_tempdir.path(),
 		&mut bun_updates,
 		&bun_definition,
@@ -10911,7 +10933,7 @@ fn apply_versioned_file_definition_updates_bun_lockb_and_deno_text_variants() {
 		regex: None,
 	};
 	let mut deno_updates = BTreeMap::new();
-	crate::apply_versioned_file_definition(
+	apply_versioned_file_definition(
 		deno_tempdir.path(),
 		&mut deno_updates,
 		&deno_definition,
@@ -10959,7 +10981,7 @@ fn apply_versioned_file_definition_updates_regex_versioned_files_from_cached_tex
 			"Download core from https://example.com/download/v1.0.0.tgz\n".to_string(),
 		),
 	)]);
-	crate::apply_versioned_file_definition(
+	apply_versioned_file_definition(
 		tempdir.path(),
 		&mut updates,
 		&definition,
@@ -11001,7 +11023,7 @@ fn apply_versioned_file_definition_reports_invalid_regex_patterns() {
 		regex: Some("(".to_string()),
 	};
 	let mut updates = BTreeMap::new();
-	let error = crate::apply_versioned_file_definition(
+	let error = apply_versioned_file_definition(
 		tempdir.path(),
 		&mut updates,
 		&definition,
@@ -11041,7 +11063,7 @@ fn apply_versioned_file_definition_updates_npm_manifest_and_lock_variants() {
 	};
 	let manifest_dep_names = vec!["core".to_string()];
 	let mut manifest_updates = BTreeMap::new();
-	crate::apply_versioned_file_definition(
+	apply_versioned_file_definition(
 		manifest_tempdir.path(),
 		&mut manifest_updates,
 		&manifest_definition,
@@ -11089,7 +11111,7 @@ fn apply_versioned_file_definition_updates_npm_manifest_and_lock_variants() {
 	};
 	let package_lock_dep_names = vec!["app".to_string()];
 	let mut package_lock_updates = BTreeMap::new();
-	crate::apply_versioned_file_definition(
+	apply_versioned_file_definition(
 		package_lock_tempdir.path(),
 		&mut package_lock_updates,
 		&package_lock_definition,
@@ -11131,7 +11153,7 @@ fn apply_versioned_file_definition_updates_npm_manifest_and_lock_variants() {
 	};
 	let pnpm_dep_names = vec!["core".to_string()];
 	let mut pnpm_updates = BTreeMap::new();
-	crate::apply_versioned_file_definition(
+	apply_versioned_file_definition(
 		pnpm_tempdir.path(),
 		&mut pnpm_updates,
 		&pnpm_definition,
@@ -11170,7 +11192,7 @@ fn apply_versioned_file_definition_updates_npm_manifest_and_lock_variants() {
 	};
 	let bun_dep_names = vec!["left-pad".to_string()];
 	let mut bun_updates = BTreeMap::new();
-	crate::apply_versioned_file_definition(
+	apply_versioned_file_definition(
 		bun_tempdir.path(),
 		&mut bun_updates,
 		&bun_definition,
@@ -11224,7 +11246,7 @@ dependencies = ["python-core>=1.0.0"]
 	};
 	let dep_names = vec!["python-core".to_string()];
 	let mut updates = BTreeMap::new();
-	crate::apply_versioned_file_definition(
+	apply_versioned_file_definition(
 		tempdir.path(),
 		&mut updates,
 		&manifest_definition,
@@ -11254,7 +11276,7 @@ dependencies = ["python-core>=1.0.0"]
 		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
-	crate::apply_versioned_file_definition(
+	apply_versioned_file_definition(
 		tempdir.path(),
 		&mut updates,
 		&lock_definition,
@@ -11297,7 +11319,7 @@ async fn apply_versioned_file_definition_reports_python_error_paths() {
 		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
 		regex: None,
 	};
-	let error = crate::apply_versioned_file_definition(
+	let error = apply_versioned_file_definition(
 		tempdir.path(),
 		&mut updates,
 		&unsupported_definition,
@@ -11330,7 +11352,7 @@ async fn apply_versioned_file_definition_reports_python_error_paths() {
 		manifest_path,
 		crate::CachedDocument::Text("[project\n".to_string()),
 	);
-	let error = crate::apply_versioned_file_definition(
+	let error = apply_versioned_file_definition(
 		tempdir.path(),
 		&mut updates,
 		&manifest_definition,
@@ -11366,7 +11388,7 @@ fn apply_versioned_file_definition_updates_deno_and_dart_variants() {
 	};
 	let deno_manifest_dep_names = vec!["core".to_string()];
 	let mut deno_manifest_updates = BTreeMap::new();
-	crate::apply_versioned_file_definition(
+	apply_versioned_file_definition(
 		deno_manifest_tempdir.path(),
 		&mut deno_manifest_updates,
 		&deno_manifest_definition,
@@ -11404,7 +11426,7 @@ fn apply_versioned_file_definition_updates_deno_and_dart_variants() {
 	};
 	let deno_lock_dep_names = vec!["app".to_string()];
 	let mut deno_lock_updates = BTreeMap::new();
-	crate::apply_versioned_file_definition(
+	apply_versioned_file_definition(
 		deno_lock_tempdir.path(),
 		&mut deno_lock_updates,
 		&deno_lock_definition,
@@ -11441,7 +11463,7 @@ fn apply_versioned_file_definition_updates_deno_and_dart_variants() {
 	};
 	let dart_manifest_dep_names = vec!["shared".to_string()];
 	let mut dart_manifest_updates = BTreeMap::new();
-	crate::apply_versioned_file_definition(
+	apply_versioned_file_definition(
 		dart_manifest_tempdir.path(),
 		&mut dart_manifest_updates,
 		&dart_manifest_definition,
@@ -11481,7 +11503,7 @@ fn apply_versioned_file_definition_updates_deno_and_dart_variants() {
 	};
 	let dart_lock_dep_names = vec!["nested_dart_app".to_string()];
 	let mut dart_lock_updates = BTreeMap::new();
-	crate::apply_versioned_file_definition(
+	apply_versioned_file_definition(
 		dart_lock_tempdir.path(),
 		&mut dart_lock_updates,
 		&dart_lock_definition,
@@ -13842,7 +13864,7 @@ fn apply_versioned_file_definition_reports_invalid_glob_pattern() {
 		regex: Some(r"v(?<version>\d+\.\d+\.\d+)".to_string()),
 	};
 	let mut updates = BTreeMap::new();
-	let error = crate::apply_versioned_file_definition(
+	let error = apply_versioned_file_definition(
 		tempdir.path(),
 		&mut updates,
 		&definition,
@@ -13873,7 +13895,7 @@ fn apply_versioned_file_definition_reports_missing_ecosystem_type() {
 		regex: None,
 	};
 	let mut updates = BTreeMap::new();
-	let error = crate::apply_versioned_file_definition(
+	let error = apply_versioned_file_definition(
 		tempdir.path(),
 		&mut updates,
 		&definition,

--- a/crates/monochange/src/__tests__/versioned_files_tests.rs
+++ b/crates/monochange/src/__tests__/versioned_files_tests.rs
@@ -12,7 +12,7 @@ use super::VersionedFileUpdateContext;
 use super::add_json_field_path;
 use super::add_toml_field_path;
 use super::add_yaml_field_path;
-use super::apply_versioned_file_definition;
+use super::apply_versioned_file_definition_to_paths;
 use super::build_versioned_file_updates_with_base_updates;
 use super::inferred_lockfile_ecosystem_type;
 use super::inferred_lockfile_paths;
@@ -21,6 +21,28 @@ use super::released_versions_by_record_id;
 use super::seed_cached_text_updates;
 use super::update_format_versioned_file_text;
 use super::versioned_file_kind;
+
+fn apply_versioned_file_definition(
+	root: &Path,
+	updates: &mut BTreeMap<PathBuf, super::CachedDocument>,
+	definition: &monochange_core::VersionedFileDefinition,
+	owner_version: &str,
+	shared_release_version: Option<&String>,
+	dep_names: &[impl AsRef<str>],
+	context: &super::VersionedFileUpdateContext<'_>,
+) -> monochange_core::MonochangeResult<()> {
+	let resolved_paths = monochange_core::workspace_glob_files(root, &definition.path)?;
+	super::apply_versioned_file_definition_to_paths(
+		root,
+		updates,
+		definition,
+		&resolved_paths,
+		owner_version,
+		shared_release_version,
+		dep_names,
+		context,
+	)
+}
 
 fn fixture_path(relative: &str) -> PathBuf {
 	PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -633,6 +655,72 @@ fn apply_versioned_file_definition_supports_format_mode_and_reports_format_error
 }
 
 #[test]
+fn recursive_versioned_file_globs_skip_ignored_workspace_directories() {
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	let package_metadata = root.join("packages/app/metadata.json");
+	let fvm_metadata = root.join(".fvm/versions/3.44.1/metadata.json");
+	let repos_metadata = root.join(".repos/external/metadata.json");
+	for path in [&package_metadata, &fvm_metadata, &repos_metadata] {
+		std::fs::create_dir_all(path.parent().unwrap_or(root))
+			.unwrap_or_else(|error| panic!("create metadata parent: {error}"));
+		std::fs::write(path, "{\"release\":{\"version\":\"1.0.0\"}}")
+			.unwrap_or_else(|error| panic!("write metadata: {error}"));
+	}
+	let configuration =
+		monochange_config::load_workspace_configuration(&fixture_path("monochange/release-base"))
+			.unwrap_or_else(|error| panic!("configuration: {error}"));
+	let context = VersionedFileUpdateContext {
+		package_by_config_id: BTreeMap::new(),
+		package_by_native_name: BTreeMap::new(),
+		current_versions_by_native_name: BTreeMap::new(),
+		released_versions_by_native_name: BTreeMap::new(),
+		configuration: &configuration,
+	};
+	let definition = monochange_core::VersionedFileDefinition {
+		path: "**/metadata.json".to_string(),
+		ecosystem_type: None,
+		format: Some(monochange_core::VersionedFileFormat::Json),
+		prefix: None,
+		fields: Some(vec!["release.version".to_string()]),
+		name: None,
+		missing_field_behavior: monochange_core::MissingFieldBehavior::default(),
+		regex: None,
+	};
+	let mut updates = BTreeMap::new();
+	apply_versioned_file_definition(
+		root,
+		&mut updates,
+		&definition,
+		"1.2.3",
+		None,
+		&["metadata".to_string()],
+		&context,
+	)
+	.unwrap_or_else(|error| panic!("apply recursive versioned glob: {error}"));
+
+	assert!(updates.contains_key(&package_metadata));
+	assert!(!updates.contains_key(&fvm_metadata));
+	assert!(!updates.contains_key(&repos_metadata));
+
+	let explicit_definition = monochange_core::VersionedFileDefinition {
+		path: ".fvm/versions/3.44.1/metadata.json".to_string(),
+		..definition
+	};
+	apply_versioned_file_definition(
+		root,
+		&mut updates,
+		&explicit_definition,
+		"1.2.3",
+		None,
+		&["metadata".to_string()],
+		&context,
+	)
+	.unwrap_or_else(|error| panic!("apply explicit ignored versioned file: {error}"));
+	assert!(updates.contains_key(&fvm_metadata));
+}
+
+#[test]
 fn build_versioned_file_updates_returns_empty_for_empty_configuration() {
 	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	let root = tempdir.path();
@@ -657,6 +745,164 @@ fn build_versioned_file_updates_returns_empty_for_empty_configuration() {
 			.unwrap_or_else(|error| panic!("build versioned updates: {error}"));
 
 	assert!(updates.is_empty());
+}
+
+#[test]
+fn build_versioned_file_updates_reports_invalid_glob_pattern_in_package_prewarm() {
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	std::fs::create_dir_all(root.join("packages/app"))
+		.unwrap_or_else(|error| panic!("create packages/app: {error}"));
+	std::fs::write(
+		root.join("packages/app/package.json"),
+		"{\"name\":\"app\",\"version\":\"1.0.0\"}\n",
+	)
+	.unwrap_or_else(|error| panic!("write package.json: {error}"));
+	std::fs::write(
+		root.join("monochange.toml"),
+		"[defaults]\npackage_type = \"npm\"\n\n[package.app]\npath = \"packages/app\"\nversioned_files = [{ path = \"**/[invalid\", format = \"json\", fields = [\"version\"] }]\n",
+	)
+	.unwrap_or_else(|error| panic!("write monochange config: {error}"));
+	let configuration = monochange_config::load_workspace_configuration(root)
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+	let package = npm_package_record(root, "app");
+	let plan = package_release_plan(root, &package);
+
+	let error = build_versioned_file_updates_with_base_updates(
+		root,
+		&configuration,
+		&[package],
+		&plan,
+		&[],
+	)
+	.expect_err("invalid glob should error during prewarm");
+
+	assert!(error.to_string().contains("invalid glob pattern"));
+}
+
+#[test]
+fn build_versioned_file_updates_prewarms_group_versioned_file_globs() {
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	std::fs::create_dir_all(root.join("packages/app"))
+		.unwrap_or_else(|error| panic!("create packages/app: {error}"));
+	std::fs::write(
+		root.join("packages/app/package.json"),
+		"{\"name\":\"app\",\"version\":\"1.0.0\"}\n",
+	)
+	.unwrap_or_else(|error| panic!("write package.json: {error}"));
+	std::fs::write(
+		root.join("shared-version.json"),
+		"{\"version\":\"1.0.0\"}\n",
+	)
+	.unwrap_or_else(|error| panic!("write shared-version.json: {error}"));
+	std::fs::write(
+		root.join("monochange.toml"),
+		"[defaults]\npackage_type = \"npm\"\n\n[package.app]\npath = \"packages/app\"\n\n[group.main]\npackages = [\"app\"]\nversioned_files = [{ path = \"shared-version.json\", format = \"json\", fields = [\"version\"] }]\n",
+	)
+	.unwrap_or_else(|error| panic!("write monochange config: {error}"));
+	let configuration = monochange_config::load_workspace_configuration(root)
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+	let package = npm_package_record(root, "app");
+	let plan = monochange_core::ReleasePlan {
+		workspace_root: root.to_path_buf(),
+		decisions: vec![monochange_core::ReleaseDecision {
+			package_id: package.id.clone(),
+			trigger_type: "changeset".to_string(),
+			recommended_bump: monochange_core::BumpSeverity::Minor,
+			planned_version: Some("1.2.3".parse().unwrap()),
+			group_id: Some("main".to_string()),
+			reasons: Vec::new(),
+			upstream_sources: Vec::new(),
+			warnings: Vec::new(),
+		}],
+		groups: vec![monochange_core::PlannedVersionGroup {
+			group_id: "main".to_string(),
+			display_name: "main".to_string(),
+			members: vec!["app".to_string()],
+			mismatch_detected: false,
+			planned_version: Some("1.2.3".parse().unwrap()),
+			recommended_bump: monochange_core::BumpSeverity::Minor,
+		}],
+		warnings: Vec::new(),
+		unresolved_items: Vec::new(),
+		compatibility_evidence: Vec::new(),
+	};
+
+	let updates = build_versioned_file_updates_with_base_updates(
+		root,
+		&configuration,
+		&[package],
+		&plan,
+		&[],
+	)
+	.unwrap_or_else(|error| panic!("build versioned updates: {error}"));
+
+	let shared_update = updates
+		.iter()
+		.find(|update| update.path.ends_with("shared-version.json"))
+		.unwrap_or_else(|| panic!("expected shared-version.json update: {updates:?}"));
+	let content = String::from_utf8(shared_update.content.clone()).unwrap();
+	assert!(
+		content.contains("\"1.2.3\""),
+		"shared version should be 1.2.3: {content}"
+	);
+}
+
+#[test]
+fn build_versioned_file_updates_reports_invalid_glob_pattern_in_group_prewarm() {
+	let tempdir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	std::fs::create_dir_all(root.join("packages/app"))
+		.unwrap_or_else(|error| panic!("create packages/app: {error}"));
+	std::fs::write(
+		root.join("packages/app/package.json"),
+		"{\"name\":\"app\",\"version\":\"1.0.0\"}\n",
+	)
+	.unwrap_or_else(|error| panic!("write package.json: {error}"));
+	std::fs::write(
+		root.join("monochange.toml"),
+		"[defaults]\npackage_type = \"npm\"\n\n[package.app]\npath = \"packages/app\"\n\n[group.main]\npackages = [\"app\"]\nversioned_files = [{ path = \"**/[invalid\", format = \"json\", fields = [\"version\"] }]\n",
+	)
+	.unwrap_or_else(|error| panic!("write monochange config: {error}"));
+	let configuration = monochange_config::load_workspace_configuration(root)
+		.unwrap_or_else(|error| panic!("configuration: {error}"));
+	let package = npm_package_record(root, "app");
+	let plan = monochange_core::ReleasePlan {
+		workspace_root: root.to_path_buf(),
+		decisions: vec![monochange_core::ReleaseDecision {
+			package_id: package.id.clone(),
+			trigger_type: "changeset".to_string(),
+			recommended_bump: monochange_core::BumpSeverity::Minor,
+			planned_version: Some("1.2.3".parse().unwrap()),
+			group_id: Some("main".to_string()),
+			reasons: Vec::new(),
+			upstream_sources: Vec::new(),
+			warnings: Vec::new(),
+		}],
+		groups: vec![monochange_core::PlannedVersionGroup {
+			group_id: "main".to_string(),
+			display_name: "main".to_string(),
+			members: vec!["app".to_string()],
+			mismatch_detected: false,
+			planned_version: Some("1.2.3".parse().unwrap()),
+			recommended_bump: monochange_core::BumpSeverity::Minor,
+		}],
+		warnings: Vec::new(),
+		unresolved_items: Vec::new(),
+		compatibility_evidence: Vec::new(),
+	};
+
+	let error = build_versioned_file_updates_with_base_updates(
+		root,
+		&configuration,
+		&[package],
+		&plan,
+		&[],
+	)
+	.expect_err("invalid group glob should error during prewarm");
+
+	assert!(error.to_string().contains("invalid glob pattern"));
 }
 
 #[test]

--- a/crates/monochange/src/versioned_files.rs
+++ b/crates/monochange/src/versioned_files.rs
@@ -97,6 +97,43 @@ fn dedup_versioned_file_definitions(
 		.collect()
 }
 
+#[derive(Debug, Default)]
+struct VersionedFilePathCache {
+	paths_by_pattern: BTreeMap<String, Vec<PathBuf>>,
+}
+
+impl VersionedFilePathCache {
+	fn prewarm<'a, I>(&mut self, root: &Path, patterns: I) -> MonochangeResult<()>
+	where
+		I: IntoIterator<Item = &'a str>,
+	{
+		let pending_patterns = patterns
+			.into_iter()
+			.filter(|pattern| !self.paths_by_pattern.contains_key(*pattern))
+			.collect::<BTreeSet<_>>();
+		if pending_patterns.is_empty() {
+			return Ok(());
+		}
+
+		let resolved_paths = monochange_core::workspace_glob_files_many(root, pending_patterns)?;
+		self.paths_by_pattern.extend(resolved_paths);
+		Ok(())
+	}
+
+	fn paths(&mut self, root: &Path, pattern: &str) -> MonochangeResult<&[PathBuf]> {
+		if !self.paths_by_pattern.contains_key(pattern) {
+			let resolved_paths = monochange_core::workspace_glob_files(root, pattern)?;
+			self.paths_by_pattern
+				.insert(pattern.to_string(), resolved_paths);
+		}
+
+		Ok(self
+			.paths_by_pattern
+			.get(pattern)
+			.expect("versioned file path cache should include resolved pattern"))
+	}
+}
+
 fn cached_document_key(path: &Path) -> PathBuf {
 	fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
@@ -213,6 +250,23 @@ pub(crate) fn build_versioned_file_updates_with_base_updates(
 	let mut updates = BTreeMap::<PathBuf, CachedDocument>::new();
 	seed_cached_text_updates(root, &mut updates, base_updates)?;
 
+	let mut path_cache = VersionedFilePathCache::default();
+	path_cache.prewarm(
+		root,
+		configuration
+			.packages
+			.iter()
+			.filter(|package_definition| {
+				released_versions_by_config_id.contains_key(package_definition.id.as_str())
+			})
+			.flat_map(|package_definition| {
+				package_definition
+					.versioned_files
+					.iter()
+					.map(|versioned_file| versioned_file.path.as_str())
+			}),
+	)?;
+
 	for package_definition in &configuration.packages {
 		let Some(version) = released_versions_by_config_id.get(package_definition.id.as_str())
 		else {
@@ -233,10 +287,12 @@ pub(crate) fn build_versioned_file_updates_with_base_updates(
 		{
 			if let Some(override_name) = versioned_file.name.as_deref() {
 				let effective_dep_names = [override_name];
-				apply_versioned_file_definition(
+				let resolved_paths = path_cache.paths(root, &versioned_file.path)?;
+				apply_versioned_file_definition_to_paths(
 					root,
 					&mut updates,
 					versioned_file,
+					resolved_paths,
 					version,
 					shared_release_version.as_ref(),
 					&effective_dep_names,
@@ -245,10 +301,12 @@ pub(crate) fn build_versioned_file_updates_with_base_updates(
 				continue;
 			}
 
-			apply_versioned_file_definition(
+			let resolved_paths = path_cache.paths(root, &versioned_file.path)?;
+			apply_versioned_file_definition_to_paths(
 				root,
 				&mut updates,
 				versioned_file,
+				resolved_paths,
 				version,
 				shared_release_version.as_ref(),
 				&dep_names,
@@ -267,6 +325,21 @@ pub(crate) fn build_versioned_file_updates_with_base_updates(
 				.map(|version| (group.group_id.as_str(), version))
 		})
 		.collect::<BTreeMap<_, _>>();
+	path_cache.prewarm(
+		root,
+		configuration
+			.groups
+			.iter()
+			.filter(|group_definition| {
+				planned_group_versions.contains_key(group_definition.id.as_str())
+			})
+			.flat_map(|group_definition| {
+				group_definition
+					.versioned_files
+					.iter()
+					.map(|versioned_file| versioned_file.path.as_str())
+			}),
+	)?;
 	let mut group_dep_names = Vec::new();
 
 	for group_definition in &configuration.groups {
@@ -286,10 +359,12 @@ pub(crate) fn build_versioned_file_updates_with_base_updates(
 		}));
 
 		for versioned_file in &group_definition.versioned_files {
-			apply_versioned_file_definition(
+			let resolved_paths = path_cache.paths(root, &versioned_file.path)?;
+			apply_versioned_file_definition_to_paths(
 				root,
 				&mut updates,
 				versioned_file,
+				resolved_paths,
 				&group_version,
 				Some(&group_version),
 				&group_dep_names,
@@ -306,6 +381,7 @@ pub(crate) fn build_versioned_file_updates_with_base_updates(
 		shared_release_version.as_ref(),
 		&context,
 		&mut updates,
+		&mut path_cache,
 	)?;
 
 	updates
@@ -314,6 +390,7 @@ pub(crate) fn build_versioned_file_updates_with_base_updates(
 		.collect()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn apply_inferred_lockfile_updates(
 	root: &Path,
 	configuration: &monochange_core::WorkspaceConfiguration,
@@ -322,6 +399,7 @@ fn apply_inferred_lockfile_updates(
 	shared_release_version: Option<&String>,
 	context: &VersionedFileUpdateContext<'_>,
 	updates: &mut BTreeMap<PathBuf, CachedDocument>,
+	path_cache: &mut VersionedFilePathCache,
 ) -> MonochangeResult<()> {
 	let released_versions = released_versions_by_record_id(plan);
 	let mut dep_names_by_lockfile =
@@ -362,10 +440,12 @@ fn apply_inferred_lockfile_updates(
 		// That keeps normal `monochange release` runs on the fast path instead of paying
 		// package-manager startup and dependency-resolution costs for every bump.
 		let dep_names = dep_names.into_iter().collect::<Vec<_>>();
-		apply_versioned_file_definition(
+		let resolved_paths = path_cache.paths(root, &definition.path)?;
+		apply_versioned_file_definition_to_paths(
 			root,
 			updates,
 			&definition,
+			resolved_paths,
 			"",
 			shared_release_version,
 			&dep_names,
@@ -1268,26 +1348,20 @@ fn update_versioned_file_regex(
 		.into_owned())
 }
 
-pub(crate) fn apply_versioned_file_definition(
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn apply_versioned_file_definition_to_paths(
 	root: &Path,
 	updates: &mut BTreeMap<PathBuf, CachedDocument>,
 	definition: &VersionedFileDefinition,
+	resolved_paths: &[PathBuf],
 	owner_version: &str,
 	shared_release_version: Option<&String>,
 	dep_names: &[impl AsRef<str>],
 	context: &VersionedFileUpdateContext<'_>,
 ) -> MonochangeResult<()> {
 	if let Some(pattern) = &definition.regex {
-		let glob_pattern = root.join(&definition.path).to_string_lossy().to_string();
-		let matched_paths = glob::glob(&glob_pattern).map_err(|error| {
-			MonochangeError::Config(format!(
-				"invalid glob pattern `{}`: {error}",
-				definition.path
-			))
-		})?;
-		for resolved_path in matched_paths {
-			let resolved_path =
-				resolved_path.map_err(|error| MonochangeError::Config(error.to_string()))?;
+		for resolved_path in resolved_paths {
+			let resolved_path = resolved_path.clone();
 			let contents = read_cached_text_document(updates, &resolved_path)?;
 			updates.insert(
 				resolved_path,
@@ -1309,16 +1383,8 @@ pub(crate) fn apply_versioned_file_definition(
 			))
 		})?;
 		let name = dep_names.first().map(AsRef::as_ref);
-		let glob_pattern = root.join(&definition.path).to_string_lossy().to_string();
-		let matched_paths = glob::glob(&glob_pattern).map_err(|error| {
-			MonochangeError::Config(format!(
-				"invalid glob pattern `{}`: {error}",
-				definition.path
-			))
-		})?;
-		for resolved_path in matched_paths {
-			let resolved_path =
-				resolved_path.map_err(|error| MonochangeError::Config(error.to_string()))?;
+		for resolved_path in resolved_paths {
+			let resolved_path = resolved_path.clone();
 			let contents = read_cached_text_document(updates, &resolved_path)?;
 			let changed_text = update_format_versioned_file_text(
 				&contents,
@@ -1380,17 +1446,8 @@ pub(crate) fn apply_versioned_file_definition(
 		return Ok(());
 	}
 
-	let glob_pattern = root.join(&definition.path).to_string_lossy().to_string();
-	let matched_paths = glob::glob(&glob_pattern).map_err(|error| {
-		MonochangeError::Config(format!(
-			"invalid glob pattern `{}`: {error}",
-			definition.path
-		))
-	})?;
-
-	for resolved_path in matched_paths {
-		let resolved_path =
-			resolved_path.map_err(|error| MonochangeError::Config(error.to_string()))?;
+	for resolved_path in resolved_paths {
+		let resolved_path = resolved_path.clone();
 		let Some(kind) = versioned_file_kind(ecosystem_type, &resolved_path) else {
 			return Err(MonochangeError::Config(format!(
 				"versioned_files glob `{}` matched unsupported file `{}` for ecosystem `{}`; narrow the glob or change the `type`",

--- a/crates/monochange_cargo/Cargo.toml
+++ b/crates/monochange_cargo/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = { workspace = true }
 description = "Manage versions and releases for your multiplatform, multilanguage monorepo"
 
 [dependencies]
-glob = { workspace = true, default-features = true }
 monochange_core = { workspace = true }
 monochange_linting = { workspace = true }
 monochange_publish = { workspace = true }

--- a/crates/monochange_cargo/src/lib.rs
+++ b/crates/monochange_cargo/src/lib.rs
@@ -44,7 +44,6 @@ use std::path::PathBuf;
 
 pub use analysis::CargoSemanticAnalyzer;
 pub use analysis::semantic_analyzer;
-use glob::glob;
 use monochange_core::AdapterDiscovery;
 use monochange_core::BumpSeverity;
 use monochange_core::ChangeSignal;
@@ -882,12 +881,12 @@ fn expand_manifest_patterns(
 	let filter = DiscoveryPathFilter::new(root);
 	let excluded = exclude_patterns
 		.iter()
-		.flat_map(|pattern| glob_pattern_paths(root, pattern, &filter))
+		.flat_map(|pattern| workspace_manifest_pattern_paths(root, pattern))
 		.collect::<HashSet<_>>();
 	let mut manifests = BTreeSet::new();
 
 	for pattern in member_patterns {
-		let matches = glob_pattern_paths(root, pattern, &filter);
+		let matches = workspace_manifest_pattern_paths(root, pattern);
 		if matches.is_empty() {
 			warnings.push(format!(
 				"cargo workspace pattern `{pattern}` under {} matched no packages",
@@ -917,14 +916,8 @@ fn expand_manifest_patterns(
 	manifests
 }
 
-fn glob_pattern_paths(root: &Path, pattern: &str, filter: &DiscoveryPathFilter) -> Vec<PathBuf> {
-	let joined_pattern = root.join(pattern).to_string_lossy().to_string();
-	glob(&joined_pattern)
-		.into_iter()
-		.flat_map(|paths| paths.filter_map(Result::ok))
-		.map(|path| normalize_path(&path))
-		.filter(|path| filter.allows(path))
-		.collect()
+fn workspace_manifest_pattern_paths(root: &Path, pattern: &str) -> Vec<PathBuf> {
+	monochange_core::workspace_glob_paths(root, pattern, true).unwrap_or_default()
 }
 
 fn parse_package_manifest(

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -3875,7 +3875,7 @@ fn validate_command_step_definition(
 }
 
 fn path_uses_glob(path: &str) -> bool {
-	path.contains('*') || path.contains('?') || path.contains('[')
+	monochange_core::workspace_glob_has_magic(path)
 }
 
 #[derive(Default)]
@@ -6001,16 +6001,7 @@ fn validate_single_versioned_file_content(
 ) -> MonochangeResult<()> {
 	if path_uses_glob(&definition.path) {
 		// Glob path: warn if zero files match.
-		let pattern = root.join(&definition.path).to_string_lossy().to_string();
-		let matches = glob::glob(&pattern)
-			.map_err(|error| {
-				MonochangeError::Config(format!(
-					"invalid glob pattern `{}`: {error}",
-					definition.path
-				))
-			})?
-			.filter_map(Result::ok)
-			.collect::<Vec<_>>();
+		let matches = monochange_core::workspace_glob_files(root, &definition.path)?;
 		if matches.is_empty() {
 			warnings.push(format!(
 				"{owner_kind} `{owner_id}` versioned file glob `{}` matches no files",

--- a/crates/monochange_core/Cargo.toml
+++ b/crates/monochange_core/Cargo.toml
@@ -18,6 +18,7 @@ schema = ["dep:schemars"]
 
 [dependencies]
 async-trait = { workspace = true, default-features = true }
+glob = { workspace = true, default-features = true }
 ignore = { workspace = true, default-features = true }
 monochange_schema = { workspace = true, default-features = true }
 reqwest = { workspace = true, optional = true }

--- a/crates/monochange_core/src/__tests__/lib_tests.rs
+++ b/crates/monochange_core/src/__tests__/lib_tests.rs
@@ -994,6 +994,321 @@ fn discovery_path_filter_skips_nested_git_worktrees() {
 }
 
 #[test]
+fn workspace_glob_files_skip_ignored_workspace_directories() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	for file_path in [
+		"packages/app/metadata.json",
+		".fvm/versions/3.44.1/metadata.json",
+		".repos/external/metadata.json",
+		"node_modules/pkg/metadata.json",
+		"ignored/metadata.json",
+	] {
+		let path = root.join(file_path);
+		fs::create_dir_all(path.parent().unwrap_or(root))
+			.unwrap_or_else(|error| panic!("create parent for {file_path}: {error}"));
+		fs::write(path, "{}\n").unwrap_or_else(|error| panic!("write {file_path}: {error}"));
+	}
+	fs::write(root.join(".gitignore"), "ignored/\n")
+		.unwrap_or_else(|error| panic!("write gitignore: {error}"));
+
+	let matches = crate::workspace_glob_files(root, "**/metadata.json")
+		.unwrap_or_else(|error| panic!("workspace glob files: {error}"));
+	let relative_matches = matches
+		.iter()
+		.map(|path| path.strip_prefix(root).unwrap_or(path).to_path_buf())
+		.collect::<Vec<_>>();
+
+	assert_eq!(
+		relative_matches,
+		vec![PathBuf::from("packages/app/metadata.json")]
+	);
+}
+
+#[test]
+fn workspace_glob_literal_paths_can_target_ignored_directories() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	let metadata_path = root.join(".fvm/versions/3.44.1/metadata.json");
+	fs::create_dir_all(metadata_path.parent().unwrap_or(root))
+		.unwrap_or_else(|error| panic!("create fvm parent: {error}"));
+	fs::write(&metadata_path, "{}\n").unwrap_or_else(|error| panic!("write metadata: {error}"));
+
+	let matches = crate::workspace_glob_files(root, ".fvm/versions/3.44.1/metadata.json")
+		.unwrap_or_else(|error| panic!("workspace glob literal: {error}"));
+
+	assert_eq!(matches, vec![metadata_path]);
+}
+
+#[test]
+fn workspace_glob_paths_can_return_directories_for_workspace_members() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	for directory in [
+		"packages/app",
+		"packages/core",
+		"packages/core/nested",
+		"target/ignored",
+	] {
+		fs::create_dir_all(root.join(directory))
+			.unwrap_or_else(|error| panic!("create {directory}: {error}"));
+	}
+
+	let matches = crate::workspace_glob_paths(root, "packages/*", true)
+		.unwrap_or_else(|error| panic!("workspace glob directories: {error}"));
+	let relative_matches = matches
+		.iter()
+		.map(|path| path.strip_prefix(root).unwrap_or(path).to_path_buf())
+		.collect::<Vec<_>>();
+
+	assert_eq!(
+		relative_matches,
+		vec![
+			PathBuf::from("packages/app"),
+			PathBuf::from("packages/core")
+		]
+	);
+}
+
+#[test]
+fn workspace_glob_files_many_matches_multiple_patterns_with_shared_walk_semantics() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	for file_path in [
+		"packages/app/metadata.json",
+		"packages/app/pubspec.yaml",
+		"packages/core/metadata.json",
+		".fvm/versions/3.44.1/pubspec.yaml",
+	] {
+		let path = root.join(file_path);
+		fs::create_dir_all(path.parent().unwrap_or(root))
+			.unwrap_or_else(|error| panic!("create parent for {file_path}: {error}"));
+		fs::write(path, "{}\n").unwrap_or_else(|error| panic!("write {file_path}: {error}"));
+	}
+
+	let matches = crate::workspace_glob_files_many(
+		root,
+		[
+			"**/metadata.json",
+			"**/pubspec.yaml",
+			"**/metadata.json",
+			"packages/app/pubspec.yaml",
+		],
+	)
+	.unwrap_or_else(|error| panic!("workspace glob files many: {error}"));
+	let relative_matches = matches
+		.into_iter()
+		.map(|(pattern, paths)| {
+			let relative_paths = paths
+				.iter()
+				.map(|path| path.strip_prefix(root).unwrap_or(path).to_path_buf())
+				.collect::<Vec<_>>();
+			(pattern, relative_paths)
+		})
+		.collect::<BTreeMap<_, _>>();
+
+	assert_eq!(
+		relative_matches
+			.get("**/metadata.json")
+			.expect("metadata glob result"),
+		&vec![
+			PathBuf::from("packages/app/metadata.json"),
+			PathBuf::from("packages/core/metadata.json")
+		]
+	);
+	assert_eq!(
+		relative_matches
+			.get("**/pubspec.yaml")
+			.expect("pubspec glob result"),
+		&vec![PathBuf::from("packages/app/pubspec.yaml")]
+	);
+	assert_eq!(
+		relative_matches
+			.get("packages/app/pubspec.yaml")
+			.expect("literal result"),
+		&vec![PathBuf::from("packages/app/pubspec.yaml")]
+	);
+}
+
+#[test]
+fn workspace_glob_paths_many_preserves_literal_separator_matching() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	for directory in ["packages/app", "packages/core", "packages/core/nested"] {
+		fs::create_dir_all(root.join(directory))
+			.unwrap_or_else(|error| panic!("create {directory}: {error}"));
+	}
+
+	let matches = crate::workspace_glob_paths_many(root, ["packages/*"], true)
+		.unwrap_or_else(|error| panic!("workspace glob paths many: {error}"));
+	let relative_matches = matches
+		.get("packages/*")
+		.expect("packages glob result")
+		.iter()
+		.map(|path| path.strip_prefix(root).unwrap_or(path).to_path_buf())
+		.collect::<Vec<_>>();
+
+	assert_eq!(
+		relative_matches,
+		vec![
+			PathBuf::from("packages/app"),
+			PathBuf::from("packages/core")
+		]
+	);
+}
+
+#[test]
+fn workspace_glob_files_many_resolves_absolute_literal_paths() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	let metadata_path = root.join("packages/app/metadata.json");
+	fs::create_dir_all(metadata_path.parent().unwrap_or(root))
+		.unwrap_or_else(|error| panic!("create parent: {error}"));
+	fs::write(&metadata_path, "{}\n").unwrap_or_else(|error| panic!("write metadata: {error}"));
+
+	let absolute_metadata = metadata_path.to_string_lossy().into_owned();
+	let matches = crate::workspace_glob_files_many(root, [absolute_metadata.as_str()])
+		.unwrap_or_else(|error| panic!("workspace glob files many absolute: {error}"));
+
+	assert_eq!(
+		matches
+			.get(absolute_metadata.as_str())
+			.expect("absolute literal result"),
+		&vec![metadata_path.clone()]
+	);
+}
+
+#[test]
+fn workspace_glob_files_many_resolves_absolute_glob_patterns_within_root() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	let metadata_path = root.join("packages/app/metadata.json");
+	fs::create_dir_all(metadata_path.parent().unwrap_or(root))
+		.unwrap_or_else(|error| panic!("create parent: {error}"));
+	fs::write(&metadata_path, "{}\n").unwrap_or_else(|error| panic!("write metadata: {error}"));
+
+	let absolute_glob = root.join("**/metadata.json").to_string_lossy().into_owned();
+	let matches = crate::workspace_glob_files_many(root, [absolute_glob.as_str()])
+		.unwrap_or_else(|error| panic!("workspace glob files many absolute glob: {error}"));
+	let relative_matches = matches
+		.get(absolute_glob.as_str())
+		.expect("absolute glob result")
+		.iter()
+		.map(|path| path.strip_prefix(root).unwrap_or(path).to_path_buf())
+		.collect::<Vec<_>>();
+
+	assert_eq!(
+		relative_matches,
+		vec![PathBuf::from("packages/app/metadata.json")]
+	);
+}
+
+#[test]
+fn workspace_glob_files_many_reports_invalid_glob_patterns() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	let error = crate::workspace_glob_files_many(root, ["**/[invalid"])
+		.expect_err("invalid glob pattern should error");
+
+	assert!(error.to_string().contains("invalid glob pattern"));
+}
+
+#[test]
+fn workspace_glob_files_many_skips_nonexistent_search_roots() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+
+	let matches = crate::workspace_glob_files_many(root, ["nonexistent/**/*.json"])
+		.unwrap_or_else(|error| panic!("workspace glob files many nonexistent: {error}"));
+
+	assert!(
+		matches
+			.get("nonexistent/**/*.json")
+			.expect("result")
+			.is_empty()
+	);
+}
+
+#[test]
+fn workspace_glob_files_many_skips_entries_without_file_type() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	let metadata_path = root.join("packages/app/metadata.json");
+	fs::create_dir_all(metadata_path.parent().unwrap_or(root))
+		.unwrap_or_else(|error| panic!("create parent: {error}"));
+	fs::write(&metadata_path, "{}\n").unwrap_or_else(|error| panic!("write metadata: {error}"));
+
+	// Create a broken symlink that has no file_type when followed.
+	let broken_link = root.join("packages/broken-link");
+	#[cfg(unix)]
+	{
+		use std::os::unix::fs::symlink;
+		symlink("/nonexistent/target", &broken_link)
+			.unwrap_or_else(|error| panic!("create broken symlink: {error}"));
+	}
+
+	let matches = crate::workspace_glob_files_many(root, ["**/metadata.json"])
+		.unwrap_or_else(|error| panic!("workspace glob files many: {error}"));
+	let relative_matches = matches
+		.get("**/metadata.json")
+		.expect("metadata glob result")
+		.iter()
+		.map(|path| path.strip_prefix(root).unwrap_or(path).to_path_buf())
+		.collect::<Vec<_>>();
+
+	assert_eq!(
+		relative_matches,
+		vec![PathBuf::from("packages/app/metadata.json")]
+	);
+}
+
+#[test]
+fn workspace_code_does_not_call_raw_glob_expansion() {
+	let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+	let crates_dir = workspace_root.join("crates");
+	let banned_patterns = [concat!("use glob::", "glob;"), concat!("glob::", "glob(")];
+	let mut offenders = Vec::new();
+	collect_raw_glob_offenders(&crates_dir, &banned_patterns, &mut offenders);
+
+	assert!(
+		offenders.is_empty(),
+		"use monochange_core::workspace_glob_files or workspace_glob_paths instead of raw glob expansion:\n{}",
+		offenders.join("\n")
+	);
+}
+
+fn collect_raw_glob_offenders(path: &Path, banned_patterns: &[&str], offenders: &mut Vec<String>) {
+	let entries =
+		fs::read_dir(path).unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+	for entry in entries {
+		let entry = entry.unwrap_or_else(|error| panic!("read directory entry: {error}"));
+		let path = entry.path();
+		let file_name = path
+			.file_name()
+			.and_then(|name| name.to_str())
+			.unwrap_or_default();
+		if file_name == "target" || file_name.starts_with('.') {
+			continue;
+		}
+		if path.is_dir() {
+			collect_raw_glob_offenders(&path, banned_patterns, offenders);
+			continue;
+		}
+		if path.extension().and_then(|extension| extension.to_str()) != Some("rs") {
+			continue;
+		}
+		let contents = fs::read_to_string(&path)
+			.unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+		for banned_pattern in banned_patterns {
+			if contents.contains(banned_pattern) {
+				offenders.push(path.display().to_string());
+				break;
+			}
+		}
+	}
+}
+
+#[test]
 fn ecosystem_registry_gracefully_handles_panicked_discovery_worker() {
 	let registry = crate::EcosystemRegistry::new().with_adapter(Box::new(PanicDiscoveryAdapter));
 	let result = registry

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -68,6 +68,9 @@ pub mod git;
 pub mod lint;
 
 pub use analysis::*;
+use glob::MatchOptions;
+use glob::Pattern;
+use ignore::WalkBuilder;
 use ignore::gitignore::Gitignore;
 use ignore::gitignore::GitignoreBuilder;
 use semver::Version;
@@ -554,12 +557,210 @@ impl DiscoveryPathFilter {
 	}
 }
 
+/// Return workspace files matching a glob pattern without traversing ignored workspace trees.
+///
+/// Literal paths are resolved directly and may target ignored directories when explicitly named.
+/// Patterns containing glob metacharacters are matched through the shared discovery filter so broad
+/// patterns such as `**/pubspec.yaml` do not scan local toolchains, dependency directories, or
+/// nested repository checkouts.
+pub fn workspace_glob_files(root: &Path, pattern: &str) -> MonochangeResult<Vec<PathBuf>> {
+	workspace_glob_paths(root, pattern, false)
+}
+
+/// Return workspace files for many glob patterns without traversing ignored workspace trees.
+///
+/// Patterns with the same literal search root share one filesystem walk. Use this instead of
+/// calling [`workspace_glob_files`] in a loop when a command needs to expand many config globs.
+pub fn workspace_glob_files_many<'a, I>(
+	root: &Path,
+	patterns: I,
+) -> MonochangeResult<BTreeMap<String, Vec<PathBuf>>>
+where
+	I: IntoIterator<Item = &'a str>,
+{
+	workspace_glob_paths_many(root, patterns, false)
+}
+
+/// Return workspace paths for many glob patterns without traversing ignored workspace trees.
+///
+/// When `include_directories` is `false`, only files are returned. Literal paths are resolved
+/// directly and may target ignored directories when explicitly named.
+pub fn workspace_glob_paths_many<'a, I>(
+	root: &Path,
+	patterns: I,
+	include_directories: bool,
+) -> MonochangeResult<BTreeMap<String, Vec<PathBuf>>>
+where
+	I: IntoIterator<Item = &'a str>,
+{
+	let mut matched_paths_by_pattern = BTreeMap::<String, Vec<PathBuf>>::new();
+	let mut glob_requests_by_search_root = BTreeMap::<PathBuf, Vec<WorkspaceGlobRequest>>::new();
+
+	for pattern in patterns {
+		if matched_paths_by_pattern.contains_key(pattern) {
+			continue;
+		}
+
+		if !workspace_glob_has_magic(pattern) {
+			let resolved_path = resolve_workspace_glob_literal(root, pattern);
+			let matches_kind =
+				resolved_path.is_file() || (include_directories && resolved_path.is_dir());
+			let matched_paths = matches_kind.then_some(resolved_path).into_iter().collect();
+			matched_paths_by_pattern.insert(pattern.to_string(), matched_paths);
+			continue;
+		}
+
+		let pattern_text = root_relative_workspace_glob_pattern(root, pattern);
+		let pattern_matcher = Pattern::new(&pattern_text).map_err(|error| {
+			MonochangeError::Config(format!("invalid glob pattern `{pattern}`: {error}"))
+		})?;
+		let search_root = workspace_glob_search_root(root, &pattern_text);
+		matched_paths_by_pattern.insert(pattern.to_string(), Vec::new());
+		if search_root.exists() {
+			glob_requests_by_search_root
+				.entry(search_root)
+				.or_default()
+				.push(WorkspaceGlobRequest {
+					pattern: pattern.to_string(),
+					matcher: pattern_matcher,
+				});
+		}
+	}
+
+	let match_options = workspace_glob_match_options();
+	for (search_root, requests) in glob_requests_by_search_root {
+		let path_filter = DiscoveryPathFilter::new(root);
+		let mut builder = WalkBuilder::new(&search_root);
+		builder
+			.hidden(false)
+			.ignore(true)
+			.git_ignore(true)
+			.git_exclude(true)
+			.git_global(false)
+			.parents(true)
+			.filter_entry(move |entry| {
+				entry.depth() == 0 || path_filter.should_descend(entry.path())
+			});
+
+		for entry in builder.build() {
+			// patch-coverage:ignore-start -- walk errors and None file_type entries are filesystem edge cases not reliably testable.
+			let entry = entry.map_err(|error| {
+				MonochangeError::Io(format!("failed to walk {}: {error}", search_root.display()))
+			})?;
+			let Some(file_type) = entry.file_type() else {
+				continue;
+			};
+			// patch-coverage:ignore-end
+			if !(file_type.is_file() || include_directories && file_type.is_dir()) {
+				continue;
+			}
+			let relative_path = entry.path().strip_prefix(root).unwrap_or(entry.path());
+			for request in &requests {
+				if request
+					.matcher
+					.matches_path_with(relative_path, match_options)
+					&& let Some(matched_paths) = matched_paths_by_pattern.get_mut(&request.pattern)
+				{
+					matched_paths.push(entry.path().to_path_buf());
+				}
+			}
+		}
+	}
+
+	for matched_paths in matched_paths_by_pattern.values_mut() {
+		matched_paths.sort();
+	}
+
+	Ok(matched_paths_by_pattern)
+}
+
+/// Return workspace paths matching a glob pattern without traversing ignored workspace trees.
+///
+/// When `include_directories` is `false`, only files are returned. Literal paths are resolved
+/// directly and may target ignored directories when explicitly named.
+pub fn workspace_glob_paths(
+	root: &Path,
+	pattern: &str,
+	include_directories: bool,
+) -> MonochangeResult<Vec<PathBuf>> {
+	workspace_glob_paths_many(root, [pattern], include_directories).map(|mut matches| {
+		matches
+			.remove(pattern)
+			.expect("workspace glob result should include requested pattern")
+	})
+}
+
+struct WorkspaceGlobRequest {
+	pattern: String,
+	matcher: Pattern,
+}
+
+fn workspace_glob_match_options() -> MatchOptions {
+	MatchOptions {
+		case_sensitive: true,
+		require_literal_separator: true,
+		require_literal_leading_dot: false,
+	}
+}
+
+#[must_use]
+pub fn workspace_glob_has_magic(path: &str) -> bool {
+	path.chars()
+		.any(|character| matches!(character, '*' | '?' | '['))
+}
+
+fn resolve_workspace_glob_literal(root: &Path, path: &str) -> PathBuf {
+	let path = Path::new(path);
+	if path.is_absolute() {
+		path.to_path_buf()
+	} else {
+		root.join(path)
+	}
+}
+
+fn root_relative_workspace_glob_pattern(root: &Path, path: &str) -> String {
+	let path = Path::new(path);
+	if path.is_absolute()
+		&& let Ok(relative) = path.strip_prefix(root)
+	{
+		return relative.to_string_lossy().into_owned();
+	}
+
+	path.to_string_lossy().into_owned()
+}
+
+fn workspace_glob_search_root(root: &Path, pattern: &str) -> PathBuf {
+	let literal_walk_root = literal_workspace_glob_walk_root(pattern);
+	if literal_walk_root.as_os_str().is_empty() {
+		root.to_path_buf()
+	} else {
+		root.join(literal_walk_root)
+	}
+}
+
+fn literal_workspace_glob_walk_root(pattern: &str) -> PathBuf {
+	let mut root = PathBuf::new();
+	for component in Path::new(pattern).components() {
+		let component_text = component.as_os_str().to_string_lossy();
+		if workspace_glob_has_magic(&component_text) {
+			break;
+		}
+		root.push(component.as_os_str());
+	}
+
+	root
+}
+
 fn ignored_discovery_dir_name(path: &Path) -> bool {
 	path.components().any(|component| {
 		component.as_os_str().to_str().is_some_and(|name| {
 			matches!(
 				name,
-				".git" | "target" | "node_modules" | ".devenv" | ".claude" | "book"
+				".git"
+					| "target" | "node_modules"
+					| ".devenv" | ".claude"
+					| ".fvm" | ".repos"
+					| "book"
 			)
 		})
 	})

--- a/crates/monochange_dart/Cargo.toml
+++ b/crates/monochange_dart/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = { workspace = true }
 description = "Dart and Flutter workspace discovery for monochange"
 
 [dependencies]
-glob = { workspace = true, default-features = true }
 monochange_core = { workspace = true }
 monochange_publish = { workspace = true }
 rayon = { workspace = true }

--- a/crates/monochange_dart/src/lib.rs
+++ b/crates/monochange_dart/src/lib.rs
@@ -41,7 +41,6 @@ use std::path::PathBuf;
 
 pub use analysis::DartSemanticAnalyzer;
 pub use analysis::semantic_analyzer;
-use glob::glob;
 use monochange_core::AdapterDiscovery;
 use monochange_core::DependencyKind;
 use monochange_core::DependencySyncChange;
@@ -577,11 +576,9 @@ fn expand_workspace_patterns(
 	let filter = DiscoveryPathFilter::new(root);
 	let mut manifests = BTreeSet::new();
 	for pattern in patterns {
-		let joined_pattern = root.join(pattern).to_string_lossy().to_string();
-		let matches = glob(&joined_pattern)
+		let matches = monochange_core::workspace_glob_paths(root, pattern, true)
+			.unwrap_or_default()
 			.into_iter()
-			.flat_map(|paths| paths.filter_map(Result::ok))
-			.map(|path| normalize_path(&path))
 			.filter(|path| filter.allows(path))
 			.collect::<Vec<_>>();
 		if matches.is_empty() {

--- a/crates/monochange_deno/Cargo.toml
+++ b/crates/monochange_deno/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = { workspace = true }
 description = "Deno workspace and package discovery for monochange"
 
 [dependencies]
-glob = { workspace = true, default-features = true }
 monochange_core = { workspace = true }
 monochange_ecmascript = { workspace = true }
 monochange_publish = { workspace = true }

--- a/crates/monochange_deno/src/lib.rs
+++ b/crates/monochange_deno/src/lib.rs
@@ -39,7 +39,6 @@ use std::path::PathBuf;
 
 pub use analysis::DenoSemanticAnalyzer;
 pub use analysis::semantic_analyzer;
-use glob::glob;
 use monochange_core::AdapterDiscovery;
 use monochange_core::DependencyKind;
 use monochange_core::DiscoveryPathFilter;
@@ -340,11 +339,9 @@ fn expand_workspace_patterns(
 	let filter = DiscoveryPathFilter::new(root);
 	let mut manifests = BTreeSet::new();
 	for pattern in patterns {
-		let joined_pattern = root.join(pattern).to_string_lossy().to_string();
-		let matches = glob(&joined_pattern)
+		let matches = monochange_core::workspace_glob_paths(root, pattern, true)
+			.unwrap_or_default()
 			.into_iter()
-			.flat_map(|paths| paths.filter_map(Result::ok))
-			.map(|path| normalize_path(&path))
 			.filter(|path| filter.allows(path))
 			.collect::<Vec<_>>();
 		if matches.is_empty() {

--- a/crates/monochange_go/Cargo.toml
+++ b/crates/monochange_go/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = { workspace = true }
 description = "Go ecosystem adapter for monochange — discovers Go modules and resolves versions from git tags"
 
 [dependencies]
-glob = { workspace = true, default-features = true }
 monochange_core = { workspace = true }
 monochange_publish = { workspace = true }
 regex = { workspace = true, default-features = true }

--- a/crates/monochange_npm/Cargo.toml
+++ b/crates/monochange_npm/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = { workspace = true }
 description = "Manage versions and releases for your multiplatform, multilanguage monorepo"
 
 [dependencies]
-glob = { workspace = true, default-features = true }
 monochange_core = { workspace = true }
 monochange_ecmascript = { workspace = true }
 monochange_github = { workspace = true }

--- a/crates/monochange_npm/src/lib.rs
+++ b/crates/monochange_npm/src/lib.rs
@@ -41,7 +41,6 @@ use std::path::PathBuf;
 
 pub use analysis::NpmSemanticAnalyzer;
 pub use analysis::semantic_analyzer;
-use glob::glob;
 use monochange_core::AdapterDiscovery;
 use monochange_core::DependencyKind;
 use monochange_core::DependencySyncChange;
@@ -971,11 +970,9 @@ fn expand_member_patterns(
 	let filter = DiscoveryPathFilter::new(root);
 	let mut manifests = BTreeSet::new();
 	for pattern in patterns {
-		let joined_pattern = root.join(pattern).to_string_lossy().to_string();
-		let matches = glob(&joined_pattern)
+		let matches = monochange_core::workspace_glob_paths(root, pattern, true)
+			.unwrap_or_default()
 			.into_iter()
-			.flat_map(|paths| paths.filter_map(Result::ok))
-			.map(|path| normalize_path(&path))
 			.filter(|path| filter.allows(path))
 			.collect::<Vec<_>>();
 		if matches.is_empty() {

--- a/crates/monochange_python/Cargo.toml
+++ b/crates/monochange_python/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = { workspace = true }
 description = "Python ecosystem adapter for monochange — discovers uv workspaces, Poetry, and setuptools projects"
 
 [dependencies]
-glob = { workspace = true, default-features = true }
 monochange_core = { workspace = true }
 monochange_publish = { workspace = true }
 semver = { workspace = true, default-features = true }

--- a/crates/monochange_python/src/lib.rs
+++ b/crates/monochange_python/src/lib.rs
@@ -31,7 +31,6 @@ use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 
-use glob::glob;
 use monochange_core::AdapterDiscovery;
 use monochange_core::DependencyKind;
 use monochange_core::Ecosystem;
@@ -458,12 +457,8 @@ fn expand_workspace_members(
 	let mut manifests = BTreeSet::new();
 
 	for pattern in patterns {
-		let joined = root.join(pattern).to_string_lossy().to_string();
-		let matches: Vec<PathBuf> = glob(&joined)
-			.into_iter()
-			.flat_map(|paths| paths.filter_map(Result::ok))
-			.map(|path| normalize_path(&path))
-			.collect();
+		let matches =
+			monochange_core::workspace_glob_paths(root, pattern, true).unwrap_or_default();
 
 		if matches.is_empty() {
 			warnings.push(format!(


### PR DESCRIPTION
## Summary

- Add `workspace_glob_files_many` and `workspace_glob_paths_many` batch APIs to `monochange_core` that expand multiple glob patterns in a single workspace walk
- Patterns sharing the same literal search root are grouped and matched in one `ignore::WalkBuilder` traversal, collapsing N walks into one
- Release planning now prewarms a `VersionedFilePathCache` that collects all unique glob patterns from released packages and groups, expands them in one batch before the update loop, and serves cached results per-pattern
- Also fixes the `mc_release_help` benchmark to use the correct `run release` subcommand path and adds `release` to `command_args` for proper invocation

## Performance

| Benchmark | Before | After |
|-----------|--------|-------|
| `prepare_release_skips_ignored_trees` (1 glob, 4000 ignored files) | ~485ms | ~431ms |
| `prepare_release_multi_glob_batch_walk` (20 globs, 4000 ignored files) | ~20×485ms (estimated) | ~469ms |

The multi-glob case is the big win: 20 broad globs now complete in one walk instead of 20, collapsing ~9.7s (estimated) to ~469ms — roughly a 20× improvement for multi-glob configs.

## Validation

- `cargo test -p monochange_core workspace_glob` — 10 passed
- `cargo test -p monochange --lib versioned_files` — 31 passed
- `cargo test -p monochange --lib apply_versioned_file_definition` — 18 passed
- `cargo test -p monochange_cargo -p monochange_dart -p monochange_deno -p monochange_npm -p monochange_python --lib` — all passed
- `cargo test -p monochange_config --lib` — 282 passed
- `cargo clippy --workspace --exclude xtask --all-features -- -D warnings` — clean
- `cargo bench -p monochange --bench cli_commands versioned_file_globs` — both benchmarks show improvement
- `monochange step validate` — passed
- Patch coverage: 100% (227/227 executable changed lines covered)