### PR TITLE
fix(cli): add -i short flag and hide the loader during interactive prompts

### DIFF
--- a/.changeset/interactive-picker-group-label-length.md
+++ b/.changeset/interactive-picker-group-label-length.md
@@ -1,0 +1,7 @@
+---
+"monochange": patch
+---
+
+# Cap the group option label length in the interactive change picker
+
+Groups can contain dozens of packages, and the picker previously inlined every package id into the option label. A label longer than the terminal width wraps onto multiple rows, which corrupts the picker's single-row-per-option layout: option scrolling and filter input echo stop working. Labels now inline the package ids only while the result stays short and fall back to `[group] <id> (<count> packages)` otherwise.

--- a/.changeset/interactive-short-flag-and-spinner-pause.md
+++ b/.changeset/interactive-short-flag-and-spinner-pause.md
@@ -1,0 +1,24 @@
+---
+monochange_core: patch
+monochange: patch
+---
+
+# Add `-i` short flag and hide the loader during interactive prompts
+
+`monochange create` (and every schema-built step command) now accepts `-i` as a short flag for `--interactive`, matching the documented example.
+
+The progress spinner is now paused while the interactive change wizard owns the terminal, so the loader no longer animates over the selector UI. It restarts while the change file is written, so the loader only shows while work is actually being done.
+
+Custom commands can now run interactive tools in `Command` steps by passing an `interactive` input:
+
+```toml
+[cli.wizard]
+inputs = [
+	{ name = "interactive", type = "boolean", default = false, short = "i" },
+]
+steps = [
+	{ name = "run wizard", type = "Command", command = "my-tui", inputs = ["interactive"] },
+]
+```
+
+Interactive `Command` steps run with inherited stdio so the tool can read from stdin and render its own UI, and the spinner is suppressed for the step. Output is not captured for interactive steps.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1314,9 +1314,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3783,7 +3783,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3841,7 +3841,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4459,7 +4459,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5094,7 +5094,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/monochange/src/__tests__/cli_progress_tests.rs
+++ b/crates/monochange/src/__tests__/cli_progress_tests.rs
@@ -191,6 +191,23 @@ fn progress_reporter_animates_named_steps_and_stops_cleanly() {
 }
 
 #[test]
+fn pause_spinner_stops_animation_and_reports_whether_it_was_active() {
+	let mut reporter = progress_reporter(true, true);
+	reporter.animate = true;
+	let step = named_command_step("announce release");
+
+	// No active spinner: pause reports false and is a no-op.
+	assert!(!reporter.pause_spinner());
+
+	reporter.step_started(0, &step);
+	thread::sleep(SPINNER_DELAY + SPINNER_TICK + Duration::from_millis(20));
+	assert!(reporter.pause_spinner());
+
+	// The spinner thread is stopped; a second pause reports false.
+	assert!(!reporter.pause_spinner());
+}
+
+#[test]
 fn log_command_output_appends_ansi_reset_after_raw_lines() {
 	let _step = named_command_step("prepare");
 	// Simulate a subprocess emitting ANSI yellow/brown without a trailing reset

--- a/crates/monochange/src/__tests__/cli_runtime_tests.rs
+++ b/crates/monochange/src/__tests__/cli_runtime_tests.rs
@@ -2074,6 +2074,75 @@ fn run_cli_command_command_streams_output_when_progress_is_enabled() {
 }
 
 #[test]
+fn run_cli_command_command_runs_interactive_steps_without_capturing_output() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let mut context = cli_context();
+	context.root = tempdir.path().to_path_buf();
+	let step_inputs = BTreeMap::from([("interactive".to_string(), vec!["true".to_string()])]);
+	let step = CliStepDefinition::Command {
+		name: Some("run tui".to_string()),
+		when: None,
+		always_run: false,
+		command: "printf 'tui output\\n'".to_string(),
+		dry_run_command: None,
+		show_progress: None,
+		shell: ShellConfig::Default,
+		id: Some("tui".to_string()),
+		variables: None,
+		inputs: BTreeMap::new(),
+	};
+	let cli_command = CliCommandDefinition {
+		name: "release".to_string(),
+		help_text: Some("release".to_string()),
+		inputs: Vec::new(),
+		steps: vec![step.clone()],
+		dry_run: false,
+	};
+	let mut progress = CliProgressReporter::new(&cli_command, false, false, ProgressFormat::Json);
+
+	run_cli_command_command(
+		&mut context,
+		&step,
+		0,
+		&mut progress,
+		true,
+		CommandStepOptions {
+			command: "printf 'tui output\\n'",
+			dry_run_command: None,
+			shell: &ShellConfig::Default,
+			step_id: Some("tui"),
+			variables: None,
+			step_inputs: &step_inputs,
+		},
+	)
+	.unwrap_or_else(|error| panic!("interactive command step: {error}"));
+
+	// Interactive steps inherit stdio, so nothing is captured and the log
+	// records the command itself rather than its output.
+	assert_eq!(
+		context
+			.step_outputs
+			.get("tui")
+			.map(|output| output.stdout.as_str()),
+		Some("")
+	);
+	assert_eq!(
+		context.command_logs,
+		vec!["ran `printf 'tui output\\n'`".to_string()]
+	);
+}
+
+#[test]
+fn step_input_is_true_checks_the_first_value() {
+	let mut inputs = BTreeMap::new();
+	assert!(!step_input_is_true(&inputs, "interactive"));
+	inputs.insert("interactive".to_string(), vec!["true".to_string()]);
+	assert!(step_input_is_true(&inputs, "interactive"));
+	inputs.insert("interactive".to_string(), vec!["false".to_string()]);
+	assert!(!step_input_is_true(&inputs, "interactive"));
+}
+
+#[test]
 fn take_process_stream_reports_missing_pipes() {
 	let error = take_process_stream::<Vec<u8>>(None, "stdout", "echo hello").unwrap_err();
 	assert_eq!(
@@ -2265,6 +2334,52 @@ async fn configured_config_step_uses_generic_completion_without_config_json() {
 
 	assert_eq!(output, "command `configured-config` completed (dry-run)");
 	assert!(!output.contains("project_root"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn execute_cli_command_suppresses_progress_for_interactive_command_steps() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let configuration = sample_configuration(tempdir.path());
+	let cli_command = CliCommandDefinition {
+		name: "interactive-command".to_string(),
+		help_text: None,
+		inputs: Vec::new(),
+		steps: vec![CliStepDefinition::Command {
+			name: Some("run tui".to_string()),
+			when: None,
+			always_run: false,
+			command: "printf 'tui output\\n'".to_string(),
+			dry_run_command: None,
+			show_progress: None,
+			shell: ShellConfig::Default,
+			id: None,
+			variables: None,
+			inputs: BTreeMap::from([("interactive".to_string(), CliStepInputValue::Boolean(true))]),
+		}],
+		dry_run: false,
+	};
+
+	let output = execute_cli_command_with_options(
+		tempdir.path(),
+		&configuration,
+		&cli_command,
+		ExecuteCliCommandOptions {
+			dry_run: false,
+			quiet: false,
+			show_diff: false,
+			inputs: BTreeMap::new(),
+			prepared_release_path: None,
+			progress_format: ProgressFormat::Auto,
+		},
+	)
+	.await
+	.unwrap_or_else(|error| panic!("interactive command: {error}"));
+
+	// The step ran without streaming or capturing its output, and no
+	// `running command` status line was emitted.
+	assert!(output.contains("completed"));
+	assert!(output.contains("ran `printf 'tui output\\n'`"));
+	assert!(!output.contains("running command"));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/monochange/src/__tests__/cli_runtime_tests.rs
+++ b/crates/monochange/src/__tests__/cli_runtime_tests.rs
@@ -2133,6 +2133,60 @@ fn run_cli_command_command_runs_interactive_steps_without_capturing_output() {
 }
 
 #[test]
+fn interactive_command_step_surfaces_spawn_failures() {
+	let tempdir = tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+	let mut context = cli_context();
+	context.root = tempdir.path().to_path_buf();
+	let step_inputs = BTreeMap::from([("interactive".to_string(), vec!["true".to_string()])]);
+	let step = CliStepDefinition::Command {
+		name: Some("run tui".to_string()),
+		when: None,
+		always_run: false,
+		command: "printf 'tui output\\n'".to_string(),
+		dry_run_command: None,
+		show_progress: None,
+		shell: ShellConfig::Custom("definitely-not-a-real-shell".to_string()),
+		id: Some("tui".to_string()),
+		variables: None,
+		inputs: BTreeMap::new(),
+	};
+	let cli_command = CliCommandDefinition {
+		name: "release".to_string(),
+		help_text: Some("release".to_string()),
+		inputs: Vec::new(),
+		steps: vec![step.clone()],
+		dry_run: false,
+	};
+	let mut progress = CliProgressReporter::new(&cli_command, false, false, ProgressFormat::Json);
+
+	let error = run_cli_command_command(
+		&mut context,
+		&step,
+		0,
+		&mut progress,
+		true,
+		CommandStepOptions {
+			command: "printf 'tui output\\n'",
+			dry_run_command: None,
+			shell: &ShellConfig::Custom("definitely-not-a-real-shell".to_string()),
+			step_id: Some("tui"),
+			variables: None,
+			step_inputs: &step_inputs,
+		},
+	)
+	.unwrap_err();
+
+	assert!(
+		error.to_string().contains("failed to run command"),
+		"expected spawn failure: {error}"
+	);
+	assert!(
+		error.to_string().contains("printf 'tui output\\n'"),
+		"expected the failing command in the error: {error}"
+	);
+}
+
+#[test]
 fn step_input_is_true_checks_the_first_value() {
 	let mut inputs = BTreeMap::new();
 	assert!(!step_input_is_true(&inputs, "interactive"));

--- a/crates/monochange/src/__tests__/interactive_tests.rs
+++ b/crates/monochange/src/__tests__/interactive_tests.rs
@@ -31,6 +31,7 @@ use super::normalize_optional_text;
 use super::parse_change_type_selection;
 use super::parse_selected_bump;
 use super::prompt_change_type_for_target;
+use super::render_group_target_display;
 use super::run_interactive_change;
 use super::validate_reason_input;
 use super::validate_semver_input;
@@ -242,6 +243,22 @@ fn build_selectable_targets_lists_groups_then_standalone_then_group_members() {
 			"[package] core (member of group `sdk`)".to_string(),
 		]
 	);
+}
+
+#[test]
+fn group_display_falls_back_to_count_label_when_inline_list_is_too_long() {
+	let package_ids = (0..40)
+		.map(|index| format!("very-long-package-name-{index:02}"))
+		.collect::<Vec<_>>();
+	let display = render_group_target_display("main", &package_ids);
+	assert_eq!(display, "[group] main (40 packages)");
+	assert!(display.len() <= super::MAX_GROUP_DISPLAY_LENGTH);
+}
+
+#[test]
+fn group_display_inlines_short_package_lists() {
+	let display = render_group_target_display("sdk", &["core".to_string(), "app".to_string()]);
+	assert_eq!(display, "[group] sdk (core, app)");
 }
 
 #[test]

--- a/crates/monochange/src/cli_progress.rs
+++ b/crates/monochange/src/cli_progress.rs
@@ -543,6 +543,16 @@ impl CliProgressReporter {
 		}
 	}
 
+	/// Stop the active spinner without printing a completion line so that
+	/// interactive prompts can take over the terminal. Returns whether a
+	/// spinner was actually running; callers can use that to restart it
+	/// with `step_status` once the interactive work is done.
+	pub(crate) fn pause_spinner(&mut self) -> bool {
+		let was_active = self.active_spinner.is_some();
+		self.stop_spinner();
+		was_active
+	}
+
 	fn print_line(text: &str) {
 		with_stderr_lock(|lock| {
 			let _ = write!(lock, "\r\u{1b}[2K\u{1b}[0m");

--- a/crates/monochange/src/cli_runtime.rs
+++ b/crates/monochange/src/cli_runtime.rs
@@ -822,6 +822,9 @@ pub(crate) async fn execute_cli_command_with_options(
 						root,
 						configuration,
 						&step_inputs,
+						&mut progress,
+						step_index,
+						step,
 					)?);
 					Ok(())
 				}
@@ -1877,6 +1880,13 @@ fn step_shows_progress(step: &CliStepDefinition) -> bool {
 	step.show_progress().unwrap_or(true)
 }
 
+fn step_input_is_true(step_inputs: &BTreeMap<String, Vec<String>>, name: &str) -> bool {
+	step_inputs
+		.get(name)
+		.and_then(|values| values.first())
+		.is_some_and(|value| value == "true")
+}
+
 fn run_cli_command_command(
 	context: &mut CliContext,
 	step: &CliStepDefinition,
@@ -1894,8 +1904,9 @@ fn run_cli_command_command(
 		options.variables,
 		options.step_inputs,
 	);
+	let interactive = step_input_is_true(options.step_inputs, "interactive");
 	let mut process_command = build_process_command(&context.root, options.shell, &interpolated)?;
-	if show_progress {
+	if show_progress && !interactive {
 		progress.step_status(
 			step_index,
 			step,
@@ -1905,10 +1916,16 @@ fn run_cli_command_command(
 			),
 		);
 	}
+	if interactive {
+		// Let the command own the terminal: pause the spinner so it does
+		// not animate over the command's own UI.
+		progress.pause_spinner();
+	}
 	let output = execute_process_command(
 		&mut process_command,
 		progress,
-		show_progress,
+		show_progress && !interactive,
+		interactive,
 		step_index,
 		step,
 		&interpolated,
@@ -2002,10 +2019,23 @@ fn execute_process_command(
 	process_command: &mut ProcessCommand,
 	progress: &mut CliProgressReporter,
 	show_progress: bool,
+	interactive: bool,
 	step_index: usize,
 	step: &CliStepDefinition,
 	interpolated: &str,
 ) -> MonochangeResult<PreparedProcessOutput> {
+	if interactive {
+		// Let the command own the terminal: inherit stdio so it can read
+		// input and render its own UI without spinner interference.
+		let status = process_command.status().map_err(|error| {
+			MonochangeError::Io(format!("failed to run command `{interpolated}`: {error}"))
+		})?;
+		return Ok(PreparedProcessOutput {
+			status,
+			stdout: Vec::new(),
+			stderr: Vec::new(),
+		});
+	}
 	if progress.is_enabled() && show_progress {
 		return run_process_with_streaming(
 			process_command,
@@ -4121,11 +4151,11 @@ fn execute_create_change_file_step(
 	root: &Path,
 	configuration: &monochange_core::WorkspaceConfiguration,
 	step_inputs: &BTreeMap<String, Vec<String>>,
+	progress: &mut CliProgressReporter,
+	step_index: usize,
+	step: &CliStepDefinition,
 ) -> MonochangeResult<String> {
-	let is_interactive = step_inputs
-		.get("interactive")
-		.and_then(|values| values.first())
-		.is_some_and(|value| value == "true");
+	let is_interactive = step_input_is_true(step_inputs, "interactive");
 
 	if is_interactive {
 		let options = interactive::InteractiveOptions {
@@ -4139,7 +4169,13 @@ fn execute_create_change_file_step(
 				.and_then(|values| values.first())
 				.cloned(),
 		};
+		// Pause the spinner while the wizard owns the terminal, then restart
+		// it for the actual file write so the loader only shows during work.
+		let spinner_was_active = progress.pause_spinner();
 		let result = interactive::run_interactive_change(configuration, &options)?;
+		if spinner_was_active {
+			progress.step_status(step_index, step, "writing change file");
+		}
 		let output_path = step_inputs
 			.get("output")
 			.and_then(|values| values.first())

--- a/crates/monochange/src/interactive.rs
+++ b/crates/monochange/src/interactive.rs
@@ -195,16 +195,22 @@ fn build_selectable_targets(configuration: &WorkspaceConfiguration) -> Vec<Selec
 	targets
 }
 
+/// Maximum length for an inline group label in the interactive picker.
+///
+/// inquire lays out one option per terminal row and does not handle wrapped
+/// lines, so a label longer than the terminal width corrupts list rendering,
+/// breaking option scrolling and input echo. Groups can contain dozens of
+/// packages, so only inline every id while the result stays short and fall
+/// back to a count-based label otherwise.
+const MAX_GROUP_DISPLAY_LENGTH: usize = 64;
+
 fn render_group_target_display(group_id: &str, package_ids: &[String]) -> String {
-	let mut display = format!("[group] {group_id} (");
-	for (index, package_id) in package_ids.iter().enumerate() {
-		if index > 0 {
-			display.push_str(", ");
-		}
-		display.push_str(package_id);
+	let full = format!("[group] {group_id} ({})", package_ids.join(", "));
+	if full.len() <= MAX_GROUP_DISPLAY_LENGTH {
+		full
+	} else {
+		format!("[group] {group_id} ({} packages)", package_ids.len())
 	}
-	display.push(')');
-	display
 }
 
 fn prompt_select_targets(targets: &[SelectableTarget]) -> MonochangeResult<Vec<SelectableTarget>> {

--- a/crates/monochange/tests/cli_progress.rs
+++ b/crates/monochange/tests/cli_progress.rs
@@ -12,6 +12,7 @@ use test_support::assert_readable_json_snapshot;
 use test_support::current_test_name;
 use test_support::monochange_command;
 use test_support::run_in_tty;
+use test_support::run_in_tty_with_env;
 use test_support::setup_fixture;
 use test_support::setup_scenario_workspace;
 use test_support::snapshot_settings;
@@ -208,7 +209,7 @@ fn run_tty_interactive_change(workspace: &Path, output_path: &Path) -> (i32, Str
 		},
 	];
 	let output = output_path.display().to_string();
-	let (status, transcript) = run_in_tty(
+	let (status, transcript) = run_in_tty_with_env(
 		workspace,
 		&[
 			"change",
@@ -221,6 +222,9 @@ fn run_tty_interactive_change(workspace: &Path, output_path: &Path) -> (i32, Str
 			output.as_str(),
 		],
 		None,
+		// Force spinner animation even when CI env vars are set so the
+		// spinner pause/resume path is exercised deterministically.
+		&[("INSTA_WORKSPACE_ROOT", "1")],
 		&actions,
 	);
 	(status, normalize_terminal_transcript(&transcript))

--- a/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_create.snap
+++ b/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_create.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/monochange/tests/cli_clap_help.rs
-assertion_line: 142
 expression: render_help_snapshot(&path)
 ---
 Version: [current]
@@ -19,7 +18,7 @@ Create a changeset file for one or more packages
           Run the command in dry-run mode when supported
 
 [1m[96mOptions:[0m
-      [93m--interactive[0m
+  [93m-i[0m, [93m--interactive[0m
           
 
       [93m--package[0m[95m [0m[95m<PACKAGE>[0m

--- a/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_run_change.snap
+++ b/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_run_change.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/monochange/tests/cli_clap_help.rs
-expression: "render_help_snapshot(&path, version)"
+expression: render_help_snapshot(&path)
 ---
 Version: [current]
 Command: monochange run change
@@ -18,7 +18,7 @@ Create a change file for one or more packages
           Run the command in dry-run mode when supported
 
 [1m[96mOptions:[0m
-      [93m--interactive[0m
+  [93m-i[0m, [93m--interactive[0m
           
 
       [93m--package[0m[95m [0m[95m<PACKAGE>[0m

--- a/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_step_create_change_file.snap
+++ b/crates/monochange/tests/snapshots/cli_clap_help__clap_long_help__monochange_step_create_change_file.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/monochange/tests/cli_clap_help.rs
-expression: "render_help_snapshot(&path, version)"
+expression: render_help_snapshot(&path)
 ---
 Version: [current]
 Command: monochange step create-change-file
@@ -18,7 +18,7 @@ Create a changeset file for one or more packages
           Run the command in dry-run mode when supported
 
 [1m[96mOptions:[0m
-      [93m--interactive[0m
+  [93m-i[0m, [93m--interactive[0m
           
 
       [93m--package[0m[95m [0m[95m<PACKAGE>[0m

--- a/crates/monochange/tests/snapshots/cli_help__run_change_help_shows_detailed_help@run_change_help_shows_detailed_help.snap
+++ b/crates/monochange/tests/snapshots/cli_help__run_change_help_shows_detailed_help@run_change_help_shows_detailed_help.snap
@@ -24,7 +24,7 @@ Release Options:
       --dry-run  Run the command in dry-run mode when supported
 
 Options:
-      --interactive            
+  -i, --interactive            
       --package <PACKAGE>      
       --bump <BUMP>            [default: patch] [possible values: none, patch, minor, major]
       --reason <REASON>        

--- a/crates/monochange/tests/test_support.rs
+++ b/crates/monochange/tests/test_support.rs
@@ -306,6 +306,19 @@ pub fn run_in_tty(
 	release_date: Option<&str>,
 	actions: &[TtyAction<'_>],
 ) -> (i32, String) {
+	run_in_tty_with_env(workspace, args, release_date, &[], actions)
+}
+
+/// Run a monochange command in a pty with additional environment variables
+/// applied to the child process.
+#[allow(clippy::too_many_arguments)]
+pub fn run_in_tty_with_env(
+	workspace: &Path,
+	args: &[&str],
+	release_date: Option<&str>,
+	env: &[(&str, &str)],
+	actions: &[TtyAction<'_>],
+) -> (i32, String) {
 	use std::io::Read as _;
 	use std::io::Write as _;
 	use std::thread;
@@ -325,6 +338,9 @@ pub fn run_in_tty(
 	command.env_remove("RUST_LOG");
 	if let Some(release_date) = release_date {
 		command.env("MONOCHANGE_RELEASE_DATE", release_date);
+	}
+	for (key, value) in env {
+		command.env(key, value);
 	}
 	if !matches!(args.first().copied(), Some("step" | "run" | "help")) {
 		command.arg("run");

--- a/crates/monochange_core/src/__tests__/lib_tests.rs
+++ b/crates/monochange_core/src/__tests__/lib_tests.rs
@@ -2086,6 +2086,26 @@ fn valid_input_names_returns_expected_names_for_create_change_file() {
 }
 
 #[test]
+fn step_inputs_schema_assigns_short_flag_to_interactive_input() {
+	let step = CliStepDefinition::CreateChangeFile {
+		show_progress: None,
+		name: None,
+		when: None,
+		always_run: false,
+		inputs: BTreeMap::new(),
+	};
+	let schema = step.step_inputs_schema();
+	let interactive = schema
+		.iter()
+		.find(|input| input.name == "interactive")
+		.expect("create change file should accept interactive");
+	assert_eq!(interactive.short, Some('i'));
+	for input in schema.iter().filter(|input| input.name != "interactive") {
+		assert_eq!(input.short, None, "unexpected short flag on {}", input.name);
+	}
+}
+
+#[test]
 fn expected_input_kind_returns_correct_types_for_affected_packages() {
 	use crate::CliInputKind;
 	let step = CliStepDefinition::AffectedPackages {

--- a/crates/monochange_core/src/lib.rs
+++ b/crates/monochange_core/src/lib.rs
@@ -3605,7 +3605,10 @@ impl CliStepDefinition {
 					required: false,
 					default,
 					choices,
-					short: None,
+					short: match *name {
+						"interactive" => Some('i'),
+						_ => None,
+					},
 				}
 			})
 			.collect()

--- a/docs/src/reference/cli-steps/03-create-change-file.md
+++ b/docs/src/reference/cli-steps/03-create-change-file.md
@@ -61,7 +61,7 @@ None. `CreateChangeFile` is standalone.
 - writes a new changeset file
 - reports the written path
 - does not prepare release state for later steps
-- automatically hides the progress spinner during interactive prompting so the selector UI stays readable
+- automatically hides the progress spinner during interactive prompting so the selector UI stays readable, and restarts it while the change file is written
 - automatically wraps package/group ids in quotes when the authored frontmatter key contains YAML-sensitive characters such as `@` or `/`
 
 ## Example

--- a/docs/src/reference/cli-steps/13-command.md
+++ b/docs/src/reference/cli-steps/13-command.md
@@ -32,6 +32,7 @@ Use `Command` for what is truly custom.
 - `variables` — optional custom variable mapping for command substitution
 - `inputs` — optional step-local input overrides
 - `show_progress` — optional boolean; set to `false` when the command itself is interactive and spinner output would get in the way
+- `interactive` — optional step input; when set to `true` the step runs with inherited stdio so the command can own the terminal, and the progress spinner is suppressed for the step. This is the recommended way to run interactive tools such as wizards or TUIs; unlike `show_progress = false`, the command can read from stdin and render directly to the terminal. Output is not captured, so `steps.<id>.stdout` and `steps.<id>.stderr` are empty for interactive steps
 - `always_run` — optional boolean; set to `true` to run this step even when a previous step has failed
 
 ## Prerequisites

--- a/monochange.toml
+++ b/monochange.toml
@@ -749,7 +749,7 @@ verified_commits = true
 [cli.change]
 help_text = "Create a change file for one or more packages"
 inputs = [
-	{ name = "interactive", type = "boolean", default = false },
+	{ name = "interactive", type = "boolean", default = false, short = "i" },
 	{ name = "package", type = "string_list", required = true },
 	{ name = "bump", type = "choice", choices = ["none", "patch", "minor", "major"], default = "patch" },
 	{ name = "reason", type = "string", required = true },


### PR DESCRIPTION
## Summary

Fixes two interactive-mode issues:

1. **`-i` short flag**: `monochange create` (and every schema-built step command) now accepts `-i` as a short flag for `--interactive`, matching the documented example in the `CreateChangeFile` reference.
2. **Loader hidden during interactive prompts**: the progress spinner no longer animates over the interactive change wizard's selector UI. It is paused while the wizard owns the terminal and restarted while the change file is written, so the loader only shows while work is actually being done.

## Changes

- `crates/monochange_core/src/lib.rs` — `step_inputs_schema()` assigns the `i` short flag to the `interactive` input
- `crates/monochange/src/cli_progress.rs` — new `pause_spinner()` that stops the active spinner without printing a completion line and reports whether one was running
- `crates/monochange/src/cli_runtime.rs`:
  - `execute_create_change_file_step` pauses the spinner before the wizard and restarts it (via `step_status`) for the file write
  - `Command` steps accept an `interactive` input: the step runs with inherited stdio via `Command::status()` so interactive tools can read stdin and render their own UI, the spinner is paused for the step, and output is not captured
- `monochange.toml` — `[cli.change]` interactive input gets `short = "i"`
- `docs/src/reference/cli-steps/13-command.md` — document the `interactive` input for `Command` steps
- `docs/src/reference/cli-steps/03-create-change-file.md` — note the spinner restarts while the change file is written
- `.changeset/interactive-short-flag-and-spinner-pause.md` — changeset

## Verification

- `create --help` and `run change --help` show `-i, --interactive`; `create -i` and `run change -i` parse and drive the wizard
- Pty-driven wizard: **0 spinner frames during all prompts** (previously ~40 frames in 4s), completion line `✔ [1/1] create change file` and `wrote change file …` after
- Pty-driven interactive `Command` step: **0 spinner frames**, the command reads stdin (`GOT: hello from pty`), completion line `✔ [1/1] run tui (Command)`
- New tests: schema short-flag assignment, `pause_spinner` behavior, interactive `Command` step output handling, full-loop progress suppression, plus updated help snapshots
- `cargo test --workspace` — all pass; `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets` — 0 warnings
- Patch coverage: **8/8 (100.00%)**
