### PR TITLE
fix(cli): swap spinner frames in place instead of reprinting the full line

### DIFF
--- a/.changeset/spinner-frame-in-place-update.md
+++ b/.changeset/spinner-frame-in-place-update.md
@@ -1,0 +1,9 @@
+---
+monochange: patch
+---
+
+# Swap the load status indicator frames in place instead of reprinting the line
+
+The load status indicator (spinner) previously rewrote its full line on every 90ms frame tick. When output is captured through a pty or log capture tool that renders carriage returns as new lines, every frame change produced a separate line, making logs very long.
+
+The spinner now writes the full line only when the content changes — when it starts or after another writer (for example command output or publish progress) clears the line. Between those events it swaps only the frame character in place, so captured output stays compact while terminals still animate.

--- a/crates/monochange/src/__tests__/cli_progress_tests.rs
+++ b/crates/monochange/src/__tests__/cli_progress_tests.rs
@@ -191,7 +191,6 @@ fn progress_reporter_animates_named_steps_and_stops_cleanly() {
 }
 
 #[test]
-#[test]
 fn pause_spinner_stops_animation_and_reports_whether_it_was_active() {
 	let mut reporter = progress_reporter(true, true);
 	reporter.animate = true;

--- a/crates/monochange/src/__tests__/cli_progress_tests.rs
+++ b/crates/monochange/src/__tests__/cli_progress_tests.rs
@@ -191,6 +191,7 @@ fn progress_reporter_animates_named_steps_and_stops_cleanly() {
 }
 
 #[test]
+#[test]
 fn pause_spinner_stops_animation_and_reports_whether_it_was_active() {
 	let mut reporter = progress_reporter(true, true);
 	reporter.animate = true;
@@ -205,6 +206,47 @@ fn pause_spinner_stops_animation_and_reports_whether_it_was_active() {
 
 	// The spinner thread is stopped; a second pause reports false.
 	assert!(!reporter.pause_spinner());
+}
+
+#[test]
+fn spinner_tick_renders_full_line_only_when_content_changes() {
+	// First tick (or after another writer cleared the line): full line with
+	// erase so the message is always visible.
+	assert_eq!(
+		render_spinner_tick("\u{2B8B}", "running command `x`", false, true),
+		"\r\u{1b}[2K\u{1b}[0m\u{2B8B} running command `x`",
+	);
+	// Unchanged content: only the frame is swapped in place, the message is
+	// not reprinted.
+	assert_eq!(
+		render_spinner_tick("\u{2B99}", "running command `x`", false, false),
+		"\r\u{2B99}",
+	);
+	// Color mode paints the frame.
+	assert_eq!(
+		render_spinner_tick("\u{2B8B}", "msg", true, true),
+		"\r\u{1b}[2K\u{1b}[0m\u{1b}[36;1m\u{2B8B}\u{1b}[0m msg",
+	);
+	assert_eq!(
+		render_spinner_tick("\u{2B99}", "msg", true, false),
+		"\r\u{1b}[36;1m\u{2B99}\u{1b}[0m",
+	);
+}
+
+#[test]
+fn spinner_rewrites_full_line_after_another_writer_clears_it() {
+	let mut reporter = progress_reporter(true, true);
+	reporter.animate = true;
+	let step = named_command_step("announce release");
+
+	reporter.step_started(0, &step);
+	thread::sleep(SPINNER_DELAY + SPINNER_TICK + Duration::from_millis(20));
+	// Simulate another writer (for example `print_line` or publish progress)
+	// clearing the spinner line: the next tick must restore the full line.
+	mark_spinner_line_cleared();
+	thread::sleep(SPINNER_TICK + Duration::from_millis(20));
+	reporter.step_finished(0, &step, Duration::from_millis(12), &[]);
+	reporter.command_finished(Duration::from_millis(25));
 }
 
 #[test]

--- a/crates/monochange/src/__tests__/publish_progress_tests.rs
+++ b/crates/monochange/src/__tests__/publish_progress_tests.rs
@@ -118,6 +118,13 @@ fn disabled_reporter_ignores_events() {
 }
 
 #[test]
+fn interactive_reporter_marks_spinner_line_cleared() {
+	let mut reporter = StderrPublishProgressReporter::new(false);
+	reporter.interactive = true;
+	reporter.report(PublishProgressEvent::PackageStarted(package()));
+}
+
+#[test]
 fn render_report_line_clears_active_spinner_line_when_interactive() {
 	let event = PublishProgressEvent::RunStarted {
 		mode: PackagePublishRunMode::Placeholder,

--- a/crates/monochange/src/cli_progress.rs
+++ b/crates/monochange/src/cli_progress.rs
@@ -24,6 +24,17 @@ const SPINNER_DELAY: Duration = Duration::from_millis(120);
 const PHASE_TIMING_DETAIL_LIMIT: usize = 5;
 const PHASE_TIMING_MINIMUM: Duration = Duration::from_millis(5);
 
+/// Set by any writer that clears the active spinner line (for example
+/// `print_line` or publish progress) so the spinner thread knows the message
+/// must be rewritten in full instead of swapping only the frame in place.
+static SPINNER_LINE_CLEARED: AtomicBool = AtomicBool::new(false);
+
+/// Marks the active spinner line as cleared by another writer. The next
+/// spinner tick rewrites the full line so the message stays visible.
+pub(crate) fn mark_spinner_line_cleared() {
+	SPINNER_LINE_CLEARED.store(true, Ordering::Relaxed);
+}
+
 #[derive(Clone, Copy)]
 pub(crate) enum CommandStream {
 	Stdout,
@@ -505,17 +516,17 @@ impl CliProgressReporter {
 		let spinner_frames = self.symbols.spinner_frames;
 		let handle = thread::spawn(move || {
 			thread::sleep(SPINNER_DELAY);
+			let mut full_line = true;
 			for frame in spinner_frames.iter().copied().cycle() {
 				if stop_flag.load(Ordering::Relaxed) {
 					break;
 				}
 				with_stderr_lock(|lock| {
-					let _ = write!(
-						lock,
-						"\r\u{1b}[2K\u{1b}[0m{} {}",
-						paint_text(frame, Style::Accent, color),
-						message,
-					);
+					let line_cleared = SPINNER_LINE_CLEARED.swap(false, Ordering::Relaxed);
+					let rendered =
+						render_spinner_tick(frame, &message, color, full_line || line_cleared);
+					full_line = false;
+					let _ = lock.write_all(rendered.as_bytes());
 					let _ = lock.flush();
 				});
 				rendered_flag.store(true, Ordering::Relaxed);
@@ -558,6 +569,7 @@ impl CliProgressReporter {
 			let _ = write!(lock, "\r\u{1b}[2K\u{1b}[0m");
 			let _ = writeln!(lock, "{text}");
 			let _ = lock.flush();
+			SPINNER_LINE_CLEARED.store(true, Ordering::Relaxed);
 		});
 	}
 
@@ -660,6 +672,22 @@ fn paint_text(text: &str, style: Style, color: bool) -> String {
 		Style::Muted => "2",
 	};
 	format!("\u{1b}[{code}m{text}\u{1b}[0m")
+}
+
+/// Renders a single spinner tick. The full line (with erase) is only written
+/// when the message must be (re)established — the first tick or after another
+/// writer cleared the line. Otherwise only the frame is swapped in place so
+/// captured output does not reprint the whole line on every tick.
+fn render_spinner_tick(frame: &str, message: &str, color: bool, full_line: bool) -> String {
+	if full_line {
+		format!(
+			"\r\u{1b}[2K\u{1b}[0m{} {}",
+			paint_text(frame, Style::Accent, color),
+			message,
+		)
+	} else {
+		format!("\r{}", paint_text(frame, Style::Accent, color))
+	}
 }
 
 fn with_stderr_lock(action: impl FnOnce(&mut io::StderrLock<'static>)) {

--- a/crates/monochange/src/publish_progress.rs
+++ b/crates/monochange/src/publish_progress.rs
@@ -122,6 +122,9 @@ impl PublishProgressReporter for StderrPublishProgressReporter {
 		let mut lock = stderr.lock();
 		let _ = lock.write_all(output.as_bytes());
 		let _ = lock.flush();
+		if self.interactive {
+			crate::cli_progress::mark_spinner_line_cleared();
+		}
 	}
 }
 

--- a/crates/monochange/tests/cli_progress.rs
+++ b/crates/monochange/tests/cli_progress.rs
@@ -252,6 +252,31 @@ fn release_progress_streams_named_steps_on_tty() {
 
 #[test]
 #[cfg(unix)]
+fn spinner_swaps_frames_in_place_without_reprinting_the_full_line() {
+	let tempdir = setup_fixture("monochange/release-progress");
+
+	let (status, transcript) = run_in_tty(tempdir.path(), &["progress-spinner"], None, &[]);
+	assert_eq!(status, 0, "{transcript}");
+
+	// The full spinner line (message included) must only be written when the
+	// content changes: once when the spinner starts and once after the command
+	// output line clears it. Frame-only in-place updates must not reprint it.
+	let full_line_count = transcript
+		.matches("running command `sleep 1.5; echo done`")
+		.count();
+	assert!(
+		full_line_count <= 4,
+		"spinner reprinted the full line {full_line_count} times:\n{transcript}"
+	);
+	// The spinner still animates in place between full-line writes.
+	assert!(
+		transcript.contains("\r⠙"),
+		"expected in-place frame updates in transcript:\n{transcript}"
+	);
+}
+
+#[test]
+#[cfg(unix)]
 fn release_progress_renders_skipped_failed_steps_and_stderr_on_tty() {
 	let tempdir = setup_fixture("monochange/release-progress-failure");
 

--- a/crates/monochange/tests/cli_progress.rs
+++ b/crates/monochange/tests/cli_progress.rs
@@ -255,7 +255,16 @@ fn release_progress_streams_named_steps_on_tty() {
 fn spinner_swaps_frames_in_place_without_reprinting_the_full_line() {
 	let tempdir = setup_fixture("monochange/release-progress");
 
-	let (status, transcript) = run_in_tty(tempdir.path(), &["progress-spinner"], None, &[]);
+	// Force the test-harness detection so the spinner animates even when the
+	// test runner does not set the usual harness variables (for example the
+	// coverage job runs plain `cargo llvm-cov test` with CI env vars set).
+	let (status, transcript) = run_in_tty_with_env(
+		tempdir.path(),
+		&["progress-spinner"],
+		None,
+		&[("INSTA_WORKSPACE_ROOT", "1")],
+		&[],
+	);
 	assert_eq!(status, 0, "{transcript}");
 
 	// The full spinner line (message included) must only be written when the

--- a/crates/monochange/tests/test_support.rs
+++ b/crates/monochange/tests/test_support.rs
@@ -311,7 +311,9 @@ pub fn run_in_tty(
 
 /// Run a monochange command in a pty with additional environment variables
 /// applied to the child process.
+#[cfg(unix)]
 #[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
 pub fn run_in_tty_with_env(
 	workspace: &Path,
 	args: &[&str],

--- a/deny.toml
+++ b/deny.toml
@@ -37,16 +37,15 @@ skip = [
 	# direct control. Track them explicitly so cargo-deny stays focused on new
 	# duplicate introductions.
 	"getrandom@0.2.17",
-	"getrandom@0.4.2",
+	"getrandom@0.4.3",
 	"r-efi@5.3.0",
-	"rand@0.8.6",
+	"rand@0.8.7",
 	"rand_chacha@0.3.1",
 	"rand_core@0.6.4",
 	"shlex@1.3.0",
 	"similar@2.7.0",
 	"unicode-width@0.1.14",
 	"windows-sys@0.52.0",
-	"wit-bindgen@0.51.0",
 ]
 
 [sources]

--- a/fixtures/tests/monochange/release-progress/monochange.toml
+++ b/fixtures/tests/monochange/release-progress/monochange.toml
@@ -47,6 +47,12 @@ steps = [
   { type = "Command", name = "stream summary", shell = true, command = "printf 'line one\n\nline three\n'" },
 ]
 
+[cli.progress-spinner]
+help_text = "Exercise spinner output"
+steps = [
+  { type = "Command", name = "slow spinner", shell = true, command = "sleep 1.5; echo done" },
+]
+
 [cli.progress-json]
 help_text = "Exercise progress output"
 steps = [


### PR DESCRIPTION
## Summary

The load status indicator (spinner) rewrote its full line on every 90ms frame tick. When output is captured through a pty or a log capture tool that renders carriage returns as new lines, every frame change produced a separate line, making logs very long (for example `monochange run publish`):

```
⠋ [1/3] publish dart packages (Command) — running command `m⠙ [1/3] publish dart packages (Command) — running command `m⠹ [1/3] ...
```

## Changes

- The spinner now writes the full line only when the content changes: when it starts, or after another writer (command output, publish progress) clears the line.
- Between those events it swaps only the frame character in place (`\r⠙`), so captured output stays compact while terminals still animate.
- A shared `SPINNER_LINE_CLEARED` flag lets `print_line` and the publish progress reporter signal that the spinner line was cleared, so the spinner restores the full message on the next tick instead of orphaning a bare frame character.

## Verification

- New unit tests cover the tick renderer (full line vs frame-only, color mode) and the line-cleared restore path.
- New pty integration test (`spinner_swaps_frames_in_place_without_reprinting_the_full_line`) asserts the full line is written at most 4 times for a 1.5s command while in-place frame updates still occur. Confirmed the test fails without the fix (old behavior reprints the full line ~16 times).
- End-to-end check: a 1.5s command now produces 1 full line + 15 frame-only updates instead of ~16 full lines.
- `cargo test --workspace` green, `cargo fmt --check` clean, clippy clean, `coverage:patch` 19/19 (100.00%), `monochange step validate` passes.
