### PR TITLE
fix(check): pass after successful autofix

### DIFF
--- a/.changeset/check-fix-exit-success.md
+++ b/.changeset/check-fix-exit-success.md
@@ -1,0 +1,8 @@
+---
+monochange: patch
+monochange_config: patch
+---
+
+# exit successfully after fixing all check issues
+
+`monochange check --fix` now re-checks manifests after applying fixes and exits successfully when no errors remain. Changeset heading length diagnostics now refer to the changeset header when the first body line is a heading.

--- a/crates/monochange/src/__tests__/lint_check_reporter_tests.rs
+++ b/crates/monochange/src/__tests__/lint_check_reporter_tests.rs
@@ -92,6 +92,7 @@ fn reporter_helpers_cover_color_and_spinner_paths() {
 	reporter.print_success("done");
 	reporter.print_info("info");
 	reporter.summary(0, 1, 1, false);
+	reporter.summary(1, 0, 1, true);
 	reporter.start_spinner("spinning".to_string());
 	thread::sleep(SPINNER_DELAY + SPINNER_TICK + Duration::from_millis(50));
 	reporter.stop_spinner();
@@ -120,6 +121,7 @@ fn reporter_summary_renders_counts() {
 	// the fact it doesn't panic is the real test).
 	reporter.summary(2, 3, 1, false);
 	reporter.summary(1, 0, 0, true);
+	reporter.summary(1, 0, 1, true);
 }
 
 #[test]

--- a/crates/monochange/src/__tests__/lint_tests.rs
+++ b/crates/monochange/src/__tests__/lint_tests.rs
@@ -275,6 +275,15 @@ fn run_lint_step_reports_successful_check_output() {
 }
 
 #[test]
+fn run_lint_step_rechecks_after_fixing_errors() {
+	let tempdir = readonly_fix_workspace();
+	let (output, has_errors) = run_lint_step(tempdir.path(), true)
+		.unwrap_or_else(|error| panic!("expected fixable lint step to succeed: {error}"));
+	assert!(!has_errors);
+	assert!(output.contains("Fixed all auto-fixable issues."));
+}
+
+#[test]
 fn run_lint_step_supports_fix_write_failures() {
 	let tempdir = readonly_fix_workspace();
 	let cargo_toml = tempdir.path().join("crates/example/Cargo.toml");

--- a/crates/monochange/src/lint.rs
+++ b/crates/monochange/src/lint.rs
@@ -149,7 +149,7 @@ pub(crate) fn run_check_command(
 		None
 	};
 
-	let report = if let Some(ref r) = reporter {
+	let mut report = if let Some(ref r) = reporter {
 		linter.lint_workspace(root, &configuration, r)
 	} else {
 		linter.lint_workspace(
@@ -160,10 +160,12 @@ pub(crate) fn run_check_command(
 	};
 
 	let mut fixed_files: Vec<(PathBuf, String)> = Vec::new();
+	let mut fixed_file_count = 0usize;
 	if fix {
 		let fixes = linter.apply_fixes(&report);
+		fixed_file_count = fixes.len();
 		if let Some(ref r) = reporter {
-			r.fix_started(fixes.len());
+			r.fix_started(fixed_file_count);
 		}
 		for (file_path, fixed_content) in fixes {
 			std::fs::write(&file_path, fixed_content).map_err(|error| {
@@ -187,16 +189,27 @@ pub(crate) fn run_check_command(
 		if let Some(ref r) = reporter {
 			r.fix_finished(fixed_files.len());
 		}
+
+		if fixed_file_count > 0 {
+			// NOTE: optimize later by re-linting only fixed files or adding a safe
+			// fast-path for “all original errors were fixed.”
+			report = linter.lint_workspace(
+				root,
+				&configuration,
+				&monochange_core::lint::NoopLintProgressReporter,
+			);
+		}
 	}
 
 	let lint_has_errors = report.has_errors();
 	let validation_has_errors = !validation_errors.is_empty();
+	let fixed_any_files = fixed_file_count > 0;
 	if let Some(r) = reporter {
 		r.summary(
 			report.error_count,
 			report.warning_count,
 			report.autofixable().len(),
-			fix,
+			fixed_any_files,
 		);
 		r.finish();
 	}
@@ -210,7 +223,7 @@ pub(crate) fn run_check_command(
 				.unwrap_or_else(|error| panic!("serializing lint reports should succeed: {error}")))
 		}
 		OutputFormat::Text | OutputFormat::Markdown => {
-			output.push_str(&format_check_report(&report, fix, verbose));
+			output.push_str(&format_check_report(&report, fixed_any_files, verbose));
 			if validation_has_errors || lint_has_errors {
 				Err(MonochangeError::Config(format!("check failed:\n{output}")))
 			} else {
@@ -225,15 +238,16 @@ pub(crate) fn run_check_command(
 pub(crate) fn run_lint_step(root: &Path, fix: bool) -> MonochangeResult<(String, bool)> {
 	let configuration = load_workspace_configuration(root)?;
 	let linter = build_linter(&configuration, LintSelection::all());
-	let report = linter.lint_workspace(
+	let mut report = linter.lint_workspace(
 		root,
 		&configuration,
 		&monochange_core::lint::NoopLintProgressReporter,
 	);
-	let has_errors = report.has_errors();
+	let mut fixed_file_count = 0usize;
 
 	if fix {
 		let fixes = linter.apply_fixes(&report);
+		fixed_file_count = fixes.len();
 		for (file_path, fixed_content) in fixes {
 			std::fs::write(&file_path, fixed_content).map_err(|error| {
 				MonochangeError::Io(format!(
@@ -243,9 +257,23 @@ pub(crate) fn run_lint_step(root: &Path, fix: bool) -> MonochangeResult<(String,
 				))
 			})?;
 		}
+
+		if fixed_file_count > 0 {
+			// NOTE: keep this in sync with `run_check_command`'s post-fix
+			// verification path.
+			report = linter.lint_workspace(
+				root,
+				&configuration,
+				&monochange_core::lint::NoopLintProgressReporter,
+			);
+		}
 	}
 
-	Ok((format_check_report(&report, fix, false), has_errors))
+	let has_errors = report.has_errors();
+	Ok((
+		format_check_report(&report, fixed_file_count > 0, false),
+		has_errors,
+	))
 }
 
 #[allow(clippy::unnecessary_wraps)]
@@ -495,7 +523,11 @@ impl LintRuleRunner for {struct_name} {{
 
 fn format_check_report(report: &LintReport, fixed: bool, verbose: bool) -> String {
 	if report.results.is_empty() && report.warnings.is_empty() {
-		return "lint: no issues found\n".to_string();
+		let mut output = "lint: no issues found\n".to_string();
+		if fixed {
+			output.push_str("Fixed all auto-fixable issues.\n");
+		}
+		return output;
 	}
 
 	let mut output = String::new();
@@ -556,15 +588,20 @@ fn format_check_report(report: &LintReport, fixed: bool, verbose: bool) -> Strin
 		output.push('\n');
 	}
 
-	if fixed {
+	let autofixable_count = report.autofixable().len();
+	if fixed && autofixable_count == 0 {
 		output.push_str("Fixed all auto-fixable issues.\n");
-	} else if report.autofixable().is_empty() {
+	} else if fixed {
+		let _ = writeln!(
+			output,
+			"Applied fixes; {autofixable_count} issue(s) remain auto-fixable. Run with --fix again to apply."
+		);
+	} else if autofixable_count == 0 {
 		output.push_str("No auto-fixable issues found.\n");
 	} else {
 		let _ = writeln!(
 			output,
-			"{} issue(s) can be auto-fixed. Run with --fix to apply.",
-			report.autofixable().len()
+			"{autofixable_count} issue(s) can be auto-fixed. Run with --fix to apply."
 		);
 	}
 

--- a/crates/monochange/src/lint_check_reporter.rs
+++ b/crates/monochange/src/lint_check_reporter.rs
@@ -285,19 +285,34 @@ impl LintProgressReporter for HumanLintProgressReporter {
 			self.print_line(&summary_line);
 		}
 
-		if fixable > 0 && !fixed {
-			let hint = format!(
-				"{info_icon} {fixable} issue{} can be auto-fixed. Run `{cmd}` to apply.",
-				if fixable == 1 { "" } else { "s" },
-				cmd = if self.color {
-					paint(
-						"monochange check --fix",
-						Style::new().fg_color(Some(anstyle::Color::Ansi(AnsiColor::Cyan))),
-					)
-				} else {
-					"monochange check --fix".to_string()
-				},
-			);
+		if fixable > 0 {
+			let hint = if fixed {
+				format!(
+					"{info_icon} {fixable} issue{} remain auto-fixable. Run `{cmd}` again to apply.",
+					if fixable == 1 { "" } else { "s" },
+					cmd = if self.color {
+						paint(
+							"monochange check --fix",
+							Style::new().fg_color(Some(anstyle::Color::Ansi(AnsiColor::Cyan))),
+						)
+					} else {
+						"monochange check --fix".to_string()
+					},
+				)
+			} else {
+				format!(
+					"{info_icon} {fixable} issue{} can be auto-fixed. Run `{cmd}` to apply.",
+					if fixable == 1 { "" } else { "s" },
+					cmd = if self.color {
+						paint(
+							"monochange check --fix",
+							Style::new().fg_color(Some(anstyle::Color::Ansi(AnsiColor::Cyan))),
+						)
+					} else {
+						"monochange check --fix".to_string()
+					},
+				)
+			};
 			self.print_line(&hint);
 		}
 	}

--- a/crates/monochange_config/src/__tests__/lib_tests.rs
+++ b/crates/monochange_config/src/__tests__/lib_tests.rs
@@ -2556,8 +2556,14 @@ fn lint_markdown_changeset_covers_summary_type_and_scope_failures() {
 	settings.summary.max_length = Some(5);
 	expect_config_error(
 		crate::lint_markdown_changeset("## Summary too long", &changes, &settings, path),
+		"header must be at most 5 characters",
+	);
+	settings.summary.required = false;
+	expect_config_error(
+		crate::lint_markdown_changeset("summary too long", &changes, &settings, path),
 		"summary must be at most 5 characters",
 	);
+	settings.summary.required = true;
 	settings.summary.max_length = None;
 	settings.summary.forbid_trailing_period = true;
 	expect_config_error(

--- a/crates/monochange_config/src/__tests__/lints_tests.rs
+++ b/crates/monochange_config/src/__tests__/lints_tests.rs
@@ -332,7 +332,7 @@ fn summary_rule_reports_length_period_and_prefix_issues_together() {
 	assert!(
 		results
 			.iter()
-			.any(|result| { result.message == "changeset summary must be at most 5 characters" })
+			.any(|result| { result.message == "changeset header must be at most 5 characters" })
 	);
 	assert!(
 		results
@@ -357,7 +357,7 @@ fn summary_rule_enforces_default_max_heading_length_of_60() {
 	assert!(
 		results
 			.iter()
-			.any(|result| { result.message == "changeset summary must be at most 60 characters" }),
+			.any(|result| { result.message == "changeset header must be at most 60 characters" }),
 		"expected default max_heading_length of 60 for headings, got: {results:?}"
 	);
 }
@@ -384,13 +384,23 @@ fn summary_rule_enforces_explicit_max_length() {
 	let heading = format!("# {}", "a".repeat(61));
 	let mut options = BTreeMap::new();
 	options.insert("max_length".to_string(), json!(60));
-	let results = run_rule(&rule, &lint_file(&heading, Vec::new()), &detailed(options));
+	let config = detailed(options);
+	let results = run_rule(&rule, &lint_file(&heading, Vec::new()), &config);
 
 	assert!(
 		results
 			.iter()
-			.any(|result| { result.message == "changeset summary must be at most 60 characters" }),
+			.any(|result| { result.message == "changeset header must be at most 60 characters" }),
 		"explicit max_length should be enforced, got: {results:?}"
+	);
+
+	let paragraph = "a".repeat(61);
+	let paragraph_results = run_rule(&rule, &lint_file(&paragraph, Vec::new()), &config);
+	assert!(
+		paragraph_results
+			.iter()
+			.any(|result| { result.message == "changeset summary must be at most 60 characters" }),
+		"explicit max_length should be enforced for plain summaries, got: {paragraph_results:?}"
 	);
 }
 
@@ -475,7 +485,7 @@ fn summary_rule_reports_heading_level_and_length_issues_together() {
 	assert!(results.iter().any(|result| {
 		result
 			.message
-			.contains("changeset summary must be at most 5 characters")
+			.contains("changeset header must be at most 5 characters")
 	}));
 }
 

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -3221,7 +3221,8 @@ fn lint_markdown_summary(
 			format!("changeset summary must be at least {min_length} characters"),
 		));
 	}
-	let effective_max_length = if heading_level.is_some() {
+	let summary_is_heading = heading_level.is_some();
+	let effective_max_length = if summary_is_heading {
 		summary_settings
 			.max_length
 			.or(summary_settings.max_heading_length)
@@ -3231,9 +3232,14 @@ fn lint_markdown_summary(
 	if let Some(max) = effective_max_length
 		&& summary.chars().count() > max
 	{
+		let subject = if summary_is_heading {
+			"changeset header"
+		} else {
+			"changeset summary"
+		};
 		return Err(changeset_lint_error(
 			changes_path,
-			format!("changeset summary must be at most {max} characters"),
+			format!("{subject} must be at most {max} characters"),
 		));
 	}
 	if summary_settings.forbid_trailing_period && summary.ends_with('.') {

--- a/crates/monochange_config/src/lints.rs
+++ b/crates/monochange_config/src/lints.rs
@@ -325,7 +325,8 @@ impl LintRuleRunner for SummaryRule {
 			));
 		}
 
-		let effective_max_length = if heading.is_some() {
+		let summary_is_heading = heading.is_some();
+		let effective_max_length = if summary_is_heading {
 			max_length.or(max_heading_length)
 		} else {
 			max_length
@@ -333,10 +334,15 @@ impl LintRuleRunner for SummaryRule {
 		if let Some(max) = effective_max_length
 			&& summary.chars().count() > max
 		{
+			let subject = if summary_is_heading {
+				"changeset header"
+			} else {
+				"changeset summary"
+			};
 			results.push(LintResult::new(
 				self.rule.id.clone(),
 				LintLocation::new(ctx.manifest_path, 1, 1),
-				format!("changeset summary must be at most {max} characters"),
+				format!("{subject} must be at most {max} characters"),
 				severity,
 			));
 		}

--- a/crates/monochange_integration_tests/tests/snapshots/check_lint_output__check_fix_preserves_package_json_when_multiple_full_file_fixes_exist.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/check_lint_output__check_fix_preserves_package_json_when_multiple_full_file_fixes_exist.snap
@@ -4,11 +4,9 @@ expression: "normalize_workspace_paths(fixture.path(), output)"
 ---
 config error: check failed:
 workspace validation passed for [workspace]
-lint: 6 errors, 1 warnings
+lint: 5 errors, 1 warnings
 
 [workspace]/packages/app/package.json:
-  ✗ **npm/workspace-protocol** at 8:10 [fixable]
-     internal dependency `shared` should use the workspace: protocol (found `^0.0.0`)
   ⚠ **npm/sorted-dependencies** at 6:6 [fixable]
      dependencies in `dependencies` are not sorted alphabetically
   ✗ **npm/required-package-fields** at 1:1
@@ -24,4 +22,4 @@ lint: 6 errors, 1 warnings
   ✗ **npm/required-package-fields** at 1:1
      missing required package.json field `license`
 
-Fixed all auto-fixable issues.
+Applied fixes; 1 issue(s) remain auto-fixable. Run with --fix again to apply.

--- a/crates/monochange_integration_tests/tests/snapshots/check_lint_output__check_sorted_fix_preserves_package_json_field_order.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/check_lint_output__check_sorted_fix_preserves_package_json_field_order.snap
@@ -4,11 +4,9 @@ expression: "normalize_workspace_paths(fixture.path(), output)"
 ---
 config error: check failed:
 workspace validation passed for [workspace]
-lint: 5 errors, 1 warnings
+lint: 5 errors, 0 warnings
 
 [workspace]/packages/app/package.json:
-  ⚠ **npm/sorted-dependencies** at 6:6 [fixable]
-     dependencies in `dependencies` are not sorted alphabetically
   ✗ **npm/required-package-fields** at 1:1
      missing required package.json field `repository`
   ✗ **npm/required-package-fields** at 1:1

--- a/fixtures/tests/lint-check/read-only-fix/workspace/monochange.toml
+++ b/fixtures/tests/lint-check/read-only-fix/workspace/monochange.toml
@@ -7,7 +7,7 @@ changelog = false
 "cargo/internal-dependency-workspace" = "off"
 "cargo/required-package-fields" = "off"
 "cargo/sorted-dependencies" = "off"
-"cargo/unlisted-package-private" = { level = "warning", fix = true }
+"cargo/unlisted-package-private" = { level = "error", fix = true }
 
 [ecosystems.cargo]
 enabled = true


### PR DESCRIPTION
## Summary
- Re-run lint after applying check autofixes so exit status reflects remaining issues
- Report post-fix lint output, including remaining autofixable issues when another pass is needed
- Clarify heading-length diagnostics to say changeset header rather than changeset summary
- Add regression coverage and a patch changeset

## Verification
- devenv shell cargo test -p monochange run_check_command_applies_fixes --lib
- devenv shell cargo test -p monochange run_lint_step_rechecks_after_fixing_errors --lib
- devenv shell cargo test -p monochange_integration_tests --test check_lint_output
- devenv shell cargo test -p monochange_config summary_rule --lib
- devenv shell cargo test -p monochange_config lint_markdown_changeset_covers_summary_type_and_scope_failures --lib
- devenv shell coverage:all
- devenv shell coverage:patch (75/75, 100.00%)
- devenv shell monochange step validate