### PR TITLE
fix(publish): report Dart trusted publishing auth errors

### DIFF
--- a/.changeset/dart-publish-auth-errors.md
+++ b/.changeset/dart-publish-auth-errors.md
@@ -1,0 +1,19 @@
+---
+monochange_publish: patch
+---
+
+# report Dart trusted publishing authentication failures
+
+Built-in package publishing now runs registry publish commands with stdin closed so commands cannot wait indefinitely for interactive authentication prompts in CI. This helps `dart pub publish --force` fail fast when pub.dev credentials or trusted-publishing context are missing instead of waiting until the workflow timeout.
+
+When pub.dev publishing reports an authentication or credential error, monochange now appends guidance for the common trusted-publishing setup issues:
+
+```text
+pub.dev publishing could not authenticate non-interactively. If this package uses trusted publishing, verify the GitHub workflow has `id-token: write`, runs with the GitHub Actions environment configured on pub.dev, matches the package repository and tag/event policy, and runs `dart-lang/setup-dart` before `dart pub publish`.
+```
+
+Token fallback workflows are also pointed to the explicit pub token setup command:
+
+```bash
+dart pub token add https://pub.dev --env-var PUB_TOKEN
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2554,6 +2554,7 @@ dependencies = [
 name = "monochange_publish"
 version = "0.8.3"
 dependencies = [
+ "insta",
  "monochange_core",
  "reqwest",
  "rustls",

--- a/crates/monochange_publish/Cargo.toml
+++ b/crates/monochange_publish/Cargo.toml
@@ -23,5 +23,8 @@ tokio = { workspace = true, features = ["rt-multi-thread"], default-features = t
 tracing = { workspace = true, default-features = true }
 urlencoding = { workspace = true, default-features = true }
 
+[dev-dependencies]
+insta = { workspace = true, default-features = true }
+
 [lints]
 workspace = true

--- a/crates/monochange_publish/src/__tests__/lib_tests.rs
+++ b/crates/monochange_publish/src/__tests__/lib_tests.rs
@@ -439,6 +439,25 @@ fn render_publish_command_error_adds_npm_otp_recovery_guidance() {
 }
 
 #[test]
+fn render_publish_command_error_adds_pub_dev_trusted_publishing_guidance() {
+	let mut request = sample_publish_request_for_registry(RegistryKind::PubDev);
+	request.ecosystem = Ecosystem::Dart;
+	let output = CommandOutput {
+		success: false,
+		stdout: "Pub needs your authorization to upload packages on your behalf.".to_string(),
+		stderr: "No credentials were available for pub.dev authentication.".to_string(),
+	};
+
+	let message = render_publish_command_error(&output, &request, PackagePublishRunMode::Release);
+
+	assert!(message.contains("No credentials were available"));
+	assert!(message.contains("pub.dev publishing could not authenticate non-interactively"));
+	assert!(message.contains("id-token: write"));
+	assert!(message.contains("dart-lang/setup-dart"));
+	assert!(message.contains("dart pub token add https://pub.dev --env-var PUB_TOKEN"));
+}
+
+#[test]
 fn publish_command_sets_stream_output_environment_when_metadata_is_enabled() {
 	let mut request = sample_publish_request_for_registry(RegistryKind::Npm);
 	request.package_metadata.insert(
@@ -486,6 +505,23 @@ fn process_command_executor_streams_when_environment_is_enabled() {
 		.run(&command)
 		.expect_err("invalid streaming command should fail");
 	assert!(error.to_string().contains("failed to run"));
+}
+
+#[test]
+fn process_command_executor_closes_stdin_for_captured_commands() {
+	let root = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let command = CommandSpec {
+		program: "sh".to_string(),
+		args: vec!["-c".to_string(), "read ignored".to_string()],
+		cwd: root.path().to_path_buf(),
+		env: BTreeMap::new(),
+	};
+	let mut executor = ProcessCommandExecutor::new(false);
+
+	let output = executor
+		.run(&command)
+		.unwrap_or_else(|error| panic!("run command: {error}"));
+	assert!(!output.success);
 }
 
 #[test]

--- a/crates/monochange_publish/src/__tests__/lib_tests.rs
+++ b/crates/monochange_publish/src/__tests__/lib_tests.rs
@@ -450,11 +450,7 @@ fn render_publish_command_error_adds_pub_dev_trusted_publishing_guidance() {
 
 	let message = render_publish_command_error(&output, &request, PackagePublishRunMode::Release);
 
-	assert!(message.contains("No credentials were available"));
-	assert!(message.contains("pub.dev publishing could not authenticate non-interactively"));
-	assert!(message.contains("id-token: write"));
-	assert!(message.contains("dart-lang/setup-dart"));
-	assert!(message.contains("dart pub token add https://pub.dev --env-var PUB_TOKEN"));
+	insta::assert_snapshot!("pub_dev_trusted_publishing_auth_error", message);
 }
 
 #[test]

--- a/crates/monochange_publish/src/__tests__/snapshots/monochange_publish__tests__pub_dev_trusted_publishing_auth_error.snap
+++ b/crates/monochange_publish/src/__tests__/snapshots/monochange_publish__tests__pub_dev_trusted_publishing_auth_error.snap
@@ -1,0 +1,8 @@
+---
+source: crates/monochange_publish/src/__tests__/lib_tests.rs
+assertion_line: 453
+expression: message
+---
+No credentials were available for pub.dev authentication.
+
+pub.dev publishing could not authenticate non-interactively. If this package uses trusted publishing, verify the GitHub workflow has `id-token: write`, runs with the GitHub Actions environment configured on pub.dev, matches the package repository and tag/event policy, and runs `dart-lang/setup-dart` before `dart pub publish`. If using a token fallback, add it before publishing with `dart pub token add https://pub.dev --env-var PUB_TOKEN`.

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -4,6 +4,7 @@ use std::env;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
+use std::process::Stdio;
 
 use monochange_core::DependencyEdge;
 use monochange_core::DependencyKind;
@@ -1393,7 +1394,8 @@ fn run_captured_process_command(spec: &CommandSpec) -> MonochangeResult<CommandO
 	command
 		.args(&spec.args)
 		.current_dir(&spec.cwd)
-		.envs(&spec.env);
+		.envs(&spec.env)
+		.stdin(Stdio::null());
 	let output = command.output().map_err(|error| {
 		MonochangeError::Io(format!(
 			"failed to run `{}` in {}: {error}",
@@ -1410,13 +1412,13 @@ fn run_captured_process_command(spec: &CommandSpec) -> MonochangeResult<CommandO
 
 fn run_streaming_process_command(spec: &CommandSpec) -> MonochangeResult<CommandOutput> {
 	use std::process::Command;
-	use std::process::Stdio;
 
 	let mut command = Command::new(&spec.program);
 	command
 		.args(&spec.args)
 		.current_dir(&spec.cwd)
 		.envs(&spec.env)
+		.stdin(Stdio::null())
 		.stdout(Stdio::piped())
 		.stderr(Stdio::piped());
 	let mut child = command
@@ -1521,11 +1523,17 @@ fn render_publish_command_error(
 	mode: PackagePublishRunMode,
 ) -> String {
 	let message = render_command_error(output);
-	if !is_npm_otp_error(output, request) {
-		return message;
+	if is_npm_otp_error(output, request) {
+		return format!("{message}\n\n{}", npm_otp_recovery_message(mode));
+	}
+	if is_pub_dev_auth_error(output, request) {
+		return format!(
+			"{message}\n\n{}",
+			pub_dev_trusted_publishing_recovery_message()
+		);
 	}
 
-	format!("{message}\n\n{}", npm_otp_recovery_message(mode))
+	message
 }
 
 fn is_npm_otp_error(output: &CommandOutput, request: &PublishRequest) -> bool {
@@ -1545,6 +1553,32 @@ fn npm_otp_recovery_message(mode: PackagePublishRunMode) -> &'static str {
 			"npm requires a publish-time one-time password. Get the current OTP code from your npm authenticator, then rerun the publish command with `NPM_CONFIG_OTP=<CODE>` set in the environment."
 		}
 	}
+}
+
+fn is_pub_dev_auth_error(output: &CommandOutput, request: &PublishRequest) -> bool {
+	if request.registry != RegistryKind::PubDev {
+		return false;
+	}
+	let combined = format!("{}\n{}", output.stdout, output.stderr).to_ascii_lowercase();
+	[
+		"authentication",
+		"authorization",
+		"authorize",
+		"credential",
+		"credentials",
+		"log in",
+		"login",
+		"oauth",
+		"oidc",
+		"pub token",
+		"token add",
+	]
+	.iter()
+	.any(|needle| combined.contains(needle))
+}
+
+fn pub_dev_trusted_publishing_recovery_message() -> &'static str {
+	"pub.dev publishing could not authenticate non-interactively. If this package uses trusted publishing, verify the GitHub workflow has `id-token: write`, runs with the GitHub Actions environment configured on pub.dev, matches the package repository and tag/event policy, and runs `dart-lang/setup-dart` before `dart pub publish`. If using a token fallback, add it before publishing with `dart pub token add https://pub.dev --env-var PUB_TOKEN`."
 }
 
 pub fn build_publish_command(


### PR DESCRIPTION
## Summary

- Run built-in publish subprocesses with stdin closed so registry CLIs cannot wait indefinitely for interactive authentication prompts.
- Add pub.dev/Dart authentication guidance when  reports credential, token, OAuth, or OIDC errors.
- Cover the new pub.dev guidance and non-interactive stdin behavior with unit tests.

## Validation

- devenv shell cargo test -p monochange_publish
- devenv shell lint:all
- devenv shell monochange step validate
- devenv shell coverage:patch
- git push hook lint:test