### PR TITLE
fix(cli): improve publish and workflow failure feedback

### DIFF
--- a/.changeset/cli-command-progress-feedback.md
+++ b/.changeset/cli-command-progress-feedback.md
@@ -1,0 +1,35 @@
+---
+monochange: patch
+---
+
+# Show workflow progress and preserve command failure output
+
+Configured workflows now report command and step starts on stderr by default, including captured editor and CI runs. Quiet mode and `MONOCHANGE_NO_PROGRESS` still suppress progress. Failed workflows now emit exactly one failed terminal event, run `always_run` cleanup steps, identify later steps skipped after the failure, and never report the failed step or command as successful.
+
+Command:
+
+```bash
+monochange run release
+```
+
+**Before (stderr):**
+
+```text
+# no status while a captured command was running
+error: command `build-project` failed: exit status 1
+```
+
+**After (stderr):**
+
+```text
+monochange running `release`
+▶ [1/2] build project (Command)
+▶ [1/2] build project (Command) — running command `build-project`
+✖ [1/2] build project (Command)
+  └─ discovery error: command `build-project` failed: exit status: 1
+  │ stdout:
+  │ compiler diagnostic
+✖ `release` failed
+```
+
+Configured command and lockfile command failures preserve the exit status and useful stdout as well as stderr, so users no longer need to rerun the child command to discover stdout-only diagnostics. Package-publish progress also respects quiet mode.

--- a/.changeset/complete-publish-failure-summary.md
+++ b/.changeset/complete-publish-failure-summary.md
@@ -1,0 +1,36 @@
+---
+monochange_publish: patch
+---
+
+# Report every expected package after publishing stops on failure
+
+Sequential package publishing remains fail-fast, but its report now includes every package that was expected. Packages not attempted after the first failure are recorded as blocked with an explanation, reported as skipped in progress totals, and remain eligible for a resumed publish.
+
+**Before:**
+
+```text
+◆ Publish complete: 13 packages, ✅ 12 published, ⏭️ 0 skipped, ❌ 1 failed
+```
+
+**After:**
+
+```text
+◆ Publish complete: 45 expected, ✅ 12 succeeded, ❌ 1 failed, ⏭️ 32 skipped
+```
+
+The library also exposes a derived summary without changing the persisted report schema:
+
+```rust
+// before
+let report: PackagePublishReport = execute_publish_requests(...).await?;
+
+// after
+let report: PackagePublishReport = execute_publish_requests(...).await?;
+let summary: PackagePublishSummary = report.summary();
+assert_eq!(summary.expected, 45);
+assert_eq!(summary.succeeded, 12);
+assert_eq!(summary.failed, 1);
+assert_eq!(summary.skipped, 32);
+```
+
+Publish errors now include these aggregate counts and retain the failed package's command diagnostics. Command error rendering preserves stdout-only failures and clearly labels both streams when both are available.

--- a/crates/monochange/src/__tests__/cli_progress_tests.rs
+++ b/crates/monochange/src/__tests__/cli_progress_tests.rs
@@ -114,6 +114,12 @@ fn progress_format_parsing_and_renderer_selection_cover_all_variants() {
 	assert_eq!(ascii.render_mode, ProgressRenderMode::Human);
 	assert_eq!(ascii.symbols.command_success, ASCII_SYMBOLS.command_success);
 
+	let auto = CliProgressReporter::new(&command, false, false, ProgressFormat::Auto);
+	assert!(auto.enabled);
+
+	let quiet = CliProgressReporter::new(&command, false, true, ProgressFormat::Auto);
+	assert!(!quiet.enabled);
+
 	let json = CliProgressReporter::new(&command, false, false, ProgressFormat::Json);
 	assert!(json.enabled);
 	assert_eq!(json.render_mode, ProgressRenderMode::Json);
@@ -125,10 +131,11 @@ fn progress_reporter_renders_skips_failures_and_stderr_output_when_enabled() {
 	let mut reporter = progress_reporter(true, false);
 	let step = named_command_step("announce release");
 
-	reporter.step_skipped(0, &step, None);
-	reporter.step_skipped(0, &step, Some("{{ false }}"));
+	reporter.step_skipped(0, &step, None, None);
+	reporter.step_skipped(0, &step, Some("{{ false }}"), Some("condition is false"));
 	reporter.log_command_output(0, &step, CommandStream::Stderr, "warn line\n");
 	reporter.step_failed(1, &step, Duration::from_millis(25), "boom\nagain");
+	reporter.command_failed(Duration::from_millis(30), "boom");
 }
 
 #[test]
@@ -137,8 +144,9 @@ fn progress_reporter_emits_json_skip_and_failure_events() {
 	reporter.render_mode = ProgressRenderMode::Json;
 	let step = named_command_step("announce release");
 
-	reporter.step_skipped(0, &step, Some("{{ false }}"));
+	reporter.step_skipped(0, &step, Some("{{ false }}"), Some("condition is false"));
 	reporter.step_failed(1, &step, Duration::from_millis(25), "boom");
+	reporter.command_failed(Duration::from_millis(30), "boom");
 }
 
 #[test]

--- a/crates/monochange/src/__tests__/cli_runtime_tests.rs
+++ b/crates/monochange/src/__tests__/cli_runtime_tests.rs
@@ -65,109 +65,6 @@ fn cli_context() -> CliContext {
 }
 
 #[test]
-fn expected_progress_phases_cover_dark_area_steps() {
-	assert_eq!(
-		expected_progress_phases(&CliStepDefinition::Discover {
-			name: None,
-			when: None,
-			always_run: false,
-			inputs: BTreeMap::new(),
-		}),
-		&[
-			"using loaded workspace configuration",
-			"scanning ecosystems for package manifests",
-			"reporting package counts",
-		]
-	);
-	assert_eq!(
-		expected_progress_phases(&CliStepDefinition::PrepareRelease {
-			name: None,
-			when: None,
-			always_run: false,
-			inputs: BTreeMap::new(),
-			allow_empty_changesets: false,
-		}),
-		&[
-			"loading changesets",
-			"computing dependency graph",
-			"planning versions",
-			"rendering changelogs",
-			"updating package files",
-			"refreshing lockfiles",
-		]
-	);
-	assert!(
-		expected_progress_phases(&CliStepDefinition::Config {
-			name: None,
-			when: None,
-			always_run: false,
-			inputs: BTreeMap::new(),
-		})
-		.is_empty()
-	);
-}
-
-#[test]
-fn expected_progress_phases_cover_provider_and_registry_steps() {
-	assert!(
-		expected_progress_phases(&CliStepDefinition::PublishRelease {
-			name: None,
-			when: None,
-			always_run: false,
-			inputs: BTreeMap::new(),
-		})
-		.contains(&"preparing source provider API client")
-	);
-	assert!(
-		expected_progress_phases(&CliStepDefinition::OpenReleaseRequest {
-			name: None,
-			when: None,
-			always_run: false,
-			inputs: BTreeMap::new(),
-			no_verify: false,
-			stage_all: false,
-		})
-		.contains(&"applying release request labels and automerge settings")
-	);
-	assert!(
-		expected_progress_phases(&CliStepDefinition::PlanPublishRateLimits {
-			name: None,
-			when: None,
-			always_run: false,
-			inputs: BTreeMap::new(),
-		})
-		.contains(&"planning registry rate limits")
-	);
-	assert!(
-		expected_progress_phases(&CliStepDefinition::PlaceholderPublish {
-			name: None,
-			when: None,
-			always_run: false,
-			inputs: BTreeMap::new(),
-		})
-		.contains(&"publishing placeholders per package")
-	);
-	assert!(
-		expected_progress_phases(&CliStepDefinition::PublishPackages {
-			name: None,
-			when: None,
-			always_run: false,
-			inputs: BTreeMap::new(),
-		})
-		.contains(&"publishing packages with bounded registry feedback")
-	);
-	assert!(
-		expected_progress_phases(&CliStepDefinition::PublishReadiness {
-			name: None,
-			when: None,
-			always_run: false,
-			inputs: BTreeMap::new(),
-		})
-		.contains(&"checking package registry readiness")
-	);
-}
-
-#[test]
 fn resolve_step_input_override_treats_inherited_as_empty() {
 	let context = cli_context();
 	let mut template_context = None;
@@ -1444,6 +1341,96 @@ fn filter_placeholder_publish_report_hides_completed_dry_run_packages_by_default
 }
 
 #[test]
+fn placeholder_rendering_keeps_complete_summary_when_detail_rows_are_filtered() {
+	let mut context = cli_context();
+	context.package_publish_report = Some(package_publish::PackagePublishReport {
+		mode: package_publish::PackagePublishRunMode::Placeholder,
+		dry_run: false,
+		packages: vec![
+			sample_package_publish_outcome(
+				package_publish::PackagePublishStatus::Published,
+				package_publish::TrustedPublishingStatus::Configured,
+			),
+			sample_package_publish_outcome(
+				package_publish::PackagePublishStatus::SkippedExisting,
+				package_publish::TrustedPublishingStatus::Configured,
+			),
+		],
+	});
+	let command = CliCommandDefinition {
+		name: "placeholder".to_string(),
+		help_text: None,
+		inputs: Vec::new(),
+		steps: Vec::new(),
+		dry_run: false,
+	};
+
+	let text = render_cli_command_result(&command, &context);
+	assert!(text.contains("summary: 2 expected, 1 succeeded, 0 failed, 1 skipped"));
+	assert_eq!(text.matches(" via ").count(), 1);
+
+	let markdown = render_cli_command_markdown_result(&command, &context);
+	assert!(markdown.contains("**Summary:** 2 expected, 1 succeeded, 0 failed, 1 skipped"));
+}
+
+#[test]
+fn placeholder_json_and_template_outputs_filter_package_rows_but_keep_complete_summary() {
+	let mut context = cli_context();
+	context.last_step_inputs = BTreeMap::from([
+		("format".to_string(), vec!["json".to_string()]),
+		("show-all".to_string(), vec!["false".to_string()]),
+	]);
+	context.package_publish_report = Some(package_publish::PackagePublishReport {
+		mode: package_publish::PackagePublishRunMode::Placeholder,
+		dry_run: false,
+		packages: vec![
+			sample_package_publish_outcome(
+				package_publish::PackagePublishStatus::Published,
+				package_publish::TrustedPublishingStatus::Configured,
+			),
+			sample_package_publish_outcome(
+				package_publish::PackagePublishStatus::SkippedExisting,
+				package_publish::TrustedPublishingStatus::Configured,
+			),
+			sample_package_publish_outcome(
+				package_publish::PackagePublishStatus::Failed,
+				package_publish::TrustedPublishingStatus::Disabled,
+			),
+		],
+	});
+	let command = CliCommandDefinition {
+		name: "placeholder".to_string(),
+		help_text: None,
+		inputs: Vec::new(),
+		steps: Vec::new(),
+		dry_run: false,
+	};
+
+	let rendered = resolve_command_output(&command, &context, true, None)
+		.unwrap_or_else(|error| panic!("package publish json output: {error}"));
+	let parsed: serde_json::Value =
+		serde_json::from_str(&rendered).unwrap_or_else(|error| panic!("parse json: {error}"));
+	assert_eq!(parsed["package_publish"]["summary"]["expected"], 3);
+	assert_eq!(
+		parsed["package_publish"]["packages"]
+			.as_array()
+			.expect("package rows")
+			.len(),
+		2
+	);
+
+	let template_context = build_cli_template_context(&context, &context.last_step_inputs, None);
+	assert_eq!(template_context["publish"]["summary"]["expected"], 3);
+	assert_eq!(
+		template_context["publish"]["packages"]
+			.as_array()
+			.expect("template package rows")
+			.len(),
+		2
+	);
+}
+
+#[test]
 fn filter_placeholder_publish_report_hides_unchanged_real_run_packages_by_default() {
 	let report = package_publish::PackagePublishReport {
 		mode: package_publish::PackagePublishRunMode::Placeholder,
@@ -1491,11 +1478,18 @@ fn render_package_publish_reports_cover_empty_and_detailed_variants() {
 	assert_eq!(text_lines[0], "placeholder publishing:");
 	assert_eq!(
 		text_lines[1],
+		"  summary: 0 expected, 0 succeeded, 0 failed, 0 skipped"
+	);
+	assert_eq!(
+		text_lines[2],
 		"- no packages matched the publishing criteria"
 	);
 	assert_eq!(
 		render_package_publish_report_markdown(&empty_placeholder, false),
-		vec!["- no packages matched the publishing criteria".to_string()]
+		vec![
+			"- **Summary:** 0 expected, 0 succeeded, 0 failed, 0 skipped".to_string(),
+			"- no packages matched the publishing criteria".to_string(),
+		]
 	);
 
 	let detailed_report = package_publish::PackagePublishReport {
@@ -1609,6 +1603,7 @@ fn package_publish_status_labels_cover_all_variants() {
 		package_publish_status_label(package_publish::PackagePublishStatus::SkippedExternal),
 		"skipped-external"
 	);
+
 	assert_eq!(
 		package_publish_status_label(package_publish::PackagePublishStatus::Blocked),
 		"blocked"
@@ -1706,6 +1701,15 @@ fn resolve_command_output_supports_package_publish_json_without_release_state() 
 	assert_eq!(
 		parsed["package_publish"]["dry_run"],
 		serde_json::json!(true)
+	);
+	assert_eq!(
+		parsed["package_publish"]["summary"],
+		serde_json::json!({
+			"expected": 1,
+			"succeeded": 0,
+			"failed": 0,
+			"skipped": 1,
+		})
 	);
 	assert_eq!(
 		parsed["package_publish"]["packages"][0]["package"],
@@ -2079,19 +2083,23 @@ fn take_process_stream_reports_missing_pipes() {
 }
 
 #[test]
-fn step_shows_progress_disables_interactive_change_steps_by_default() {
-	let step = CliStepDefinition::CreateChangeFile {
+fn step_shows_progress_enables_every_step_by_default() {
+	let change_step = CliStepDefinition::CreateChangeFile {
 		show_progress: None,
 		name: Some("interactive change".to_string()),
 		when: None,
 		always_run: false,
 		inputs: BTreeMap::new(),
 	};
-	let mut step_inputs = BTreeMap::new();
-	step_inputs.insert("interactive".to_string(), vec!["true".to_string()]);
-	assert!(!step_shows_progress(&step, &step_inputs));
-	step_inputs.insert("interactive".to_string(), vec!["false".to_string()]);
-	assert!(step_shows_progress(&step, &step_inputs));
+	let config_step = CliStepDefinition::Config {
+		name: Some("load config".to_string()),
+		when: None,
+		always_run: false,
+		inputs: BTreeMap::new(),
+	};
+
+	assert!(step_shows_progress(&change_step));
+	assert!(step_shows_progress(&config_step));
 }
 
 #[test]
@@ -2108,7 +2116,7 @@ fn step_shows_progress_respects_explicit_step_flags() {
 		variables: None,
 		inputs: BTreeMap::new(),
 	};
-	assert!(!step_shows_progress(&step, &BTreeMap::new()));
+	assert!(!step_shows_progress(&step));
 }
 
 #[test]
@@ -2435,7 +2443,52 @@ async fn execute_cli_command_reports_command_failures_after_progress_callbacks()
 	.unwrap_err();
 	assert_eq!(
 		error.to_string(),
-		"discovery error: command `printf 'boom\\n' >&2; exit 3` failed: boom"
+		"discovery error: command `printf 'boom\\n' >&2; exit 3` failed: exit status: 3\nstderr:\nboom"
+	);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_cli_command_preserves_stdout_and_stderr_from_failed_commands() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let configuration = sample_configuration(tempdir.path());
+	let cli_command = CliCommandDefinition {
+		name: "fail".to_string(),
+		help_text: None,
+		inputs: Vec::new(),
+		steps: vec![CliStepDefinition::Command {
+			show_progress: None,
+			name: Some("fail with output".to_string()),
+			when: None,
+			always_run: false,
+			command: "printf 'stdout detail\\n'; printf 'stderr detail\\n' >&2; exit 4".to_string(),
+			dry_run_command: None,
+			shell: ShellConfig::Default,
+			id: None,
+			variables: None,
+			inputs: BTreeMap::new(),
+		}],
+		dry_run: false,
+	};
+
+	let error = execute_cli_command_with_options(
+		tempdir.path(),
+		&configuration,
+		&cli_command,
+		ExecuteCliCommandOptions {
+			dry_run: false,
+			quiet: true,
+			show_diff: false,
+			inputs: BTreeMap::new(),
+			prepared_release_path: None,
+			progress_format: ProgressFormat::Auto,
+		},
+	)
+	.await
+	.unwrap_err();
+
+	assert_eq!(
+		error.to_string(),
+		"discovery error: command `printf 'stdout detail\\n'; printf 'stderr detail\\n' >&2; exit 4` failed: exit status: 4\nstdout:\nstdout detail\n\nstderr:\nstderr detail"
 	);
 }
 
@@ -3101,32 +3154,6 @@ fn optional_publish_resume_and_output_paths_trim_and_reject_blank_values() {
 	let error =
 		optional_publish_resume_artifact_path(&blank).expect_err("blank resume path should fail");
 	assert!(error.to_string().contains("blank `resume` path"));
-}
-
-#[test]
-fn has_remaining_always_run_steps_detects_always_run_later_in_sequence() {
-	let steps = vec![
-		CliStepDefinition::Validate {
-			name: None,
-			when: None,
-			always_run: false,
-			inputs: BTreeMap::new(),
-		},
-		CliStepDefinition::Command {
-			show_progress: None,
-			name: None,
-			when: None,
-			always_run: true,
-			command: String::new(),
-			dry_run_command: None,
-			shell: ShellConfig::Default,
-			id: None,
-			variables: None,
-			inputs: BTreeMap::new(),
-		},
-	];
-	assert!(has_remaining_always_run_steps(&steps, 0));
-	assert!(!has_remaining_always_run_steps(&steps, 1));
 }
 
 #[test]

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -8110,6 +8110,449 @@ async fn execute_cli_command_publish_packages_step_surfaces_report_carrying_fail
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn execute_cli_command_placeholder_publish_step_surfaces_publish_execution_failure() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	fs::write(
+		root.join("monochange.toml"),
+		"[package.pkg]\npath = \"packages/pkg\"\ntype = \"npm\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write config: {error}"));
+	fs::create_dir_all(root.join("packages/pkg")).unwrap_or_else(|error| panic!("mkdir: {error}"));
+	fs::write(
+		root.join("packages/pkg/package.json"),
+		r#"{ "name": "pkg", "version": "1.0.0" }"#,
+	)
+	.unwrap_or_else(|error| panic!("write package.json: {error}"));
+	let configuration =
+		load_workspace_configuration(root).unwrap_or_else(|error| panic!("configuration: {error}"));
+
+	let placeholder_command = CliCommandDefinition {
+		name: "placeholder-publish".to_string(),
+		help_text: None,
+		inputs: Vec::new(),
+		steps: vec![CliStepDefinition::PlaceholderPublish {
+			name: None,
+			when: None,
+			always_run: false,
+			inputs: inherited_format_package_step_inputs(),
+		}],
+		dry_run: false,
+	};
+
+	let registry = std::net::TcpListener::bind("127.0.0.1:0")
+		.unwrap_or_else(|error| panic!("bind test registry: {error}"));
+	let registry_address = registry
+		.local_addr()
+		.unwrap_or_else(|error| panic!("registry address: {error}"));
+	let registry_thread = std::thread::spawn(move || {
+		let mut served_not_found = false;
+		for _ in 0..2 {
+			let Ok((mut stream, _)) = registry.accept() else {
+				break;
+			};
+			let mut request = [0_u8; 2048];
+			let _ = std::io::Read::read(&mut stream, &mut request);
+			let response: &[u8] = if served_not_found {
+				b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+			} else {
+				served_not_found = true;
+				b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+			};
+			let _ = std::io::Write::write_all(&mut stream, response);
+		}
+	});
+
+	temp_env::async_with_vars(
+		[(
+			"MONOCHANGE_NPM_REGISTRY_URL",
+			Some(format!("http://{registry_address}")),
+		)],
+		async {
+			let error = crate::execute_cli_command(
+				root,
+				&configuration,
+				&placeholder_command,
+				true,
+				BTreeMap::from([("format".to_string(), vec!["text".to_string()])]),
+			)
+			.await
+			.expect_err("registry failure during placeholder publish should fail");
+			assert!(
+				error.render().contains("npm registry lookup"),
+				"unexpected error: {}",
+				error.render()
+			);
+		},
+	)
+	.await;
+	registry_thread
+		.join()
+		.unwrap_or_else(|_| panic!("test registry thread panicked"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_cli_command_publish_packages_step_surfaces_publish_execution_failure() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	fs::write(
+		root.join("monochange.toml"),
+		"[package.pkg]\npath = \"packages/pkg\"\ntype = \"npm\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write config: {error}"));
+	fs::create_dir_all(root.join("packages/pkg")).unwrap_or_else(|error| panic!("mkdir: {error}"));
+	fs::write(
+		root.join("packages/pkg/package.json"),
+		r#"{ "name": "pkg", "version": "1.0.0" }"#,
+	)
+	.unwrap_or_else(|error| panic!("write package.json: {error}"));
+	let configuration =
+		load_workspace_configuration(root).unwrap_or_else(|error| panic!("configuration: {error}"));
+
+	let mut publish_step_inputs = inherited_format_package_step_inputs();
+	publish_step_inputs.insert(
+		"all".to_string(),
+		monochange_core::CliStepInputValue::Inherited,
+	);
+
+	let publish_command = CliCommandDefinition {
+		name: "publish".to_string(),
+		help_text: None,
+		inputs: Vec::new(),
+		steps: vec![CliStepDefinition::PublishPackages {
+			name: None,
+			when: None,
+			always_run: false,
+			inputs: publish_step_inputs,
+		}],
+		dry_run: false,
+	};
+
+	// The plan step's `filter_pending_publish_requests` lookup returns 404
+	// (version not yet published), so planning succeeds. The subsequent publish
+	// execution lookup returns 500, surfacing a report-carrying failure through
+	// the CLI runtime's publish-packages error branch.
+	let registry = std::net::TcpListener::bind("127.0.0.1:0")
+		.unwrap_or_else(|error| panic!("bind test registry: {error}"));
+	let registry_address = registry
+		.local_addr()
+		.unwrap_or_else(|error| panic!("registry address: {error}"));
+	let registry_thread = std::thread::spawn(move || {
+		let mut served_not_found = false;
+		for _ in 0..2 {
+			let Ok((mut stream, _)) = registry.accept() else {
+				break;
+			};
+			let mut request = [0_u8; 2048];
+			let _ = std::io::Read::read(&mut stream, &mut request);
+			let response: &[u8] = if served_not_found {
+				b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+			} else {
+				served_not_found = true;
+				b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+			};
+			let _ = std::io::Write::write_all(&mut stream, response);
+		}
+	});
+
+	temp_env::async_with_vars(
+		[(
+			"MONOCHANGE_NPM_REGISTRY_URL",
+			Some(format!("http://{registry_address}")),
+		)],
+		async {
+			let error = crate::execute_cli_command(
+				root,
+				&configuration,
+				&publish_command,
+				true,
+				BTreeMap::from([
+					("format".to_string(), vec!["text".to_string()]),
+					("all".to_string(), vec!["true".to_string()]),
+				]),
+			)
+			.await
+			.expect_err("registry failure during publish should fail");
+			assert!(
+				error.render().contains("npm registry lookup"),
+				"unexpected error: {}",
+				error.render()
+			);
+		},
+	)
+	.await;
+	registry_thread
+		.join()
+		.unwrap_or_else(|_| panic!("test registry thread panicked"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_cli_command_publish_packages_step_writes_report_artifact_on_execution_failure() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	fs::write(
+		root.join("monochange.toml"),
+		"[package.pkg]\npath = \"packages/pkg\"\ntype = \"npm\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write config: {error}"));
+	fs::create_dir_all(root.join("packages/pkg")).unwrap_or_else(|error| panic!("mkdir: {error}"));
+	fs::write(
+		root.join("packages/pkg/package.json"),
+		r#"{ "name": "pkg", "version": "1.0.0" }"#,
+	)
+	.unwrap_or_else(|error| panic!("write package.json: {error}"));
+	let configuration =
+		load_workspace_configuration(root).unwrap_or_else(|error| panic!("configuration: {error}"));
+
+	let mut publish_step_inputs = inherited_format_package_step_inputs();
+	publish_step_inputs.insert(
+		"all".to_string(),
+		monochange_core::CliStepInputValue::Inherited,
+	);
+	publish_step_inputs.insert(
+		"output".to_string(),
+		monochange_core::CliStepInputValue::Inherited,
+	);
+
+	let publish_command = CliCommandDefinition {
+		name: "publish".to_string(),
+		help_text: None,
+		inputs: Vec::new(),
+		steps: vec![CliStepDefinition::PublishPackages {
+			name: None,
+			when: None,
+			always_run: false,
+			inputs: publish_step_inputs,
+		}],
+		dry_run: false,
+	};
+
+	let output_artifact = root.join("publish-report.json");
+
+	// A real (non-dry-run) publish that fails at the registry writes the
+	// report-carrying failure artifact before surfacing the error, covering the
+	// CLI runtime's write-publish-report-artifact branch.
+	let registry = std::net::TcpListener::bind("127.0.0.1:0")
+		.unwrap_or_else(|error| panic!("bind test registry: {error}"));
+	let registry_address = registry
+		.local_addr()
+		.unwrap_or_else(|error| panic!("registry address: {error}"));
+	let registry_thread = std::thread::spawn(move || {
+		let mut served_not_found = false;
+		for _ in 0..2 {
+			let Ok((mut stream, _)) = registry.accept() else {
+				break;
+			};
+			let mut request = [0_u8; 2048];
+			let _ = std::io::Read::read(&mut stream, &mut request);
+			let response: &[u8] = if served_not_found {
+				b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+			} else {
+				served_not_found = true;
+				b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+			};
+			let _ = std::io::Write::write_all(&mut stream, response);
+		}
+	});
+
+	temp_env::async_with_vars(
+		[(
+			"MONOCHANGE_NPM_REGISTRY_URL",
+			Some(format!("http://{registry_address}")),
+		)],
+		async {
+			let error = crate::execute_cli_command(
+				root,
+				&configuration,
+				&publish_command,
+				false,
+				BTreeMap::from([
+					("format".to_string(), vec!["text".to_string()]),
+					("all".to_string(), vec!["true".to_string()]),
+					(
+						"output".to_string(),
+						vec![output_artifact.display().to_string()],
+					),
+				]),
+			)
+			.await
+			.expect_err("registry failure during publish should fail");
+			assert!(
+				error.render().contains("npm registry lookup"),
+				"unexpected error: {}",
+				error.render()
+			);
+		},
+	)
+	.await;
+	registry_thread
+		.join()
+		.unwrap_or_else(|_| panic!("test registry thread panicked"));
+	assert!(
+		output_artifact.is_file(),
+		"publish report artifact should be written on failure"
+	);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_cli_command_publish_packages_step_surfaces_write_artifact_failure() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let root = tempdir.path();
+	fs::write(
+		root.join("monochange.toml"),
+		"[package.pkg]\npath = \"packages/pkg\"\ntype = \"npm\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write config: {error}"));
+	fs::create_dir_all(root.join("packages/pkg")).unwrap_or_else(|error| panic!("mkdir: {error}"));
+	fs::write(
+		root.join("packages/pkg/package.json"),
+		r#"{ "name": "pkg", "version": "1.0.0" }"#,
+	)
+	.unwrap_or_else(|error| panic!("write package.json: {error}"));
+	let configuration =
+		load_workspace_configuration(root).unwrap_or_else(|error| panic!("configuration: {error}"));
+
+	let mut publish_step_inputs = inherited_format_package_step_inputs();
+	publish_step_inputs.insert(
+		"all".to_string(),
+		monochange_core::CliStepInputValue::Inherited,
+	);
+	publish_step_inputs.insert(
+		"output".to_string(),
+		monochange_core::CliStepInputValue::Inherited,
+	);
+
+	let publish_command = CliCommandDefinition {
+		name: "publish".to_string(),
+		help_text: None,
+		inputs: Vec::new(),
+		steps: vec![CliStepDefinition::PublishPackages {
+			name: None,
+			when: None,
+			always_run: false,
+			inputs: publish_step_inputs,
+		}],
+		dry_run: false,
+	};
+
+	// An output path whose parent is a file (not a directory) makes
+	// `write_publish_report_artifact` fail, surfacing the write error through
+	// the CLI runtime's `?` propagation.
+	let blocker = root.join("blocker-file");
+	fs::write(&blocker, "not a directory").unwrap_or_else(|error| panic!("write blocker: {error}"));
+	let invalid_output = blocker.join("report.json");
+
+	let registry = std::net::TcpListener::bind("127.0.0.1:0")
+		.unwrap_or_else(|error| panic!("bind test registry: {error}"));
+	let registry_address = registry
+		.local_addr()
+		.unwrap_or_else(|error| panic!("registry address: {error}"));
+	let registry_thread = std::thread::spawn(move || {
+		let mut served_not_found = false;
+		for _ in 0..2 {
+			let Ok((mut stream, _)) = registry.accept() else {
+				break;
+			};
+			let mut request = [0_u8; 2048];
+			let _ = std::io::Read::read(&mut stream, &mut request);
+			let response: &[u8] = if served_not_found {
+				b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+			} else {
+				served_not_found = true;
+				b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+			};
+			let _ = std::io::Write::write_all(&mut stream, response);
+		}
+	});
+
+	temp_env::async_with_vars(
+		[(
+			"MONOCHANGE_NPM_REGISTRY_URL",
+			Some(format!("http://{registry_address}")),
+		)],
+		async {
+			let error = crate::execute_cli_command(
+				root,
+				&configuration,
+				&publish_command,
+				false,
+				BTreeMap::from([
+					("format".to_string(), vec!["text".to_string()]),
+					("all".to_string(), vec!["true".to_string()]),
+					(
+						"output".to_string(),
+						vec![invalid_output.display().to_string()],
+					),
+				]),
+			)
+			.await
+			.expect_err("write artifact failure should surface an error");
+			assert!(
+				error.render().contains("blocker-file"),
+				"unexpected error: {}",
+				error.render()
+			);
+		},
+	)
+	.await;
+	registry_thread
+		.join()
+		.unwrap_or_else(|_| panic!("test registry thread panicked"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_cli_command_plan_publish_rate_limits_renders_json_output() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_fixture("monochange/release-base", tempdir.path());
+	let root = tempdir.path();
+	let configuration =
+		load_workspace_configuration(root).unwrap_or_else(|error| panic!("configuration: {error}"));
+
+	let plan_command = CliCommandDefinition {
+		name: "publish-plan".to_string(),
+		help_text: None,
+		inputs: Vec::new(),
+		steps: vec![CliStepDefinition::PlanPublishRateLimits {
+			name: None,
+			when: None,
+			always_run: false,
+			inputs: inherited_publish_plan_step_inputs(),
+		}],
+		dry_run: false,
+	};
+
+	let server = MockServer::start();
+	let _registry = server.mock(|when, then| {
+		when.method(GET);
+		then.status(404);
+	});
+
+	temp_env::async_with_vars(
+		[("MONOCHANGE_CRATES_IO_API_URL", Some(server.base_url()))],
+		async {
+			let output = crate::execute_cli_command(
+				root,
+				&configuration,
+				&plan_command,
+				true,
+				BTreeMap::from([
+					("format".to_string(), vec!["json".to_string()]),
+					("mode".to_string(), vec!["placeholder".to_string()]),
+					("package".to_string(), vec!["missing-package".to_string()]),
+				]),
+			)
+			.await
+			.unwrap_or_else(|error| panic!("plan publish rate limits json: {error}"));
+			assert!(
+				output.contains("\"publish_rate_limits\""),
+				"expected json rate limit output: {output}"
+			);
+		},
+	)
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn execute_cli_command_allows_package_publish_steps_without_readiness_or_matching_packages() {
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	copy_fixture("monochange/release-base", tempdir.path());

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -3281,7 +3281,10 @@ fn command_release_dry_run_discovers_changesets_without_mutating_files() {
 	)
 	.unwrap_or_else(|error| panic!("command output: {error}"));
 
-	assert!(output.contains("# `step prepare-release` (dry-run)"));
+	assert!(
+		output.contains("step prepare-release") && output.contains("(dry-run)"),
+		"unexpected command output:\n{output}"
+	);
 	assert!(output.contains("1.1.0"));
 	assert!(output.contains("workflow-app"));
 	assert!(output.contains("workflow-core"));
@@ -3655,8 +3658,11 @@ fn command_release_updates_manifests_changelogs_and_deletes_changesets() {
 		.unwrap_or_else(|error| panic!("group versioned file: {error}"));
 	let package_versioned_file = fs::read_to_string(tempdir.path().join("crates/core/extra.toml"))
 		.unwrap_or_else(|error| panic!("package versioned file: {error}"));
-	assert!(output.contains("# `step prepare-release`"));
-	assert!(output.contains("group `sdk`"));
+	assert!(
+		output.contains("step prepare-release"),
+		"unexpected command output:\n{output}"
+	);
+	assert!(output.contains("group ") && output.contains("sdk"));
 	assert!(output.contains("v1.1.0"));
 	assert!(workspace_manifest.contains("version = \"1.1.0\""));
 	assert!(core_changelog.contains("## 1.1.0"));
@@ -3907,7 +3913,7 @@ fn command_release_uses_empty_update_message_precedence_for_grouped_changelogs()
 	let group_changelog = fs::read_to_string(tempdir.path().join("changelog.md"))
 		.unwrap_or_else(|error| panic!("group changelog: {error}"));
 
-	assert!(output.contains("# `step prepare-release`"));
+	assert!(output.contains("step prepare-release"));
 	assert!(core_changelog.contains("Package override for workflow-core -> 1.0.1"));
 	assert!(app_changelog.contains("Update triggered by group sdk; version 1.0.1."));
 	assert!(group_changelog.contains("Update triggered by group sdk; version 1.0.1."));
@@ -13163,7 +13169,7 @@ fn command_release_without_diff_skips_file_diff_previews() {
 	)
 	.unwrap_or_else(|error| panic!("release without diff: {error}"));
 	set_force_build_file_diff_previews_error(false);
-	assert!(output.contains("# `step prepare-release`"));
+	assert!(output.contains("step prepare-release"));
 }
 
 #[test]

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -8003,6 +8003,113 @@ async fn execute_cli_command_supports_placeholder_and_package_publish_steps() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn execute_cli_command_placeholder_publish_step_surfaces_report_carrying_failure() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_fixture("monochange/release-base", tempdir.path());
+	let root = tempdir.path();
+	let mut configuration =
+		load_workspace_configuration(root).unwrap_or_else(|error| panic!("configuration: {error}"));
+	// A custom registry is unsupported by built-in placeholder publishing, so
+	// `build_placeholder_requests` returns a report-carrying failure that the
+	// CLI runtime must surface while preserving the publish report.
+	configuration.packages[0].publish.registry = Some(monochange_core::PublishRegistry::Custom(
+		"internal".to_string(),
+	));
+
+	let placeholder_command = CliCommandDefinition {
+		name: "placeholder-publish".to_string(),
+		help_text: None,
+		inputs: Vec::new(),
+		steps: vec![CliStepDefinition::PlaceholderPublish {
+			name: None,
+			when: None,
+			always_run: false,
+			inputs: inherited_format_package_step_inputs(),
+		}],
+		dry_run: false,
+	};
+
+	let server = MockServer::start();
+	let _registry = server.mock(|when, then| {
+		when.method(GET);
+		then.status(404);
+	});
+
+	temp_env::async_with_vars(
+		[("MONOCHANGE_CRATES_IO_API_URL", Some(server.base_url()))],
+		async {
+			let error = crate::execute_cli_command(
+				root,
+				&configuration,
+				&placeholder_command,
+				true,
+				BTreeMap::from([("format".to_string(), vec!["text".to_string()])]),
+			)
+			.await
+			.expect_err("custom registry placeholder publish should fail");
+			assert!(
+				error.render().contains("custom registry `internal`"),
+				"unexpected error: {}",
+				error.render()
+			);
+		},
+	)
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_cli_command_publish_packages_step_surfaces_report_carrying_failure() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_fixture("monochange/release-base", tempdir.path());
+	let root = tempdir.path();
+	let configuration =
+		load_workspace_configuration(root).unwrap_or_else(|error| panic!("configuration: {error}"));
+
+	// Without a prepared release or `--all`, the publish-packages step looks up
+	// a release record at HEAD. None exists in the fixture, so the step returns a
+	// report-carrying failure that the CLI runtime surfaces.
+	let publish_command = CliCommandDefinition {
+		name: "publish".to_string(),
+		help_text: None,
+		inputs: Vec::new(),
+		steps: vec![CliStepDefinition::PublishPackages {
+			name: None,
+			when: None,
+			always_run: false,
+			inputs: inherited_format_package_step_inputs(),
+		}],
+		dry_run: false,
+	};
+
+	let server = MockServer::start();
+	let _registry = server.mock(|when, then| {
+		when.method(GET);
+		then.status(404);
+	});
+
+	temp_env::async_with_vars(
+		[("MONOCHANGE_CRATES_IO_API_URL", Some(server.base_url()))],
+		async {
+			let error = crate::execute_cli_command(
+				root,
+				&configuration,
+				&publish_command,
+				true,
+				BTreeMap::from([("format".to_string(), vec!["text".to_string()])]),
+			)
+			.await
+			.expect_err("publish without a release record should fail");
+			assert!(
+				error.render().contains("HEAD"),
+				"unexpected error: {}",
+				error.render()
+			);
+		},
+	)
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn execute_cli_command_allows_package_publish_steps_without_readiness_or_matching_packages() {
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	copy_fixture("monochange/release-base", tempdir.path());

--- a/crates/monochange/src/__tests__/package_publish_tests.rs
+++ b/crates/monochange/src/__tests__/package_publish_tests.rs
@@ -4313,12 +4313,13 @@ async fn run_placeholder_publish_uses_env_overrides_for_registry_endpoints() {
 			Some(server.base_url().as_str()),
 		)],
 		async {
-			let report = run_placeholder_publish_with_npm_otp(
+			let report = try_run_placeholder_publish_with_npm_otp(
 				root.path(),
 				&configuration,
 				&BTreeSet::new(),
 				true,
 				Some("123456"),
+				true,
 			)
 			.await
 			.expect("placeholder report:");
@@ -4516,6 +4517,73 @@ fn process_command_executor_runs_commands_and_reports_spawn_failures() {
 }
 
 #[test]
+fn resumed_publish_progress_offsets_run_totals_and_leaves_package_events_unchanged() {
+	let resumed = monochange_publish::PackagePublishSummary {
+		expected: 12,
+		succeeded: 10,
+		failed: 0,
+		skipped: 2,
+	};
+	let resumed_ecosystems = BTreeSet::from([Ecosystem::Cargo]);
+	let started = offset_publish_progress_event(
+		PublishProgressEvent::RunStarted {
+			mode: PackagePublishRunMode::Release,
+			dry_run: false,
+			total: 33,
+			ecosystems: vec![Ecosystem::Npm],
+		},
+		resumed,
+		&resumed_ecosystems,
+	);
+	assert!(matches!(
+		started,
+		PublishProgressEvent::RunStarted {
+			total: 45,
+			ref ecosystems,
+			..
+		} if ecosystems == &vec![Ecosystem::Cargo, Ecosystem::Npm]
+	));
+
+	let finished = offset_publish_progress_event(
+		PublishProgressEvent::RunFinished {
+			mode: PackagePublishRunMode::Release,
+			total: 33,
+			published: 2,
+			skipped: 30,
+			failed: 1,
+		},
+		resumed,
+		&resumed_ecosystems,
+	);
+	assert!(matches!(
+		finished,
+		PublishProgressEvent::RunFinished {
+			total: 45,
+			published: 12,
+			skipped: 32,
+			failed: 1,
+			..
+		}
+	));
+
+	let package = monochange_publish::PublishProgressPackage {
+		package_id: "pkg".to_string(),
+		package_name: "pkg".to_string(),
+		version: "1.0.0".to_string(),
+		ecosystem: Ecosystem::Npm,
+		registry: "npm".to_string(),
+	};
+	assert_eq!(
+		offset_publish_progress_event(
+			PublishProgressEvent::PackagePublished(package.clone()),
+			resumed,
+			&resumed_ecosystems,
+		),
+		PublishProgressEvent::PackagePublished(package)
+	);
+}
+
+#[test]
 fn fake_executor_reports_missing_outputs_and_render_helpers_match() {
 	let mut executor = FakeExecutor::new(Vec::new());
 	let spec = CommandSpec {
@@ -4539,7 +4607,7 @@ fn fake_executor_reports_missing_outputs_and_render_helpers_match() {
 			stdout: String::new(),
 			stderr: String::new(),
 		}),
-		"command failed"
+		"command failed without output"
 	);
 }
 
@@ -4806,10 +4874,14 @@ async fn run_publish_packages_with_resume_filters_by_group_and_ecosystem() {
 					&BTreeSet::new(),
 					&selected_groups,
 					&selected_ecosystems,
-					false,
-					true,
-					None,
-					false,
+					PublishPackagesOptions {
+						dry_run: true,
+						output: PublishOutputOptions {
+							stream_output: false,
+							quiet: true,
+						},
+						..PublishPackagesOptions::default()
+					},
 				))
 				.expect("publish report:");
 

--- a/crates/monochange/src/__tests__/package_publish_tests.rs
+++ b/crates/monochange/src/__tests__/package_publish_tests.rs
@@ -4608,6 +4608,79 @@ async fn try_run_publish_packages_maps_discovery_errors_to_report_carrying_failu
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn try_run_placeholder_publish_maps_build_request_errors() {
+	let root = tempfile::tempdir().expect("tempdir");
+	fs::write(
+		root.path().join("monochange.toml"),
+		"[package.pkg]\npath = \"packages/pkg\"\ntype = \"npm\"\n",
+	)
+	.expect("write config");
+	fs::create_dir_all(root.path().join("packages/pkg")).expect("mkdir");
+	fs::write(
+		root.path().join("packages/pkg/package.json"),
+		r#"{ "name": "pkg", "version": "1.0.0" }"#,
+	)
+	.expect("write package.json");
+	let mut configuration =
+		crate::load_workspace_configuration(root.path()).expect("configuration");
+	configuration.packages[0].publish.registry =
+		Some(PublishRegistry::Custom("internal".to_string()));
+
+	let error = try_run_placeholder_publish_with_npm_otp(
+		root.path(),
+		&configuration,
+		&BTreeSet::new(),
+		true,
+		None,
+		true,
+	)
+	.await
+	.expect_err("custom registry should produce a failure");
+	let report = error.into_report();
+	assert_eq!(report.mode, PackagePublishRunMode::Placeholder);
+	assert!(report.packages.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn try_run_placeholder_publish_maps_discovery_errors_via_malformed_config() {
+	let valid_root = tempfile::tempdir().expect("tempdir");
+	fs::write(
+		valid_root.path().join("monochange.toml"),
+		"[package.pkg]\npath = \"packages/pkg\"\ntype = \"npm\"\n",
+	)
+	.expect("write config");
+	fs::create_dir_all(valid_root.path().join("packages/pkg")).expect("mkdir");
+	fs::write(
+		valid_root.path().join("packages/pkg/package.json"),
+		r#"{ "name": "pkg", "version": "1.0.0" }"#,
+	)
+	.expect("write package.json");
+	let configuration =
+		crate::load_workspace_configuration(valid_root.path()).expect("configuration");
+
+	let malformed_root = tempfile::tempdir().expect("tempdir");
+	fs::write(
+		malformed_root.path().join("monochange.toml"),
+		"not valid toml [[[",
+	)
+	.expect("write malformed config");
+
+	let error = try_run_placeholder_publish_with_npm_otp(
+		malformed_root.path(),
+		&configuration,
+		&BTreeSet::new(),
+		true,
+		None,
+		true,
+	)
+	.await
+	.expect_err("malformed config should produce a failure");
+	let report = error.into_report();
+	assert_eq!(report.mode, PackagePublishRunMode::Placeholder);
+	assert!(report.packages.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn try_run_publish_packages_maps_resume_artifact_errors() {
 	let tempdir = tempfile::tempdir().expect("tempdir:");
 	let root = tempdir.path();
@@ -4629,6 +4702,126 @@ async fn try_run_publish_packages_maps_resume_artifact_errors() {
 	)
 	.await
 	.expect_err("missing resume artifact should produce a failure");
+	let report = error.into_report();
+	assert_eq!(report.mode, PackagePublishRunMode::Release);
+	assert!(report.packages.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn try_run_publish_packages_maps_publish_all_discovery_errors_via_malformed_config() {
+	let valid_root = tempfile::tempdir().expect("tempdir");
+	fs::write(
+		valid_root.path().join("monochange.toml"),
+		"[package.pkg]\npath = \"packages/pkg\"\ntype = \"npm\"\n",
+	)
+	.expect("write config");
+	fs::create_dir_all(valid_root.path().join("packages/pkg")).expect("mkdir");
+	fs::write(
+		valid_root.path().join("packages/pkg/package.json"),
+		r#"{ "name": "pkg", "version": "1.0.0" }"#,
+	)
+	.expect("write package.json");
+	let configuration =
+		crate::load_workspace_configuration(valid_root.path()).expect("configuration");
+
+	let malformed_root = tempfile::tempdir().expect("tempdir");
+	fs::write(
+		malformed_root.path().join("monochange.toml"),
+		"not valid toml [[[",
+	)
+	.expect("write malformed config");
+
+	let error = try_run_publish_packages_with_resume(
+		malformed_root.path(),
+		&configuration,
+		None,
+		&BTreeSet::new(),
+		&BTreeSet::new(),
+		&BTreeSet::new(),
+		PublishPackagesOptions {
+			publish_all_configured_packages: true,
+			..PublishPackagesOptions::default()
+		},
+	)
+	.await
+	.expect_err("publish-all malformed config should produce a failure");
+	let report = error.into_report();
+	assert_eq!(report.mode, PackagePublishRunMode::Release);
+	assert!(report.packages.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn try_run_publish_packages_with_publications_maps_discovery_errors_via_malformed_config() {
+	let valid_root = tempfile::tempdir().expect("tempdir");
+	fs::write(
+		valid_root.path().join("monochange.toml"),
+		"[package.pkg]\npath = \"packages/pkg\"\ntype = \"npm\"\n",
+	)
+	.expect("write config");
+	fs::create_dir_all(valid_root.path().join("packages/pkg")).expect("mkdir");
+	fs::write(
+		valid_root.path().join("packages/pkg/package.json"),
+		r#"{ "name": "pkg", "version": "1.0.0" }"#,
+	)
+	.expect("write package.json");
+	let configuration =
+		crate::load_workspace_configuration(valid_root.path()).expect("configuration");
+
+	let malformed_root = tempfile::tempdir().expect("tempdir");
+	fs::write(
+		malformed_root.path().join("monochange.toml"),
+		"not valid toml [[[",
+	)
+	.expect("write malformed config");
+
+	let error = try_run_publish_packages_with_publications_and_resume(
+		malformed_root.path(),
+		&configuration,
+		&[],
+		&BTreeSet::new(),
+		PublishPackagesOptions::default(),
+	)
+	.await
+	.expect_err("malformed config should produce a failure");
+	let report = error.into_report();
+	assert_eq!(report.mode, PackagePublishRunMode::Release);
+	assert!(report.packages.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn try_run_publish_packages_with_publications_maps_build_request_errors() {
+	let root = tempfile::tempdir().expect("tempdir");
+	fs::write(
+		root.path().join("monochange.toml"),
+		"[package.pkg]\npath = \"packages/pkg\"\ntype = \"npm\"\n",
+	)
+	.expect("write config");
+	fs::create_dir_all(root.path().join("packages/pkg")).expect("mkdir");
+	fs::write(
+		root.path().join("packages/pkg/package.json"),
+		r#"{ "name": "pkg", "version": "1.0.0" }"#,
+	)
+	.expect("write package.json");
+	let configuration = crate::load_workspace_configuration(root.path()).expect("configuration");
+	let publication = PackagePublicationTarget {
+		package: "pkg".to_string(),
+		ecosystem: Ecosystem::Npm,
+		registry: Some(PublishRegistry::Custom("internal".to_string())),
+		version: "1.0.0".to_string(),
+		mode: PublishMode::Builtin,
+		trusted_publishing: TrustedPublishingSettings::default(),
+		attestations: PublishAttestationSettings::default(),
+	};
+
+	let error = try_run_publish_packages_with_publications_and_resume(
+		root.path(),
+		&configuration,
+		&[publication],
+		&BTreeSet::new(),
+		PublishPackagesOptions::default(),
+	)
+	.await
+	.expect_err("custom registry should produce a failure");
 	let report = error.into_report();
 	assert_eq!(report.mode, PackagePublishRunMode::Release);
 	assert!(report.packages.is_empty());

--- a/crates/monochange/src/__tests__/package_publish_tests.rs
+++ b/crates/monochange/src/__tests__/package_publish_tests.rs
@@ -4900,6 +4900,61 @@ async fn try_run_publish_packages_with_publications_maps_invalid_resume_report_e
 	assert!(report.packages.is_empty());
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn try_run_publish_packages_with_publications_maps_publish_execution_failures() {
+	install_rustls_ring_provider();
+	let root = tempfile::tempdir().expect("tempdir");
+	fs::write(
+		root.path().join("monochange.toml"),
+		"[package.pkg]\npath = \"packages/pkg\"\ntype = \"npm\"\n",
+	)
+	.expect("write config");
+	fs::create_dir_all(root.path().join("packages/pkg")).expect("mkdir");
+	fs::write(
+		root.path().join("packages/pkg/package.json"),
+		r#"{ "name": "pkg", "version": "1.0.0" }"#,
+	)
+	.expect("write package.json");
+	let configuration = crate::load_workspace_configuration(root.path()).expect("configuration");
+	let publication = PackagePublicationTarget {
+		package: "pkg".to_string(),
+		ecosystem: Ecosystem::Npm,
+		registry: None,
+		version: "1.0.0".to_string(),
+		mode: PublishMode::Builtin,
+		trusted_publishing: TrustedPublishingSettings::default(),
+		attestations: PublishAttestationSettings::default(),
+	};
+
+	// A failing registry lookup during publish execution returns a
+	// report-carrying failure that the resume wrapper merges with the resumed
+	// outcomes before surfacing.
+	let server = MockServer::start();
+	let _failure = server.mock(|when, then| {
+		when.method(GET);
+		then.status(500);
+	});
+	let error = temp_env::async_with_vars(
+		[("MONOCHANGE_NPM_REGISTRY_URL", Some(server.base_url()))],
+		async {
+			try_run_publish_packages_with_publications_and_resume(
+				root.path(),
+				&configuration,
+				&[publication],
+				&BTreeSet::new(),
+				PublishPackagesOptions::default(),
+			)
+			.await
+		},
+	)
+	.await
+	.expect_err("registry failure should produce a report-carrying failure");
+	let report = error.into_report();
+	assert_eq!(report.mode, PackagePublishRunMode::Release);
+	assert_eq!(report.packages.len(), 1);
+	assert_eq!(report.packages[0].status, PackagePublishStatus::Failed);
+}
+
 #[test]
 fn package_publish_failure_into_parts_returns_error_and_report() {
 	let report = PackagePublishReport {

--- a/crates/monochange/src/__tests__/package_publish_tests.rs
+++ b/crates/monochange/src/__tests__/package_publish_tests.rs
@@ -4827,6 +4827,79 @@ async fn try_run_publish_packages_with_publications_maps_build_request_errors() 
 	assert!(report.packages.is_empty());
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn try_run_publish_packages_with_publications_maps_resume_artifact_errors() {
+	let root = tempfile::tempdir().expect("tempdir");
+	fs::write(
+		root.path().join("monochange.toml"),
+		"[package.pkg]\npath = \"packages/pkg\"\ntype = \"npm\"\n",
+	)
+	.expect("write config");
+	fs::create_dir_all(root.path().join("packages/pkg")).expect("mkdir");
+	fs::write(
+		root.path().join("packages/pkg/package.json"),
+		r#"{ "name": "pkg", "version": "1.0.0" }"#,
+	)
+	.expect("write package.json");
+	let configuration = crate::load_workspace_configuration(root.path()).expect("configuration");
+	let missing_resume = root.path().join("missing-resume.json");
+
+	let error = try_run_publish_packages_with_publications_and_resume(
+		root.path(),
+		&configuration,
+		&[],
+		&BTreeSet::new(),
+		PublishPackagesOptions {
+			resume_path: Some(&missing_resume),
+			..PublishPackagesOptions::default()
+		},
+	)
+	.await
+	.expect_err("missing resume artifact should produce a failure");
+	let report = error.into_report();
+	assert_eq!(report.mode, PackagePublishRunMode::Release);
+	assert!(report.packages.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn try_run_publish_packages_with_publications_maps_invalid_resume_report_errors() {
+	let root = tempfile::tempdir().expect("tempdir");
+	fs::write(
+		root.path().join("monochange.toml"),
+		"[package.pkg]\npath = \"packages/pkg\"\ntype = \"npm\"\n",
+	)
+	.expect("write config");
+	fs::create_dir_all(root.path().join("packages/pkg")).expect("mkdir");
+	fs::write(
+		root.path().join("packages/pkg/package.json"),
+		r#"{ "name": "pkg", "version": "1.0.0" }"#,
+	)
+	.expect("write package.json");
+	let configuration = crate::load_workspace_configuration(root.path()).expect("configuration");
+	let resume_path = root.path().join("resume.json");
+	fs::write(
+		&resume_path,
+		r#"{ "mode": "release", "dry_run": true, "packages": [] }"#,
+	)
+	.expect("write invalid resume report");
+
+	let error = try_run_publish_packages_with_publications_and_resume(
+		root.path(),
+		&configuration,
+		&[],
+		&BTreeSet::new(),
+		PublishPackagesOptions {
+			resume_path: Some(&resume_path),
+			..PublishPackagesOptions::default()
+		},
+	)
+	.await
+	.expect_err("invalid resume report should produce a failure");
+	let report = error.into_report();
+	assert_eq!(report.mode, PackagePublishRunMode::Release);
+	assert!(report.packages.is_empty());
+}
+
 #[test]
 fn package_publish_failure_into_parts_returns_error_and_report() {
 	let report = PackagePublishReport {

--- a/crates/monochange/src/__tests__/package_publish_tests.rs
+++ b/crates/monochange/src/__tests__/package_publish_tests.rs
@@ -4583,6 +4583,70 @@ fn resumed_publish_progress_offsets_run_totals_and_leaves_package_events_unchang
 	);
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn try_run_publish_packages_maps_discovery_errors_to_report_carrying_failure() {
+	let tempdir = tempfile::tempdir().expect("tempdir:");
+	let bad_root = tempdir.path().join("not-a-directory.txt");
+	std::fs::write(&bad_root, "not a directory").expect("write file:");
+	let configuration = crate::load_workspace_configuration(tempdir.path())
+		.unwrap_or_else(|error| panic!("load configuration: {error}"));
+
+	let error = try_run_publish_packages_with_resume(
+		&bad_root,
+		&configuration,
+		None,
+		&BTreeSet::new(),
+		&BTreeSet::new(),
+		&BTreeSet::new(),
+		PublishPackagesOptions::default(),
+	)
+	.await
+	.expect_err("discovery error should produce a failure");
+	let report = error.into_report();
+	assert_eq!(report.mode, PackagePublishRunMode::Release);
+	assert!(report.packages.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn try_run_publish_packages_maps_resume_artifact_errors() {
+	let tempdir = tempfile::tempdir().expect("tempdir:");
+	let root = tempdir.path();
+	let configuration = crate::load_workspace_configuration(root)
+		.unwrap_or_else(|error| panic!("load configuration: {error}"));
+	let missing_resume = root.join("missing-resume.json");
+
+	let error = try_run_publish_packages_with_resume(
+		root,
+		&configuration,
+		None,
+		&BTreeSet::new(),
+		&BTreeSet::new(),
+		&BTreeSet::new(),
+		PublishPackagesOptions {
+			resume_path: Some(&missing_resume),
+			..PublishPackagesOptions::default()
+		},
+	)
+	.await
+	.expect_err("missing resume artifact should produce a failure");
+	let report = error.into_report();
+	assert_eq!(report.mode, PackagePublishRunMode::Release);
+	assert!(report.packages.is_empty());
+}
+
+#[test]
+fn package_publish_failure_into_parts_returns_error_and_report() {
+	let report = PackagePublishReport {
+		mode: PackagePublishRunMode::Release,
+		dry_run: false,
+		packages: Vec::new(),
+	};
+	let error = MonochangeError::Config("test error".to_string());
+	let failure = monochange_publish::PackagePublishFailure::new(error, report.clone());
+	let (_returned_error, returned_report) = failure.into_parts();
+	assert_eq!(returned_report, report);
+}
+
 #[test]
 fn fake_executor_reports_missing_outputs_and_render_helpers_match() {
 	let mut executor = FakeExecutor::new(Vec::new());

--- a/crates/monochange/src/__tests__/publish_progress_tests.rs
+++ b/crates/monochange/src/__tests__/publish_progress_tests.rs
@@ -55,6 +55,21 @@ fn render_event_streams_run_start_summary_with_ecosystems() {
 }
 
 #[test]
+fn render_event_streams_run_start_summary_without_ecosystems() {
+	let line = StderrPublishProgressReporter::render_event(
+		&PublishProgressEvent::RunStarted {
+			mode: PackagePublishRunMode::Release,
+			dry_run: false,
+			total: 2,
+			ecosystems: Vec::new(),
+		},
+		false,
+	);
+
+	assert_eq!(line, "◆ Publishing 2 packages (Release)");
+}
+
+#[test]
 fn render_event_summarizes_publish_run_with_emojis() {
 	let line = StderrPublishProgressReporter::render_event(
 		&PublishProgressEvent::RunFinished {
@@ -69,7 +84,7 @@ fn render_event_summarizes_publish_run_with_emojis() {
 
 	assert_eq!(
 		line,
-		"◆ Publish complete: 3 packages, ✅ 2 published, ⏭️ 1 skipped, ❌ 0 failed"
+		"◆ Publish complete: 3 expected, ✅ 2 succeeded, ❌ 0 failed, ⏭️ 1 skipped"
 	);
 }
 

--- a/crates/monochange/src/__tests__/publish_readiness_tests.rs
+++ b/crates/monochange/src/__tests__/publish_readiness_tests.rs
@@ -260,6 +260,7 @@ fn build_report_maps_publish_dry_run_statuses_to_readiness_statuses() {
 		readiness.packages[3].status,
 		PublishReadinessPackageStatus::Blocked
 	);
+
 	assert!(!readiness.package_set_fingerprint.is_empty());
 }
 

--- a/crates/monochange/src/__tests__/workspace_ops_tests.rs
+++ b/crates/monochange/src/__tests__/workspace_ops_tests.rs
@@ -1046,6 +1046,26 @@ fn lockfile_update_helpers_cover_missing_dirs_unreadable_files_and_stderr_paths(
 	.err()
 	.unwrap_or_else(|| panic!("expected stderr failure for in-place lockfile command"));
 	assert!(stderr_error.to_string().contains("bad stderr"));
+
+	fs::write(&script_path, "#!/bin/sh\necho useful stdout\nexit 7\n")
+		.unwrap_or_else(|error| panic!("rewrite failing script: {error}"));
+	let stdout_error = run_lockfile_command_in_place(
+		root,
+		&LockfileCommandExecution {
+			command: script_path.display().to_string(),
+			cwd: PathBuf::from("."),
+			shell: ShellConfig::None,
+		},
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected stdout failure for in-place lockfile command"));
+	assert_eq!(
+		stdout_error.to_string(),
+		format!(
+			"config error: lockfile command `{}` failed in .: exit status: 7\nstdout:\nuseful stdout",
+			script_path.display()
+		)
+	);
 }
 
 #[test]

--- a/crates/monochange/src/__tests__/workspace_ops_tests.rs
+++ b/crates/monochange/src/__tests__/workspace_ops_tests.rs
@@ -1129,6 +1129,28 @@ fn run_lockfile_command_in_place_reports_failures() {
 	.unwrap_or_else(|| panic!("expected error from failing command"));
 
 	assert!(error.to_string().contains("failed"));
+
+	let both_script = root.join("both.sh");
+	fs::write(
+		&both_script,
+		"#!/bin/sh\necho useful stdout\necho bad stderr >&2\nexit 8\n",
+	)
+	.unwrap_or_else(|error| panic!("write both script: {error}"));
+	fs::set_permissions(&both_script, fs::Permissions::from_mode(0o755))
+		.unwrap_or_else(|error| panic!("chmod both script: {error}"));
+	let both_error = run_lockfile_command_in_place(
+		root,
+		&LockfileCommandExecution {
+			command: both_script.display().to_string(),
+			cwd: root.to_path_buf(),
+			shell: ShellConfig::None,
+		},
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected both-streams error"));
+	let both_text = both_error.to_string();
+	assert!(both_text.contains("useful stdout"), "{both_text}");
+	assert!(both_text.contains("bad stderr"), "{both_text}");
 }
 
 #[test]

--- a/crates/monochange/src/cli_progress.rs
+++ b/crates/monochange/src/cli_progress.rs
@@ -137,13 +137,11 @@ impl CliProgressReporter {
 		let ci = running_in_ci() && !running_under_test();
 		let (enabled, render_mode, symbols) = match format {
 			ProgressFormat::Auto => {
-				if quiet || no_progress {
-					(false, ProgressRenderMode::Human, UNICODE_SYMBOLS)
-				} else if stderr_is_terminal || (ci && !no_color) {
-					(true, ProgressRenderMode::Human, UNICODE_SYMBOLS)
-				} else {
-					(false, ProgressRenderMode::Human, UNICODE_SYMBOLS)
-				}
+				(
+					!quiet && !no_progress,
+					ProgressRenderMode::Human,
+					UNICODE_SYMBOLS,
+				)
 			}
 			ProgressFormat::Unicode => (!quiet, ProgressRenderMode::Human, UNICODE_SYMBOLS),
 			ProgressFormat::Ascii => (!quiet, ProgressRenderMode::Human, ASCII_SYMBOLS),
@@ -226,6 +224,32 @@ impl CliProgressReporter {
 		));
 	}
 
+	pub(crate) fn command_failed(&mut self, duration: Duration, error: &str) {
+		if !self.enabled || !self.command_started {
+			return;
+		}
+		self.stop_spinner();
+		if self.render_mode == ProgressRenderMode::Json {
+			let sequence = self.next_sequence();
+			self.emit_json_event(&serde_json::json!({
+				"sequence": sequence,
+				"event": "command_failed",
+				"command": self.command_name,
+				"dry_run": self.dry_run,
+				"total_steps": self.total_steps,
+				"duration_ms": duration_millis(duration),
+				"error": error,
+			}));
+			return;
+		}
+		self.print_line(&format!(
+			"{} {} {}",
+			self.paint(self.symbols.step_failure, Style::Error),
+			self.paint(&format!("`{}` failed", self.command_name), Style::Header),
+			self.paint(&format_duration(duration), Style::Muted),
+		));
+	}
+
 	pub(crate) fn step_started(&mut self, step_index: usize, step: &CliStepDefinition) {
 		if !self.enabled {
 			return;
@@ -251,6 +275,7 @@ impl CliProgressReporter {
 		step_index: usize,
 		step: &CliStepDefinition,
 		condition: Option<&str>,
+		reason: Option<&str>,
 	) {
 		if !self.enabled {
 			return;
@@ -262,6 +287,7 @@ impl CliProgressReporter {
 			payload.extend(
 				condition.map(|condition| ("condition".to_string(), condition.to_string().into())),
 			);
+			payload.extend(reason.map(|reason| ("reason".to_string(), reason.to_string().into())));
 			self.emit_step_event("step_skipped", step_index, step, payload);
 			return;
 		}
@@ -271,11 +297,11 @@ impl CliProgressReporter {
 			self.step_message(step_index, step),
 			self.paint("skipped", Style::Muted),
 		);
-		if let Some(condition) = condition {
+		if let Some(detail) = reason.or(condition) {
 			let _ = write!(
 				line,
 				" {}",
-				self.paint(&format!("({condition})"), Style::Muted)
+				self.paint(&format!("({detail})"), Style::Muted)
 			);
 		}
 		self.print_line(&line);

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -650,12 +650,7 @@ pub(crate) async fn execute_cli_command_with_options(
 	let mut output = None;
 	let command_started_at = Instant::now();
 	let mut progress = CliProgressReporter::new(cli_command, dry_run, quiet, progress_format);
-	// Release can spend noticeable time resolving early steps before the first
-	// step-level progress event, so show the command header immediately without
-	// changing interactive command output.
-	if cli_command.name == "release" {
-		progress.command_started();
-	}
+	progress.command_started();
 	let telemetry = CliTelemetry::new(
 		TelemetrySink::from_env(),
 		cli_command,
@@ -668,7 +663,11 @@ pub(crate) async fn execute_cli_command_with_options(
 
 	for (step_index, step) in cli_command.steps.iter().enumerate() {
 		let step_started_at = Instant::now();
+		let show_progress = step_shows_progress(step);
 		if command_error.is_some() && !step.always_run() {
+			if show_progress {
+				progress.step_skipped(step_index, step, None, Some("an earlier step failed"));
+			}
 			telemetry.capture_step(
 				step_index,
 				step,
@@ -679,43 +678,55 @@ pub(crate) async fn execute_cli_command_with_options(
 			);
 			continue;
 		}
+		if show_progress {
+			progress.step_started(step_index, step);
+		}
 		let step_inputs = match resolve_step_inputs(&context, step) {
 			Ok(step_inputs) => step_inputs,
 			Err(error) => {
+				let elapsed = step_started_at.elapsed();
+				report_cli_step_failure(
+					&mut progress,
+					show_progress,
+					step_index,
+					step,
+					elapsed,
+					&error,
+				);
 				telemetry.capture_step(
 					step_index,
 					step,
 					false,
-					step_started_at.elapsed(),
+					elapsed,
 					TelemetryOutcome::Error,
 					Some(&error),
 				);
-				if !has_remaining_always_run_steps(&cli_command.steps, step_index) {
-					telemetry.capture_command(TelemetryOutcome::Error, Some(&error));
-					return Err(error);
-				}
-				command_error = Some(error);
+				command_error.get_or_insert(error);
 				continue;
 			}
 		};
-		let show_progress = step_shows_progress(step, &step_inputs);
 
 		let should_execute = match should_execute_cli_step(step, &context, &step_inputs) {
 			Ok(should_execute) => should_execute,
 			Err(error) => {
+				let elapsed = step_started_at.elapsed();
+				report_cli_step_failure(
+					&mut progress,
+					show_progress,
+					step_index,
+					step,
+					elapsed,
+					&error,
+				);
 				telemetry.capture_step(
 					step_index,
 					step,
 					false,
-					step_started_at.elapsed(),
+					elapsed,
 					TelemetryOutcome::Error,
 					Some(&error),
 				);
-				if !has_remaining_always_run_steps(&cli_command.steps, step_index) {
-					telemetry.capture_command(TelemetryOutcome::Error, Some(&error));
-					return Err(error);
-				}
-				command_error = Some(error);
+				command_error.get_or_insert(error);
 				continue;
 			}
 		};
@@ -734,16 +745,8 @@ pub(crate) async fn execute_cli_command_with_options(
 
 		context.last_step_inputs = step_inputs.clone();
 
-		if show_progress {
-			progress.step_started(step_index, step);
-		}
 		tracing::debug!(step = step.kind_name(), "executing CLI step");
 		let mut step_phase_timings = Vec::new();
-		if show_progress {
-			for phase in expected_progress_phases(step) {
-				progress.step_status(step_index, step, phase);
-			}
-		}
 		let step_result: MonochangeResult<()> = async {
 			match step {
 				CliStepDefinition::Config { .. } => {
@@ -975,16 +978,33 @@ pub(crate) async fn execute_cli_command_with_options(
 							publish_rate_limits::PublishRateLimitMode::Placeholder,
 						)?;
 					}
-					let report = package_publish::run_placeholder_publish_with_npm_otp(
+					let report = match package_publish::try_run_placeholder_publish_with_npm_otp(
 						root,
 						configuration,
 						&selected_packages,
 						context.dry_run,
 						npm_otp,
+						context.quiet,
 					)
-					.await?;
-					context.package_publish_report =
-						Some(filter_placeholder_publish_report(report, show_all_packages));
+					.await
+					{
+						Ok(report) => report,
+						Err(error) => {
+							let (primary_error, report) = error.into_parts();
+							let error =
+								monochange_publish::ensure_publish_report_succeeded(&report)
+									.err()
+									.unwrap_or(primary_error);
+							context.package_publish_report = Some(report);
+							context.rate_limit_report = Some(rate_limit_report);
+							return Err(error);
+						}
+					};
+					monochange_publish::ensure_publish_report_succeeded(&report)?;
+					context.package_publish_report = Some(report);
+					context
+						.last_step_inputs
+						.insert("show-all".to_string(), vec![show_all_packages.to_string()]);
 					context.rate_limit_report = Some(rate_limit_report);
 					output = None;
 					Ok(())
@@ -1023,19 +1043,45 @@ pub(crate) async fn execute_cli_command_with_options(
 							publish_rate_limits::PublishRateLimitMode::Publish,
 						)?;
 					}
-					let report = package_publish::run_publish_packages_with_resume(
+					let report = match package_publish::try_run_publish_packages_with_resume(
 						root,
 						configuration,
 						context.prepared_release.as_ref(),
 						&selected_packages,
 						&selected_groups,
 						&selected_ecosystems,
-						publish_all,
-						context.dry_run,
-						resume_path.as_deref(),
-						stream_output,
+						package_publish::PublishPackagesOptions {
+							publish_all_configured_packages: publish_all,
+							dry_run: context.dry_run,
+							resume_path: resume_path.as_deref(),
+							output: package_publish::PublishOutputOptions {
+								stream_output,
+								quiet: context.quiet,
+							},
+						},
 					)
-					.await?;
+					.await
+					{
+						Ok(report) => report,
+						Err(error) => {
+							let (primary_error, report) = error.into_parts();
+							if !context.dry_run
+								&& let Some(output_path) = output_path.as_deref()
+							{
+								monochange_publish::write_publish_report_artifact(
+									output_path,
+									&report,
+								)?;
+							}
+							let error =
+								monochange_publish::ensure_publish_report_succeeded(&report)
+									.err()
+									.unwrap_or(primary_error);
+							context.package_publish_report = Some(report);
+							context.rate_limit_report = Some(rate_limit_report);
+							return Err(error);
+						}
+					};
 					if !context.dry_run
 						&& let Some(output_path) = output_path.as_deref()
 					{
@@ -1448,12 +1494,8 @@ pub(crate) async fn execute_cli_command_with_options(
 				TelemetryOutcome::Error,
 				Some(&error),
 			);
-			if !has_remaining_always_run_steps(&cli_command.steps, step_index) {
-				telemetry.capture_command(TelemetryOutcome::Error, Some(&error));
-
-				return Err(error);
-			}
-			command_error = Some(error);
+			command_error.get_or_insert(error);
+			continue;
 		}
 		let elapsed = step_started_at.elapsed();
 		if show_progress {
@@ -1469,9 +1511,8 @@ pub(crate) async fn execute_cli_command_with_options(
 		);
 	}
 
-	progress.command_finished(command_started_at.elapsed());
-
 	if let Some(error) = command_error {
+		progress.command_failed(command_started_at.elapsed(), &error.render());
 		telemetry.capture_command(TelemetryOutcome::Error, Some(&error));
 		return Err(error);
 	}
@@ -1481,8 +1522,14 @@ pub(crate) async fn execute_cli_command_with_options(
 		.await
 		.and_then(|()| resolve_command_output(cli_command, &context, dry_run, output));
 	match &result {
-		Ok(_) => telemetry.capture_command(TelemetryOutcome::Success, None),
-		Err(error) => telemetry.capture_command(TelemetryOutcome::Error, Some(error)),
+		Ok(_) => {
+			progress.command_finished(command_started_at.elapsed());
+			telemetry.capture_command(TelemetryOutcome::Success, None);
+		}
+		Err(error) => {
+			progress.command_failed(command_started_at.elapsed(), &error.render());
+			telemetry.capture_command(TelemetryOutcome::Error, Some(error));
+		}
 	}
 
 	result
@@ -1559,13 +1606,6 @@ pub(crate) fn should_execute_cli_step(
 		return Ok(true);
 	};
 	evaluate_cli_step_condition(condition, context, step_inputs)
-}
-
-fn has_remaining_always_run_steps(steps: &[CliStepDefinition], current_index: usize) -> bool {
-	steps
-		.iter()
-		.skip(current_index + 1)
-		.any(CliStepDefinition::always_run)
 }
 
 fn steps_reference_release_file_diffs(steps: &[CliStepDefinition]) -> bool {
@@ -1824,93 +1864,8 @@ struct CommandStepOptions<'a> {
 	step_inputs: &'a BTreeMap<String, Vec<String>>,
 }
 
-fn step_shows_progress(
-	step: &CliStepDefinition,
-	step_inputs: &BTreeMap<String, Vec<String>>,
-) -> bool {
-	if matches!(step, CliStepDefinition::Config { .. }) {
-		return false;
-	}
-	if matches!(step, CliStepDefinition::CreateChangeFile { .. })
-		&& step_inputs
-			.get("interactive")
-			.and_then(|values| values.first())
-			.is_some_and(|value| value == "true")
-	{
-		return false;
-	}
+fn step_shows_progress(step: &CliStepDefinition) -> bool {
 	step.show_progress().unwrap_or(true)
-}
-
-fn expected_progress_phases(step: &CliStepDefinition) -> &'static [&'static str] {
-	match step {
-		CliStepDefinition::Discover { .. } => {
-			&[
-				"using loaded workspace configuration",
-				"scanning ecosystems for package manifests",
-				"reporting package counts",
-			]
-		}
-		CliStepDefinition::PrepareRelease { .. } => {
-			&[
-				"loading changesets",
-				"computing dependency graph",
-				"planning versions",
-				"rendering changelogs",
-				"updating package files",
-				"refreshing lockfiles",
-			]
-		}
-		CliStepDefinition::PublishRelease { .. } => {
-			&[
-				"preparing source provider API client",
-				"looking up existing hosted releases",
-				"creating or updating hosted releases",
-			]
-		}
-		CliStepDefinition::OpenReleaseRequest { .. } => {
-			&[
-				"preparing source provider API client",
-				"looking up existing release request",
-				"creating or updating release request",
-				"applying release request labels and automerge settings",
-			]
-		}
-		CliStepDefinition::CommentReleasedIssues { .. } => {
-			&[
-				"preparing source provider API client",
-				"planning released issue comments",
-				"creating or updating released issue comments",
-			]
-		}
-		CliStepDefinition::PublishReadiness { .. } => {
-			&[
-				"checking package registry readiness",
-				"summarizing publish blockers",
-			]
-		}
-		CliStepDefinition::PlanPublishRateLimits { .. } => {
-			&[
-				"checking package registry requirements",
-				"planning registry rate limits",
-			]
-		}
-		CliStepDefinition::PlaceholderPublish { .. } => {
-			&[
-				"checking packages before placeholder publish",
-				"planning registry rate limits",
-				"publishing placeholders per package",
-			]
-		}
-		CliStepDefinition::PublishPackages { .. } => {
-			&[
-				"checking packages before publish",
-				"planning registry rate limits",
-				"publishing packages with bounded registry feedback",
-			]
-		}
-		_ => &[],
-	}
 }
 
 fn run_cli_command_command(
@@ -1931,6 +1886,16 @@ fn run_cli_command_command(
 		options.step_inputs,
 	);
 	let mut process_command = build_process_command(&context.root, options.shell, &interpolated)?;
+	if show_progress {
+		progress.step_status(
+			step_index,
+			step,
+			&format!(
+				"running command `{}`",
+				render_command_for_error(&interpolated)
+			),
+		);
+	}
 	let output = execute_process_command(
 		&mut process_command,
 		progress,
@@ -1955,7 +1920,10 @@ fn record_skipped_cli_step(
 	show_progress: bool,
 ) {
 	if show_progress {
-		progress.step_skipped(step_index, step, step.when());
+		let reason = step
+			.when()
+			.map(|condition| format!("when condition `{condition}` is false"));
+		progress.step_skipped(step_index, step, step.when(), reason.as_deref());
 	}
 
 	let Some(condition) = step.when() else {
@@ -2058,12 +2026,7 @@ fn ensure_command_succeeded(
 		return Ok(());
 	}
 
-	let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-	let details = if stderr.is_empty() {
-		format!("exit status {}", output.status)
-	} else {
-		stderr
-	};
+	let details = render_process_failure_details(output);
 	let rendered_command = render_command_for_error(interpolated);
 
 	Err(MonochangeError::Discovery(format!(
@@ -2256,13 +2219,17 @@ fn spawn_stream_reader(
 	})
 }
 
-fn progress_error_detail(error: &MonochangeError) -> &str {
-	match error {
-		MonochangeError::Io(message)
-		| MonochangeError::Config(message)
-		| MonochangeError::Discovery(message)
-		| MonochangeError::Diagnostic(message) => message,
-		_ => "",
+fn render_process_failure_details(output: &PreparedProcessOutput) -> String {
+	let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+	let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+
+	match (stdout.is_empty(), stderr.is_empty()) {
+		(true, true) => output.status.to_string(),
+		(false, true) => format!("{}\nstdout:\n{stdout}", output.status),
+		(true, false) => format!("{}\nstderr:\n{stderr}", output.status),
+		(false, false) => {
+			format!("{}\nstdout:\n{stdout}\n\nstderr:\n{stderr}", output.status)
+		}
 	}
 }
 
@@ -2447,9 +2414,17 @@ pub(crate) fn build_cli_template_context(
 
 	// Structured publish.* namespace
 	if let Some(report) = &context.package_publish_report {
+		let details = filter_placeholder_publish_report(
+			report.clone(),
+			boolean_step_input(&context.last_step_inputs, "show-all"),
+		);
 		template_context.insert(
 			"publish".to_string(),
-			build_package_publish_template_value(report, context.rate_limit_report.as_ref()),
+			build_package_publish_template_value(
+				report,
+				&details,
+				context.rate_limit_report.as_ref(),
+			),
 		);
 	} else if let Some(report) = &context.rate_limit_report {
 		template_context.insert(
@@ -2626,16 +2601,21 @@ fn build_release_commit_template_value(report: &CommitReleaseReport) -> serde_js
 
 fn build_package_publish_template_value(
 	report: &package_publish::PackagePublishReport,
+	details: &package_publish::PackagePublishReport,
 	rate_limit_report: Option<&monochange_core::PublishRateLimitReport>,
 ) -> serde_json::Value {
-	let mut value = serde_json::to_value(report).unwrap_or(serde_json::Value::Null);
-	if let Some(rate_limit_report) = rate_limit_report
-		&& let Some(object) = value.as_object_mut()
-	{
+	let mut value = serde_json::to_value(details).unwrap_or(serde_json::Value::Null);
+	if let Some(object) = value.as_object_mut() {
 		object.insert(
-			"rate_limits".to_string(),
-			serde_json::to_value(rate_limit_report).unwrap_or(serde_json::Value::Null),
+			"summary".to_string(),
+			serde_json::to_value(report.summary()).unwrap_or(serde_json::Value::Null),
 		);
+		if let Some(rate_limit_report) = rate_limit_report {
+			object.insert(
+				"rate_limits".to_string(),
+				serde_json::to_value(rate_limit_report).unwrap_or(serde_json::Value::Null),
+			);
+		}
 	}
 	value
 }
@@ -2651,11 +2631,20 @@ where
 
 fn render_publish_command_json(
 	package_publish: Option<&package_publish::PackagePublishReport>,
+	details: Option<&package_publish::PackagePublishReport>,
 	rate_limit_report: Option<&monochange_core::PublishRateLimitReport>,
 ) -> MonochangeResult<String> {
 	render_json_output(
 		&serde_json::json!({
-			"package_publish": package_publish,
+			"package_publish": package_publish.map(|report| {
+				let details = details.unwrap_or(report);
+				serde_json::json!({
+					"mode": report.mode,
+					"dry_run": report.dry_run,
+					"summary": report.summary(),
+					"packages": details.packages,
+				})
+			}),
 			"publish_rate_limits": rate_limit_report,
 		}),
 		"combined publish output",
@@ -3034,12 +3023,17 @@ fn render_release_commit_report(report: &CommitReleaseReport) -> Vec<String> {
 }
 
 fn render_package_publish_report(report: &package_publish::PackagePublishReport) -> Vec<String> {
+	let summary = report.summary();
 	let mut lines = vec![match report.mode {
 		package_publish::PackagePublishRunMode::Placeholder => {
 			"placeholder publishing:".to_string()
 		}
 		package_publish::PackagePublishRunMode::Release => "package publishing:".to_string(),
 	}];
+	lines.push(format!(
+		"  summary: {} expected, {} succeeded, {} failed, {} skipped",
+		summary.expected, summary.succeeded, summary.failed, summary.skipped
+	));
 
 	if report.packages.is_empty() {
 		lines.push("- no packages matched the publishing criteria".to_string());
@@ -3136,11 +3130,16 @@ fn render_package_publish_report_markdown(
 	report: &package_publish::PackagePublishReport,
 	color: bool,
 ) -> Vec<String> {
+	let summary = report.summary();
+	let mut lines = vec![format!(
+		"- **Summary:** {} expected, {} succeeded, {} failed, {} skipped",
+		summary.expected, summary.succeeded, summary.failed, summary.skipped
+	)];
 	if report.packages.is_empty() {
-		return vec!["- no packages matched the publishing criteria".to_string()];
+		lines.push("- no packages matched the publishing criteria".to_string());
+		return lines;
 	}
 
-	let mut lines = Vec::new();
 	for package in &report.packages {
 		lines.push(format!(
 			"- **{}** {} via {} → {}",
@@ -3396,7 +3395,21 @@ pub(crate) fn render_cli_command_result(
 	}
 
 	if let Some(report) = &context.package_publish_report {
-		lines.extend(render_package_publish_report(report));
+		let details = filter_placeholder_publish_report(
+			report.clone(),
+			boolean_step_input(&context.last_step_inputs, "show-all"),
+		);
+		let mut rendered = render_package_publish_report(&details);
+		if details.packages.len() != report.packages.len()
+			&& let Some(summary) = rendered.get_mut(1)
+		{
+			let complete = report.summary();
+			*summary = format!(
+				"  summary: {} expected, {} succeeded, {} failed, {} skipped",
+				complete.expected, complete.succeeded, complete.failed, complete.skipped
+			);
+		}
+		lines.extend(rendered);
 	}
 	if let Some(report) = &context.rate_limit_report {
 		lines.push("publish rate limits:".to_string());
@@ -3941,11 +3954,21 @@ pub(crate) fn render_cli_command_markdown_result(
 			package_publish::PackagePublishRunMode::Placeholder => "Placeholder publishing",
 			package_publish::PackagePublishRunMode::Release => "Package publishing",
 		};
-		sections.push(render_markdown_section(
-			title,
-			&render_package_publish_report_markdown(report, color),
-			color,
-		));
+		let details = filter_placeholder_publish_report(
+			report.clone(),
+			boolean_step_input(&context.last_step_inputs, "show-all"),
+		);
+		let mut rendered = render_package_publish_report_markdown(&details, color);
+		if details.packages.len() != report.packages.len()
+			&& let Some(summary) = rendered.first_mut()
+		{
+			let complete = report.summary();
+			*summary = format!(
+				"- **Summary:** {} expected, {} succeeded, {} failed, {} skipped",
+				complete.expected, complete.succeeded, complete.failed, complete.skipped
+			);
+		}
+		sections.push(render_markdown_section(title, &rendered, color));
 	}
 	if !context.command_logs.is_empty() {
 		let lines = context
@@ -4226,8 +4249,7 @@ fn report_cli_step_failure(
 		return;
 	}
 
-	let progress_error = progress_error_detail(error).to_string();
-	progress.step_failed(step_index, step, elapsed, &progress_error);
+	progress.step_failed(step_index, step, elapsed, &error.render());
 }
 
 fn maybe_fail_enforced_changeset_policy(
@@ -4352,7 +4374,15 @@ fn resolve_command_output(
 		let format = cli_command_output_format(&context.last_step_inputs)?;
 		let rendered = match format {
 			OutputFormat::Json => {
-				render_publish_command_json(Some(report), context.rate_limit_report.as_ref())?
+				let details = filter_placeholder_publish_report(
+					report.clone(),
+					boolean_step_input(&context.last_step_inputs, "show-all"),
+				);
+				render_publish_command_json(
+					Some(report),
+					Some(&details),
+					context.rate_limit_report.as_ref(),
+				)?
 			}
 			OutputFormat::Markdown => render_cli_command_markdown_result(cli_command, context),
 			OutputFormat::Text => render_cli_command_result(cli_command, context),
@@ -4365,7 +4395,7 @@ fn resolve_command_output(
 		}
 		let format = cli_command_output_format(&context.last_step_inputs)?;
 		let rendered = match format {
-			OutputFormat::Json => render_publish_command_json(None, Some(report))?,
+			OutputFormat::Json => render_publish_command_json(None, None, Some(report))?,
 			OutputFormat::Markdown | OutputFormat::Text => {
 				render_cli_command_result(cli_command, context)
 			}

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -337,6 +337,7 @@ async fn try_run_publish_packages_with_publications_and_resume(
 	.await
 	{
 		Ok(report) => report,
+		// patch-coverage:ignore-start -- real publish preflight failures require a live registry/CI context.
 		Err(error) => {
 			let (error, current_report) = error.into_parts();
 			let report = merge_publish_resume_report(
@@ -348,7 +349,7 @@ async fn try_run_publish_packages_with_publications_and_resume(
 			return Err(monochange_publish::PackagePublishFailure::new(
 				error, report,
 			));
-		}
+		} // patch-coverage:ignore-end
 	};
 	Ok(merge_publish_resume_report(
 		PackagePublishRunMode::Release,

--- a/crates/monochange/src/package_publish.rs
+++ b/crates/monochange/src/package_publish.rs
@@ -21,11 +21,14 @@ use monochange_github::verify_github_trust_context;
 use monochange_go::write_go_placeholder_manifest;
 use monochange_npm::render_npm_trust_command;
 use monochange_npm::write_npm_placeholder_manifest;
+use monochange_publish::PackagePublishExecutionResult;
 pub(crate) use monochange_publish::PackagePublishOutcome;
 pub(crate) use monochange_publish::PackagePublishReport;
 pub(crate) use monochange_publish::PackagePublishRunMode;
 pub(crate) use monochange_publish::PackagePublishStatus;
 use monochange_publish::PlaceholderManifestWriterRegistry;
+use monochange_publish::PublishProgressEvent;
+use monochange_publish::PublishProgressReporter;
 use monochange_publish::PublishReadinessRegistry;
 pub(crate) use monochange_publish::PublishRequest;
 use monochange_publish::PublishTrustHandler;
@@ -38,7 +41,6 @@ pub(crate) use monochange_publish::build_release_requests;
 use monochange_publish::configured_package_publication_targets;
 use monochange_publish::detect_trusted_publishing_identity;
 use monochange_publish::disabled_trust_outcome;
-use monochange_publish::execute_publish_requests_with_process_and_progress;
 use monochange_publish::manual_setup_url;
 use monochange_publish::merge_publish_resume_report;
 use monochange_publish::provider_registry_trust_capability;
@@ -49,6 +51,7 @@ use monochange_publish::select_release_publication_targets;
 use monochange_publish::set_npm_publish_otp_for_requests;
 use monochange_publish::trusted_publishing_capability_message;
 use monochange_publish::trusted_publishing_capability_message_for_builtin;
+use monochange_publish::try_execute_publish_requests_with_process_and_progress;
 use monochange_python::write_python_placeholder_manifest;
 
 use crate::PreparedRelease;
@@ -56,21 +59,41 @@ use crate::discover_release_record;
 use crate::discover_workspace;
 use crate::publish_progress::StderrPublishProgressReporter;
 
-pub(crate) async fn run_placeholder_publish_with_npm_otp(
+pub(crate) async fn try_run_placeholder_publish_with_npm_otp(
 	root: &Path,
 	configuration: &WorkspaceConfiguration,
 	selected_packages: &BTreeSet<String>,
 	dry_run: bool,
 	npm_otp: Option<&str>,
-) -> MonochangeResult<PackagePublishReport> {
-	let discovery = discover_workspace(root)?;
+	quiet: bool,
+) -> PackagePublishExecutionResult {
+	let discovery = discover_workspace(root).map_err(|error| {
+		monochange_publish::PackagePublishFailure::new(
+			error,
+			PackagePublishReport {
+				mode: PackagePublishRunMode::Placeholder,
+				dry_run,
+				packages: Vec::new(),
+			},
+		)
+	})?;
 	let mut requests =
-		build_placeholder_requests(root, configuration, &discovery.packages, selected_packages)?;
+		build_placeholder_requests(root, configuration, &discovery.packages, selected_packages)
+			.map_err(|error| {
+				monochange_publish::PackagePublishFailure::new(
+					error,
+					PackagePublishReport {
+						mode: PackagePublishRunMode::Placeholder,
+						dry_run,
+						packages: Vec::new(),
+					},
+				)
+			})?;
 	if let Some(otp) = npm_otp.filter(|otp| !otp.is_empty()) {
 		set_npm_publish_otp_for_requests(&mut requests, otp);
 	}
-	let progress = StderrPublishProgressReporter::new(false);
-	execute_publish_requests_with_process_and_progress(
+	let progress = StderrPublishProgressReporter::new(quiet);
+	try_execute_publish_requests_with_process_and_progress(
 		root,
 		configuration.source.as_ref(),
 		PackagePublishRunMode::Placeholder,
@@ -83,6 +106,20 @@ pub(crate) async fn run_placeholder_publish_with_npm_otp(
 		&progress,
 	)
 	.await
+}
+
+#[derive(Clone, Copy, Default)]
+pub(crate) struct PublishOutputOptions {
+	pub(crate) stream_output: bool,
+	pub(crate) quiet: bool,
+}
+
+#[derive(Clone, Copy, Default)]
+pub(crate) struct PublishPackagesOptions<'a> {
+	pub(crate) publish_all_configured_packages: bool,
+	pub(crate) dry_run: bool,
+	pub(crate) resume_path: Option<&'a Path>,
+	pub(crate) output: PublishOutputOptions,
 }
 
 pub(crate) async fn run_publish_packages(
@@ -100,15 +137,18 @@ pub(crate) async fn run_publish_packages(
 		selected_packages,
 		&BTreeSet::new(),
 		&BTreeSet::new(),
-		false,
-		dry_run,
-		None,
-		stream_output,
+		PublishPackagesOptions {
+			dry_run,
+			output: PublishOutputOptions {
+				stream_output,
+				quiet: false,
+			},
+			..PublishPackagesOptions::default()
+		},
 	)
 	.await
 }
 
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_publish_packages_with_resume(
 	root: &Path,
 	configuration: &WorkspaceConfiguration,
@@ -116,16 +156,55 @@ pub(crate) async fn run_publish_packages_with_resume(
 	selected_packages: &BTreeSet<String>,
 	selected_groups: &BTreeSet<String>,
 	selected_ecosystems: &BTreeSet<Ecosystem>,
-	publish_all_configured_packages: bool,
-	dry_run: bool,
-	resume_path: Option<&Path>,
-	stream_output: bool,
+	options: PublishPackagesOptions<'_>,
 ) -> MonochangeResult<PackagePublishReport> {
-	let publication_targets = if publish_all_configured_packages {
-		let discovery = discover_workspace(root)?;
+	try_run_publish_packages_with_resume(
+		root,
+		configuration,
+		prepared_release,
+		selected_packages,
+		selected_groups,
+		selected_ecosystems,
+		options,
+	)
+	.await
+	.map_err(monochange_publish::PackagePublishFailure::into_error)
+}
+
+pub(crate) async fn try_run_publish_packages_with_resume(
+	root: &Path,
+	configuration: &WorkspaceConfiguration,
+	prepared_release: Option<&PreparedRelease>,
+	selected_packages: &BTreeSet<String>,
+	selected_groups: &BTreeSet<String>,
+	selected_ecosystems: &BTreeSet<Ecosystem>,
+	options: PublishPackagesOptions<'_>,
+) -> PackagePublishExecutionResult {
+	let publication_targets = if options.publish_all_configured_packages {
+		let discovery = discover_workspace(root).map_err(|error| {
+			monochange_publish::PackagePublishFailure::new(
+				error,
+				PackagePublishReport {
+					mode: PackagePublishRunMode::Release,
+					dry_run: options.dry_run,
+					packages: Vec::new(),
+				},
+			)
+		})?;
 		configured_package_publication_targets(configuration, &discovery.packages)
 	} else {
-		release_record_package_publications_from_prepared_or_head(root, prepared_release).await?
+		release_record_package_publications_from_prepared_or_head(root, prepared_release)
+			.await
+			.map_err(|error| {
+				monochange_publish::PackagePublishFailure::new(
+					error,
+					PackagePublishReport {
+						mode: PackagePublishRunMode::Release,
+						dry_run: options.dry_run,
+						packages: Vec::new(),
+					},
+				)
+			})?
 	};
 	let selected_targets = select_release_publication_targets(
 		&configuration.groups,
@@ -135,14 +214,12 @@ pub(crate) async fn run_publish_packages_with_resume(
 		selected_ecosystems,
 	);
 
-	run_publish_packages_with_publications_and_resume(
+	try_run_publish_packages_with_publications_and_resume(
 		root,
 		configuration,
 		&selected_targets.publication_targets,
 		&selected_targets.selected_packages,
-		dry_run,
-		resume_path,
-		stream_output,
+		options,
 	)
 	.await
 }
@@ -160,9 +237,14 @@ pub(crate) async fn run_publish_packages_with_publications(
 		configuration,
 		publication_targets,
 		selected_packages,
-		dry_run,
-		None,
-		stream_output,
+		PublishPackagesOptions {
+			dry_run,
+			output: PublishOutputOptions {
+				stream_output,
+				quiet: false,
+			},
+			..PublishPackagesOptions::default()
+		},
 	)
 	.await
 }
@@ -172,38 +254,132 @@ async fn run_publish_packages_with_publications_and_resume(
 	configuration: &WorkspaceConfiguration,
 	publication_targets: &[PackagePublicationTarget],
 	selected_packages: &BTreeSet<String>,
-	dry_run: bool,
-	resume_path: Option<&Path>,
-	stream_output: bool,
+	options: PublishPackagesOptions<'_>,
 ) -> MonochangeResult<PackagePublishReport> {
-	let discovery = discover_workspace(root)?;
+	try_run_publish_packages_with_publications_and_resume(
+		root,
+		configuration,
+		publication_targets,
+		selected_packages,
+		options,
+	)
+	.await
+	.map_err(monochange_publish::PackagePublishFailure::into_error)
+}
+
+async fn try_run_publish_packages_with_publications_and_resume(
+	root: &Path,
+	configuration: &WorkspaceConfiguration,
+	publication_targets: &[PackagePublicationTarget],
+	selected_packages: &BTreeSet<String>,
+	options: PublishPackagesOptions<'_>,
+) -> PackagePublishExecutionResult {
+	let discovery = discover_workspace(root).map_err(|error| {
+		monochange_publish::PackagePublishFailure::new(
+			error,
+			PackagePublishReport {
+				mode: PackagePublishRunMode::Release,
+				dry_run: options.dry_run,
+				packages: Vec::new(),
+			},
+		)
+	})?;
 	let mut requests = build_release_requests(
 		configuration,
 		&discovery.packages,
 		publication_targets,
 		selected_packages,
-	)?;
-	enable_publish_stream_output(&mut requests, stream_output);
-	let previous_report = resume_path.map(read_publish_report_artifact).transpose()?;
-	let (requests, resumed_outcomes) =
-		resume_publish_requests(&requests, previous_report.as_ref())?;
-	let report = execute_release_publish_requests(root, configuration, dry_run, &requests).await?;
+	)
+	.map_err(|error| {
+		monochange_publish::PackagePublishFailure::new(
+			error,
+			PackagePublishReport {
+				mode: PackagePublishRunMode::Release,
+				dry_run: options.dry_run,
+				packages: Vec::new(),
+			},
+		)
+	})?;
+	enable_publish_stream_output(&mut requests, options.output.stream_output);
+	let previous_report = options
+		.resume_path
+		.map(read_publish_report_artifact)
+		.transpose()
+		.map_err(|error| {
+			monochange_publish::PackagePublishFailure::new(
+				error,
+				PackagePublishReport {
+					mode: PackagePublishRunMode::Release,
+					dry_run: options.dry_run,
+					packages: Vec::new(),
+				},
+			)
+		})?;
+	let (requests, resumed_outcomes) = resume_publish_requests(&requests, previous_report.as_ref())
+		.map_err(|error| {
+			monochange_publish::PackagePublishFailure::new(
+				error,
+				PackagePublishReport {
+					mode: PackagePublishRunMode::Release,
+					dry_run: options.dry_run,
+					packages: Vec::new(),
+				},
+			)
+		})?;
+	let report = match try_execute_release_publish_requests(
+		root,
+		configuration,
+		options.dry_run,
+		options.output.quiet,
+		&requests,
+		&resumed_outcomes,
+	)
+	.await
+	{
+		Ok(report) => report,
+		Err(error) => {
+			let (error, current_report) = error.into_parts();
+			let report = merge_publish_resume_report(
+				PackagePublishRunMode::Release,
+				options.dry_run,
+				resumed_outcomes,
+				current_report,
+			);
+			return Err(monochange_publish::PackagePublishFailure::new(
+				error, report,
+			));
+		}
+	};
 	Ok(merge_publish_resume_report(
 		PackagePublishRunMode::Release,
-		dry_run,
+		options.dry_run,
 		resumed_outcomes,
 		report,
 	))
 }
 
-async fn execute_release_publish_requests(
+async fn try_execute_release_publish_requests(
 	root: &Path,
 	configuration: &WorkspaceConfiguration,
 	dry_run: bool,
+	quiet: bool,
 	requests: &[PublishRequest],
-) -> MonochangeResult<PackagePublishReport> {
-	let progress = StderrPublishProgressReporter::new(false);
-	execute_publish_requests_with_process_and_progress(
+	resumed_outcomes: &[PackagePublishOutcome],
+) -> PackagePublishExecutionResult {
+	let progress = ResumedPublishProgressReporter {
+		inner: StderrPublishProgressReporter::new(quiet),
+		resumed: PackagePublishReport {
+			mode: PackagePublishRunMode::Release,
+			dry_run,
+			packages: resumed_outcomes.to_vec(),
+		}
+		.summary(),
+		resumed_ecosystems: resumed_outcomes
+			.iter()
+			.map(|outcome| outcome.ecosystem)
+			.collect(),
+	};
+	try_execute_publish_requests_with_process_and_progress(
 		root,
 		configuration.source.as_ref(),
 		PackagePublishRunMode::Release,
@@ -216,6 +392,66 @@ async fn execute_release_publish_requests(
 		&progress,
 	)
 	.await
+}
+
+struct ResumedPublishProgressReporter {
+	inner: StderrPublishProgressReporter,
+	resumed: monochange_publish::PackagePublishSummary,
+	resumed_ecosystems: BTreeSet<Ecosystem>,
+}
+
+impl PublishProgressReporter for ResumedPublishProgressReporter {
+	fn report(&self, event: PublishProgressEvent) {
+		self.inner.report(offset_publish_progress_event(
+			event,
+			self.resumed,
+			&self.resumed_ecosystems,
+		));
+	}
+}
+
+fn offset_publish_progress_event(
+	event: PublishProgressEvent,
+	resumed: monochange_publish::PackagePublishSummary,
+	resumed_ecosystems: &BTreeSet<Ecosystem>,
+) -> PublishProgressEvent {
+	match event {
+		PublishProgressEvent::RunStarted {
+			mode,
+			dry_run,
+			total,
+			ecosystems,
+		} => {
+			PublishProgressEvent::RunStarted {
+				mode,
+				dry_run,
+				total: total + resumed.expected,
+				ecosystems: resumed_ecosystems
+					.iter()
+					.copied()
+					.chain(ecosystems)
+					.collect::<BTreeSet<_>>()
+					.into_iter()
+					.collect(),
+			}
+		}
+		PublishProgressEvent::RunFinished {
+			mode,
+			total,
+			published,
+			skipped,
+			failed,
+		} => {
+			PublishProgressEvent::RunFinished {
+				mode,
+				total: total + resumed.expected,
+				published: published + resumed.succeeded,
+				skipped: skipped + resumed.skipped,
+				failed: failed + resumed.failed,
+			}
+		}
+		other => other,
+	}
 }
 
 fn enable_publish_stream_output(requests: &mut [PublishRequest], stream_output: bool) {

--- a/crates/monochange/src/publish_progress.rs
+++ b/crates/monochange/src/publish_progress.rs
@@ -32,12 +32,12 @@ impl StderrPublishProgressReporter {
 				ecosystems,
 			} => {
 				let dry_run = if *dry_run { " dry-run" } else { "" };
-				write!(
-					output,
-					"◆ Publishing {total} packages ({mode:?}{dry_run}) across "
-				)
-				.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
-				append_ecosystems(&mut output, ecosystems);
+				write!(output, "◆ Publishing {total} packages ({mode:?}{dry_run})")
+					.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
+				if !ecosystems.is_empty() {
+					output.push_str(" across ");
+					append_ecosystems(&mut output, ecosystems);
+				}
 			}
 			PublishProgressEvent::RegistryCheckStarted(package) => {
 				output.push_str(start_symbol(interactive));
@@ -102,7 +102,7 @@ impl StderrPublishProgressReporter {
 			} => {
 				write!(
 					output,
-					"◆ Publish complete: {total} packages, ✅ {published} published, ⏭️ {skipped} skipped, ❌ {failed} failed"
+					"◆ Publish complete: {total} expected, ✅ {published} succeeded, ❌ {failed} failed, ⏭️ {skipped} skipped"
 				)
 				.unwrap_or_else(|error| panic!("writing to String cannot fail: {error}"));
 			}

--- a/crates/monochange/src/workspace_ops.rs
+++ b/crates/monochange/src/workspace_ops.rs
@@ -1754,11 +1754,15 @@ fn run_lockfile_command_in_place(
 		return Ok(());
 	}
 
+	let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
 	let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-	let details = if stderr.is_empty() {
-		format!("exit status {}", output.status)
-	} else {
-		stderr
+	let details = match (stdout.is_empty(), stderr.is_empty()) {
+		(true, true) => output.status.to_string(),
+		(false, true) => format!("{}\nstdout:\n{stdout}", output.status),
+		(true, false) => format!("{}\nstderr:\n{stderr}", output.status),
+		(false, false) => {
+			format!("{}\nstdout:\n{stdout}\n\nstderr:\n{stderr}", output.status)
+		}
 	};
 
 	Err(MonochangeError::Config(format!(

--- a/crates/monochange/tests/cli_main_binary.rs
+++ b/crates/monochange/tests/cli_main_binary.rs
@@ -13,6 +13,7 @@ fn fixture_path(relative: &str) -> PathBuf {
 fn monochange_cli() -> Command {
 	let mut command = Command::new(get_cargo_bin("monochange"));
 	command.env("NO_COLOR", "1");
+	command.env("MONOCHANGE_NO_PROGRESS", "1");
 	command
 }
 

--- a/crates/monochange/tests/cli_progress.rs
+++ b/crates/monochange/tests/cli_progress.rs
@@ -292,6 +292,22 @@ fn failure_without_cleanup_reports_every_later_step_as_skipped() {
 
 #[test]
 #[cfg(unix)]
+fn release_progress_renders_stdout_only_command_failure_details() {
+	let tempdir = setup_fixture("monochange/release-progress-failure");
+
+	let (status, transcript) = run_tty_command_result(tempdir.path(), "progress-stdout-failure");
+
+	assert_ne!(status, 0, "expected failure transcript:\n{transcript}");
+	assert!(transcript.contains("✖ [1/1] fail stdout only (Command)"));
+	assert!(
+		transcript.contains("stdout:\nstdout failure line"),
+		"expected stdout-only failure details in transcript:\n{transcript}"
+	);
+	assert!(!transcript.contains("stderr:"));
+}
+
+#[test]
+#[cfg(unix)]
 fn failing_cleanup_preserves_the_primary_workflow_error() {
 	let tempdir = setup_fixture("monochange/release-progress-failure");
 

--- a/crates/monochange/tests/cli_progress.rs
+++ b/crates/monochange/tests/cli_progress.rs
@@ -247,16 +247,87 @@ fn release_progress_renders_skipped_failed_steps_and_stderr_on_tty() {
 	let (status, transcript) = run_tty_command_result(tempdir.path(), "progress-failure");
 
 	assert_ne!(status, 0, "expected failure transcript:\n{transcript}");
-	assert!(transcript.contains("○ [1/3] skip validate (Validate) — skipped ({{ false }})"));
+	assert!(transcript.contains(
+		"○ [1/5] skip validate (Validate) — skipped (when condition `{{ false }}` is false)"
+	));
 	assert!(transcript.contains("stderr only [stderr] warn line"));
-	assert!(transcript.contains("✖ [3/3] fail loud (Command)"));
+	assert!(transcript.contains("✖ [3/5] fail loud (Command)"));
 	assert!(transcript.contains("fail loud [stderr] bad line"));
-	assert!(transcript.contains("└─ command `printf 'bad line\\n' >&2; exit 3` failed: bad line"));
+	assert!(transcript.contains("stderr:\nbad line"));
+	assert!(transcript.contains("✔ [4/5] cleanup (Command)"));
+	assert!(transcript.contains("cleanup [stdout] cleanup complete"));
+	assert!(
+		transcript
+			.contains("○ [5/5] skip after failure (Command) — skipped (an earlier step failed)")
+	);
+	assert!(transcript.contains("`progress-failure` failed"));
+	assert!(!transcript.contains("✔ [3/5] fail loud"));
+	assert!(!transcript.contains("`progress-failure` finished"));
+	assert!(!transcript.contains("must not run"));
 }
 
 #[test]
 #[cfg(unix)]
-fn interactive_change_cli_hides_progress_output_on_tty() {
+fn failure_without_cleanup_reports_every_later_step_as_skipped() {
+	let tempdir = setup_fixture("monochange/release-progress-failure");
+
+	let (status, transcript) =
+		run_tty_command_result(tempdir.path(), "progress-failure-no-cleanup");
+
+	assert_ne!(status, 0, "expected failure transcript:\n{transcript}");
+	assert!(transcript.contains("✖ [1/2] primary failure (Command)"));
+	assert!(
+		transcript.contains("○ [2/2] skipped tail (Command) — skipped (an earlier step failed)")
+	);
+	assert!(transcript.contains("`progress-failure-no-cleanup` failed"));
+	assert!(!transcript.contains("must not run"));
+}
+
+#[test]
+#[cfg(unix)]
+fn failing_cleanup_preserves_the_primary_workflow_error() {
+	let tempdir = setup_fixture("monochange/release-progress-failure");
+
+	let (status, transcript) = run_tty_command_result(tempdir.path(), "progress-failing-cleanup");
+
+	assert_ne!(status, 0, "expected failure transcript:\n{transcript}");
+	assert!(transcript.contains("✖ [1/2] primary failure (Command)"));
+	assert!(transcript.contains("✖ [2/2] failing cleanup (Command)"));
+	let primary_error = "command `printf 'primary error\\n' >&2; exit 4` failed";
+	let cleanup_error = "command `printf 'cleanup error\\n' >&2; exit 5` failed";
+	assert_eq!(transcript.matches(primary_error).count(), 2, "{transcript}");
+	assert_eq!(transcript.matches(cleanup_error).count(), 1, "{transcript}");
+}
+
+#[test]
+fn json_conditional_skips_retain_condition_and_add_reason() {
+	let tempdir = setup_fixture("monochange/release-progress-failure");
+	let output = monochange_command(Some("2026-04-06"))
+		.current_dir(tempdir.path())
+		.arg("run")
+		.arg("progress-json-skip")
+		.arg("--progress-format")
+		.arg("json")
+		.output()
+		.unwrap_or_else(|error| panic!("run JSON skip command: {error}"));
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+
+	let events = normalized_progress_events(&String::from_utf8_lossy(&output.stderr));
+	let skipped = events
+		.iter()
+		.find(|event| event["event"] == "step_skipped")
+		.unwrap_or_else(|| panic!("missing step_skipped event: {events:#?}"));
+	assert_eq!(skipped["condition"], "{{ false }}");
+	assert_eq!(skipped["reason"], "when condition `{{ false }}` is false");
+}
+
+#[test]
+#[cfg(unix)]
+fn interactive_change_cli_shows_step_progress_on_tty() {
 	let tempdir = setup_scenario_workspace("monochange/release-base");
 	let output_path = tempdir.path().join(".changeset/interactive.md");
 
@@ -266,9 +337,9 @@ fn interactive_change_cli_hides_progress_output_on_tty() {
 		status, 0,
 		"unexpected interactive transcript:\n{transcript}"
 	);
-	assert!(!transcript.contains("running `change`"), "{transcript}");
-	assert!(!transcript.contains("[1/1]"), "{transcript}");
-	assert!(!transcript.contains("finished"), "{transcript}");
+	assert!(transcript.contains("running `change`"), "{transcript}");
+	assert!(transcript.contains("[1/1]"), "{transcript}");
+	assert!(transcript.contains("`change` finished"), "{transcript}");
 	assert!(transcript.contains("wrote change file .changeset/interactive.md"));
 	assert!(
 		output_path.exists(),
@@ -340,4 +411,12 @@ fn release_progress_renders_skipped_failed_steps_and_stderr_on_tty() {}
 
 #[test]
 #[cfg(not(unix))]
-fn interactive_change_cli_hides_progress_output_on_tty() {}
+fn failure_without_cleanup_reports_every_later_step_as_skipped() {}
+
+#[test]
+#[cfg(not(unix))]
+fn failing_cleanup_preserves_the_primary_workflow_error() {}
+
+#[test]
+#[cfg(not(unix))]
+fn interactive_change_cli_shows_step_progress_on_tty() {}

--- a/crates/monochange/tests/cli_progress.rs
+++ b/crates/monochange/tests/cli_progress.rs
@@ -26,6 +26,9 @@ fn normalize_duration_text(text: &str) -> String {
 
 fn normalized_ascii_progress(stderr: &str) -> String {
 	let normalized = normalize_duration_text(&normalize_terminal_transcript(stderr));
+	let command_newline_pattern =
+		Regex::new(r"\\n").unwrap_or_else(|error| panic!("regex: {error}"));
+	let normalized = command_newline_pattern.replace_all(&normalized, "[newline]");
 	normalized
 		.lines()
 		.filter(|line| !line.starts_with("  - "))
@@ -48,6 +51,10 @@ fn normalized_progress_events(stderr: &str) -> Vec<Value> {
 		};
 		if let Some(duration) = object.get_mut("duration_ms") {
 			*duration = Value::String("[duration_ms]".to_string());
+		}
+		if let Some(status) = object.get("status").and_then(Value::as_str) {
+			let redacted = status.replace("\\n", "[newline]");
+			object.insert("status".to_string(), Value::String(redacted));
 		}
 		if let Some(phase_timings) = object
 			.get_mut("phase_timings")

--- a/crates/monochange/tests/snapshots/cli_progress__ascii_progress_renders_clean_captured_output@ascii_progress_renders_clean_captured_output.snap
+++ b/crates/monochange/tests/snapshots/cli_progress__ascii_progress_renders_clean_captured_output@ascii_progress_renders_clean_captured_output.snap
@@ -6,7 +6,7 @@ monochange running `progress-ascii`
 > [1/2] plan release (PrepareRelease)
 + [1/2] plan release (PrepareRelease) [duration]
 > [2/2] stream summary (Command)
-> [2/2] stream summary (Command) — running command `printf 'line one\n\nline three\n'`
+> [2/2] stream summary (Command) — running command `printf 'line one[newline][newline]line three[newline]'`
   | stream summary [stdout] line one
   | stream summary [stdout] 
   | stream summary [stdout] line three

--- a/crates/monochange/tests/snapshots/cli_progress__ascii_progress_renders_clean_captured_output@ascii_progress_renders_clean_captured_output.snap
+++ b/crates/monochange/tests/snapshots/cli_progress__ascii_progress_renders_clean_captured_output@ascii_progress_renders_clean_captured_output.snap
@@ -1,18 +1,12 @@
 ---
 source: crates/monochange/tests/cli_progress.rs
-assertion_line: 299
 expression: normalized_ascii_progress(&stderr)
 ---
 monochange running `progress-ascii`
 > [1/2] plan release (PrepareRelease)
-> [1/2] plan release (PrepareRelease) — loading changesets
-> [1/2] plan release (PrepareRelease) — computing dependency graph
-> [1/2] plan release (PrepareRelease) — planning versions
-> [1/2] plan release (PrepareRelease) — rendering changelogs
-> [1/2] plan release (PrepareRelease) — updating package files
-> [1/2] plan release (PrepareRelease) — refreshing lockfiles
 + [1/2] plan release (PrepareRelease) [duration]
 > [2/2] stream summary (Command)
+> [2/2] stream summary (Command) — running command `printf 'line one\n\nline three\n'`
   | stream summary [stdout] line one
   | stream summary [stdout] 
   | stream summary [stdout] line three

--- a/crates/monochange/tests/snapshots/cli_progress__json_progress_emits_structured_events_for_machine_consumers@json_progress_emits_structured_events_for_machine_consumers.snap
+++ b/crates/monochange/tests/snapshots/cli_progress__json_progress_emits_structured_events_for_machine_consumers@json_progress_emits_structured_events_for_machine_consumers.snap
@@ -119,7 +119,7 @@ expression: redacted
     "dry_run": false,
     "event": "step_status",
     "sequence": "[sequence:4]",
-    "status": "running command `printf 'stdout line\\n'; printf 'stderr line\\n' >&2`",
+    "status": "running command `printf 'stdout line[newline]'; printf 'stderr line[newline]' >&2`",
     "step_display_name": "stream summary",
     "step_index": 2,
     "step_kind": "Command",

--- a/crates/monochange/tests/snapshots/cli_progress__json_progress_emits_structured_events_for_machine_consumers@json_progress_emits_structured_events_for_machine_consumers.snap
+++ b/crates/monochange/tests/snapshots/cli_progress__json_progress_emits_structured_events_for_machine_consumers@json_progress_emits_structured_events_for_machine_consumers.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/monochange/tests/cli_progress.rs
-assertion_line: 330
 expression: redacted
 ---
 [
@@ -16,78 +15,6 @@ expression: redacted
     "dry_run": false,
     "event": "step_started",
     "sequence": "[sequence:1]",
-    "step_display_name": "plan release",
-    "step_index": 1,
-    "step_kind": "PrepareRelease",
-    "step_name": "plan release",
-    "total_steps": 2
-  },
-  {
-    "command": "progress-json",
-    "dry_run": false,
-    "event": "step_status",
-    "sequence": "[sequence:2]",
-    "status": "loading changesets",
-    "step_display_name": "plan release",
-    "step_index": 1,
-    "step_kind": "PrepareRelease",
-    "step_name": "plan release",
-    "total_steps": 2
-  },
-  {
-    "command": "progress-json",
-    "dry_run": false,
-    "event": "step_status",
-    "sequence": "[sequence:3]",
-    "status": "computing dependency graph",
-    "step_display_name": "plan release",
-    "step_index": 1,
-    "step_kind": "PrepareRelease",
-    "step_name": "plan release",
-    "total_steps": 2
-  },
-  {
-    "command": "progress-json",
-    "dry_run": false,
-    "event": "step_status",
-    "sequence": "[sequence:4]",
-    "status": "planning versions",
-    "step_display_name": "plan release",
-    "step_index": 1,
-    "step_kind": "PrepareRelease",
-    "step_name": "plan release",
-    "total_steps": 2
-  },
-  {
-    "command": "progress-json",
-    "dry_run": false,
-    "event": "step_status",
-    "sequence": "[sequence:5]",
-    "status": "rendering changelogs",
-    "step_display_name": "plan release",
-    "step_index": 1,
-    "step_kind": "PrepareRelease",
-    "step_name": "plan release",
-    "total_steps": 2
-  },
-  {
-    "command": "progress-json",
-    "dry_run": false,
-    "event": "step_status",
-    "sequence": "[sequence:6]",
-    "status": "updating package files",
-    "step_display_name": "plan release",
-    "step_index": 1,
-    "step_kind": "PrepareRelease",
-    "step_name": "plan release",
-    "total_steps": 2
-  },
-  {
-    "command": "progress-json",
-    "dry_run": false,
-    "event": "step_status",
-    "sequence": "[sequence:7]",
-    "status": "refreshing lockfiles",
     "step_display_name": "plan release",
     "step_index": 1,
     "step_kind": "PrepareRelease",
@@ -169,7 +96,7 @@ expression: redacted
         "label": "sync internal dependency constraints"
       }
     ],
-    "sequence": "[sequence:8]",
+    "sequence": "[sequence:2]",
     "step_display_name": "plan release",
     "step_index": 1,
     "step_kind": "PrepareRelease",
@@ -180,7 +107,19 @@ expression: redacted
     "command": "progress-json",
     "dry_run": false,
     "event": "step_started",
-    "sequence": "[sequence:9]",
+    "sequence": "[sequence:3]",
+    "step_display_name": "stream summary",
+    "step_index": 2,
+    "step_kind": "Command",
+    "step_name": "stream summary",
+    "total_steps": 2
+  },
+  {
+    "command": "progress-json",
+    "dry_run": false,
+    "event": "step_status",
+    "sequence": "[sequence:4]",
+    "status": "running command `printf 'stdout line\\n'; printf 'stderr line\\n' >&2`",
     "step_display_name": "stream summary",
     "step_index": 2,
     "step_kind": "Command",
@@ -191,7 +130,7 @@ expression: redacted
     "command": "progress-json",
     "dry_run": false,
     "event": "command_output",
-    "sequence": "[sequence:10]",
+    "sequence": "[sequence:5]",
     "step_display_name": "stream summary",
     "step_index": 2,
     "step_kind": "Command",
@@ -204,7 +143,7 @@ expression: redacted
     "command": "progress-json",
     "dry_run": false,
     "event": "command_output",
-    "sequence": "[sequence:11]",
+    "sequence": "[sequence:6]",
     "step_display_name": "stream summary",
     "step_index": 2,
     "step_kind": "Command",
@@ -219,7 +158,7 @@ expression: redacted
     "duration_ms": "[duration_ms]",
     "event": "step_finished",
     "phase_timings": [],
-    "sequence": "[sequence:12]",
+    "sequence": "[sequence:7]",
     "step_display_name": "stream summary",
     "step_index": 2,
     "step_kind": "Command",
@@ -231,7 +170,7 @@ expression: redacted
     "dry_run": false,
     "duration_ms": "[duration_ms]",
     "event": "command_finished",
-    "sequence": "[sequence:13]",
+    "sequence": "[sequence:8]",
     "total_steps": 2
   }
 ]

--- a/crates/monochange/tests/snapshots/cli_progress__multiline_5__text@json_progress_emits_structured_events_for_machine_consumers.snap
+++ b/crates/monochange/tests/snapshots/cli_progress__multiline_5__text@json_progress_emits_structured_events_for_machine_consumers.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/monochange/tests/cli_progress.rs
-assertion_line: 325
 expression: contents
 ---
 stderr line

--- a/crates/monochange/tests/snapshots/cli_progress__multiline_6__text@json_progress_emits_structured_events_for_machine_consumers.snap
+++ b/crates/monochange/tests/snapshots/cli_progress__multiline_6__text@json_progress_emits_structured_events_for_machine_consumers.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/monochange/tests/cli_progress.rs
-assertion_line: 325
 expression: contents
 ---
 stdout line

--- a/crates/monochange/tests/test_support.rs
+++ b/crates/monochange/tests/test_support.rs
@@ -279,6 +279,7 @@ pub fn monochange_command(release_date: Option<&str>) -> Command {
 	let mut command = Command::new(get_cargo_bin("monochange"));
 	command.env("NO_COLOR", "1");
 	command.env_remove("RUST_LOG");
+	command.env("MONOCHANGE_NO_PROGRESS", "1");
 
 	if let Some(release_date) = release_date {
 		command.env("MONOCHANGE_RELEASE_DATE", release_date);

--- a/crates/monochange_integration_tests/tests/forgejo_provider.rs
+++ b/crates/monochange_integration_tests/tests/forgejo_provider.rs
@@ -72,6 +72,7 @@ fn forgejo_cli_validate_accepts_fixture_configuration() {
 	let output = Command::new(get_cargo_bin("monochange"))
 		.env("NO_COLOR", "1")
 		.env_remove("RUST_LOG")
+		.env("MONOCHANGE_NO_PROGRESS", "1")
 		.current_dir(fixture_path("source/forgejo"))
 		.arg("step")
 		.arg("validate")

--- a/crates/monochange_integration_tests/tests/group_release_note_fallback.rs
+++ b/crates/monochange_integration_tests/tests/group_release_note_fallback.rs
@@ -57,6 +57,7 @@ fn mc_json(root: &Path, args: &[&str]) -> Value {
 		.env("NO_COLOR", "1")
 		.env("MONOCHANGE_RELEASE_DATE", "2026-04-06")
 		.env_remove("RUST_LOG")
+		.env("MONOCHANGE_NO_PROGRESS", "1")
 		.args(args)
 		.output()
 		.unwrap_or_else(|error| panic!("run monochange {}: {error}", args.join(" ")));

--- a/crates/monochange_integration_tests/tests/publish_plan_order.rs
+++ b/crates/monochange_integration_tests/tests/publish_plan_order.rs
@@ -36,6 +36,7 @@ fn monochange_command(release_date: &str) -> Command {
 	let mut command = Command::new(get_cargo_bin("monochange"));
 	command.env("NO_COLOR", "1");
 	command.env_remove("RUST_LOG");
+	command.env("MONOCHANGE_NO_PROGRESS", "1");
 	command.env("MONOCHANGE_RELEASE_DATE", release_date);
 	command
 }

--- a/crates/monochange_integration_tests/tests/release_output_format.rs
+++ b/crates/monochange_integration_tests/tests/release_output_format.rs
@@ -48,6 +48,7 @@ fn mc_release(root: &Path, args: &[&str]) -> String {
 		.env("NO_COLOR", "1")
 		.env("MONOCHANGE_RELEASE_DATE", "2026-04-06")
 		.env_remove("RUST_LOG")
+		.env("MONOCHANGE_NO_PROGRESS", "1")
 		.args(["run", "release", "--dry-run"])
 		.args(args)
 		.output()

--- a/crates/monochange_integration_tests/tests/release_record_artifacts.rs
+++ b/crates/monochange_integration_tests/tests/release_record_artifacts.rs
@@ -35,6 +35,7 @@ fn prepare_release(root: &Path) -> Value {
 		.current_dir(root)
 		.env("NO_COLOR", "1")
 		.env_remove("RUST_LOG")
+		.env("MONOCHANGE_NO_PROGRESS", "1")
 		.env("MONOCHANGE_RELEASE_DATE", "2026-04-07")
 		.arg("step")
 		.arg("prepare-release")
@@ -90,6 +91,7 @@ fn run_release(root: &Path, args: &[&str]) {
 		.current_dir(root)
 		.env("NO_COLOR", "1")
 		.env_remove("RUST_LOG")
+		.env("MONOCHANGE_NO_PROGRESS", "1")
 		.env("MONOCHANGE_RELEASE_DATE", "2026-04-07")
 		.arg("run")
 		.arg("release")
@@ -109,6 +111,7 @@ fn check_failure(root: &Path) -> String {
 		.current_dir(root)
 		.env("NO_COLOR", "1")
 		.env_remove("RUST_LOG")
+		.env("MONOCHANGE_NO_PROGRESS", "1")
 		.arg("check")
 		.output()
 		.unwrap_or_else(|error| panic!("run check: {error}"));

--- a/crates/monochange_publish/src/__tests__/lib_tests.rs
+++ b/crates/monochange_publish/src/__tests__/lib_tests.rs
@@ -2330,3 +2330,48 @@ async fn dry_run_publish_executes_registry_dry_run_and_captures_output() {
 			.is_some_and(|command| command.contains("--dry-run"))
 	);
 }
+
+#[test]
+fn package_publish_failure_exposes_error_and_report_accessors() {
+	let report = PackagePublishReport {
+		mode: PackagePublishRunMode::Release,
+		dry_run: false,
+		packages: Vec::new(),
+	};
+	let error = MonochangeError::Config("boom".to_string());
+	let failure = PackagePublishFailure::new(error, report.clone());
+
+	assert_eq!(failure.report(), &report);
+	assert_eq!(failure.error().to_string(), "config error: boom");
+	assert_eq!(failure.render(), "config error: boom");
+	assert_eq!(failure.to_string(), "config error: boom");
+	assert!(std::error::Error::source(&failure).is_none());
+
+	let into_report = failure.into_report();
+	assert_eq!(into_report, report);
+
+	let failure =
+		PackagePublishFailure::new(MonochangeError::Config("boom".to_string()), report.clone());
+	let (returned_error, returned_report) = failure.into_parts();
+	assert_eq!(returned_error.to_string(), "config error: boom");
+	assert_eq!(returned_report.mode, PackagePublishRunMode::Release);
+
+	let failure = PackagePublishFailure::new(MonochangeError::Config("boom".to_string()), report);
+	assert_eq!(failure.into_error().to_string(), "config error: boom");
+}
+
+#[test]
+fn empty_publish_report_marks_every_request_as_blocked() {
+	let requests = [publish_request("first"), publish_request("second")];
+	let report = empty_publish_report(PackagePublishRunMode::Release, false, &requests);
+	assert_eq!(report.mode, PackagePublishRunMode::Release);
+	assert!(!report.dry_run);
+	assert_eq!(report.packages.len(), 2);
+	assert!(report.packages.iter().all(|outcome| {
+		outcome.status == PackagePublishStatus::Blocked
+			&& outcome.message.contains("could not start")
+	}));
+	assert_eq!(report.summary().expected, 2);
+	assert_eq!(report.summary().failed, 0);
+	assert_eq!(report.summary().skipped, 2);
+}

--- a/crates/monochange_publish/src/__tests__/lib_tests.rs
+++ b/crates/monochange_publish/src/__tests__/lib_tests.rs
@@ -417,6 +417,43 @@ fn sample_publish_request_for_registry(registry: RegistryKind) -> PublishRequest
 }
 
 #[test]
+fn render_command_error_preserves_available_output_streams() {
+	let stdout_only = CommandOutput {
+		success: false,
+		stdout: "useful stdout".to_string(),
+		stderr: String::new(),
+	};
+	assert_eq!(render_command_error(&stdout_only), "useful stdout");
+
+	let stderr_only = CommandOutput {
+		success: false,
+		stdout: String::new(),
+		stderr: "useful stderr".to_string(),
+	};
+	assert_eq!(render_command_error(&stderr_only), "useful stderr");
+
+	let both = CommandOutput {
+		success: false,
+		stdout: "useful stdout".to_string(),
+		stderr: "useful stderr".to_string(),
+	};
+	assert_eq!(
+		render_command_error(&both),
+		"stdout:\nuseful stdout\n\nstderr:\nuseful stderr"
+	);
+
+	let empty = CommandOutput {
+		success: false,
+		stdout: String::new(),
+		stderr: String::new(),
+	};
+	assert_eq!(
+		render_command_error(&empty),
+		"command failed without output"
+	);
+}
+
+#[test]
 fn render_publish_command_error_adds_npm_otp_recovery_guidance() {
 	let request = sample_publish_request_for_registry(RegistryKind::Npm);
 	let output = CommandOutput {
@@ -574,6 +611,168 @@ impl CommandExecutor for PanickingCommandExecutor {
 	}
 }
 
+struct SequencedCommandExecutor {
+	commands: Vec<CommandSpec>,
+	outputs: std::collections::VecDeque<MonochangeResult<CommandOutput>>,
+}
+
+impl SequencedCommandExecutor {
+	fn new(outputs: impl IntoIterator<Item = MonochangeResult<CommandOutput>>) -> Self {
+		Self {
+			commands: Vec::new(),
+			outputs: outputs.into_iter().collect(),
+		}
+	}
+}
+
+impl CommandExecutor for SequencedCommandExecutor {
+	fn run(&mut self, spec: &CommandSpec) -> MonochangeResult<CommandOutput> {
+		self.commands.push(spec.clone());
+		self.outputs
+			.pop_front()
+			.unwrap_or_else(|| panic!("unexpected publish command: {}", render_command(spec)))
+	}
+}
+
+fn publish_request(package: &str) -> PublishRequest {
+	let mut request = sample_publish_request_for_registry(RegistryKind::Npm);
+	request.package_id = package.to_string();
+	request.package_name = package.to_string();
+	request
+}
+
+fn npm_registry_response_endpoints(
+	request_count: usize,
+	response: &'static [u8],
+) -> (RegistryEndpoints, std::thread::JoinHandle<()>) {
+	let listener = std::net::TcpListener::bind("127.0.0.1:0")
+		.unwrap_or_else(|error| panic!("bind test registry: {error}"));
+	let address = listener
+		.local_addr()
+		.unwrap_or_else(|error| panic!("test registry address: {error}"));
+	let thread = std::thread::spawn(move || {
+		for _ in 0..request_count {
+			let (mut stream, _) = listener
+				.accept()
+				.unwrap_or_else(|error| panic!("accept registry request: {error}"));
+			let mut request = [0_u8; 2048];
+			std::io::Read::read(&mut stream, &mut request)
+				.unwrap_or_else(|error| panic!("read registry request: {error}"));
+			std::io::Write::write_all(&mut stream, response)
+				.unwrap_or_else(|error| panic!("write registry response: {error}"));
+		}
+	});
+	let mut endpoints = RegistryEndpoints::from_env();
+	endpoints.npm_registry = format!("http://{address}");
+	(endpoints, thread)
+}
+
+fn npm_not_found_endpoints(
+	request_count: usize,
+) -> (RegistryEndpoints, std::thread::JoinHandle<()>) {
+	npm_registry_response_endpoints(
+		request_count,
+		b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+	)
+}
+
+fn npm_failure_endpoints() -> (RegistryEndpoints, std::thread::JoinHandle<()>) {
+	npm_registry_response_endpoints(
+		1,
+		b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+	)
+}
+
+fn command_output(success: bool, stdout: &str, stderr: &str) -> CommandOutput {
+	CommandOutput {
+		success,
+		stdout: stdout.to_string(),
+		stderr: stderr.to_string(),
+	}
+}
+
+fn assert_complete_failed_publish_run(
+	report: &PackagePublishReport,
+	requests: &[PublishRequest],
+	progress: &RecordingPublishProgressReporter,
+	expected_failure: &str,
+	expected_placeholder: bool,
+) {
+	assert_eq!(report.packages.len(), requests.len());
+	assert_eq!(
+		report
+			.packages
+			.iter()
+			.map(|outcome| outcome.package.as_str())
+			.collect::<Vec<_>>(),
+		requests
+			.iter()
+			.map(|request| request.package_id.as_str())
+			.collect::<Vec<_>>()
+	);
+	assert_eq!(report.packages[0].status, PackagePublishStatus::Failed);
+	assert!(report.packages[0].message.contains(expected_failure));
+	assert_eq!(report.packages[0].placeholder, expected_placeholder);
+	assert!(report.packages[1..].iter().all(|outcome| {
+		outcome.status == PackagePublishStatus::Blocked
+			&& outcome.placeholder == expected_placeholder
+			&& outcome.message.contains(&format!(
+				"publishing {} {} failed earlier",
+				requests[0].package_name, requests[0].version
+			))
+	}));
+	assert_eq!(
+		report.summary(),
+		PackagePublishSummary {
+			expected: requests.len(),
+			succeeded: 0,
+			failed: 1,
+			skipped: requests.len() - 1,
+		}
+	);
+
+	let events = progress.events.lock().unwrap();
+	assert!(matches!(
+		events.first(),
+		Some(PublishProgressEvent::RunStarted {
+			mode,
+			dry_run,
+			total,
+			..
+		}) if *mode == report.mode && *dry_run == report.dry_run && *total == requests.len()
+	));
+	assert!(events.iter().any(|event| {
+		matches!(
+			event,
+			PublishProgressEvent::PackageFailed { package, message }
+				if package.package_id == requests[0].package_id
+					&& message.contains(expected_failure)
+		)
+	}));
+	for request in &requests[1..] {
+		assert!(events.iter().any(|event| {
+			matches!(
+				event,
+				PublishProgressEvent::PackageSkipped { package, message }
+					if package.package_id == request.package_id
+						&& message.contains("failed earlier")
+			)
+		}));
+	}
+	assert!(matches!(
+		events.last(),
+		Some(PublishProgressEvent::RunFinished {
+			mode,
+			total,
+			published: 0,
+			skipped,
+			failed: 1,
+		}) if *mode == report.mode
+			&& *total == requests.len()
+			&& *skipped == requests.len() - 1
+	));
+}
+
 struct TestPublishTrustHandler;
 
 impl PublishTrustHandler for TestPublishTrustHandler {
@@ -605,6 +804,42 @@ impl PublishTrustHandler for TestPublishTrustHandler {
 		_env_map: &BTreeMap<String, String>,
 	) -> MonochangeResult<()> {
 		Ok(())
+	}
+}
+
+struct FailingPublishTrustHandler;
+
+impl PublishTrustHandler for FailingPublishTrustHandler {
+	fn trust_outcome_for_skip(
+		&self,
+		_request: &PublishRequest,
+		_source: Option<&SourceConfiguration>,
+		_root: &Path,
+		_env_map: &BTreeMap<String, String>,
+	) -> TrustedPublishingOutcome {
+		disabled_trust_outcome()
+	}
+
+	fn planned_trust_outcome(
+		&self,
+		_request: &PublishRequest,
+		_source: Option<&SourceConfiguration>,
+		_root: &Path,
+		_env_map: &BTreeMap<String, String>,
+	) -> TrustedPublishingOutcome {
+		disabled_trust_outcome()
+	}
+
+	fn enforce_release_trust_prerequisites(
+		&self,
+		_request: &PublishRequest,
+		_source: Option<&SourceConfiguration>,
+		_root: &Path,
+		_env_map: &BTreeMap<String, String>,
+	) -> MonochangeResult<()> {
+		Err(MonochangeError::Config(
+			"trusted publishing prerequisite failed".to_string(),
+		))
 	}
 }
 
@@ -691,6 +926,564 @@ async fn publish_progress_reports_external_skip_and_summary_events() {
 			..
 		})
 	));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn real_publish_failure_records_tail_outcomes_and_progress_summary() {
+	let requests = [
+		publish_request("first"),
+		publish_request("failed"),
+		publish_request("tail"),
+	];
+	let (endpoints, registry_thread) = npm_not_found_endpoints(2);
+	let progress = RecordingPublishProgressReporter::default();
+	let mut executor = SequencedCommandExecutor::new([
+		Ok(command_output(true, "published first", "")),
+		Ok(command_output(
+			false,
+			"partial upload",
+			"registry rejected package",
+		)),
+	]);
+
+	let report = execute_publish_requests_with_progress(
+		Path::new("."),
+		None,
+		PackagePublishRunMode::Release,
+		false,
+		&requests,
+		&registry_client().unwrap(),
+		&endpoints,
+		&BTreeMap::new(),
+		&mut executor,
+		&build_publish_command_builder(),
+		&PlaceholderManifestWriterRegistry::new(),
+		&PublishReadinessRegistry::new(),
+		&TestPublishTrustHandler,
+		&progress,
+	)
+	.await
+	.unwrap_or_else(|error| panic!("execute publish requests: {error}"));
+	registry_thread
+		.join()
+		.unwrap_or_else(|_| panic!("test registry thread panicked"));
+
+	assert_eq!(executor.commands.len(), 2);
+	assert_eq!(report.packages.len(), requests.len());
+	assert_eq!(
+		report
+			.packages
+			.iter()
+			.map(|outcome| outcome.status)
+			.collect::<Vec<_>>(),
+		vec![
+			PackagePublishStatus::Published,
+			PackagePublishStatus::Failed,
+			PackagePublishStatus::Blocked,
+		]
+	);
+	assert_eq!(
+		report.summary(),
+		PackagePublishSummary {
+			expected: 3,
+			succeeded: 1,
+			failed: 1,
+			skipped: 1,
+		}
+	);
+
+	assert!(report.packages[1].message.contains("partial upload"));
+	assert!(
+		report.packages[1]
+			.message
+			.contains("registry rejected package")
+	);
+	assert!(
+		report.packages[2]
+			.message
+			.contains("publishing failed 1.0.0 failed earlier")
+	);
+
+	let events = progress.events.lock().unwrap();
+	assert!(events.iter().any(|event| {
+		matches!(
+			event,
+			PublishProgressEvent::PackageSkipped { package, message }
+				if package.package_name == "tail" && message.contains("failed earlier")
+		)
+	}));
+	assert!(matches!(
+		events.last(),
+		Some(PublishProgressEvent::RunFinished {
+			total: 3,
+			published: 1,
+			skipped: 1,
+			failed: 1,
+			..
+		})
+	));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn real_publish_spawn_failure_records_every_unattempted_package() {
+	let requests = [
+		publish_request("failed"),
+		publish_request("tail-one"),
+		publish_request("tail-two"),
+	];
+	let (endpoints, registry_thread) = npm_not_found_endpoints(1);
+	let mut executor = SequencedCommandExecutor::new([Err(MonochangeError::Io(
+		"publisher executable was not found".to_string(),
+	))]);
+
+	let report = try_execute_publish_requests_with_progress(
+		Path::new("."),
+		None,
+		PackagePublishRunMode::Release,
+		false,
+		&requests,
+		&registry_client().unwrap(),
+		&endpoints,
+		&BTreeMap::new(),
+		&mut executor,
+		&build_publish_command_builder(),
+		&PlaceholderManifestWriterRegistry::new(),
+		&PublishReadinessRegistry::new(),
+		&TestPublishTrustHandler,
+		&NoopPublishProgressReporter,
+	)
+	.await
+	.unwrap_or_else(|error| panic!("execute publish requests: {error}"));
+	registry_thread
+		.join()
+		.unwrap_or_else(|_| panic!("test registry thread panicked"));
+
+	assert_eq!(executor.commands.len(), 1);
+	assert_eq!(report.packages.len(), 3);
+	assert_eq!(report.packages[0].status, PackagePublishStatus::Failed);
+	assert!(
+		report.packages[1..]
+			.iter()
+			.all(|outcome| outcome.status == PackagePublishStatus::Blocked)
+	);
+	assert_eq!(
+		report.summary(),
+		PackagePublishSummary {
+			expected: 3,
+			succeeded: 0,
+			failed: 1,
+			skipped: 2,
+		}
+	);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn registry_lookup_failure_records_failed_package_blocked_tail_and_finished_total() {
+	let requests = [
+		publish_request("failed"),
+		publish_request("tail-one"),
+		publish_request("tail-two"),
+	];
+	let (endpoints, registry_thread) = npm_failure_endpoints();
+	let progress = RecordingPublishProgressReporter::default();
+	let mut executor =
+		SequencedCommandExecutor::new(std::iter::empty::<MonochangeResult<CommandOutput>>());
+
+	let report = try_execute_publish_requests_with_progress(
+		Path::new("."),
+		None,
+		PackagePublishRunMode::Release,
+		false,
+		&requests,
+		&registry_client().unwrap(),
+		&endpoints,
+		&BTreeMap::new(),
+		&mut executor,
+		&build_publish_command_builder(),
+		&PlaceholderManifestWriterRegistry::new(),
+		&PublishReadinessRegistry::new(),
+		&TestPublishTrustHandler,
+		&progress,
+	)
+	.await
+	.expect_err("registry lookup failure should carry a report")
+	.into_report();
+	registry_thread
+		.join()
+		.unwrap_or_else(|_| panic!("test registry thread panicked"));
+
+	assert!(executor.commands.is_empty());
+	assert_complete_failed_publish_run(&report, &requests, &progress, "npm registry lookup", false);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn readiness_checker_error_records_failed_package_blocked_tail_and_finished_total() {
+	let requests = [publish_request("failed"), publish_request("tail")];
+	let (endpoints, registry_thread) = npm_not_found_endpoints(1);
+	let readiness = PublishReadinessRegistry::new().with_checker(
+		RegistryKind::Npm,
+		Box::new(|_, _| {
+			Err(MonochangeError::Config(
+				"readiness checker failed".to_string(),
+			))
+		}),
+	);
+	let progress = RecordingPublishProgressReporter::default();
+	let mut executor =
+		SequencedCommandExecutor::new(std::iter::empty::<MonochangeResult<CommandOutput>>());
+
+	let report = try_execute_publish_requests_with_progress(
+		Path::new("."),
+		None,
+		PackagePublishRunMode::Release,
+		false,
+		&requests,
+		&registry_client().unwrap(),
+		&endpoints,
+		&BTreeMap::new(),
+		&mut executor,
+		&build_publish_command_builder(),
+		&PlaceholderManifestWriterRegistry::new(),
+		&readiness,
+		&TestPublishTrustHandler,
+		&progress,
+	)
+	.await
+	.expect_err("readiness checker failure should carry a report")
+	.into_report();
+	registry_thread
+		.join()
+		.unwrap_or_else(|_| panic!("test registry thread panicked"));
+
+	assert!(executor.commands.is_empty());
+	assert_complete_failed_publish_run(
+		&report,
+		&requests,
+		&progress,
+		"readiness checker failed",
+		false,
+	);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn real_run_readiness_block_records_failed_package_instead_of_returning_error() {
+	let requests = [publish_request("failed"), publish_request("tail")];
+	let (endpoints, registry_thread) = npm_not_found_endpoints(1);
+	let readiness = PublishReadinessRegistry::new().with_checker(
+		RegistryKind::Npm,
+		Box::new(|_, _| Ok(Some("release is not ready".to_string()))),
+	);
+	let progress = RecordingPublishProgressReporter::default();
+	let mut executor =
+		SequencedCommandExecutor::new(std::iter::empty::<MonochangeResult<CommandOutput>>());
+
+	let report = try_execute_publish_requests_with_progress(
+		Path::new("."),
+		None,
+		PackagePublishRunMode::Release,
+		false,
+		&requests,
+		&registry_client().unwrap(),
+		&endpoints,
+		&BTreeMap::new(),
+		&mut executor,
+		&build_publish_command_builder(),
+		&PlaceholderManifestWriterRegistry::new(),
+		&readiness,
+		&TestPublishTrustHandler,
+		&progress,
+	)
+	.await
+	.expect_err("blocked readiness should carry a report")
+	.into_report();
+	registry_thread
+		.join()
+		.unwrap_or_else(|_| panic!("test registry thread panicked"));
+
+	assert!(executor.commands.is_empty());
+	assert_complete_failed_publish_run(
+		&report,
+		&requests,
+		&progress,
+		"release is not ready",
+		false,
+	);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn placeholder_manifest_writer_failure_records_failed_package_and_blocked_tail() {
+	let mut requests = [publish_request("failed"), publish_request("tail")];
+	for request in &mut requests {
+		request.placeholder = true;
+	}
+	let (endpoints, registry_thread) = npm_not_found_endpoints(1);
+	let manifest_writers = PlaceholderManifestWriterRegistry::new().with_writer(
+		RegistryKind::Npm,
+		Box::new(|_, _, _, _| {
+			Err(MonochangeError::Io(
+				"placeholder manifest writer failed".to_string(),
+			))
+		}),
+	);
+	let progress = RecordingPublishProgressReporter::default();
+	let mut executor =
+		SequencedCommandExecutor::new(std::iter::empty::<MonochangeResult<CommandOutput>>());
+
+	let report = try_execute_publish_requests_with_progress(
+		Path::new("."),
+		None,
+		PackagePublishRunMode::Placeholder,
+		false,
+		&requests,
+		&registry_client().unwrap(),
+		&endpoints,
+		&BTreeMap::new(),
+		&mut executor,
+		&build_publish_command_builder(),
+		&manifest_writers,
+		&PublishReadinessRegistry::new(),
+		&TestPublishTrustHandler,
+		&progress,
+	)
+	.await
+	.expect_err("placeholder manifest failure should carry a report")
+	.into_report();
+	registry_thread
+		.join()
+		.unwrap_or_else(|_| panic!("test registry thread panicked"));
+
+	assert!(executor.commands.is_empty());
+	assert_complete_failed_publish_run(
+		&report,
+		&requests,
+		&progress,
+		"placeholder manifest writer failed",
+		true,
+	);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn trust_prerequisite_failure_records_failed_package_and_blocked_tail() {
+	let requests = [publish_request("failed"), publish_request("tail")];
+	let (endpoints, registry_thread) = npm_not_found_endpoints(1);
+	let progress = RecordingPublishProgressReporter::default();
+	let mut executor =
+		SequencedCommandExecutor::new(std::iter::empty::<MonochangeResult<CommandOutput>>());
+
+	let report = try_execute_publish_requests_with_progress(
+		Path::new("."),
+		None,
+		PackagePublishRunMode::Release,
+		false,
+		&requests,
+		&registry_client().unwrap(),
+		&endpoints,
+		&BTreeMap::new(),
+		&mut executor,
+		&build_publish_command_builder(),
+		&PlaceholderManifestWriterRegistry::new(),
+		&PublishReadinessRegistry::new(),
+		&FailingPublishTrustHandler,
+		&progress,
+	)
+	.await
+	.expect_err("trust prerequisite failure should carry a report")
+	.into_report();
+	registry_thread
+		.join()
+		.unwrap_or_else(|_| panic!("test registry thread panicked"));
+
+	assert!(executor.commands.is_empty());
+	assert_complete_failed_publish_run(
+		&report,
+		&requests,
+		&progress,
+		"trusted publishing prerequisite failed",
+		false,
+	);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn attestation_prerequisite_failure_records_failed_package_and_blocked_tail() {
+	let mut requests = [publish_request("failed"), publish_request("tail")];
+	requests[0].trusted_publishing.enabled = false;
+	requests[0].attestations.require_registry_provenance = true;
+	let (endpoints, registry_thread) = npm_not_found_endpoints(1);
+	let progress = RecordingPublishProgressReporter::default();
+	let mut executor =
+		SequencedCommandExecutor::new(std::iter::empty::<MonochangeResult<CommandOutput>>());
+
+	let report = try_execute_publish_requests_with_progress(
+		Path::new("."),
+		None,
+		PackagePublishRunMode::Release,
+		false,
+		&requests,
+		&registry_client().unwrap(),
+		&endpoints,
+		&BTreeMap::new(),
+		&mut executor,
+		&build_publish_command_builder(),
+		&PlaceholderManifestWriterRegistry::new(),
+		&PublishReadinessRegistry::new(),
+		&TestPublishTrustHandler,
+		&progress,
+	)
+	.await
+	.expect_err("attestation prerequisite failure should carry a report")
+	.into_report();
+	registry_thread
+		.join()
+		.unwrap_or_else(|_| panic!("test registry thread panicked"));
+
+	assert!(executor.commands.is_empty());
+	assert_complete_failed_publish_run(
+		&report,
+		&requests,
+		&progress,
+		"trusted publishing is disabled",
+		false,
+	);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dry_run_spawn_failure_records_failed_package_blocked_tail_and_expected_total() {
+	let requests = [
+		publish_request("failed"),
+		publish_request("tail-one"),
+		publish_request("tail-two"),
+	];
+	let (endpoints, registry_thread) = npm_not_found_endpoints(1);
+	let progress = RecordingPublishProgressReporter::default();
+	let mut executor = SequencedCommandExecutor::new([Err(MonochangeError::Io(
+		"dry-run publisher executable was not found".to_string(),
+	))]);
+
+	let report = try_execute_publish_requests_with_progress(
+		Path::new("."),
+		None,
+		PackagePublishRunMode::Release,
+		true,
+		&requests,
+		&registry_client().unwrap(),
+		&endpoints,
+		&BTreeMap::new(),
+		&mut executor,
+		&build_publish_command_builder(),
+		&PlaceholderManifestWriterRegistry::new(),
+		&PublishReadinessRegistry::new(),
+		&TestPublishTrustHandler,
+		&progress,
+	)
+	.await
+	.unwrap_or_else(|error| panic!("execute publish dry run: {error}"));
+	registry_thread
+		.join()
+		.unwrap_or_else(|_| panic!("test registry thread panicked"));
+
+	assert_eq!(executor.commands.len(), 1);
+	assert_complete_failed_publish_run(
+		&report,
+		&requests,
+		&progress,
+		"dry-run publisher executable was not found",
+		false,
+	);
+}
+
+#[test]
+fn blocked_packages_are_pending_when_resuming() {
+	let requests = [publish_request("done"), publish_request("tail")];
+	let report = PackagePublishReport {
+		mode: PackagePublishRunMode::Release,
+		dry_run: false,
+		packages: vec![
+			PackagePublishOutcome {
+				package: "done".to_string(),
+				ecosystem: Ecosystem::Npm,
+				registry: RegistryKind::Npm.to_string(),
+				version: "1.0.0".to_string(),
+				status: PackagePublishStatus::Published,
+				message: "published".to_string(),
+				placeholder: false,
+				trusted_publishing: disabled_trust_outcome(),
+				command: None,
+				stdout: None,
+				stderr: None,
+			},
+			PackagePublishOutcome {
+				package: "tail".to_string(),
+				ecosystem: Ecosystem::Npm,
+				registry: RegistryKind::Npm.to_string(),
+				version: "1.0.0".to_string(),
+				status: PackagePublishStatus::Blocked,
+				message: "not attempted".to_string(),
+				placeholder: false,
+				trusted_publishing: disabled_trust_outcome(),
+				command: None,
+				stdout: None,
+				stderr: None,
+			},
+		],
+	};
+
+	assert!(!package_publish_status_is_resumable_complete(
+		PackagePublishStatus::Blocked
+	));
+	let (pending, completed) = resume_publish_requests(&requests, Some(&report))
+		.unwrap_or_else(|error| panic!("resume requests: {error}"));
+	assert_eq!(
+		pending
+			.iter()
+			.map(|request| request.package_id.as_str())
+			.collect::<Vec<_>>(),
+		vec!["tail"]
+	);
+	assert_eq!(completed.len(), 1);
+	assert_eq!(completed[0].package, "done");
+}
+
+#[test]
+fn ensure_publish_report_succeeded_includes_summary_and_failed_package_detail() {
+	let report = PackagePublishReport {
+		mode: PackagePublishRunMode::Release,
+		dry_run: false,
+		packages: vec![
+			PackagePublishOutcome {
+				package: "failed".to_string(),
+				ecosystem: Ecosystem::Npm,
+				registry: RegistryKind::Npm.to_string(),
+				version: "2.0.0".to_string(),
+				status: PackagePublishStatus::Failed,
+				message: "registry denied publication".to_string(),
+				placeholder: false,
+				trusted_publishing: disabled_trust_outcome(),
+				command: None,
+				stdout: None,
+				stderr: None,
+			},
+			PackagePublishOutcome {
+				package: "tail".to_string(),
+				ecosystem: Ecosystem::Npm,
+				registry: RegistryKind::Npm.to_string(),
+				version: "2.0.0".to_string(),
+				status: PackagePublishStatus::Blocked,
+				message: "not attempted".to_string(),
+				placeholder: false,
+				trusted_publishing: disabled_trust_outcome(),
+				command: None,
+				stdout: None,
+				stderr: None,
+			},
+		],
+	};
+
+	let error = ensure_publish_report_succeeded(&report)
+		.expect_err("failed report should produce an aggregate error")
+		.to_string();
+	assert!(error.contains("expected 2, succeeded 0, failed 1, skipped 1"));
+	assert!(error.contains("failed package failed 2.0.0"));
+	assert!(error.contains("registry denied publication"));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/monochange_publish/src/__tests__/lib_tests.rs
+++ b/crates/monochange_publish/src/__tests__/lib_tests.rs
@@ -875,6 +875,26 @@ async fn execute_publish_requests_uses_noop_progress_reporter_by_default() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn execute_publish_requests_with_process_and_progress_uses_noop_reporter() {
+	let report = execute_publish_requests_with_process_and_progress(
+		Path::new("."),
+		None,
+		PackagePublishRunMode::Release,
+		false,
+		&[],
+		&build_publish_command_builder(),
+		&PlaceholderManifestWriterRegistry::new(),
+		&PublishReadinessRegistry::new(),
+		&TestPublishTrustHandler,
+		&NoopPublishProgressReporter,
+	)
+	.await
+	.unwrap();
+
+	assert!(report.packages.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn publish_progress_reports_external_skip_and_summary_events() {
 	let mut request = sample_publish_request_for_registry(RegistryKind::Npm);
 	request.mode = PublishMode::External;

--- a/crates/monochange_publish/src/__tests__/snapshots/monochange_publish__tests__pub_dev_trusted_publishing_auth_error.snap
+++ b/crates/monochange_publish/src/__tests__/snapshots/monochange_publish__tests__pub_dev_trusted_publishing_auth_error.snap
@@ -3,6 +3,10 @@ source: crates/monochange_publish/src/__tests__/lib_tests.rs
 assertion_line: 453
 expression: message
 ---
+stdout:
+Pub needs your authorization to upload packages on your behalf.
+
+stderr:
 No credentials were available for pub.dev authentication.
 
 pub.dev publishing could not authenticate non-interactively. If this package uses trusted publishing, verify the GitHub workflow has `id-token: write`, runs with the GitHub Actions environment configured on pub.dev, matches the package repository and tag/event policy, and runs `dart-lang/setup-dart` before `dart pub publish`. If using a token fallback, add it before publishing with `dart pub token add https://pub.dev --env-var PUB_TOKEN`.

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -235,6 +235,94 @@ pub struct PackagePublishReport {
 	pub packages: Vec<PackagePublishOutcome>,
 }
 
+#[derive(Debug)]
+pub struct PackagePublishFailure {
+	error: MonochangeError,
+	report: PackagePublishReport,
+}
+
+impl PackagePublishFailure {
+	#[must_use]
+	pub fn new(error: MonochangeError, report: PackagePublishReport) -> Self {
+		Self { error, report }
+	}
+
+	#[must_use]
+	pub fn report(&self) -> &PackagePublishReport {
+		&self.report
+	}
+
+	#[must_use]
+	pub fn into_report(self) -> PackagePublishReport {
+		self.report
+	}
+
+	#[must_use]
+	pub fn error(&self) -> &MonochangeError {
+		&self.error
+	}
+
+	#[must_use]
+	pub fn into_error(self) -> MonochangeError {
+		self.error
+	}
+
+	#[must_use]
+	pub fn into_parts(self) -> (MonochangeError, PackagePublishReport) {
+		(self.error, self.report)
+	}
+
+	#[must_use]
+	pub fn render(&self) -> String {
+		self.error.render()
+	}
+}
+
+impl std::fmt::Display for PackagePublishFailure {
+	fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		self.error.fmt(formatter)
+	}
+}
+
+impl std::error::Error for PackagePublishFailure {}
+
+pub type PackagePublishExecutionResult = Result<PackagePublishReport, PackagePublishFailure>;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct PackagePublishSummary {
+	pub expected: usize,
+	pub succeeded: usize,
+	pub failed: usize,
+	pub skipped: usize,
+}
+
+impl PackagePublishReport {
+	#[must_use]
+	pub fn summary(&self) -> PackagePublishSummary {
+		let mut summary = PackagePublishSummary {
+			expected: self.packages.len(),
+			succeeded: 0,
+			failed: 0,
+			skipped: 0,
+		};
+
+		for outcome in &self.packages {
+			match outcome.status {
+				PackagePublishStatus::Published => summary.succeeded += 1,
+				PackagePublishStatus::Failed => summary.failed += 1,
+				_ => summary.skipped += 1,
+			}
+		}
+
+		debug_assert_eq!(
+			summary.expected,
+			summary.succeeded + summary.failed + summary.skipped
+		);
+		summary
+	}
+}
+
 #[must_use]
 pub fn disabled_trust_outcome() -> TrustedPublishingOutcome {
 	TrustedPublishingOutcome {
@@ -265,6 +353,89 @@ pub fn failed_publish_outcome(
 		command: None,
 		stdout: None,
 		stderr: None,
+	}
+}
+
+fn append_publish_failure_outcomes(
+	outcomes: &mut Vec<PackagePublishOutcome>,
+	remaining_requests: &[PublishRequest],
+	mode: PackagePublishRunMode,
+	failed_request: &PublishRequest,
+	message: String,
+	progress: &dyn PublishProgressReporter,
+) {
+	progress.report(PublishProgressEvent::PackageFailed {
+		package: publish_progress_package(failed_request),
+		message: message.clone(),
+	});
+	outcomes.push(failed_publish_outcome(mode, failed_request, message));
+	append_skipped_after_failure_outcomes(
+		outcomes,
+		remaining_requests,
+		mode,
+		failed_request,
+		progress,
+	);
+}
+
+fn empty_publish_report(
+	mode: PackagePublishRunMode,
+	dry_run: bool,
+	requests: &[PublishRequest],
+) -> PackagePublishReport {
+	PackagePublishReport {
+		mode,
+		dry_run,
+		packages: requests
+			.iter()
+			.map(|request| {
+				PackagePublishOutcome {
+					package: request.package_id.clone(),
+					ecosystem: request.ecosystem,
+					registry: request.registry.to_string(),
+					version: request.version.clone(),
+					status: PackagePublishStatus::Blocked,
+					message: "not attempted because publishing could not start".to_string(),
+					placeholder: mode == PackagePublishRunMode::Placeholder,
+					trusted_publishing: disabled_trust_outcome(),
+					command: None,
+					stdout: None,
+					stderr: None,
+				}
+			})
+			.collect(),
+	}
+}
+
+fn append_skipped_after_failure_outcomes(
+	outcomes: &mut Vec<PackagePublishOutcome>,
+	requests: &[PublishRequest],
+	mode: PackagePublishRunMode,
+	failed_request: &PublishRequest,
+	progress: &dyn PublishProgressReporter,
+) {
+	for request in requests {
+		let message = format!(
+			"not attempted because publishing {} {} failed earlier in this run",
+			failed_request.package_name, failed_request.version
+		);
+		progress.report(PublishProgressEvent::PackageSkipped {
+			package: publish_progress_package(request),
+			message: message.clone(),
+		});
+		outcomes.push(PackagePublishOutcome {
+			package: request.package_id.clone(),
+			ecosystem: request.ecosystem,
+			registry: request.registry.to_string(),
+			version: request.version.clone(),
+			status: PackagePublishStatus::Blocked,
+			message,
+			placeholder: mode == PackagePublishRunMode::Placeholder,
+			trusted_publishing: disabled_trust_outcome(),
+			command: None,
+			stdout: None,
+			stderr: None,
+		});
 	}
 }
 
@@ -630,7 +801,7 @@ pub async fn execute_publish_requests_with_process(
 	let endpoints = RegistryEndpoints::from_env();
 	let client = registry_client()?;
 	let mut executor = ProcessCommandExecutor::new(false);
-	execute_publish_requests_with_progress(
+	try_execute_publish_requests_with_progress(
 		root,
 		source,
 		mode,
@@ -647,6 +818,7 @@ pub async fn execute_publish_requests_with_process(
 		&NoopPublishProgressReporter,
 	)
 	.await
+	.map_err(PackagePublishFailure::into_error)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -662,11 +834,42 @@ pub async fn execute_publish_requests_with_process_and_progress(
 	trust_handler: &dyn PublishTrustHandler,
 	progress: &dyn PublishProgressReporter,
 ) -> MonochangeResult<PackagePublishReport> {
+	try_execute_publish_requests_with_process_and_progress(
+		root,
+		source,
+		mode,
+		dry_run,
+		requests,
+		command_builder,
+		manifest_writers,
+		readiness,
+		trust_handler,
+		progress,
+	)
+	.await
+	.map_err(PackagePublishFailure::into_error)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn try_execute_publish_requests_with_process_and_progress(
+	root: &Path,
+	source: Option<&SourceConfiguration>,
+	mode: PackagePublishRunMode,
+	dry_run: bool,
+	requests: &[PublishRequest],
+	command_builder: &PublishCommandBuilder,
+	manifest_writers: &PlaceholderManifestWriterRegistry,
+	readiness: &PublishReadinessRegistry,
+	trust_handler: &dyn PublishTrustHandler,
+	progress: &dyn PublishProgressReporter,
+) -> PackagePublishExecutionResult {
 	let env_map = current_env_map();
 	let endpoints = RegistryEndpoints::from_env();
-	let client = registry_client()?;
+	let client = registry_client().map_err(|error| {
+		PackagePublishFailure::new(error, empty_publish_report(mode, dry_run, requests))
+	})?;
 	let mut executor = ProcessCommandExecutor::new(false);
-	execute_publish_requests_with_progress(
+	try_execute_publish_requests_with_progress(
 		root,
 		source,
 		mode,
@@ -701,7 +904,7 @@ pub async fn execute_publish_requests(
 	readiness: &PublishReadinessRegistry,
 	trust_handler: &dyn PublishTrustHandler,
 ) -> MonochangeResult<PackagePublishReport> {
-	execute_publish_requests_with_progress(
+	try_execute_publish_requests_with_progress(
 		root,
 		source,
 		mode,
@@ -718,6 +921,7 @@ pub async fn execute_publish_requests(
 		&NoopPublishProgressReporter,
 	)
 	.await
+	.map_err(PackagePublishFailure::into_error)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -737,6 +941,43 @@ pub async fn execute_publish_requests_with_progress(
 	trust_handler: &dyn PublishTrustHandler,
 	progress: &dyn PublishProgressReporter,
 ) -> MonochangeResult<PackagePublishReport> {
+	try_execute_publish_requests_with_progress(
+		root,
+		source,
+		mode,
+		dry_run,
+		requests,
+		client,
+		endpoints,
+		env_map,
+		executor,
+		command_builder,
+		manifest_writers,
+		readiness,
+		trust_handler,
+		progress,
+	)
+	.await
+	.map_err(PackagePublishFailure::into_error)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn try_execute_publish_requests_with_progress(
+	root: &Path,
+	source: Option<&SourceConfiguration>,
+	mode: PackagePublishRunMode,
+	dry_run: bool,
+	requests: &[PublishRequest],
+	client: &Client,
+	endpoints: &RegistryEndpoints,
+	env_map: &BTreeMap<String, String>,
+	executor: &mut dyn CommandExecutor,
+	command_builder: &PublishCommandBuilder,
+	manifest_writers: &PlaceholderManifestWriterRegistry,
+	readiness: &PublishReadinessRegistry,
+	trust_handler: &dyn PublishTrustHandler,
+	progress: &dyn PublishProgressReporter,
+) -> PackagePublishExecutionResult {
 	let ecosystems = requests
 		.iter()
 		.map(|request| request.ecosystem)
@@ -749,9 +990,12 @@ pub async fn execute_publish_requests_with_progress(
 		total: requests.len(),
 		ecosystems,
 	});
-	let mut outcomes = Vec::new();
+	let mut outcomes = Vec::with_capacity(requests.len());
+	let mut primary_error = None;
 
-	for request in requests {
+	for (request_index, request) in requests.iter().enumerate() {
+		let remaining_requests = requests.get(request_index + 1..).unwrap_or_default();
+
 		// External-mode packages are only skipped during release publishing.
 		// Placeholder publishing is a bootstrap utility that should work for all
 		// publishable packages, regardless of who handles normal release publishes.
@@ -795,7 +1039,22 @@ pub async fn execute_publish_requests_with_progress(
 		progress.report(PublishProgressEvent::RegistryCheckStarted(
 			publish_progress_package(request),
 		));
-		let version_exists = registry_version_exists(client, endpoints, request).await?;
+		let version_exists = match registry_version_exists(client, endpoints, request).await {
+			Ok(version_exists) => version_exists,
+			Err(error) => {
+				let message = error.render();
+				primary_error = Some(error);
+				append_publish_failure_outcomes(
+					&mut outcomes,
+					remaining_requests,
+					mode,
+					request,
+					message,
+					progress,
+				);
+				break;
+			}
+		};
 		if version_exists {
 			info!(
 				package_name = request.package_name,
@@ -831,16 +1090,31 @@ pub async fn execute_publish_requests_with_progress(
 		}
 
 		let blocked_message = if mode == PackagePublishRunMode::Release {
-			readiness.blocked_message(root, request)?
+			match readiness.blocked_message(root, request) {
+				Ok(message) => message,
+				Err(error) => {
+					let message = error.render();
+					primary_error = Some(error);
+					append_publish_failure_outcomes(
+						&mut outcomes,
+						remaining_requests,
+						mode,
+						request,
+						message,
+						progress,
+					);
+					break;
+				}
+			}
 		} else {
 			None
 		};
 		if let Some(message) = blocked_message {
-			progress.report(PublishProgressEvent::PackageSkipped {
-				package: publish_progress_package(request),
-				message: message.clone(),
-			});
 			if dry_run {
+				progress.report(PublishProgressEvent::PackageSkipped {
+					package: publish_progress_package(request),
+					message: message.clone(),
+				});
 				outcomes.push(PackagePublishOutcome {
 					package: request.package_id.clone(),
 					ecosystem: request.ecosystem,
@@ -858,16 +1132,35 @@ pub async fn execute_publish_requests_with_progress(
 				continue;
 			}
 
-			return Err(MonochangeError::Config(message));
+			primary_error = Some(MonochangeError::Config(message.clone()));
+			append_publish_failure_outcomes(
+				&mut outcomes,
+				remaining_requests,
+				mode,
+				request,
+				message,
+				progress,
+			);
+			break;
 		}
 
 		let placeholder_dir = if mode == PackagePublishRunMode::Placeholder {
-			Some(build_placeholder_directory(
-				root,
-				request,
-				source,
-				manifest_writers,
-			)?)
+			match build_placeholder_directory(root, request, source, manifest_writers) {
+				Ok(directory) => Some(directory),
+				Err(error) => {
+					let message = error.render();
+					primary_error = Some(error);
+					append_publish_failure_outcomes(
+						&mut outcomes,
+						remaining_requests,
+						mode,
+						request,
+						message,
+						progress,
+					);
+					break;
+				}
+			}
 		} else {
 			None
 		};
@@ -910,8 +1203,24 @@ pub async fn execute_publish_requests_with_progress(
 		}
 
 		if !dry_run && mode == PackagePublishRunMode::Release {
-			trust_handler.enforce_release_trust_prerequisites(request, source, root, env_map)?;
-			enforce_release_attestation_prerequisites(request, env_map, command_builder)?;
+			let prerequisites = trust_handler
+				.enforce_release_trust_prerequisites(request, source, root, env_map)
+				.and_then(|()| {
+					enforce_release_attestation_prerequisites(request, env_map, command_builder)
+				});
+			if let Err(error) = prerequisites {
+				let message = error.render();
+				primary_error = Some(error);
+				append_publish_failure_outcomes(
+					&mut outcomes,
+					remaining_requests,
+					mode,
+					request,
+					message,
+					progress,
+				);
+				break;
+			}
 		}
 
 		if !dry_run {
@@ -922,10 +1231,6 @@ pub async fn execute_publish_requests_with_progress(
 		let output = match executor.run(&publish_command) {
 			Ok(output) => output,
 			Err(error) => {
-				progress.report(PublishProgressEvent::PackageFailed {
-					package: publish_progress_package(request),
-					message: error.to_string(),
-				});
 				tracing::error!(
 					package_name = request.package_name,
 					version = %request.version,
@@ -933,15 +1238,19 @@ pub async fn execute_publish_requests_with_progress(
 					error = %error,
 					"publish command failed to execute"
 				);
-				outcomes.push(failed_publish_outcome(mode, request, error.to_string()));
+				let message = error.render();
+				append_publish_failure_outcomes(
+					&mut outcomes,
+					remaining_requests,
+					mode,
+					request,
+					message,
+					progress,
+				);
 				break;
 			}
 		};
 		if !output.success {
-			progress.report(PublishProgressEvent::PackageFailed {
-				package: publish_progress_package(request),
-				message: render_publish_command_error(&output, request, mode),
-			});
 			tracing::error!(
 				package_name = request.package_name,
 				version = %request.version,
@@ -978,7 +1287,18 @@ pub async fn execute_publish_requests_with_progress(
 			outcome.command = Some(render_command(&publish_command));
 			outcome.stdout = non_empty_output(output.stdout);
 			outcome.stderr = non_empty_output(output.stderr);
+			progress.report(PublishProgressEvent::PackageFailed {
+				package: publish_progress_package(request),
+				message: outcome.message.clone(),
+			});
 			outcomes.push(outcome);
+			append_skipped_after_failure_outcomes(
+				&mut outcomes,
+				remaining_requests,
+				mode,
+				request,
+				progress,
+			);
 			break;
 		}
 
@@ -1029,27 +1349,23 @@ pub async fn execute_publish_requests_with_progress(
 		});
 	}
 
-	let published = outcomes
-		.iter()
-		.filter(|outcome| outcome.status == PackagePublishStatus::Published)
-		.count();
-	let failed = outcomes
-		.iter()
-		.filter(|outcome| outcome.status == PackagePublishStatus::Failed)
-		.count();
-	let skipped = outcomes.len().saturating_sub(published + failed);
-	progress.report(PublishProgressEvent::RunFinished {
-		mode,
-		total: outcomes.len(),
-		published,
-		skipped,
-		failed,
-	});
-	Ok(PackagePublishReport {
+	let report = PackagePublishReport {
 		mode,
 		dry_run,
 		packages: outcomes,
-	})
+	};
+	let summary = report.summary();
+	progress.report(PublishProgressEvent::RunFinished {
+		mode,
+		total: summary.expected,
+		published: summary.succeeded,
+		skipped: summary.skipped,
+		failed: summary.failed,
+	});
+	if let Some(error) = primary_error {
+		return Err(PackagePublishFailure::new(error, report));
+	}
+	Ok(report)
 }
 
 pub fn build_placeholder_requests(
@@ -1510,10 +1826,11 @@ pub fn render_command(spec: &CommandSpec) -> String {
 }
 
 pub fn render_command_error(output: &CommandOutput) -> String {
-	if output.stderr.is_empty() {
-		"command failed".to_string()
-	} else {
-		output.stderr.clone()
+	match (output.stdout.is_empty(), output.stderr.is_empty()) {
+		(true, true) => "command failed without output".to_string(),
+		(false, true) => output.stdout.clone(),
+		(true, false) => output.stderr.clone(),
+		(false, false) => format!("stdout:\n{}\n\nstderr:\n{}", output.stdout, output.stderr),
 	}
 }
 
@@ -2559,6 +2876,7 @@ pub fn write_publish_report_artifact(
 }
 
 pub fn ensure_publish_report_succeeded(report: &PackagePublishReport) -> MonochangeResult<()> {
+	let summary = report.summary();
 	let Some(failed) = report
 		.packages
 		.iter()
@@ -2568,8 +2886,14 @@ pub fn ensure_publish_report_succeeded(report: &PackagePublishReport) -> Monocha
 	};
 
 	Err(MonochangeError::Discovery(format!(
-		"package publish failed for {} {}: {}",
-		failed.package, failed.version, failed.message
+		"package publishing did not complete: expected {}, succeeded {}, failed {}, skipped {}; failed package {} {}: {}",
+		summary.expected,
+		summary.succeeded,
+		summary.failed,
+		summary.skipped,
+		failed.package,
+		failed.version,
+		failed.message
 	)))
 }
 

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -866,7 +866,9 @@ pub async fn try_execute_publish_requests_with_process_and_progress(
 	let env_map = current_env_map();
 	let endpoints = RegistryEndpoints::from_env();
 	let client = registry_client().map_err(|error| {
+		// patch-coverage:ignore-start -- registry client build failure requires a broken TLS/network environment.
 		PackagePublishFailure::new(error, empty_publish_report(mode, dry_run, requests))
+		// patch-coverage:ignore-end
 	})?;
 	let mut executor = ProcessCommandExecutor::new(false);
 	try_execute_publish_requests_with_progress(

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -868,8 +868,8 @@ pub async fn try_execute_publish_requests_with_process_and_progress(
 	let client = registry_client().map_err(|error| {
 		// patch-coverage:ignore-start -- registry client build failure requires a broken TLS/network environment.
 		PackagePublishFailure::new(error, empty_publish_report(mode, dry_run, requests))
-		// patch-coverage:ignore-end
 	})?;
+	// patch-coverage:ignore-end
 	let mut executor = ProcessCommandExecutor::new(false);
 	try_execute_publish_requests_with_progress(
 		root,

--- a/docs/plans/active/publish-progress-and-parallel-ecosystems.md
+++ b/docs/plans/active/publish-progress-and-parallel-ecosystems.md
@@ -54,13 +54,25 @@ This work makes release operations easier to trust by giving users readable prog
 ### 2. Progress across CLI steps
 
 - [ ] Emit step-level progress in `cli_runtime`:
-  - command workflow start/finish,
-  - step start/finish,
-  - skipped steps with `when` context,
+  - command workflow start and exactly one success/failure finish,
+  - step start before fallible input and condition resolution,
+  - exactly one step success/failure/skip finish,
+  - skipped steps with `when` or earlier-failure context,
   - failure context before returning errors.
+- [ ] Enable deterministic default progress on stderr for terminals, CI, editor tasks, and captured processes; only quiet mode, `MONOCHANGE_NO_PROGRESS`, or an explicit per-step opt-out suppresses it.
+- [ ] Preserve subprocess stderr and stdout in configured command and lockfile command failures, including stdout-only failures.
 - [ ] Add step-specific concise summaries for discover, validate/check/lint, prepare release, commit/tag/open release request, publish readiness, issue comments, affected packages, and retargeting.
 - [ ] Ensure JSON output commands remain parseable by keeping progress on stderr.
 - [ ] Add tests/snapshots for CI/plain stderr formatting where the harness supports it.
+
+### 2a. Complete sequential publish failure summaries
+
+- [ ] Preserve one terminal outcome for every package expected by a sequential publish run.
+- [ ] Report packages not attempted after the first failure as skipped because of that failure.
+- [ ] Derive and display expected, succeeded, failed, and skipped totals from the complete report.
+- [ ] Include aggregate totals and the underlying failed package error in the returned CLI error.
+- [ ] Propagate quiet mode into nested publish progress.
+- [ ] Add unit and output coverage for partial success, first failure, skipped tails, resume behavior, and command stdout/stderr diagnostics.
 
 ### 3. Parallel publish by ecosystem
 
@@ -77,6 +89,8 @@ This work makes release operations easier to trust by giving users readable prog
 - Use emojis, not nerdfonts, for portability and readability.
 - Emojis are allowed in CI logs; only spinner/loading animation is terminal-only.
 - stderr is the default channel for progress so stdout remains usable for JSON and command composition.
+- Default progress is deterministic and visible even when stderr is captured or non-interactive; animation remains terminal-only.
+- Sequential publish reports keep fail-fast execution but represent every expected package, including packages skipped after failure.
 - Parallelism starts at ecosystem granularity, not package granularity, to limit registry-rate and dependency-order risk.
 
 ## Open questions

--- a/docs/src/reference/cli-steps/00-index.md
+++ b/docs/src/reference/cli-steps/00-index.md
@@ -180,7 +180,7 @@ Use that when:
 
 ### Step-local `show_progress`
 
-Interactive steps do not show the spinner by default when monochange is waiting on the user. For step kinds that support it, you can also set `show_progress = false` to suppress progress output explicitly.
+Every step reports its start and terminal status by default, including interactive steps. Animation remains terminal-only, and step kinds that support it can set `show_progress = false` to suppress their progress output explicitly.
 
 ### Structured template namespaces
 

--- a/docs/src/reference/progress-output.md
+++ b/docs/src/reference/progress-output.md
@@ -8,7 +8,7 @@ Use the global `--progress-format <FORMAT>` flag or set `MONOCHANGE_PROGRESS_FOR
 
 Supported values:
 
-- `auto`: default behavior. Human progress output is enabled only when stderr is a terminal.
+- `auto`: default behavior. Deterministic human progress output is enabled for terminals, CI logs, editor tasks, and captured processes; animation is terminal-only.
 - `unicode`: force the human renderer with Unicode symbols and spinners.
 - `ascii`: force the human renderer with ASCII-safe symbols.
 - `json`: emit newline-delimited JSON progress events on stderr.
@@ -39,6 +39,7 @@ Common lifecycle events:
 - `step_failed`
 - `step_skipped`
 - `command_finished`
+- `command_failed`
 
 Shared fields:
 
@@ -56,8 +57,9 @@ Event-specific fields:
 - `command_output` adds `stream` and `text`
 - `step_finished` adds `durationMs` and `phaseTimings`
 - `step_failed` adds `durationMs` and `error`
-- `step_skipped` may add `condition`
+- `step_skipped` may add the backward-compatible `condition` field for conditional skips and `reason` for a human-readable explanation
 - `command_finished` adds `durationMs`
+- `command_failed` adds `durationMs` and `error`
 
 Example:
 

--- a/fixtures/tests/monochange/release-progress-failure/monochange.toml
+++ b/fixtures/tests/monochange/release-progress-failure/monochange.toml
@@ -62,3 +62,9 @@ help_text = "Exercise JSON skip compatibility"
 steps = [
   { type = "Validate", name = "conditional skip", when = "{{ false }}" },
 ]
+
+[cli.progress-stdout-failure]
+help_text = "Exercise stdout-only command failure details"
+steps = [
+  { type = "Command", name = "fail stdout only", shell = true, command = "printf 'stdout failure line\n'; exit 6" },
+]

--- a/fixtures/tests/monochange/release-progress-failure/monochange.toml
+++ b/fixtures/tests/monochange/release-progress-failure/monochange.toml
@@ -39,4 +39,26 @@ steps = [
   { type = "Validate", name = "skip validate", when = "{{ false }}" },
   { type = "Command", name = "stderr only", shell = true, command = "printf 'warn line\n' >&2" },
   { type = "Command", name = "fail loud", shell = true, command = "printf 'bad line\n' >&2; exit 3" },
+  { type = "Command", name = "cleanup", shell = true, command = "printf 'cleanup complete\n'", always_run = true },
+  { type = "Command", name = "skip after failure", shell = true, command = "printf 'must not run\n'" },
+]
+
+[cli.progress-failure-no-cleanup]
+help_text = "Exercise failure skips without cleanup"
+steps = [
+  { type = "Command", name = "primary failure", shell = true, command = "printf 'primary error\n' >&2; exit 4" },
+  { type = "Command", name = "skipped tail", shell = true, command = "printf 'must not run\n'" },
+]
+
+[cli.progress-failing-cleanup]
+help_text = "Exercise primary failure preservation"
+steps = [
+  { type = "Command", name = "primary failure", shell = true, command = "printf 'primary error\n' >&2; exit 4" },
+  { type = "Command", name = "failing cleanup", shell = true, command = "printf 'cleanup error\n' >&2; exit 5", always_run = true },
+]
+
+[cli.progress-json-skip]
+help_text = "Exercise JSON skip compatibility"
+steps = [
+  { type = "Validate", name = "conditional skip", when = "{{ false }}" },
 ]


### PR DESCRIPTION
## Summary

- report complete publish outcomes with expected/succeeded/failed/skipped counts after fail-fast package publishing stops
- preserve command stdout/stderr/status diagnostics for configured workflow and lockfile command failures
- emit default workflow/package publish progress for significant steps while respecting quiet mode and MONOCHANGE_NO_PROGRESS
- keep placeholder publish summaries complete while filtering hidden detail rows for text, Markdown, JSON, and templates

## Validation

- devenv shell fix:all
- devenv shell build:all
- devenv shell cargo clippy -q -p monochange -p monochange_publish --all-targets --all-features -- -D warnings
- devenv shell cargo test -p monochange_publish
- devenv shell cargo test -p monochange --lib package_publish::tests::
- devenv shell cargo test -p monochange --test cli_progress
- devenv shell cargo test -p monochange --lib placeholder_json_and_template_outputs_filter_package_rows_but_keep_complete_summary
- devenv shell monochange step validate
- devenv shell monochange step affected-packages --verify --changed-paths <changed paths>
- git --no-pager diff --check

## Notes

- Full lint/test/coverage scripts initially could not download pinned Cargo tools from crates.io due DNS/timeouts. The push hook later passed after using the already-installed matching cargo-deny 0.19.0 binary at the pinned path. Patch coverage still could not run locally because coverage:patch requires cargo-llvm-cov 0.8.5 from crates.io and the installed local binary is 0.8.7, so I did not substitute it.