### PR TITLE
ci: fix workflow security checks and Node 20 warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,7 +299,7 @@ jobs:
 
       - name: upload coverage to codecov
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           use_oidc: true
           files: ./target/coverage/lcov.info
@@ -339,7 +339,7 @@ jobs:
           path: target/coverage/flags
 
       - name: upload crate coverage flag to codecov
-        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           use_oidc: true
           files: ./target/coverage/flags/${{ matrix.flag }}.lcov
@@ -443,7 +443,7 @@ jobs:
 
       - name: comment benchmark results on PR
         if: always() && steps.bench.outcome == 'success'
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: binary-benchmark
           message: ${{ steps.bench.outputs.results }}
@@ -509,7 +509,7 @@ jobs:
 
       - name: comment binary size on PR
         if: always() && steps.size.outcome == 'success'
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: binary-size
           message: ${{ steps.size.outputs.results }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

- pin Codecov v7.0.0 to its underlying commit instead of its annotated tag object
- upgrade `marocchino/sticky-pull-request-comment` from v2.9.4 to v3.0.5, which uses Node 24
- update `crossbeam-epoch` from 0.9.18 to 0.9.20 to resolve RUSTSEC-2026-0204

## Why

The main CI run failed in two independent checks:

1. zizmor's `impostor-commit` audit could not inspect the Codecov pin because `e53489f...` is the annotated `v7.0.0` tag object, not the commit it points to. The GitHub compare API returned 404, so zizmor aborted without completing the audit.
2. `cargo deny` rejected `crossbeam-epoch` 0.9.18 after RUSTSEC-2026-0204 was published.

The Node 20 deprecation warning came from sticky-pull-request-comment v2.9.4. v3.0.5 declares `runs.using: node24`, so no insecure runtime override is needed.

## Validation

- `devenv shell fix:all`
- `devenv shell lint:workflows`
- `cargo-deny check`
- pre-push `lint:push`
- `monochange step affected-packages --verify --changed-paths .github/workflows/ci.yml --changed-paths Cargo.lock`

## Changeset

Not required: changeset verification reports that no configured package is affected.

## Risk and rollout

Low risk. The action input contract used here is unchanged in sticky-pull-request-comment v3, and both third-party actions remain pinned to immutable commit SHAs.
