### PR TITLE
chore(cli)!: remove mc npm bin alias and remaining mc references

### DIFF
--- a/.changeset/remove-mc-npm-alias.md
+++ b/.changeset/remove-mc-npm-alias.md
@@ -1,0 +1,31 @@
+---
+"@monochange/cli": major
+monochange: patch
+monochange_schema: patch
+---
+
+# Remove the `mc` npm bin alias
+
+> **Breaking change** — the `@monochange/cli` package no longer installs an `mc` executable.
+>
+> Invoke `monochange` directly, or add your own shell alias if you want the short name locally.
+
+The Rust binary already shipped only `monochange`; this removes the leftover npm `mc` bin entry so the published package and the migration guide agree.
+
+```nu
+# before
+mc check
+mc versions --format json
+
+# after
+monochange check
+monochange versions --format json
+```
+
+Add a local alias if you still want the short name:
+
+```nu
+alias mc = monochange
+```
+
+Update any scripts, CI workflows, or docs that call `mc` to use `monochange` instead.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,14 +412,14 @@ jobs:
           free-runner-space: "true"
 
       - name: build PR binary
-        run: cargo build --profile dist --bin monochange && cp target/dist/monochange /tmp/mc-pr
+        run: cargo build --profile dist --bin monochange && cp target/dist/monochange /tmp/monochange-pr
         shell: devenv shell -- bash -e {0}
 
       - name: build main binary
         run: |
           git stash --include-untracked
           git checkout origin/main
-          cargo build --profile dist --bin monochange && cp target/dist/monochange /tmp/mc-main
+          cargo build --profile dist --bin monochange && cp target/dist/monochange /tmp/monochange-main
           git checkout -
           git stash pop || true
         shell: devenv shell -- bash -e {0}
@@ -428,8 +428,8 @@ jobs:
         id: bench
         run: |
           pnpm node scripts/benchmark-cli.ts run \
-            --main-bin /tmp/mc-main \
-            --pr-bin /tmp/mc-pr \
+            --main-bin /tmp/monochange-main \
+            --pr-bin /tmp/monochange-pr \
             --output /tmp/benchmark-comment.md \
             --violations-output /tmp/benchmark-violations.txt
 
@@ -480,14 +480,14 @@ jobs:
           free-runner-space: "true"
 
       - name: build PR binary
-        run: cargo build --profile dist --bin monochange && cp target/dist/monochange /tmp/mc-pr
+        run: cargo build --profile dist --bin monochange && cp target/dist/monochange /tmp/monochange-pr
         shell: devenv shell -- bash -e {0}
 
       - name: build main binary
         run: |
           git stash --include-untracked
           git checkout origin/main
-          cargo build --profile dist --bin monochange && cp target/dist/monochange /tmp/mc-main
+          cargo build --profile dist --bin monochange && cp target/dist/monochange /tmp/monochange-main
           git checkout -
           git stash pop || true
         shell: devenv shell -- bash -e {0}
@@ -496,8 +496,8 @@ jobs:
         id: size
         run: |
           pnpm node scripts/binary-size.ts compare \
-            --main-bin /tmp/mc-main \
-            --pr-bin /tmp/mc-pr \
+            --main-bin /tmp/monochange-main \
+            --pr-bin /tmp/monochange-pr \
             --output /tmp/size-comment.md
 
           {

--- a/crates/monochange/benches/cli_commands.rs
+++ b/crates/monochange/benches/cli_commands.rs
@@ -952,7 +952,7 @@ fn bench_cli_startup_help(c: &mut Criterion) {
 		group.bench_with_input(BenchmarkId::from_parameter(label), &args, |b, args| {
 			b.iter(|| {
 				block_on_bench(monochange::run_with_args_in_dir(
-					"mc",
+					"monochange",
 					args.clone(),
 					tempdir.path(),
 				))

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -15582,9 +15582,9 @@ versioned_files = [
 async fn snapshot_command_outputs_full_cli_surface() {
 	let fixture_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/mixed");
 	let output = crate::run_with_args_in_dir(
-		"mc",
+		"monochange",
 		[
-			OsString::from("mc"),
+			OsString::from("monochange"),
 			OsString::from("snapshot"),
 			OsString::from("--view"),
 			OsString::from("light"),
@@ -15596,7 +15596,7 @@ async fn snapshot_command_outputs_full_cli_surface() {
 	let value: serde_json::Value = serde_json::from_str(&output).unwrap();
 
 	assert_eq!(value["kind"], "cli-surface");
-	assert_eq!(value["tool"]["name"], "mc");
+	assert_eq!(value["tool"]["name"], "monochange");
 	let step_command = value["commands"]
 		.as_array()
 		.unwrap()
@@ -15616,9 +15616,9 @@ async fn snapshot_command_outputs_full_cli_surface() {
 async fn global_snapshot_flag_outputs_subcommand_surface() {
 	let fixture_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/mixed");
 	let output = crate::run_with_args_in_dir(
-		"mc",
+		"monochange",
 		[
-			OsString::from("mc"),
+			OsString::from("monochange"),
 			OsString::from("step"),
 			OsString::from("discover"),
 			OsString::from("--snapshot"),
@@ -15675,7 +15675,7 @@ fn change_classify_reports_cli_snapshot_diffs() {
 	let output = run_cli(
 		tempdir.path(),
 		[
-			OsString::from("mc"),
+			OsString::from("monochange"),
 			OsString::from("change"),
 			OsString::from("classify"),
 			OsString::from("--cli-snapshot-before"),
@@ -15694,16 +15694,16 @@ fn change_classify_reports_cli_snapshot_diffs() {
 
 #[test]
 fn snapshot_request_parsing_covers_root_subtree_and_missing_cases() {
-	let empty = vec![OsString::from("mc")];
+	let empty = vec![OsString::from("monochange")];
 	assert!(parse_snapshot_request(&empty).is_none());
 
-	let root = vec![OsString::from("mc"), OsString::from("--snapshot")];
+	let root = vec![OsString::from("monochange"), OsString::from("--snapshot")];
 	let request = parse_snapshot_request(&root).unwrap_or_else(|| panic!("root request"));
 	assert!(request.path.is_empty());
 	assert_eq!(request.view, monochange_snapshot::SnapshotView::Full);
 
 	let subtree = vec![
-		OsString::from("mc"),
+		OsString::from("monochange"),
 		OsString::from("step"),
 		OsString::from("discover"),
 		OsString::from("--snapshot"),
@@ -15712,7 +15712,7 @@ fn snapshot_request_parsing_covers_root_subtree_and_missing_cases() {
 	assert_eq!(request.path, vec!["step", "discover"]);
 
 	let nested_subtree = vec![
-		OsString::from("mc"),
+		OsString::from("monochange"),
 		OsString::from("migrate"),
 		OsString::from("audit"),
 		OsString::from("--snapshot"),
@@ -15737,7 +15737,7 @@ fn snapshot_request_parsing_covers_root_subtree_and_missing_cases() {
 
 #[test]
 fn snapshot_rendering_reports_missing_subtrees() {
-	let command = Command::new("mc").subcommand(Command::new("known"));
+	let command = Command::new("monochange").subcommand(Command::new("known"));
 	let request = SnapshotRequest {
 		path: vec!["missing".to_string()],
 		view: monochange_snapshot::SnapshotView::Full,
@@ -15753,9 +15753,9 @@ fn snapshot_rendering_reports_missing_subtrees() {
 
 #[test]
 fn command_path_from_matches_collects_nested_subcommands() {
-	let matches = Command::new("mc")
+	let matches = Command::new("monochange")
 		.subcommand(Command::new("step").subcommand(Command::new("discover")))
-		.try_get_matches_from(["mc", "step", "discover"])
+		.try_get_matches_from(["monochange", "step", "discover"])
 		.unwrap_or_else(|error| panic!("matches: {error}"));
 
 	assert_eq!(
@@ -15767,7 +15767,7 @@ fn command_path_from_matches_collects_nested_subcommands() {
 #[test]
 fn cli_snapshot_classification_reports_parse_and_missing_value_errors() {
 	let args = vec![
-		OsString::from("mc"),
+		OsString::from("monochange"),
 		OsString::from("change"),
 		OsString::from("classify"),
 		OsString::from("--cli-snapshot-before"),
@@ -15780,7 +15780,7 @@ fn cli_snapshot_classification_reports_parse_and_missing_value_errors() {
 	);
 
 	let args = vec![
-		OsString::from("mc"),
+		OsString::from("monochange"),
 		OsString::from("change"),
 		OsString::from("classify"),
 		OsString::from("--cli-snapshot-after"),
@@ -15796,7 +15796,7 @@ fn cli_snapshot_classification_reports_parse_and_missing_value_errors() {
 	let invalid = tempdir.path().join("invalid.json");
 	fs::write(&invalid, "not json").unwrap_or_else(|error| panic!("write invalid: {error}"));
 	let args = vec![
-		OsString::from("mc"),
+		OsString::from("monochange"),
 		OsString::from("change"),
 		OsString::from("classify"),
 		OsString::from("--cli-snapshot-before"),
@@ -15809,7 +15809,7 @@ fn cli_snapshot_classification_reports_parse_and_missing_value_errors() {
 
 	let missing = tempdir.path().join("missing.json");
 	let args = vec![
-		OsString::from("mc"),
+		OsString::from("monochange"),
 		OsString::from("change"),
 		OsString::from("classify"),
 		OsString::from("--cli-snapshot-before"),
@@ -15820,21 +15820,21 @@ fn cli_snapshot_classification_reports_parse_and_missing_value_errors() {
 	let error = render_cli_snapshot_classification(&args).unwrap_err();
 	assert!(error.to_string().contains("failed to read CLI snapshot"));
 
-	let args = vec![OsString::from("mc")];
+	let args = vec![OsString::from("monochange")];
 	assert!(render_cli_snapshot_classification(&args).unwrap().is_none());
 
-	let args = vec![OsString::from("mc"), OsString::from("step")];
+	let args = vec![OsString::from("monochange"), OsString::from("step")];
 	assert!(render_cli_snapshot_classification(&args).unwrap().is_none());
 
 	let args = vec![
-		OsString::from("mc"),
+		OsString::from("monochange"),
 		OsString::from("step"),
 		OsString::from("classify"),
 	];
 	assert!(render_cli_snapshot_classification(&args).unwrap().is_none());
 
 	let args = vec![
-		OsString::from("mc"),
+		OsString::from("monochange"),
 		OsString::from("change"),
 		OsString::from("classify"),
 		OsString::from("--ignored"),
@@ -15867,7 +15867,7 @@ fn cli_snapshot_classification_renders_json_output() {
 	.unwrap_or_else(|error| panic!("write after: {error}"));
 
 	let args = vec![
-		OsString::from("mc"),
+		OsString::from("monochange"),
 		OsString::from("change"),
 		OsString::from("classify"),
 		OsString::from("--format"),
@@ -15904,7 +15904,7 @@ fn cli_snapshot_classification_renders_json_output() {
 	)
 	.unwrap_or_else(|error| panic!("write after text: {error}"));
 	let args = vec![
-		OsString::from("mc"),
+		OsString::from("monochange"),
 		OsString::from("change"),
 		OsString::from("classify"),
 		OsString::from("--cli-snapshot-before"),

--- a/crates/monochange/src/monochange.toml.template
+++ b/crates/monochange/src/monochange.toml.template
@@ -500,7 +500,7 @@ version_format = "primary"
 # this top-level section.
 #
 [lints]
-# Start with baseline presets so existing repositories can adopt `mc check`
+# Start with baseline presets so existing repositories can adopt `monochange check`
 # without turning formatting preferences into blocking errors. Upgrade to
 # `*/recommended` or `*/strict` when the workspace is ready to enforce policy.
 use = ["cargo/baseline", "npm/baseline", "dart/baseline"]

--- a/crates/monochange/tests/hosted_release_benchmarks.rs
+++ b/crates/monochange/tests/hosted_release_benchmarks.rs
@@ -215,8 +215,8 @@ fn benchmark_cli_run_fixture_supports_hosted_fixture_metadata() {
 
 	let bin_dir = tempdir.path().join("bin");
 	fs::create_dir_all(&bin_dir).unwrap_or_else(|error| panic!("mkdir bin: {error}"));
-	let fake_main = bin_dir.join("mc-main");
-	let fake_pr = bin_dir.join("mc-pr");
+	let fake_main = bin_dir.join("monochange-main");
+	let fake_pr = bin_dir.join("monochange-pr");
 	let fake_hyperfine = bin_dir.join("hyperfine");
 	let output_path = tempdir.path().join("comment.md");
 	let violations_path = tempdir.path().join("violations.txt");

--- a/crates/monochange_integration_tests/tests/check_lint_output.rs
+++ b/crates/monochange_integration_tests/tests/check_lint_output.rs
@@ -1,4 +1,4 @@
-//! Integration tests for `mc check` lint output.
+//! Integration tests for `monochange check` lint output.
 
 use std::ffi::OsString;
 use std::path::Path;

--- a/crates/monochange_integration_tests/tests/cli_snapshot.rs
+++ b/crates/monochange_integration_tests/tests/cli_snapshot.rs
@@ -22,9 +22,9 @@ async fn snapshot_index_output_is_agent_readable() {
 async fn max_bump_caps_cli_snapshot_classification() {
 	let fixture = monochange_test_helpers::setup_fixture!("cli-snapshot/max-bump");
 	let output = monochange::run_with_args_in_dir(
-		"mc",
+		"monochange",
 		[
-			OsString::from("mc"),
+			OsString::from("monochange"),
 			OsString::from("change"),
 			OsString::from("classify"),
 			OsString::from("--cli-snapshot-before"),
@@ -49,9 +49,9 @@ async fn max_bump_caps_cli_snapshot_classification() {
 async fn subcommand_snapshot_arg_renders_nested_subtree() {
 	let fixture = monochange_test_helpers::setup_fixture!("cli-snapshot/minimal-workspace");
 	let snapshot_arg_output = monochange::run_with_args_in_dir(
-		"mc",
+		"monochange",
 		[
-			OsString::from("mc"),
+			OsString::from("monochange"),
 			OsString::from("migrate"),
 			OsString::from("audit"),
 			OsString::from("--snapshot"),
@@ -92,10 +92,10 @@ async fn snapshot_subtree_light_output_is_agent_readable() {
 }
 
 async fn run_snapshot<const N: usize>(root: &Path, args: [&str; N]) -> String {
-	let mut cli_args = vec![OsString::from("mc"), OsString::from("snapshot")];
+	let mut cli_args = vec![OsString::from("monochange"), OsString::from("snapshot")];
 	cli_args.extend(args.into_iter().map(OsString::from));
 
-	monochange::run_with_args_in_dir("mc", cli_args, root)
+	monochange::run_with_args_in_dir("monochange", cli_args, root)
 		.await
 		.unwrap_or_else(|error| panic!("snapshot command failed: {error}"))
 }

--- a/crates/monochange_integration_tests/tests/release_output_format.rs
+++ b/crates/monochange_integration_tests/tests/release_output_format.rs
@@ -51,10 +51,10 @@ fn mc_release(root: &Path, args: &[&str]) -> String {
 		.args(["run", "release", "--dry-run"])
 		.args(args)
 		.output()
-		.unwrap_or_else(|error| panic!("run mc release: {error}"));
+		.unwrap_or_else(|error| panic!("run monochange release: {error}"));
 	assert!(
 		output.status.success(),
-		"mc release failed\nstdout:\n{}\nstderr:\n{}",
+		"monochange release failed\nstdout:\n{}\nstderr:\n{}",
 		String::from_utf8_lossy(&output.stdout),
 		String::from_utf8_lossy(&output.stderr)
 	);

--- a/crates/monochange_integration_tests/tests/snapshots/cli_snapshot__snapshot_index_output_is_agent_readable.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/cli_snapshot__snapshot_index_output_is_agent_readable.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/monochange_integration_tests/tests/cli_snapshot.rs
-assertion_line: 15
 expression: value
 ---
 {
@@ -787,7 +786,7 @@ expression: value
     }
   },
   "tool": {
-    "name": "mc",
+    "name": "monochange",
     "version": "[version]"
   }
 }

--- a/crates/monochange_integration_tests/tests/snapshots/cli_snapshot__snapshot_subtree_light_output_is_agent_readable.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/cli_snapshot__snapshot_subtree_light_output_is_agent_readable.snap
@@ -176,7 +176,7 @@ expression: value
     }
   },
   "tool": {
-    "name": "mc",
+    "name": "monochange",
     "version": "[version]"
   }
 }

--- a/crates/monochange_schema/schemas/artifacts/0.2/release-record/01.json
+++ b/crates/monochange_schema/schemas/artifacts/0.2/release-record/01.json
@@ -26,7 +26,7 @@
 			]
 		}
 	],
-	"command": "mc release --commit",
+	"command": "monochange release --commit",
 	"createdAt": "2026-01-01T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-1.md"

--- a/crates/monochange_schema/schemas/artifacts/0.2/release-record/02.json
+++ b/crates/monochange_schema/schemas/artifacts/0.2/release-record/02.json
@@ -26,7 +26,7 @@
 			]
 		}
 	],
-	"command": "mc release --commit",
+	"command": "monochange release --commit",
 	"createdAt": "2026-01-02T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-2.md"

--- a/crates/monochange_schema/schemas/artifacts/0.2/release-record/03.json
+++ b/crates/monochange_schema/schemas/artifacts/0.2/release-record/03.json
@@ -26,7 +26,7 @@
 			]
 		}
 	],
-	"command": "mc release --commit",
+	"command": "monochange release --commit",
 	"createdAt": "2026-01-03T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-3.md"

--- a/crates/monochange_schema/schemas/artifacts/0.2/release-record/04.json
+++ b/crates/monochange_schema/schemas/artifacts/0.2/release-record/04.json
@@ -26,7 +26,7 @@
 			]
 		}
 	],
-	"command": "mc release --commit",
+	"command": "monochange release --commit",
 	"createdAt": "2026-01-04T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-4.md"

--- a/crates/monochange_schema/schemas/artifacts/0.2/release-record/05.json
+++ b/crates/monochange_schema/schemas/artifacts/0.2/release-record/05.json
@@ -26,7 +26,7 @@
 			]
 		}
 	],
-	"command": "mc release --dry-run",
+	"command": "monochange release --dry-run",
 	"createdAt": "2026-01-05T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-5.md"

--- a/crates/monochange_schema/schemas/artifacts/0.2/release-record/06.json
+++ b/crates/monochange_schema/schemas/artifacts/0.2/release-record/06.json
@@ -26,7 +26,7 @@
 			]
 		}
 	],
-	"command": "mc release --dry-run",
+	"command": "monochange release --dry-run",
 	"createdAt": "2026-01-06T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-6.md"

--- a/crates/monochange_schema/schemas/artifacts/0.2/release-record/07.json
+++ b/crates/monochange_schema/schemas/artifacts/0.2/release-record/07.json
@@ -26,7 +26,7 @@
 			]
 		}
 	],
-	"command": "mc release --dry-run",
+	"command": "monochange release --dry-run",
 	"createdAt": "2026-01-07T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-7.md"

--- a/crates/monochange_schema/schemas/artifacts/0.2/release-record/08.json
+++ b/crates/monochange_schema/schemas/artifacts/0.2/release-record/08.json
@@ -26,7 +26,7 @@
 			]
 		}
 	],
-	"command": "mc release --dry-run",
+	"command": "monochange release --dry-run",
 	"createdAt": "2026-01-08T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-8.md"

--- a/crates/monochange_schema/schemas/artifacts/0.2/release-record/09.json
+++ b/crates/monochange_schema/schemas/artifacts/0.2/release-record/09.json
@@ -26,7 +26,7 @@
 			]
 		}
 	],
-	"command": "mc release --commit",
+	"command": "monochange release --commit",
 	"createdAt": "2026-01-09T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-9.md"

--- a/crates/monochange_schema/schemas/artifacts/0.2/release-record/10.json
+++ b/crates/monochange_schema/schemas/artifacts/0.2/release-record/10.json
@@ -26,7 +26,7 @@
 			]
 		}
 	],
-	"command": "mc release --commit",
+	"command": "monochange release --commit",
 	"createdAt": "2026-01-10T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-10.md"

--- a/crates/monochange_schema/schemas/artifacts/0.3/release-record/01.json
+++ b/crates/monochange_schema/schemas/artifacts/0.3/release-record/01.json
@@ -24,7 +24,7 @@
 			]
 		}
 	],
-	"command": "mc release --dry-run",
+	"command": "monochange release --dry-run",
 	"createdAt": "2026-01-01T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-1.md"

--- a/crates/monochange_schema/schemas/artifacts/0.3/release-record/03.json
+++ b/crates/monochange_schema/schemas/artifacts/0.3/release-record/03.json
@@ -28,7 +28,7 @@
 			]
 		}
 	],
-	"command": "mc release --commit",
+	"command": "monochange release --commit",
 	"createdAt": "2026-01-03T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-3.md"

--- a/crates/monochange_schema/schemas/artifacts/0.3/release-record/04.json
+++ b/crates/monochange_schema/schemas/artifacts/0.3/release-record/04.json
@@ -24,7 +24,7 @@
 			]
 		}
 	],
-	"command": "mc release --dry-run",
+	"command": "monochange release --dry-run",
 	"createdAt": "2026-01-04T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-4.md"

--- a/crates/monochange_schema/schemas/artifacts/0.3/release-record/05.json
+++ b/crates/monochange_schema/schemas/artifacts/0.3/release-record/05.json
@@ -29,7 +29,7 @@
 			]
 		}
 	],
-	"command": "mc release --dry-run",
+	"command": "monochange release --dry-run",
 	"createdAt": "2026-01-05T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-5.md"

--- a/crates/monochange_schema/schemas/artifacts/0.3/release-record/06.json
+++ b/crates/monochange_schema/schemas/artifacts/0.3/release-record/06.json
@@ -47,7 +47,7 @@
 			]
 		}
 	],
-	"command": "mc release --dry-run",
+	"command": "monochange release --dry-run",
 	"createdAt": "2026-01-06T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-6.md"

--- a/crates/monochange_schema/schemas/artifacts/0.3/release-record/07.json
+++ b/crates/monochange_schema/schemas/artifacts/0.3/release-record/07.json
@@ -54,7 +54,7 @@
 			]
 		}
 	],
-	"command": "mc release --dry-run",
+	"command": "monochange release --dry-run",
 	"createdAt": "2026-01-07T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-7.md"

--- a/crates/monochange_schema/schemas/artifacts/0.3/release-record/08.json
+++ b/crates/monochange_schema/schemas/artifacts/0.3/release-record/08.json
@@ -24,7 +24,7 @@
 			]
 		}
 	],
-	"command": "mc release --commit",
+	"command": "monochange release --commit",
 	"createdAt": "2026-01-08T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-8.md"

--- a/crates/monochange_schema/schemas/artifacts/0.3/release-record/10.json
+++ b/crates/monochange_schema/schemas/artifacts/0.3/release-record/10.json
@@ -25,7 +25,7 @@
 			]
 		}
 	],
-	"command": "mc release --commit",
+	"command": "monochange release --commit",
 	"createdAt": "2026-01-10T00:00:00Z",
 	"deletedChangesets": [
 		".changeset/schema-artifact-10.md"

--- a/docs/agents/release-checklist.md
+++ b/docs/agents/release-checklist.md
@@ -73,7 +73,7 @@ npm packages are handled differently from cargo crates. Platform-specific npm pa
 ## 9. Asset build and attestation
 
 - [ ] `release.yml` cross-compiles for all targets in the matrix. Verify the target list matches what npm platform packages expect (`darwin-arm64`, `darwin-x64`, `linux-arm64-gnu`, `linux-arm64-musl`, `linux-x64-gnu`, `linux-x64-musl`, `win32-x64-msvc`, `win32-arm64-msvc`).
-- [ ] Verify `taiki-e/upload-rust-binary-action` is configured with `bin: monochange,mc` and `archive: "monochange-$target-$tag"` — the download step in `publish.yml` matches this pattern (`monochange-*-${RELEASE_TAG}.tar.gz` / `.zip`) and cargo-binstall can find both package binaries in each archive.
+- [ ] Verify `taiki-e/upload-rust-binary-action` is configured with `bin: monochange` and `archive: "monochange-$target-$tag"` — the download step in `publish.yml` matches this pattern (`monochange-*-${RELEASE_TAG}.tar.gz` / `.zip`) and cargo-binstall can find the package binary in each archive.
 - [ ] Build attestations (`actions/attest-build-provenance@v3`) and verification steps exist and pass.
 
 ## 10. Post-release verification

--- a/docs/plans/active/api-classification-followups.md
+++ b/docs/plans/active/api-classification-followups.md
@@ -4,8 +4,8 @@
 
 Work through the five immediate followups from the API snapshot classification MVP:
 
-1. Dogfood `mc change classify --format markdown` and `mc api diff --format json` on monochange itself.
-2. Add CI/docs guidance for advisory `mc changeset validate --api` usage.
+1. Dogfood `monochange change classify --format markdown` and `monochange api diff --format json` on monochange itself.
+2. Add CI/docs guidance for advisory `monochange changeset validate --api` usage.
 3. Improve JavaScript/TypeScript classifier precision so implementation-only exported function body changes are not reported as breaking API changes.
 4. Add dependency propagation modes beyond MVP `none`, starting with public dependency propagation.
 5. Extend monochange-owned API snapshot support to the next ecosystem.
@@ -23,9 +23,9 @@ Work through the five immediate followups from the API snapshot classification M
 - [x] Dogfood the merged API classification commands against this branch/main and capture any usability/doc gaps.
 - [x] Add a changeset for the followup behavior.
 - [x] Document agent/CI advisory usage for:
-  - `mc change classify --format markdown`
-  - `mc api diff --format json`
-  - `mc changeset validate --api --format markdown`
+  - `monochange change classify --format markdown`
+  - `monochange api diff --format json`
+  - `monochange changeset validate --api --format markdown`
 - [x] Add failing tests showing JS and TS exported function body-only changes classify as `patch`/no public API change rather than `major`.
 - [x] Update ECMAScript export signature extraction to compare public signatures instead of full declaration bodies.
 - [x] Add classification dependency propagation primitives:
@@ -41,7 +41,7 @@ Work through the five immediate followups from the API snapshot classification M
 
 ## Notes
 
-- Dogfooding found one CLI usability gap: in this workspace `cargo run -p monochange` must specify `--bin mc` because the package has both `mc` and `monochange` binaries. The docs/skill examples continue to use the installed `mc` binary.
+- Dogfooding found one CLI usability gap: in this workspace `cargo run -p monochange` is unambiguous because the package ships only the `monochange` binary. The docs/skill examples continue to use the installed `monochange` binary.
 - `coverage:patch` ran the changed suites and API classification coverage successfully, then stopped in an unrelated `group_release_note_fallback` fixture because local git inherited signed-commit config but `gpg` was not available in the coverage environment.
 - Public dependency propagation in this followup means direct package-level propagation from a package with public API changes to packages declaring that package as a dependency. It is intentionally conservative and reports propagated recommendations separately from first-party API diffs.
 - Dart is the lowest-risk next ecosystem because `monochange_dart` already extracts public Dart symbols for semantic analysis.

--- a/docs/plans/active/api-snapshot-change-classification.md
+++ b/docs/plans/active/api-snapshot-change-classification.md
@@ -83,7 +83,7 @@ monochange already has pieces that can become this workflow:
 - `crates/monochange_npm/src/analysis.rs`
   - Already uses the shared ECMAScript symbol diffing.
   - Already analyzes npm manifest/export/dependency/metadata changes.
-- `mc analyze`
+- `monochange analyze`
   - Already exists as a user-facing command for semantic analysis, but it is not yet shaped around a simple agent workflow and changeset recommendation.
 
 The plan should avoid throwing this away. Instead, promote the current semantic-analysis model into a durable API snapshot + impact classification model.
@@ -95,13 +95,13 @@ The plan should avoid throwing this away. Instead, promote the current semantic-
 After changing code, the agent runs:
 
 ```nushell
-mc change classify --base origin/main --format markdown
+monochange change classify --base origin/main --format markdown
 ```
 
 For structured consumption:
 
 ```nushell
-mc change classify --base origin/main --format json
+monochange change classify --base origin/main --format json
 ```
 
 Then the agent writes the changeset using the highest required impact from the report.
@@ -109,13 +109,13 @@ Then the agent writes the changeset using the highest required impact from the r
 Before finishing, the agent validates:
 
 ```nushell
-mc changeset validate --base origin/main --api
+monochange changeset validate --base origin/main --api
 ```
 
 Suggested skill instruction:
 
 ```text
-Before creating or finalizing a changeset, run `mc change classify --base origin/main --format markdown`. If it reports a high-confidence breaking API change for a package, use a major changeset for that package or ask the maintainer before overriding. If it reports additive public API only, prefer minor. If it reports no public API impact, choose patch or no changeset based on repository policy and changed paths.
+Before creating or finalizing a changeset, run `monochange change classify --base origin/main --format markdown`. If it reports a high-confidence breaking API change for a package, use a major changeset for that package or ask the maintainer before overriding. If it reports additive public API only, prefer minor. If it reports no public API impact, choose patch or no changeset based on repository policy and changed paths.
 ```
 
 ### Human workflow
@@ -123,9 +123,9 @@ Before creating or finalizing a changeset, run `mc change classify --base origin
 Humans can inspect the same evidence:
 
 ```nushell
-mc api snapshot --package monochange_core --ecosystem cargo --format json
-mc api diff --base origin/main --package monochange_core --format markdown
-mc change classify --base origin/main --format markdown
+monochange api snapshot --package monochange_core --ecosystem cargo --format json
+monochange api diff --base origin/main --package monochange_core --format markdown
+monochange change classify --base origin/main --format markdown
 ```
 
 ### CI workflow, advisory first
@@ -133,25 +133,25 @@ mc change classify --base origin/main --format markdown
 Start with advisory CI:
 
 ```nushell
-mc change classify --base origin/main --format markdown --output api-impact.md
-mc changeset validate --base origin/main --api --warn-only
+monochange change classify --base origin/main --format markdown --output api-impact.md
+monochange changeset validate --base origin/main --api --warn-only
 ```
 
 Later, strict CI can fail only on high-confidence mismatches:
 
 ```nushell
-mc changeset validate --base origin/main --api --fail-on high-confidence-breaking
+monochange changeset validate --base origin/main --api --fail-on high-confidence-breaking
 ```
 
 ## Proposed command APIs
 
-### 1. `mc api snapshot`
+### 1. `monochange api snapshot`
 
 Generate a normalized API snapshot for one package at the current checkout.
 
 ```nushell
-mc api snapshot --package monochange_core --format json
-mc api snapshot --package my-npm-package --format json
+monochange api snapshot --package monochange_core --format json
+monochange api snapshot --package my-npm-package --format json
 ```
 
 Possible options:
@@ -170,13 +170,13 @@ MVP behavior:
 - npm: parse source files and package manifest/export information using the existing `monochange_npm` + `monochange_ecmascript` internals.
 - The command is mainly a debug/development command, not the primary agent command.
 
-### 2. `mc api diff`
+### 2. `monochange api diff`
 
 Compare API snapshots for a package between two refs.
 
 ```nushell
-mc api diff --base origin/main --package monochange_core --format markdown
-mc api diff --base origin/main --package my-npm-package --format json
+monochange api diff --base origin/main --package monochange_core --format markdown
+monochange api diff --base origin/main --package my-npm-package --format json
 ```
 
 Possible options:
@@ -196,13 +196,13 @@ MVP behavior:
 - Diff normalized API items.
 - Convert raw diffs into impact records.
 
-### 3. `mc change classify`
+### 3. `monochange change classify`
 
 Primary agent-facing command. Analyze affected packages and recommend bumps.
 
 ```nushell
-mc change classify --base origin/main --format markdown
-mc change classify --base origin/main --format json
+monochange change classify --base origin/main --format markdown
+monochange change classify --base origin/main --format json
 ```
 
 Possible options:
@@ -253,12 +253,12 @@ Additive changes:
   - after: `export function createChangeset(...)`
 ```
 
-### 4. `mc changeset validate --api`
+### 4. `monochange changeset validate --api`
 
 Validate that pending changesets are compatible with the API impact report.
 
 ```nushell
-mc changeset validate --base origin/main --api
+monochange changeset validate --base origin/main --api
 ```
 
 Possible options:
@@ -339,7 +339,7 @@ npm:export:.
 npm:export:./cli
 npm:symbol:createChangeset
 npm:symbol:ChangeClassification
-npm:bin:mc
+npm:bin:monochange
 ```
 
 Example snapshot JSON:
@@ -613,7 +613,7 @@ Once implemented, update the monochange skill with a short mandatory step:
 
 Before writing or finalizing `.changeset/*.md`, run:
 
-`mc change classify --base origin/main --format markdown --for-agent`
+`monochange change classify --base origin/main --format markdown --for-agent`
 
 Use the highest suggested bump per package unless you have explicit maintainer guidance. If the report shows high-confidence breaking API changes and you think a major bump is wrong, stop and ask the maintainer instead of silently downgrading to patch/minor.
 ```
@@ -638,8 +638,8 @@ Required action:
 
 ### Phase 0: tighten language and product contract
 
-- [x] Confirm command names: `mc change classify` vs `mc classify` vs extending `mc analyze`.
-- [x] Confirm whether `mc changeset validate --api` should be new or folded into existing `mc validate`/`mc check` flows.
+- [x] Confirm command names: `monochange change classify` vs `monochange classify` vs extending `monochange analyze`.
+- [x] Confirm whether `monochange changeset validate --api` should be new or folded into existing `monochange validate`/`monochange check` flows.
 - [x] Confirm default base ref behavior (`origin/main`, with `--head HEAD`).
 - [x] Confirm initial dependency propagation policy (`none` recommended for MVP).
 - [x] Confirm whether snapshot files are purely ephemeral initially or can be written to `.monochange/api-snapshots/`.
@@ -682,15 +682,15 @@ Required action:
 
 ### Phase 5: CLI commands
 
-- [x] Add `mc api snapshot`.
-- [x] Add `mc api diff`.
-- [x] Add `mc change classify` or selected equivalent.
+- [x] Add `monochange api snapshot`.
+- [x] Add `monochange api diff`.
+- [x] Add `monochange change classify` or selected equivalent.
 - [x] Add `--format json` and markdown output coverage.
 - [x] Add integration tests in `crates/monochange_integration_tests` with fixtures and Insta snapshots.
 
 ### Phase 6: changeset validation
 
-- [x] Add `mc changeset validate --api` or selected equivalent.
+- [x] Add `monochange changeset validate --api` or selected equivalent.
 - [x] Compare pending changeset bumps against classification results.
 - [x] Start with advisory/warn-only behavior unless strict flag is passed.
 - [x] Add override mechanism for false positives.
@@ -723,7 +723,7 @@ CLI changes are public API changes too, but they should be a later analyzer.
 Treat CLI as a module tree:
 
 ```text
-mc
+monochange
 ├── change
 │   └── classify
 ├── api
@@ -803,7 +803,7 @@ Possible TOML override:
 Possible CLI flag:
 
 ```nushell
-mc changeset validate --api --allow-impact-override
+monochange changeset validate --api --allow-impact-override
 ```
 
 Recommendation:
@@ -814,9 +814,9 @@ Recommendation:
 
 ## Suggestions and product feedback
 
-### Suggestion 1: make `mc change classify` the centre, not `mc api diff`
+### Suggestion 1: make `monochange change classify` the centre, not `monochange api diff`
 
-`mc api diff` is useful for developers, but agents should have one obvious command. The skill should tell agents to run `mc change classify`, not assemble lower-level commands.
+`monochange api diff` is useful for developers, but agents should have one obvious command. The skill should tell agents to run `monochange change classify`, not assemble lower-level commands.
 
 ### Suggestion 2: separate detection from recommendation
 
@@ -849,27 +849,27 @@ Because speed is a product requirement, include a performance budget.
 Suggested MVP target for this repo:
 
 ```text
-mc change classify --base origin/main --format json
+monochange change classify --base origin/main --format json
 ```
 
 should complete in a few seconds on typical small/medium PRs, because it only snapshots affected packages and avoids rustdoc/rustc.
 
 ## Acceptance criteria for the MVP
 
-- `mc change classify --base <ref> --format json` returns package-level suggested bumps for Cargo and npm packages.
-- `mc change classify --base <ref> --format markdown --for-agent` is concise enough to put directly into agent instructions.
+- `monochange change classify --base <ref> --format json` returns package-level suggested bumps for Cargo and npm packages.
+- `monochange change classify --base <ref> --format markdown --for-agent` is concise enough to put directly into agent instructions.
 - Cargo removed/modified public functions produce high-confidence major recommendations.
 - Cargo added public functions produce high-confidence minor recommendations.
 - npm removed/modified exports produce high-confidence major recommendations.
 - npm added exports produce high-confidence minor recommendations.
 - Manifest export removals in npm produce high-confidence major recommendations.
 - Analyzer warnings are surfaced and lower confidence where appropriate.
-- Existing `mc analyze` behavior remains compatible or has a documented migration path.
+- Existing `monochange analyze` behavior remains compatible or has a documented migration path.
 - Changeset validation can warn when a high-confidence major recommendation is paired with a patch/minor changeset.
 
 ## Open questions
 
-1. Should the primary command be `mc change classify`, `mc changeset suggest`, or an extension of `mc analyze`?
+1. Should the primary command be `monochange change classify`, `monochange changeset suggest`, or an extension of `monochange analyze`?
 2. Should snapshot files ever be committed, or should they remain ephemeral/generated by default?
 3. Should `dependency_breaking_policy` default to `none` for MVP or `public` for ideal semantics?
 4. How strict should npm dependency range changes be classified in the first version?
@@ -884,6 +884,6 @@ Create an implementation issue/plan for Phase 1 through Phase 5 only:
 2. Cargo adapter.
 3. npm adapter.
 4. Diff + classification.
-5. `mc change classify` command.
+5. `monochange change classify` command.
 
 Defer strict changeset validation and future ecosystem analyzers until the classification output is proven useful in real agent workflows.

--- a/docs/plans/active/async-perf.md
+++ b/docs/plans/active/async-perf.md
@@ -86,12 +86,12 @@ Measured with `hyperfine --warmup 1 --runs 6`.
 | :------------------------------------------------- | :--------------------------------------- | --------: | -------: | ------: | --------: |
 | Baseline, 20 packages / 50 changesets / 50 commits | `monochange step validate`               |   37.5 ms |  25.4 ms |   0.68× |     32.3% |
 | Baseline, 20 packages / 50 changesets / 50 commits | `monochange step discover --format json` |   31.2 ms |  16.4 ms |   0.53× |     47.4% |
-| Baseline, 20 packages / 50 changesets / 50 commits | `mc release --dry-run`                   |  316.6 ms | 131.8 ms |   0.42× |     58.4% |
-| Baseline, 20 packages / 50 changesets / 50 commits | `mc release`                             |  345.9 ms | 148.9 ms |   0.43× |     57.0% |
+| Baseline, 20 packages / 50 changesets / 50 commits | `monochange release --dry-run`           |  316.6 ms | 131.8 ms |   0.42× |     58.4% |
+| Baseline, 20 packages / 50 changesets / 50 commits | `monochange release`                     |  345.9 ms | 148.9 ms |   0.43× |     57.0% |
 | Large, 200 packages / 500 changesets / 500 commits | `monochange step validate`               |  595.1 ms | 475.3 ms |   0.80× |     20.1% |
 | Large, 200 packages / 500 changesets / 500 commits | `monochange step discover --format json` |  548.0 ms | 380.7 ms |   0.69× |     30.5% |
-| Large, 200 packages / 500 changesets / 500 commits | `mc release --dry-run`                   | 2769.8 ms | 708.6 ms |   0.26× |     74.4% |
-| Large, 200 packages / 500 changesets / 500 commits | `mc release`                             | 3021.1 ms | 784.6 ms |   0.26× |     74.0% |
+| Large, 200 packages / 500 changesets / 500 commits | `monochange release --dry-run`           | 2769.8 ms | 708.6 ms |   0.26× |     74.4% |
+| Large, 200 packages / 500 changesets / 500 commits | `monochange release`                     | 3021.1 ms | 784.6 ms |   0.26× |     74.0% |
 
 Top-level CLI benchmark violations: `0`.
 
@@ -182,7 +182,7 @@ Peak memory sampling with `/usr/bin/time -l` for `step diagnose-changesets` impr
    - The low-gain follow-up rerun now shows this command faster than `main`; remaining work is to isolate prepare-release and serialization costs for additional headroom.
 4. Large-fixture `monochange step validate` still spends roughly `0.49 s` on the PR branch.
    - Next work: identify whether validation repeatedly loads manifests or performs serial registry/source checks that can be cached or batched.
-5. Release phase timings do not fully explain the wall-clock `mc release` / `mc release --dry-run` durations.
+5. Release phase timings do not fully explain the wall-clock `monochange release` / `monochange release --dry-run` durations.
    - Next work: add or inspect outer phase spans around command startup, fixture setup, workflow orchestration, and subprocess boundaries so the remaining wall time is attributable.
 6. Memory usage has targeted spot checks but not broad benchmark coverage yet.
    - Next work: add peak RSS measurements for the benchmarked command matrix, then target allocation-heavy structures with borrowed data, streaming iteration, or smaller owned summaries.
@@ -212,14 +212,14 @@ devenv shell -- coverage:patch
 ```sh
 workdir=/tmp/monochange-async-perf-20260513
 node "$workdir/async/scripts/benchmark-cli.ts" run \
-  --main-bin "$workdir/main/target/release/mc" \
-  --pr-bin "$workdir/async/target/release/mc" \
+  --main-bin "$workdir/main/target/release/monochange" \
+  --pr-bin "$workdir/async/target/release/monochange" \
   --output "$workdir/async-performance.md" \
   --violations-output "$workdir/async-performance-violations.txt"
 
 node "$workdir/async/scripts/benchmark-step-commands.ts" run \
-  --main-bin "$workdir/main/target/release/mc" \
-  --pr-bin "$workdir/async/target/release/mc" \
+  --main-bin "$workdir/main/target/release/monochange" \
+  --pr-bin "$workdir/async/target/release/monochange" \
   --output "$workdir/async-step-performance-rerun.md" \
   --violations-output "$workdir/async-step-performance-rerun-violations.txt" \
   --warmup 3 \

--- a/docs/plans/active/auto-discover-packages-from-ecosystems.md
+++ b/docs/plans/active/auto-discover-packages-from-ecosystems.md
@@ -72,7 +72,7 @@ The `{{ name }}` default means auto-discovered packages use the same canonical i
 - **Groups**: Auto-discovered packages can be referenced in `[group.*].packages` by their id just like explicit packages.
 - **Discovery**: Auto-discovery produces declared packages. The `[ecosystems.*]` discovery step (which finds packages by walking filesystem manifests) still runs, but its output is merged with auto-discovered declarations.
 - **Validation**: `monochange step validate` will warn about glob patterns that match zero directories and error on ambiguous overlaps.
-- **`mc init`**: Can generate `auto_discover` settings by detecting the repo layout, eliminating the need for most `[package.*]` entries.
+- **`monochange init`**: Can generate `auto_discover` settings by detecting the repo layout, eliminating the need for most `[package.*]` entries.
 
 ## Implementation plan
 

--- a/docs/plans/active/cli-startup-config-loading-performance.md
+++ b/docs/plans/active/cli-startup-config-loading-performance.md
@@ -2,7 +2,7 @@
 
 ## Problem statement
 
-In large workspaces such as `/Users/ifiokjr/Developer/projects/solana_kit`, `mc` and `monochange` startup can take tens of seconds even for commands such as `--version`, `--help`, and no-argument invocation. Diagnostics showed the main cost is `monochange_config::load_workspace_configuration`, especially repeated expansion of inherited ecosystem-level `versioned_files` globs such as `**/pubspec.yaml`.
+In large workspaces such as `/Users/ifiokjr/Developer/projects/solana_kit`, `monochange` startup can take tens of seconds even for commands such as `--version`, `--help`, and no-argument invocation. Diagnostics showed the main cost is `monochange_config::load_workspace_configuration`, especially repeated expansion of inherited ecosystem-level `versioned_files` globs such as `**/pubspec.yaml`.
 
 The current startup path also performs more work than required:
 
@@ -13,11 +13,11 @@ The current startup path also performs more work than required:
 
 ## Goals
 
-- Make `mc --version`, `mc -V`, `monochange --version`, and `monochange -V` config-free and millisecond-fast.
+- Make `monochange --version` and `monochange -V` config-free and millisecond-fast.
 - Make help and command-dispatch paths perform the minimum configuration work needed for the requested operation.
 - Make full configuration loading fast for inherited ecosystem glob scenarios, with no repeated filesystem walks for the same glob.
 - Add regression benchmarks for inherited ecosystem `versioned_files` globs across all supported ecosystems.
-- Add CLI startup benchmarks that make slow paths visible for `mc` and `monochange` commands.
+- Add CLI startup benchmarks that make slow paths visible for `monochange` commands.
 - Keep behavior compatible for validated commands that intentionally need full package and versioned-file checks.
 
 ## Non-goals
@@ -36,14 +36,14 @@ Diagnostic build findings in `solana_kit`:
 - The same glob expansion ran once for the ecosystem and again for each package.
 - Each expansion took roughly 0.5-0.7s in the real repo.
 - `validate_package_and_group_definitions` accounted for roughly 25-28s per full config load.
-- `mc --help` loaded config twice in the instrumented path, making it roughly twice as slow.
-- `monochange --version` lacks the sync version fast path that `mc` has.
+- `monochange --help` loaded config twice in the instrumented path, making it roughly twice as slow.
+- `monochange --version` lacked a sync version fast path.
 
 ## Affected files and crates
 
 Likely files:
 
-- `crates/monochange/src/bin/mc.rs`
+- `crates/monochange/src/main.rs`
 - `crates/monochange/src/main.rs`
 - `crates/monochange/src/lib.rs`
 - `crates/monochange/src/cli.rs`
@@ -58,7 +58,7 @@ Likely files:
 
 ### 1. Config-free version handling
 
-- Keep `mc` sync version handling.
+- Keep `monochange` sync version handling.
 - Add equivalent sync version handling to the `monochange` binary.
 - Ensure version fast paths tolerate global flags only when they can do so without config, or intentionally fall back for unsupported combinations.
 - Verify no code path used for version calls `build_command_for_root`, `cli_commands_for_root`, or `load_workspace_configuration`.
@@ -185,16 +185,16 @@ Acceptance target:
 
 Extend existing CLI command benchmarks to cover both binaries and common command classes:
 
-- `mc --version`
-- `mc -V`
 - `monochange --version`
 - `monochange -V`
-- `mc --help`
+- `monochange --version`
+- `monochange -V`
 - `monochange --help`
-- `mc help`
-- `mc help <custom-command>` with a fixture config
-- `mc lint --list`
-- `mc lint --explain <rule>`
+- `monochange --help`
+- `monochange help`
+- `monochange help <custom-command>` with a fixture config
+- `monochange lint --list`
+- `monochange lint --explain <rule>`
 - `monochange step config --format json`
 - representative no-arg invocation/error path
 
@@ -205,7 +205,7 @@ Benchmarks should run against a fixture containing inherited ecosystem globs to 
 Add regression tests for:
 
 - `monochange --version` does not load config, even when cwd has expensive config.
-- `mc --version` still does not load config.
+- `monochange --version` still does not load config.
 - root help loads configuration at most once.
 - root help can render custom commands using CLI-only config without validating package paths/globs.
 - inherited ecosystem versioned-file globs are validated once, not once per package.
@@ -226,7 +226,7 @@ Use test fixtures and counters where practical instead of relying on wall-clock 
 - [ ] Add inherited glob validation cache/deduplication.
 - [ ] Add tests for config-free and CLI-only behavior.
 - [ ] Add inherited ecosystem glob benchmarks for Cargo, npm, Deno, Dart, Python, and Go.
-- [ ] Extend CLI startup benchmarks for both `mc` and `monochange`.
+- [ ] Extend CLI startup benchmarks for `monochange`.
 - [ ] Run focused unit tests.
 - [ ] Run benchmark script locally against the new fixture.
 - [ ] Run `devenv shell lint:monochange` or the repo-required validation subset.
@@ -235,8 +235,8 @@ Use test fixtures and counters where practical instead of relying on wall-clock 
 
 ## Acceptance checks
 
-- `mc --version` and `monochange --version` are milliseconds in `solana_kit`.
-- `mc --help` and `monochange --help` no longer perform full package/glob validation.
+- `monochange --version` is milliseconds in `solana_kit`.
+- `monochange --help` no longer performs full package/glob validation.
 - Full config loading for inherited ecosystem glob fixtures is under 1s locally.
 - Benchmarks cover all supported ecosystems with ecosystem-level glob inheritance.
 - Tests prove expensive validation is not triggered for commands that do not need it.
@@ -261,19 +261,19 @@ Implemented in this branch:
 
 - Added `monochange_config::load_cli_commands(root)` to parse raw config and merge CLI command metadata without package/group/ecosystem validation.
 - Changed CLI startup/help paths to use CLI-only loading for root help, no-arg help, `help`, `help <command>`, and `<command> --help`.
-- Added a config-free `monochange --version` sync fast path and changed the `mc` sync version fast path to print to stdout.
+- Added a config-free `monochange --version` sync fast path that prints to stdout.
 - Added per-config-load glob validation dedupe for package/group `versioned_files`, so inherited ecosystem globs are not re-expanded once per package.
 - Added regression tests for CLI-only config loading and version/root-help behavior with invalid package/versioned-file config.
-- Added `cli_startup_help` Criterion cases for `mc --version`, root help, and command help.
+- Added `cli_startup_help` Criterion cases for `monochange --version`, root help, and command help.
 
 Real `solana_kit` release-binary timings after warmup:
 
-- `mc --version`: ~0.006s median
+- `monochange --version`: ~0.006s median
 - `monochange --version`: ~0.005s median
-- `mc --help`: ~0.006s median
-- `mc` with no args: ~0.006s median
-- `mc help release`: ~0.006s median
-- `mc release --help`: ~0.007s median
+- `monochange --help`: ~0.006s median
+- `monochange` with no args: ~0.006s median
+- `monochange help release`: ~0.006s median
+- `monochange release --help`: ~0.007s median
 - `monochange step config`: ~2.5s median, down from the previous repeated-glob 25s+ config-load behavior
 
 Remaining possible follow-ups:

--- a/docs/plans/active/cli-surface-snapshots.md
+++ b/docs/plans/active/cli-surface-snapshots.md
@@ -74,7 +74,7 @@ Sketch:
 	"schema_version": "0.7",
 	"kind": "cli-surface",
 	"tool": {
-		"name": "mc",
+		"name": "monochange",
 		"version": "0.6.8"
 	},
 	"standard_entrypoints": {
@@ -262,7 +262,7 @@ Possible layouts and views:
 
 1. One complete snapshot file, stable sorted by command path.
 2. Optional index file mapping command paths to per-command files.
-3. Optional `mc snapshot show <path> --format json` later for focused retrieval.
+3. Optional `monochange snapshot show <path> --format json` later for focused retrieval.
 4. Full view: includes descriptions, examples, output notes, and compatibility metadata.
 5. Light view: omits descriptions/examples/prose and keeps only command paths, options, positionals, parser behavior, outputs, errors, max bump policy, and semantic ids.
 6. Index view: command paths plus short summaries only.
@@ -273,24 +273,24 @@ Initial preference: one complete snapshot plus a built-in renderer that can prod
 
 - [x] Finalize naming: `monochange_snapshot`.
 - [x] Finalize initial normalized schema fields for CLI invocation snapshots.
-- [x] Decide first scope: monochange's own `mc` CLI via clap metadata.
+- [x] Decide first scope: monochange's own `monochange` CLI via clap metadata.
 - [x] Add internal data model crate/module.
 - [x] Add extractor trait that produces the normalized snapshot plus confidence/provenance metadata.
 - [x] Add first extractor from clap metadata.
 - [x] Reserve room for future extractors: TypeScript/JavaScript CLI builders, Python frameworks, Fig-like specs, shell completion scripts, and help-text inference.
 - [x] Add snapshot rendering modes: full, light/no-descriptions, and command index.
 - [x] Add manual annotation data types for command output schemas where extractors cannot infer them.
-- [x] Add snapshot rendering command: `mc snapshot` plus global `--snapshot`.
-- [x] Add fixture-backed integration snapshots for `mc` surface output.
+- [x] Add snapshot rendering command: `monochange snapshot` plus global `--snapshot`.
+- [x] Add fixture-backed integration snapshots for `monochange` surface output.
 - [x] Add diff classifier for CLI surface snapshots.
-- [x] Integrate classification into `mc change classify`.
+- [x] Integrate classification into `monochange change classify`.
 - [x] Keep affected changeset policy enforcement deferred until CLI classification is trusted by fixture snapshots and a stored baseline format.
 
 ## Open questions
 
 1. Name: should this be `monochange_surface`, `monochange_contract`, or something more command-specific?
 2. Command spelling: should `step affected-packages` be modeled as one path segment or normalized as `step affected-packages` with an alias back to the colon spelling?
-3. Standard metadata command: should monochange expose `mc schema`, `mc snapshot`, `mc __schema`, or only an explicit command under `mc api`/`mc surface`?
+3. Standard metadata command: should monochange expose `monochange schema`, `monochange snapshot`, `monochange __schema`, or only an explicit command under `monochange api`/`monochange surface`?
 4. Output schemas: should we derive with `schemars`, hand-author stable output contracts, or start with snapshot examples and graduate to schemas?
 5. Stability tags: should every command default to stable, or should experimental/user-defined commands be marked separately?
 6. User-defined `[cli.*]` commands: are they part of the package API surface, or only built-in binary/step commands?

--- a/docs/plans/active/durable-schema-migrations.md
+++ b/docs/plans/active/durable-schema-migrations.md
@@ -27,7 +27,7 @@ Those artifacts currently mix internal Rust struct layout with serialized wire s
 
 ## What “CLI JSON” means here
 
-`--format json` currently renders many command results to stdout, for example `monochange step discover --format json`, `mc release --dry-run --format json`, `monochange step diagnose-changesets --format json`, `monochange step release-record --format json`, and `monochange step tag-release --dry-run --format json`.
+`--format json` currently renders many command results to stdout, for example `monochange step discover --format json`, `monochange release --dry-run --format json`, `monochange step diagnose-changesets --format json`, `monochange step release-record --format json`, and `monochange step tag-release --dry-run --format json`.
 
 That JSON is useful for automation, but it is different from persisted artifacts because monochange does not necessarily read it back later. For this plan, only JSON artifacts that monochange writes to disk or embeds into git history and later consumes are durable public schemas.
 

--- a/docs/plans/active/feat-versions-command-polish.md
+++ b/docs/plans/active/feat-versions-command-polish.md
@@ -1,10 +1,10 @@
-# Polish the `mc versions` command
+# Polish the `monochange versions` command
 
 ## Goal
 
 Make the internal dependency version sync command feel like a first-class migration and maintenance command:
 
-- Rename `mc sync versions` to `mc versions`.
+- Rename `monochange sync versions` to `monochange versions`.
 - Preserve the existing Dart and npm sync behavior.
 - Add a clearer plan/apply model, JSON output, unsupported ecosystem reporting, and snapshot-tested CLI output.
 - Document when users should run it, especially while migrating to monochange or validating that grouped packages have coherent internal dependency constraints.
@@ -19,7 +19,7 @@ Make the internal dependency version sync command feel like a first-class migrat
 5. [x] Report unsupported ecosystems explicitly, including skipped file/package counts.
 6. [x] Improve conflict/error surfaces by including file paths and ecosystem context in plan/apply failures.
 7. [x] Add snapshot-style integration tests for human and JSON CLI output.
-8. [x] Add a Criterion benchmark for `mc versions --dry-run --format json` on representative fixtures.
+8. [x] Add a Criterion benchmark for `monochange versions --dry-run --format json` on representative fixtures.
 9. [x] Update docs and changesets, including the previous sync-versions changeset text.
 10. [x] Create a follow-up issue for version consistency cases that cannot be fixed by dependency constraint syncing alone.
 

--- a/docs/plans/active/perf-progress-dark-areas.md
+++ b/docs/plans/active/perf-progress-dark-areas.md
@@ -29,8 +29,8 @@ Make monochange feel alive and predictable in lesser-used ecosystems and provide
 12. Placeholder publish: dry-run and real publish paths need visible package-by-package progress.
 13. Git provenance/diagnostics: deep history and `git log --follow` style operations can become slow.
 14. Release-record reconstruction: tag/commit discovery can be slow in repos with many tags.
-15. `mc init`: broad auto-discovery across all ecosystems can walk the tree many times.
-16. `mc check --fix`: manifest rewrite paths should report per-file progress and avoid rereading unchanged files.
+15. `monochange init`: broad auto-discovery across all ecosystems can walk the tree many times.
+16. `monochange check --fix`: manifest rewrite paths should report per-file progress and avoid rereading unchanged files.
 17. Lint suites: each ecosystem linter may reread manifests already parsed during discovery.
 18. MCP operations: agent callers need JSON progress or structured “still working” output for long tasks.
 19. Provider HTTP clients: missing explicit connect/request timeouts can create indefinite waits.

--- a/docs/plans/active/pr-276-failing-checks.md
+++ b/docs/plans/active/pr-276-failing-checks.md
@@ -2,7 +2,7 @@
 
 ## Problem statement
 
-PR #276 (`feat(lint): add beautiful interactive progress reporting for mc check and mc lint`) is blocked by failing `lint` and `coverage` checks.
+PR #276 (`feat(lint): add beautiful interactive progress reporting for monochange check and monochange lint`) is blocked by failing `lint` and `coverage` checks.
 
 ## Scope
 

--- a/docs/plans/active/skill-command.md
+++ b/docs/plans/active/skill-command.md
@@ -1,12 +1,12 @@
-# `mc skill` subcommand
+# `monochange skill` subcommand
 
 ## Goal
 
-Add a built-in `mc skill` command that installs the monochange skill bundle into the current project through the upstream `skills add` workflow.
+Add a built-in `monochange skill` command that installs the monochange skill bundle into the current project through the upstream `skills add` workflow.
 
 ## Scope
 
-- add CLI wiring for `mc skill`
+- add CLI wiring for `monochange skill`
 - detect an available launcher from `npx`, `pnpm dlx`, or `bunx`
 - forward interactive or non-interactive `skills add` flags to the upstream installer
 - document the new command in CLI help and assistant-facing docs
@@ -14,7 +14,7 @@ Add a built-in `mc skill` command that installs the monochange skill bundle into
 
 ## Non-goals
 
-- replacing `mc subagents` or `mc mcp`
+- replacing `monochange subagents` or `monochange mcp`
 - reimplementing the upstream `skills add` prompt flow inside monochange
 - adding a global skill-management surface beyond installing the monochange skill source
 
@@ -30,11 +30,11 @@ Add a built-in `mc skill` command that installs the monochange skill bundle into
 
 ## Checklist
 
-- [x] add a failing CLI test for `mc skill` parsing and forwarded flags
+- [x] add a failing CLI test for `monochange skill` parsing and forwarded flags
 - [x] implement runner detection and source resolution for the monochange skill bundle
 - [x] execute `skills add <monochange-source>` with forwarded args in the workspace root
 - [x] cover runner fallback and missing-runner failures with tests
-- [x] update docs and skill references to point at `mc skill`
+- [x] update docs and skill references to point at `monochange skill`
 - [x] add or update the changeset
 - [x] run validation, including patch coverage
 
@@ -48,6 +48,6 @@ Add a built-in `mc skill` command that installs the monochange skill bundle into
 
 ## Notes
 
-- `mc skill` should stay thin and let the upstream `skills` CLI own the interactive install UX.
+- `monochange skill` should stay thin and let the upstream `skills` CLI own the interactive install UX.
 - The command should prefer local project installation by default, while still allowing forwarded upstream flags such as `-g`, `-a`, `--skill`, `--copy`, `--list`, `--all`, and `-y`.
 - After rebasing `feat/skill-command` onto the latest `main`, `devenv shell coverage:patch` completed successfully but reported `PATCH_COVERAGE 0/0 (100.00%)` because the branch no longer had committed diff hunks yet; committed patch coverage should be rechecked again after the feature commit is created.

--- a/docs/plans/active/telemetry-research.md
+++ b/docs/plans/active/telemetry-research.md
@@ -249,7 +249,7 @@ Properties:
 - [x] Add sanitized error classification for the core error enum without sending raw messages.
 - [ ] Decide backend: PostHog for product analytics, OpenTelemetry for standards-based traces, Sentry for error monitoring; remote OpenTelemetry tracked in [#297](https://github.com/monochange/monochange/issues/297).
 - [ ] Add stronger tests ensuring telemetry is disabled by default, never sends during tests by default, and redacts paths/package names; tracked in [#299](https://github.com/monochange/monochange/issues/299).
-- [ ] Add a `mc telemetry status|enable|disable|reset-id|preview` command set if the UX is accepted; tracked in [#295](https://github.com/monochange/monochange/issues/295).
+- [ ] Add a `monochange telemetry status|enable|disable|reset-id|preview` command set if the UX is accepted; tracked in [#295](https://github.com/monochange/monochange/issues/295).
 - [ ] Document self-hosted backend options; tracked in [#300](https://github.com/monochange/monochange/issues/300).
 
 ## Acceptance checks for a future implementation

--- a/docs/plans/completed/prerelease-mode.md
+++ b/docs/plans/completed/prerelease-mode.md
@@ -177,7 +177,7 @@ not current manifest version
 
 - [x] Run formatting/fix command. (`cargo fmt`; `fix:all` pending.)
 - [x] Run build command. (`cargo build --workspace --all-features` passes.)
-- [x] Run lint/typecheck command. (`cargo clippy --workspace --all-features --all-targets -- -D warnings`, `monochange step validate`, and `mc check` pass.)
+- [x] Run lint/typecheck command. (`cargo clippy --workspace --all-features --all-targets -- -D warnings`, `monochange step validate`, and `monochange check` pass.)
 - [x] Run tests. (`cargo test -q` passes after updating current and versioned schema assets, clippy fixes, and prerelease-state field rename.)
 - [x] Run patch coverage and reach 100%. (`350/350 (100%)` after focused tests and narrow ignores.)
 - [x] Commit signed changes on `feat/prerelease-mode`.
@@ -198,7 +198,7 @@ devenv shell lint:all
 devenv shell coverage:patch
 ```
 
-If local devenv linking fails because of the known macOS SDK/libiconv issue, record the failure in this plan and rely on CI after pushing the PR, while still running any available prebuilt `target/release/mc` checks that do not require relinking.
+If local devenv linking fails because of the known macOS SDK/libiconv issue, record the failure in this plan and rely on CI after pushing the PR, while still running any available prebuilt `target/release/monochange` checks that do not require relinking.
 
 ## Progress log
 
@@ -225,10 +225,10 @@ If local devenv linking fails because of the known macOS SDK/libiconv issue, rec
 - 2026-05-22: Generated coverage data; overall line coverage is 96.03%, and initial patch coverage command reported `0/0 (100%)` because the branch has not been committed yet. Added `.changeset/prerelease-mode.md`; will rerun patch coverage after committing so `HEAD` contains the patch.
 - 2026-05-22: Patch coverage after the first commit was 260/367 (70.84%). Added focused unit coverage for invalid prerelease config branches, prerelease numbering/base mismatch branches, grouped no-changeset prerelease state creation, and unsupported prerelease state schema handling.
 - 2026-05-22: Expanded focused prerelease/config tests for read failures, invalid channels, stale-state validation, fixed-base overrides, unplanned groups, and skipped stale/unknown state entries. Added narrow patch-coverage ignores for practically unreachable serialization and OS deletion race branches. Final patch coverage is 350/350 (100%).
-- 2026-05-22: Reran `cargo fmt --check`, `cargo llvm-cov --workspace --all-features --lcov --output-path target/coverage/lcov.info`, `pnpm node scripts/check-patch-coverage.ts --repo-root $PWD --lcov target/coverage/lcov.info --base origin/main --head HEAD --target 100`, `cargo clippy --workspace --all-features --all-targets -- -D warnings`, `cargo build --workspace --all-features`, `cargo run -q -p monochange --bin mc -- step validate`, and `cargo run -q -p monochange --bin mc -- check`; all pass.
+- 2026-05-22: Reran `cargo fmt --check`, `cargo llvm-cov --workspace --all-features --lcov --output-path target/coverage/lcov.info`, `pnpm node scripts/check-patch-coverage.ts --repo-root $PWD --lcov target/coverage/lcov.info --base origin/main --head HEAD --target 100`, `cargo clippy --workspace --all-features --all-targets -- -D warnings`, `cargo build --workspace --all-features`, `cargo run -q -p monochange --bin monochange -- step validate`, and `cargo run -q -p monochange --bin monochange -- check`; all pass.
 - 2026-05-22: Opened PR #522, fixed CI changeset coverage by adding all affected packages to the changeset, fixed CI formatting by running `dprint fmt` on generated schemas/docs, and confirmed the latest PR checks pass.
 - 2026-05-22: Addressed review feedback in the separate worktree: removed generated `schemas/artifacts/0.3` fixtures, kept regenerated schema artifacts under `schemas/artifacts/current`, moved prerelease integration scenarios into committed `fixtures/tests/prerelease/*` directories, and added `[prerelease].branches` branch-policy override support with focused tests.
-- 2026-05-22: Validated the review-feedback commit with `cargo fmt --check`, `cargo test -q`, `cargo clippy --workspace --all-features --all-targets -- -D warnings`, `cargo run -q -p monochange --bin mc -- step validate`, `cargo run -q -p monochange --bin mc -- check`, `cargo llvm-cov --workspace --all-features --lcov --output-path target/coverage/lcov.info`, and `pnpm node scripts/check-patch-coverage.ts --repo-root $PWD --lcov target/coverage/lcov.info --base origin/main --head HEAD --target 100`; patch coverage is 375/375 (100%).
+- 2026-05-22: Validated the review-feedback commit with `cargo fmt --check`, `cargo test -q`, `cargo clippy --workspace --all-features --all-targets -- -D warnings`, `cargo run -q -p monochange --bin monochange -- step validate`, `cargo run -q -p monochange --bin monochange -- check`, `cargo llvm-cov --workspace --all-features --lcov --output-path target/coverage/lcov.info`, and `pnpm node scripts/check-patch-coverage.ts --repo-root $PWD --lcov target/coverage/lcov.info --base origin/main --head HEAD --target 100`; patch coverage is 375/375 (100%).
 - 2026-05-22: CI lint failed because regenerated schema JSON files needed `dprint fmt`. Ran `dprint fmt`, confirmed `dprint check`, `cargo fmt --check`, and `cargo test -q -p monochange_integration_tests --test schema_assets` pass, and prepared an amended push.
 - 2026-05-22: CI test then exposed a parallel-test race where source follow-up command tests prepared releases directly in `fixtures/tests/monochange/release-base`, creating transient manifest-cache temp files while another test copied the fixture. Updated those tests to copy the fixture into tempdirs first; confirmed `cargo fmt --check`, `dprint check`, filtered `execute_cli_command_` tests, and `cargo test -q -p monochange` pass.
 - 2026-05-22: CI lint/release-lint then reported one `clippy::needless_borrow` from the tempdir test refactor. Removed the extra borrow and confirmed `cargo fmt --check` plus `cargo clippy --workspace --all-features --all-targets -- -D warnings` pass locally.

--- a/docs/plans/completed/publish-plan-private-package-fixes.md
+++ b/docs/plans/completed/publish-plan-private-package-fixes.md
@@ -10,7 +10,7 @@ Completed in PR #264: https://github.com/monochange/monochange/pull/264
 
 ## Goal
 
-Fix publish planning so disabled or private packages never appear in publish batches, make placeholder publishing treat any existing registry version as already bootstrapped, correct npm trusted-publishing setup URLs, and harden crates.io lookups so transient API behavior does not break `mc publish-plan`.
+Fix publish planning so disabled or private packages never appear in publish batches, make placeholder publishing treat any existing registry version as already bootstrapped, correct npm trusted-publishing setup URLs, and harden crates.io lookups so transient API behavior does not break `monochange publish-plan`.
 
 ## Scope
 
@@ -50,4 +50,4 @@ Validation completed for PR #264. The key targeted coverage lives in `crates/mon
 ## Notes
 
 - Favor fixture-first coverage for workspace/discovery scenarios.
-- Keep the publish filtering logic aligned between `mc publish` and `mc publish-plan`.
+- Keep the publish filtering logic aligned between `monochange publish` and `monochange publish-plan`.

--- a/docs/plans/completed/publish-readiness.md
+++ b/docs/plans/completed/publish-readiness.md
@@ -5,12 +5,12 @@
 Completed in PR #324: https://github.com/monochange/monochange/pull/324
 
 - Merge commit: `69f221dc1f9b4823e8aa98ebdea6b84aaa57baeb`
-- Previous publish-readiness slices shipped `monochange step publish-readiness`, readiness enforcement in `mc publish`, Cargo readiness blockers, readiness-backed publish planning, `monochange step placeholder-publish`, and package publish resume artifacts.
+- Previous publish-readiness slices shipped `monochange step publish-readiness`, readiness enforcement in `monochange publish`, Cargo readiness blockers, readiness-backed publish planning, `monochange step placeholder-publish`, and package publish resume artifacts.
 - This completed slice added deeper freshness checks for readiness artifacts by fingerprinting publish inputs that affect registry behavior.
 
 ## Problem
 
-A readiness artifact already proves that a release record and package set were ready at the time the artifact was written. It did not explicitly prove that the workspace publish inputs stayed unchanged afterward. A workflow could generate readiness, then alter `monochange.toml`, a package manifest, a lockfile, `.npmrc`, Cargo config, or another publish tooling input before `mc publish --readiness <path>` consumed the artifact.
+A readiness artifact already proves that a release record and package set were ready at the time the artifact was written. It did not explicitly prove that the workspace publish inputs stayed unchanged afterward. A workflow could generate readiness, then alter `monochange.toml`, a package manifest, a lockfile, `.npmrc`, Cargo config, or another publish tooling input before `monochange publish --readiness <path>` consumed the artifact.
 
 ## Scope
 
@@ -21,7 +21,7 @@ This slice extends readiness artifacts so they include a deterministic `inputFin
 - root and package lockfiles,
 - root publish tooling files such as `.npmrc`, `.cargo/config.toml`, `.cargo/config`, `rust-toolchain.toml`, `rust-toolchain`, workspace `Cargo.toml`, `pnpm-workspace.yaml`, Python tooling config, Deno config, and pubspec files.
 
-`mc publish` and readiness-backed `mc publish-plan` rebuild current readiness and reject saved artifacts whose publish input fingerprint no longer matches.
+`monochange publish` and readiness-backed `monochange publish-plan` rebuild current readiness and reject saved artifacts whose publish input fingerprint no longer matches.
 
 ## Non-goals for this slice
 

--- a/docs/src/reference/async-performance-comparison.md
+++ b/docs/src/reference/async-performance-comparison.md
@@ -35,14 +35,14 @@ cargo build --manifest-path "$workdir/main/Cargo.toml" --release -p monochange -
 cargo build --manifest-path "$workdir/async/Cargo.toml" --release -p monochange --bin monochange
 
 node "$workdir/async/scripts/benchmark-cli.ts" run \
-  --main-bin "$workdir/main/target/release/mc" \
-  --pr-bin "$workdir/async/target/release/mc" \
+  --main-bin "$workdir/main/target/release/monochange" \
+  --pr-bin "$workdir/async/target/release/monochange" \
   --output "$workdir/async-performance.md" \
   --violations-output "$workdir/async-performance-violations.txt"
 
 node "$workdir/async/scripts/benchmark-step-commands.ts" run \
-  --main-bin "$workdir/main/target/release/mc" \
-  --pr-bin "$workdir/async/target/release/mc" \
+  --main-bin "$workdir/main/target/release/monochange" \
+  --pr-bin "$workdir/async/target/release/monochange" \
   --output "$workdir/async-step-performance.md" \
   --violations-output "$workdir/async-step-performance-violations.txt"
 

--- a/docs/src/reference/hosted-release-benchmarks.md
+++ b/docs/src/reference/hosted-release-benchmarks.md
@@ -46,8 +46,8 @@ Build the `main` and PR binaries first, then run the benchmark script against a 
 gh repo clone ifiokjr/monochange-release-benchmark-fixture /tmp/monochange-release-benchmark-fixture
 
 pnpm node scripts/benchmark-cli.ts run-fixture \
-  --main-bin /tmp/mc-main \
-  --pr-bin /tmp/mc-pr \
+  --main-bin /tmp/monochange-main \
+  --pr-bin /tmp/monochange-pr \
   --fixture-dir /tmp/monochange-release-benchmark-fixture \
   --scenario-id hosted_github \
   --scenario-name "Hosted GitHub fixture" \

--- a/packages/monochange__cli/package.json
+++ b/packages/monochange__cli/package.json
@@ -21,7 +21,6 @@
 		"url": "git+https://github.com/monochange/monochange.git"
 	},
 	"bin": {
-		"mc": "bin/monochange.js",
 		"monochange": "bin/monochange.js"
 	},
 	"files": [

--- a/scripts/benchmark-commands.sh
+++ b/scripts/benchmark-commands.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
-BINARY="$ROOT_DIR/target/release/mc"
+BINARY="$ROOT_DIR/target/release/monochange"
 RESULTS_FILE="${1:-/tmp/monochange-benchmark-$(date +%s).json}"
 
 # Colors for output

--- a/scripts/binary-size.ts
+++ b/scripts/binary-size.ts
@@ -9,14 +9,14 @@
  *
  * Usage:
  *   node scripts/binary-size.ts compare \
- *     --main-bin /tmp/mc-main \
- *     --pr-bin /tmp/mc-pr \
+ *     --main-bin /tmp/monochange-main \
+ *     --pr-bin /tmp/monochange-pr \
  *     --output /tmp/size-comment.md
  *
  *   node scripts/binary-size.ts compare \
- *     --main-bin /tmp/mc-main \
+ *     --main-bin /tmp/monochange-main \
  *     --main-size-bytes 30_886_048 \
- *     --pr-bin /tmp/mc-pr \
+ *     --pr-bin /tmp/monochange-pr \
  *     --output /tmp/size-comment.md
  *
  * When --main-size-bytes is provided, the main binary itself is not


### PR DESCRIPTION
## Summary

Removes the leftover `mc` npm bin alias and migrates every remaining live `mc` reference to `monochange`, keeping the migration guide and historical `changelog.md` / `release.json` content.

## Motivation

The migration guide already claimed the packaged `mc` binary alias was removed, but `packages/monochange__cli/package.json` still shipped `"mc": "bin/monochange.js"`. This finishes the removal so the published npm package, the Rust binary, scripts, CI, tests, and docs all agree on `monochange`.

## Changes

- **npm**: drop the `mc` bin entry from `@monochange/cli`'s `package.json` (breaking for users who invoke `mc`).
- **Scripts/CI**: `scripts/benchmark-commands.sh` no longer points at the nonexistent `target/release/mc`; rename the `/tmp/mc-main` / `/tmp/mc-pr` benchmark temp paths to `/tmp/monochange-main` / `/tmp/monochange-pr` in `ci.yml`, `scripts/binary-size.ts`, and the benchmark test.
- **Tests**: use `monochange` as the CLI `bin_name`/argv fixture in `lib_tests.rs`, `cli_snapshot.rs`, `benches/cli_commands.rs`, and the `release_output_format` / `check_lint_output` prose; regenerate the two affected `cli_snapshot` insta snapshots.
- **Schema fixtures**: update `release-record/*.json` example `"command"` values from `mc release …` to `monochange release …`.
- **Docs**: migrate `mc` executable references across `docs/plans/`, the release checklist, and benchmark reference docs, and fix the stale `bin: monochange,mc` checklist item to `bin: monochange` (matching `release.yml`).
- Kept `docs/src/guide/16-cli-command-migration.md` (its purpose is to document `mc` → `monochange`) and the `packages/monochange__skill/skills/commands.md` instruction that tells agents not to use `mc`.
- Kept all `changelog.md` and `.monochange/releases/*/release.json` content unchanged.

## Breaking change

Update any scripts, CI workflows, or docs that call `mc` to use `monochange`. Add a local shell alias (`alias mc = monochange`) if you still want the short name.

## Validation

`fix:all`, `lint:all`, `build:all`, `test:all`, and `coverage:patch` (100%) all pass locally.