### PR TITLE
fix(cli): keep publish progress lines on their own lines next to the step spinner

### DIFF
--- a/.changeset/publish-progress-line-collision.md
+++ b/.changeset/publish-progress-line-collision.md
@@ -1,0 +1,9 @@
+---
+monochange: patch
+---
+
+# Keep publish progress lines on their own lines next to the step spinner
+
+Publish progress events (for example `◆ Publishing 56 packages …` and per-package `⏭️`/`✅`/`❌` lines) previously appended to the active CLI step spinner line, so leading symbols appeared mid-line instead of at the start of a new line.
+
+Both reporters now share the global stderr lock, and publish progress clears the active spinner line before writing, so every publish progress line starts on its own line while the step spinner continues animating below it.

--- a/crates/monochange/src/__tests__/cli_progress_tests.rs
+++ b/crates/monochange/src/__tests__/cli_progress_tests.rs
@@ -19,7 +19,6 @@ fn progress_reporter(enabled: bool, color: bool) -> CliProgressReporter {
 		command_name: "release".to_string(),
 		dry_run: false,
 		total_steps: 3,
-		writer_lock: Arc::new(Mutex::new(())),
 		active_spinner: None,
 		command_started: false,
 		render_mode: ProgressRenderMode::Human,

--- a/crates/monochange/src/__tests__/publish_progress_tests.rs
+++ b/crates/monochange/src/__tests__/publish_progress_tests.rs
@@ -116,3 +116,29 @@ fn disabled_reporter_ignores_events() {
 	StderrPublishProgressReporter::new(true)
 		.report(PublishProgressEvent::PackageStarted(package()));
 }
+
+#[test]
+fn render_report_line_clears_active_spinner_line_when_interactive() {
+	let event = PublishProgressEvent::RunStarted {
+		mode: PackagePublishRunMode::Placeholder,
+		dry_run: false,
+		total: 1,
+		ecosystems: vec![Ecosystem::Npm],
+	};
+
+	let interactive = render_report_line(&event, true);
+	assert!(
+		interactive.starts_with("\r\u{1b}[2K\u{1b}[0m"),
+		"interactive publish progress must clear the active spinner line first: {interactive:?}"
+	);
+	assert!(interactive.ends_with('\n'));
+	assert!(interactive.contains("◆ Publishing 1 packages"));
+
+	let plain = render_report_line(&event, false);
+	assert!(
+		!plain.starts_with("\r\u{1b}[2K"),
+		"non-interactive publish progress must not emit terminal clear codes: {plain:?}"
+	);
+	assert!(plain.ends_with('\n'));
+	assert!(plain.contains("◆ Publishing 1 packages"));
+}

--- a/crates/monochange/src/cli_progress.rs
+++ b/crates/monochange/src/cli_progress.rs
@@ -5,7 +5,6 @@ use std::io;
 use std::io::IsTerminal;
 use std::io::Write;
 use std::sync::Arc;
-use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::thread;
@@ -102,7 +101,6 @@ pub(crate) struct CliProgressReporter {
 	command_name: String,
 	dry_run: bool,
 	total_steps: usize,
-	writer_lock: Arc<Mutex<()>>,
 	active_spinner: Option<SpinnerState>,
 	command_started: bool,
 	render_mode: ProgressRenderMode,
@@ -158,7 +156,6 @@ impl CliProgressReporter {
 			command_name: cli_command.name.clone(),
 			dry_run,
 			total_steps: cli_command.steps.len(),
-			writer_lock: Arc::new(Mutex::new(())),
 			active_spinner: None,
 			command_started: false,
 			render_mode,
@@ -180,7 +177,7 @@ impl CliProgressReporter {
 
 		if self.render_mode == ProgressRenderMode::Json {
 			let sequence = self.next_sequence();
-			self.emit_json_event(&serde_json::json!({
+			Self::emit_json_event(&serde_json::json!({
 				"sequence": sequence,
 				"event": "command_started",
 				"command": self.command_name,
@@ -191,7 +188,7 @@ impl CliProgressReporter {
 		}
 
 		let suffix = if self.dry_run { " (dry-run)" } else { "" };
-		self.print_line(&format!(
+		Self::print_line(&format!(
 			"{} {}{}",
 			self.paint("monochange", Style::Accent),
 			self.paint(&format!("running `{}`", self.command_name), Style::Header),
@@ -206,7 +203,7 @@ impl CliProgressReporter {
 		self.stop_spinner();
 		if self.render_mode == ProgressRenderMode::Json {
 			let sequence = self.next_sequence();
-			self.emit_json_event(&serde_json::json!({
+			Self::emit_json_event(&serde_json::json!({
 				"sequence": sequence,
 				"event": "command_finished",
 				"command": self.command_name,
@@ -216,7 +213,7 @@ impl CliProgressReporter {
 			}));
 			return;
 		}
-		self.print_line(&format!(
+		Self::print_line(&format!(
 			"{} {} {}",
 			self.paint(self.symbols.command_success, Style::Success),
 			self.paint(&format!("`{}` finished", self.command_name), Style::Header),
@@ -231,7 +228,7 @@ impl CliProgressReporter {
 		self.stop_spinner();
 		if self.render_mode == ProgressRenderMode::Json {
 			let sequence = self.next_sequence();
-			self.emit_json_event(&serde_json::json!({
+			Self::emit_json_event(&serde_json::json!({
 				"sequence": sequence,
 				"event": "command_failed",
 				"command": self.command_name,
@@ -242,7 +239,7 @@ impl CliProgressReporter {
 			}));
 			return;
 		}
-		self.print_line(&format!(
+		Self::print_line(&format!(
 			"{} {} {}",
 			self.paint(self.symbols.step_failure, Style::Error),
 			self.paint(&format!("`{}` failed", self.command_name), Style::Header),
@@ -263,7 +260,7 @@ impl CliProgressReporter {
 		if self.animate {
 			self.start_spinner(message);
 		} else {
-			self.print_line(&format!(
+			Self::print_line(&format!(
 				"{} {message}",
 				self.paint(self.symbols.step_start, Style::Accent)
 			));
@@ -304,7 +301,7 @@ impl CliProgressReporter {
 				self.paint(&format!("({detail})"), Style::Muted)
 			);
 		}
-		self.print_line(&line);
+		Self::print_line(&line);
 	}
 
 	pub(crate) fn step_status(
@@ -333,7 +330,7 @@ impl CliProgressReporter {
 		if self.animate {
 			self.start_spinner(message);
 		} else {
-			self.print_line(&format!(
+			Self::print_line(&format!(
 				"{} {message}",
 				self.paint(self.symbols.step_start, Style::Accent),
 			));
@@ -376,14 +373,14 @@ impl CliProgressReporter {
 			self.emit_step_event("step_finished", step_index, step, payload);
 			return;
 		}
-		self.print_line(&format!(
+		Self::print_line(&format!(
 			"{} {} {}",
 			self.paint(self.symbols.step_success, Style::Success),
 			self.step_message(step_index, step),
 			self.paint(&format_duration(duration), Style::Muted),
 		));
 		for phase in summarized_phase_timings(phase_timings) {
-			self.print_line(&format!(
+			Self::print_line(&format!(
 				"  {} {} {}\u{1b}[0m",
 				self.paint(self.symbols.bullet, Style::Muted),
 				self.paint(&phase.label, Style::Detail),
@@ -417,7 +414,7 @@ impl CliProgressReporter {
 			self.emit_step_event("step_failed", step_index, step, payload);
 			return;
 		}
-		self.print_line(&format!(
+		Self::print_line(&format!(
 			"{} {} {}",
 			self.paint(self.symbols.step_failure, Style::Error),
 			self.step_message(step_index, step),
@@ -429,7 +426,7 @@ impl CliProgressReporter {
 			} else {
 				self.symbols.log_pipe
 			};
-			self.print_line(&format!(
+			Self::print_line(&format!(
 				"  {} {}",
 				self.paint(branch, Style::Error),
 				self.paint(line, Style::Error),
@@ -470,7 +467,7 @@ impl CliProgressReporter {
 		};
 		let step_label = step.display_name();
 		for line in text.lines() {
-			self.print_line(&format!(
+			Self::print_line(&format!(
 				"  {} {} {}\u{1b}[0m",
 				self.paint(self.symbols.log_pipe, Style::Muted),
 				self.paint(&format!("{step_label} [{stream_label}]"), Style::Detail),
@@ -504,7 +501,6 @@ impl CliProgressReporter {
 		let rendered = Arc::new(AtomicBool::new(false));
 		let stop_flag = Arc::clone(&stop);
 		let rendered_flag = Arc::clone(&rendered);
-		let writer_lock = Arc::clone(&self.writer_lock);
 		let color = self.color;
 		let spinner_frames = self.symbols.spinner_frames;
 		let handle = thread::spawn(move || {
@@ -513,13 +509,14 @@ impl CliProgressReporter {
 				if stop_flag.load(Ordering::Relaxed) {
 					break;
 				}
-				with_stderr_lock(&writer_lock, || {
-					eprint!(
+				with_stderr_lock(|lock| {
+					let _ = write!(
+						lock,
 						"\r\u{1b}[2K\u{1b}[0m{} {}",
 						paint_text(frame, Style::Accent, color),
 						message,
 					);
-					let _ = io::stderr().flush();
+					let _ = lock.flush();
 				});
 				rendered_flag.store(true, Ordering::Relaxed);
 				thread::sleep(SPINNER_TICK);
@@ -539,18 +536,18 @@ impl CliProgressReporter {
 		spinner.stop.store(true, Ordering::Relaxed);
 		let _ = spinner.handle.join();
 		if spinner.rendered.load(Ordering::Relaxed) {
-			with_stderr_lock(&self.writer_lock, || {
-				eprint!("\r\u{1b}[2K\u{1b}[0m");
-				let _ = io::stderr().flush();
+			with_stderr_lock(|lock| {
+				let _ = write!(lock, "\r\u{1b}[2K\u{1b}[0m");
+				let _ = lock.flush();
 			});
 		}
 	}
 
-	fn print_line(&self, text: &str) {
-		with_stderr_lock(&self.writer_lock, || {
-			eprint!("\r\u{1b}[2K\u{1b}[0m");
-			eprintln!("{text}");
-			let _ = io::stderr().flush();
+	fn print_line(text: &str) {
+		with_stderr_lock(|lock| {
+			let _ = write!(lock, "\r\u{1b}[2K\u{1b}[0m");
+			let _ = writeln!(lock, "{text}");
+			let _ = lock.flush();
 		});
 	}
 
@@ -606,17 +603,18 @@ impl CliProgressReporter {
 				serde_json::Value::String(name.to_string())
 			}),
 		);
-		self.emit_json_event(&serde_json::Value::Object(payload));
+		Self::emit_json_event(&serde_json::Value::Object(payload));
 	}
 
-	fn emit_json_event(&self, value: &serde_json::Value) {
-		with_stderr_lock(&self.writer_lock, || {
-			eprintln!(
+	fn emit_json_event(value: &serde_json::Value) {
+		with_stderr_lock(|lock| {
+			let _ = writeln!(
+				lock,
 				"{}",
 				serde_json::to_string(&value)
 					.unwrap_or_else(|error| panic!("progress json event serialization: {error}"))
 			);
-			let _ = io::stderr().flush();
+			let _ = lock.flush();
 		});
 	}
 }
@@ -654,11 +652,10 @@ fn paint_text(text: &str, style: Style, color: bool) -> String {
 	format!("\u{1b}[{code}m{text}\u{1b}[0m")
 }
 
-fn with_stderr_lock(write_lock: &Arc<Mutex<()>>, action: impl FnOnce()) {
-	let _lock = write_lock
-		.lock()
-		.unwrap_or_else(std::sync::PoisonError::into_inner);
-	action();
+fn with_stderr_lock(action: impl FnOnce(&mut io::StderrLock<'static>)) {
+	let stderr = io::stderr();
+	let mut lock = stderr.lock();
+	action(&mut lock);
 }
 
 fn format_duration(duration: Duration) -> String {

--- a/crates/monochange/src/publish_progress.rs
+++ b/crates/monochange/src/publish_progress.rs
@@ -1,6 +1,7 @@
 use std::fmt::Write as _;
 use std::io;
 use std::io::IsTerminal;
+use std::io::Write;
 
 use monochange_publish::EcosystemProgressPresentation;
 use monochange_publish::PublishProgressEvent;
@@ -116,8 +117,28 @@ impl PublishProgressReporter for StderrPublishProgressReporter {
 		if !self.enabled {
 			return;
 		}
-		eprintln!("{}", Self::render_event(&event, self.interactive));
+		let output = render_report_line(&event, self.interactive);
+		let stderr = io::stderr();
+		let mut lock = stderr.lock();
+		let _ = lock.write_all(output.as_bytes());
+		let _ = lock.flush();
 	}
+}
+
+/// Renders a publish progress line, clearing any active CLI step spinner line
+/// first so publish progress always starts on its own line instead of appending
+/// to the spinner.
+fn render_report_line(event: &PublishProgressEvent, interactive: bool) -> String {
+	let mut output = String::new();
+	if interactive {
+		output.push_str("\r\u{1b}[2K\u{1b}[0m");
+	}
+	output.push_str(&StderrPublishProgressReporter::render_event(
+		event,
+		interactive,
+	));
+	output.push('\n');
+	output
 }
 
 fn start_symbol(interactive: bool) -> &'static str {


### PR DESCRIPTION
## Summary

Publish progress events (e.g. `◆ Publishing 56 packages …`, per-package `⏭️`/`✅`/`❌` lines) previously appended to the active CLI step spinner line, so leading symbols appeared mid-line instead of at the start of a new line:

```
⠙ [1/1] PlaceholderPublish — publishing placeholders per package◆ Publishing 56 packages (Placeholder) across 📦 npm, 🎯 dart
⠙ [1/1] PlaceholderPublish — publishing placeholders per package⏭️ 📦 npm codama-renderers-dart … already exists on npm
```

## Fix

- `CliProgressReporter` now writes through the **global stderr lock** (`io::stderr().lock()`) instead of a per-instance mutex, so the step spinner and publish progress serialize on the same lock.
- `StderrPublishProgressReporter::report` clears the active spinner line (`\r\x1b[2K\x1b[0m`) before writing each publish progress line, so every publish line starts on its own line while the spinner continues animating below it.

## Test plan

- [x] New unit test `render_report_line_clears_active_spinner_line_when_interactive` verifies the clear-before-line behavior (and that non-interactive output has no terminal codes)
- [x] Existing `cli_progress` unit + TTY integration tests pass
- [x] `cargo test --workspace` green
- [x] `lint:all` green (clippy, fmt, schema, changeset, architecture, workflows)