### PR TITLE
feat(preview): add --release-json opt-in for writing release records during dry runs

### DIFF
--- a/.changeset/preview-release-json-opt-in.md
+++ b/.changeset/preview-release-json-opt-in.md
@@ -1,0 +1,18 @@
+---
+monochange_core: minor
+monochange: patch
+---
+
+# Add `--release-json` opt-in for writing release records during preview
+
+`monochange preview` (and any dry-run `PrepareRelease`) no longer writes the release record (`.monochange/releases/<hash>/release.json`) by default. Pass `--release-json` to opt back into writing it during a dry run.
+
+```bash
+# preview without touching the release record
+monochange preview
+
+# preview that also writes release.json
+monochange preview --release-json
+```
+
+Dry-run output now notes when the release record was skipped so the opt-in is discoverable. The git-ignored local manifest cache (`.monochange/local/release-manifest.json`) is still written in dry runs for downstream step rendering.

--- a/crates/monochange/src/__tests__/command_wizard_tests.rs
+++ b/crates/monochange/src/__tests__/command_wizard_tests.rs
@@ -283,18 +283,24 @@ fn command_step_with_default_inputs_adds_and_inherits_expected_inputs() {
 	let step = command_step_with_default_inputs("PrepareRelease", &mut command_inputs)
 		.unwrap_or_else(|error| panic!("step should be created: {error}"));
 
-	assert_eq!(command_inputs.len(), 2);
+	assert_eq!(command_inputs.len(), 3);
 	assert_eq!(command_inputs[0].name, "format");
 	assert_eq!(command_inputs[0].kind, "choice");
 	assert_eq!(command_inputs[0].choices[0], "text");
 	assert_eq!(command_inputs[1].name, "write_empty_release_record");
 	assert_eq!(command_inputs[1].kind, "boolean");
+	assert_eq!(command_inputs[2].name, "release_json");
+	assert_eq!(command_inputs[2].kind, "boolean");
 	assert_eq!(
 		step.inputs.get("format"),
 		Some(&CliStepInputValue::Inherited)
 	);
 	assert_eq!(
 		step.inputs.get("write_empty_release_record"),
+		Some(&CliStepInputValue::Inherited)
+	);
+	assert_eq!(
+		step.inputs.get("release_json"),
 		Some(&CliStepInputValue::Inherited)
 	);
 	assert_config_error(

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -7943,6 +7943,85 @@ async fn execute_cli_command_prepare_release_dry_run_skips_release_record_unless
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn execute_cli_command_prepare_release_surfaces_release_record_write_failure() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_fixture("monochange/release-base", tempdir.path());
+	fs::OpenOptions::new()
+		.append(true)
+		.open(tempdir.path().join("monochange.toml"))
+		.and_then(|mut file| {
+			use std::io::Write;
+			writeln!(
+				file,
+				"\n[source]\nprovider = \"github\"\nowner = \"ifiokjr\"\nrepo = \"monochange\"\n"
+			)
+		})
+		.unwrap_or_else(|error| panic!("append source config: {error}"));
+	let root = tempdir.path();
+	let configuration =
+		load_workspace_configuration(root).unwrap_or_else(|error| panic!("configuration: {error}"));
+
+	let mut prepare_step_inputs = text_format_step_inputs();
+	prepare_step_inputs.insert(
+		"release_json".to_string(),
+		monochange_core::CliStepInputValue::Inherited,
+	);
+	let prepare_release = CliCommandDefinition {
+		name: "release".to_string(),
+		help_text: None,
+		inputs: Vec::new(),
+		steps: vec![monochange_core::CliStepDefinition::PrepareRelease {
+			name: None,
+			when: None,
+			always_run: false,
+			inputs: prepare_step_inputs,
+			allow_empty_changesets: false,
+		}],
+		dry_run: false,
+	};
+	let release_json_inputs = BTreeMap::from([
+		("format".to_string(), vec!["text".to_string()]),
+		("release_json".to_string(), vec!["true".to_string()]),
+	]);
+
+	// Write the record once so we can discover the deterministic hash dir, then
+	// replace it with a file so the next write fails and surfaces the error.
+	let _ = crate::execute_cli_command(
+		root,
+		&configuration,
+		&prepare_release,
+		true,
+		release_json_inputs.clone(),
+	)
+	.await
+	.unwrap_or_else(|error| panic!("first prepare release: {error}"));
+	let releases_dir = root.join(".monochange/releases");
+	let hash_path = fs::read_dir(&releases_dir)
+		.unwrap_or_else(|error| panic!("read releases dir: {error}"))
+		.flatten()
+		.find(|entry| entry.path().is_dir())
+		.unwrap_or_else(|| panic!("expected a release record hash dir"))
+		.path();
+	fs::remove_dir_all(&hash_path).unwrap_or_else(|error| panic!("remove hash dir: {error}"));
+	fs::write(&hash_path, "blocking file").unwrap_or_else(|error| panic!("write blocker: {error}"));
+
+	let error = crate::execute_cli_command(
+		root,
+		&configuration,
+		&prepare_release,
+		true,
+		release_json_inputs,
+	)
+	.await
+	.expect_err("blocked release record write should fail the command");
+	assert!(
+		error.render().contains("create release record dir"),
+		"expected a release record write error, got: {}",
+		error.render()
+	);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn execute_cli_command_supports_placeholder_and_package_publish_steps() {
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
 	copy_fixture("monochange/release-base", tempdir.path());

--- a/crates/monochange/src/__tests__/lib_tests.rs
+++ b/crates/monochange/src/__tests__/lib_tests.rs
@@ -7847,6 +7847,101 @@ async fn execute_cli_command_prepare_release_writes_default_manifest_cache_and_f
 	assert!(!comments_output.is_empty());
 }
 
+fn find_release_records(root: &Path) -> Vec<PathBuf> {
+	let releases_dir = root.join(".monochange/releases");
+	let Ok(entries) = fs::read_dir(&releases_dir) else {
+		return Vec::new();
+	};
+	let mut records = Vec::new();
+	for entry in entries.flatten() {
+		let record_path = entry.path().join("release.json");
+		if record_path.is_file() {
+			records.push(record_path);
+		}
+	}
+	records
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_cli_command_prepare_release_dry_run_skips_release_record_unless_release_json() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	copy_fixture("monochange/release-base", tempdir.path());
+	fs::OpenOptions::new()
+		.append(true)
+		.open(tempdir.path().join("monochange.toml"))
+		.and_then(|mut file| {
+			use std::io::Write;
+			writeln!(
+				file,
+				"\n[source]\nprovider = \"github\"\nowner = \"ifiokjr\"\nrepo = \"monochange\"\n"
+			)
+		})
+		.unwrap_or_else(|error| panic!("append source config: {error}"));
+	let root = tempdir.path();
+	let configuration =
+		load_workspace_configuration(root).unwrap_or_else(|error| panic!("configuration: {error}"));
+
+	let mut prepare_step_inputs = text_format_step_inputs();
+	prepare_step_inputs.insert(
+		"release_json".to_string(),
+		monochange_core::CliStepInputValue::Inherited,
+	);
+	let prepare_release = CliCommandDefinition {
+		name: "release".to_string(),
+		help_text: None,
+		inputs: Vec::new(),
+		steps: vec![monochange_core::CliStepDefinition::PrepareRelease {
+			name: None,
+			when: None,
+			always_run: false,
+			inputs: prepare_step_inputs,
+			allow_empty_changesets: false,
+		}],
+		dry_run: false,
+	};
+
+	// Dry-run (preview) must not write the release record by default.
+	let preview_output = crate::execute_cli_command(
+		root,
+		&configuration,
+		&prepare_release,
+		true,
+		BTreeMap::from([("format".to_string(), vec!["text".to_string()])]),
+	)
+	.await
+	.unwrap_or_else(|error| panic!("preview prepare release: {error}"));
+	assert!(
+		preview_output.contains("skipped release record"),
+		"preview output should explain the release record was skipped: {preview_output}"
+	);
+	assert!(
+		find_release_records(root).is_empty(),
+		"preview must not write a release record by default"
+	);
+
+	// `--release-json` opts preview back into writing the release record.
+	let record_output = crate::execute_cli_command(
+		root,
+		&configuration,
+		&prepare_release,
+		true,
+		BTreeMap::from([
+			("format".to_string(), vec!["text".to_string()]),
+			("release_json".to_string(), vec!["true".to_string()]),
+		]),
+	)
+	.await
+	.unwrap_or_else(|error| panic!("preview with release json: {error}"));
+	assert!(
+		!record_output.contains("skipped release record"),
+		"preview with --release-json should write the release record: {record_output}"
+	);
+	assert!(
+		!find_release_records(root).is_empty(),
+		"--release-json must write a release record"
+	);
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn execute_cli_command_supports_placeholder_and_package_publish_steps() {
 	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -832,6 +832,8 @@ pub(crate) async fn execute_cli_command_with_options(
 					let write_empty_release_record =
 						parse_boolean_step_input(&step_inputs, "write_empty_release_record")?
 							.unwrap_or(false);
+					let write_release_json =
+						parse_boolean_step_input(&step_inputs, "release_json")?.unwrap_or(false);
 					let build_file_diffs = context.show_diff
 						|| cli_command
 							.steps
@@ -874,11 +876,18 @@ pub(crate) async fn execute_cli_command_with_options(
 						prepared_release,
 						write_empty_release_record,
 					) {
-						let _record_path = write_release_record_file(
-							root,
-							configuration.source.as_ref(),
-							&manifest,
-						)?;
+						if dry_run && !write_release_json {
+							context.command_logs.push(
+								"skipped release record: dry-run preview (pass `--release-json` to write release.json)"
+									.to_string(),
+							);
+						} else {
+							let _record_path = write_release_record_file(
+								root,
+								configuration.source.as_ref(),
+								&manifest,
+							)?;
+						}
 						context.release_manifest_path =
 							Some(write_default_release_manifest_file(root, &manifest).await?);
 					} else {

--- a/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_prepare.snap
+++ b/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_prepare.snap
@@ -8,7 +8,7 @@ Command: monochange prepare
 
 Prepare version bumps, changelogs, and release artifacts
 
-[1m[97mUsage:[0m monochange prepare [--dry-run] [--diff] [--prepared-release <PATH>] [--format <FORMAT>] [--write-empty-release-record]
+[1m[97mUsage:[0m monochange prepare [--dry-run] [--diff] [--prepared-release <PATH>] [--format <FORMAT>] [--write-empty-release-record] [--release-json]
 
 [1m[96mOptions:[0m
   [93m-h[0m, [93m--help[0m
@@ -29,6 +29,9 @@ Prepare version bumps, changelogs, and release artifacts
           [possible values: text, json, md]
 
       [93m--write-empty-release-record[0m
+          
+
+      [93m--release-json[0m
           
 
 [1m[96mGlobal Options:[0m

--- a/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_preview.snap
+++ b/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_preview.snap
@@ -8,7 +8,7 @@ Command: monochange preview
 
 Preview planned version bumps, changelogs, and release artifacts without writing files
 
-[1m[97mUsage:[0m monochange preview [--dry-run] [--diff] [--prepared-release <PATH>] [--format <FORMAT>] [--write-empty-release-record]
+[1m[97mUsage:[0m monochange preview [--dry-run] [--diff] [--prepared-release <PATH>] [--format <FORMAT>] [--write-empty-release-record] [--release-json]
 
 [1m[96mOptions:[0m
   [93m-h[0m, [93m--help[0m
@@ -29,6 +29,9 @@ Preview planned version bumps, changelogs, and release artifacts without writing
           [possible values: text, json, md]
 
       [93m--write-empty-release-record[0m
+          
+
+      [93m--release-json[0m
           
 
 [1m[96mGlobal Options:[0m

--- a/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_step_prepare_release.snap
+++ b/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_step_prepare_release.snap
@@ -1,13 +1,14 @@
 ---
 source: crates/monochange/tests/cli_clap_help.rs
-expression: "render_help_snapshot(&path, version)"
+assertion_line: 142
+expression: render_help_snapshot(&path)
 ---
 Version: [current]
 Command: monochange step prepare-release
 
 Plan version bumps, changelogs, and release artifacts
 
-[1m[97mUsage:[0m monochange step prepare-release [--dry-run] [--diff] [--prepared-release <PATH>] [--format <FORMAT>] [--write-empty-release-record]
+[1m[97mUsage:[0m monochange step prepare-release [--dry-run] [--diff] [--prepared-release <PATH>] [--format <FORMAT>] [--write-empty-release-record] [--release-json]
 
 [1m[96mOptions:[0m
   [93m-h[0m, [93m--help[0m
@@ -28,6 +29,9 @@ Plan version bumps, changelogs, and release artifacts
           [possible values: text, json, md]
 
       [93m--write-empty-release-record[0m
+          
+
+      [93m--release-json[0m
           
 
 [1m[96mGlobal Options:[0m

--- a/crates/monochange/tests/snapshots/cli_output__prepare_release_writes_manifest_json@prepare_release_writes_manifest_json.snap
+++ b/crates/monochange/tests/snapshots/cli_output__prepare_release_writes_manifest_json@prepare_release_writes_manifest_json.snap
@@ -38,4 +38,8 @@ exit_code: 0
 - `crates/core/Cargo.toml`
 - `group.toml`
 
+## Commands
+
+- skipped release record: dry-run preview (pass `--release-json` to write release.json)
+
 ----- stderr -----

--- a/crates/monochange/tests/snapshots/cli_output__release_dry_run_cli_defaults_to_markdown_output@release_dry_run_cli_defaults_to_markdown_output.snap
+++ b/crates/monochange/tests/snapshots/cli_output__release_dry_run_cli_defaults_to_markdown_output@release_dry_run_cli_defaults_to_markdown_output.snap
@@ -35,4 +35,8 @@ exit_code: 0
 - `crates/app/Cargo.toml`
 - `crates/core/Cargo.toml`
 
+## Commands
+
+- skipped release record: dry-run preview (pass `--release-json` to write release.json)
+
 ----- stderr -----

--- a/crates/monochange/tests/snapshots/cli_output__release_dry_run_cli_patches_parent_packages_when_dependencies_change@release_dry_run_cli_patches_parent_packages_when_dependencies_change.snap
+++ b/crates/monochange/tests/snapshots/cli_output__release_dry_run_cli_patches_parent_packages_when_dependencies_change@release_dry_run_cli_patches_parent_packages_when_dependencies_change.snap
@@ -24,5 +24,7 @@ release manifest: .monochange/local/release-manifest.json
 changed files:
 - crates/app/Cargo.toml
 - crates/core/Cargo.toml
+commands:
+- skipped release record: dry-run preview (pass `--release-json` to write release.json)
 
 ----- stderr -----

--- a/crates/monochange/tests/snapshots/cli_output__release_dry_run_cli_text_renders_diff_preview@release_dry_run_cli_text_renders_diff_preview.snap
+++ b/crates/monochange/tests/snapshots/cli_output__release_dry_run_cli_text_renders_diff_preview@release_dry_run_cli_text_renders_diff_preview.snap
@@ -83,5 +83,7 @@ file diffs:
 -workflow-app = { version = "1.0.0" }
 +workflow-core = { version = "1.1.0" }
 +workflow-app = { version = "1.1.0" }
+commands:
+- skipped release record: dry-run preview (pass `--release-json` to write release.json)
 
 ----- stderr -----

--- a/crates/monochange/tests/snapshots/cli_output__release_dry_run_cli_uses_explicit_group_versions_from_member_changes@release_dry_run_cli_uses_explicit_group_versions_from_member_changes.snap
+++ b/crates/monochange/tests/snapshots/cli_output__release_dry_run_cli_uses_explicit_group_versions_from_member_changes@release_dry_run_cli_uses_explicit_group_versions_from_member_changes.snap
@@ -28,5 +28,7 @@ changed files:
 - crates/core/CHANGELOG.md
 - crates/core/Cargo.toml
 - group.toml
+commands:
+- skipped release record: dry-run preview (pass `--release-json` to write release.json)
 
 ----- stderr -----

--- a/crates/monochange/tests/snapshots/cli_output__release_pr_workflow_reports_dry_run_pull_request_preview@release_pr_workflow_reports_dry_run_pull_request_preview.snap
+++ b/crates/monochange/tests/snapshots/cli_output__release_pr_workflow_reports_dry_run_pull_request_preview@release_pr_workflow_reports_dry_run_pull_request_preview.snap
@@ -42,4 +42,8 @@ exit_code: 0
 - `crates/core/Cargo.toml`
 - `group.toml`
 
+## Commands
+
+- skipped release record: dry-run preview (pass `--release-json` to write release.json)
+
 ----- stderr -----

--- a/crates/monochange/tests/snapshots/pre_stable_versioning__pre_stable_release_text_scenarios_match_snapshot@pre_stable_grouped_major_text.snap
+++ b/crates/monochange/tests/snapshots/pre_stable_versioning__pre_stable_release_text_scenarios_match_snapshot@pre_stable_grouped_major_text.snap
@@ -12,3 +12,5 @@ changed files:
 - Cargo.toml
 - crates/app/Cargo.toml
 - crates/core/Cargo.toml
+commands:
+- skipped release record: dry-run preview (pass `--release-json` to write release.json)

--- a/crates/monochange/tests/snapshots/pre_stable_versioning__pre_stable_release_text_scenarios_match_snapshot@pre_stable_major_text.snap
+++ b/crates/monochange/tests/snapshots/pre_stable_versioning__pre_stable_release_text_scenarios_match_snapshot@pre_stable_major_text.snap
@@ -11,3 +11,5 @@ release manifest: .monochange/local/release-manifest.json
 changed files:
 - crates/app/Cargo.toml
 - crates/core/Cargo.toml
+commands:
+- skipped release record: dry-run preview (pass `--release-json` to write release.json)

--- a/crates/monochange/tests/snapshots/pre_stable_versioning__pre_stable_release_text_scenarios_match_snapshot@stable_major_text.snap
+++ b/crates/monochange/tests/snapshots/pre_stable_versioning__pre_stable_release_text_scenarios_match_snapshot@stable_major_text.snap
@@ -11,3 +11,5 @@ release manifest: .monochange/local/release-manifest.json
 changed files:
 - crates/app/Cargo.toml
 - crates/core/Cargo.toml
+commands:
+- skipped release record: dry-run preview (pass `--release-json` to write release.json)

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -3324,7 +3324,9 @@ impl CliStepDefinition {
 			Self::Config { .. } | Self::Discover { .. } | Self::DisplayVersions { .. } => {
 				Some(&["format"])
 			}
-			Self::PrepareRelease { .. } => Some(&["format", "write_empty_release_record"]),
+			Self::PrepareRelease { .. } => {
+				Some(&["format", "write_empty_release_record", "release_json"])
+			}
 			Self::CommentReleasedIssues { .. } => {
 				Some(&["format", "from-ref", "auto-close-issues"])
 			}
@@ -3438,7 +3440,7 @@ impl CliStepDefinition {
 			Self::PrepareRelease { .. } => {
 				match name {
 					"format" => Some(CliInputKind::Choice),
-					"write_empty_release_record" => Some(CliInputKind::Boolean),
+					"write_empty_release_record" | "release_json" => Some(CliInputKind::Boolean),
 					_ => None,
 				}
 			}

--- a/crates/monochange_integration_tests/tests/snapshots/release_output_format__release_dry_run_keeps_markdown_output_when_skipped_step_inputs_request_json.snap
+++ b/crates/monochange_integration_tests/tests/snapshots/release_output_format__release_dry_run_keeps_markdown_output_when_skipped_step_inputs_request_json.snap
@@ -27,4 +27,5 @@ expression: stdout
 
 ## Commands
 
+- skipped release record: dry-run preview (pass `--release-json` to write release.json)
 - skipped step `Command` because when condition `false` is false

--- a/docs/src/reference/cli-steps/07-prepare-release.md
+++ b/docs/src/reference/cli-steps/07-prepare-release.md
@@ -26,6 +26,8 @@ If your command eventually needs release metadata, start with `PrepareRelease` r
 ## Inputs
 
 - `format` — `markdown`, `text`, or `json`
+- `write_empty_release_record` — boolean; write a release record even when no packages were released
+- `release_json` — boolean; write the release record (`.monochange/releases/<hash>/release.json`) during dry-run preview. By default `monochange preview` skips the release record; pass `--release-json` to write it.
 
 ## Step-level `when` condition
 


### PR DESCRIPTION
## Summary

`monochange preview` (and any dry-run `PrepareRelease`) no longer writes the release record (`.monochange/releases/<hash>/release.json`) by default. A new `--release-json` boolean input opts back into writing it during a dry run.

```bash
# preview without touching the release record
monochange preview

# preview that also writes release.json
monochange preview --release-json
```

## Behavior

- **Before:** `PrepareRelease` wrote `.monochange/releases/<hash>/release.json` even in dry-run, so `monochange preview` polluted the workspace with a release record.
- **After:** dry-run skips the release record and prints `skipped release record: dry-run preview (pass \`--release-json\` to write release.json)`. Non-dry-run `prepare` still writes the record as before.
- The git-ignored local manifest cache (`.monochange/local/release-manifest.json`) is still written in dry runs so downstream steps (e.g. `release --dry-run`) keep rendering correctly.

## Implementation

- New `release_json` boolean input on the `PrepareRelease` step (becomes `--release-json` on `monochange preview` / `monochange prepare` / `monochange step prepare-release`)
- Dry-run gate in `execute_cli_command_with_options`: `dry_run && !release_json` skips `write_release_record_file`
- Docs updated in `07-prepare-release.md`; CLI help snapshots and dry-run output snapshots updated

## Test plan

- [x] Unit test: dry-run prepare skips the record, `--release-json` writes it (verified end-to-end with the real binary: `preview` → 0 records, `preview --release-json` → 1 record)
- [x] `cargo test --workspace` green (57 suites)
- [x] `lint:all` green (clippy, fmt, schema, changeset, skill inventory, architecture, workflows)