### PR TITLE
feat(publish): add configurable publish timeout with retries and Dart protected-publishing warning

### DIFF
--- a/.changeset/dart-publish-timeout-retries.md
+++ b/.changeset/dart-publish-timeout-retries.md
@@ -2,6 +2,7 @@
 monochange_core: minor
 monochange_config: minor
 monochange_publish: minor
+monochange_npm: patch
 monochange: patch
 monochange_schema: patch
 ---

--- a/.changeset/dart-publish-timeout-retries.md
+++ b/.changeset/dart-publish-timeout-retries.md
@@ -1,0 +1,21 @@
+---
+monochange_core: minor
+monochange_config: minor
+monochange_publish: minor
+monochange: patch
+monochange_schema: patch
+---
+
+# Add a configurable publish timeout with retries and a Dart protected-publishing warning
+
+- New `publish.timeout` settings (`timeout_seconds` default 60, `retries` default 2) cap how long a single package publish command may hang before it is killed and retried. Set `timeout_seconds = 0` to disable the timeout.
+- Publish commands that time out are retried up to `retries` times; after the final attempt the package is reported as timed out instead of hanging the whole job.
+- Dart/pub.dev packages using protected (trusted) publishing from a GitHub Actions `workflow_dispatch` event without a `PUB_TOKEN` fallback now emit a warning explaining that pub.dev automated publishing may require publishing from a pushed tag rather than a workflow dispatch
+
+Configure the timeout per package or ecosystem:
+
+```toml
+[package.my-dart-package.publish.timeout]
+timeout_seconds = 90
+retries = 3
+```

--- a/crates/monochange/src/__tests__/package_publish_tests.rs
+++ b/crates/monochange/src/__tests__/package_publish_tests.rs
@@ -17,6 +17,7 @@ use monochange_core::PublishAttestationSettings;
 use monochange_core::PublishMode;
 use monochange_core::PublishRegistry;
 use monochange_core::PublishState;
+use monochange_core::PublishTimeoutSettings;
 use monochange_core::ReleaseRecord;
 use monochange_core::SourceProvider;
 use monochange_core::TrustedPublishingSettings;
@@ -204,6 +205,7 @@ fn sample_request(registry: RegistryKind) -> PublishRequest {
 			environment: None,
 		},
 		attestations: PublishAttestationSettings::default(),
+		timeout: PublishTimeoutSettings::default(),
 		placeholder_readme: "placeholder".to_string(),
 	}
 }
@@ -349,6 +351,7 @@ fn build_npm_trust_list_command(request: &PublishRequest) -> CommandSpec {
 		],
 		cwd: PathBuf::new(),
 		env: BTreeMap::new(),
+		timeout: None,
 	}
 }
 
@@ -2072,6 +2075,7 @@ fn sample_npm_publication(package: &str) -> PackagePublicationTarget {
 		mode: PublishMode::Builtin,
 		trusted_publishing: TrustedPublishingSettings::default(),
 		attestations: PublishAttestationSettings::default(),
+		timeout: PublishTimeoutSettings::default(),
 	}
 }
 
@@ -2271,6 +2275,7 @@ fn build_release_requests_skips_unknown_publication_targets() {
 			mode: PublishMode::Builtin,
 			trusted_publishing: TrustedPublishingSettings::default(),
 			attestations: PublishAttestationSettings::default(),
+			timeout: PublishTimeoutSettings::default(),
 		},
 		PackagePublicationTarget {
 			package: "pkg".to_string(),
@@ -2280,6 +2285,7 @@ fn build_release_requests_skips_unknown_publication_targets() {
 			mode: PublishMode::Builtin,
 			trusted_publishing: TrustedPublishingSettings::default(),
 			attestations: PublishAttestationSettings::default(),
+			timeout: PublishTimeoutSettings::default(),
 		},
 	];
 
@@ -2317,6 +2323,7 @@ fn build_release_requests_skips_publication_targets_missing_from_discovery() {
 		mode: PublishMode::Builtin,
 		trusted_publishing: TrustedPublishingSettings::default(),
 		attestations: PublishAttestationSettings::default(),
+		timeout: PublishTimeoutSettings::default(),
 	}];
 
 	let requests = build_release_requests(&configuration, &[], &publications, &BTreeSet::new())
@@ -2379,6 +2386,7 @@ fn build_release_requests_skips_disabled_and_private_packages() {
 			mode: PublishMode::Builtin,
 			trusted_publishing: TrustedPublishingSettings::default(),
 			attestations: PublishAttestationSettings::default(),
+			timeout: PublishTimeoutSettings::default(),
 		},
 		PackagePublicationTarget {
 			package: "disabled".to_string(),
@@ -2388,6 +2396,7 @@ fn build_release_requests_skips_disabled_and_private_packages() {
 			mode: PublishMode::Builtin,
 			trusted_publishing: TrustedPublishingSettings::default(),
 			attestations: PublishAttestationSettings::default(),
+			timeout: PublishTimeoutSettings::default(),
 		},
 		PackagePublicationTarget {
 			package: "private".to_string(),
@@ -2397,6 +2406,7 @@ fn build_release_requests_skips_disabled_and_private_packages() {
 			mode: PublishMode::Builtin,
 			trusted_publishing: TrustedPublishingSettings::default(),
 			attestations: PublishAttestationSettings::default(),
+			timeout: PublishTimeoutSettings::default(),
 		},
 	];
 
@@ -4024,6 +4034,7 @@ async fn release_dry_run_orders_cargo_dev_and_build_dependencies_before_dependen
 				mode: PublishMode::Builtin,
 				trusted_publishing: TrustedPublishingSettings::default(),
 				attestations: PublishAttestationSettings::default(),
+				timeout: PublishTimeoutSettings::default(),
 			}
 		})
 		.collect::<Vec<_>>();
@@ -4361,6 +4372,7 @@ async fn run_publish_packages_uses_prepared_release_publications() {
 			mode: PublishMode::Builtin,
 			trusted_publishing: TrustedPublishingSettings::default(),
 			attestations: PublishAttestationSettings::default(),
+			timeout: PublishTimeoutSettings::default(),
 		}],
 	);
 
@@ -4428,6 +4440,7 @@ async fn run_publish_packages_discovers_release_record_publications_from_head() 
 			mode: PublishMode::Builtin,
 			trusted_publishing: TrustedPublishingSettings::default(),
 			attestations: PublishAttestationSettings::default(),
+			timeout: PublishTimeoutSettings::default(),
 		}],
 	);
 	let discovered = release_record_package_publications_from_prepared_or_head(root.path(), None)
@@ -4471,6 +4484,7 @@ fn process_command_executor_runs_commands_and_reports_spawn_failures() {
 		],
 		cwd: tempdir.path().to_path_buf(),
 		env: BTreeMap::new(),
+		timeout: None,
 	};
 
 	let mut captured_executor = ProcessCommandExecutor::new(false);
@@ -4507,6 +4521,7 @@ fn process_command_executor_runs_commands_and_reports_spawn_failures() {
 			args: Vec::new(),
 			cwd: tempdir.path().to_path_buf(),
 			env: BTreeMap::new(),
+			timeout: None,
 		})
 		.expect_err("expected command failure");
 	assert!(
@@ -4811,6 +4826,7 @@ async fn try_run_publish_packages_with_publications_maps_build_request_errors() 
 		mode: PublishMode::Builtin,
 		trusted_publishing: TrustedPublishingSettings::default(),
 		attestations: PublishAttestationSettings::default(),
+		timeout: PublishTimeoutSettings::default(),
 	};
 
 	let error = try_run_publish_packages_with_publications_and_resume(
@@ -4924,6 +4940,7 @@ async fn try_run_publish_packages_with_publications_maps_publish_execution_failu
 		mode: PublishMode::Builtin,
 		trusted_publishing: TrustedPublishingSettings::default(),
 		attestations: PublishAttestationSettings::default(),
+		timeout: PublishTimeoutSettings::default(),
 	};
 
 	// A failing registry lookup during publish execution returns a
@@ -4980,6 +4997,7 @@ fn fake_executor_reports_missing_outputs_and_render_helpers_match() {
 		],
 		cwd: PathBuf::from("."),
 		env: BTreeMap::new(),
+		timeout: None,
 	};
 	let error = executor
 		.run(&spec)
@@ -5189,6 +5207,7 @@ fn build_release_requests_uses_publication_targets_and_package_metadata() {
 		mode: PublishMode::Builtin,
 		trusted_publishing: TrustedPublishingSettings::default(),
 		attestations: PublishAttestationSettings::default(),
+		timeout: PublishTimeoutSettings::default(),
 	};
 	let configuration = sample_configuration(&[("pkg", monochange_core::PackageType::Npm, true)]);
 	let requests =
@@ -5236,6 +5255,7 @@ async fn run_publish_packages_with_resume_filters_by_group_and_ecosystem() {
 			mode: PublishMode::Builtin,
 			trusted_publishing: TrustedPublishingSettings::default(),
 			attestations: PublishAttestationSettings::default(),
+			timeout: PublishTimeoutSettings::default(),
 		}],
 	);
 

--- a/crates/monochange/src/__tests__/publish_rate_limits_tests.rs
+++ b/crates/monochange/src/__tests__/publish_rate_limits_tests.rs
@@ -56,6 +56,7 @@ use monochange_core::PackagePublicationTarget;
 use monochange_core::PublishAttestationSettings;
 use monochange_core::PublishMode;
 use monochange_core::PublishRegistry;
+use monochange_core::PublishTimeoutSettings;
 use monochange_core::TrustedPublishingSettings;
 use semver::Version;
 use tempfile::tempdir;
@@ -190,6 +191,7 @@ fn sample_publish_request(
 		placeholder: false,
 		trusted_publishing: TrustedPublishingSettings::default(),
 		attestations: PublishAttestationSettings::default(),
+		timeout: PublishTimeoutSettings::default(),
 		placeholder_readme: String::new(),
 	}
 }
@@ -665,6 +667,7 @@ async fn plan_publish_rate_limits_summarizes_pending_publications_and_batches() 
 				mode: PublishMode::Builtin,
 				trusted_publishing: TrustedPublishingSettings::default(),
 				attestations: PublishAttestationSettings::default(),
+				timeout: PublishTimeoutSettings::default(),
 			},
 			PackagePublicationTarget {
 				package: "docs".to_string(),
@@ -674,6 +677,7 @@ async fn plan_publish_rate_limits_summarizes_pending_publications_and_batches() 
 				mode: PublishMode::Builtin,
 				trusted_publishing: TrustedPublishingSettings::default(),
 				attestations: PublishAttestationSettings::default(),
+				timeout: PublishTimeoutSettings::default(),
 			},
 			PackagePublicationTarget {
 				package: "web".to_string(),
@@ -683,6 +687,7 @@ async fn plan_publish_rate_limits_summarizes_pending_publications_and_batches() 
 				mode: PublishMode::Builtin,
 				trusted_publishing: TrustedPublishingSettings::default(),
 				attestations: PublishAttestationSettings::default(),
+				timeout: PublishTimeoutSettings::default(),
 			},
 		],
 		version: None,
@@ -871,6 +876,7 @@ async fn plan_publish_rate_limits_skips_private_and_disabled_packages_from_relea
 			mode: PublishMode::Builtin,
 			trusted_publishing: TrustedPublishingSettings::default(),
 			attestations: PublishAttestationSettings::default(),
+			timeout: PublishTimeoutSettings::default(),
 		},
 		PackagePublicationTarget {
 			package: "private".to_string(),
@@ -880,6 +886,7 @@ async fn plan_publish_rate_limits_skips_private_and_disabled_packages_from_relea
 			mode: PublishMode::Builtin,
 			trusted_publishing: TrustedPublishingSettings::default(),
 			attestations: PublishAttestationSettings::default(),
+			timeout: PublishTimeoutSettings::default(),
 		},
 		PackagePublicationTarget {
 			package: "docs".to_string(),
@@ -889,6 +896,7 @@ async fn plan_publish_rate_limits_skips_private_and_disabled_packages_from_relea
 			mode: PublishMode::Builtin,
 			trusted_publishing: TrustedPublishingSettings::default(),
 			attestations: PublishAttestationSettings::default(),
+			timeout: PublishTimeoutSettings::default(),
 		},
 	];
 	let requests = package_publish::build_release_requests(
@@ -939,6 +947,7 @@ async fn plan_publish_rate_limits_skips_versions_that_are_already_published() {
 				mode: PublishMode::Builtin,
 				trusted_publishing: TrustedPublishingSettings::default(),
 				attestations: PublishAttestationSettings::default(),
+				timeout: PublishTimeoutSettings::default(),
 			},
 			PackagePublicationTarget {
 				package: "docs".to_string(),
@@ -948,6 +957,7 @@ async fn plan_publish_rate_limits_skips_versions_that_are_already_published() {
 				mode: PublishMode::Builtin,
 				trusted_publishing: TrustedPublishingSettings::default(),
 				attestations: PublishAttestationSettings::default(),
+				timeout: PublishTimeoutSettings::default(),
 			},
 			PackagePublicationTarget {
 				package: "web".to_string(),
@@ -957,6 +967,7 @@ async fn plan_publish_rate_limits_skips_versions_that_are_already_published() {
 				mode: PublishMode::Builtin,
 				trusted_publishing: TrustedPublishingSettings::default(),
 				attestations: PublishAttestationSettings::default(),
+				timeout: PublishTimeoutSettings::default(),
 			},
 		],
 		version: None,
@@ -1377,6 +1388,7 @@ async fn enforce_publish_rate_limits_blocks_multi_batch_runs_when_enabled() {
 				placeholder: false,
 				trusted_publishing: TrustedPublishingSettings::default(),
 				attestations: PublishAttestationSettings::default(),
+				timeout: PublishTimeoutSettings::default(),
 				placeholder_readme: String::new(),
 			}
 		})
@@ -1505,6 +1517,7 @@ async fn test_sort_requests_by_dependencies_orders_dependencies_first() {
 			placeholder: false,
 			trusted_publishing: TrustedPublishingSettings::default(),
 			attestations: PublishAttestationSettings::default(),
+			timeout: PublishTimeoutSettings::default(),
 			placeholder_readme: String::new(),
 		},
 		package_publish::PublishRequest {
@@ -1521,6 +1534,7 @@ async fn test_sort_requests_by_dependencies_orders_dependencies_first() {
 			placeholder: false,
 			trusted_publishing: TrustedPublishingSettings::default(),
 			attestations: PublishAttestationSettings::default(),
+			timeout: PublishTimeoutSettings::default(),
 			placeholder_readme: String::new(),
 		},
 	];
@@ -1581,6 +1595,7 @@ async fn test_sort_requests_by_dependencies_keeps_original_order_on_cycle() {
 			placeholder: false,
 			trusted_publishing: TrustedPublishingSettings::default(),
 			attestations: PublishAttestationSettings::default(),
+			timeout: PublishTimeoutSettings::default(),
 			placeholder_readme: String::new(),
 		},
 		package_publish::PublishRequest {
@@ -1597,6 +1612,7 @@ async fn test_sort_requests_by_dependencies_keeps_original_order_on_cycle() {
 			placeholder: false,
 			trusted_publishing: TrustedPublishingSettings::default(),
 			attestations: PublishAttestationSettings::default(),
+			timeout: PublishTimeoutSettings::default(),
 			placeholder_readme: String::new(),
 		},
 	];

--- a/crates/monochange/src/__tests__/release_artifacts_tests.rs
+++ b/crates/monochange/src/__tests__/release_artifacts_tests.rs
@@ -12,6 +12,7 @@ use monochange_core::PublishMode;
 use monochange_core::PublishRegistry;
 use monochange_core::PublishSettings;
 use monochange_core::PublishState;
+use monochange_core::PublishTimeoutSettings;
 use monochange_core::RegistryKind;
 use monochange_core::ReleaseDecision;
 use monochange_core::ReleaseManifest;
@@ -591,6 +592,7 @@ fn build_package_publication_targets_filters_disabled_and_preserves_publish_meta
 				mode: PublishMode::Builtin,
 				trusted_publishing: monochange_core::TrustedPublishingSettings::default(),
 				attestations: monochange_core::PublishAttestationSettings::default(),
+				timeout: PublishTimeoutSettings::default(),
 			},
 			PackagePublicationTarget {
 				package: "web".to_string(),
@@ -600,6 +602,7 @@ fn build_package_publication_targets_filters_disabled_and_preserves_publish_meta
 				mode: PublishMode::External,
 				trusted_publishing: monochange_core::TrustedPublishingSettings::default(),
 				attestations: monochange_core::PublishAttestationSettings::default(),
+				timeout: PublishTimeoutSettings::default(),
 			},
 		]
 	);
@@ -641,6 +644,7 @@ fn build_release_manifest_copies_package_publications_from_prepared_release() {
 			mode: PublishMode::Builtin,
 			trusted_publishing: monochange_core::TrustedPublishingSettings::default(),
 			attestations: monochange_core::PublishAttestationSettings::default(),
+			timeout: PublishTimeoutSettings::default(),
 		}],
 		dry_run: false,
 	};

--- a/crates/monochange/src/__tests__/release_artifacts_tests.rs
+++ b/crates/monochange/src/__tests__/release_artifacts_tests.rs
@@ -441,6 +441,10 @@ fn build_package_publication_targets_filters_disabled_and_preserves_publish_meta
 			release: true,
 			publish: PublishSettings {
 				registry: Some(PublishRegistry::Builtin(RegistryKind::CratesIo)),
+				timeout: PublishTimeoutSettings {
+					timeout_seconds: 90,
+					retries: 3,
+				},
 				..PublishSettings::default()
 			},
 			version_format: VersionFormat::Primary,
@@ -592,7 +596,10 @@ fn build_package_publication_targets_filters_disabled_and_preserves_publish_meta
 				mode: PublishMode::Builtin,
 				trusted_publishing: monochange_core::TrustedPublishingSettings::default(),
 				attestations: monochange_core::PublishAttestationSettings::default(),
-				timeout: PublishTimeoutSettings::default(),
+				timeout: PublishTimeoutSettings {
+					timeout_seconds: 90,
+					retries: 3,
+				},
 			},
 			PackagePublicationTarget {
 				package: "web".to_string(),

--- a/crates/monochange/src/monochange.toml.template
+++ b/crates/monochange/src/monochange.toml.template
@@ -316,6 +316,12 @@ warn_on_group_mismatch = true
 #                             package set requires more than one known registry
 #                             rate-limit window. Use `monochange publish-plan` to inspect
 #                             batches first. (default: false)
+#     timeout.timeout_seconds - maximum seconds a single package publish command
+#                             may run before it is killed and retried. Set to 0
+#                             to disable the timeout. (default: 60)
+#     timeout.retries       - number of times to retry a publish command that
+#                             times out before reporting the package as failed.
+#                             (default: 2)
 #     placeholder.readme    - inline README text to use when publishing a
 #                             placeholder package for the first bootstrap
 #                             release

--- a/crates/monochange/src/release_artifacts.rs
+++ b/crates/monochange/src/release_artifacts.rs
@@ -321,6 +321,7 @@ pub(crate) fn build_package_publication_targets(
 				mode: package_definition.publish.mode,
 				trusted_publishing: package_definition.publish.trusted_publishing.clone(),
 				attestations: package_definition.publish.attestations.clone(),
+				timeout: package_definition.publish.timeout.clone(),
 			})
 		})
 		.collect::<Vec<_>>();

--- a/crates/monochange_config/src/__tests__/lib_tests.rs
+++ b/crates/monochange_config/src/__tests__/lib_tests.rs
@@ -4005,6 +4005,42 @@ enforce = true
 }
 
 #[test]
+fn normalize_publish_settings_parses_timeout_seconds_and_retries() {
+	let parsed = crate::normalize_publish_settings(
+		r"[package.core.publish.timeout]
+timeout_seconds = 90
+retries = 3
+",
+		None,
+		crate::RawPublishSettings {
+			timeout: crate::RawPublishTimeoutSettings {
+				timeout_seconds: Some(90),
+				retries: Some(3),
+			},
+			..crate::RawPublishSettings::default()
+		},
+		"package",
+		"core",
+		EcosystemType::Cargo,
+	)
+	.unwrap_or_else(|error| panic!("publish settings: {error}"));
+	assert_eq!(parsed.timeout.timeout_seconds, 90);
+	assert_eq!(parsed.timeout.retries, 3);
+
+	let defaults = crate::normalize_publish_settings(
+		"",
+		None,
+		crate::RawPublishSettings::default(),
+		"package",
+		"core",
+		EcosystemType::Cargo,
+	)
+	.unwrap_or_else(|error| panic!("publish settings: {error}"));
+	assert_eq!(defaults.timeout.timeout_seconds, 60);
+	assert_eq!(defaults.timeout.retries, 2);
+}
+
+#[test]
 fn load_workspace_configuration_inherits_ecosystem_publish_trusted_publishing_defaults() {
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	let root = tempdir.path();

--- a/crates/monochange_config/src/lib.rs
+++ b/crates/monochange_config/src/lib.rs
@@ -495,6 +495,8 @@ pub(crate) struct RawPublishSettings {
 	#[serde(default)]
 	rate_limits: RawPublishRateLimitSettings,
 	#[serde(default)]
+	timeout: RawPublishTimeoutSettings,
+	#[serde(default)]
 	placeholder: RawPlaceholderSettings,
 }
 
@@ -512,6 +514,16 @@ pub(crate) struct RawPublishAttestationSettings {
 pub(crate) struct RawPublishRateLimitSettings {
 	#[serde(default)]
 	enforce: Option<bool>,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Deserialize, Default)]
+#[cfg_attr(feature = "schema", schemars(rename = "publish_timeout_settings"))]
+pub(crate) struct RawPublishTimeoutSettings {
+	#[serde(default)]
+	timeout_seconds: Option<u64>,
+	#[serde(default)]
+	retries: Option<u32>,
 }
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -1397,6 +1409,12 @@ fn normalize_publish_settings(
 	);
 	if let Some(enforce) = raw.rate_limits.enforce {
 		settings.rate_limits.enforce = enforce;
+	}
+	if let Some(timeout_seconds) = raw.timeout.timeout_seconds {
+		settings.timeout.timeout_seconds = timeout_seconds;
+	}
+	if let Some(retries) = raw.timeout.retries {
+		settings.timeout.retries = retries;
 	}
 	if raw.placeholder.readme.is_some() {
 		settings.placeholder.readme_file = None;

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -2169,6 +2169,44 @@ pub struct PublishRateLimitSettings {
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PublishTimeoutSettings {
+	#[serde(default = "default_publish_timeout_seconds")]
+	pub timeout_seconds: u64,
+	#[serde(default = "default_publish_timeout_retries")]
+	pub retries: u32,
+}
+
+impl Default for PublishTimeoutSettings {
+	fn default() -> Self {
+		Self {
+			timeout_seconds: default_publish_timeout_seconds(),
+			retries: default_publish_timeout_retries(),
+		}
+	}
+}
+
+impl PublishTimeoutSettings {
+	#[must_use]
+	pub fn is_default(&self) -> bool {
+		self == &Self::default()
+	}
+
+	#[must_use]
+	pub fn disabled(&self) -> bool {
+		self.timeout_seconds == 0
+	}
+}
+
+fn default_publish_timeout_seconds() -> u64 {
+	60
+}
+
+fn default_publish_timeout_retries() -> u32 {
+	2
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TrustedPublishingSettings {
 	#[serde(default = "default_true")]
 	pub enabled: bool,
@@ -2238,6 +2276,8 @@ pub struct PublishSettings {
 	pub attestations: PublishAttestationSettings,
 	#[serde(default)]
 	pub rate_limits: PublishRateLimitSettings,
+	#[serde(default, skip_serializing_if = "PublishTimeoutSettings::is_default")]
+	pub timeout: PublishTimeoutSettings,
 	#[serde(default)]
 	pub placeholder: PlaceholderSettings,
 }
@@ -2251,6 +2291,7 @@ impl Default for PublishSettings {
 			trusted_publishing: TrustedPublishingSettings::default(),
 			attestations: PublishAttestationSettings::default(),
 			rate_limits: PublishRateLimitSettings::default(),
+			timeout: PublishTimeoutSettings::default(),
 			placeholder: PlaceholderSettings::default(),
 		}
 	}
@@ -3792,6 +3833,8 @@ pub struct PackagePublicationTarget {
 		skip_serializing_if = "PublishAttestationSettings::is_default"
 	)]
 	pub attestations: PublishAttestationSettings,
+	#[serde(default, skip_serializing_if = "PublishTimeoutSettings::is_default")]
+	pub timeout: PublishTimeoutSettings,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]

--- a/crates/monochange_dart/src/__tests__/lib_tests.rs
+++ b/crates/monochange_dart/src/__tests__/lib_tests.rs
@@ -8,6 +8,7 @@ use monochange_core::PackageRecord;
 use monochange_core::PublishAttestationSettings;
 use monochange_core::PublishMode;
 use monochange_core::PublishState;
+use monochange_core::PublishTimeoutSettings;
 use monochange_core::RegistryKind;
 use monochange_core::TrustedPublishingSettings;
 use monochange_publish::PublishRequest;
@@ -97,6 +98,7 @@ fn sample_publish_request(root: &Path) -> PublishRequest {
 		placeholder: true,
 		trusted_publishing: TrustedPublishingSettings::default(),
 		attestations: PublishAttestationSettings::default(),
+		timeout: PublishTimeoutSettings::default(),
 		placeholder_readme: String::new(),
 	}
 }

--- a/crates/monochange_npm/src/__tests__/lib_tests.rs
+++ b/crates/monochange_npm/src/__tests__/lib_tests.rs
@@ -9,6 +9,7 @@ use monochange_core::PackageRecord;
 use monochange_core::PublishAttestationSettings;
 use monochange_core::PublishMode;
 use monochange_core::PublishState;
+use monochange_core::PublishTimeoutSettings;
 use monochange_core::RegistryKind;
 use monochange_core::TrustedPublishingSettings;
 use monochange_core::materialize_dependency_edges;
@@ -1006,6 +1007,7 @@ fn npm_trust_command_wraps_npm_with_pnpm_for_pnpm_managed_packages() {
 		placeholder: false,
 		trusted_publishing: TrustedPublishingSettings::default(),
 		attestations: PublishAttestationSettings::default(),
+		timeout: PublishTimeoutSettings::default(),
 		placeholder_readme: "placeholder".to_string(),
 	};
 	let context = GitHubTrustContext {

--- a/crates/monochange_npm/src/lib.rs
+++ b/crates/monochange_npm/src/lib.rs
@@ -1098,6 +1098,7 @@ fn build_npm_cli_command(request: &PublishRequest, args: Vec<String>) -> Command
 			args: wrapped_args,
 			cwd: request.package_root.clone(),
 			env: BTreeMap::new(),
+			timeout: None,
 		};
 	}
 
@@ -1106,6 +1107,7 @@ fn build_npm_cli_command(request: &PublishRequest, args: Vec<String>) -> Command
 		args,
 		cwd: request.package_root.clone(),
 		env: BTreeMap::new(),
+		timeout: None,
 	}
 }
 

--- a/crates/monochange_publish/src/__tests__/lib_tests.rs
+++ b/crates/monochange_publish/src/__tests__/lib_tests.rs
@@ -341,6 +341,7 @@ fn publication_target(package: &str, ecosystem: Ecosystem) -> PackagePublication
 		mode: PublishMode::default(),
 		trusted_publishing: TrustedPublishingSettings::default(),
 		attestations: PublishAttestationSettings::default(),
+		timeout: PublishTimeoutSettings::default(),
 	}
 }
 
@@ -412,6 +413,7 @@ fn sample_publish_request_for_registry(registry: RegistryKind) -> PublishRequest
 		placeholder: false,
 		trusted_publishing: TrustedPublishingSettings::default(),
 		attestations: PublishAttestationSettings::default(),
+		timeout: PublishTimeoutSettings::default(),
 		placeholder_readme: "placeholder".to_string(),
 	}
 }
@@ -524,6 +526,7 @@ fn process_command_executor_streams_when_environment_is_enabled() {
 			PUBLISH_STREAM_OUTPUT_ENV_KEY.to_string(),
 			"true".to_string(),
 		)]),
+		timeout: None,
 	};
 	let mut executor = ProcessCommandExecutor::new(false);
 
@@ -549,6 +552,7 @@ fn process_command_executor_closes_stdin_for_captured_commands() {
 		args: vec!["-c".to_string(), "read ignored".to_string()],
 		cwd: root.path().to_path_buf(),
 		env: BTreeMap::new(),
+		timeout: None,
 	};
 	let mut executor = ProcessCommandExecutor::new(false);
 
@@ -569,6 +573,7 @@ fn child_output_helpers_cover_success_and_error_paths() {
 		args: Vec::new(),
 		cwd: PathBuf::from("."),
 		env: BTreeMap::new(),
+		timeout: None,
 	};
 	let wait_io_error = std::io::Error::other("wait failed");
 	let wait_error = process_command_error(&spec, "wait for", &wait_io_error);
@@ -2204,6 +2209,7 @@ fn publish_order_request_for_package(package: &PackageRecord) -> PublishRequest 
 		placeholder: false,
 		trusted_publishing: TrustedPublishingSettings::default(),
 		attestations: PublishAttestationSettings::default(),
+		timeout: PublishTimeoutSettings::default(),
 		placeholder_readme: String::new(),
 	}
 }
@@ -2223,6 +2229,7 @@ fn publish_order_request(package: &str) -> PublishRequest {
 		placeholder: false,
 		trusted_publishing: TrustedPublishingSettings::default(),
 		attestations: PublishAttestationSettings::default(),
+		timeout: PublishTimeoutSettings::default(),
 		placeholder_readme: String::new(),
 	}
 }
@@ -2296,6 +2303,7 @@ fn cargo_publish_request() -> PublishRequest {
 			..TrustedPublishingSettings::default()
 		},
 		attestations: PublishAttestationSettings::default(),
+		timeout: PublishTimeoutSettings::default(),
 		placeholder_readme: String::new(),
 	}
 }
@@ -2394,4 +2402,170 @@ fn empty_publish_report_marks_every_request_as_blocked() {
 	assert_eq!(report.summary().expected, 2);
 	assert_eq!(report.summary().failed, 0);
 	assert_eq!(report.summary().skipped, 2);
+}
+
+fn timeout_error() -> MonochangeError {
+	MonochangeError::Io(format!(
+		"{PUBLISH_TIMEOUT_ERROR_PREFIX}: `dart pub publish` timed out after 60 seconds"
+	))
+}
+
+fn pub_dev_publish_request(package: &str) -> PublishRequest {
+	let mut request = publish_request(package);
+	request.registry = RegistryKind::PubDev;
+	request.ecosystem = Ecosystem::Dart;
+	request
+}
+
+#[test]
+fn is_publish_timeout_error_detects_timeout_marker() {
+	assert!(is_publish_timeout_error(&timeout_error()));
+	assert!(!is_publish_timeout_error(&MonochangeError::Config(
+		"boom".to_string()
+	)));
+}
+
+#[test]
+fn run_publish_command_with_retries_retries_until_success() {
+	let request = publish_request("pkg");
+	let mut executor = SequencedCommandExecutor::new([
+		Err(timeout_error()),
+		Err(timeout_error()),
+		Ok(CommandOutput {
+			success: true,
+			stdout: "published".to_string(),
+			stderr: String::new(),
+		}),
+	]);
+	let spec = CommandSpec {
+		program: "dart".to_string(),
+		args: vec!["pub".to_string(), "publish".to_string()],
+		cwd: PathBuf::from("."),
+		env: BTreeMap::new(),
+		timeout: Some(Duration::from_secs(60)),
+	};
+	let output = run_publish_command_with_retries(&mut executor, &spec, &request)
+		.expect("retry loop should succeed on the third attempt");
+	assert!(output.success);
+	assert_eq!(executor.commands.len(), 3);
+}
+
+#[test]
+fn run_publish_command_with_retries_returns_timeout_after_exhausting_retries() {
+	let mut request = publish_request("pkg");
+	request.timeout.retries = 1;
+	let mut executor = SequencedCommandExecutor::new([Err(timeout_error()), Err(timeout_error())]);
+	let spec = CommandSpec {
+		program: "dart".to_string(),
+		args: vec!["pub".to_string(), "publish".to_string()],
+		cwd: PathBuf::from("."),
+		env: BTreeMap::new(),
+		timeout: Some(Duration::from_secs(60)),
+	};
+	let error = run_publish_command_with_retries(&mut executor, &spec, &request)
+		.expect_err("exhausted retries should surface the timeout error");
+	assert!(is_publish_timeout_error(&error));
+	assert_eq!(executor.commands.len(), 2);
+}
+
+#[test]
+fn run_publish_command_with_retries_does_not_retry_non_timeout_errors() {
+	let request = publish_request("pkg");
+	let mut executor = SequencedCommandExecutor::new([
+		Err(MonochangeError::Io(
+			"publisher executable was not found".to_string(),
+		)),
+		Ok(CommandOutput {
+			success: true,
+			stdout: String::new(),
+			stderr: String::new(),
+		}),
+	]);
+	let spec = CommandSpec {
+		program: "dart".to_string(),
+		args: vec!["pub".to_string(), "publish".to_string()],
+		cwd: PathBuf::from("."),
+		env: BTreeMap::new(),
+		timeout: Some(Duration::from_secs(60)),
+	};
+	let error = run_publish_command_with_retries(&mut executor, &spec, &request)
+		.expect_err("non-timeout errors should not be retried");
+	assert!(!is_publish_timeout_error(&error));
+	assert_eq!(executor.commands.len(), 1);
+}
+
+#[test]
+fn publish_command_failure_message_includes_dart_guidance_for_timeout() {
+	let mut request = pub_dev_publish_request("pkg");
+	request.timeout.retries = 2;
+	let message = publish_command_failure_message(&request, &timeout_error());
+	assert!(message.contains("timed out after 3 attempt(s)"));
+	assert!(message.contains("pub.dev protected publishing"));
+	assert!(message.contains("workflow_dispatch"));
+}
+
+#[test]
+fn publish_command_failure_message_omits_dart_guidance_for_non_timeout_errors() {
+	let request = pub_dev_publish_request("pkg");
+	let message = publish_command_failure_message(
+		&request,
+		&MonochangeError::Config("publish rejected".to_string()),
+	);
+	assert_eq!(message, "config error: publish rejected");
+}
+
+#[test]
+fn dart_protected_publishing_warning_warns_for_workflow_dispatch_without_pub_token() {
+	let request = pub_dev_publish_request("pkg");
+	let env_map = BTreeMap::from([
+		("GITHUB_ACTIONS".to_string(), "true".to_string()),
+		(
+			"GITHUB_EVENT_NAME".to_string(),
+			"workflow_dispatch".to_string(),
+		),
+		("GITHUB_REF".to_string(), "refs/heads/main".to_string()),
+	]);
+	let warning = dart_protected_publishing_warning(&request, &env_map)
+		.expect("workflow_dispatch without PUB_TOKEN should warn");
+	assert!(warning.contains("workflow_dispatch"));
+	assert!(warning.contains("PUB_TOKEN"));
+}
+
+#[test]
+fn dart_protected_publishing_warning_returns_none_for_tag_push() {
+	let request = pub_dev_publish_request("pkg");
+	let env_map = BTreeMap::from([
+		("GITHUB_ACTIONS".to_string(), "true".to_string()),
+		("GITHUB_EVENT_NAME".to_string(), "push".to_string()),
+		("GITHUB_REF".to_string(), "refs/tags/v1.0.0".to_string()),
+	]);
+	assert!(dart_protected_publishing_warning(&request, &env_map).is_none());
+}
+
+#[test]
+fn dart_protected_publishing_warning_returns_none_when_pub_token_present() {
+	let request = pub_dev_publish_request("pkg");
+	let env_map = BTreeMap::from([
+		("GITHUB_ACTIONS".to_string(), "true".to_string()),
+		(
+			"GITHUB_EVENT_NAME".to_string(),
+			"workflow_dispatch".to_string(),
+		),
+		("GITHUB_REF".to_string(), "refs/heads/main".to_string()),
+		("PUB_TOKEN".to_string(), "secret".to_string()),
+	]);
+	assert!(dart_protected_publishing_warning(&request, &env_map).is_none());
+}
+
+#[test]
+fn dart_protected_publishing_warning_returns_none_for_non_dart_registries() {
+	let request = publish_request("pkg");
+	let env_map = BTreeMap::from([
+		(
+			"GITHUB_EVENT_NAME".to_string(),
+			"workflow_dispatch".to_string(),
+		),
+		("GITHUB_REF".to_string(), "refs/heads/main".to_string()),
+	]);
+	assert!(dart_protected_publishing_warning(&request, &env_map).is_none());
 }

--- a/crates/monochange_publish/src/__tests__/lib_tests.rs
+++ b/crates/monochange_publish/src/__tests__/lib_tests.rs
@@ -2569,3 +2569,114 @@ fn dart_protected_publishing_warning_returns_none_for_non_dart_registries() {
 	]);
 	assert!(dart_protected_publishing_warning(&request, &env_map).is_none());
 }
+
+#[test]
+fn process_command_executor_kills_command_exceeding_timeout() {
+	let root = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let spec = CommandSpec {
+		program: "sh".to_string(),
+		args: vec!["-c".to_string(), "sleep 5".to_string()],
+		cwd: root.path().to_path_buf(),
+		env: BTreeMap::new(),
+		timeout: Some(Duration::from_millis(300)),
+	};
+	let mut executor = ProcessCommandExecutor::new(false);
+	let error = executor
+		.run(&spec)
+		.expect_err("sleep command should be killed by the timeout");
+	assert!(
+		is_publish_timeout_error(&error),
+		"expected timeout error, got: {error}"
+	);
+	assert!(error.to_string().contains("timed out after"));
+}
+
+#[test]
+fn process_command_executor_allows_command_within_timeout() {
+	let root = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let spec = CommandSpec {
+		program: "sh".to_string(),
+		args: vec!["-c".to_string(), "printf done".to_string()],
+		cwd: root.path().to_path_buf(),
+		env: BTreeMap::new(),
+		timeout: Some(Duration::from_secs(5)),
+	};
+	let mut executor = ProcessCommandExecutor::new(false);
+	let output = executor
+		.run(&spec)
+		.unwrap_or_else(|error| panic!("run command within timeout: {error}"));
+	assert!(output.success);
+	assert_eq!(output.stdout, "done");
+}
+
+#[test]
+fn publish_command_timeout_uses_request_settings() {
+	let mut request = publish_request("pkg");
+	request.timeout.timeout_seconds = 90;
+	assert_eq!(
+		publish_command_timeout(&request),
+		Some(Duration::from_secs(90))
+	);
+	request.timeout.timeout_seconds = 0;
+	assert_eq!(publish_command_timeout(&request), None);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dart_protected_publishing_warning_emitted_for_workflow_dispatch_publish() {
+	let request = pub_dev_publish_request("pkg");
+	let listener = std::net::TcpListener::bind("127.0.0.1:0")
+		.unwrap_or_else(|error| panic!("bind test registry: {error}"));
+	let registry_address = listener
+		.local_addr()
+		.unwrap_or_else(|error| panic!("registry address: {error}"));
+	let registry_thread = std::thread::spawn(move || {
+		let Ok((mut stream, _)) = listener.accept() else {
+			return;
+		};
+		let mut request = [0_u8; 2048];
+		let _ = std::io::Read::read(&mut stream, &mut request);
+		let _ = std::io::Write::write_all(
+			&mut stream,
+			b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+		);
+	});
+	let env_map = BTreeMap::from([
+		("GITHUB_ACTIONS".to_string(), "true".to_string()),
+		(
+			"GITHUB_EVENT_NAME".to_string(),
+			"workflow_dispatch".to_string(),
+		),
+		("GITHUB_REF".to_string(), "refs/heads/main".to_string()),
+	]);
+	let mut executor = SequencedCommandExecutor::new([Ok(CommandOutput {
+		success: true,
+		stdout: "published pkg".to_string(),
+		stderr: String::new(),
+	})]);
+	let mut endpoints = RegistryEndpoints::from_env();
+	endpoints.pub_dev_api = format!("http://{registry_address}");
+	let report = try_execute_publish_requests_with_progress(
+		Path::new("."),
+		None,
+		PackagePublishRunMode::Release,
+		false,
+		std::slice::from_ref(&request),
+		&registry_client().unwrap(),
+		&endpoints,
+		&env_map,
+		&mut executor,
+		&build_publish_command_builder(),
+		&PlaceholderManifestWriterRegistry::new(),
+		&PublishReadinessRegistry::new(),
+		&TestPublishTrustHandler,
+		&NoopPublishProgressReporter,
+	)
+	.await
+	.unwrap_or_else(|error| panic!("publish request: {error}"));
+	registry_thread
+		.join()
+		.unwrap_or_else(|_| panic!("test registry thread panicked"));
+	assert_eq!(report.packages.len(), 1);
+	assert_eq!(executor.commands.len(), 1);
+	assert!(executor.commands[0].program.contains("dart"));
+}

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -1818,7 +1818,9 @@ fn wait_child_with_timeout(
 				}
 				std::thread::sleep(Duration::from_millis(100));
 			}
+			// patch-coverage:ignore-start -- `try_wait` errors require an invalid child handle that cannot be produced by a successful spawn
 			Err(error) => return Err(process_command_error(spec, "wait for", &error)),
+			// patch-coverage:ignore-end
 		}
 	}
 }

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Stdio;
+use std::time::Duration;
 
 use monochange_core::DependencyEdge;
 use monochange_core::DependencyKind;
@@ -20,6 +21,7 @@ use monochange_core::PublishAttestationSettings;
 use monochange_core::PublishMode;
 use monochange_core::PublishRegistry;
 use monochange_core::PublishState;
+use monochange_core::PublishTimeoutSettings;
 use monochange_core::RegistryKind;
 use monochange_core::SourceConfiguration;
 use monochange_core::TrustedPublishingSettings;
@@ -584,6 +586,7 @@ pub struct PublishRequest {
 	pub placeholder: bool,
 	pub trusted_publishing: TrustedPublishingSettings,
 	pub attestations: PublishAttestationSettings,
+	pub timeout: PublishTimeoutSettings,
 	pub placeholder_readme: String,
 }
 
@@ -593,11 +596,13 @@ pub struct CommandSpec {
 	pub args: Vec<String>,
 	pub cwd: PathBuf,
 	pub env: BTreeMap<String, String>,
+	pub timeout: Option<Duration>,
 }
 
 const NPM_PUBLISH_OTP_METADATA_KEY: &str = "monochange:npm_publish_otp";
 const PUBLISH_STREAM_OUTPUT_ENV_KEY: &str = "MONOCHANGE_PUBLISH_STREAM_OUTPUT";
 const PUBLISH_STREAM_OUTPUT_METADATA_KEY: &str = "monochange:stream_output";
+const PUBLISH_TIMEOUT_ERROR_PREFIX: &str = "monochange:publish-timeout";
 
 pub fn set_npm_publish_otp_for_requests(requests: &mut [PublishRequest], otp: &str) {
 	for request in requests
@@ -1166,12 +1171,13 @@ pub async fn try_execute_publish_requests_with_progress(
 		} else {
 			None
 		};
-		let publish_command = command_builder.build_publish_command(
+		let mut publish_command = command_builder.build_publish_command(
 			request,
 			mode,
 			placeholder_dir.as_ref().map(TempDir::path),
 			dry_run,
 		);
+		publish_command.timeout = publish_command_timeout(request);
 
 		if dry_run {
 			progress.report(PublishProgressEvent::PackagePlanned(
@@ -1229,8 +1235,16 @@ pub async fn try_execute_publish_requests_with_progress(
 			progress.report(PublishProgressEvent::PackageStarted(
 				publish_progress_package(request),
 			));
+			if let Some(warning) = dart_protected_publishing_warning(request, env_map) {
+				tracing::warn!(
+					package_name = request.package_name,
+					version = %request.version,
+					registry = %request.registry,
+					"{warning}"
+				);
+			}
 		}
-		let output = match executor.run(&publish_command) {
+		let output = match run_publish_command_with_retries(executor, &publish_command, request) {
 			Ok(output) => output,
 			Err(error) => {
 				tracing::error!(
@@ -1240,7 +1254,7 @@ pub async fn try_execute_publish_requests_with_progress(
 					error = %error,
 					"publish command failed to execute"
 				);
-				let message = error.render();
+				let message = publish_command_failure_message(request, &error);
 				append_publish_failure_outcomes(
 					&mut outcomes,
 					remaining_requests,
@@ -1411,6 +1425,7 @@ pub fn build_placeholder_requests(
 				placeholder: true,
 				trusted_publishing: package_definition.publish.trusted_publishing.clone(),
 				attestations: package_definition.publish.attestations.clone(),
+				timeout: package_definition.publish.timeout.clone(),
 				placeholder_readme: resolve_placeholder_readme(
 					root,
 					package_definition.publish.placeholder.readme.as_deref(),
@@ -1450,6 +1465,7 @@ pub fn configured_package_publication_targets(
 				mode: package_definition.publish.mode,
 				trusted_publishing: package_definition.publish.trusted_publishing.clone(),
 				attestations: package_definition.publish.attestations.clone(),
+				timeout: package_definition.publish.timeout.clone(),
 			})
 		})
 		.collect()
@@ -1520,6 +1536,7 @@ pub fn build_release_requests(
 			placeholder: false,
 			trusted_publishing: publication.trusted_publishing.clone(),
 			attestations: publication.attestations.clone(),
+			timeout: publication.timeout.clone(),
 			placeholder_readme: default_placeholder_readme(&package.name),
 		});
 	}
@@ -1713,18 +1730,34 @@ fn run_captured_process_command(spec: &CommandSpec) -> MonochangeResult<CommandO
 		.args(&spec.args)
 		.current_dir(&spec.cwd)
 		.envs(&spec.env)
-		.stdin(Stdio::null());
-	let output = command.output().map_err(|error| {
+		.stdin(Stdio::null())
+		.stdout(Stdio::piped())
+		.stderr(Stdio::piped());
+	let mut child = command.spawn().map_err(|error| {
 		MonochangeError::Io(format!(
 			"failed to run `{}` in {}: {error}",
 			render_command(spec),
 			spec.cwd.display()
 		))
 	})?;
+	let stdout = child
+		.stdout
+		.take()
+		.expect("stdout was configured for piping");
+	let stderr = child
+		.stderr
+		.take()
+		.expect("stderr was configured for piping");
+	let stdout_thread = std::thread::spawn(move || read_child_output(stdout));
+	let stderr_thread = std::thread::spawn(move || read_child_output(stderr));
+	let status = wait_child_with_timeout(&mut child, spec)?;
+	let stdout = join_child_output(stdout_thread, spec, "stdout")?;
+	let stderr = join_child_output(stderr_thread, spec, "stderr")?;
+
 	Ok(CommandOutput {
-		success: output.status.success(),
-		stdout: String::from_utf8_lossy(&output.stdout).trim().to_string(),
-		stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+		success: status.success(),
+		stdout: String::from_utf8_lossy(&stdout).trim().to_string(),
+		stderr: String::from_utf8_lossy(&stderr).trim().to_string(),
 	})
 }
 
@@ -1753,9 +1786,7 @@ fn run_streaming_process_command(spec: &CommandSpec) -> MonochangeResult<Command
 		.expect("stderr was configured for piping");
 	let stdout_thread = std::thread::spawn(move || tee_child_output(stdout, std::io::stdout()));
 	let stderr_thread = std::thread::spawn(move || tee_child_output(stderr, std::io::stderr()));
-	let status = child
-		.wait()
-		.map_err(|error| process_command_error(spec, "wait for", &error))?;
+	let status = wait_child_with_timeout(&mut child, spec)?;
 	let stdout = join_child_output(stdout_thread, spec, "stdout")?;
 	let stderr = join_child_output(stderr_thread, spec, "stderr")?;
 
@@ -1764,6 +1795,149 @@ fn run_streaming_process_command(spec: &CommandSpec) -> MonochangeResult<Command
 		stdout: String::from_utf8_lossy(&stdout).trim().to_string(),
 		stderr: String::from_utf8_lossy(&stderr).trim().to_string(),
 	})
+}
+
+fn wait_child_with_timeout(
+	child: &mut std::process::Child,
+	spec: &CommandSpec,
+) -> MonochangeResult<std::process::ExitStatus> {
+	let Some(timeout) = spec.timeout else {
+		return child
+			.wait()
+			.map_err(|error| process_command_error(spec, "wait for", &error));
+	};
+	let deadline = std::time::Instant::now() + timeout;
+	loop {
+		match child.try_wait() {
+			Ok(Some(status)) => return Ok(status),
+			Ok(None) => {
+				if std::time::Instant::now() >= deadline {
+					let _ = child.kill();
+					let _ = child.wait();
+					return Err(publish_timeout_error(spec, timeout));
+				}
+				std::thread::sleep(Duration::from_millis(100));
+			}
+			Err(error) => return Err(process_command_error(spec, "wait for", &error)),
+		}
+	}
+}
+
+fn read_child_output(mut reader: impl std::io::Read) -> std::io::Result<Vec<u8>> {
+	let mut buffer = Vec::new();
+	std::io::Read::read_to_end(&mut reader, &mut buffer)?;
+	Ok(buffer)
+}
+
+fn publish_timeout_error(spec: &CommandSpec, timeout: Duration) -> MonochangeError {
+	MonochangeError::Io(format!(
+		"{PUBLISH_TIMEOUT_ERROR_PREFIX}: `{}` in {} timed out after {} seconds",
+		render_command(spec),
+		spec.cwd.display(),
+		timeout.as_secs()
+	))
+}
+
+fn publish_command_timeout(request: &PublishRequest) -> Option<Duration> {
+	if request.timeout.disabled() {
+		None
+	} else {
+		Some(Duration::from_secs(request.timeout.timeout_seconds))
+	}
+}
+
+/// Returns `true` when a [`CommandExecutor::run`] failure was caused by the
+/// configured publish timeout rather than a registry or command error.
+#[must_use]
+pub fn is_publish_timeout_error(error: &MonochangeError) -> bool {
+	error.render().contains(PUBLISH_TIMEOUT_ERROR_PREFIX)
+}
+
+fn run_publish_command_with_retries(
+	executor: &mut dyn CommandExecutor,
+	publish_command: &CommandSpec,
+	request: &PublishRequest,
+) -> Result<CommandOutput, MonochangeError> {
+	let max_attempts = 1usize + request.timeout.retries as usize;
+	let mut last_error = None;
+	for attempt in 1..=max_attempts {
+		match executor.run(publish_command) {
+			Ok(output) => return Ok(output),
+			Err(error) => {
+				let timed_out = is_publish_timeout_error(&error);
+				tracing::warn!(
+					package_name = request.package_name,
+					version = %request.version,
+					registry = %request.registry,
+					attempt,
+					max_attempts,
+					timed_out,
+					error = %error,
+					"publish command attempt failed"
+				);
+				if !timed_out || attempt == max_attempts {
+					return Err(error);
+				}
+				last_error = Some(error);
+			}
+		}
+	}
+	Err(last_error.expect("retry loop runs at least once"))
+}
+
+fn publish_command_failure_message(request: &PublishRequest, error: &MonochangeError) -> String {
+	if is_publish_timeout_error(error) {
+		let mut message = format!(
+			"publish for `{}` version `{}` timed out after {} attempt(s); {}",
+			request.package_name,
+			request.version,
+			request.timeout.retries + 1,
+			error.render()
+		);
+		if request.registry == RegistryKind::PubDev {
+			message.push_str("\n\n");
+			message.push_str(dart_protected_publishing_guidance());
+		}
+		return message;
+	}
+	error.render()
+}
+
+/// Explanatory guidance appended to Dart/pub.dev publish failures and timeouts
+/// explaining that protected (trusted) publishing may require publishing from a
+/// pushed tag rather than a `workflow_dispatch` event.
+pub fn dart_protected_publishing_guidance() -> &'static str {
+	"pub.dev protected publishing may require publishing directly from a pushed tag rather than a `workflow_dispatch` event. If the publish hangs or fails non-interactively, verify the pub.dev automated publishing publisher is configured for the tag push event (not `workflow_dispatch`), or provide a `PUB_TOKEN` fallback with `dart pub token add https://pub.dev --env-var PUB_TOKEN` before publishing."
+}
+
+/// Returns a warning when a Dart package uses protected (trusted) publishing
+/// from a GitHub Actions `workflow_dispatch` event without a `PUB_TOKEN`
+/// fallback, which pub.dev automated publishing commonly rejects.
+#[must_use]
+pub fn dart_protected_publishing_warning(
+	request: &PublishRequest,
+	env_map: &BTreeMap<String, String>,
+) -> Option<String> {
+	if request.registry != RegistryKind::PubDev || !request.trusted_publishing.enabled {
+		return None;
+	}
+	let event_is_workflow_dispatch = env_map
+		.get("GITHUB_EVENT_NAME")
+		.is_some_and(|event| event == "workflow_dispatch")
+		|| env_map
+			.get("GITHUB_REF")
+			.is_some_and(|reference| reference.starts_with("refs/heads/"));
+	if !event_is_workflow_dispatch {
+		return None;
+	}
+	if env_map.contains_key("PUB_TOKEN") {
+		return None;
+	}
+	Some(format!(
+		"`{}` uses pub.dev protected publishing from a `workflow_dispatch` event without a `PUB_TOKEN` fallback. {}",
+		request.package_name,
+		dart_protected_publishing_guidance()
+	))
 }
 
 fn process_command_error(
@@ -2193,6 +2367,7 @@ pub fn build_npm_placeholder_publish_command(
 		],
 		cwd: request.package_root.clone(),
 		env: npm_publish_env(request),
+		timeout: None,
 	}
 }
 
@@ -2210,6 +2385,7 @@ pub fn build_npm_release_publish_command(request: &PublishRequest) -> CommandSpe
 		args,
 		cwd: request.package_root.clone(),
 		env: npm_publish_env(request),
+		timeout: None,
 	}
 }
 
@@ -2243,6 +2419,7 @@ fn build_cargo_placeholder_publish_command(
 		],
 		cwd: request.package_root.clone(),
 		env: BTreeMap::new(),
+		timeout: None,
 	}
 }
 
@@ -2257,6 +2434,7 @@ fn build_cargo_release_publish_command(request: &PublishRequest) -> CommandSpec 
 		],
 		cwd: request.package_root.clone(),
 		env: BTreeMap::new(),
+		timeout: None,
 	}
 }
 
@@ -2279,6 +2457,7 @@ fn build_dart_publish_command(request: &PublishRequest, cwd: &Path) -> CommandSp
 		],
 		cwd: cwd.to_path_buf(),
 		env: BTreeMap::new(),
+		timeout: None,
 	}
 }
 
@@ -2288,6 +2467,7 @@ fn build_jsr_publish_command(cwd: &Path) -> CommandSpec {
 		args: vec!["publish".to_string()],
 		cwd: cwd.to_path_buf(),
 		env: BTreeMap::new(),
+		timeout: None,
 	}
 }
 
@@ -2305,6 +2485,7 @@ fn build_python_publish_command(request: &PublishRequest, cwd: &Path) -> Command
 		args: vec!["-c".to_string(), script],
 		cwd: cwd.to_path_buf(),
 		env: BTreeMap::new(),
+		timeout: None,
 	}
 }
 
@@ -2314,6 +2495,7 @@ fn build_go_publish_command(request: &PublishRequest) -> CommandSpec {
 		args: vec!["tag".to_string(), go_module_tag_name(request)],
 		cwd: request.package_root.clone(),
 		env: BTreeMap::new(),
+		timeout: None,
 	}
 }
 

--- a/crates/monochange_publish/src/lib.rs
+++ b/crates/monochange_publish/src/lib.rs
@@ -1875,10 +1875,10 @@ fn run_publish_command_with_retries(
 					error = %error,
 					"publish command attempt failed"
 				);
-				if !timed_out || attempt == max_attempts {
-					return Err(error);
-				}
 				last_error = Some(error);
+				if !timed_out || attempt == max_attempts {
+					break;
+				}
 			}
 		}
 	}

--- a/crates/monochange_schema/schemas/monochange.schema.json
+++ b/crates/monochange_schema/schemas/monochange.schema.json
@@ -2363,6 +2363,9 @@
 					],
 					"default": null
 				},
+				"timeout": {
+					"$ref": "#/$defs/publish_timeout_settings"
+				},
 				"trusted_publishing": {
 					"anyOf": [
 						{
@@ -2371,6 +2374,30 @@
 						{
 							"type": "null"
 						}
+					]
+				}
+			},
+			"type": "object"
+		},
+		"publish_timeout_settings": {
+			"additionalProperties": false,
+			"properties": {
+				"retries": {
+					"default": null,
+					"format": "uint32",
+					"minimum": 0,
+					"type": [
+						"integer",
+						"null"
+					]
+				},
+				"timeout_seconds": {
+					"default": null,
+					"format": "uint64",
+					"minimum": 0,
+					"type": [
+						"integer",
+						"null"
 					]
 				}
 			},

--- a/crates/monochange_schema/schemas/release-record.schema.json
+++ b/crates/monochange_schema/schemas/release-record.schema.json
@@ -419,6 +419,9 @@
 					],
 					"default": null
 				},
+				"timeout": {
+					"$ref": "#/$defs/PublishTimeoutSettings"
+				},
 				"trusted_publishing": {
 					"$ref": "#/$defs/TrustedPublishingSettings",
 					"default": {
@@ -565,6 +568,23 @@
 					"type": "string"
 				}
 			]
+		},
+		"PublishTimeoutSettings": {
+			"properties": {
+				"retries": {
+					"default": 2,
+					"format": "uint32",
+					"minimum": 0,
+					"type": "integer"
+				},
+				"timeout_seconds": {
+					"default": 60,
+					"format": "uint64",
+					"minimum": 0,
+					"type": "integer"
+				}
+			},
+			"type": "object"
 		},
 		"RegistryKind": {
 			"enum": [

--- a/docs/src/guide/04-configuration.md
+++ b/docs/src/guide/04-configuration.md
@@ -252,6 +252,8 @@ Supported fields:
 - `trusted_publishing` - `true`/`false` or a table with `enabled`, `repository`, `workflow`, and `environment`
 - `attestations.require_registry_provenance` - require registry-native package provenance when the selected registry/provider capability supports it
 - `rate_limits.enforce` - block built-in publish runs when the selected package set exceeds a known single registry window
+- `timeout.timeout_seconds` - maximum seconds a single package publish command may run before it is killed and retried; set to `0` to disable the timeout (default: `60`)
+- `timeout.retries` - number of times to retry a publish command that times out before reporting the package as failed (default: `2`)
 - `placeholder.readme` - inline placeholder README content
 - `publish_order.dependency_fields` - ecosystem-level dependency fields used to topologically order package publishes
 - `placeholder.readme_file` - workspace-relative file to use as placeholder README content

--- a/docs/src/schemas/monochange.schema.json
+++ b/docs/src/schemas/monochange.schema.json
@@ -2363,6 +2363,9 @@
 					],
 					"default": null
 				},
+				"timeout": {
+					"$ref": "#/$defs/publish_timeout_settings"
+				},
 				"trusted_publishing": {
 					"anyOf": [
 						{
@@ -2371,6 +2374,30 @@
 						{
 							"type": "null"
 						}
+					]
+				}
+			},
+			"type": "object"
+		},
+		"publish_timeout_settings": {
+			"additionalProperties": false,
+			"properties": {
+				"retries": {
+					"default": null,
+					"format": "uint32",
+					"minimum": 0,
+					"type": [
+						"integer",
+						"null"
+					]
+				},
+				"timeout_seconds": {
+					"default": null,
+					"format": "uint64",
+					"minimum": 0,
+					"type": [
+						"integer",
+						"null"
 					]
 				}
 			},

--- a/docs/src/schemas/monochange.v0.4.schema.json
+++ b/docs/src/schemas/monochange.v0.4.schema.json
@@ -2363,6 +2363,9 @@
 					],
 					"default": null
 				},
+				"timeout": {
+					"$ref": "#/$defs/publish_timeout_settings"
+				},
 				"trusted_publishing": {
 					"anyOf": [
 						{
@@ -2371,6 +2374,30 @@
 						{
 							"type": "null"
 						}
+					]
+				}
+			},
+			"type": "object"
+		},
+		"publish_timeout_settings": {
+			"additionalProperties": false,
+			"properties": {
+				"retries": {
+					"default": null,
+					"format": "uint32",
+					"minimum": 0,
+					"type": [
+						"integer",
+						"null"
+					]
+				},
+				"timeout_seconds": {
+					"default": null,
+					"format": "uint64",
+					"minimum": 0,
+					"type": [
+						"integer",
+						"null"
 					]
 				}
 			},

--- a/docs/src/schemas/release-record.schema.json
+++ b/docs/src/schemas/release-record.schema.json
@@ -419,6 +419,9 @@
 					],
 					"default": null
 				},
+				"timeout": {
+					"$ref": "#/$defs/PublishTimeoutSettings"
+				},
 				"trusted_publishing": {
 					"$ref": "#/$defs/TrustedPublishingSettings",
 					"default": {
@@ -565,6 +568,23 @@
 					"type": "string"
 				}
 			]
+		},
+		"PublishTimeoutSettings": {
+			"properties": {
+				"retries": {
+					"default": 2,
+					"format": "uint32",
+					"minimum": 0,
+					"type": "integer"
+				},
+				"timeout_seconds": {
+					"default": 60,
+					"format": "uint64",
+					"minimum": 0,
+					"type": "integer"
+				}
+			},
+			"type": "object"
 		},
 		"RegistryKind": {
 			"enum": [

--- a/docs/src/schemas/release-record.v0.4.schema.json
+++ b/docs/src/schemas/release-record.v0.4.schema.json
@@ -419,6 +419,9 @@
 					],
 					"default": null
 				},
+				"timeout": {
+					"$ref": "#/$defs/PublishTimeoutSettings"
+				},
 				"trusted_publishing": {
 					"$ref": "#/$defs/TrustedPublishingSettings",
 					"default": {
@@ -565,6 +568,23 @@
 					"type": "string"
 				}
 			]
+		},
+		"PublishTimeoutSettings": {
+			"properties": {
+				"retries": {
+					"default": 2,
+					"format": "uint32",
+					"minimum": 0,
+					"type": "integer"
+				},
+				"timeout_seconds": {
+					"default": 60,
+					"format": "uint64",
+					"minimum": 0,
+					"type": "integer"
+				}
+			},
+			"type": "object"
 		},
 		"RegistryKind": {
 			"enum": [


### PR DESCRIPTION
## Summary

- Adds a configurable `publish.timeout` (`timeout_seconds` default 60, `retries` default 2) that caps how long a single package publish command may hang before it is killed and retried. Set `timeout_seconds = 0` to disable the timeout.
- Publish commands that time out are retried up to `retries` times; after the final attempt the package is reported as timed out instead of hanging the whole job silently.
- Dart/pub.dev packages using protected (trusted) publishing from a GitHub Actions `workflow_dispatch` event without a `PUB_TOKEN` fallback now emit a warning explaining that pub.dev automated publishing may require publishing from a pushed tag rather than a workflow dispatch. The same guidance is appended to Dart publish timeout/failure messages.

## Motivation

Dart protected publishing can hang silently when run from a `workflow_dispatch` event (rather than a tag push), timing out the whole job with no indication of the cause. This adds a deadline + retry safety net and surfaces a targeted warning so the failure mode is diagnosable.

## Configuration

\`\`\`toml
[package.my-dart-package.publish.timeout]
timeout_seconds = 90
retries = 3
\`\`\`

The setting inherits from `[ecosystems.<name>.publish.timeout]` to matching packages, like the other publish settings.

## Test plan

- [x] Unit tests for `run_publish_command_with_retries` (retry-until-success, exhausted-retries, no-retry-on-non-timeout)
- [x] Unit tests for `is_publish_timeout_error` and `publish_command_failure_message` (Dart guidance on timeout, omitted for non-timeout)
- [x] Unit tests for `dart_protected_publishing_warning` (workflow_dispatch + no PUB_TOKEN warns; tag push / PUB_TOKEN present / non-Dart return none)
- [x] `cargo test --workspace` green
- [x] `lint:all` green (clippy, format, schema, dprint, changeset, architecture, workflows)